### PR TITLE
To support uniform and unique configmaps names across kubeflow applications

### DIFF
--- a/admission-webhook/bootstrap/base/config-map.yaml
+++ b/admission-webhook/bootstrap/base/config-map.yaml
@@ -128,4 +128,4 @@ data:
     done
 kind: ConfigMap
 metadata:
-  name: config-map
+  name: parameters

--- a/admission-webhook/bootstrap/base/kustomization.yaml
+++ b/admission-webhook/bootstrap/base/kustomization.yaml
@@ -19,21 +19,21 @@ configurations:
 - params.yaml
 namespace: kubeflow
 configMapGenerator:
-- name: config-map
+- name: parameters
   behavior: merge
   env: params.env
 vars:
 - name: webhookNamePrefix
   objref:
     kind: ConfigMap
-    name: config-map
+    name: parameters
     apiVersion: v1
   fieldref:
     fieldpath: data.webhookNamePrefix
 - name: namespace
   objref:
     kind: ConfigMap
-    name: config-map 
+    name: parameters
     apiVersion: v1
   fieldref:
     fieldpath: data.namespace    

--- a/admission-webhook/bootstrap/base/stateful-set.yaml
+++ b/admission-webhook/bootstrap/base/stateful-set.yaml
@@ -20,7 +20,7 @@ spec:
       serviceAccountName: service-account
       volumes:
       - configMap:
-          name: config-map
+          name: parameters
         name: admission-webhook-config
   # Workaround for https://github.com/kubernetes-sigs/kustomize/issues/677
   volumeClaimTemplates: []

--- a/admission-webhook/webhook/base/kustomization.yaml
+++ b/admission-webhook/webhook/base/kustomization.yaml
@@ -18,7 +18,7 @@ images:
     newTag: v20190520-v0-139-gcee39dbc-dirty-0d8f4c
 namespace: kubeflow  
 configMapGenerator:
-- name: admission-webhook-parameters
+- name: parameters
   env: params.env
 generatorOptions:
   disableNameSuffixHash: true
@@ -26,7 +26,7 @@ vars:
 - name: namespace
   objref:
     kind: ConfigMap
-    name: admission-webhook-parameters 
+    name: parameters 
     apiVersion: v1
   fieldref:
     fieldpath: data.namespace	

--- a/argo/base/config-map.yaml
+++ b/argo/base/config-map.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: workflow-controller-configmap
+  name: parameters
   namespace: kubeflow
 data:
   config: |

--- a/argo/base/deployment.yaml
+++ b/argo/base/deployment.yaml
@@ -81,7 +81,7 @@ spec:
       containers:
       - args:
         - --configmap
-        - workflow-controller-configmap
+        - workflow-controller-parameters
         command:
         - workflow-controller
         env:

--- a/argo/base/kustomization.yaml
+++ b/argo/base/kustomization.yaml
@@ -10,6 +10,7 @@ resources:
 - service.yaml
 commonLabels:
   kustomize.component: argo
+namePrefix: workflow-controller-
 images:
   - name: argoproj/argoui
     newName: argoproj/argoui
@@ -18,7 +19,7 @@ images:
     newName: argoproj/workflow-controller
     newTag: v2.3.0
 configMapGenerator:
-- name: workflow-controller-parameters
+- name: parameters
   env: params.env
 generatorOptions:
   disableNameSuffixHash: true
@@ -26,84 +27,84 @@ vars:
 - name: executorImage
   objref:
     kind: ConfigMap
-    name: workflow-controller-parameters
+    name: parameters
     apiVersion: v1
   fieldref:
     fieldpath: data.executorImage
 - name: containerRuntimeExecutor
   objref:
     kind: ConfigMap
-    name: workflow-controller-parameters
+    name: parameters
     apiVersion: v1
   fieldref:
     fieldpath: data.containerRuntimeExecutor
 - name: artifactRepositoryBucket
   objref:
     kind: ConfigMap
-    name: workflow-controller-parameters
+    name: parameters
     apiVersion: v1
   fieldref:
     fieldpath: data.artifactRepositoryBucket
 - name: artifactRepositoryKeyPrefix
   objref:
     kind: ConfigMap
-    name: workflow-controller-parameters
+    name: parameters
     apiVersion: v1
   fieldref:
     fieldpath: data.artifactRepositoryKeyPrefix
 - name: artifactRepositoryEndpoint
   objref:
     kind: ConfigMap
-    name: workflow-controller-parameters
+    name: parameters
     apiVersion: v1
   fieldref:
     fieldpath: data.artifactRepositoryEndpoint
 - name: artifactRepositoryInsecure
   objref:
     kind: ConfigMap
-    name: workflow-controller-parameters
+    name: parameters
     apiVersion: v1
   fieldref:
     fieldpath: data.artifactRepositoryInsecure
 - name: artifactRepositoryAccessKeySecretName
   objref:
     kind: ConfigMap
-    name: workflow-controller-parameters
+    name: parameters
     apiVersion: v1
   fieldref:
     fieldpath: data.artifactRepositoryAccessKeySecretName
 - name: artifactRepositoryAccessKeySecretKey
   objref:
     kind: ConfigMap
-    name: workflow-controller-parameters
+    name: parameters
     apiVersion: v1
   fieldref:
     fieldpath: data.artifactRepositoryAccessKeySecretKey
 - name: artifactRepositorySecretKeySecretName
   objref:
     kind: ConfigMap
-    name: workflow-controller-parameters
+    name: parameters
     apiVersion: v1
   fieldref:
     fieldpath: data.artifactRepositorySecretKeySecretName
 - name: artifactRepositorySecretKeySecretKey
   objref:
     kind: ConfigMap
-    name: workflow-controller-parameters
+    name: parameters
     apiVersion: v1
   fieldref:
     fieldpath: data.artifactRepositorySecretKeySecretKey
 - name: namespace
   objref:
     kind: ConfigMap
-    name: workflow-controller-parameters
+    name: parameters
     apiVersion: v1
   fieldref:
     fieldpath: data.namespace
 - name: clusterDomain
   objref:
     kind: ConfigMap
-    name: workflow-controller-parameters
+    name: parameters
     apiVersion: v1
   fieldref:
     fieldpath: data.clusterDomain

--- a/cert-manager/cert-manager/base/kustomization.yaml
+++ b/cert-manager/cert-manager/base/kustomization.yaml
@@ -7,12 +7,13 @@ resources:
 - service-account.yaml
 commonLabels:
   kustomize.component: cert-manager
+namePrefix: cert-manager-
 images:
   - name: quay.io/jetstack/cert-manager-controller
     newName: quay.io/jetstack/cert-manager-controller
     newTag: v0.4.0
 configMapGenerator:
-- name: cert-manager-parameters
+- name: parameters
   env: params.env
 generatorOptions:
   disableNameSuffixHash: true
@@ -20,14 +21,14 @@ vars:
 - name: acmeEmail
   objref:
     kind: ConfigMap
-    name: cert-manager-parameters
+    name: parameters
     apiVersion: v1
   fieldref:
     fieldpath: data.acmeEmail
 - name: acmeUrl
   objref:
     kind: ConfigMap
-    name: cert-manager-parameters
+    name: parameters
     apiVersion: v1
   fieldref:
     fieldpath: data.acmeUrl

--- a/common/ambassador/base/kustomization.yaml
+++ b/common/ambassador/base/kustomization.yaml
@@ -13,8 +13,9 @@ images:
   - name: quay.io/datawire/ambassador
     newName: quay.io/datawire/ambassador
     newTag: 0.37.0
+namePrefix: ambassador-
 configMapGenerator:
-- name: ambassador-parameters
+- name: parameters
   env: params.env
 generatorOptions:
   disableNameSuffixHash: true
@@ -29,7 +30,7 @@ vars:
 - name: ambassadorServiceType
   objref:
     kind: ConfigMap
-    name: ambassador-parameters
+    name: parameters
     apiVersion: v1
   fieldref:
     fieldpath: data.ambassadorServiceType

--- a/common/basic-auth/base/kustomization.yaml
+++ b/common/basic-auth/base/kustomization.yaml
@@ -8,6 +8,7 @@ resources:
 commonLabels:
   kustomize.component: basic-auth
 namespace: kubeflow
+namePrefix: basic-auth-
 images:
   - name: gcr.io/kubeflow-images-public/kflogin-ui
     newName: gcr.io/kubeflow-images-public/kflogin-ui
@@ -18,7 +19,7 @@ images:
 generatorOptions:
   disableNameSuffixHash: true
 configMapGenerator:
-- name: basic-auth-parameters
+- name: parameters
   env: params.env
 vars:
 - name: service-namespace
@@ -31,14 +32,14 @@ vars:
 - name: authSecretName
   objref:
     kind: ConfigMap
-    name: basic-auth-parameters
+    name: parameters
     apiVersion: v1
   fieldref:
     fieldpath: data.authSecretName
 - name: clusterDomain
   objref:
     kind: ConfigMap
-    name: basic-auth-parameters
+    name: parameters
     apiVersion: v1
   fieldref:
     fieldpath: data.clusterDomain

--- a/common/centraldashboard/base/kustomization.yaml
+++ b/common/centraldashboard/base/kustomization.yaml
@@ -11,6 +11,7 @@ resources:
 namespace: kubeflow
 commonLabels:
   kustomize.component: centraldashboard
+namePrefix: centraldashboard-
 images:
   - name: gcr.io/kubeflow-images-public/centraldashboard
     newName: gcr.io/kubeflow-images-public/centraldashboard
@@ -24,7 +25,7 @@ vars:
 - name: namespace
   objref:
     kind: Service
-    name: centraldashboard
+    name: service
     apiVersion: v1
   fieldref:
     fieldpath: metadata.namespace

--- a/common/centraldashboard/base/service.yaml
+++ b/common/centraldashboard/base/service.yaml
@@ -12,7 +12,7 @@ metadata:
       service: centraldashboard.$(namespace)
   labels:
     app: centraldashboard
-  name: centraldashboard
+  name: service
 spec:
   ports:
   - port: 80

--- a/common/spartakus/base/kustomization.yaml
+++ b/common/spartakus/base/kustomization.yaml
@@ -11,8 +11,9 @@ images:
   - name: gcr.io/google_containers/spartakus-amd64
     newName: gcr.io/google_containers/spartakus-amd64
     newTag: v1.1.0
+namePrefix: spartakus-
 configMapGenerator:
-- name: spartakus-parameters
+- name: parameters
   env: params.env
 generatorOptions:
   disableNameSuffixHash: true
@@ -20,7 +21,7 @@ vars:
 - name: usageId
   objref:
     kind: ConfigMap
-    name: spartakus-parameters
+    name: parameters
     apiVersion: v1
   fieldref:
     fieldpath: data.usageId

--- a/istio/istio/base/kustomization.yaml
+++ b/istio/istio/base/kustomization.yaml
@@ -2,15 +2,18 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
 - kf-istio-resources.yaml
+namePrefix: istio-
+generatorOptions:
+  disableNameSuffixHash: true
 namespace: kubeflow
 configMapGenerator:
-- name: istio-parameters
+- name: parameters
   env: params.env
 vars:
 - name: clusterRbacConfig
   objref:
     kind: ConfigMap
-    name: istio-parameters
+    name: parameters
     apiVersion: v1
   fieldref:
     fieldpath: data.clusterRbacConfig

--- a/jupyter/jupyter-web-app/base/config-map.yaml
+++ b/jupyter/jupyter-web-app/base/config-map.yaml
@@ -140,4 +140,4 @@ data:
         readOnly: false
 kind: ConfigMap
 metadata:
-  name: config
+  name: parameters

--- a/jupyter/jupyter/base/kustomization.yaml
+++ b/jupyter/jupyter/base/kustomization.yaml
@@ -8,6 +8,7 @@ resources:
 - service.yaml
 - stateful-set.yaml
 namespace: kubeflow
+namePrefix: jupyter-
 commonLabels:
   kustomize.component: jupyter
   app: jupyter
@@ -31,7 +32,7 @@ vars:
 - name: namespace
   objref:
     kind: Service
-    name: jupyter-lb
+    name: service
     apiVersion: v1
   fieldref:
     fieldpath: metadata.namespace

--- a/katib-v1alpha1/katib-ui/base/katib-ui-service.yaml
+++ b/katib-v1alpha1/katib-ui/base/katib-ui-service.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 kind: Service
 metadata:
-  name: katib-ui
+  name: service
   labels:
     component: ui
 spec:

--- a/katib-v1alpha1/katib-ui/base/kustomization.yaml
+++ b/katib-v1alpha1/katib-ui/base/kustomization.yaml
@@ -3,8 +3,9 @@ resources:
 - katib-ui-deployment.yaml
 - katib-ui-rbac.yaml
 - katib-ui-service.yaml
+namePrefix: katib-ui-
 configMapGenerator:
-- name: katib-parameters
+- name: parameters
   env: params.env
 generatorOptions:
   disableNameSuffixHash: true
@@ -15,14 +16,14 @@ vars:
 - name: clusterDomain
   objref:
     kind: ConfigMap
-    name: katib-parameters
+    name: parameters
     apiVersion: v1
   fieldref:
     fieldpath: data.clusterDomain
 - name: namespace
   objref:
     kind: Service
-    name: katib-ui
+    name: service
     apiVersion: v1
   fieldref:
     fieldpath: metadata.namespace

--- a/katib-v1alpha2/katib-ui/base/kustomization.yaml
+++ b/katib-v1alpha2/katib-ui/base/kustomization.yaml
@@ -4,8 +4,9 @@ resources:
 - katib-ui-rbac.yaml
 - katib-ui-service.yaml
 configMapGenerator:
-- name: katib-parameters
+- name: parameters
   env: params.env
+namePrefix: katib-ui-
 generatorOptions:
   disableNameSuffixHash: true
 images:
@@ -15,14 +16,14 @@ vars:
 - name: clusterDomain
   objref:
     kind: ConfigMap
-    name: katib-parameters
+    name: parameters
     apiVersion: v1
   fieldref:
     fieldpath: data.clusterDomain
 - name: namespace
   objref:
     kind: Service
-    name: katib-ui
+    name: service
     apiVersion: v1
   fieldref:
     fieldpath: metadata.namespace

--- a/kfserving/kfserving-install/base/kustomization.yaml
+++ b/kfserving/kfserving-install/base/kustomization.yaml
@@ -8,16 +8,19 @@ resources:
 - secret.yaml
 - statefulset.yaml
 - service.yaml
+namePrefix: kfserving-
 commonLabels:
   kustomize.component: kfserving
+generatorOptions:
+  disableNameSuffixHash: true
 configMapGenerator:
-  - name: kfserving-parameters
+  - name: parameters
     env: params.env
 vars:
   - name: registry
     objref:
       kind: ConfigMap
-      name: kfserving-parameters
+      name: parameters
       apiVersion: v1
     fieldref:
       fieldpath: data.registry

--- a/kubebench/base/kustomization.yaml
+++ b/kubebench/base/kustomization.yaml
@@ -9,6 +9,8 @@ resources:
 namespace: kubeflow
 commonLabels:
   kustomize.component: kubebench
+generatorOptions:
+  disableNameSuffixHash: true
 configMapGenerator:
 - name: parameters
   env: params.env

--- a/metadata/base/kustomization.yaml
+++ b/metadata/base/kustomization.yaml
@@ -1,11 +1,13 @@
-namePrefix: metadata-
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 commonLabels:
   kustomize.component: metadata
 configMapGenerator:
-- name: ui-parameters
+- name: parameters
   env: params.env
+generatorOptions:
+  disableNameSuffixHash: true
+namePrefix: metadata-
 resources:
 - metadata-db-pvc.yaml
 - metadata-db-secret.yaml
@@ -23,21 +25,21 @@ vars:
 - name: ui-namespace
   objref:
     kind: Service
-    name: ui
+    name: service
     apiVersion: v1
   fieldref:
     fieldpath: metadata.namespace
 - name: ui-clusterDomain
   objref:
     kind: ConfigMap
-    name: ui-parameters
+    name: parameters
     version: v1
   fieldref:
     fieldpath: data.uiClusterDomain
 - name: service
   objref:
     kind: Service
-    name: ui
+    name: service
     apiVersion: v1
   fieldref:
     fieldpath: metadata.name

--- a/mpi-job/mpi-operator/base/kustomization.yaml
+++ b/mpi-job/mpi-operator/base/kustomization.yaml
@@ -13,8 +13,9 @@ images:
 - name: mpioperator/mpi-operator
   newName: mpioperator/mpi-operator
   newTag: 0.1.0
+namePrefix: mpi-operator-
 configMapGenerator:
-- name: mpi-operator-config
+- name: parameters
   env: params.env
 generatorOptions:
   disableNameSuffixHash: true
@@ -22,7 +23,7 @@ vars:
 - name: kubectl-delivery-image
   objref:
     kind: ConfigMap
-    name: mpi-operator-config
+    name: parameters
     apiVersion: v1
   fieldref:
     fieldpath: data.kubectl-delivery-image

--- a/pipeline/minio/base/kustomization.yaml
+++ b/pipeline/minio/base/kustomization.yaml
@@ -7,8 +7,9 @@ resources:
 - secret.yaml
 - service.yaml
 - persistent-volume-claim.yaml
+namePrefix: pipeline-minio-
 configMapGenerator:
-- name: pipeline-minio-parameters
+- name: parameters
   env: params.env
 generatorOptions:
   disableNameSuffixHash: true
@@ -16,7 +17,7 @@ vars:
 - name: minioPvcName
   objref:
     kind: ConfigMap
-    name: pipeline-minio-parameters
+    name: parameters
     apiVersion: v1
   fieldref:
     fieldpath: data.minioPvcName

--- a/pipeline/minio/base/service.yaml
+++ b/pipeline/minio/base/service.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 kind: Service
 metadata:
-  name: minio-service
+  name: service
 spec:
   ports:
   - port: 9000

--- a/pipeline/mysql/base/kustomization.yaml
+++ b/pipeline/mysql/base/kustomization.yaml
@@ -6,8 +6,9 @@ resources:
 - deployment.yaml
 - service.yaml
 - persistent-volume-claim.yaml
+namePrefix: pipeline-mysql-
 configMapGenerator:
-- name: pipeline-mysql-parameters
+- name: parameters
   env: params.env
 generatorOptions:
   disableNameSuffixHash: true
@@ -15,7 +16,7 @@ vars:
 - name: mysqlPvcName
   objref:
     kind: ConfigMap
-    name: pipeline-mysql-parameters
+    name: parameters
     apiVersion: v1
   fieldref:
     fieldpath: data.mysqlPvcName

--- a/pipeline/mysql/base/service.yaml
+++ b/pipeline/mysql/base/service.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 kind: Service
 metadata:
-  name: mysql
+  name: service
 spec:
   ports:
   - port: 3306

--- a/pipeline/pipelines-ui/base/kustomization.yaml
+++ b/pipeline/pipelines-ui/base/kustomization.yaml
@@ -7,9 +7,12 @@ resources:
 - role.yaml
 - service-account.yaml
 - service.yaml
+generatorOptions:
+  disableNameSuffixHash: true
 configMapGenerator:
-- name: ui-parameters
+- name: parameters
   env: params.env
+namePrefix: pipelines-ui-
 images:
 - name: gcr.io/ml-pipeline/frontend
   newTag: '0.1.23'
@@ -17,28 +20,28 @@ vars:
 - name: ui-namespace
   objref:
     kind: Service
-    name: ml-pipeline-ui
+    name: service
     apiVersion: v1
   fieldref:
     fieldpath: metadata.namespace
 - name: ui-clusterDomain
   objref:
     kind: ConfigMap
-    name: ui-parameters
+    name: parameters
     version: v1
   fieldref:
     fieldpath: data.uiClusterDomain
 - name: service
   objref:
     kind: Service
-    name: ml-pipeline-ui
+    name: service
     apiVersion: v1
   fieldref:
     fieldpath: metadata.name
 - name: tensorboard-service
   objref:
     kind: Service
-    name: ml-pipeline-tensorboard-ui
+    name: tensorboard
     apiVersion: v1
   fieldref:
     fieldpath: metadata.name

--- a/pipeline/pipelines-ui/base/service.yaml
+++ b/pipeline/pipelines-ui/base/service.yaml
@@ -2,7 +2,7 @@
 apiVersion: v1
 kind: Service
 metadata:
-  name: ml-pipeline-ui
+  name: ml-service
   annotations:
     getambassador.io/config: |-
       ---
@@ -26,7 +26,7 @@ spec:
 apiVersion: v1
 kind: Service
 metadata:
-  name: ml-pipeline-tensorboard-ui
+  name: ml-tensorboard-service
   annotations:
     getambassador.io/config: |-
       ---

--- a/profiles/base/kustomization.yaml
+++ b/profiles/base/kustomization.yaml
@@ -12,8 +12,10 @@ namePrefix: profiles-
 namespace: kubeflow
 commonLabels:
   kustomize.component: profiles
+generatorOptions:
+  disableNameSuffixHash: true
 configMapGenerator:
-  - name: profiles-parameters
+  - name: parameters
     env: params.env
 images:
   - name: gcr.io/kubeflow-images-public/profile-controller
@@ -23,21 +25,21 @@ vars:
   - name: admin
     objref:
       kind: ConfigMap
-      name: profiles-parameters
+      name: parameters
       apiVersion: v1
     fieldref:
       fieldpath: data.admin
   - name: userid-header
     objref:
       kind: ConfigMap
-      name: profiles-parameters
+      name: parameters
       apiVersion: v1
     fieldref:
       fieldpath: data.userid-header
   - name: userid-prefix
     objref:
       kind: ConfigMap
-      name: profiles-parameters
+      name: parameters
       apiVersion: v1
     fieldref:
       fieldpath: data.userid-prefix

--- a/pytorch-job/pytorch-operator/base/config-map.yaml
+++ b/pytorch-job/pytorch-operator/base/config-map.yaml
@@ -6,4 +6,4 @@ data:
     }
 kind: ConfigMap
 metadata:
-  name: pytorch-operator-config
+  name: parameters

--- a/pytorch-job/pytorch-operator/base/deployment.yaml
+++ b/pytorch-job/pytorch-operator/base/deployment.yaml
@@ -35,5 +35,5 @@ spec:
       serviceAccountName: pytorch-operator
       volumes:
       - configMap:
-          name: pytorch-operator-config
+          name: parameters
         name: config-volume

--- a/pytorch-job/pytorch-operator/base/kustomization.yaml
+++ b/pytorch-job/pytorch-operator/base/kustomization.yaml
@@ -10,6 +10,9 @@ resources:
 - service.yaml
 commonLabels:
   kustomize.component: pytorch-operator
+generatorOptions:
+  disableNameSuffixHash: true
+namePrefix: pytorch-operator
 images:
   - name: gcr.io/kubeflow-images-public/pytorch-operator
     newName: gcr.io/kubeflow-images-public/pytorch-operator

--- a/pytorch-job/pytorch-operator/base/service.yaml
+++ b/pytorch-job/pytorch-operator/base/service.yaml
@@ -7,7 +7,7 @@ metadata:
     prometheus.io/scrape: "true"
   labels:
     app: pytorch-operator
-  name: pytorch-operator
+  name: service
 spec:
   ports:
   - name: monitoring-port

--- a/tensorboard/base/kustomization.yaml
+++ b/tensorboard/base/kustomization.yaml
@@ -6,6 +6,9 @@ resources:
 - service.yaml
 commonLabels:
   kustomize.component: tensorboard
+namePrefix: tensorboard-
+generatorOptions:
+  disableNameSuffixHash: true
 configMapGenerator:
 - name: parameters
   env: params.env
@@ -13,7 +16,7 @@ vars:
 - name: namespace
   objref:
     kind: Service
-    name: tensorboard
+    name: service
     apiVersion: v1
   fieldref:
     fieldpath: metadata.namespace

--- a/tensorboard/base/service.yaml
+++ b/tensorboard/base/service.yaml
@@ -13,7 +13,7 @@ metadata:
       service: tensorboard.$(namespace):9000
   labels:
     app: tensorboard
-  name: tensorboard
+  name: service
 spec:
   ports:
   - name: tb

--- a/tests/argo-base_test.go
+++ b/tests/argo-base_test.go
@@ -126,7 +126,7 @@ rules:
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: workflow-controller-configmap
+  name: workflow-controller-parameters
   namespace: kubeflow
 data:
   config: |
@@ -253,7 +253,7 @@ spec:
       containers:
       - args:
         - --configmap
-        - workflow-controller-configmap
+        - workflow-controller-parameters
         command:
         - workflow-controller
         env:

--- a/tests/argo-overlays-istio_test.go
+++ b/tests/argo-overlays-istio_test.go
@@ -163,7 +163,7 @@ rules:
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: workflow-controller-configmap
+  name: workflow-controller-parameters
   namespace: kubeflow
 data:
   config: |
@@ -290,7 +290,7 @@ spec:
       containers:
       - args:
         - --configmap
-        - workflow-controller-configmap
+        - workflow-controller-parameters
         command:
         - workflow-controller
         env:

--- a/tests/bootstrap-base_test.go
+++ b/tests/bootstrap-base_test.go
@@ -183,7 +183,7 @@ data:
     done
 kind: ConfigMap
 metadata:
-  name: config-map
+  name: parameters
 `)
 	th.writeF("/manifests/admission-webhook/bootstrap/base/service-account.yaml", `
 apiVersion: v1
@@ -214,7 +214,7 @@ spec:
       serviceAccountName: service-account
       volumes:
       - configMap:
-          name: config-map
+          name: parameters
         name: admission-webhook-config
   # Workaround for https://github.com/kubernetes-sigs/kustomize/issues/677
   volumeClaimTemplates: []
@@ -250,21 +250,21 @@ configurations:
 - params.yaml
 namespace: kubeflow
 configMapGenerator:
-- name: config-map
+- name: parameters
   behavior: merge
   env: params.env
 vars:
 - name: webhookNamePrefix
   objref:
     kind: ConfigMap
-    name: config-map
+    name: parameters
     apiVersion: v1
   fieldref:
     fieldpath: data.webhookNamePrefix
 - name: namespace
   objref:
     kind: ConfigMap
-    name: config-map 
+    name: parameters
     apiVersion: v1
   fieldref:
     fieldpath: data.namespace    

--- a/tests/pytorch-operator-base_test.go
+++ b/tests/pytorch-operator-base_test.go
@@ -88,7 +88,7 @@ data:
     }
 kind: ConfigMap
 metadata:
-  name: pytorch-operator-config
+  name: pytorch-operator-parameters
 `)
 	th.writeF("/manifests/pytorch-job/pytorch-operator/base/deployment.yaml", `
 apiVersion: extensions/v1beta1
@@ -128,7 +128,7 @@ spec:
       serviceAccountName: pytorch-operator
       volumes:
       - configMap:
-          name: pytorch-operator-config
+          name: pytorch-operator-parameters
         name: config-volume
 `)
 	th.writeF("/manifests/pytorch-job/pytorch-operator/base/service-account.yaml", `

--- a/tests/pytorch-operator-overlays-application_test.go
+++ b/tests/pytorch-operator-overlays-application_test.go
@@ -149,7 +149,7 @@ data:
     }
 kind: ConfigMap
 metadata:
-  name: pytorch-operator-config
+  name: pytorch-operator-parameters
 `)
 	th.writeF("/manifests/pytorch-job/pytorch-operator/base/deployment.yaml", `
 apiVersion: extensions/v1beta1
@@ -189,7 +189,7 @@ spec:
       serviceAccountName: pytorch-operator
       volumes:
       - configMap:
-          name: pytorch-operator-config
+          name: pytorch-operator-parameters
         name: config-volume
 `)
 	th.writeF("/manifests/pytorch-job/pytorch-operator/base/service-account.yaml", `

--- a/tf-training/tf-job-operator/base/cluster-role-binding.yaml
+++ b/tf-training/tf-job-operator/base/cluster-role-binding.yaml
@@ -4,25 +4,25 @@ kind: ClusterRoleBinding
 metadata:
   labels:
     app: tf-job-dashboard
-  name: tf-job-dashboard
+  name: dashboard
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
-  name: tf-job-dashboard
+  name: dashboard
 subjects:
 - kind: ServiceAccount
-  name: tf-job-dashboard
+  name: dashboard
 ---
 apiVersion: rbac.authorization.k8s.io/v1beta1
 kind: ClusterRoleBinding
 metadata:
   labels:
     app: tf-job-operator
-  name: tf-job-operator
+  name: operator
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
-  name: tf-job-operator
+  name: operator
 subjects:
 - kind: ServiceAccount
-  name: tf-job-operator
+  name: operator

--- a/tf-training/tf-job-operator/base/cluster-role.yaml
+++ b/tf-training/tf-job-operator/base/cluster-role.yaml
@@ -4,7 +4,7 @@ kind: ClusterRole
 metadata:
   labels:
     app: tf-job-dashboard
-  name: tf-job-dashboard
+  name: dashboard
 rules:
 - apiGroups:
   - tensorflow.org
@@ -58,7 +58,7 @@ kind: ClusterRole
 metadata:
   labels:
     app: tf-job-operator
-  name: tf-job-operator
+  name: operator
 rules:
 - apiGroups:
   - tensorflow.org

--- a/tf-training/tf-job-operator/base/config-map.yaml
+++ b/tf-training/tf-job-operator/base/config-map.yaml
@@ -6,4 +6,4 @@ data:
     }
 kind: ConfigMap
 metadata:
-  name: tf-job-operator-config
+  name: operator-parameters

--- a/tf-training/tf-job-operator/base/deployment.yaml
+++ b/tf-training/tf-job-operator/base/deployment.yaml
@@ -1,12 +1,12 @@
 apiVersion: extensions/v1beta1
 kind: Deployment
 metadata:
-  name: tf-job-dashboard
+  name: dashboard
 spec:
   template:
     metadata:
       labels:
-        name: tf-job-dashboard
+        name: dashboard
     spec:
       containers:
       - command:
@@ -17,7 +17,7 @@ spec:
             fieldRef:
               fieldPath: metadata.namespace
         image: gcr.io/kubeflow-images-public/tf_operator:v0.6.0.rc0
-        name: tf-job-dashboard
+        name: dashboard
         ports:
         - containerPort: 8080
       serviceAccountName: tf-job-dashboard
@@ -25,13 +25,13 @@ spec:
 apiVersion: extensions/v1beta1
 kind: Deployment
 metadata:
-  name: tf-job-operator
+  name: operator
 spec:
   replicas: 1
   template:
     metadata:
       labels:
-        name: tf-job-operator
+        name: operator
     spec:
       containers:
       - command:
@@ -49,12 +49,12 @@ spec:
             fieldRef:
               fieldPath: metadata.name
         image: gcr.io/kubeflow-images-public/tf_operator:v0.6.0.rc0
-        name: tf-job-operator
+        name: operator
         volumeMounts:
         - mountPath: /etc/config
           name: config-volume
       serviceAccountName: tf-job-operator
       volumes:
       - configMap:
-          name: tf-job-operator-config
+          name: operator-parameters
         name: config-volume

--- a/tf-training/tf-job-operator/base/kustomization.yaml
+++ b/tf-training/tf-job-operator/base/kustomization.yaml
@@ -11,6 +11,9 @@ resources:
 - service.yaml
 commonLabels:
   kustomize.component: tf-job-operator
+namePrefix: tf-job-
+generatorOptions:
+  disableNameSuffixHash: true
 configMapGenerator:
 - name: parameters
   env: params.env
@@ -18,7 +21,7 @@ vars:
 - name: namespace
   objref:
     kind: Service
-    name: tf-job-dashboard
+    name: dashboard-service
     apiVersion: v1
   fieldref:
     fieldpath: metadata.namespace

--- a/tf-training/tf-job-operator/base/service-account.yaml
+++ b/tf-training/tf-job-operator/base/service-account.yaml
@@ -4,11 +4,11 @@ kind: ServiceAccount
 metadata:
   labels:
     app: tf-job-dashboard
-  name: tf-job-dashboard
+  name: dashboard
 ---
 apiVersion: v1
 kind: ServiceAccount
 metadata:
   labels:
     app: tf-job-operator
-  name: tf-job-operator
+  name: operator

--- a/tf-training/tf-job-operator/base/service.yaml
+++ b/tf-training/tf-job-operator/base/service.yaml
@@ -10,13 +10,13 @@ metadata:
       prefix: /tfjobs/
       rewrite: /tfjobs/
       service: tf-job-dashboard.$(namespace)
-  name: tf-job-dashboard
+  name: dashboard-service
 spec:
   ports:
   - port: 80
     targetPort: 8080
   selector:
-    name: tf-job-dashboard
+    name: dashboard
   type: ClusterIP
 ---
 apiVersion: v1
@@ -28,12 +28,12 @@ metadata:
     prometheus.io/port: "8443"
   labels:
     app: tf-job-operator
-  name: tf-job-operator
+  name: operator-service
 spec:
   ports:
   - name: monitoring-port
     port: 8443
     targetPort: 8443
   selector:
-    name: tf-job-operator
+    name: operator
   type: ClusterIP


### PR DESCRIPTION
**Which issue is resolved by this Pull Request:**
Resolves #
Currently multiple application creates config maps with the same generic name "parameters".
Changes planned here is to have a unique configmaps for each application in an uniform way using the namePrefix.
Similarly for services too.

https://github.com/kubeflow/manifests/issues/288
https://github.com/kubeflow/manifests/issues/256
https://github.com/kubeflow/manifests/issues/147

**Description of your changes:**
To support unique configmaps and service names
The pattern followed is inline with kustomize ability to prefix names.

Specific example for where its used like one below where namePrefix is used
https://github.com/kubeflow/manifests/blob/02ddd6616650642b2ff865f16b164ede3385c54b/jupyter/jupyter-web-app/base/kustomization.yaml#L12
and the config map is named
https://github.com/kubeflow/manifests/blob/02ddd6616650642b2ff865f16b164ede3385c54b/jupyter/jupyter-web-app/base/kustomization.yaml#L23


Not using namePrefix but hardcoding of the name as below and does not have any namePrefix:
https://github.com/kubeflow/manifests/blob/02ddd6616650642b2ff865f16b164ede3385c54b/argo/base/kustomization.yaml#L21


Tensorboard example where namePrefix is not present and configMap name is just “parameters”:
https://github.com/kubeflow/manifests/blob/02ddd6616650642b2ff865f16b164ede3385c54b/tensorboard/base/kustomization.yaml#L10


Multiple applications are using either “parameters” or “config-map” as name for configMap with and without namePrefix. The PR makes it uniform to have “parameters” consistently across all applications.



configmaps name: "<namePrefix>-parameters"
service name: "<namePrefix>-service"

Disabled name suffix Hash where ever missing.
generatorOptions:
  disableNameSuffixHash: true

**Checklist:**
- [ ] Unit tests have been rebuilt: 
    1. `cd manifests/tests`
    2. `make generate`
    3. `make test`

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/manifests/331)
<!-- Reviewable:end -->
