### PR TITLE
Add containerRuntimeExecutor field for other argo executors

### DIFF
--- a/argo/base/config-map.yaml
+++ b/argo/base/config-map.yaml
@@ -7,6 +7,7 @@ data:
   config: |
     {
     executorImage: $(executorImage),
+    containerRuntimeExecutor: $(containerRuntimeExecutor),
     artifactRepository:
     {
         s3: {

--- a/argo/base/kustomization.yaml
+++ b/argo/base/kustomization.yaml
@@ -30,6 +30,13 @@ vars:
     apiVersion: v1
   fieldref:
     fieldpath: data.executorImage
+- name: containerRuntimeExecutor
+  objref:
+    kind: ConfigMap
+    name: workflow-controller-parameters
+    apiVersion: v1
+  fieldref:
+    fieldpath: data.containerRuntimeExecutor
 - name: artifactRepositoryBucket
   objref:
     kind: ConfigMap

--- a/argo/base/params.env
+++ b/argo/base/params.env
@@ -1,5 +1,6 @@
 namespace=
 executorImage=argoproj/argoexec:v2.3.0
+containerRuntimeExecutor=docker
 artifactRepositoryBucket=mlpipeline
 artifactRepositoryKeyPrefix=artifacts
 artifactRepositoryEndpoint=minio-service.kubeflow:9000

--- a/tests/argo-base_test.go
+++ b/tests/argo-base_test.go
@@ -132,6 +132,7 @@ data:
   config: |
     {
     executorImage: $(executorImage),
+    containerRuntimeExecutor: $(containerRuntimeExecutor),
     artifactRepository:
     {
         s3: {
@@ -325,6 +326,7 @@ varReference:
 	th.writeF("/manifests/argo/base/params.env", `
 namespace=
 executorImage=argoproj/argoexec:v2.3.0
+containerRuntimeExecutor=docker
 artifactRepositoryBucket=mlpipeline
 artifactRepositoryKeyPrefix=artifacts
 artifactRepositoryEndpoint=minio-service.kubeflow:9000
@@ -368,6 +370,13 @@ vars:
     apiVersion: v1
   fieldref:
     fieldpath: data.executorImage
+- name: containerRuntimeExecutor
+  objref:
+    kind: ConfigMap
+    name: workflow-controller-parameters
+    apiVersion: v1
+  fieldref:
+    fieldpath: data.containerRuntimeExecutor
 - name: artifactRepositoryBucket
   objref:
     kind: ConfigMap

--- a/tests/argo-overlays-istio_test.go
+++ b/tests/argo-overlays-istio_test.go
@@ -169,6 +169,7 @@ data:
   config: |
     {
     executorImage: $(executorImage),
+    containerRuntimeExecutor: $(containerRuntimeExecutor),
     artifactRepository:
     {
         s3: {
@@ -362,6 +363,7 @@ varReference:
 	th.writeF("/manifests/argo/base/params.env", `
 namespace=
 executorImage=argoproj/argoexec:v2.3.0
+containerRuntimeExecutor=docker
 artifactRepositoryBucket=mlpipeline
 artifactRepositoryKeyPrefix=artifacts
 artifactRepositoryEndpoint=minio-service.kubeflow:9000
@@ -405,6 +407,13 @@ vars:
     apiVersion: v1
   fieldref:
     fieldpath: data.executorImage
+- name: containerRuntimeExecutor
+  objref:
+    kind: ConfigMap
+    name: workflow-controller-parameters
+    apiVersion: v1
+  fieldref:
+    fieldpath: data.containerRuntimeExecutor
 - name: artifactRepositoryBucket
   objref:
     kind: ConfigMap


### PR DESCRIPTION
**Description of your changes:**
By default, Argo will use the `docker` containerRuntimeExecutor which it will not work on Kubernetes Cluster that doesn't use docker runtime. Therefore, we want to add the containerRuntimeExecutor field so that users who need different executor runtime can easily change the containerRuntimeExecutor params using kustomize. 


**Checklist:**
- [x] Unit tests have been rebuilt: 
    1. `cd manifests/tests`
    2. `make generate`
    3. `make test`

cc: @animeshsingh

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/manifests/259)
<!-- Reviewable:end -->
