### PR TITLE
fix jwt validation

### DIFF
--- a/gcp/iap-ingress/base/policy.yaml
+++ b/gcp/iap-ingress/base/policy.yaml
@@ -7,7 +7,7 @@ spec:
   - jwt:
       audiences:
       - TO_BE_PATCHED
-      issuer: $(issuer)
+      issuer: https://cloud.google.com/iap
       jwksUri: https://www.gstatic.com/iap/verify/public_key-jwk
       jwtHeaders:
       - x-goog-iap-jwt-assertion

--- a/tests/iap-ingress-base_test.go
+++ b/tests/iap-ingress-base_test.go
@@ -492,7 +492,7 @@ spec:
   - jwt:
       audiences:
       - TO_BE_PATCHED
-      issuer: $(issuer)
+      issuer: https://cloud.google.com/iap
       jwksUri: https://www.gstatic.com/iap/verify/public_key-jwk
       jwtHeaders:
       - x-goog-iap-jwt-assertion


### PR DESCRIPTION
For https://github.com/kubeflow/kubeflow/issues/3456

That issuer var was replaced by `letencrypt-prod`, which is the issuer for cert.
Here the issuer in the JWT is always going to be `https://cloud.google.com/iap` for IAP

/cc @jlewi @kunmingg

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/manifests/141)
<!-- Reviewable:end -->
