### PR TITLE
Ambassador overlay

### DIFF
--- a/katib-v1alpha2/katib-ui/base/params.yaml
+++ b/katib-v1alpha2/katib-ui/base/params.yaml
@@ -3,5 +3,3 @@ varReference:
   kind: ConfigMap
 - path: data/config
   kind: Deployment
-- path: metadata/annotations/getambassador.io\/config
-  kind: Service

--- a/katib-v1alpha2/katib-ui/overlays/ambassador/katib-ui-service.yaml
+++ b/katib-v1alpha2/katib-ui/overlays/ambassador/katib-ui-service.yaml
@@ -1,0 +1,12 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: katib-ui
+  annotations:
+    getambassador.io/config: |-
+      ---
+      apiVersion: ambassador/v0
+      kind:  Mapping
+      name: katib-ui-mapping
+      prefix: /katib/
+      service: katib-ui.$(namespace)

--- a/katib-v1alpha2/katib-ui/overlays/ambassador/kustomization.yaml
+++ b/katib-v1alpha2/katib-ui/overlays/ambassador/kustomization.yaml
@@ -1,0 +1,9 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+bases:
+- ../../base
+patchesStrategicMerge:
+- katib-ui-service.yaml
+configurations:
+- params.yaml
+

--- a/katib-v1alpha2/katib-ui/overlays/ambassador/params.yaml
+++ b/katib-v1alpha2/katib-ui/overlays/ambassador/params.yaml
@@ -1,0 +1,3 @@
+varReference:
+- path: metadata/annotations/getambassador.io\/config
+  kind: Service

--- a/metadata/overlays/ambassador/kustomization.yaml
+++ b/metadata/overlays/ambassador/kustomization.yaml
@@ -1,0 +1,9 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+bases:
+- ../../base
+patchesStrategicMerge:
+- metadata-ui-service.yaml
+configurations:
+- params.yaml
+

--- a/metadata/overlays/ambassador/metadata-ui-service.yaml
+++ b/metadata/overlays/ambassador/metadata-ui-service.yaml
@@ -1,0 +1,12 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: ui
+  annotations:
+    getambassador.io/config: |-
+      ---
+      apiVersion: ambassador/v0
+      kind:  Mapping
+      name: metadata-ui-mapping
+      prefix: /metadata/
+      service: metadata-ui.$(namespace)

--- a/metadata/overlays/ambassador/params.yaml
+++ b/metadata/overlays/ambassador/params.yaml
@@ -1,0 +1,3 @@
+varReference:
+- path: metadata/annotations/getambassador.io\/config
+  kind: Service

--- a/tests/katib-ui-overlays-application_test.go
+++ b/tests/katib-ui-overlays-application_test.go
@@ -174,8 +174,6 @@ varReference:
   kind: ConfigMap
 - path: data/config
   kind: Deployment
-- path: metadata/annotations/getambassador.io\/config
-  kind: Service
 `)
 	th.writeF("/manifests/katib-v1alpha2/katib-ui/base/params.env", `
 clusterDomain=cluster.local

--- a/tests/katib-ui-overlays-istio_test.go
+++ b/tests/katib-ui-overlays-istio_test.go
@@ -138,8 +138,6 @@ varReference:
   kind: ConfigMap
 - path: data/config
   kind: Deployment
-- path: metadata/annotations/getambassador.io\/config
-  kind: Service
 `)
 	th.writeF("/manifests/katib-v1alpha2/katib-ui/base/params.env", `
 clusterDomain=cluster.local

--- a/tests/metadata-overlays-ambassador_test.go
+++ b/tests/metadata-overlays-ambassador_test.go
@@ -1,0 +1,349 @@
+package tests_test
+
+import (
+	"sigs.k8s.io/kustomize/k8sdeps/kunstruct"
+	"sigs.k8s.io/kustomize/k8sdeps/transformer"
+	"sigs.k8s.io/kustomize/pkg/fs"
+	"sigs.k8s.io/kustomize/pkg/loader"
+	"sigs.k8s.io/kustomize/pkg/resmap"
+	"sigs.k8s.io/kustomize/pkg/resource"
+	"sigs.k8s.io/kustomize/pkg/target"
+	"testing"
+)
+
+func writeMetadataOverlaysAmbassador(th *KustTestHarness) {
+	th.writeF("/manifests/metadata/overlays/ambassador/metadata-ui-service.yaml", `
+apiVersion: v1
+kind: Service
+metadata:
+  name: ui
+  annotations:
+    getambassador.io/config: |-
+      ---
+      apiVersion: ambassador/v0
+      kind:  Mapping
+      name: metadata-ui-mapping
+      prefix: /metadata/
+      service: metadata-ui.$(namespace)
+`)
+	th.writeF("/manifests/metadata/overlays/ambassador/params.yaml", `
+varReference:
+- path: metadata/annotations/getambassador.io\/config
+  kind: Service
+`)
+	th.writeK("/manifests/metadata/overlays/ambassador", `
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+bases:
+- ../../base
+patchesStrategicMerge:
+- metadata-ui-service.yaml
+configurations:
+- params.yaml
+
+`)
+	th.writeF("/manifests/metadata/base/metadata-db-pvc.yaml", `
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: mysql
+spec:
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: 10Gi
+`)
+	th.writeF("/manifests/metadata/base/metadata-db-secret.yaml", `
+apiVersion: v1
+kind: Secret
+type: Opaque
+metadata:
+  name: db-secrets
+data:
+  MYSQL_ROOT_PASSWORD: dGVzdA== # "test"
+`)
+	th.writeF("/manifests/metadata/base/metadata-db-deployment.yaml", `
+apiVersion: extensions/v1beta1
+kind: Deployment
+metadata:
+  name: db
+  labels:
+    component: db
+spec:
+  replicas: 1
+  template:
+    metadata:
+      name: db
+      labels:
+        component: db
+    spec:
+      containers:
+      - name: db-container
+        image: mysql:8.0.3
+        args:
+        - --datadir
+        - /var/lib/mysql/datadir
+        env:
+          - name: MYSQL_ROOT_PASSWORD
+            valueFrom:
+              secretKeyRef:
+                name: metadata-db-secrets
+                key: MYSQL_ROOT_PASSWORD
+          - name: MYSQL_ALLOW_EMPTY_PASSWORD
+            value: "true"
+          - name: MYSQL_DATABASE
+            value: "metadb"
+        ports:
+        - name: dbapi
+          containerPort: 3306
+        readinessProbe:
+          exec:
+            command:
+            - "/bin/bash"
+            - "-c"
+            - "mysql -D $$MYSQL_DATABASE -p$$MYSQL_ROOT_PASSWORD -e 'SELECT 1'"
+          initialDelaySeconds: 5
+          periodSeconds: 2
+          timeoutSeconds: 1
+        volumeMounts:
+        - name: metadata-mysql
+          mountPath: /var/lib/mysql
+      volumes:
+      - name: metadata-mysql
+        persistentVolumeClaim:
+          claimName: metadata-mysql
+`)
+	th.writeF("/manifests/metadata/base/metadata-db-service.yaml", `
+apiVersion: v1
+kind: Service
+metadata:
+  name: db
+  labels:
+    component: db
+spec:
+  type: ClusterIP
+  ports:
+    - port: 3306
+      protocol: TCP
+      name: dbapi
+  selector:
+    component: db
+`)
+	th.writeF("/manifests/metadata/base/metadata-deployment.yaml", `
+apiVersion: extensions/v1beta1
+kind: Deployment
+metadata:
+  name: deployment
+  labels:
+    component: server
+spec:
+  replicas: 3
+  selector:
+    matchLabels:
+      component: server
+  template:
+    metadata:
+      labels:
+        component: server
+    spec:
+      containers:
+      - name: container
+        image: gcr.io/kubeflow-images-public/metadata:v0.1.8
+        env:
+          - name: MYSQL_ROOT_PASSWORD
+            valueFrom:
+              secretKeyRef:
+                name: metadata-db-secrets
+                key: MYSQL_ROOT_PASSWORD
+        command: ["./server/server",
+                  "--http_port=8080",
+                  "--mysql_service_host=metadata-db.kubeflow",
+                  "--mysql_service_port=3306",
+                  "--mysql_service_user=root",
+                  "--mysql_service_password=$(MYSQL_ROOT_PASSWORD)",
+                  "--mlmd_db_name=metadb"]
+        ports:
+        - name: backendapi
+          containerPort: 8080
+`)
+	th.writeF("/manifests/metadata/base/metadata-service.yaml", `
+kind: Service
+apiVersion: v1
+metadata:
+  labels:
+    app: metadata
+  name: service
+spec:
+  selector:
+    component: server
+  type: ClusterIP
+  ports:
+  - port: 8080
+    protocol: TCP
+    name: backendapi
+`)
+	th.writeF("/manifests/metadata/base/metadata-ui-deployment.yaml", `
+apiVersion: apps/v1beta2
+kind: Deployment
+metadata:
+  name: ui
+  labels:
+    app: metadata-ui
+spec:
+  selector:
+    matchLabels:
+      app: metadata-ui
+  template:
+    metadata:
+      name: ui
+      labels:
+        app: metadata-ui
+    spec:
+      containers:
+      - image: gcr.io/kubeflow-images-public/metadata-frontend:v0.1.8
+        imagePullPolicy: IfNotPresent
+        name: metadata-ui
+        ports:
+        - containerPort: 3000
+      serviceAccountName: ui
+
+`)
+	th.writeF("/manifests/metadata/base/metadata-ui-role.yaml", `
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: Role
+metadata:
+  labels:
+    app: metadata-ui
+  name: ui
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - pods
+  - pods/log
+  verbs:
+  - create
+  - get
+  - list
+- apiGroups:
+  - "kubeflow.org"
+  resources:
+  - viewers
+  verbs:
+  - create
+  - get
+  - list
+  - watch
+  - delete
+`)
+	th.writeF("/manifests/metadata/base/metadata-ui-rolebinding.yaml", `
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: RoleBinding
+metadata:
+  labels:
+    app: metadata-ui
+  name: ui
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: ui
+subjects:
+- kind: ServiceAccount
+  name: ui
+  namespace: kubeflow
+`)
+	th.writeF("/manifests/metadata/base/metadata-ui-sa.yaml", `
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: ui
+`)
+	th.writeF("/manifests/metadata/base/metadata-ui-service.yaml", `
+apiVersion: v1
+kind: Service
+metadata:
+  name: ui
+  labels:
+    app: metadata-ui
+spec:
+  ports:
+  - port: 80
+    targetPort: 3000
+  selector:
+    app: metadata-ui
+`)
+	th.writeF("/manifests/metadata/base/params.env", `
+uiClusterDomain=cluster.local
+`)
+	th.writeK("/manifests/metadata/base", `
+namePrefix: metadata-
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+commonLabels:
+  kustomize.component: metadata
+configMapGenerator:
+- name: ui-parameters
+  env: params.env
+resources:
+- metadata-db-pvc.yaml
+- metadata-db-secret.yaml
+- metadata-db-deployment.yaml
+- metadata-db-service.yaml
+- metadata-deployment.yaml
+- metadata-service.yaml
+- metadata-ui-deployment.yaml
+- metadata-ui-role.yaml
+- metadata-ui-rolebinding.yaml
+- metadata-ui-sa.yaml
+- metadata-ui-service.yaml
+namespace: kubeflow
+vars:
+- name: ui-namespace
+  objref:
+    kind: Service
+    name: ui
+    apiVersion: v1
+  fieldref:
+    fieldpath: metadata.namespace
+- name: ui-clusterDomain
+  objref:
+    kind: ConfigMap
+    name: ui-parameters
+    version: v1
+  fieldref:
+    fieldpath: data.uiClusterDomain
+- name: service
+  objref:
+    kind: Service
+    name: ui
+    apiVersion: v1
+  fieldref:
+    fieldpath: metadata.name`)
+}
+
+func TestMetadataOverlaysAmbassador(t *testing.T) {
+	th := NewKustTestHarness(t, "/manifests/metadata/overlays/ambassador")
+	writeMetadataOverlaysAmbassador(th)
+	m, err := th.makeKustTarget().MakeCustomizedResMap()
+	if err != nil {
+		t.Fatalf("Err: %v", err)
+	}
+	targetPath := "../metadata/overlays/ambassador"
+	fsys := fs.MakeRealFS()
+	_loader, loaderErr := loader.NewLoader(targetPath, fsys)
+	if loaderErr != nil {
+		t.Fatalf("could not load kustomize loader: %v", loaderErr)
+	}
+	rf := resmap.NewFactory(resource.NewFactory(kunstruct.NewKunstructuredFactoryImpl()))
+	kt, err := target.NewKustTarget(_loader, rf, transformer.NewFactoryImpl())
+	if err != nil {
+		th.t.Fatalf("Unexpected construction error %v", err)
+	}
+	n, err := kt.MakeCustomizedResMap()
+	if err != nil {
+		t.Fatalf("Err: %v", err)
+	}
+	expected, err := n.EncodeAsYaml()
+	th.assertActualEqualsExpected(m, string(expected))
+}


### PR DESCRIPTION
**Which issue is resolved by this Pull Request:**
Resolves #3850

**Description of your changes:**
Ambassador overlay for katib and metadata, which adds corresponding annotations for ambassador. Other components add the ambassador configuration in the base, however this is a cleaner approach and closer to the kustomize philosophy.

**Checklist:**
- [+] Unit tests have been rebuilt: 
    1. `cd manifests/tests`
    2. `make generate`
    3. `make test`

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/manifests/300)
<!-- Reviewable:end -->
