### PR TITLE
Restores Istio README

### DIFF
--- a/istio/README.md
+++ b/istio/README.md
@@ -1,0 +1,19 @@
+# Istio manifest for Kubeflow
+
+The manifest is taken from OSS Istio pre-release
+[1.1-20190111-09-15](https://gcsweb.istio.io/gcs/istio-prerelease/daily-build/release-1.1-20190111-09-15/).
+
+We need custom configuration as discussed in the
+[issue](https://github.com/kubeflow/kubeflow/issues/1909#issuecomment-438409215).
+
+Specifically, the things we changed are:
+
+1. The policy of configmap `istio-sidecar-injector` is changed from `enabled` to `disabled`.
+   According to this [table](https://github.com/istio/istio/issues/6476#issuecomment-399219937),
+   `policy=disabled` and `namespace label=enabled` is what we want.
+1. The service type of `istio-ingressgateway` is changed from `LoadBalancer` to `NodePort`.
+1. Add annotation to service `istio-ingressgateway`: `beta.cloud.google.com/backend-config: XXX`.
+   This is to [enable IAP](https://cloud.google.com/iap/docs/enabling-kubernetes-howto#kubernetes-configure).
+
+*TODO*: To allow egress, we need to know cluster specific IP ranges. Also, Istio's recommended way is to use
+serviceEntry. We will figure out this part later.

--- a/istio/README.md
+++ b/istio/README.md
@@ -1,19 +1,20 @@
 # Istio manifest for Kubeflow
 
-The manifest is taken from OSS Istio pre-release
-[1.1-20190111-09-15](https://gcsweb.istio.io/gcs/istio-prerelease/daily-build/release-1.1-20190111-09-15/).
+The manifest is taken from OSS Istio
+[1.1.6](https://github.com/istio/istio/tree/1.1.6/install/kubernetes/helm/istio).
 
 We need custom configuration as discussed in the
 [issue](https://github.com/kubeflow/kubeflow/issues/1909#issuecomment-438409215).
 
 Specifically, the things we changed are:
 
-1. The policy of configmap `istio-sidecar-injector` is changed from `enabled` to `disabled`.
-   According to this [table](https://github.com/istio/istio/issues/6476#issuecomment-399219937),
-   `policy=disabled` and `namespace label=enabled` is what we want.
 1. The service type of `istio-ingressgateway` is changed from `LoadBalancer` to `NodePort`.
 1. Add annotation to service `istio-ingressgateway`: `beta.cloud.google.com/backend-config: XXX`.
    This is to [enable IAP](https://cloud.google.com/iap/docs/enabling-kubernetes-howto#kubernetes-configure).
+
+## Istio Sidecar Injection Policy Reference Table
+
+Refer [table](https://github.com/istio/istio/issues/6476#issuecomment-399219937).
 
 *TODO*: To allow egress, we need to know cluster specific IP ranges. Also, Istio's recommended way is to use
 serviceEntry. We will figure out this part later.


### PR DESCRIPTION
**Which issue is resolved by this Pull Request:**
Resolves #

**Description of your changes:**
Moves README from kubeflow repo - https://github.com/kubeflow/kubeflow/blob/v0.5-branch/dependencies/istio/install/README.md to manifests

**Checklist:**
- [ ] Unit tests have been rebuilt: 
    1. `cd manifests/tests`
    2. `make generate`
    3. `make test`

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/manifests/321)
<!-- Reviewable:end -->
