### PR TITLE
remove unused variable viewer-clusterDomain from pipeline/pipelines-viewer/base/kustomization.yaml, regenerate tests

### DIFF
--- a/pipeline/pipelines-viewer/base/kustomization.yaml
+++ b/pipeline/pipelines-viewer/base/kustomization.yaml
@@ -13,16 +13,3 @@ resources:
 images:
 - name: gcr.io/ml-pipeline/viewer-crd-controller
   newTag: '0.1.18'
-configMapGenerator:
-- name: viewer-parameters
-  env: params.env
-vars:
-- name: viewer-clusterDomain
-  objref:
-    kind: ConfigMap
-    name: viewer-parameters
-    version: v1
-  fieldref:
-    fieldpath: data.viewerClusterDomain
-configurations:
-- params.yaml

--- a/pipeline/pipelines-viewer/base/params.env
+++ b/pipeline/pipelines-viewer/base/params.env
@@ -1,1 +1,0 @@
-viewerClusterDomain=cluster.local

--- a/pipeline/pipelines-viewer/base/params.yaml
+++ b/pipeline/pipelines-viewer/base/params.yaml
@@ -1,3 +1,0 @@
-varReference:
-- path: metadata/annotations/getambassador.io\/config
-  kind: Service

--- a/tests/iap-ingress-base_test.go
+++ b/tests/iap-ingress-base_test.go
@@ -633,8 +633,7 @@ oauthSecretName=kubeflow-oauth
 project=
 adminSaSecretName=admin-gcp-sa
 tlsSecretName=envoy-ingress-tls
-istioNamespace=istio-system
-`)
+istioNamespace=istio-system`)
 	th.writeK("/manifests/gcp/iap-ingress/base", `
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization

--- a/tests/minio-base_test.go
+++ b/tests/minio-base_test.go
@@ -84,11 +84,9 @@ varReference:
 - path: spec/template/spec/volumes/persistentVolumeClaim/claimName
   kind: Deployment
 - path: metadata/name
-  kind: PersistentVolumeClaim
-`)
+  kind: PersistentVolumeClaim`)
 	th.writeF("/manifests/pipeline/minio/base/params.env", `
-minioPvcName=
-`)
+minioPvcName=`)
 	th.writeK("/manifests/pipeline/minio/base", `
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization

--- a/tests/minio-overlays-minioPd_test.go
+++ b/tests/minio-overlays-minioPd_test.go
@@ -33,8 +33,7 @@ metadata:
   name: $(minioPvcName)
 spec:
   volumeName: $(minioPvName)
-  storageClassName: ""
-`)
+  storageClassName: ""`)
 	th.writeF("/manifests/pipeline/minio/overlays/minioPd/params.yaml", `
 varReference:
 - path: spec/gcePersistentDisk/pdName
@@ -155,11 +154,9 @@ varReference:
 - path: spec/template/spec/volumes/persistentVolumeClaim/claimName
   kind: Deployment
 - path: metadata/name
-  kind: PersistentVolumeClaim
-`)
+  kind: PersistentVolumeClaim`)
 	th.writeF("/manifests/pipeline/minio/base/params.env", `
-minioPvcName=
-`)
+minioPvcName=`)
 	th.writeK("/manifests/pipeline/minio/base", `
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization

--- a/tests/mysql-base_test.go
+++ b/tests/mysql-base_test.go
@@ -58,15 +58,13 @@ spec:
   - ReadWriteOnce
   resources:
     requests:
-      storage: 20Gi
-`)
+      storage: 20Gi`)
 	th.writeF("/manifests/pipeline/mysql/base/params.yaml", `
 varReference:
 - path: spec/template/spec/volumes/persistentVolumeClaim/claimName
   kind: Deployment
 - path: metadata/name
-  kind: PersistentVolumeClaim
-`)
+  kind: PersistentVolumeClaim`)
 	th.writeF("/manifests/pipeline/mysql/base/params.env", `
 mysqlPvcName=
 `)

--- a/tests/mysql-overlays-mysqlPd_test.go
+++ b/tests/mysql-overlays-mysqlPd_test.go
@@ -129,15 +129,13 @@ spec:
   - ReadWriteOnce
   resources:
     requests:
-      storage: 20Gi
-`)
+      storage: 20Gi`)
 	th.writeF("/manifests/pipeline/mysql/base/params.yaml", `
 varReference:
 - path: spec/template/spec/volumes/persistentVolumeClaim/claimName
   kind: Deployment
 - path: metadata/name
-  kind: PersistentVolumeClaim
-`)
+  kind: PersistentVolumeClaim`)
 	th.writeF("/manifests/pipeline/mysql/base/params.env", `
 mysqlPvcName=
 `)

--- a/tests/pipelines-viewer-base_test.go
+++ b/tests/pipelines-viewer-base_test.go
@@ -102,14 +102,6 @@ kind: ServiceAccount
 metadata:
   name: crd-service-account
 `)
-	th.writeF("/manifests/pipeline/pipelines-viewer/base/params.yaml", `
-varReference:
-- path: metadata/annotations/getambassador.io\/config
-  kind: Service
-`)
-	th.writeF("/manifests/pipeline/pipelines-viewer/base/params.env", `
-viewerClusterDomain=cluster.local
-`)
 	th.writeK("/manifests/pipeline/pipelines-viewer/base", `
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
@@ -126,19 +118,6 @@ resources:
 images:
 - name: gcr.io/ml-pipeline/viewer-crd-controller
   newTag: '0.1.18'
-configMapGenerator:
-- name: viewer-parameters
-  env: params.env
-vars:
-- name: viewer-clusterDomain
-  objref:
-    kind: ConfigMap
-    name: viewer-parameters
-    version: v1
-  fieldref:
-    fieldpath: data.viewerClusterDomain
-configurations:
-- params.yaml
 `)
 }
 

--- a/tests/profiles-base_test.go
+++ b/tests/profiles-base_test.go
@@ -125,8 +125,7 @@ metadata:
   name: kfam
 spec:
   ports:
-    - port: 8081
-`)
+    - port: 8081`)
 	th.writeF("/manifests/profiles/base/deployment.yaml", `
 apiVersion: apps/v1
 kind: Deployment

--- a/tests/profiles-overlays-debug_test.go
+++ b/tests/profiles-overlays-debug_test.go
@@ -180,8 +180,7 @@ metadata:
   name: kfam
 spec:
   ports:
-    - port: 8081
-`)
+    - port: 8081`)
 	th.writeF("/manifests/profiles/base/deployment.yaml", `
 apiVersion: apps/v1
 kind: Deployment

--- a/tests/profiles-overlays-devices_test.go
+++ b/tests/profiles-overlays-devices_test.go
@@ -151,8 +151,7 @@ metadata:
   name: kfam
 spec:
   ports:
-    - port: 8081
-`)
+    - port: 8081`)
 	th.writeF("/manifests/profiles/base/deployment.yaml", `
 apiVersion: apps/v1
 kind: Deployment

--- a/tests/profiles-overlays-istio_test.go
+++ b/tests/profiles-overlays-istio_test.go
@@ -166,8 +166,7 @@ metadata:
   name: kfam
 spec:
   ports:
-    - port: 8081
-`)
+    - port: 8081`)
 	th.writeF("/manifests/profiles/base/deployment.yaml", `
 apiVersion: apps/v1
 kind: Deployment


### PR DESCRIPTION
the kustomize var viewer-clusterDomain is never used in pipeline/pipelines-viewer/base resources

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/manifests/169)
<!-- Reviewable:end -->
