### PR TITLE
Parameterize container image name and image tag to read from kfDef fi…

### DIFF
--- a/common/centraldashboard/base/deployment.yaml
+++ b/common/centraldashboard/base/deployment.yaml
@@ -15,7 +15,7 @@ spec:
         app: centraldashboard
     spec:
       containers:
-      - image: gcr.io/kubeflow-images-public/centraldashboard:v0.5.0
+      - image: $(registry)/$(centraldashboardImageName):$(centraldashboardImageTag)
         imagePullPolicy: IfNotPresent
         name: centraldashboard
         ports:

--- a/common/centraldashboard/base/kustomization.yaml
+++ b/common/centraldashboard/base/kustomization.yaml
@@ -28,6 +28,27 @@ vars:
     apiVersion: v1
   fieldref:
     fieldpath: metadata.namespace
+- name: registry
+  objref:
+    kind: ConfigMap
+    name: parameters
+    apiVersion: v1
+  fieldref:
+    fieldpath: metadata.registry
+- name: centraldashboardImageName
+  objref:
+    kind: ConfigMap
+    name: parameters
+    apiVersion: v1
+  fieldref:
+    fieldpath: metadata.centraldashboardImageName
+- name: centraldashboardImageTag
+  objref:
+    kind: ConfigMap
+    name: parameters
+    apiVersion: v1
+  fieldref:
+    fieldpath: metadata.centraldashboardImageTag
 - name: clusterDomain
   objref:
     kind: ConfigMap

--- a/common/centraldashboard/base/params.env
+++ b/common/centraldashboard/base/params.env
@@ -1,3 +1,6 @@
 clusterDomain=cluster.local
 userid-header=
 userid-prefix=
+registry=gcr.io
+centraldashboardImageName=kubeflow-images-public/centraldashboard
+centraldashboardImageTag=v20190823-v0.6.0-rc.0-69-gcb7dab59

--- a/common/centraldashboard/base/params.yaml
+++ b/common/centraldashboard/base/params.yaml
@@ -7,3 +7,5 @@ varReference:
   kind: Deployment
 - path: spec/template/spec/containers/0/env/1/value
   kind: Deployment
+- path: spec/template/spec/containers/image
+  kind: Deployment


### PR DESCRIPTION

**Which issue is resolved by this Pull Request:**
Resolves #
https://github.com/kubeflow/manifests/pull/211
https://github.com/kubeflow/kubeflow/issues/3210 
https://github.com/kubeflow/manifests/pull/211#issuecomment-524304213

Resolves the issue with the hardcoded values of container registry, name and tag details of all the kubeflow applications.

**Description of your changes:**
Changes will allow us to parameterize the container Image Registry, Image Name and Image Tag for each application.
Values for each of these can be provided from the kfDef file (app.yaml)
If not present in the kfDef file then default value present in the params.env willbe considered.

**e.g: app.yaml:**
  - kustomizeConfig:
      parameters:
      - name: centraldashboardImageName
        value: gcr.io/kubeflow-images-public/centraldashboard
      - name: centraldashboardImageTag
        value: v20190823-v0.6.0-rc.0-69-gcb7dab59
      overlays:
      - istio
      repoRef:
        name: manifests
        path: common/centraldashboard
    name: centraldashboard

*********************
This does same job as and de-funcs newImage and newTag options available from kustomization.yaml at every base/ 

This is sample changes done for centraldashboard app, which needs to be replicated for all the applications to achieve these customization/parameterization.

**Checklist:**
- [ ] Unit tests have been rebuilt: 
    1. `cd manifests/tests`
    2. `make generate`
    3. `make test`

/assign @kkasravi @jlewi

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/manifests/339)
<!-- Reviewable:end -->
