### PR TITLE
envoy-config: fix port name in setup_backend.sh

### DIFF
--- a/gcp/iap-ingress/base/config-map.yaml
+++ b/gcp/iap-ingress/base/config-map.yaml
@@ -115,7 +115,7 @@ data:
       . /var/shared/healthz.env
 
       # If node port or backend id change, so does the JWT audience.
-      CURR_NODE_PORT=$(kubectl --namespace=${NAMESPACE} get svc ${SERVICE} -o jsonpath='{.spec.ports[0].nodePort}')
+      CURR_NODE_PORT=$(kubectl --namespace=${NAMESPACE} get svc ${SERVICE} -o jsonpath='{.spec.ports[?(@.name=="http2")].nodePort}')
       read -ra toks <<<"$(gcloud compute --project=${PROJECT} backend-services list --filter=name~k8s-be-${CURR_NODE_PORT}- --format='value(id,timeoutSec)')"
       CURR_BACKEND_ID="${toks[0]}"
       CURR_BACKEND_TIMEOUT="${toks[1]}"

--- a/tests/iap-ingress-base_test.go
+++ b/tests/iap-ingress-base_test.go
@@ -225,7 +225,7 @@ data:
       . /var/shared/healthz.env
 
       # If node port or backend id change, so does the JWT audience.
-      CURR_NODE_PORT=$(kubectl --namespace=${NAMESPACE} get svc ${SERVICE} -o jsonpath='{.spec.ports[0].nodePort}')
+      CURR_NODE_PORT=$(kubectl --namespace=${NAMESPACE} get svc ${SERVICE} -o jsonpath='{.spec.ports[?(@.name=="http2")].nodePort}')
       read -ra toks <<<"$(gcloud compute --project=${PROJECT} backend-services list --filter=name~k8s-be-${CURR_NODE_PORT}- --format='value(id,timeoutSec)')"
       CURR_BACKEND_ID="${toks[0]}"
       CURR_BACKEND_TIMEOUT="${toks[1]}"


### PR DESCRIPTION
This should fix https://github.com/kubeflow/kubeflow/issues/3628. See also https://github.com/kubeflow/kubeflow/pull/3691 (which modified the wrong file).

**Checklist:**
- [x] Unit tests have been rebuilt: 
    1. `cd manifests/tests`
    2. `make generate`
    3. `make test`

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/manifests/219)
<!-- Reviewable:end -->
