### PR TITLE
jupyter-web-app requires access to storageclasses resources

### DIFF
--- a/jupyter/jupyter-web-app/base/cluster-role.yaml
+++ b/jupyter/jupyter-web-app/base/cluster-role.yaml
@@ -30,3 +30,11 @@ rules:
   - delete
   - get
   - list
+- apiGroups:
+  - storage.k8s.io
+  resources:
+  - storageclasses
+  verbs:
+  - get
+  - list
+  - watch


### PR DESCRIPTION
This PR address rbac issue while accessing storageclasses in jupyter-web-app [here](https://github.com/kubeflow/kubeflow/blob/master/components/jupyter-web-app/kubeflow_jupyter/default/app.py#L140)

Signed-off-by: Abhilash Pallerlamudi <stp.abhi@gmail.com>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/manifests/73)
<!-- Reviewable:end -->
