### PR TITLE
Update tf-operator to v1

### DIFF
--- a/tf-training/tf-job-operator/base/crd.yaml
+++ b/tf-training/tf-job-operator/base/crd.yaml
@@ -41,11 +41,11 @@ spec:
                     replicas:
                       minimum: 1
                       type: integer
-  version: v1beta1
+  version: v1
   versions:
-  - name: v1beta1
-    served: true
-    storage: true
   - name: v1beta2
     served: true
     storage: false
+  - name: v1
+    served: true
+    storage: true

--- a/tf-training/tf-job-operator/base/deployment.yaml
+++ b/tf-training/tf-job-operator/base/deployment.yaml
@@ -16,7 +16,7 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: metadata.namespace
-        image: gcr.io/kubeflow-images-public/tf_operator:v0.5.0
+        image: gcr.io/kubeflow-images-public/tf_operator:kubeflow-tf-operator-postsubmit-v1-63de5cb-2948-fd60
         name: tf-job-dashboard
         ports:
         - containerPort: 8080
@@ -35,7 +35,7 @@ spec:
     spec:
       containers:
       - command:
-        - /opt/kubeflow/tf-operator.v1beta2
+        - /opt/kubeflow/tf-operator.v1
         - --alsologtostderr
         - -v=1
         env:
@@ -47,7 +47,7 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: metadata.name
-        image: gcr.io/kubeflow-images-public/tf_operator:v0.5.0
+        image: gcr.io/kubeflow-images-public/tf_operator:kubeflow-tf-operator-postsubmit-v1-63de5cb-2948-fd60
         name: tf-job-operator
         volumeMounts:
         - mountPath: /etc/config


### PR DESCRIPTION
Fixes https://github.com/kubeflow/tf-operator/issues/991

Notes:
- Currently using a postsubmit image tag. This will be updated when tf-operator 0.6 image is tagged.
- Both v1beta2 and v1 versions are served for backward compatibility.
- V1beta1 is deprecated and no longer served.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/manifests/80)
<!-- Reviewable:end -->
