### PR TITLE
fixes to iap_ingress and pipeline, regenerated tests

### DIFF
--- a/gcp/iap-ingress/base/stateful-set.yaml
+++ b/gcp/iap-ingress/base/stateful-set.yaml
@@ -46,3 +46,4 @@ spec:
       - name: sa-key
         secret:
           secretName: admin-gcp-sa
+  volumeClaimTemplates: []

--- a/pipeline/api-service/base/deployment.yaml
+++ b/pipeline/api-service/base/deployment.yaml
@@ -12,7 +12,7 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: metadata.namespace
-        image: gcr.io/ml-pipeline/api-server:0.1.18
+        image: gcr.io/ml-pipeline/api-server:0.1.20
         imagePullPolicy: IfNotPresent
         ports:
         - containerPort: 8888

--- a/pipeline/api-service/base/kustomization.yaml
+++ b/pipeline/api-service/base/kustomization.yaml
@@ -11,4 +11,4 @@ resources:
 - service.yaml
 images:
 - name: gcr.io/ml-pipeline/api-server
-  newTag: '0.1.18'
+  newTag: '0.1.20'

--- a/tests/api-service-base_test.go
+++ b/tests/api-service-base_test.go
@@ -27,7 +27,7 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: metadata.namespace
-        image: gcr.io/ml-pipeline/api-server:0.1.18
+        image: gcr.io/ml-pipeline/api-server:0.1.20
         imagePullPolicy: IfNotPresent
         ports:
         - containerPort: 8888
@@ -113,7 +113,7 @@ resources:
 - service.yaml
 images:
 - name: gcr.io/ml-pipeline/api-server
-  newTag: '0.1.18'
+  newTag: '0.1.20'
 `)
 }
 

--- a/tests/iap-ingress-base_test.go
+++ b/tests/iap-ingress-base_test.go
@@ -589,6 +589,7 @@ spec:
       - name: sa-key
         secret:
           secretName: admin-gcp-sa
+  volumeClaimTemplates: []
 `)
 	th.writeF("/manifests/gcp/iap-ingress/base/params.yaml", `
 varReference:

--- a/tests/minio-base_test.go
+++ b/tests/minio-base_test.go
@@ -1,0 +1,110 @@
+package tests_test
+
+import (
+	"sigs.k8s.io/kustomize/k8sdeps/kunstruct"
+	"sigs.k8s.io/kustomize/k8sdeps/transformer"
+	"sigs.k8s.io/kustomize/pkg/fs"
+	"sigs.k8s.io/kustomize/pkg/loader"
+	"sigs.k8s.io/kustomize/pkg/resmap"
+	"sigs.k8s.io/kustomize/pkg/resource"
+	"sigs.k8s.io/kustomize/pkg/target"
+	"testing"
+)
+
+func writeMinioBase(th *KustTestHarness) {
+	th.writeF("/manifests/pipeline/minio/base/deployment.yaml", `
+apiVersion: apps/v1beta1
+kind: Deployment
+metadata:
+  name: deployment
+spec:
+  strategy:
+    type: Recreate
+  template:
+    spec:
+      containers:
+      - name: minio
+        args:
+        - server
+        - /data
+        env:
+        - name: MINIO_ACCESS_KEY
+          value: minio
+        - name: MINIO_SECRET_KEY
+          value: minio123
+        image: minio/minio:RELEASE.2018-02-09T22-40-05Z
+        ports:
+        - containerPort: 9000
+        volumeMounts:
+        - mountPath: /data
+          name: data
+          subPath: minio
+      volumes:
+      - name: data
+        persistentVolumeClaim:
+          claimName: minio-pvc
+`)
+	th.writeF("/manifests/pipeline/minio/base/secret.yaml", `
+apiVersion: v1
+data:
+  accesskey: bWluaW8=
+  secretkey: bWluaW8xMjM=
+kind: Secret
+metadata:
+  name: artifact
+type: Opaque
+`)
+	th.writeF("/manifests/pipeline/minio/base/service.yaml", `
+apiVersion: v1
+kind: Service
+metadata:
+  name: service
+spec:
+  ports:
+  - port: 9000
+    protocol: TCP
+    targetPort: 9000
+  selector:
+    app: minio
+`)
+	th.writeK("/manifests/pipeline/minio/base", `
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+nameprefix: minio-
+commonLabels:
+  app: minio
+resources:
+- deployment.yaml
+- secret.yaml
+- service.yaml
+images:
+- name: minio/minio
+  newTag: RELEASE.2018-02-09T22-40-05Z
+`)
+}
+
+func TestMinioBase(t *testing.T) {
+	th := NewKustTestHarness(t, "/manifests/pipeline/minio/base")
+	writeMinioBase(th)
+	m, err := th.makeKustTarget().MakeCustomizedResMap()
+	if err != nil {
+		t.Fatalf("Err: %v", err)
+	}
+	targetPath := "../pipeline/minio/base"
+	fsys := fs.MakeRealFS()
+	_loader, loaderErr := loader.NewLoader(targetPath, fsys)
+	if loaderErr != nil {
+		t.Fatalf("could not load kustomize loader: %v", loaderErr)
+	}
+	rf := resmap.NewFactory(resource.NewFactory(kunstruct.NewKunstructuredFactoryImpl()))
+	kt, err := target.NewKustTarget(_loader, rf, transformer.NewFactoryImpl())
+	if err != nil {
+		th.t.Fatalf("Unexpected construction error %v", err)
+	}
+	n, err := kt.MakeCustomizedResMap()
+	if err != nil {
+		t.Fatalf("Err: %v", err)
+	}
+	expected, err := n.EncodeAsYaml()
+	th.assertActualEqualsExpected(m, string(expected))
+}

--- a/tests/minio-overlays-minioPd_test.go
+++ b/tests/minio-overlays-minioPd_test.go
@@ -1,0 +1,171 @@
+package tests_test
+
+import (
+	"sigs.k8s.io/kustomize/k8sdeps/kunstruct"
+	"sigs.k8s.io/kustomize/k8sdeps/transformer"
+	"sigs.k8s.io/kustomize/pkg/fs"
+	"sigs.k8s.io/kustomize/pkg/loader"
+	"sigs.k8s.io/kustomize/pkg/resmap"
+	"sigs.k8s.io/kustomize/pkg/resource"
+	"sigs.k8s.io/kustomize/pkg/target"
+	"testing"
+)
+
+func writeMinioOverlaysMinioPd(th *KustTestHarness) {
+	th.writeF("/manifests/pipeline/minio/overlays/minioPd/persistent-volume.yaml", `
+apiVersion: v1
+kind: PersistentVolume
+metadata: 
+  name: persistent-volume
+spec:
+  capacity:
+    storage: 20Gi
+  accessModes: 
+  - ReadWriteOnce
+  gcePersistentDisk:
+    pdName: $(minioPd)
+    fsType: ext4
+`)
+	th.writeF("/manifests/pipeline/minio/overlays/minioPd/persistent-volume-claim.yaml", `
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: persistent-volume-claim
+spec:
+  accessModes:
+  - ReadWriteOnce
+  resources:
+    requests:
+      storage: 20Gi
+      storageClassName: ""
+      volumeName: persistent-volume-claim
+`)
+	th.writeF("/manifests/pipeline/minio/overlays/minioPd/params.yaml", `
+varReference:
+- path: spec/gcePersistentDisk/pdName
+  kind: PersistentVolume
+`)
+	th.writeF("/manifests/pipeline/minio/overlays/minioPd/params.env", `
+minioPd=dls-kf-storage-artifact-store
+`)
+	th.writeK("/manifests/pipeline/minio/overlays/minioPd", `
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+nameprefix: minio-
+bases:
+- ../../base
+resources:
+- persistent-volume.yaml
+- persistent-volume-claim.yaml
+configMapGenerator:
+- name: minio-parameters
+  env: params.env
+generatorOptions:
+  disableNameSuffixHash: true
+vars:
+- name: minioPd
+  objref:
+    kind: ConfigMap
+    name: minio-parameters
+    apiVersion: v1
+  fieldref:
+      fieldpath: data.minioPd
+configurations:
+- params.yaml
+`)
+	th.writeF("/manifests/pipeline/minio/base/deployment.yaml", `
+apiVersion: apps/v1beta1
+kind: Deployment
+metadata:
+  name: deployment
+spec:
+  strategy:
+    type: Recreate
+  template:
+    spec:
+      containers:
+      - name: minio
+        args:
+        - server
+        - /data
+        env:
+        - name: MINIO_ACCESS_KEY
+          value: minio
+        - name: MINIO_SECRET_KEY
+          value: minio123
+        image: minio/minio:RELEASE.2018-02-09T22-40-05Z
+        ports:
+        - containerPort: 9000
+        volumeMounts:
+        - mountPath: /data
+          name: data
+          subPath: minio
+      volumes:
+      - name: data
+        persistentVolumeClaim:
+          claimName: minio-pvc
+`)
+	th.writeF("/manifests/pipeline/minio/base/secret.yaml", `
+apiVersion: v1
+data:
+  accesskey: bWluaW8=
+  secretkey: bWluaW8xMjM=
+kind: Secret
+metadata:
+  name: artifact
+type: Opaque
+`)
+	th.writeF("/manifests/pipeline/minio/base/service.yaml", `
+apiVersion: v1
+kind: Service
+metadata:
+  name: service
+spec:
+  ports:
+  - port: 9000
+    protocol: TCP
+    targetPort: 9000
+  selector:
+    app: minio
+`)
+	th.writeK("/manifests/pipeline/minio/base", `
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+nameprefix: minio-
+commonLabels:
+  app: minio
+resources:
+- deployment.yaml
+- secret.yaml
+- service.yaml
+images:
+- name: minio/minio
+  newTag: RELEASE.2018-02-09T22-40-05Z
+`)
+}
+
+func TestMinioOverlaysMinioPd(t *testing.T) {
+	th := NewKustTestHarness(t, "/manifests/pipeline/minio/overlays/minioPd")
+	writeMinioOverlaysMinioPd(th)
+	m, err := th.makeKustTarget().MakeCustomizedResMap()
+	if err != nil {
+		t.Fatalf("Err: %v", err)
+	}
+	targetPath := "../pipeline/minio/overlays/minioPd"
+	fsys := fs.MakeRealFS()
+	_loader, loaderErr := loader.NewLoader(targetPath, fsys)
+	if loaderErr != nil {
+		t.Fatalf("could not load kustomize loader: %v", loaderErr)
+	}
+	rf := resmap.NewFactory(resource.NewFactory(kunstruct.NewKunstructuredFactoryImpl()))
+	kt, err := target.NewKustTarget(_loader, rf, transformer.NewFactoryImpl())
+	if err != nil {
+		th.t.Fatalf("Unexpected construction error %v", err)
+	}
+	n, err := kt.MakeCustomizedResMap()
+	if err != nil {
+		t.Fatalf("Err: %v", err)
+	}
+	expected, err := n.EncodeAsYaml()
+	th.assertActualEqualsExpected(m, string(expected))
+}

--- a/tests/mysql-overlays-mysqlPd_test.go
+++ b/tests/mysql-overlays-mysqlPd_test.go
@@ -1,0 +1,149 @@
+package tests_test
+
+import (
+	"sigs.k8s.io/kustomize/k8sdeps/kunstruct"
+	"sigs.k8s.io/kustomize/k8sdeps/transformer"
+	"sigs.k8s.io/kustomize/pkg/fs"
+	"sigs.k8s.io/kustomize/pkg/loader"
+	"sigs.k8s.io/kustomize/pkg/resmap"
+	"sigs.k8s.io/kustomize/pkg/resource"
+	"sigs.k8s.io/kustomize/pkg/target"
+	"testing"
+)
+
+func writeMysqlOverlaysMysqlPd(th *KustTestHarness) {
+	th.writeF("/manifests/pipeline/mysql/overlays/mysqlPd/persistent-volume.yaml", `
+apiVersion: v1
+kind: PersistentVolume
+metadata: 
+  name: persistent-volume
+spec:
+  capacity:
+    storage: 20Gi
+  accessModes: 
+  - ReadWriteOnce
+  gcePersistentDisk:
+    pdName: $(mysqlPd)
+    fsType: ext4
+`)
+	th.writeF("/manifests/pipeline/mysql/overlays/mysqlPd/persistent-volume-claim.yaml", `
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: persistent-volume-claim
+spec:
+  accessModes:
+  - ReadWriteOnce
+  resources:
+    requests:
+      storage: 20Gi
+      storageClassName: ""
+      volumeName: persistent-volume
+`)
+	th.writeF("/manifests/pipeline/mysql/overlays/mysqlPd/params.yaml", `
+varReference:
+- path: spec/gcePersistentDisk/pdName
+  kind: PersistentVolume
+`)
+	th.writeF("/manifests/pipeline/mysql/overlays/mysqlPd/params.env", `
+mysqlPd=dls-kf-storage-metadata-store
+`)
+	th.writeK("/manifests/pipeline/mysql/overlays/mysqlPd", `
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+nameprefix: ml-pipeline-mysql-
+bases:
+- ../../base
+resources:
+- persistent-volume.yaml
+- persistent-volume-claim.yaml
+configMapGenerator:
+- name: parameters
+  env: params.env
+generatorOptions:
+  disableNameSuffixHash: true
+vars:
+- name: mysqlPd
+  objref:
+    kind: ConfigMap
+    name: parameters
+    apiVersion: v1
+  fieldref:
+    fieldpath: data.mysqlPd
+configurations:
+- params.yaml
+`)
+	th.writeF("/manifests/pipeline/mysql/base/deployment.yaml", `
+apiVersion: apps/v1beta2
+kind: Deployment
+metadata:
+  name: deployment
+spec:
+  strategy:
+    type: Recreate
+  template:
+    spec:
+      containers:
+      - name: container
+        env:
+        - name: MYSQL_ALLOW_EMPTY_PASSWORD
+          value: "true"
+        image: mysql:5.6
+        ports:
+        - containerPort: 3306
+          name: mysql
+        volumeMounts:
+        - mountPath: /var/lib/mysql
+          name: persistent-storage
+      volumes:
+      - name: persistent-storage
+        persistentVolumeClaim:
+          claimName: ml-pipeline-mysql-persistent-volume-claim
+`)
+	th.writeF("/manifests/pipeline/mysql/base/service.yaml", `
+apiVersion: v1
+kind: Service
+metadata:
+  name: service
+spec:
+  ports:
+  - port: 3306
+`)
+	th.writeK("/manifests/pipeline/mysql/base", `
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+nameprefix: ml-pipeline-mysql-
+resources:
+- deployment.yaml
+- service.yaml
+images:
+- name: mysql
+  newTag: '5.6'
+`)
+}
+
+func TestMysqlOverlaysMysqlPd(t *testing.T) {
+	th := NewKustTestHarness(t, "/manifests/pipeline/mysql/overlays/mysqlPd")
+	writeMysqlOverlaysMysqlPd(th)
+	m, err := th.makeKustTarget().MakeCustomizedResMap()
+	if err != nil {
+		t.Fatalf("Err: %v", err)
+	}
+	targetPath := "../pipeline/mysql/overlays/mysqlPd"
+	fsys := fs.MakeRealFS()
+	_loader, loaderErr := loader.NewLoader(targetPath, fsys)
+	if loaderErr != nil {
+		t.Fatalf("could not load kustomize loader: %v", loaderErr)
+	}
+	rf := resmap.NewFactory(resource.NewFactory(kunstruct.NewKunstructuredFactoryImpl()))
+	kt, err := target.NewKustTarget(_loader, rf, transformer.NewFactoryImpl())
+	if err != nil {
+		th.t.Fatalf("Unexpected construction error %v", err)
+	}
+	n, err := kt.MakeCustomizedResMap()
+	if err != nil {
+		t.Fatalf("Err: %v", err)
+	}
+	expected, err := n.EncodeAsYaml()
+	th.assertActualEqualsExpected(m, string(expected))
+}


### PR DESCRIPTION
bump pipeline api-runner to 1.20 due to crash-loop-backoff
add   volumeClaimTemplates: [] to iap-ingress/base/stateful-set.yaml
regen tests so that things merged to master pass tests

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/manifests/91)
<!-- Reviewable:end -->
