### PR TITLE
pipelines: add PVC with default StorageClass in MySQL, Minio bases

### DIFF
--- a/pipeline/minio/base/deployment.yaml
+++ b/pipeline/minio/base/deployment.yaml
@@ -27,4 +27,4 @@ spec:
       volumes:
       - name: data
         persistentVolumeClaim:
-          claimName: minio-pv-claim
+          claimName: $(minioPvcName)

--- a/pipeline/minio/base/kustomization.yaml
+++ b/pipeline/minio/base/kustomization.yaml
@@ -6,6 +6,20 @@ resources:
 - deployment.yaml
 - secret.yaml
 - service.yaml
+- persistent-volume-claim.yaml
+configMapGenerator:
+- name: parameters
+  env: params.env
+vars:
+- name: minioPvcName
+  objref:
+    kind: ConfigMap
+    name: parameters
+    apiVersion: v1
+  fieldref:
+    fieldpath: data.minioPvcName
 images:
 - name: minio/minio
   newTag: RELEASE.2018-02-09T22-40-05Z
+configurations:
+- params.yaml

--- a/pipeline/minio/base/params.env
+++ b/pipeline/minio/base/params.env
@@ -1,0 +1,1 @@
+minioPvcName=

--- a/pipeline/minio/base/params.yaml
+++ b/pipeline/minio/base/params.yaml
@@ -1,0 +1,5 @@
+varReference:
+- path: spec/template/spec/volumes/persistentVolumeClaim/claimName
+  kind: Deployment
+- path: metadata/name
+  kind: PersistentVolumeClaim

--- a/pipeline/minio/base/persistent-volume-claim.yaml
+++ b/pipeline/minio/base/persistent-volume-claim.yaml
@@ -1,0 +1,10 @@
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: $(minioPvcName)
+spec:
+  accessModes:
+  - ReadWriteOnce
+  resources:
+    requests:
+      storage: 20Gi

--- a/pipeline/minio/overlays/minioPd/kustomization.yaml
+++ b/pipeline/minio/overlays/minioPd/kustomization.yaml
@@ -4,7 +4,8 @@ bases:
 - ../../base
 resources:
 - persistent-volume.yaml
-- persistent-volume-claim.yaml
+patchesStrategicMerge:
+- persistent-volume-claim-patch.yaml
 configMapGenerator:
 - name: minio-parameters
   env: params.env
@@ -25,12 +26,5 @@ vars:
     apiVersion: v1
   fieldref:
       fieldpath: data.minioPvName
-- name: minioPvcName
-  objref:
-    kind: ConfigMap
-    name: minio-parameters
-    apiVersion: v1
-  fieldref:
-      fieldpath: data.minioPvcName
 configurations:
 - params.yaml

--- a/pipeline/minio/overlays/minioPd/params.env
+++ b/pipeline/minio/overlays/minioPd/params.env
@@ -1,3 +1,2 @@
 minioPd=dls-kf-storage-artifact-store
 minioPvName=
-minioPvcName=

--- a/pipeline/minio/overlays/minioPd/persistent-volume-claim-patch.yaml
+++ b/pipeline/minio/overlays/minioPd/persistent-volume-claim-patch.yaml
@@ -3,10 +3,5 @@ kind: PersistentVolumeClaim
 metadata:
   name: $(minioPvcName)
 spec:
-  accessModes:
-  - ReadWriteOnce
-  resources:
-    requests:
-      storage: 20Gi
-  storageClassName: ""
   volumeName: $(minioPvName)
+  storageClassName: ""

--- a/pipeline/mysql/base/kustomization.yaml
+++ b/pipeline/mysql/base/kustomization.yaml
@@ -5,6 +5,7 @@ commonLabels:
 resources:
 - deployment.yaml
 - service.yaml
+- persistent-volume-claim.yaml
 configMapGenerator:
 - name: parameters
   env: params.env

--- a/pipeline/mysql/base/params.yaml
+++ b/pipeline/mysql/base/params.yaml
@@ -1,3 +1,5 @@
 varReference:
 - path: spec/template/spec/volumes/persistentVolumeClaim/claimName
   kind: Deployment
+- path: metadata/name
+  kind: PersistentVolumeClaim

--- a/pipeline/mysql/base/persistent-volume-claim.yaml
+++ b/pipeline/mysql/base/persistent-volume-claim.yaml
@@ -1,0 +1,10 @@
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: $(mysqlPvcName)
+spec:
+  accessModes:
+  - ReadWriteOnce
+  resources:
+    requests:
+      storage: 20Gi

--- a/pipeline/mysql/overlays/mysqlPd/kustomization.yaml
+++ b/pipeline/mysql/overlays/mysqlPd/kustomization.yaml
@@ -4,7 +4,8 @@ bases:
 - ../../base
 resources:
 - persistent-volume.yaml
-- persistent-volume-claim.yaml
+patchesStrategicMerge:
+- persistent-volume-claim-patch.yaml
 configMapGenerator:
 - name: overlay-params
   env: params.env

--- a/pipeline/mysql/overlays/mysqlPd/persistent-volume-claim-patch.yaml
+++ b/pipeline/mysql/overlays/mysqlPd/persistent-volume-claim-patch.yaml
@@ -3,10 +3,5 @@ kind: PersistentVolumeClaim
 metadata:
   name: $(mysqlPvcName)
 spec:
-  accessModes:
-  - ReadWriteOnce
-  resources:
-    requests:
-      storage: 20Gi
   storageClassName: ""
   volumeName: $(mysqlPvName)

--- a/tests/iap-ingress-base_test.go
+++ b/tests/iap-ingress-base_test.go
@@ -633,8 +633,7 @@ oauthSecretName=kubeflow-oauth
 project=
 adminSaSecretName=admin-gcp-sa
 tlsSecretName=envoy-ingress-tls
-istioNamespace=istio-system
-`)
+istioNamespace=istio-system`)
 	th.writeK("/manifests/gcp/iap-ingress/base", `
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization

--- a/tests/minio-base_test.go
+++ b/tests/minio-base_test.go
@@ -42,7 +42,7 @@ spec:
       volumes:
       - name: data
         persistentVolumeClaim:
-          claimName: minio-pv-claim
+          claimName: $(minioPvcName)
 `)
 	th.writeF("/manifests/pipeline/minio/base/secret.yaml", `
 apiVersion: v1
@@ -67,6 +67,26 @@ spec:
   selector:
     app: minio
 `)
+	th.writeF("/manifests/pipeline/minio/base/persistent-volume-claim.yaml", `
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: $(minioPvcName)
+spec:
+  accessModes:
+  - ReadWriteOnce
+  resources:
+    requests:
+      storage: 20Gi
+`)
+	th.writeF("/manifests/pipeline/minio/base/params.yaml", `
+varReference:
+- path: spec/template/spec/volumes/persistentVolumeClaim/claimName
+  kind: Deployment
+- path: metadata/name
+  kind: PersistentVolumeClaim`)
+	th.writeF("/manifests/pipeline/minio/base/params.env", `
+minioPvcName=`)
 	th.writeK("/manifests/pipeline/minio/base", `
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
@@ -76,9 +96,23 @@ resources:
 - deployment.yaml
 - secret.yaml
 - service.yaml
+- persistent-volume-claim.yaml
+configMapGenerator:
+- name: parameters
+  env: params.env
+vars:
+- name: minioPvcName
+  objref:
+    kind: ConfigMap
+    name: parameters
+    apiVersion: v1
+  fieldref:
+    fieldpath: data.minioPvcName
 images:
 - name: minio/minio
   newTag: RELEASE.2018-02-09T22-40-05Z
+configurations:
+- params.yaml
 `)
 }
 

--- a/tests/minio-overlays-minioPd_test.go
+++ b/tests/minio-overlays-minioPd_test.go
@@ -26,20 +26,14 @@ spec:
     pdName: $(minioPd)
     fsType: ext4
 `)
-	th.writeF("/manifests/pipeline/minio/overlays/minioPd/persistent-volume-claim.yaml", `
+	th.writeF("/manifests/pipeline/minio/overlays/minioPd/persistent-volume-claim-patch.yaml", `
 apiVersion: v1
 kind: PersistentVolumeClaim
 metadata:
   name: $(minioPvcName)
 spec:
-  accessModes:
-  - ReadWriteOnce
-  resources:
-    requests:
-      storage: 20Gi
-  storageClassName: ""
   volumeName: $(minioPvName)
-`)
+  storageClassName: ""`)
 	th.writeF("/manifests/pipeline/minio/overlays/minioPd/params.yaml", `
 varReference:
 - path: spec/gcePersistentDisk/pdName
@@ -54,7 +48,6 @@ varReference:
 	th.writeF("/manifests/pipeline/minio/overlays/minioPd/params.env", `
 minioPd=dls-kf-storage-artifact-store
 minioPvName=
-minioPvcName=
 `)
 	th.writeK("/manifests/pipeline/minio/overlays/minioPd", `
 apiVersion: kustomize.config.k8s.io/v1beta1
@@ -63,7 +56,8 @@ bases:
 - ../../base
 resources:
 - persistent-volume.yaml
-- persistent-volume-claim.yaml
+patchesStrategicMerge:
+- persistent-volume-claim-patch.yaml
 configMapGenerator:
 - name: minio-parameters
   env: params.env
@@ -84,13 +78,6 @@ vars:
     apiVersion: v1
   fieldref:
       fieldpath: data.minioPvName
-- name: minioPvcName
-  objref:
-    kind: ConfigMap
-    name: minio-parameters
-    apiVersion: v1
-  fieldref:
-      fieldpath: data.minioPvcName
 configurations:
 - params.yaml
 `)
@@ -124,7 +111,7 @@ spec:
       volumes:
       - name: data
         persistentVolumeClaim:
-          claimName: minio-pv-claim
+          claimName: $(minioPvcName)
 `)
 	th.writeF("/manifests/pipeline/minio/base/secret.yaml", `
 apiVersion: v1
@@ -149,6 +136,26 @@ spec:
   selector:
     app: minio
 `)
+	th.writeF("/manifests/pipeline/minio/base/persistent-volume-claim.yaml", `
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: $(minioPvcName)
+spec:
+  accessModes:
+  - ReadWriteOnce
+  resources:
+    requests:
+      storage: 20Gi
+`)
+	th.writeF("/manifests/pipeline/minio/base/params.yaml", `
+varReference:
+- path: spec/template/spec/volumes/persistentVolumeClaim/claimName
+  kind: Deployment
+- path: metadata/name
+  kind: PersistentVolumeClaim`)
+	th.writeF("/manifests/pipeline/minio/base/params.env", `
+minioPvcName=`)
 	th.writeK("/manifests/pipeline/minio/base", `
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
@@ -158,9 +165,23 @@ resources:
 - deployment.yaml
 - secret.yaml
 - service.yaml
+- persistent-volume-claim.yaml
+configMapGenerator:
+- name: parameters
+  env: params.env
+vars:
+- name: minioPvcName
+  objref:
+    kind: ConfigMap
+    name: parameters
+    apiVersion: v1
+  fieldref:
+    fieldpath: data.minioPvcName
 images:
 - name: minio/minio
   newTag: RELEASE.2018-02-09T22-40-05Z
+configurations:
+- params.yaml
 `)
 }
 

--- a/tests/mysql-base_test.go
+++ b/tests/mysql-base_test.go
@@ -48,11 +48,23 @@ spec:
   ports:
   - port: 3306
 `)
+	th.writeF("/manifests/pipeline/mysql/base/persistent-volume-claim.yaml", `
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: $(mysqlPvcName)
+spec:
+  accessModes:
+  - ReadWriteOnce
+  resources:
+    requests:
+      storage: 20Gi`)
 	th.writeF("/manifests/pipeline/mysql/base/params.yaml", `
 varReference:
 - path: spec/template/spec/volumes/persistentVolumeClaim/claimName
   kind: Deployment
-`)
+- path: metadata/name
+  kind: PersistentVolumeClaim`)
 	th.writeF("/manifests/pipeline/mysql/base/params.env", `
 mysqlPvcName=
 `)
@@ -64,6 +76,7 @@ commonLabels:
 resources:
 - deployment.yaml
 - service.yaml
+- persistent-volume-claim.yaml
 configMapGenerator:
 - name: parameters
   env: params.env


### PR DESCRIPTION
The MySQL, Minio components in the pipelines package need a PVC to work.
Currently, that PVC is created inside the minioPd, mySqlPd overlays.
This only works in GCP enviroments.

This PR refactors the components so that the PVC is created inside the base with a default StorageClass.
The overlays then edit the PVC with their custom values using a strategicMergePatch.

This means that:
* Base will work for clusters with a default storage class.
* The GCP overlay is still working as it was before.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/manifests/140)
<!-- Reviewable:end -->
