### PR TITLE
Move the gcp credential part (env/volume) to patch

### DIFF
--- a/gcp/basic-auth-ingress/base/cluster-role-binding.yaml
+++ b/gcp/basic-auth-ingress/base/cluster-role-binding.yaml
@@ -1,12 +1,12 @@
 apiVersion: rbac.authorization.k8s.io/v1beta1
 kind: ClusterRoleBinding
 metadata:
-  name: envoy
+  name: kf-admin-basic-auth
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
-  name: envoy
+  name: kf-admin-basic-auth
 subjects:
 - kind: ServiceAccount
-  name: envoy
+  name: kf-admin
   namespace: kubeflow

--- a/gcp/basic-auth-ingress/base/cluster-role.yaml
+++ b/gcp/basic-auth-ingress/base/cluster-role.yaml
@@ -1,7 +1,7 @@
 apiVersion: rbac.authorization.k8s.io/v1beta1
 kind: ClusterRole
 metadata:
-  name: envoy
+  name: kf-admin-basic-auth
 rules:
 - apiGroups:
   - ""

--- a/gcp/basic-auth-ingress/base/gcp-credentials-patch.yaml
+++ b/gcp/basic-auth-ingress/base/gcp-credentials-patch.yaml
@@ -1,3 +1,4 @@
+# Patch the env/volumes/volumeMounts for GCP credentials
 apiVersion: apps/v1beta2
 kind: StatefulSet
 metadata:

--- a/gcp/basic-auth-ingress/base/gcp-credentials.yaml
+++ b/gcp/basic-auth-ingress/base/gcp-credentials.yaml
@@ -1,0 +1,20 @@
+apiVersion: apps/v1beta2
+kind: StatefulSet
+metadata:
+  name: backend-updater
+spec:
+  template:
+    spec:
+      containers:
+      - name: backend-updater
+        env:
+        - name: GOOGLE_APPLICATION_CREDENTIALS
+          value: /var/run/secrets/sa/admin-gcp-sa.json
+        volumeMounts:
+        - mountPath: /var/run/secrets/sa
+          name: sa-key
+          readOnly: true
+      volumes:
+      - name: sa-key
+        secret:
+          secretName: admin-gcp-sa

--- a/gcp/basic-auth-ingress/base/job.yaml
+++ b/gcp/basic-auth-ingress/base/job.yaml
@@ -23,7 +23,7 @@ spec:
         - mountPath: /var/ingress-config/
           name: ingress-config
       restartPolicy: OnFailure
-      serviceAccountName: envoy
+      serviceAccountName: kf-admin
       volumes:
       - configMap:
           defaultMode: 493

--- a/gcp/basic-auth-ingress/base/kustomization.yaml
+++ b/gcp/basic-auth-ingress/base/kustomization.yaml
@@ -80,4 +80,4 @@ vars:
 configurations:
 - params.yaml
 patches:
-- gcp-credentials.yaml
+- gcp-credentials-patch.yaml

--- a/gcp/basic-auth-ingress/base/kustomization.yaml
+++ b/gcp/basic-auth-ingress/base/kustomization.yaml
@@ -79,3 +79,5 @@ vars:
     fieldpath: data.issuer
 configurations:
 - params.yaml
+patches:
+- gcp-credentials.yaml

--- a/gcp/basic-auth-ingress/base/service-account.yaml
+++ b/gcp/basic-auth-ingress/base/service-account.yaml
@@ -1,4 +1,4 @@
 apiVersion: v1
 kind: ServiceAccount
 metadata:
-  name: envoy
+  name: kf-admin

--- a/gcp/basic-auth-ingress/base/stateful-set.yaml
+++ b/gcp/basic-auth-ingress/base/stateful-set.yaml
@@ -23,8 +23,6 @@ spec:
           value: $(namespace)
         - name: SERVICE
           value: ambassador
-        - name: GOOGLE_APPLICATION_CREDENTIALS
-          value: /var/run/secrets/sa/admin-gcp-sa.json
         - name: HEALTHCHECK_PATH
           value: /whoami
         - name: INGRESS_NAME
@@ -34,16 +32,10 @@ spec:
         volumeMounts:
         - mountPath: /var/envoy-config/
           name: config-volume
-        - mountPath: /var/run/secrets/sa
-          name: sa-key
-          readOnly: true
-      serviceAccountName: envoy
+      serviceAccountName: kf-admin
       volumes:
       - configMap:
           name: envoy-config
         name: config-volume
-      - name: sa-key
-        secret:
-          secretName: admin-gcp-sa
   # Workaround for https://github.com/kubernetes-sigs/kustomize/issues/677
   volumeClaimTemplates: []

--- a/gcp/cloud-endpoints/base/cluster-role-binding.yaml
+++ b/gcp/cloud-endpoints/base/cluster-role-binding.yaml
@@ -8,4 +8,4 @@ roleRef:
   name: cloud-endpoints-controller
 subjects:
 - kind: ServiceAccount
-  name: cloud-endpoints-controller
+  name: kf-admin

--- a/gcp/cloud-endpoints/base/cluster-role.yaml
+++ b/gcp/cloud-endpoints/base/cluster-role.yaml
@@ -1,7 +1,7 @@
 apiVersion: rbac.authorization.k8s.io/v1beta1
 kind: ClusterRole
 metadata:
-  name: cloud-endpoints-controller
+  name: kf-admin
 rules:
 - apiGroups:
   - ""

--- a/gcp/cloud-endpoints/base/deployment.yaml
+++ b/gcp/cloud-endpoints/base/deployment.yaml
@@ -10,10 +10,7 @@ spec:
         app: cloud-endpoints-controller
     spec:
       containers:
-      - env:
-        - name: GOOGLE_APPLICATION_CREDENTIALS
-          value: /var/run/secrets/sa/admin-gcp-sa.json
-        image: gcr.io/cloud-solutions-group/cloud-endpoints-controller:0.2.1
+      - image: gcr.io/cloud-solutions-group/cloud-endpoints-controller:0.2.1
         imagePullPolicy: Always
         name: cloud-endpoints-controller
         readinessProbe:
@@ -25,13 +22,5 @@ spec:
           periodSeconds: 5
           successThreshold: 1
           timeoutSeconds: 5
-        volumeMounts:
-        - mountPath: /var/run/secrets/sa
-          name: sa-key
-          readOnly: true
-      serviceAccountName: cloud-endpoints-controller
+      serviceAccountName: kf-admin
       terminationGracePeriodSeconds: 5
-      volumes:
-      - name: sa-key
-        secret:
-          secretName: $(secretName)

--- a/gcp/cloud-endpoints/base/gcp-credentials-patch.yaml
+++ b/gcp/cloud-endpoints/base/gcp-credentials-patch.yaml
@@ -1,3 +1,4 @@
+# Patch the env/volumes/volumeMounts for GCP credentials
 apiVersion: apps/v1beta1
 kind: Deployment
 metadata:

--- a/gcp/cloud-endpoints/base/gcp-credentials.yaml
+++ b/gcp/cloud-endpoints/base/gcp-credentials.yaml
@@ -1,0 +1,20 @@
+apiVersion: apps/v1beta1
+kind: Deployment
+metadata:
+  name: cloud-endpoints-controller
+spec:
+  template:
+    spec:
+      containers:
+      - name: cloud-endpoints-controller
+        env:
+        - name: GOOGLE_APPLICATION_CREDENTIALS
+          value: /var/run/secrets/sa/admin-gcp-sa.json
+        volumeMounts:
+        - mountPath: /var/run/secrets/sa
+          name: sa-key
+          readOnly: true
+      volumes:
+      - name: sa-key
+        secret:
+          secretName: admin-gcp-sa

--- a/gcp/cloud-endpoints/base/kustomization.yaml
+++ b/gcp/cloud-endpoints/base/kustomization.yaml
@@ -37,3 +37,5 @@ vars:
     fieldpath: data.namespace
 configurations:
 - params.yaml
+patches:
+- gcp-credentials-patch.yaml

--- a/gcp/cloud-endpoints/base/service-account.yaml
+++ b/gcp/cloud-endpoints/base/service-account.yaml
@@ -1,4 +1,4 @@
 apiVersion: v1
 kind: ServiceAccount
 metadata:
-  name: cloud-endpoints-controller
+  name: kf-admin

--- a/gcp/iap-ingress/base/cluster-role-binding.yaml
+++ b/gcp/iap-ingress/base/cluster-role-binding.yaml
@@ -1,11 +1,11 @@
 apiVersion: rbac.authorization.k8s.io/v1beta1
 kind: ClusterRoleBinding
 metadata:
-  name: envoy
+  name: kf-admin-iap
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
-  name: envoy
+  name: kf-admin-iap
 subjects:
 - kind: ServiceAccount
-  name: envoy
+  name: kf-admin

--- a/gcp/iap-ingress/base/cluster-role.yaml
+++ b/gcp/iap-ingress/base/cluster-role.yaml
@@ -1,7 +1,7 @@
 apiVersion: rbac.authorization.k8s.io/v1beta1
 kind: ClusterRole
 metadata:
-  name: envoy
+  name: kf-admin-iap
 rules:
 - apiGroups:
   - ""

--- a/gcp/iap-ingress/base/deployment.yaml
+++ b/gcp/iap-ingress/base/deployment.yaml
@@ -52,8 +52,6 @@ spec:
           value: $(ingressName)
         - name: ENVOY_ADMIN
           value: http://localhost:8001
-        - name: GOOGLE_APPLICATION_CREDENTIALS
-          value: /var/run/secrets/sa/admin-gcp-sa.json
         - name: USE_ISTIO
           value: "true"
         image: gcr.io/kubeflow-images-public/ingress-setup:latest
@@ -61,15 +59,9 @@ spec:
         volumeMounts:
         - mountPath: /var/envoy-config/
           name: config-volume
-        - mountPath: /var/run/secrets/sa
-          name: sa-key
-          readOnly: true
       restartPolicy: Always
-      serviceAccountName: envoy
+      serviceAccountName: kf-admin
       volumes:
       - configMap:
           name: envoy-config
         name: config-volume
-      - name: sa-key
-        secret:
-          secretName: $(adminSaSecretName)

--- a/gcp/iap-ingress/base/gcp-credentials-patch.yaml
+++ b/gcp/iap-ingress/base/gcp-credentials-patch.yaml
@@ -1,3 +1,4 @@
+# Patch the env/volumes/volumeMounts for GCP credentials
 apiVersion: extensions/v1beta1
 kind: Deployment
 metadata:

--- a/gcp/iap-ingress/base/gcp-credentials.yaml
+++ b/gcp/iap-ingress/base/gcp-credentials.yaml
@@ -1,0 +1,41 @@
+apiVersion: extensions/v1beta1
+kind: Deployment
+metadata:
+  name: iap-enabler
+spec:
+  template:
+    spec:
+      containers:
+      - name: iap
+        env:
+        - name: GOOGLE_APPLICATION_CREDENTIALS
+          value: /var/run/secrets/sa/admin-gcp-sa.json
+        volumeMounts:
+        - mountPath: /var/run/secrets/sa
+          name: sa-key
+          readOnly: true
+      volumes:
+      - name: sa-key
+        secret:
+          secretName: admin-gcp-sa
+---
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: backend-updater
+spec:
+  template:
+    spec:
+      containers:
+      - name: backend-updater
+        env:
+        - name: GOOGLE_APPLICATION_CREDENTIALS
+          value: /var/run/secrets/sa/admin-gcp-sa.json
+        volumeMounts:
+        - mountPath: /var/run/secrets/sa
+          name: sa-key
+          readOnly: true
+      volumes:
+      - name: sa-key
+        secret:
+          secretName: admin-gcp-sa

--- a/gcp/iap-ingress/base/job.yaml
+++ b/gcp/iap-ingress/base/job.yaml
@@ -35,7 +35,7 @@ spec:
         - mountPath: /var/ingress-config/
           name: ingress-config
       restartPolicy: OnFailure
-      serviceAccountName: envoy
+      serviceAccountName: kf-admin
       volumes:
       - configMap:
           defaultMode: 493

--- a/gcp/iap-ingress/base/kustomization.yaml
+++ b/gcp/iap-ingress/base/kustomization.yaml
@@ -113,4 +113,4 @@ vars:
 configurations:
 - params.yaml
 patches:
-- gcp-credentials.yaml
+- gcp-credentials-patch.yaml

--- a/gcp/iap-ingress/base/kustomization.yaml
+++ b/gcp/iap-ingress/base/kustomization.yaml
@@ -112,3 +112,5 @@ vars:
     fieldpath: data.istioNamespace
 configurations:
 - params.yaml
+patches:
+- gcp-credentials.yaml

--- a/gcp/iap-ingress/base/service-account.yaml
+++ b/gcp/iap-ingress/base/service-account.yaml
@@ -1,4 +1,4 @@
 apiVersion: v1
 kind: ServiceAccount
 metadata:
-  name: envoy
+  name: kf-admin

--- a/gcp/iap-ingress/base/stateful-set.yaml
+++ b/gcp/iap-ingress/base/stateful-set.yaml
@@ -23,8 +23,6 @@ spec:
           value: $(istioNamespace)
         - name: SERVICE
           value: istio-ingressgateway
-        - name: GOOGLE_APPLICATION_CREDENTIALS
-          value: /var/run/secrets/sa/admin-gcp-sa.json
         - name: INGRESS_NAME
           value: $(ingressName)
         - name: USE_ISTIO
@@ -34,15 +32,9 @@ spec:
         volumeMounts:
         - mountPath: /var/envoy-config/
           name: config-volume
-        - mountPath: /var/run/secrets/sa
-          name: sa-key
-          readOnly: true
-      serviceAccountName: envoy
+      serviceAccountName: kf-admin
       volumes:
       - configMap:
           name: envoy-config
         name: config-volume
-      - name: sa-key
-        secret:
-          secretName: admin-gcp-sa
   volumeClaimTemplates: []

--- a/tests/basic-auth-ingress-base_test.go
+++ b/tests/basic-auth-ingress-base_test.go
@@ -373,7 +373,8 @@ varReference:
 - path: spec/targetIngress/name
   kind: CloudEndpoint
 `)
-	th.writeF("/manifests/gcp/basic-auth-ingress/base/gcp-credentials.yaml", `
+	th.writeF("/manifests/gcp/basic-auth-ingress/base/gcp-credentials-patch.yaml", `
+# Patch the env/volumes/volumeMounts for GCP credentials
 apiVersion: apps/v1beta2
 kind: StatefulSet
 metadata:
@@ -488,7 +489,7 @@ vars:
 configurations:
 - params.yaml
 patches:
-- gcp-credentials.yaml`)
+- gcp-credentials-patch.yaml`)
 }
 
 func TestBasicAuthIngressBase(t *testing.T) {

--- a/tests/cloud-endpoints-base_test.go
+++ b/tests/cloud-endpoints-base_test.go
@@ -142,6 +142,29 @@ varReference:
 - path: spec/hooks/sync/webhook/url
   kind: CompositeController
 `)
+	th.writeF("/manifests/gcp/cloud-endpoints/base/gcp-credentials-patch.yaml", `
+# Patch the env/volumes/volumeMounts for GCP credentials
+apiVersion: apps/v1beta1
+kind: Deployment
+metadata:
+  name: cloud-endpoints-controller
+spec:
+  template:
+    spec:
+      containers:
+      - name: cloud-endpoints-controller
+        env:
+        - name: GOOGLE_APPLICATION_CREDENTIALS
+          value: /var/run/secrets/sa/admin-gcp-sa.json
+        volumeMounts:
+        - mountPath: /var/run/secrets/sa
+          name: sa-key
+          readOnly: true
+      volumes:
+      - name: sa-key
+        secret:
+          secretName: admin-gcp-sa
+`)
 	th.writeF("/manifests/gcp/cloud-endpoints/base/params.env", `
 namespace=kubeflow
 secretName=admin-gcp-sa
@@ -186,6 +209,8 @@ vars:
     fieldpath: data.namespace
 configurations:
 - params.yaml
+patches:
+- gcp-credentials-patch.yaml
 `)
 }
 

--- a/tests/cloud-endpoints-base_test.go
+++ b/tests/cloud-endpoints-base_test.go
@@ -23,13 +23,13 @@ roleRef:
   name: cloud-endpoints-controller
 subjects:
 - kind: ServiceAccount
-  name: cloud-endpoints-controller
+  name: kf-admin
 `)
 	th.writeF("/manifests/gcp/cloud-endpoints/base/cluster-role.yaml", `
 apiVersion: rbac.authorization.k8s.io/v1beta1
 kind: ClusterRole
 metadata:
-  name: cloud-endpoints-controller
+  name: kf-admin
 rules:
 - apiGroups:
   - ""
@@ -99,10 +99,7 @@ spec:
         app: cloud-endpoints-controller
     spec:
       containers:
-      - env:
-        - name: GOOGLE_APPLICATION_CREDENTIALS
-          value: /var/run/secrets/sa/admin-gcp-sa.json
-        image: gcr.io/cloud-solutions-group/cloud-endpoints-controller:0.2.1
+      - image: gcr.io/cloud-solutions-group/cloud-endpoints-controller:0.2.1
         imagePullPolicy: Always
         name: cloud-endpoints-controller
         readinessProbe:
@@ -114,22 +111,14 @@ spec:
           periodSeconds: 5
           successThreshold: 1
           timeoutSeconds: 5
-        volumeMounts:
-        - mountPath: /var/run/secrets/sa
-          name: sa-key
-          readOnly: true
-      serviceAccountName: cloud-endpoints-controller
+      serviceAccountName: kf-admin
       terminationGracePeriodSeconds: 5
-      volumes:
-      - name: sa-key
-        secret:
-          secretName: $(secretName)
 `)
 	th.writeF("/manifests/gcp/cloud-endpoints/base/service-account.yaml", `
 apiVersion: v1
 kind: ServiceAccount
 metadata:
-  name: cloud-endpoints-controller
+  name: kf-admin
 `)
 	th.writeF("/manifests/gcp/cloud-endpoints/base/service.yaml", `
 apiVersion: v1

--- a/tests/iap-ingress-base_test.go
+++ b/tests/iap-ingress-base_test.go
@@ -606,7 +606,8 @@ varReference:
 - path: data/healthcheck_route.yaml
   kind: ConfigMap
 `)
-	th.writeF("/manifests/gcp/iap-ingress/base/gcp-credentials.yaml", `
+	th.writeF("/manifests/gcp/iap-ingress/base/gcp-credentials-patch.yaml", `
+# Patch the env/volumes/volumeMounts for GCP credentials
 apiVersion: extensions/v1beta1
 kind: Deployment
 metadata:
@@ -778,7 +779,7 @@ vars:
 configurations:
 - params.yaml
 patches:
-- gcp-credentials.yaml`)
+- gcp-credentials-patch.yaml`)
 }
 
 func TestIapIngressBase(t *testing.T) {

--- a/tests/istio-base_test.go
+++ b/tests/istio-base_test.go
@@ -1,8 +1,6 @@
 package tests_test
 
 import (
-	"testing"
-
 	"sigs.k8s.io/kustomize/k8sdeps/kunstruct"
 	"sigs.k8s.io/kustomize/k8sdeps/transformer"
 	"sigs.k8s.io/kustomize/pkg/fs"
@@ -10,6 +8,7 @@ import (
 	"sigs.k8s.io/kustomize/pkg/resmap"
 	"sigs.k8s.io/kustomize/pkg/resource"
 	"sigs.k8s.io/kustomize/pkg/target"
+	"testing"
 )
 
 func writeIstioBase(th *KustTestHarness) {

--- a/tests/minio-base_test.go
+++ b/tests/minio-base_test.go
@@ -84,9 +84,11 @@ varReference:
 - path: spec/template/spec/volumes/persistentVolumeClaim/claimName
   kind: Deployment
 - path: metadata/name
-  kind: PersistentVolumeClaim`)
+  kind: PersistentVolumeClaim
+`)
 	th.writeF("/manifests/pipeline/minio/base/params.env", `
-minioPvcName=`)
+minioPvcName=
+`)
 	th.writeK("/manifests/pipeline/minio/base", `
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization

--- a/tests/minio-overlays-minioPd_test.go
+++ b/tests/minio-overlays-minioPd_test.go
@@ -33,7 +33,8 @@ metadata:
   name: $(minioPvcName)
 spec:
   volumeName: $(minioPvName)
-  storageClassName: ""`)
+  storageClassName: ""
+`)
 	th.writeF("/manifests/pipeline/minio/overlays/minioPd/params.yaml", `
 varReference:
 - path: spec/gcePersistentDisk/pdName
@@ -154,9 +155,11 @@ varReference:
 - path: spec/template/spec/volumes/persistentVolumeClaim/claimName
   kind: Deployment
 - path: metadata/name
-  kind: PersistentVolumeClaim`)
+  kind: PersistentVolumeClaim
+`)
 	th.writeF("/manifests/pipeline/minio/base/params.env", `
-minioPvcName=`)
+minioPvcName=
+`)
 	th.writeK("/manifests/pipeline/minio/base", `
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization

--- a/tests/mysql-base_test.go
+++ b/tests/mysql-base_test.go
@@ -58,13 +58,15 @@ spec:
   - ReadWriteOnce
   resources:
     requests:
-      storage: 20Gi`)
+      storage: 20Gi
+`)
 	th.writeF("/manifests/pipeline/mysql/base/params.yaml", `
 varReference:
 - path: spec/template/spec/volumes/persistentVolumeClaim/claimName
   kind: Deployment
 - path: metadata/name
-  kind: PersistentVolumeClaim`)
+  kind: PersistentVolumeClaim
+`)
 	th.writeF("/manifests/pipeline/mysql/base/params.env", `
 mysqlPvcName=
 `)

--- a/tests/mysql-overlays-mysqlPd_test.go
+++ b/tests/mysql-overlays-mysqlPd_test.go
@@ -129,13 +129,15 @@ spec:
   - ReadWriteOnce
   resources:
     requests:
-      storage: 20Gi`)
+      storage: 20Gi
+`)
 	th.writeF("/manifests/pipeline/mysql/base/params.yaml", `
 varReference:
 - path: spec/template/spec/volumes/persistentVolumeClaim/claimName
   kind: Deployment
 - path: metadata/name
-  kind: PersistentVolumeClaim`)
+  kind: PersistentVolumeClaim
+`)
 	th.writeF("/manifests/pipeline/mysql/base/params.env", `
 mysqlPvcName=
 `)

--- a/tests/profiles-base_test.go
+++ b/tests/profiles-base_test.go
@@ -125,7 +125,8 @@ metadata:
   name: kfam
 spec:
   ports:
-    - port: 8081`)
+    - port: 8081
+`)
 	th.writeF("/manifests/profiles/base/deployment.yaml", `
 apiVersion: apps/v1
 kind: Deployment

--- a/tests/profiles-overlays-debug_test.go
+++ b/tests/profiles-overlays-debug_test.go
@@ -180,7 +180,8 @@ metadata:
   name: kfam
 spec:
   ports:
-    - port: 8081`)
+    - port: 8081
+`)
 	th.writeF("/manifests/profiles/base/deployment.yaml", `
 apiVersion: apps/v1
 kind: Deployment

--- a/tests/profiles-overlays-devices_test.go
+++ b/tests/profiles-overlays-devices_test.go
@@ -151,7 +151,8 @@ metadata:
   name: kfam
 spec:
   ports:
-    - port: 8081`)
+    - port: 8081
+`)
 	th.writeF("/manifests/profiles/base/deployment.yaml", `
 apiVersion: apps/v1
 kind: Deployment

--- a/tests/profiles-overlays-istio_test.go
+++ b/tests/profiles-overlays-istio_test.go
@@ -166,7 +166,8 @@ metadata:
   name: kfam
 spec:
   ports:
-    - port: 8081`)
+    - port: 8081
+`)
 	th.writeF("/manifests/profiles/base/deployment.yaml", `
 apiVersion: apps/v1
 kind: Deployment

--- a/tests/prometheus-base_test.go
+++ b/tests/prometheus-base_test.go
@@ -295,7 +295,8 @@ varReference:
 	th.writeF("/manifests/gcp/prometheus/base/params.env", `
 projectId=
 clusterName=
-zone=`)
+zone=
+`)
 	th.writeK("/manifests/gcp/prometheus/base", `
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization


### PR DESCRIPTION
**Which issue is resolved by this Pull Request:**
This is for workload identity kubeflow/kubeflow#3638

**Description of your changes:**
The result of kustomize build should be unchanged.
But this allows us to later in kfctl do: 
```
if enableWorkloadIdentity {
  remove gcp-credential patch
}
```

Also, change the service account name in gcp package to kf-admin.
This can later be provisioned by kfctl, and it will have the GSA credential.

/cc @jlewi 

**Checklist:**
- [x] Unit tests have been rebuilt: 
    1. `cd manifests/tests`
    2. `make generate`
    3. `make test`

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/manifests/238)
<!-- Reviewable:end -->
