### PR TITLE
Automated cherry pick of #274: central dashboard: parameterize userid-{header, prefix} Cherry pick of #274 on v0.6-branch. #274: central dashboard: parameterize userid-{header, prefix}

### DIFF
--- a/common/centraldashboard/base/kustomization.yaml
+++ b/common/centraldashboard/base/kustomization.yaml
@@ -35,6 +35,20 @@ vars:
     apiVersion: v1
   fieldref:
     fieldpath: data.clusterDomain
+- name: userid-header
+  objref:
+    kind: ConfigMap
+    name: parameters
+    apiVersion: v1
+  fieldref:
+    fieldpath: data.userid-header
+- name: userid-prefix
+  objref:
+    kind: ConfigMap
+    name: parameters
+    apiVersion: v1
+  fieldref:
+    fieldpath: data.userid-prefix
 configurations:
 - params.yaml
 

--- a/common/centraldashboard/base/params.env
+++ b/common/centraldashboard/base/params.env
@@ -1,1 +1,3 @@
 clusterDomain=cluster.local
+userid-header=
+userid-prefix=

--- a/common/centraldashboard/base/params.yaml
+++ b/common/centraldashboard/base/params.yaml
@@ -3,3 +3,7 @@ varReference:
   kind: Service
 - path: spec/http/route/destination/host
   kind: VirtualService
+- path: spec/template/spec/containers/0/env/0/value
+  kind: Deployment
+- path: spec/template/spec/containers/0/env/1/value
+  kind: Deployment

--- a/jupyter/jupyter-web-app/base/deployment.yaml
+++ b/jupyter/jupyter-web-app/base/deployment.yaml
@@ -18,6 +18,10 @@ spec:
             configMapKeyRef:
               name: parameters
               key: UI
+        - name: USERID_HEADER
+          value: $(userid-header)
+        - name: USERID_PREFIX
+          value: $(userid-prefix)
         image: gcr.io/kubeflow-images-public/jupyter-web-app:v0.5.0
         imagePullPolicy: $(policy)
         name: jupyter-web-app

--- a/jupyter/jupyter-web-app/base/kustomization.yaml
+++ b/jupyter/jupyter-web-app/base/kustomization.yaml
@@ -52,5 +52,19 @@ vars:
     apiVersion: v1
   fieldref:
     fieldpath: metadata.namespace
+- name: userid-header
+  objref:
+    kind: ConfigMap
+    name: parameters
+    apiVersion: v1
+  fieldref:
+    fieldpath: data.userid-header
+- name: userid-prefix
+  objref:
+    kind: ConfigMap
+    name: parameters
+    apiVersion: v1
+  fieldref:
+    fieldpath: data.userid-prefix
 configurations:
 - params.yaml

--- a/jupyter/jupyter-web-app/base/params.env
+++ b/jupyter/jupyter-web-app/base/params.env
@@ -3,3 +3,5 @@ ROK_SECRET_NAME=secret-rok-{username}
 policy=Always
 prefix=jupyter
 clusterDomain=cluster.local
+userid-header=
+userid-prefix=

--- a/jupyter/jupyter-web-app/base/params.yaml
+++ b/jupyter/jupyter-web-app/base/params.yaml
@@ -3,3 +3,7 @@ varReference:
   kind: Deployment
 - path: metadata/annotations/getambassador.io\/config
   kind: Service
+- path: spec/template/spec/containers/0/env/2/value
+  kind: Deployment
+- path: spec/template/spec/containers/0/env/3/value
+  kind: Deployment

--- a/profiles/base/deployment.yaml
+++ b/profiles/base/deployment.yaml
@@ -8,6 +8,11 @@ spec:
       containers:
       - command:
         - /manager
+        args:
+        - "-userid-header"
+        - $(userid-header)
+        - "-userid-prefix"
+        - $(userid-prefix)
         image: gcr.io/kubeflow-images-public/profile-controller:v20190619-v0-219-gbd3daa8c-dirty-1ced0e
         imagePullPolicy: Always
         name: manager
@@ -16,6 +21,10 @@ spec:
         args:
         - "-cluster-admin"
         - $(admin)
+        - "-userid-header"
+        - $(userid-header)
+        - "-userid-prefix"
+        - $(userid-prefix)
         image: gcr.io/kubeflow-images-public/kfam:v20190612-v0-170-ga06cdb79-dirty-a33ee4
         imagePullPolicy: Always
         name: kfam

--- a/profiles/base/kustomization.yaml
+++ b/profiles/base/kustomization.yaml
@@ -27,6 +27,20 @@ vars:
       apiVersion: v1
     fieldref:
       fieldpath: data.admin
+  - name: userid-header
+    objref:
+      kind: ConfigMap
+      name: profiles-parameters
+      apiVersion: v1
+    fieldref:
+      fieldpath: data.userid-header
+  - name: userid-prefix
+    objref:
+      kind: ConfigMap
+      name: profiles-parameters
+      apiVersion: v1
+    fieldref:
+      fieldpath: data.userid-prefix
   - name: namespace
     objref:
       kind: Service

--- a/profiles/base/params.env
+++ b/profiles/base/params.env
@@ -1,1 +1,3 @@
 admin=
+userid-header=
+userid-prefix=

--- a/profiles/base/params.yaml
+++ b/profiles/base/params.yaml
@@ -1,4 +1,11 @@
 varReference:
+- path: spec/template/spec/containers/0/args/1
+  kind: Deployment
+- path: spec/template/spec/containers/0/args/3
+  kind: Deployment
 - path: spec/template/spec/containers/1/args/1
   kind: Deployment
-
+- path: spec/template/spec/containers/1/args/3
+  kind: Deployment
+- path: spec/template/spec/containers/1/args/5
+  kind: Deployment

--- a/tests/centraldashboard-base_test.go
+++ b/tests/centraldashboard-base_test.go
@@ -76,8 +76,11 @@ spec:
           value: $(userid-header)
         - name: USERID_PREFIX
           value: $(userid-prefix)
+<<<<<<< HEAD
         - name: PROFILES_KFAM_SERVICE_HOST
           value: profiles-kfam.kubeflow
+=======
+>>>>>>> regenerate tests
       serviceAccountName: centraldashboard
 `)
 	th.writeF("/manifests/common/centraldashboard/base/role-binding.yaml", `
@@ -161,10 +164,14 @@ varReference:
   kind: Service
 - path: spec/http/route/destination/host
   kind: VirtualService
-`)
+- path: spec/template/spec/containers/0/env/0/value
+  kind: Deployment
+- path: spec/template/spec/containers/0/env/1/value
+  kind: Deployment`)
 	th.writeF("/manifests/common/centraldashboard/base/params.env", `
 clusterDomain=cluster.local
-`)
+userid-header=
+userid-prefix=`)
 	th.writeK("/manifests/common/centraldashboard/base", `
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
@@ -203,6 +210,20 @@ vars:
     apiVersion: v1
   fieldref:
     fieldpath: data.clusterDomain
+- name: userid-header
+  objref:
+    kind: ConfigMap
+    name: parameters
+    apiVersion: v1
+  fieldref:
+    fieldpath: data.userid-header
+- name: userid-prefix
+  objref:
+    kind: ConfigMap
+    name: parameters
+    apiVersion: v1
+  fieldref:
+    fieldpath: data.userid-prefix
 configurations:
 - params.yaml
 

--- a/tests/centraldashboard-overlays-application_test.go
+++ b/tests/centraldashboard-overlays-application_test.go
@@ -230,10 +230,14 @@ varReference:
   kind: Service
 - path: spec/http/route/destination/host
   kind: VirtualService
-`)
+- path: spec/template/spec/containers/0/env/0/value
+  kind: Deployment
+- path: spec/template/spec/containers/0/env/1/value
+  kind: Deployment`)
 	th.writeF("/manifests/common/centraldashboard/base/params.env", `
 clusterDomain=cluster.local
-`)
+userid-header=
+userid-prefix=`)
 	th.writeK("/manifests/common/centraldashboard/base", `
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
@@ -272,6 +276,20 @@ vars:
     apiVersion: v1
   fieldref:
     fieldpath: data.clusterDomain
+- name: userid-header
+  objref:
+    kind: ConfigMap
+    name: parameters
+    apiVersion: v1
+  fieldref:
+    fieldpath: data.userid-header
+- name: userid-prefix
+  objref:
+    kind: ConfigMap
+    name: parameters
+    apiVersion: v1
+  fieldref:
+    fieldpath: data.userid-prefix
 configurations:
 - params.yaml
 

--- a/tests/centraldashboard-overlays-istio_test.go
+++ b/tests/centraldashboard-overlays-istio_test.go
@@ -199,10 +199,14 @@ varReference:
   kind: Service
 - path: spec/http/route/destination/host
   kind: VirtualService
-`)
+- path: spec/template/spec/containers/0/env/0/value
+  kind: Deployment
+- path: spec/template/spec/containers/0/env/1/value
+  kind: Deployment`)
 	th.writeF("/manifests/common/centraldashboard/base/params.env", `
 clusterDomain=cluster.local
-`)
+userid-header=
+userid-prefix=`)
 	th.writeK("/manifests/common/centraldashboard/base", `
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
@@ -241,6 +245,20 @@ vars:
     apiVersion: v1
   fieldref:
     fieldpath: data.clusterDomain
+- name: userid-header
+  objref:
+    kind: ConfigMap
+    name: parameters
+    apiVersion: v1
+  fieldref:
+    fieldpath: data.userid-header
+- name: userid-prefix
+  objref:
+    kind: ConfigMap
+    name: parameters
+    apiVersion: v1
+  fieldref:
+    fieldpath: data.userid-prefix
 configurations:
 - params.yaml
 

--- a/tests/jupyter-web-app-base_test.go
+++ b/tests/jupyter-web-app-base_test.go
@@ -234,6 +234,10 @@ spec:
             configMapKeyRef:
               name: parameters
               key: UI
+        - name: USERID_HEADER
+          value: $(userid-header)
+        - name: USERID_PREFIX
+          value: $(userid-prefix)
         image: gcr.io/kubeflow-images-public/jupyter-web-app:v0.5.0
         imagePullPolicy: $(policy)
         name: jupyter-web-app
@@ -335,14 +339,18 @@ varReference:
   kind: Deployment
 - path: metadata/annotations/getambassador.io\/config
   kind: Service
-`)
+- path: spec/template/spec/containers/0/env/2/value
+  kind: Deployment
+- path: spec/template/spec/containers/0/env/3/value
+  kind: Deployment`)
 	th.writeF("/manifests/jupyter/jupyter-web-app/base/params.env", `
 UI=default
 ROK_SECRET_NAME=secret-rok-{username}
 policy=Always
 prefix=jupyter
 clusterDomain=cluster.local
-`)
+userid-header=
+userid-prefix=`)
 	th.writeK("/manifests/jupyter/jupyter-web-app/base", `
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
@@ -398,6 +406,20 @@ vars:
     apiVersion: v1
   fieldref:
     fieldpath: metadata.namespace
+- name: userid-header
+  objref:
+    kind: ConfigMap
+    name: parameters
+    apiVersion: v1
+  fieldref:
+    fieldpath: data.userid-header
+- name: userid-prefix
+  objref:
+    kind: ConfigMap
+    name: parameters
+    apiVersion: v1
+  fieldref:
+    fieldpath: data.userid-prefix
 configurations:
 - params.yaml
 `)

--- a/tests/jupyter-web-app-overlays-application_test.go
+++ b/tests/jupyter-web-app-overlays-application_test.go
@@ -298,6 +298,10 @@ spec:
             configMapKeyRef:
               name: parameters
               key: UI
+        - name: USERID_HEADER
+          value: $(userid-header)
+        - name: USERID_PREFIX
+          value: $(userid-prefix)
         image: gcr.io/kubeflow-images-public/jupyter-web-app:v0.5.0
         imagePullPolicy: $(policy)
         name: jupyter-web-app
@@ -399,14 +403,18 @@ varReference:
   kind: Deployment
 - path: metadata/annotations/getambassador.io\/config
   kind: Service
-`)
+- path: spec/template/spec/containers/0/env/2/value
+  kind: Deployment
+- path: spec/template/spec/containers/0/env/3/value
+  kind: Deployment`)
 	th.writeF("/manifests/jupyter/jupyter-web-app/base/params.env", `
 UI=default
 ROK_SECRET_NAME=secret-rok-{username}
 policy=Always
 prefix=jupyter
 clusterDomain=cluster.local
-`)
+userid-header=
+userid-prefix=`)
 	th.writeK("/manifests/jupyter/jupyter-web-app/base", `
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
@@ -462,6 +470,20 @@ vars:
     apiVersion: v1
   fieldref:
     fieldpath: metadata.namespace
+- name: userid-header
+  objref:
+    kind: ConfigMap
+    name: parameters
+    apiVersion: v1
+  fieldref:
+    fieldpath: data.userid-header
+- name: userid-prefix
+  objref:
+    kind: ConfigMap
+    name: parameters
+    apiVersion: v1
+  fieldref:
+    fieldpath: data.userid-prefix
 configurations:
 - params.yaml
 `)

--- a/tests/jupyter-web-app-overlays-istio_test.go
+++ b/tests/jupyter-web-app-overlays-istio_test.go
@@ -273,6 +273,10 @@ spec:
             configMapKeyRef:
               name: parameters
               key: UI
+        - name: USERID_HEADER
+          value: $(userid-header)
+        - name: USERID_PREFIX
+          value: $(userid-prefix)
         image: gcr.io/kubeflow-images-public/jupyter-web-app:v0.5.0
         imagePullPolicy: $(policy)
         name: jupyter-web-app
@@ -374,14 +378,18 @@ varReference:
   kind: Deployment
 - path: metadata/annotations/getambassador.io\/config
   kind: Service
-`)
+- path: spec/template/spec/containers/0/env/2/value
+  kind: Deployment
+- path: spec/template/spec/containers/0/env/3/value
+  kind: Deployment`)
 	th.writeF("/manifests/jupyter/jupyter-web-app/base/params.env", `
 UI=default
 ROK_SECRET_NAME=secret-rok-{username}
 policy=Always
 prefix=jupyter
 clusterDomain=cluster.local
-`)
+userid-header=
+userid-prefix=`)
 	th.writeK("/manifests/jupyter/jupyter-web-app/base", `
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
@@ -437,6 +445,20 @@ vars:
     apiVersion: v1
   fieldref:
     fieldpath: metadata.namespace
+- name: userid-header
+  objref:
+    kind: ConfigMap
+    name: parameters
+    apiVersion: v1
+  fieldref:
+    fieldpath: data.userid-header
+- name: userid-prefix
+  objref:
+    kind: ConfigMap
+    name: parameters
+    apiVersion: v1
+  fieldref:
+    fieldpath: data.userid-prefix
 configurations:
 - params.yaml
 `)

--- a/tests/profiles-base_test.go
+++ b/tests/profiles-base_test.go
@@ -138,6 +138,11 @@ spec:
       containers:
       - command:
         - /manager
+        args:
+        - "-userid-header"
+        - $(userid-header)
+        - "-userid-prefix"
+        - $(userid-prefix)
         image: gcr.io/kubeflow-images-public/profile-controller:v20190619-v0-219-gbd3daa8c-dirty-1ced0e
         imagePullPolicy: Always
         name: manager
@@ -146,6 +151,10 @@ spec:
         args:
         - "-cluster-admin"
         - $(admin)
+        - "-userid-header"
+        - $(userid-header)
+        - "-userid-prefix"
+        - $(userid-prefix)
         image: gcr.io/kubeflow-images-public/kfam:v20190612-v0-170-ga06cdb79-dirty-a33ee4
         imagePullPolicy: Always
         name: kfam
@@ -153,12 +162,20 @@ spec:
 `)
 	th.writeF("/manifests/profiles/base/params.yaml", `
 varReference:
+- path: spec/template/spec/containers/0/args/1
+  kind: Deployment
+- path: spec/template/spec/containers/0/args/3
+  kind: Deployment
 - path: spec/template/spec/containers/1/args/1
   kind: Deployment
-
-`)
+- path: spec/template/spec/containers/1/args/3
+  kind: Deployment
+- path: spec/template/spec/containers/1/args/5
+  kind: Deployment`)
 	th.writeF("/manifests/profiles/base/params.env", `
 admin=
+userid-header=
+userid-prefix=
 `)
 	th.writeK("/manifests/profiles/base", `
 apiVersion: kustomize.config.k8s.io/v1beta1
@@ -190,6 +207,20 @@ vars:
       apiVersion: v1
     fieldref:
       fieldpath: data.admin
+  - name: userid-header
+    objref:
+      kind: ConfigMap
+      name: profiles-parameters
+      apiVersion: v1
+    fieldref:
+      fieldpath: data.userid-header
+  - name: userid-prefix
+    objref:
+      kind: ConfigMap
+      name: profiles-parameters
+      apiVersion: v1
+    fieldref:
+      fieldpath: data.userid-prefix
   - name: namespace
     objref:
       kind: Service

--- a/tests/profiles-overlays-debug_test.go
+++ b/tests/profiles-overlays-debug_test.go
@@ -193,6 +193,11 @@ spec:
       containers:
       - command:
         - /manager
+        args:
+        - "-userid-header"
+        - $(userid-header)
+        - "-userid-prefix"
+        - $(userid-prefix)
         image: gcr.io/kubeflow-images-public/profile-controller:v20190619-v0-219-gbd3daa8c-dirty-1ced0e
         imagePullPolicy: Always
         name: manager
@@ -201,6 +206,10 @@ spec:
         args:
         - "-cluster-admin"
         - $(admin)
+        - "-userid-header"
+        - $(userid-header)
+        - "-userid-prefix"
+        - $(userid-prefix)
         image: gcr.io/kubeflow-images-public/kfam:v20190612-v0-170-ga06cdb79-dirty-a33ee4
         imagePullPolicy: Always
         name: kfam
@@ -208,12 +217,20 @@ spec:
 `)
 	th.writeF("/manifests/profiles/base/params.yaml", `
 varReference:
+- path: spec/template/spec/containers/0/args/1
+  kind: Deployment
+- path: spec/template/spec/containers/0/args/3
+  kind: Deployment
 - path: spec/template/spec/containers/1/args/1
   kind: Deployment
-
-`)
+- path: spec/template/spec/containers/1/args/3
+  kind: Deployment
+- path: spec/template/spec/containers/1/args/5
+  kind: Deployment`)
 	th.writeF("/manifests/profiles/base/params.env", `
 admin=
+userid-header=
+userid-prefix=
 `)
 	th.writeK("/manifests/profiles/base", `
 apiVersion: kustomize.config.k8s.io/v1beta1
@@ -245,6 +262,20 @@ vars:
       apiVersion: v1
     fieldref:
       fieldpath: data.admin
+  - name: userid-header
+    objref:
+      kind: ConfigMap
+      name: profiles-parameters
+      apiVersion: v1
+    fieldref:
+      fieldpath: data.userid-header
+  - name: userid-prefix
+    objref:
+      kind: ConfigMap
+      name: profiles-parameters
+      apiVersion: v1
+    fieldref:
+      fieldpath: data.userid-prefix
   - name: namespace
     objref:
       kind: Service

--- a/tests/profiles-overlays-devices_test.go
+++ b/tests/profiles-overlays-devices_test.go
@@ -164,6 +164,11 @@ spec:
       containers:
       - command:
         - /manager
+        args:
+        - "-userid-header"
+        - $(userid-header)
+        - "-userid-prefix"
+        - $(userid-prefix)
         image: gcr.io/kubeflow-images-public/profile-controller:v20190619-v0-219-gbd3daa8c-dirty-1ced0e
         imagePullPolicy: Always
         name: manager
@@ -172,6 +177,10 @@ spec:
         args:
         - "-cluster-admin"
         - $(admin)
+        - "-userid-header"
+        - $(userid-header)
+        - "-userid-prefix"
+        - $(userid-prefix)
         image: gcr.io/kubeflow-images-public/kfam:v20190612-v0-170-ga06cdb79-dirty-a33ee4
         imagePullPolicy: Always
         name: kfam
@@ -179,12 +188,20 @@ spec:
 `)
 	th.writeF("/manifests/profiles/base/params.yaml", `
 varReference:
+- path: spec/template/spec/containers/0/args/1
+  kind: Deployment
+- path: spec/template/spec/containers/0/args/3
+  kind: Deployment
 - path: spec/template/spec/containers/1/args/1
   kind: Deployment
-
-`)
+- path: spec/template/spec/containers/1/args/3
+  kind: Deployment
+- path: spec/template/spec/containers/1/args/5
+  kind: Deployment`)
 	th.writeF("/manifests/profiles/base/params.env", `
 admin=
+userid-header=
+userid-prefix=
 `)
 	th.writeK("/manifests/profiles/base", `
 apiVersion: kustomize.config.k8s.io/v1beta1
@@ -216,6 +233,20 @@ vars:
       apiVersion: v1
     fieldref:
       fieldpath: data.admin
+  - name: userid-header
+    objref:
+      kind: ConfigMap
+      name: profiles-parameters
+      apiVersion: v1
+    fieldref:
+      fieldpath: data.userid-header
+  - name: userid-prefix
+    objref:
+      kind: ConfigMap
+      name: profiles-parameters
+      apiVersion: v1
+    fieldref:
+      fieldpath: data.userid-prefix
   - name: namespace
     objref:
       kind: Service

--- a/tests/profiles-overlays-istio_test.go
+++ b/tests/profiles-overlays-istio_test.go
@@ -179,6 +179,11 @@ spec:
       containers:
       - command:
         - /manager
+        args:
+        - "-userid-header"
+        - $(userid-header)
+        - "-userid-prefix"
+        - $(userid-prefix)
         image: gcr.io/kubeflow-images-public/profile-controller:v20190619-v0-219-gbd3daa8c-dirty-1ced0e
         imagePullPolicy: Always
         name: manager
@@ -187,6 +192,10 @@ spec:
         args:
         - "-cluster-admin"
         - $(admin)
+        - "-userid-header"
+        - $(userid-header)
+        - "-userid-prefix"
+        - $(userid-prefix)
         image: gcr.io/kubeflow-images-public/kfam:v20190612-v0-170-ga06cdb79-dirty-a33ee4
         imagePullPolicy: Always
         name: kfam
@@ -194,12 +203,20 @@ spec:
 `)
 	th.writeF("/manifests/profiles/base/params.yaml", `
 varReference:
+- path: spec/template/spec/containers/0/args/1
+  kind: Deployment
+- path: spec/template/spec/containers/0/args/3
+  kind: Deployment
 - path: spec/template/spec/containers/1/args/1
   kind: Deployment
-
-`)
+- path: spec/template/spec/containers/1/args/3
+  kind: Deployment
+- path: spec/template/spec/containers/1/args/5
+  kind: Deployment`)
 	th.writeF("/manifests/profiles/base/params.env", `
 admin=
+userid-header=
+userid-prefix=
 `)
 	th.writeK("/manifests/profiles/base", `
 apiVersion: kustomize.config.k8s.io/v1beta1
@@ -231,6 +248,20 @@ vars:
       apiVersion: v1
     fieldref:
       fieldpath: data.admin
+  - name: userid-header
+    objref:
+      kind: ConfigMap
+      name: profiles-parameters
+      apiVersion: v1
+    fieldref:
+      fieldpath: data.userid-header
+  - name: userid-prefix
+    objref:
+      kind: ConfigMap
+      name: profiles-parameters
+      apiVersion: v1
+    fieldref:
+      fieldpath: data.userid-prefix
   - name: namespace
     objref:
       kind: Service


### PR DESCRIPTION
Related to kubeflow/kubeflow#3986
<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/manifests/305)
<!-- Reviewable:end -->
