### PR TITLE
jupyter-web-app: fix istio overlay's virtualservice definition

### DIFF
--- a/jupyter/jupyter-web-app/overlays/istio/virtual-service.yaml
+++ b/jupyter/jupyter-web-app/overlays/istio/virtual-service.yaml
@@ -19,6 +19,6 @@ spec:
       uri: /
     route:
     - destination:
-        host: jupyter-web-app.$(namespace).svc.$(clusterDomain)
+        host: jupyter-web-app-service.$(namespace).svc.$(clusterDomain)
         port:
           number: 80

--- a/tests/iap-ingress-base_test.go
+++ b/tests/iap-ingress-base_test.go
@@ -633,8 +633,7 @@ oauthSecretName=kubeflow-oauth
 project=
 adminSaSecretName=admin-gcp-sa
 tlsSecretName=envoy-ingress-tls
-istioNamespace=istio-system
-`)
+istioNamespace=istio-system`)
 	th.writeK("/manifests/gcp/iap-ingress/base", `
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization

--- a/tests/jupyter-web-app-overlays-istio_test.go
+++ b/tests/jupyter-web-app-overlays-istio_test.go
@@ -34,7 +34,7 @@ spec:
       uri: /
     route:
     - destination:
-        host: jupyter-web-app.$(namespace).svc.$(clusterDomain)
+        host: jupyter-web-app-service.$(namespace).svc.$(clusterDomain)
         port:
           number: 80
 `)


### PR DESCRIPTION
Fixes: #137 

This commit fixes the Istio overlay for Jupyter Web App.
The Istio overlay adds a VirtualService that refers to the
jupyter-web-app Service.
The correct name is jupyter-web-app-service.

Signed-off-by: Yannis Zarkadas <yanniszark@arrikto.com>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/manifests/138)
<!-- Reviewable:end -->
