### PR TITLE
metadata: change metadata-deployment replica count to 1

### DIFF
--- a/metadata/base/metadata-deployment.yaml
+++ b/metadata/base/metadata-deployment.yaml
@@ -5,7 +5,7 @@ metadata:
   labels:
     component: server
 spec:
-  replicas: 3
+  replicas: 2
   selector:
     matchLabels:
       component: server

--- a/tests/metadata-base_test.go
+++ b/tests/metadata-base_test.go
@@ -108,7 +108,7 @@ metadata:
   labels:
     component: server
 spec:
-  replicas: 3
+  replicas: 2
   selector:
     matchLabels:
       component: server

--- a/tests/metadata-overlays-application_test.go
+++ b/tests/metadata-overlays-application_test.go
@@ -165,7 +165,7 @@ metadata:
   labels:
     component: server
 spec:
-  replicas: 3
+  replicas: 2
   selector:
     matchLabels:
       component: server

--- a/tests/metadata-overlays-istio_test.go
+++ b/tests/metadata-overlays-istio_test.go
@@ -146,7 +146,7 @@ metadata:
   labels:
     component: server
 spec:
-  replicas: 3
+  replicas: 2
   selector:
     matchLabels:
       component: server


### PR DESCRIPTION
As having 3 replicas of metadata-deployment is over-kill, this change updates the replica count from 3 to 1

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/manifests/275)
<!-- Reviewable:end -->
