### PR TITLE
parameterize userid header and prefix

### DIFF
--- a/common/centraldashboard/base/deployment.yaml
+++ b/common/centraldashboard/base/deployment.yaml
@@ -21,4 +21,9 @@ spec:
         ports:
         - containerPort: 8082
           protocol: TCP
+        env:
+        - name: USERID_HEADER
+          value: $(userid-header)
+        - name: USERID_PREFIX
+          value: $(userid-prefix)
       serviceAccountName: centraldashboard

--- a/common/centraldashboard/base/kustomization.yaml
+++ b/common/centraldashboard/base/kustomization.yaml
@@ -35,6 +35,20 @@ vars:
     apiVersion: v1
   fieldref:
     fieldpath: data.clusterDomain
+- name: userid-header
+  objref:
+    kind: ConfigMap
+    name: parameters
+    apiVersion: v1
+  fieldref:
+    fieldpath: data.userid-header
+- name: userid-prefix
+  objref:
+    kind: ConfigMap
+    name: parameters
+    apiVersion: v1
+  fieldref:
+    fieldpath: data.userid-prefix
 configurations:
 - params.yaml
 

--- a/common/centraldashboard/base/params.env
+++ b/common/centraldashboard/base/params.env
@@ -1,1 +1,3 @@
 clusterDomain=cluster.local
+userid-header=
+userid-prefix=

--- a/common/centraldashboard/base/params.yaml
+++ b/common/centraldashboard/base/params.yaml
@@ -3,3 +3,7 @@ varReference:
   kind: Service
 - path: spec/http/route/destination/host
   kind: VirtualService
+- path: spec/template/spec/containers/0/env/0/value
+  kind: Deployment
+- path: spec/template/spec/containers/0/env/1/value
+  kind: Deployment

--- a/jupyter/jupyter-web-app/base/deployment.yaml
+++ b/jupyter/jupyter-web-app/base/deployment.yaml
@@ -18,6 +18,10 @@ spec:
             configMapKeyRef:
               name: parameters
               key: UI
+        - name: USERID_HEADER
+          value: $(userid-header)
+        - name: USERID_PREFIX
+          value: $(userid-prefix)
         image: gcr.io/kubeflow-images-public/jupyter-web-app:v0.5.0
         imagePullPolicy: $(policy)
         name: jupyter-web-app

--- a/jupyter/jupyter-web-app/base/kustomization.yaml
+++ b/jupyter/jupyter-web-app/base/kustomization.yaml
@@ -52,5 +52,19 @@ vars:
     apiVersion: v1
   fieldref:
     fieldpath: metadata.namespace
+- name: userid-header
+  objref:
+    kind: ConfigMap
+    name: parameters
+    apiVersion: v1
+  fieldref:
+    fieldpath: data.userid-header
+- name: userid-prefix
+  objref:
+    kind: ConfigMap
+    name: parameters
+    apiVersion: v1
+  fieldref:
+    fieldpath: data.userid-prefix
 configurations:
 - params.yaml

--- a/jupyter/jupyter-web-app/base/params.env
+++ b/jupyter/jupyter-web-app/base/params.env
@@ -3,3 +3,5 @@ ROK_SECRET_NAME=secret-rok-{username}
 policy=Always
 prefix=jupyter
 clusterDomain=cluster.local
+userid-header=
+userid-prefix=

--- a/jupyter/jupyter-web-app/base/params.yaml
+++ b/jupyter/jupyter-web-app/base/params.yaml
@@ -3,3 +3,7 @@ varReference:
   kind: Deployment
 - path: metadata/annotations/getambassador.io\/config
   kind: Service
+- path: spec/template/spec/containers/0/env/2/value
+  kind: Deployment
+- path: spec/template/spec/containers/0/env/3/value
+  kind: Deployment

--- a/profiles/base/deployment.yaml
+++ b/profiles/base/deployment.yaml
@@ -8,6 +8,11 @@ spec:
       containers:
       - command:
         - /manager
+        args:
+        - "-userid-header"
+        - $(userid-header)
+        - "-userid-prefix"
+        - $(userid-prefix)
         image: gcr.io/kubeflow-images-public/profile-controller:v20190619-v0-219-gbd3daa8c-dirty-1ced0e
         imagePullPolicy: Always
         name: manager
@@ -16,6 +21,10 @@ spec:
         args:
         - "-cluster-admin"
         - $(admin)
+        - "-userid-header"
+        - $(userid-header)
+        - "-userid-prefix"
+        - $(userid-prefix)
         image: gcr.io/kubeflow-images-public/kfam:v20190612-v0-170-ga06cdb79-dirty-a33ee4
         imagePullPolicy: Always
         name: kfam

--- a/profiles/base/kustomization.yaml
+++ b/profiles/base/kustomization.yaml
@@ -27,6 +27,20 @@ vars:
       apiVersion: v1
     fieldref:
       fieldpath: data.admin
+  - name: userid-header
+    objref:
+      kind: ConfigMap
+      name: profiles-parameters
+      apiVersion: v1
+    fieldref:
+      fieldpath: data.userid-header
+  - name: userid-prefix
+    objref:
+      kind: ConfigMap
+      name: profiles-parameters
+      apiVersion: v1
+    fieldref:
+      fieldpath: data.userid-prefix
   - name: namespace
     objref:
       kind: Service

--- a/profiles/base/params.env
+++ b/profiles/base/params.env
@@ -1,1 +1,3 @@
 admin=
+userid-header=
+userid-prefix=

--- a/profiles/base/params.yaml
+++ b/profiles/base/params.yaml
@@ -1,4 +1,11 @@
 varReference:
+- path: spec/template/spec/containers/0/args/1
+  kind: Deployment
+- path: spec/template/spec/containers/0/args/3
+  kind: Deployment
 - path: spec/template/spec/containers/1/args/1
   kind: Deployment
-
+- path: spec/template/spec/containers/1/args/3
+  kind: Deployment
+- path: spec/template/spec/containers/1/args/5
+  kind: Deployment

--- a/tests/basic-auth-ingress-overlays-gcp-credentials_test.go
+++ b/tests/basic-auth-ingress-overlays-gcp-credentials_test.go
@@ -33,8 +33,7 @@ spec:
       volumes:
       - name: sa-key
         secret:
-          secretName: admin-gcp-sa
-`)
+          secretName: admin-gcp-sa`)
 	th.writeK("/manifests/gcp/basic-auth-ingress/overlays/gcp-credentials", `
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization

--- a/tests/basic-auth-ingress-overlays-managed-cert_test.go
+++ b/tests/basic-auth-ingress-overlays-managed-cert_test.go
@@ -19,8 +19,7 @@ metadata:
   name: gke-certificate
 spec:
   domains:
-  - $(hostname)
-`)
+  - $(hostname)`)
 	th.writeK("/manifests/gcp/basic-auth-ingress/overlays/managed-cert", `
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization

--- a/tests/centraldashboard-base_test.go
+++ b/tests/centraldashboard-base_test.go
@@ -71,6 +71,11 @@ spec:
         ports:
         - containerPort: 8082
           protocol: TCP
+        env:
+        - name: USERID_HEADER
+          value: $(userid-header)
+        - name: USERID_PREFIX
+          value: $(userid-prefix)
       serviceAccountName: centraldashboard
 `)
 	th.writeF("/manifests/common/centraldashboard/base/role-binding.yaml", `
@@ -154,10 +159,14 @@ varReference:
   kind: Service
 - path: spec/http/route/destination/host
   kind: VirtualService
-`)
+- path: spec/template/spec/containers/0/env/0/value
+  kind: Deployment
+- path: spec/template/spec/containers/0/env/1/value
+  kind: Deployment`)
 	th.writeF("/manifests/common/centraldashboard/base/params.env", `
 clusterDomain=cluster.local
-`)
+userid-header=
+userid-prefix=`)
 	th.writeK("/manifests/common/centraldashboard/base", `
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
@@ -196,6 +205,20 @@ vars:
     apiVersion: v1
   fieldref:
     fieldpath: data.clusterDomain
+- name: userid-header
+  objref:
+    kind: ConfigMap
+    name: parameters
+    apiVersion: v1
+  fieldref:
+    fieldpath: data.userid-header
+- name: userid-prefix
+  objref:
+    kind: ConfigMap
+    name: parameters
+    apiVersion: v1
+  fieldref:
+    fieldpath: data.userid-prefix
 configurations:
 - params.yaml
 

--- a/tests/centraldashboard-overlays-application_test.go
+++ b/tests/centraldashboard-overlays-application_test.go
@@ -140,6 +140,11 @@ spec:
         ports:
         - containerPort: 8082
           protocol: TCP
+        env:
+        - name: USERID_HEADER
+          value: $(userid-header)
+        - name: USERID_PREFIX
+          value: $(userid-prefix)
       serviceAccountName: centraldashboard
 `)
 	th.writeF("/manifests/common/centraldashboard/base/role-binding.yaml", `
@@ -223,10 +228,14 @@ varReference:
   kind: Service
 - path: spec/http/route/destination/host
   kind: VirtualService
-`)
+- path: spec/template/spec/containers/0/env/0/value
+  kind: Deployment
+- path: spec/template/spec/containers/0/env/1/value
+  kind: Deployment`)
 	th.writeF("/manifests/common/centraldashboard/base/params.env", `
 clusterDomain=cluster.local
-`)
+userid-header=
+userid-prefix=`)
 	th.writeK("/manifests/common/centraldashboard/base", `
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
@@ -265,6 +274,20 @@ vars:
     apiVersion: v1
   fieldref:
     fieldpath: data.clusterDomain
+- name: userid-header
+  objref:
+    kind: ConfigMap
+    name: parameters
+    apiVersion: v1
+  fieldref:
+    fieldpath: data.userid-header
+- name: userid-prefix
+  objref:
+    kind: ConfigMap
+    name: parameters
+    apiVersion: v1
+  fieldref:
+    fieldpath: data.userid-prefix
 configurations:
 - params.yaml
 

--- a/tests/centraldashboard-overlays-istio_test.go
+++ b/tests/centraldashboard-overlays-istio_test.go
@@ -109,6 +109,11 @@ spec:
         ports:
         - containerPort: 8082
           protocol: TCP
+        env:
+        - name: USERID_HEADER
+          value: $(userid-header)
+        - name: USERID_PREFIX
+          value: $(userid-prefix)
       serviceAccountName: centraldashboard
 `)
 	th.writeF("/manifests/common/centraldashboard/base/role-binding.yaml", `
@@ -192,10 +197,14 @@ varReference:
   kind: Service
 - path: spec/http/route/destination/host
   kind: VirtualService
-`)
+- path: spec/template/spec/containers/0/env/0/value
+  kind: Deployment
+- path: spec/template/spec/containers/0/env/1/value
+  kind: Deployment`)
 	th.writeF("/manifests/common/centraldashboard/base/params.env", `
 clusterDomain=cluster.local
-`)
+userid-header=
+userid-prefix=`)
 	th.writeK("/manifests/common/centraldashboard/base", `
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
@@ -234,6 +243,20 @@ vars:
     apiVersion: v1
   fieldref:
     fieldpath: data.clusterDomain
+- name: userid-header
+  objref:
+    kind: ConfigMap
+    name: parameters
+    apiVersion: v1
+  fieldref:
+    fieldpath: data.userid-header
+- name: userid-prefix
+  objref:
+    kind: ConfigMap
+    name: parameters
+    apiVersion: v1
+  fieldref:
+    fieldpath: data.userid-prefix
 configurations:
 - params.yaml
 

--- a/tests/cloud-endpoints-overlays-gcp-credentials_test.go
+++ b/tests/cloud-endpoints-overlays-gcp-credentials_test.go
@@ -33,8 +33,7 @@ spec:
       volumes:
       - name: sa-key
         secret:
-          secretName: admin-gcp-sa
-`)
+          secretName: admin-gcp-sa`)
 	th.writeK("/manifests/gcp/cloud-endpoints/overlays/gcp-credentials", `
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization

--- a/tests/iap-ingress-base_test.go
+++ b/tests/iap-ingress-base_test.go
@@ -542,8 +542,7 @@ varReference:
 - path: data/healthcheck_route.yaml
   kind: ConfigMap
 - path: spec/domains
-  kind: ManagedCertificate
-`)
+  kind: ManagedCertificate`)
 	th.writeF("/manifests/gcp/iap-ingress/base/params.env", `
 namespace=kubeflow
 appName=kubeflow
@@ -555,8 +554,7 @@ oauthSecretName=kubeflow-oauth
 project=
 adminSaSecretName=admin-gcp-sa
 tlsSecretName=envoy-ingress-tls
-istioNamespace=istio-system
-`)
+istioNamespace=istio-system`)
 	th.writeK("/manifests/gcp/iap-ingress/base", `
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization

--- a/tests/iap-ingress-overlays-certmanager_test.go
+++ b/tests/iap-ingress-overlays-certmanager_test.go
@@ -619,8 +619,7 @@ varReference:
 - path: data/healthcheck_route.yaml
   kind: ConfigMap
 - path: spec/domains
-  kind: ManagedCertificate
-`)
+  kind: ManagedCertificate`)
 	th.writeF("/manifests/gcp/iap-ingress/base/params.env", `
 namespace=kubeflow
 appName=kubeflow
@@ -632,8 +631,7 @@ oauthSecretName=kubeflow-oauth
 project=
 adminSaSecretName=admin-gcp-sa
 tlsSecretName=envoy-ingress-tls
-istioNamespace=istio-system
-`)
+istioNamespace=istio-system`)
 	th.writeK("/manifests/gcp/iap-ingress/base", `
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization

--- a/tests/iap-ingress-overlays-gcp-credentials_test.go
+++ b/tests/iap-ingress-overlays-gcp-credentials_test.go
@@ -54,8 +54,7 @@ spec:
       volumes:
       - name: sa-key
         secret:
-          secretName: admin-gcp-sa
-`)
+          secretName: admin-gcp-sa`)
 	th.writeK("/manifests/gcp/iap-ingress/overlays/gcp-credentials", `
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
@@ -593,8 +592,7 @@ varReference:
 - path: data/healthcheck_route.yaml
   kind: ConfigMap
 - path: spec/domains
-  kind: ManagedCertificate
-`)
+  kind: ManagedCertificate`)
 	th.writeF("/manifests/gcp/iap-ingress/base/params.env", `
 namespace=kubeflow
 appName=kubeflow
@@ -606,8 +604,7 @@ oauthSecretName=kubeflow-oauth
 project=
 adminSaSecretName=admin-gcp-sa
 tlsSecretName=envoy-ingress-tls
-istioNamespace=istio-system
-`)
+istioNamespace=istio-system`)
 	th.writeK("/manifests/gcp/iap-ingress/base", `
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization

--- a/tests/iap-ingress-overlays-managed-cert_test.go
+++ b/tests/iap-ingress-overlays-managed-cert_test.go
@@ -562,8 +562,7 @@ varReference:
 - path: data/healthcheck_route.yaml
   kind: ConfigMap
 - path: spec/domains
-  kind: ManagedCertificate
-`)
+  kind: ManagedCertificate`)
 	th.writeF("/manifests/gcp/iap-ingress/base/params.env", `
 namespace=kubeflow
 appName=kubeflow
@@ -575,8 +574,7 @@ oauthSecretName=kubeflow-oauth
 project=
 adminSaSecretName=admin-gcp-sa
 tlsSecretName=envoy-ingress-tls
-istioNamespace=istio-system
-`)
+istioNamespace=istio-system`)
 	th.writeK("/manifests/gcp/iap-ingress/base", `
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization

--- a/tests/jupyter-web-app-base_test.go
+++ b/tests/jupyter-web-app-base_test.go
@@ -234,6 +234,10 @@ spec:
             configMapKeyRef:
               name: parameters
               key: UI
+        - name: USERID_HEADER
+          value: $(userid-header)
+        - name: USERID_PREFIX
+          value: $(userid-prefix)
         image: gcr.io/kubeflow-images-public/jupyter-web-app:v0.5.0
         imagePullPolicy: $(policy)
         name: jupyter-web-app
@@ -335,14 +339,18 @@ varReference:
   kind: Deployment
 - path: metadata/annotations/getambassador.io\/config
   kind: Service
-`)
+- path: spec/template/spec/containers/0/env/2/value
+  kind: Deployment
+- path: spec/template/spec/containers/0/env/3/value
+  kind: Deployment`)
 	th.writeF("/manifests/jupyter/jupyter-web-app/base/params.env", `
 UI=default
 ROK_SECRET_NAME=secret-rok-{username}
 policy=Always
 prefix=jupyter
 clusterDomain=cluster.local
-`)
+userid-header=
+userid-prefix=`)
 	th.writeK("/manifests/jupyter/jupyter-web-app/base", `
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
@@ -398,6 +406,20 @@ vars:
     apiVersion: v1
   fieldref:
     fieldpath: metadata.namespace
+- name: userid-header
+  objref:
+    kind: ConfigMap
+    name: parameters
+    apiVersion: v1
+  fieldref:
+    fieldpath: data.userid-header
+- name: userid-prefix
+  objref:
+    kind: ConfigMap
+    name: parameters
+    apiVersion: v1
+  fieldref:
+    fieldpath: data.userid-prefix
 configurations:
 - params.yaml
 `)

--- a/tests/jupyter-web-app-overlays-application_test.go
+++ b/tests/jupyter-web-app-overlays-application_test.go
@@ -298,6 +298,10 @@ spec:
             configMapKeyRef:
               name: parameters
               key: UI
+        - name: USERID_HEADER
+          value: $(userid-header)
+        - name: USERID_PREFIX
+          value: $(userid-prefix)
         image: gcr.io/kubeflow-images-public/jupyter-web-app:v0.5.0
         imagePullPolicy: $(policy)
         name: jupyter-web-app
@@ -399,14 +403,18 @@ varReference:
   kind: Deployment
 - path: metadata/annotations/getambassador.io\/config
   kind: Service
-`)
+- path: spec/template/spec/containers/0/env/2/value
+  kind: Deployment
+- path: spec/template/spec/containers/0/env/3/value
+  kind: Deployment`)
 	th.writeF("/manifests/jupyter/jupyter-web-app/base/params.env", `
 UI=default
 ROK_SECRET_NAME=secret-rok-{username}
 policy=Always
 prefix=jupyter
 clusterDomain=cluster.local
-`)
+userid-header=
+userid-prefix=`)
 	th.writeK("/manifests/jupyter/jupyter-web-app/base", `
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
@@ -462,6 +470,20 @@ vars:
     apiVersion: v1
   fieldref:
     fieldpath: metadata.namespace
+- name: userid-header
+  objref:
+    kind: ConfigMap
+    name: parameters
+    apiVersion: v1
+  fieldref:
+    fieldpath: data.userid-header
+- name: userid-prefix
+  objref:
+    kind: ConfigMap
+    name: parameters
+    apiVersion: v1
+  fieldref:
+    fieldpath: data.userid-prefix
 configurations:
 - params.yaml
 `)

--- a/tests/jupyter-web-app-overlays-istio_test.go
+++ b/tests/jupyter-web-app-overlays-istio_test.go
@@ -273,6 +273,10 @@ spec:
             configMapKeyRef:
               name: parameters
               key: UI
+        - name: USERID_HEADER
+          value: $(userid-header)
+        - name: USERID_PREFIX
+          value: $(userid-prefix)
         image: gcr.io/kubeflow-images-public/jupyter-web-app:v0.5.0
         imagePullPolicy: $(policy)
         name: jupyter-web-app
@@ -374,14 +378,18 @@ varReference:
   kind: Deployment
 - path: metadata/annotations/getambassador.io\/config
   kind: Service
-`)
+- path: spec/template/spec/containers/0/env/2/value
+  kind: Deployment
+- path: spec/template/spec/containers/0/env/3/value
+  kind: Deployment`)
 	th.writeF("/manifests/jupyter/jupyter-web-app/base/params.env", `
 UI=default
 ROK_SECRET_NAME=secret-rok-{username}
 policy=Always
 prefix=jupyter
 clusterDomain=cluster.local
-`)
+userid-header=
+userid-prefix=`)
 	th.writeK("/manifests/jupyter/jupyter-web-app/base", `
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
@@ -437,6 +445,20 @@ vars:
     apiVersion: v1
   fieldref:
     fieldpath: metadata.namespace
+- name: userid-header
+  objref:
+    kind: ConfigMap
+    name: parameters
+    apiVersion: v1
+  fieldref:
+    fieldpath: data.userid-header
+- name: userid-prefix
+  objref:
+    kind: ConfigMap
+    name: parameters
+    apiVersion: v1
+  fieldref:
+    fieldpath: data.userid-prefix
 configurations:
 - params.yaml
 `)

--- a/tests/profiles-base_test.go
+++ b/tests/profiles-base_test.go
@@ -137,6 +137,11 @@ spec:
       containers:
       - command:
         - /manager
+        args:
+        - "-userid-header"
+        - $(userid-header)
+        - "-userid-prefix"
+        - $(userid-prefix)
         image: gcr.io/kubeflow-images-public/profile-controller:v20190619-v0-219-gbd3daa8c-dirty-1ced0e
         imagePullPolicy: Always
         name: manager
@@ -145,6 +150,10 @@ spec:
         args:
         - "-cluster-admin"
         - $(admin)
+        - "-userid-header"
+        - $(userid-header)
+        - "-userid-prefix"
+        - $(userid-prefix)
         image: gcr.io/kubeflow-images-public/kfam:v20190612-v0-170-ga06cdb79-dirty-a33ee4
         imagePullPolicy: Always
         name: kfam
@@ -152,12 +161,20 @@ spec:
 `)
 	th.writeF("/manifests/profiles/base/params.yaml", `
 varReference:
+- path: spec/template/spec/containers/0/args/1
+  kind: Deployment
+- path: spec/template/spec/containers/0/args/3
+  kind: Deployment
 - path: spec/template/spec/containers/1/args/1
   kind: Deployment
-
-`)
+- path: spec/template/spec/containers/1/args/3
+  kind: Deployment
+- path: spec/template/spec/containers/1/args/5
+  kind: Deployment`)
 	th.writeF("/manifests/profiles/base/params.env", `
 admin=
+userid-header=
+userid-prefix=
 `)
 	th.writeK("/manifests/profiles/base", `
 apiVersion: kustomize.config.k8s.io/v1beta1
@@ -189,6 +206,20 @@ vars:
       apiVersion: v1
     fieldref:
       fieldpath: data.admin
+  - name: userid-header
+    objref:
+      kind: ConfigMap
+      name: profiles-parameters
+      apiVersion: v1
+    fieldref:
+      fieldpath: data.userid-header
+  - name: userid-prefix
+    objref:
+      kind: ConfigMap
+      name: profiles-parameters
+      apiVersion: v1
+    fieldref:
+      fieldpath: data.userid-prefix
   - name: namespace
     objref:
       kind: Service

--- a/tests/profiles-overlays-debug_test.go
+++ b/tests/profiles-overlays-debug_test.go
@@ -192,6 +192,11 @@ spec:
       containers:
       - command:
         - /manager
+        args:
+        - "-userid-header"
+        - $(userid-header)
+        - "-userid-prefix"
+        - $(userid-prefix)
         image: gcr.io/kubeflow-images-public/profile-controller:v20190619-v0-219-gbd3daa8c-dirty-1ced0e
         imagePullPolicy: Always
         name: manager
@@ -200,6 +205,10 @@ spec:
         args:
         - "-cluster-admin"
         - $(admin)
+        - "-userid-header"
+        - $(userid-header)
+        - "-userid-prefix"
+        - $(userid-prefix)
         image: gcr.io/kubeflow-images-public/kfam:v20190612-v0-170-ga06cdb79-dirty-a33ee4
         imagePullPolicy: Always
         name: kfam
@@ -207,12 +216,20 @@ spec:
 `)
 	th.writeF("/manifests/profiles/base/params.yaml", `
 varReference:
+- path: spec/template/spec/containers/0/args/1
+  kind: Deployment
+- path: spec/template/spec/containers/0/args/3
+  kind: Deployment
 - path: spec/template/spec/containers/1/args/1
   kind: Deployment
-
-`)
+- path: spec/template/spec/containers/1/args/3
+  kind: Deployment
+- path: spec/template/spec/containers/1/args/5
+  kind: Deployment`)
 	th.writeF("/manifests/profiles/base/params.env", `
 admin=
+userid-header=
+userid-prefix=
 `)
 	th.writeK("/manifests/profiles/base", `
 apiVersion: kustomize.config.k8s.io/v1beta1
@@ -244,6 +261,20 @@ vars:
       apiVersion: v1
     fieldref:
       fieldpath: data.admin
+  - name: userid-header
+    objref:
+      kind: ConfigMap
+      name: profiles-parameters
+      apiVersion: v1
+    fieldref:
+      fieldpath: data.userid-header
+  - name: userid-prefix
+    objref:
+      kind: ConfigMap
+      name: profiles-parameters
+      apiVersion: v1
+    fieldref:
+      fieldpath: data.userid-prefix
   - name: namespace
     objref:
       kind: Service

--- a/tests/profiles-overlays-devices_test.go
+++ b/tests/profiles-overlays-devices_test.go
@@ -163,6 +163,11 @@ spec:
       containers:
       - command:
         - /manager
+        args:
+        - "-userid-header"
+        - $(userid-header)
+        - "-userid-prefix"
+        - $(userid-prefix)
         image: gcr.io/kubeflow-images-public/profile-controller:v20190619-v0-219-gbd3daa8c-dirty-1ced0e
         imagePullPolicy: Always
         name: manager
@@ -171,6 +176,10 @@ spec:
         args:
         - "-cluster-admin"
         - $(admin)
+        - "-userid-header"
+        - $(userid-header)
+        - "-userid-prefix"
+        - $(userid-prefix)
         image: gcr.io/kubeflow-images-public/kfam:v20190612-v0-170-ga06cdb79-dirty-a33ee4
         imagePullPolicy: Always
         name: kfam
@@ -178,12 +187,20 @@ spec:
 `)
 	th.writeF("/manifests/profiles/base/params.yaml", `
 varReference:
+- path: spec/template/spec/containers/0/args/1
+  kind: Deployment
+- path: spec/template/spec/containers/0/args/3
+  kind: Deployment
 - path: spec/template/spec/containers/1/args/1
   kind: Deployment
-
-`)
+- path: spec/template/spec/containers/1/args/3
+  kind: Deployment
+- path: spec/template/spec/containers/1/args/5
+  kind: Deployment`)
 	th.writeF("/manifests/profiles/base/params.env", `
 admin=
+userid-header=
+userid-prefix=
 `)
 	th.writeK("/manifests/profiles/base", `
 apiVersion: kustomize.config.k8s.io/v1beta1
@@ -215,6 +232,20 @@ vars:
       apiVersion: v1
     fieldref:
       fieldpath: data.admin
+  - name: userid-header
+    objref:
+      kind: ConfigMap
+      name: profiles-parameters
+      apiVersion: v1
+    fieldref:
+      fieldpath: data.userid-header
+  - name: userid-prefix
+    objref:
+      kind: ConfigMap
+      name: profiles-parameters
+      apiVersion: v1
+    fieldref:
+      fieldpath: data.userid-prefix
   - name: namespace
     objref:
       kind: Service

--- a/tests/profiles-overlays-istio_test.go
+++ b/tests/profiles-overlays-istio_test.go
@@ -178,6 +178,11 @@ spec:
       containers:
       - command:
         - /manager
+        args:
+        - "-userid-header"
+        - $(userid-header)
+        - "-userid-prefix"
+        - $(userid-prefix)
         image: gcr.io/kubeflow-images-public/profile-controller:v20190619-v0-219-gbd3daa8c-dirty-1ced0e
         imagePullPolicy: Always
         name: manager
@@ -186,6 +191,10 @@ spec:
         args:
         - "-cluster-admin"
         - $(admin)
+        - "-userid-header"
+        - $(userid-header)
+        - "-userid-prefix"
+        - $(userid-prefix)
         image: gcr.io/kubeflow-images-public/kfam:v20190612-v0-170-ga06cdb79-dirty-a33ee4
         imagePullPolicy: Always
         name: kfam
@@ -193,12 +202,20 @@ spec:
 `)
 	th.writeF("/manifests/profiles/base/params.yaml", `
 varReference:
+- path: spec/template/spec/containers/0/args/1
+  kind: Deployment
+- path: spec/template/spec/containers/0/args/3
+  kind: Deployment
 - path: spec/template/spec/containers/1/args/1
   kind: Deployment
-
-`)
+- path: spec/template/spec/containers/1/args/3
+  kind: Deployment
+- path: spec/template/spec/containers/1/args/5
+  kind: Deployment`)
 	th.writeF("/manifests/profiles/base/params.env", `
 admin=
+userid-header=
+userid-prefix=
 `)
 	th.writeK("/manifests/profiles/base", `
 apiVersion: kustomize.config.k8s.io/v1beta1
@@ -230,6 +247,20 @@ vars:
       apiVersion: v1
     fieldref:
       fieldpath: data.admin
+  - name: userid-header
+    objref:
+      kind: ConfigMap
+      name: profiles-parameters
+      apiVersion: v1
+    fieldref:
+      fieldpath: data.userid-header
+  - name: userid-prefix
+    objref:
+      kind: ConfigMap
+      name: profiles-parameters
+      apiVersion: v1
+    fieldref:
+      fieldpath: data.userid-prefix
   - name: namespace
     objref:
       kind: Service


### PR DESCRIPTION
**Which issue is resolved by this Pull Request:**
Resolves #177
Resolves #178
Resolves #179
Resolves #180
Resolves #181

**Description of your changes:**

Parameters to customize the userid header and prefix.
Essential for having multi-user capabilities in other-than-GCP platforms.

**Checklist:**
- [X] Unit tests have been rebuilt: 
    1. `cd manifests/tests`
    2. `make generate`
    3. `make test`

/assign @kkasravi @jlewi

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/manifests/274)
<!-- Reviewable:end -->
