### PR TITLE
Fix typo of jupyter yaml

### DIFF
--- a/jupyter/jupyter/base/stateful-set.yaml
+++ b/jupyter/jupyter/base/stateful-set.yaml
@@ -30,7 +30,7 @@ spec:
           valueFrom:
             configMapKeyRef:
               name: parameters
-              key: DEFAULT_JUPYTERLAB
+              key: STORAGE_CLASS
         - name: ROK_SECRET_NAME
           value: secret-rok-{username}
         image: gcr.io/kubeflow/jupyterhub-k8s:v20180531-3bb991b1


### PR DESCRIPTION
This parameter should be STORAGE_CLASS

<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/manifests/68)
<!-- Reviewable:end -->
