### PR TITLE
Fix manifest for cloud-endpoint

### DIFF
--- a/gcp/cloud-endpoints/base/cluster-role.yaml
+++ b/gcp/cloud-endpoints/base/cluster-role.yaml
@@ -1,7 +1,7 @@
 apiVersion: rbac.authorization.k8s.io/v1beta1
 kind: ClusterRole
 metadata:
-  name: kf-admin
+  name: cloud-endpoints-controller
 rules:
 - apiGroups:
   - ""

--- a/tests/cloud-endpoints-base_test.go
+++ b/tests/cloud-endpoints-base_test.go
@@ -29,7 +29,7 @@ subjects:
 apiVersion: rbac.authorization.k8s.io/v1beta1
 kind: ClusterRole
 metadata:
-  name: kf-admin
+  name: cloud-endpoints-controller
 rules:
 - apiGroups:
   - ""


### PR DESCRIPTION
**Which issue is resolved by this Pull Request:**
Fix an error in https://github.com/kubeflow/manifests/pull/238

**Description of your changes:**
The clusterrolebinding's roleref mismatches with clusterrole
https://github.com/kubeflow/manifests/blob/master/gcp/cloud-endpoints/base/cluster-role-binding.yaml#L8

/cc @jlewi 

**Checklist:**
- [x] Unit tests have been rebuilt: 
    1. `cd manifests/tests`
    2. `make generate`
    3. `make test`

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/manifests/247)
<!-- Reviewable:end -->
