### PR TITLE
Fix basic auth cloud endpoint missing target namespace and appName

### DIFF
--- a/gcp/basic-auth-ingress/base/cloud-endpoint.yaml
+++ b/gcp/basic-auth-ingress/base/cloud-endpoint.yaml
@@ -1,7 +1,7 @@
 apiVersion: ctl.isla.solutions/v1
 kind: CloudEndpoint
 metadata:
-  name: cloud-endpoint
+  name: $(appName)
 spec:
   project: $(project)
   targetIngress:

--- a/gcp/basic-auth-ingress/base/cloud-endpoint.yaml
+++ b/gcp/basic-auth-ingress/base/cloud-endpoint.yaml
@@ -6,3 +6,4 @@ spec:
   project: $(project)
   targetIngress:
     name: $(ingressName)
+    namespace: $(istioNamespace)

--- a/gcp/basic-auth-ingress/base/kustomization.yaml
+++ b/gcp/basic-auth-ingress/base/kustomization.yaml
@@ -35,6 +35,13 @@ vars:
     apiVersion: v1
   fieldref:
     fieldpath: data.secretName
+- name: appName
+  objref:
+    kind: ConfigMap
+    name: basic-auth-ingress-parameters
+    apiVersion: v1
+  fieldref:
+    fieldpath: data.appName
 - name: namespace
   objref:
     kind: ConfigMap

--- a/gcp/basic-auth-ingress/base/kustomization.yaml
+++ b/gcp/basic-auth-ingress/base/kustomization.yaml
@@ -77,5 +77,12 @@ vars:
     apiVersion: v1
   fieldref:
     fieldpath: data.issuer
+- name: istioNamespace
+  objref:
+    kind: ConfigMap
+    name: basic-auth-ingress-parameters
+    apiVersion: v1
+  fieldref:
+    fieldpath: data.istioNamespace
 configurations:
 - params.yaml

--- a/gcp/basic-auth-ingress/base/params.env
+++ b/gcp/basic-auth-ingress/base/params.env
@@ -6,3 +6,4 @@ secretName=envoy-ingress-tls
 privateGKECluster=false
 ingressName=envoy-ingress
 issuer=letsencrypt-prod
+istioNamespace=istio-system

--- a/gcp/basic-auth-ingress/base/params.env
+++ b/gcp/basic-auth-ingress/base/params.env
@@ -1,3 +1,4 @@
+appName=kubeflow
 namespace=kubeflow
 hostname=
 project=

--- a/gcp/basic-auth-ingress/base/params.yaml
+++ b/gcp/basic-auth-ingress/base/params.yaml
@@ -25,3 +25,5 @@ varReference:
   kind: CloudEndpoint
 - path: spec/targetIngress/name
   kind: CloudEndpoint
+- path: spec/targetIngress/namespace
+  kind: CloudEndpoint

--- a/gcp/basic-auth-ingress/base/params.yaml
+++ b/gcp/basic-auth-ingress/base/params.yaml
@@ -21,6 +21,8 @@ varReference:
   kind: Ingress
 - path: metadata/annotations/certmanager.k8s.io\/issuer
   kind: Ingress
+- path: metadata/name
+  kind: CloudEndpoint
 - path: spec/project
   kind: CloudEndpoint
 - path: spec/targetIngress/name

--- a/tests/basic-auth-ingress-base_test.go
+++ b/tests/basic-auth-ingress-base_test.go
@@ -36,7 +36,7 @@ spec:
 apiVersion: ctl.isla.solutions/v1
 kind: CloudEndpoint
 metadata:
-  name: cloud-endpoint
+  name: $(appName)
 spec:
   project: $(project)
   targetIngress:
@@ -377,6 +377,8 @@ varReference:
   kind: Ingress
 - path: metadata/annotations/certmanager.k8s.io\/issuer
   kind: Ingress
+- path: metadata/name
+  kind: CloudEndpoint
 - path: spec/project
   kind: CloudEndpoint
 - path: spec/targetIngress/name
@@ -385,6 +387,7 @@ varReference:
   kind: CloudEndpoint
 `)
 	th.writeF("/manifests/gcp/basic-auth-ingress/base/params.env", `
+appName=kubeflow
 namespace=kubeflow
 hostname=
 project=
@@ -433,6 +436,13 @@ vars:
     apiVersion: v1
   fieldref:
     fieldpath: data.secretName
+- name: appName
+  objref:
+    kind: ConfigMap
+    name: basic-auth-ingress-parameters
+    apiVersion: v1
+  fieldref:
+    fieldpath: data.appName
 - name: namespace
   objref:
     kind: ConfigMap

--- a/tests/basic-auth-ingress-base_test.go
+++ b/tests/basic-auth-ingress-base_test.go
@@ -41,6 +41,7 @@ spec:
   project: $(project)
   targetIngress:
     name: $(ingressName)
+    namespace: $(istioNamespace)
 `)
 	th.writeF("/manifests/gcp/basic-auth-ingress/base/cluster-role-binding.yaml", `
 apiVersion: rbac.authorization.k8s.io/v1beta1
@@ -380,6 +381,8 @@ varReference:
   kind: CloudEndpoint
 - path: spec/targetIngress/name
   kind: CloudEndpoint
+- path: spec/targetIngress/namespace
+  kind: CloudEndpoint
 `)
 	th.writeF("/manifests/gcp/basic-auth-ingress/base/params.env", `
 namespace=kubeflow
@@ -390,6 +393,7 @@ secretName=envoy-ingress-tls
 privateGKECluster=false
 ingressName=envoy-ingress
 issuer=letsencrypt-prod
+istioNamespace=istio-system
 `)
 	th.writeK("/manifests/gcp/basic-auth-ingress/base", `
 apiVersion: kustomize.config.k8s.io/v1beta1
@@ -471,6 +475,13 @@ vars:
     apiVersion: v1
   fieldref:
     fieldpath: data.issuer
+- name: istioNamespace
+  objref:
+    kind: ConfigMap
+    name: basic-auth-ingress-parameters
+    apiVersion: v1
+  fieldref:
+    fieldpath: data.istioNamespace
 configurations:
 - params.yaml
 `)

--- a/tests/iap-ingress-base_test.go
+++ b/tests/iap-ingress-base_test.go
@@ -633,7 +633,8 @@ oauthSecretName=kubeflow-oauth
 project=
 adminSaSecretName=admin-gcp-sa
 tlsSecretName=envoy-ingress-tls
-istioNamespace=istio-system`)
+istioNamespace=istio-system
+`)
 	th.writeK("/manifests/gcp/iap-ingress/base", `
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization

--- a/tests/istio-base_test.go
+++ b/tests/istio-base_test.go
@@ -1,8 +1,6 @@
 package tests_test
 
 import (
-	"testing"
-
 	"sigs.k8s.io/kustomize/k8sdeps/kunstruct"
 	"sigs.k8s.io/kustomize/k8sdeps/transformer"
 	"sigs.k8s.io/kustomize/pkg/fs"
@@ -10,6 +8,7 @@ import (
 	"sigs.k8s.io/kustomize/pkg/resmap"
 	"sigs.k8s.io/kustomize/pkg/resource"
 	"sigs.k8s.io/kustomize/pkg/target"
+	"testing"
 )
 
 func writeIstioBase(th *KustTestHarness) {

--- a/tests/minio-base_test.go
+++ b/tests/minio-base_test.go
@@ -84,9 +84,11 @@ varReference:
 - path: spec/template/spec/volumes/persistentVolumeClaim/claimName
   kind: Deployment
 - path: metadata/name
-  kind: PersistentVolumeClaim`)
+  kind: PersistentVolumeClaim
+`)
 	th.writeF("/manifests/pipeline/minio/base/params.env", `
-minioPvcName=`)
+minioPvcName=
+`)
 	th.writeK("/manifests/pipeline/minio/base", `
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization

--- a/tests/minio-overlays-minioPd_test.go
+++ b/tests/minio-overlays-minioPd_test.go
@@ -33,7 +33,8 @@ metadata:
   name: $(minioPvcName)
 spec:
   volumeName: $(minioPvName)
-  storageClassName: ""`)
+  storageClassName: ""
+`)
 	th.writeF("/manifests/pipeline/minio/overlays/minioPd/params.yaml", `
 varReference:
 - path: spec/gcePersistentDisk/pdName
@@ -154,9 +155,11 @@ varReference:
 - path: spec/template/spec/volumes/persistentVolumeClaim/claimName
   kind: Deployment
 - path: metadata/name
-  kind: PersistentVolumeClaim`)
+  kind: PersistentVolumeClaim
+`)
 	th.writeF("/manifests/pipeline/minio/base/params.env", `
-minioPvcName=`)
+minioPvcName=
+`)
 	th.writeK("/manifests/pipeline/minio/base", `
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization

--- a/tests/mysql-base_test.go
+++ b/tests/mysql-base_test.go
@@ -58,13 +58,15 @@ spec:
   - ReadWriteOnce
   resources:
     requests:
-      storage: 20Gi`)
+      storage: 20Gi
+`)
 	th.writeF("/manifests/pipeline/mysql/base/params.yaml", `
 varReference:
 - path: spec/template/spec/volumes/persistentVolumeClaim/claimName
   kind: Deployment
 - path: metadata/name
-  kind: PersistentVolumeClaim`)
+  kind: PersistentVolumeClaim
+`)
 	th.writeF("/manifests/pipeline/mysql/base/params.env", `
 mysqlPvcName=
 `)

--- a/tests/mysql-overlays-mysqlPd_test.go
+++ b/tests/mysql-overlays-mysqlPd_test.go
@@ -129,13 +129,15 @@ spec:
   - ReadWriteOnce
   resources:
     requests:
-      storage: 20Gi`)
+      storage: 20Gi
+`)
 	th.writeF("/manifests/pipeline/mysql/base/params.yaml", `
 varReference:
 - path: spec/template/spec/volumes/persistentVolumeClaim/claimName
   kind: Deployment
 - path: metadata/name
-  kind: PersistentVolumeClaim`)
+  kind: PersistentVolumeClaim
+`)
 	th.writeF("/manifests/pipeline/mysql/base/params.env", `
 mysqlPvcName=
 `)

--- a/tests/profiles-base_test.go
+++ b/tests/profiles-base_test.go
@@ -125,7 +125,8 @@ metadata:
   name: kfam
 spec:
   ports:
-    - port: 8081`)
+    - port: 8081
+`)
 	th.writeF("/manifests/profiles/base/deployment.yaml", `
 apiVersion: apps/v1
 kind: Deployment

--- a/tests/profiles-overlays-debug_test.go
+++ b/tests/profiles-overlays-debug_test.go
@@ -180,7 +180,8 @@ metadata:
   name: kfam
 spec:
   ports:
-    - port: 8081`)
+    - port: 8081
+`)
 	th.writeF("/manifests/profiles/base/deployment.yaml", `
 apiVersion: apps/v1
 kind: Deployment

--- a/tests/profiles-overlays-devices_test.go
+++ b/tests/profiles-overlays-devices_test.go
@@ -151,7 +151,8 @@ metadata:
   name: kfam
 spec:
   ports:
-    - port: 8081`)
+    - port: 8081
+`)
 	th.writeF("/manifests/profiles/base/deployment.yaml", `
 apiVersion: apps/v1
 kind: Deployment

--- a/tests/profiles-overlays-istio_test.go
+++ b/tests/profiles-overlays-istio_test.go
@@ -166,7 +166,8 @@ metadata:
   name: kfam
 spec:
   ports:
-    - port: 8081`)
+    - port: 8081
+`)
 	th.writeF("/manifests/profiles/base/deployment.yaml", `
 apiVersion: apps/v1
 kind: Deployment


### PR DESCRIPTION
Basic auth cloud endpoint missed target namespace and appName.
This PR patch them to cloud endpoint config.

**Checklist:**
- [x] Unit tests have been rebuilt: 
    1. `cd manifests/tests`
    2. `make generate`
    3. `make test`

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/manifests/243)
<!-- Reviewable:end -->
