### PR TITLE
add livenessProbe to ml-pipeline-ui

### DIFF
--- a/pipeline/pipelines-ui/base/deployment.yaml
+++ b/pipeline/pipelines-ui/base/deployment.yaml
@@ -17,6 +17,10 @@ spec:
       - name: ml-pipeline-ui
         image: gcr.io/ml-pipeline/frontend
         imagePullPolicy: IfNotPresent
+        livenessProbe:
+          httpGet:
+            path: /
+            port: 3000
         ports:
         - containerPort: 3000
       serviceAccountName: ml-pipeline-ui

--- a/tests/pipeline-pipelines-ui-base_test.go
+++ b/tests/pipeline-pipelines-ui-base_test.go
@@ -34,6 +34,10 @@ spec:
       - name: ml-pipeline-ui
         image: gcr.io/ml-pipeline/frontend
         imagePullPolicy: IfNotPresent
+        livenessProbe:
+          httpGet:
+            path: /
+            port: 3000
         ports:
         - containerPort: 3000
       serviceAccountName: ml-pipeline-ui

--- a/tests/pipeline-pipelines-ui-overlays-istio_test.go
+++ b/tests/pipeline-pipelines-ui-overlays-istio_test.go
@@ -94,6 +94,10 @@ spec:
       - name: ml-pipeline-ui
         image: gcr.io/ml-pipeline/frontend
         imagePullPolicy: IfNotPresent
+        livenessProbe:
+          httpGet:
+            path: /
+            port: 3000
         ports:
         - containerPort: 3000
       serviceAccountName: ml-pipeline-ui


### PR DESCRIPTION
**Description of your changes:**
We've had some problems with the ml-pipeline-ui pod where it has become unresponsive and memory usage grew unexpectedly - unfortunately this was a few weeks ago and we didn't persist any logs or useful troubleshooting info related to the problem.

We found that deleting the pod so that the Deployment would create a new one fixed the problem, so I thought that adding a liveness probe to be able to have Kubernetes manage this automatically could be a good idea.

I don't see a good candidate for a probe in the ui app (like `/healthz` or anything like that).

**Checklist:**
- [x] Unit tests have been rebuilt: 
    1. `cd manifests/tests`
    2. `make generate-changed-only`
    3. `make test`

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/manifests/338)
<!-- Reviewable:end -->
