### PR TITLE
add missing selector to metadata-deployment

### DIFF
--- a/metadata/base/metadata-deployment.yaml
+++ b/metadata/base/metadata-deployment.yaml
@@ -6,6 +6,9 @@ metadata:
     component: server
 spec:
   replicas: 3
+  selector:
+    matchLabels:
+      component: server
   template:
     metadata:
       labels:

--- a/tests/metadata-base_test.go
+++ b/tests/metadata-base_test.go
@@ -109,6 +109,9 @@ metadata:
     component: server
 spec:
   replicas: 3
+  selector:
+    matchLabels:
+      component: server
   template:
     metadata:
       labels:

--- a/tests/metadata-overlays-istio_test.go
+++ b/tests/metadata-overlays-istio_test.go
@@ -147,6 +147,9 @@ metadata:
     component: server
 spec:
   replicas: 3
+  selector:
+    matchLabels:
+      component: server
   template:
     metadata:
       labels:


### PR DESCRIPTION
Without a selector in the resource file itself, kustomize generates a resource that looks like:

```
apiVersion: extensions/v1beta1
kind: Deployment
metadata:
  labels:
    component: server
    kustomize.component: metadata
  name: metadata-deployment
  namespace: kubeflow
spec:
  replicas: 3
  selector:
    matchLabels:
      kustomize.component: metadata
  template:
    metadata:
      labels:
        component: server
        kustomize.component: metadata
```

this causes the Deployment to match all metadata-related pods (ui, db) which seems not desired.

**Which issue is resolved by this Pull Request:**
Resolves #

**Description of your changes:**


**Checklist:**
- [ ] Unit tests have been rebuilt: 
    1. `cd manifests/tests`
    2. `make generate`
    3. `make test`

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/manifests/254)
<!-- Reviewable:end -->
