### PR TITLE
GCP KfDef should pull deployment manager configs from kubeflow/manifests

### DIFF
--- a/kfdef/kfctl_gcp_basic_auth.yaml
+++ b/kfdef/kfctl_gcp_basic_auth.yaml
@@ -357,6 +357,14 @@ spec:
   enableApplications: true
   packageManager: kustomize
   platform: gcp
+  plugins:
+  - name: gcp
+    spec:
+      createPipelinePersistentStorage: true
+      deploymentManagerConfig:
+        repoRef:
+          name: manifests
+          path: gcp/deployment_manager_configs
   skipInitProject: true
   useBasicAuth: true
   useIstio: true

--- a/kfdef/kfctl_gcp_iap.yaml
+++ b/kfdef/kfctl_gcp_iap.yaml
@@ -7,11 +7,7 @@ metadata:
   namespace: kubeflow
 spec:
   repos:
-  - name: kubeflow
-    root: kubeflow-master
-    uri: https://github.com/kubeflow/kubeflow/archive/master.tar.gz
   - name: manifests
-    root: master/
     uri: https://github.com/kubeflow/manifests/archive/master.tar.gz
     # To get manifest at a PR:
     #uri: https://github.com/kubeflow/manifests/archive/pull/235/head.tar.gz
@@ -327,6 +323,14 @@ spec:
   enableApplications: true
   packageManager: kustomize
   platform: gcp
+  plugins:
+  - name: gcp
+    spec:
+      createPipelinePersistentStorage: true
+      deploymentManagerConfig:
+        repoRef:
+          name: manifests
+          path: gcp/deployment_manager_configs
   skipInitProject: true
   useBasicAuth: false
   useIstio: true

--- a/prow_config.yaml
+++ b/prow_config.yaml
@@ -18,4 +18,4 @@ workflows:
       workflowName: kfctl-go
       useIstio: true
       version: master
-      configPath: bootstrap/config/kfctl_gcp_iap.yaml
+      configPath: kfdef/kfctl_gcp_iap.yaml

--- a/tests/workflows/components/kfctl_go_test.jsonnet
+++ b/tests/workflows/components/kfctl_go_test.jsonnet
@@ -31,6 +31,7 @@ local artifactsDir = outputDir + "/artifacts";
 local srcRootDir = testDir + "/src";
 // The directory containing the kubeflow/kubeflow repo
 local srcDir = srcRootDir + "/kubeflow/kubeflow";
+local manifestsDir =  srcRootDir + "/kubeflow/manifests";
 
 local runPath = srcDir + "/testing/workflows/run.sh";
 local kfCtlPath = srcDir + "/bootstrap/bin/kfctl";
@@ -228,7 +229,7 @@ local dagTemplates = [
         "-s",
         "--use_basic_auth=" + params.useBasicAuth,
         "--use_istio=" + params.useIstio,
-        "--config_path=" + srcDir + "/" + params.configPath,
+        "--config_path=" + manifestsDir + "/" + params.configPath,
         // Increase the log level so that info level log statements show up.
         "--log-cli-level=info",        
         "--junitxml=" + artifactsDir + "/junit_kfctl-build-test" + nameSuffix + ".xml",


### PR DESCRIPTION
GCP KFDef specs should pull deployment manager configs from kubeflow/manifests
    
* No longer download the kubeflow/kubeflow repository
* Add a GCPPlugin spec.

Related to kubeflow/manifests#241

**Checklist:**
- [ ] Unit tests have been rebuilt: 
    1. `cd manifests/tests`
    2. `make generate`
    3. `make test`

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/manifests/354)
<!-- Reviewable:end -->
