### PR TITLE
Include cluster role configs for Central Dashboard

### DIFF
--- a/common/centraldashboard/base/kustomization.yaml
+++ b/common/centraldashboard/base/kustomization.yaml
@@ -1,8 +1,8 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
-- cluster-role-binding.yaml
-- cluster-role.yaml
+- clusterrole-binding.yaml
+- clusterrole.yaml
 - deployment.yaml
 - role-binding.yaml
 - role.yaml

--- a/common/centraldashboard/base/kustomization.yaml
+++ b/common/centraldashboard/base/kustomization.yaml
@@ -1,6 +1,8 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
+- cluster-role-binding.yaml
+- cluster-role.yaml
 - deployment.yaml
 - role-binding.yaml
 - role.yaml

--- a/tests/centraldashboard-base_test.go
+++ b/tests/centraldashboard-base_test.go
@@ -12,6 +12,41 @@ import (
 )
 
 func writeCentraldashboardBase(th *KustTestHarness) {
+	th.writeF("/manifests/common/centraldashboard/base/clusterrole-binding.yaml", `
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  labels:
+    app: centraldashboard
+  name: centraldashboard
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: centraldashboard
+subjects:
+- kind: ServiceAccount
+  name: centraldashboard
+  namespace: $(namespace)
+`)
+	th.writeF("/manifests/common/centraldashboard/base/clusterrole.yaml", `
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  labels:
+    app: centraldashboard
+  name: centraldashboard
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - events
+  - namespaces
+  - nodes
+  verbs:
+  - get
+  - list
+  - watch
+`)
 	th.writeF("/manifests/common/centraldashboard/base/deployment.yaml", `
 apiVersion: extensions/v1beta1
 kind: Deployment
@@ -127,6 +162,8 @@ clusterDomain=cluster.local
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
+- clusterrole-binding.yaml
+- clusterrole.yaml
 - deployment.yaml
 - role-binding.yaml
 - role.yaml

--- a/tests/centraldashboard-overlays-istio_test.go
+++ b/tests/centraldashboard-overlays-istio_test.go
@@ -50,6 +50,41 @@ configurations:
 - params.yaml
 
 `)
+	th.writeF("/manifests/common/centraldashboard/base/clusterrole-binding.yaml", `
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  labels:
+    app: centraldashboard
+  name: centraldashboard
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: centraldashboard
+subjects:
+- kind: ServiceAccount
+  name: centraldashboard
+  namespace: $(namespace)
+`)
+	th.writeF("/manifests/common/centraldashboard/base/clusterrole.yaml", `
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  labels:
+    app: centraldashboard
+  name: centraldashboard
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - events
+  - namespaces
+  - nodes
+  verbs:
+  - get
+  - list
+  - watch
+`)
 	th.writeF("/manifests/common/centraldashboard/base/deployment.yaml", `
 apiVersion: extensions/v1beta1
 kind: Deployment
@@ -165,6 +200,8 @@ clusterDomain=cluster.local
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
+- clusterrole-binding.yaml
+- clusterrole.yaml
 - deployment.yaml
 - role-binding.yaml
 - role.yaml


### PR DESCRIPTION
Ensures that ClusterRole and ClusterRoleBindings are created with the Central Dashboard deployment.

Fixes #152 
Fixes https://github.com/kubeflow/kubeflow/issues/3501

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/manifests/159)
<!-- Reviewable:end -->
