### PR TITLE
service namespace var in getambassador.io/config annotations

### DIFF
--- a/argo/base/kustomization.yaml
+++ b/argo/base/kustomization.yaml
@@ -86,5 +86,13 @@ vars:
     apiVersion: v1
   fieldref:
     fieldpath: data.artifactRepositorySecretKeySecretKey
+vars:
+- name: namespace
+  objref:
+    kind: Service
+    name: argo-ui
+    apiVersion: v1
+  fieldref:
+    fieldpath: metadata.namespace
 configurations:
 - params.yaml

--- a/argo/base/service.yaml
+++ b/argo/base/service.yaml
@@ -8,7 +8,7 @@ metadata:
       kind:  Mapping
       name: argo-ui-mapping
       prefix: /argo/
-      service: argo-ui.kubeflow
+      service: argo-ui.$(namespace)
   labels:
     app: argo-ui
   name: argo-ui

--- a/common/centraldashboard/base/kustomization.yaml
+++ b/common/centraldashboard/base/kustomization.yaml
@@ -12,19 +12,16 @@ images:
   - name: gcr.io/kubeflow-images-public/centraldashboard
     newName: gcr.io/kubeflow-images-public/centraldashboard
     newTag: latest
-configMapGenerator:
-- name: centraldashboard-parameters
-  env: params.env
 generatorOptions:
   disableNameSuffixHash: true
 vars:
 - name: namespace
   objref:
-    kind: ConfigMap
-    name: centraldashboard-parameters
+    kind: Service
+    name: centraldashboard
     apiVersion: v1
   fieldref:
-    fieldpath: data.namespace
+    fieldpath: metadata.namespace
 configurations:
 - params.yaml
 

--- a/common/centraldashboard/base/params.env
+++ b/common/centraldashboard/base/params.env
@@ -1,1 +1,0 @@
-namespace=kubeflow

--- a/jupyter/jupyter-web-app/base/kustomization.yaml
+++ b/jupyter/jupyter-web-app/base/kustomization.yaml
@@ -39,10 +39,10 @@ vars:
     fieldpath: data.prefix
 - name: namespace
   objref:
-    kind: ConfigMap
-    name: parameters
+    kind: Service
+    name: service
     apiVersion: v1
   fieldref:
-    fieldpath: data.namespace
+    fieldpath: metadata.namespace
 configurations:
 - params.yaml

--- a/jupyter/jupyter-web-app/base/params.env
+++ b/jupyter/jupyter-web-app/base/params.env
@@ -2,4 +2,3 @@ UI=default
 ROK_SECRET_NAME=secret-rok-{username}
 policy=Always
 prefix=jupyter
-namespace=kubeflow

--- a/jupyter/jupyter-web-app/base/service.yaml
+++ b/jupyter/jupyter-web-app/base/service.yaml
@@ -8,7 +8,7 @@ metadata:
       kind:  Mapping
       name: webapp_mapping
       prefix: /$(prefix)/
-      service: jupyter-web-app.$(namespace)
+      service: jupyter-web-app-service.$(namespace)
       add_request_headers:
         x-forwarded-prefix: /jupyter
   labels:

--- a/jupyter/jupyter/base/kustomization.yaml
+++ b/jupyter/jupyter/base/kustomization.yaml
@@ -29,10 +29,10 @@ vars:
     fieldpath: data.serviceType
 - name: namespace
   objref:
-    kind: ConfigMap
-    name: parameters
+    kind: Service
+    name: jupyter-lb
     apiVersion: v1
   fieldref:
-    fieldpath: data.namespace
+    fieldpath: metadata.namespace
 configurations:
 - params.yaml

--- a/jupyter/jupyter/base/params.env
+++ b/jupyter/jupyter/base/params.env
@@ -2,4 +2,3 @@ STORAGE_CLASS=null
 KF_AUTHENTICATOR=null
 DEFAULT_JUPYTERLAB=false
 serviceType=ClusterIP
-namespace=kubeflow

--- a/kubebench/base/kustomization.yaml
+++ b/kubebench/base/kustomization.yaml
@@ -25,3 +25,13 @@ images:
   - name: gcr.io/kubeflow-images-public/kubebench/kubebench-example-tf-cnn-post-processor
     newName: gcr.io/kubeflow-images-public/kubebench/kubebench-example-tf-cnn-post-processor
     newTag: v0.4.0-13-g262c593
+vars:
+- name: namespace
+  objref:
+    kind: Service
+    name: kubebench-dashboard
+    apiVersion: v1
+  fieldref:
+    fieldpath: metadata.namespace
+configurations:
+- params.yaml

--- a/kubebench/base/params.yaml
+++ b/kubebench/base/params.yaml
@@ -1,7 +1,3 @@
 varReference:
-- path: data/config
-  kind: ConfigMap
-- path: data/config
-  kind: Deployment
 - path: metadata/annotations/getambassador.io\/config
   kind: Service

--- a/kubebench/base/service.yaml
+++ b/kubebench/base/service.yaml
@@ -9,7 +9,7 @@ metadata:
       name: kubebench-dashboard-ui-mapping
       prefix: /dashboard/
       rewrite: /dashboard/
-      service: kubebench-dashboard.kubeflow
+      service: kubebench-dashboard.$(namespace)
   name: kubebench-dashboard
 spec:
   ports:

--- a/pipeline/pipelines-ui/base/kustomization.yaml
+++ b/pipeline/pipelines-ui/base/kustomization.yaml
@@ -8,3 +8,15 @@ resources:
 images:
 - name: gcr.io/ml-pipeline/frontend
   newTag: '0.1.14'
+
+vars:
+- name: namespace
+  objref:
+    kind: Service
+    name: ml-pipeline-ui
+    apiVersion: v1
+  fieldref:
+    fieldpath: metadata.namespace
+
+configurations:
+- params.yaml

--- a/pipeline/pipelines-ui/base/params.yaml
+++ b/pipeline/pipelines-ui/base/params.yaml
@@ -1,7 +1,3 @@
 varReference:
-- path: data/config
-  kind: ConfigMap
-- path: data/config
-  kind: Deployment
 - path: metadata/annotations/getambassador.io\/config
   kind: Service

--- a/pipeline/pipelines-ui/base/service.yaml
+++ b/pipeline/pipelines-ui/base/service.yaml
@@ -10,7 +10,7 @@ metadata:
       prefix: /pipeline
       rewrite: /pipeline
       timeout_ms: 300000
-      service: ml-pipeline-ui.kubeflow
+      service: ml-pipeline-ui.$(namespace)
       use_websocket: true
   labels:
     app: ml-pipeline-ui

--- a/pipeline/pipelines-viewer/base/kustomization.yaml
+++ b/pipeline/pipelines-viewer/base/kustomization.yaml
@@ -10,3 +10,13 @@ resources:
 images:
 - name: gcr.io/ml-pipeline/viewer-crd-controller
   newTag: '0.1.14'
+vars:
+- name: namespace
+  objref:
+    kind: Service
+    name: ml-pipeline-tensorboard-ui
+    apiVersion: v1
+  fieldref:
+    fieldpath: metadata.namespace
+configurations:
+- params.yaml

--- a/pipeline/pipelines-viewer/base/params.yaml
+++ b/pipeline/pipelines-viewer/base/params.yaml
@@ -1,7 +1,3 @@
 varReference:
-- path: data/config
-  kind: ConfigMap
-- path: data/config
-  kind: Deployment
 - path: metadata/annotations/getambassador.io\/config
   kind: Service

--- a/pipeline/pipelines-viewer/base/service.yaml
+++ b/pipeline/pipelines-viewer/base/service.yaml
@@ -10,7 +10,7 @@ metadata:
       prefix: /data
       rewrite: /data
       timeout_ms: 300000
-      service: ml-pipeline-ui.kubeflow
+      service: ml-pipeline-tensorboard-ui.$(namespace)
       use_websocket: true
   labels:
     app: ml-pipeline-tensorboard-ui

--- a/tensorboard/base/kustomization.yaml
+++ b/tensorboard/base/kustomization.yaml
@@ -6,3 +6,13 @@ resources:
 - service.yaml
 commonLabels:
   kustomize.component: tensorboard
+vars:
+- name: namespace
+  objref:
+    kind: Service
+    name: tensorboard
+    apiVersion: v1
+  fieldref:
+    fieldpath: metadata.namespace
+configurations:
+- params.yaml

--- a/tensorboard/base/params.yaml
+++ b/tensorboard/base/params.yaml
@@ -1,7 +1,3 @@
 varReference:
-- path: data/config
-  kind: ConfigMap
-- path: data/config
-  kind: Deployment
 - path: metadata/annotations/getambassador.io\/config
   kind: Service

--- a/tensorboard/base/service.yaml
+++ b/tensorboard/base/service.yaml
@@ -10,7 +10,7 @@ metadata:
       prefix: /tensorboard/ tensorboard/
       rewrite: /
       method: GET
-      service: tensorboard.kubeflow:9000
+      service: tensorboard.$(namespace):9000
   labels:
     app: tensorboard
   name: tensorboard

--- a/tf-training/tf-job-operator/base/kustomization.yaml
+++ b/tf-training/tf-job-operator/base/kustomization.yaml
@@ -10,3 +10,13 @@ resources:
 - service.yaml
 commonLabels:
   kustomize.component: tf-job-operator
+vars:
+- name: namespace
+  objref:
+    kind: Service
+    name: tf-job-dashboard
+    apiVersion: v1
+  fieldref:
+    fieldpath: metadata.namespace
+configurations:
+- params.yaml

--- a/tf-training/tf-job-operator/base/params.yaml
+++ b/tf-training/tf-job-operator/base/params.yaml
@@ -1,7 +1,3 @@
 varReference:
-- path: data/config
-  kind: ConfigMap
-- path: data/config
-  kind: Deployment
 - path: metadata/annotations/getambassador.io\/config
   kind: Service

--- a/tf-training/tf-job-operator/base/service.yaml
+++ b/tf-training/tf-job-operator/base/service.yaml
@@ -9,7 +9,7 @@ metadata:
       name: tfjobs-ui-mapping
       prefix: /tfjobs/
       rewrite: /tfjobs/
-      service: tf-job-dashboard.kubeflow
+      service: tf-job-dashboard.$(namespace)
   name: tf-job-dashboard
 spec:
   ports:


### PR DESCRIPTION
Now, if a service need to be routed by ambassador, $(service-name).$(service-namespace) is in need in its annotations. in kustonmize, service namespace is configured during build. so we'd better set service namespace in its annotations by a var.
before this PR, the namespace is set by configmap, so we must modify the configmap manually each time when we set a new namespace for the application. but if the namespace comes from its service metadata.namespace, we can never modify manually for it any more.

<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/manifests/30)
<!-- Reviewable:end -->
