### PR TITLE
Fix v0.6-branch presubmits; use v0.6-branch of kubeflow/kubeflow

### DIFF
--- a/tests/scripts/run-tests.sh
+++ b/tests/scripts/run-tests.sh
@@ -20,19 +20,10 @@ set -o errexit
 set -o nounset
 set -o pipefail
 
+cd tests
+
 # the tests depend on kustomize
 export PATH=${GOPATH}/bin:/usr/local/go/bin:${PATH}
 export GO111MODULE=on
 go get sigs.k8s.io/kustomize
-
-# Generate Go files on upstream HEAD 
-cd /src/kubeflow/manifests/tests
-make generate
-cd -
-if diff /src/kubeflow/manifests/tests/*.go tests/*.go ; then
-    cd tests
-    make test
-else
-    echo "Tests failed. Please run `make generate` and re-run tests"
-    exit 1
-fi
+make test

--- a/tests/workflows/components/kfctl_go_test.jsonnet
+++ b/tests/workflows/components/kfctl_go_test.jsonnet
@@ -202,7 +202,7 @@ local dagTemplates = [
                             env_vars=[{
                               name: "EXTRA_REPOS",
                               // TODO(jlewi): Stop pinning to 341 once its submitted.
-                              value: "kubeflow/kubeflow@HEAD;kubeflow/tf-operator@HEAD;kubeflow/testing@HEAD",
+                              value: "kubeflow/kubeflow@v0.6-branch;kubeflow/tf-operator@HEAD;kubeflow/testing@HEAD",
                             }]),
     dependencies: null,
   },  // checkout

--- a/tests/workflows/components/workflows.libsonnet
+++ b/tests/workflows/components/workflows.libsonnet
@@ -202,7 +202,7 @@
                 ],
                 env: prow_env + [{
                   name: "EXTRA_REPOS",
-                  value: "kubeflow/testing@HEAD,kubeflow/manifests@HEAD",
+                  value: "kubeflow/testing@HEAD;kubeflow/manifests@v0.6-branch",
                 }],
                 image: testWorkerImage,
                 volumeMounts: [

--- a/tests/workflows/components/workflows.libsonnet
+++ b/tests/workflows/components/workflows.libsonnet
@@ -202,7 +202,7 @@
                 ],
                 env: prow_env + [{
                   name: "EXTRA_REPOS",
-                  value: "kubeflow/testing@HEAD;kubeflow/manifests@v0.6-branch",
+                  value: "kubeflow/testing@HEAD",
                 }],
                 image: testWorkerImage,
                 volumeMounts: [


### PR DESCRIPTION
* Presubmits on v0.6-branch are currently failing. It looks like the problem
  is that they are using kubeflow/kubeflow @ master and not the v0.6-branch
  of kubeflow/kubeflow.

* Fix #348

* Related to #296 
   * Revert #299 - It looks like that PR broke the presubmits on the v0.6-branch.

**Which issue is resolved by this Pull Request:**
Resolves #

**Description of your changes:**


**Checklist:**
- [ ] Unit tests have been rebuilt: 
    1. `cd manifests/tests`
    2. `make generate`
    3. `make test`

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/manifests/350)
<!-- Reviewable:end -->
