### PR TITLE
Add ServiceAccount to Katib-ui deploy

### DIFF
--- a/katib/v1alpha1/base/katib-ui-deployment.yaml
+++ b/katib/v1alpha1/base/katib-ui-deployment.yaml
@@ -23,3 +23,4 @@ spec:
         ports:
         - name: ui
           containerPort: 80
+      serviceAccountName: katib-ui


### PR DESCRIPTION
I think, we missed ServiceAccount in the Katib-ui manifest.
According to this: https://github.com/kubeflow/manifests/blob/master/katib/v1alpha1/base/katib-ui-rbac.yaml, we should connect Katib-ui ServiceAccount with corresponding deployment.
/assign @hougangliu 
/cc @jlewi

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/manifests/16)
<!-- Reviewable:end -->
