### PR TITLE
update jupyter webapp image

### DIFF
--- a/jupyter/jupyter-web-app/base/kustomization.yaml
+++ b/jupyter/jupyter-web-app/base/kustomization.yaml
@@ -17,7 +17,7 @@ commonLabels:
 images:
   - name: gcr.io/kubeflow-images-public/jupyter-web-app
     newName: gcr.io/kubeflow-images-public/jupyter-web-app
-    newTag: b653133a
+    newTag: f6aa1dc
 configMapGenerator:
 - name: parameters
   env: params.env

--- a/tests/jupyter-web-app-base_test.go
+++ b/tests/jupyter-web-app-base_test.go
@@ -347,7 +347,7 @@ commonLabels:
 images:
   - name: gcr.io/kubeflow-images-public/jupyter-web-app
     newName: gcr.io/kubeflow-images-public/jupyter-web-app
-    newTag: b653133a
+    newTag: f6aa1dc
 configMapGenerator:
 - name: parameters
   env: params.env

--- a/tests/jupyter-web-app-overlays-application_test.go
+++ b/tests/jupyter-web-app-overlays-application_test.go
@@ -411,7 +411,7 @@ commonLabels:
 images:
   - name: gcr.io/kubeflow-images-public/jupyter-web-app
     newName: gcr.io/kubeflow-images-public/jupyter-web-app
-    newTag: b653133a
+    newTag: f6aa1dc
 configMapGenerator:
 - name: parameters
   env: params.env

--- a/tests/jupyter-web-app-overlays-istio_test.go
+++ b/tests/jupyter-web-app-overlays-istio_test.go
@@ -386,7 +386,7 @@ commonLabels:
 images:
   - name: gcr.io/kubeflow-images-public/jupyter-web-app
     newName: gcr.io/kubeflow-images-public/jupyter-web-app
-    newTag: b653133a
+    newTag: f6aa1dc
 configMapGenerator:
 - name: parameters
   env: params.env


### PR DESCRIPTION
For https://github.com/kubeflow/kubeflow/issues/3502

/cc @kunmingg @kkasravi 

The new tag is built at 6/8. Old one is 5/2.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/manifests/157)
<!-- Reviewable:end -->
