### PR TITLE
[CentralDashboard v2] Added env_var for KFAM Server address

### DIFF
--- a/common/centraldashboard/base/deployment.yaml
+++ b/common/centraldashboard/base/deployment.yaml
@@ -27,5 +27,5 @@ spec:
         - name: USERID_PREFIX
           value: $(userid-prefix)
         - name: PROFILES_KFAM_SERVICE_HOST
-          value: profiles-kfam
+          value: profiles-kfam.kubeflow
       serviceAccountName: centraldashboard

--- a/common/centraldashboard/base/deployment.yaml
+++ b/common/centraldashboard/base/deployment.yaml
@@ -26,4 +26,6 @@ spec:
           value: $(userid-header)
         - name: USERID_PREFIX
           value: $(userid-prefix)
+        - name: PROFILES_KFAM_SERVICE_HOST
+          value: profiles-kfam
       serviceAccountName: centraldashboard

--- a/tests/centraldashboard-base_test.go
+++ b/tests/centraldashboard-base_test.go
@@ -76,6 +76,8 @@ spec:
           value: $(userid-header)
         - name: USERID_PREFIX
           value: $(userid-prefix)
+        - name: PROFILES_KFAM_SERVICE_HOST
+          value: profiles-kfam.kubeflow
       serviceAccountName: centraldashboard
 `)
 	th.writeF("/manifests/common/centraldashboard/base/role-binding.yaml", `

--- a/tests/centraldashboard-overlays-application_test.go
+++ b/tests/centraldashboard-overlays-application_test.go
@@ -145,6 +145,8 @@ spec:
           value: $(userid-header)
         - name: USERID_PREFIX
           value: $(userid-prefix)
+        - name: PROFILES_KFAM_SERVICE_HOST
+          value: profiles-kfam.kubeflow
       serviceAccountName: centraldashboard
 `)
 	th.writeF("/manifests/common/centraldashboard/base/role-binding.yaml", `

--- a/tests/centraldashboard-overlays-istio_test.go
+++ b/tests/centraldashboard-overlays-istio_test.go
@@ -114,6 +114,8 @@ spec:
           value: $(userid-header)
         - name: USERID_PREFIX
           value: $(userid-prefix)
+        - name: PROFILES_KFAM_SERVICE_HOST
+          value: profiles-kfam.kubeflow
       serviceAccountName: centraldashboard
 `)
 	th.writeF("/manifests/common/centraldashboard/base/role-binding.yaml", `


### PR DESCRIPTION
#### fix for kubeflow/kubeflow#3900

## About
Added an environment variable to central dash to target the correct KFAM target

### Meta
/area centraldashboard
/area front-end
/priority p0
/assign @avdaredevil
/cc @prodonjs @kunmingg @abhi-g

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/manifests/298)
<!-- Reviewable:end -->
