### PR TITLE
adds make generate to the test workflow

### DIFF
--- a/tests/scripts/run-tests.sh
+++ b/tests/scripts/run-tests.sh
@@ -20,10 +20,19 @@ set -o errexit
 set -o nounset
 set -o pipefail
 
-cd tests
-
 # the tests depend on kustomize
 export PATH=${GOPATH}/bin:/usr/local/go/bin:${PATH}
 export GO111MODULE=on
 go get sigs.k8s.io/kustomize
-make test
+
+# Generate Go files on upstream HEAD 
+cd /src/kubeflow/manifests/tests
+make generate
+cd -
+if diff /src/kubeflow/manifests/tests/*.go tests/*.go ; then
+    cd tests
+    make test
+else
+    echo "Tests failed. Please run `make generate` and re-run tests"
+    exit 1
+fi

--- a/tests/workflows/components/workflows.libsonnet
+++ b/tests/workflows/components/workflows.libsonnet
@@ -202,7 +202,7 @@
                 ],
                 env: prow_env + [{
                   name: "EXTRA_REPOS",
-                  value: "kubeflow/testing@HEAD",
+                  value: "kubeflow/testing@HEAD,kubeflow/manifests@HEAD",
                 }],
                 image: testWorkerImage,
                 volumeMounts: [


### PR DESCRIPTION
**Which issue is resolved by this Pull Request:**
Resolves #
https://github.com/kubeflow/manifests/issues/296

**Description of your changes:**
Adds `make generate` as part of the test workflow after checkout of the manifests repo.


**Checklist:**
- [x] Unit tests have been rebuilt: 
    1. `cd manifests/tests`
    2. `make generate`
    3. `make test`

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/manifests/299)
<!-- Reviewable:end -->
