### PR TITLE
fix central dashboard version

### DIFF
--- a/application/application/overlays/application/application.yaml
+++ b/application/application/overlays/application/application.yaml
@@ -11,9 +11,9 @@ spec:
   componentKinds:
     - group: app.k8s.io
       kind: Application
-  descriptor: 
+  descriptor:
     type: kubeflow
-    version: v1beta1
+    version: v0.6.2
     description: application that aggregates all kubeflow applications
     maintainers:
     - name: Jeremy Lewi


### PR DESCRIPTION
Relates to kubeflow/kubeflow#3875

Fix central dashboard version.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/manifests/297)
<!-- Reviewable:end -->
