### PR TITLE
Fix gcp credential

### DIFF
--- a/gcp/basic-auth-ingress/overlays/gcp-credentials/kustomization.yaml
+++ b/gcp/basic-auth-ingress/overlays/gcp-credentials/kustomization.yaml
@@ -2,5 +2,5 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 bases:
 - ../../base
-patches:
+patchesStrategicMerge:
 - gcp-credentials-patch.yaml

--- a/gcp/cloud-endpoints/overlays/gcp-credentials/kustomization.yaml
+++ b/gcp/cloud-endpoints/overlays/gcp-credentials/kustomization.yaml
@@ -2,5 +2,5 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 bases:
 - ../../base
-patches:
+patchesStrategicMerge:
 - gcp-credentials-patch.yaml

--- a/gcp/iap-ingress/overlays/gcp-credentials/kustomization.yaml
+++ b/gcp/iap-ingress/overlays/gcp-credentials/kustomization.yaml
@@ -2,5 +2,5 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 bases:
 - ../../base
-patches:
+patchesStrategicMerge:
 - gcp-credentials-patch.yaml

--- a/tests/basic-auth-ingress-overlays-gcp-credentials_test.go
+++ b/tests/basic-auth-ingress-overlays-gcp-credentials_test.go
@@ -33,13 +33,14 @@ spec:
       volumes:
       - name: sa-key
         secret:
-          secretName: admin-gcp-sa`)
+          secretName: admin-gcp-sa
+`)
 	th.writeK("/manifests/gcp/basic-auth-ingress/overlays/gcp-credentials", `
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 bases:
 - ../../base
-patches:
+patchesStrategicMerge:
 - gcp-credentials-patch.yaml`)
 	th.writeF("/manifests/gcp/basic-auth-ingress/base/cloud-endpoint.yaml", `
 apiVersion: ctl.isla.solutions/v1

--- a/tests/cloud-endpoints-overlays-gcp-credentials_test.go
+++ b/tests/cloud-endpoints-overlays-gcp-credentials_test.go
@@ -33,13 +33,14 @@ spec:
       volumes:
       - name: sa-key
         secret:
-          secretName: admin-gcp-sa`)
+          secretName: admin-gcp-sa
+`)
 	th.writeK("/manifests/gcp/cloud-endpoints/overlays/gcp-credentials", `
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 bases:
 - ../../base
-patches:
+patchesStrategicMerge:
 - gcp-credentials-patch.yaml`)
 	th.writeF("/manifests/gcp/cloud-endpoints/base/cluster-role-binding.yaml", `
 apiVersion: rbac.authorization.k8s.io/v1beta1

--- a/tests/iap-ingress-base_test.go
+++ b/tests/iap-ingress-base_test.go
@@ -542,7 +542,8 @@ varReference:
 - path: data/healthcheck_route.yaml
   kind: ConfigMap
 - path: spec/domains
-  kind: ManagedCertificate`)
+  kind: ManagedCertificate
+`)
 	th.writeF("/manifests/gcp/iap-ingress/base/params.env", `
 namespace=kubeflow
 appName=kubeflow
@@ -554,7 +555,8 @@ oauthSecretName=kubeflow-oauth
 project=
 adminSaSecretName=admin-gcp-sa
 tlsSecretName=envoy-ingress-tls
-istioNamespace=istio-system`)
+istioNamespace=istio-system
+`)
 	th.writeK("/manifests/gcp/iap-ingress/base", `
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization

--- a/tests/iap-ingress-overlays-certmanager_test.go
+++ b/tests/iap-ingress-overlays-certmanager_test.go
@@ -619,7 +619,8 @@ varReference:
 - path: data/healthcheck_route.yaml
   kind: ConfigMap
 - path: spec/domains
-  kind: ManagedCertificate`)
+  kind: ManagedCertificate
+`)
 	th.writeF("/manifests/gcp/iap-ingress/base/params.env", `
 namespace=kubeflow
 appName=kubeflow
@@ -631,7 +632,8 @@ oauthSecretName=kubeflow-oauth
 project=
 adminSaSecretName=admin-gcp-sa
 tlsSecretName=envoy-ingress-tls
-istioNamespace=istio-system`)
+istioNamespace=istio-system
+`)
 	th.writeK("/manifests/gcp/iap-ingress/base", `
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization

--- a/tests/iap-ingress-overlays-gcp-credentials_test.go
+++ b/tests/iap-ingress-overlays-gcp-credentials_test.go
@@ -54,13 +54,14 @@ spec:
       volumes:
       - name: sa-key
         secret:
-          secretName: admin-gcp-sa`)
+          secretName: admin-gcp-sa
+`)
 	th.writeK("/manifests/gcp/iap-ingress/overlays/gcp-credentials", `
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 bases:
 - ../../base
-patches:
+patchesStrategicMerge:
 - gcp-credentials-patch.yaml`)
 	th.writeF("/manifests/gcp/iap-ingress/base/backend-config.yaml", `
 apiVersion: cloud.google.com/v1beta1
@@ -592,7 +593,8 @@ varReference:
 - path: data/healthcheck_route.yaml
   kind: ConfigMap
 - path: spec/domains
-  kind: ManagedCertificate`)
+  kind: ManagedCertificate
+`)
 	th.writeF("/manifests/gcp/iap-ingress/base/params.env", `
 namespace=kubeflow
 appName=kubeflow
@@ -604,7 +606,8 @@ oauthSecretName=kubeflow-oauth
 project=
 adminSaSecretName=admin-gcp-sa
 tlsSecretName=envoy-ingress-tls
-istioNamespace=istio-system`)
+istioNamespace=istio-system
+`)
 	th.writeK("/manifests/gcp/iap-ingress/base", `
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization

--- a/tests/iap-ingress-overlays-managed-cert_test.go
+++ b/tests/iap-ingress-overlays-managed-cert_test.go
@@ -562,7 +562,8 @@ varReference:
 - path: data/healthcheck_route.yaml
   kind: ConfigMap
 - path: spec/domains
-  kind: ManagedCertificate`)
+  kind: ManagedCertificate
+`)
 	th.writeF("/manifests/gcp/iap-ingress/base/params.env", `
 namespace=kubeflow
 appName=kubeflow
@@ -574,7 +575,8 @@ oauthSecretName=kubeflow-oauth
 project=
 adminSaSecretName=admin-gcp-sa
 tlsSecretName=envoy-ingress-tls
-istioNamespace=istio-system`)
+istioNamespace=istio-system
+`)
 	th.writeK("/manifests/gcp/iap-ingress/base", `
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization


### PR DESCRIPTION
**Which issue is resolved by this Pull Request:**
Fix gcp credential problem.

**Description of your changes:**
explicitly use patchStrategicMerge instead of patch.
Although kustomize supports patchStrategicMerge, patch, and patchJson6902,
https://github.com/kubernetes-sigs/kustomize/blob/master/docs/glossary.md#patchstrategicmerge

Our kustomize.go only checks patchStrategicMerge and patchJson6902
https://github.com/kubeflow/kubeflow/blob/b376b38268ce6ccec2522aa7ab88c9ec36d705a6////bootstrap/pkg/kfapp/kustomize/kustomize.go#L979

related: https://github.com/kubeflow/kubeflow/issues/3905

**Checklist:**
- [x] Unit tests have been rebuilt: 
    1. `cd manifests/tests`
    2. `make generate`
    3. `make test`

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/manifests/278)
<!-- Reviewable:end -->

