### PR TITLE
add selector for application controller StatefulSet

### DIFF
--- a/application/application/base/stateful-set.yaml
+++ b/application/application/base/stateful-set.yaml
@@ -4,7 +4,13 @@ metadata:
   name: stateful-set
 spec:
   serviceName: service
+  selector:
+    matchLabels:
+      app: application-controller
   template:
+    metadata:
+      labels:
+        app: application-controller
     spec:
       containers:
       - name: manager

--- a/tests/application-base_test.go
+++ b/tests/application-base_test.go
@@ -70,7 +70,13 @@ metadata:
   name: stateful-set
 spec:
   serviceName: service
+  selector:
+    matchLabels:
+      app: application-controller
   template:
+    metadata:
+      labels:
+        app: application-controller
     spec:
       containers:
       - name: manager

--- a/tests/application-overlays-application_test.go
+++ b/tests/application-overlays-application_test.go
@@ -118,7 +118,13 @@ metadata:
   name: stateful-set
 spec:
   serviceName: service
+  selector:
+    matchLabels:
+      app: application-controller
   template:
+    metadata:
+      labels:
+        app: application-controller
     spec:
       containers:
       - name: manager

--- a/tests/application-overlays-debug_test.go
+++ b/tests/application-overlays-debug_test.go
@@ -102,7 +102,13 @@ metadata:
   name: stateful-set
 spec:
   serviceName: service
+  selector:
+    matchLabels:
+      app: application-controller
   template:
+    metadata:
+      labels:
+        app: application-controller
     spec:
       containers:
       - name: manager


### PR DESCRIPTION
**Which issue is resolved by this Pull Request:**
Resolves kubeflow/kubeflow#3812

**Description of your changes:**
Added selector and corresponding labels (`app: application-controller`) for pods to the base kustomize package.

**Checklist:**
- [x] Unit tests have been rebuilt: 
    1. `cd manifests/tests`
    2. `make generate`
    3. `make test`

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/manifests/261)
<!-- Reviewable:end -->
