### PR TITLE
Add AWS Kustomize manifests (#221)

### DIFF
--- a/aws/OWNERS
+++ b/aws/OWNERS
@@ -1,0 +1,3 @@
+approvers:
+  - jeffwan
+  - mameshini

--- a/aws/aws-alb-ingress-controller/base/cluster-role-binding.yaml
+++ b/aws/aws-alb-ingress-controller/base/cluster-role-binding.yaml
@@ -1,0 +1,11 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: alb-ingress-controller
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: alb-ingress-controller
+subjects:
+  - kind: ServiceAccount
+    name: alb-ingress-controller

--- a/aws/aws-alb-ingress-controller/base/cluster-role.yaml
+++ b/aws/aws-alb-ingress-controller/base/cluster-role.yaml
@@ -1,0 +1,35 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: alb-ingress-controller
+rules:
+  - apiGroups:
+      - ""
+      - extensions
+    resources:
+      - configmaps
+      - endpoints
+      - events
+      - ingresses
+      - ingresses/status
+      - services
+    verbs:
+      - create
+      - get
+      - list
+      - update
+      - watch
+      - patch
+  - apiGroups:
+      - ""
+      - extensions
+    resources:
+      - nodes
+      - pods
+      - secrets
+      - services
+      - namespaces
+    verbs:
+      - get
+      - list
+      - watch

--- a/aws/aws-alb-ingress-controller/base/deployment.yaml
+++ b/aws/aws-alb-ingress-controller/base/deployment.yaml
@@ -1,0 +1,51 @@
+# Application Load Balancer (ALB) Ingress Controller Deployment Manifest.
+# This manifest details sensible defaults for deploying an ALB Ingress Controller.
+# GitHub: https://github.com/kubernetes-sigs/aws-alb-ingress-controller
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: alb-ingress-controller
+  # Namespace the ALB Ingress Controller should run in. Does not impact which
+  # namespaces it's able to resolve ingress resource for. For limiting ingress
+  # namespace scope, see --watch-namespace.
+#  namespace: kubeflow
+spec:
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: alb-ingress-controller
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: alb-ingress-controller
+    spec:
+      containers:
+        - name: alb-ingress-controller
+          args:
+            # Limit the namespace where this ALB Ingress Controller deployment will
+            # resolve ingress resources. If left commented, all namespaces are used.
+            # - --watch-namespace=your-k8s-namespace
+
+            # Setting the ingress-class flag below ensures that only ingress resources with the
+            # annotation kubernetes.io/ingress.class: "alb" are respected by the controller. You may
+            # choose any class you'd like for this controller to respect.
+            - --ingress-class=alb
+
+            # REQUIRED
+            # Name of your cluster. Used when naming resources created
+            # by the ALB Ingress Controller, providing distinction between
+            # clusters.
+#            - --cluster-name=$(CLUSTER_NAME)
+            - --cluster-name=$(CLUSTER_NAME)
+
+            # AWS VPC ID this ingress controller will use to create AWS resources.
+            # If unspecified, it will be discovered from ec2metadata.
+            # - --aws-vpc-id=vpc-xxxxxx
+
+            # AWS region this ingress controller will operate in.
+            # If unspecified, it will be discovered from ec2metadata.
+            # List of regions: http://docs.aws.amazon.com/general/latest/gr/rande.html#vpc_region
+            # - --aws-region=us-west-1
+          # Repository location of the ALB Ingress Controller.
+          image: docker.io/amazon/aws-alb-ingress-controller:v1.1.2
+          imagePullPolicy: Always
+      serviceAccountName: alb-ingress-controller

--- a/aws/aws-alb-ingress-controller/base/kustomization.yaml
+++ b/aws/aws-alb-ingress-controller/base/kustomization.yaml
@@ -1,0 +1,27 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+namespace: kubeflow
+resources:
+- cluster-role.yaml
+- cluster-role-binding.yaml
+- deployment.yaml
+- service-account.yaml
+commonLabels:
+  kustomize.component: aws-alb-ingress-controller
+generatorOptions:
+  disableNameSuffixHash: true
+images:
+- name: docker.io/amazon/aws-alb-ingress-controller
+  newName: docker.io/amazon/aws-alb-ingress-controller
+  newTag: v1.1.2
+configMapGenerator:
+- name: alb-ingress-controller-parameters
+  env: params.env
+vars:
+- name: CLUSTER_NAME
+  objref:
+    kind: ConfigMap
+    name: alb-ingress-controller-parameters
+    apiVersion: v1
+  fieldref:
+    fieldpath: data.clusterName

--- a/aws/aws-alb-ingress-controller/base/params.env
+++ b/aws/aws-alb-ingress-controller/base/params.env
@@ -1,0 +1,1 @@
+clusterName=

--- a/aws/aws-alb-ingress-controller/base/service-account.yaml
+++ b/aws/aws-alb-ingress-controller/base/service-account.yaml
@@ -1,0 +1,4 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: alb-ingress-controller

--- a/aws/aws-alb-ingress-controller/overlays/vpc/kustomization.yaml
+++ b/aws/aws-alb-ingress-controller/overlays/vpc/kustomization.yaml
@@ -1,0 +1,23 @@
+bases:
+- ../../base
+resources:
+- vpc.yaml
+configMapGenerator:
+- name: alb-ingress-controller-parameters
+  behavior: merge
+  env: params.env
+vars:
+- name: VPC_ID
+  objref:
+    kind: ConfigMap
+    name: alb-ingress-controller-parameters
+    apiVersion: v1
+  fieldref:
+    fieldpath: data.vpcId
+- name: REGION
+  objref:
+    kind: ConfigMap
+    name: alb-ingress-controller-parameters
+    apiVersion: v1
+  fieldref:
+    fieldpath: data.region

--- a/aws/aws-alb-ingress-controller/overlays/vpc/params.env
+++ b/aws/aws-alb-ingress-controller/overlays/vpc/params.env
@@ -1,0 +1,2 @@
+vpcId=
+region=us-west-2

--- a/aws/aws-alb-ingress-controller/overlays/vpc/vpc.yaml
+++ b/aws/aws-alb-ingress-controller/overlays/vpc/vpc.yaml
@@ -1,0 +1,18 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: alb-ingress-controller
+spec:
+  template:
+    spec:
+      containers:
+        - name: alb-ingress-controller
+          args:
+            # AWS VPC ID this ingress controller will use to create AWS resources.
+            # If unspecified, it will be discovered from ec2metadata.
+            - --aws-vpc-id=$(VPC_ID)
+
+            # AWS region this ingress controller will operate in.
+            # If unspecified, it will be discovered from ec2metadata.
+            # List of regions: http://docs.aws.amazon.com/general/latest/gr/rande.html#vpc_region
+            - --aws-region=$(REGION)

--- a/aws/aws-efs-csi-driver/base/csi-attacher-cluster-role-binding.yaml
+++ b/aws/aws-efs-csi-driver/base/csi-attacher-cluster-role-binding.yaml
@@ -1,0 +1,12 @@
+kind: ClusterRoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: efs-csi-external-attacher-clusterrole-binding
+subjects:
+  - kind: ServiceAccount
+    name: efs-csi-controller-sa
+    namespace: kubeflow
+roleRef:
+  kind: ClusterRole
+  name: efs-csi-external-attacher-clusterrole
+  apiGroup: rbac.authorization.k8s.io

--- a/aws/aws-efs-csi-driver/base/csi-attacher-cluster-role.yaml
+++ b/aws/aws-efs-csi-driver/base/csi-attacher-cluster-role.yaml
@@ -1,0 +1,14 @@
+kind: ClusterRole
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: efs-csi-external-attacher-clusterrole
+rules:
+  - apiGroups: [""]
+    resources: ["persistentvolumes"]
+    verbs: ["get", "list", "watch", "update"]
+  - apiGroups: [""]
+    resources: ["nodes"]
+    verbs: ["get", "list", "watch"]
+  - apiGroups: ["storage.k8s.io"]
+    resources: ["volumeattachments"]
+    verbs: ["get", "list", "watch", "update"]

--- a/aws/aws-efs-csi-driver/base/csi-controller-sa.yaml
+++ b/aws/aws-efs-csi-driver/base/csi-controller-sa.yaml
@@ -1,0 +1,4 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: efs-csi-controller-sa

--- a/aws/aws-efs-csi-driver/base/csi-controller-stateful-set.yaml
+++ b/aws/aws-efs-csi-driver/base/csi-controller-stateful-set.yaml
@@ -1,0 +1,46 @@
+kind: StatefulSet
+apiVersion: apps/v1beta1
+metadata:
+  name: efs-csi-controller
+spec:
+  serviceName: efs-csi-controller
+  replicas: 1
+  template:
+    metadata:
+      labels:
+        app: efs-csi-controller
+    spec:
+      serviceAccount: efs-csi-controller-sa
+      #priorityClassName: system-cluster-critical
+      tolerations:
+        - key: CriticalAddonsOnly
+          operator: Exists
+      containers:
+        - name: efs-plugin
+          image: amazon/aws-efs-csi-driver:latest
+          imagePullPolicy: Always
+          args :
+            - --endpoint=$(CSI_ENDPOINT)
+            - --logtostderr
+            - --v=5
+          env:
+            - name: CSI_ENDPOINT
+              value: unix:///var/lib/csi/sockets/pluginproxy/csi.sock
+          volumeMounts:
+            - name: socket-dir
+              mountPath: /var/lib/csi/sockets/pluginproxy/
+        - name: csi-attacher
+          image: quay.io/k8scsi/csi-attacher:v0.4.2
+          imagePullPolicy: Always
+          args:
+            - --csi-address=$(ADDRESS)
+            - --v=5
+          env:
+            - name: ADDRESS
+              value: /var/lib/csi/sockets/pluginproxy/csi.sock
+          volumeMounts:
+            - name: socket-dir
+              mountPath: /var/lib/csi/sockets/pluginproxy/
+      volumes:
+        - name: socket-dir
+          emptyDir: {}

--- a/aws/aws-efs-csi-driver/base/csi-default-storage.yaml
+++ b/aws/aws-efs-csi-driver/base/csi-default-storage.yaml
@@ -1,0 +1,5 @@
+apiVersion: storage.k8s.io/v1
+kind: StorageClass
+metadata:
+  name: efs-default
+provisioner: efs.csi.aws.com

--- a/aws/aws-efs-csi-driver/base/csi-node-cluster-role-binding.yaml
+++ b/aws/aws-efs-csi-driver/base/csi-node-cluster-role-binding.yaml
@@ -1,0 +1,12 @@
+kind: ClusterRoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: efs-csi-node-clusterole-binding
+subjects:
+  - kind: ServiceAccount
+    name: efs-csi-node-sa
+    namespace: kubeflow
+roleRef:
+  kind: ClusterRole
+  name: efs-csi-node-clusterrole
+  apiGroup: rbac.authorization.k8s.io

--- a/aws/aws-efs-csi-driver/base/csi-node-cluster-role.yaml
+++ b/aws/aws-efs-csi-driver/base/csi-node-cluster-role.yaml
@@ -1,0 +1,23 @@
+kind: ClusterRole
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: efs-csi-node-clusterrole
+rules:
+  - apiGroups: [""]
+    resources: ["secrets"]
+    verbs: ["get", "list"]
+  - apiGroups: [""]
+    resources: ["nodes"]
+    verbs: ["get", "list", "update"]
+  - apiGroups: [""]
+    resources: ["namespaces"]
+    verbs: ["get", "list"]
+  - apiGroups: [""]
+    resources: ["persistentvolumes"]
+    verbs: ["get", "list", "watch", "update"]
+  - apiGroups: ["storage.k8s.io"]
+    resources: ["volumeattachments"]
+    verbs: ["get", "list", "watch", "update"]
+  - apiGroups: ["csi.storage.k8s.io"]
+    resources: ["csinodeinfos"]
+    verbs: ["get", "list", "watch", "update"]

--- a/aws/aws-efs-csi-driver/base/csi-node-daemon-set.yaml
+++ b/aws/aws-efs-csi-driver/base/csi-node-daemon-set.yaml
@@ -1,0 +1,77 @@
+kind: DaemonSet
+apiVersion: apps/v1beta2
+metadata:
+  name: efs-csi-node
+spec:
+  selector:
+    matchLabels:
+      app: efs-csi-node
+  template:
+    metadata:
+      labels:
+        app: efs-csi-node
+    spec:
+      serviceAccount: efs-csi-node-sa
+      hostNetwork: true
+      containers:
+        - name: efs-plugin
+          securityContext:
+            privileged: true
+          image: amazon/aws-efs-csi-driver:latest
+          imagePullPolicy: Always
+          args:
+            - --endpoint=$(CSI_ENDPOINT)
+            - --logtostderr
+            - --v=5
+          env:
+            - name: CSI_ENDPOINT
+              value: unix:/csi/csi.sock
+          volumeMounts:
+            - name: kubelet-dir
+              mountPath: /var/lib/kubelet
+              mountPropagation: "Bidirectional"
+            - name: plugin-dir
+              mountPath: /csi
+            - name: device-dir
+              mountPath: /dev
+        - name: csi-driver-registrar
+          image: quay.io/k8scsi/driver-registrar:v0.4.2
+          imagePullPolicy: Always
+          args:
+            - --csi-address=$(ADDRESS)
+            - --mode=node-register
+            - --driver-requires-attachment=true
+            - --pod-info-mount-version="v1"
+            - --kubelet-registration-path=$(DRIVER_REG_SOCK_PATH)
+            - --v=5
+          env:
+            - name: ADDRESS
+              value: /csi/csi.sock
+            - name: DRIVER_REG_SOCK_PATH
+              value: /var/lib/kubelet/plugins/efs.csi.aws.com/csi.sock
+            - name: KUBE_NODE_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: spec.nodeName
+          volumeMounts:
+            - name: plugin-dir
+              mountPath: /csi
+            - name: registration-dir
+              mountPath: /registration
+      volumes:
+        - name: kubelet-dir
+          hostPath:
+            path: /var/lib/kubelet
+            type: Directory
+        - name: plugin-dir
+          hostPath:
+            path: /var/lib/kubelet/plugins/efs.csi.aws.com/
+            type: DirectoryOrCreate
+        - name: registration-dir
+          hostPath:
+            path: /var/lib/kubelet/plugins/
+            type: Directory
+        - name: device-dir
+          hostPath:
+            path: /dev
+            type: Directory

--- a/aws/aws-efs-csi-driver/base/csi-node-sa.yaml
+++ b/aws/aws-efs-csi-driver/base/csi-node-sa.yaml
@@ -1,0 +1,4 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: efs-csi-node-sa

--- a/aws/aws-efs-csi-driver/base/kustomization.yaml
+++ b/aws/aws-efs-csi-driver/base/kustomization.yaml
@@ -1,0 +1,25 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+namespace: kubeflow
+resources:
+- csi-controller-stateful-set.yaml
+- csi-attacher-cluster-role.yaml
+- csi-attacher-cluster-role-binding.yaml
+- csi-controller-sa.yaml
+- csi-node-cluster-role.yaml
+- csi-node-cluster-role-binding.yaml
+- csi-node-daemon-set.yaml
+- csi-node-sa.yaml
+- csi-default-storage.yaml
+generatorOptions:
+  disableNameSuffixHash: true
+images:
+- name: quay.io/k8scsi/driver-registrar
+  newName: quay.io/k8scsi/driver-registrar
+  newTag: v0.4.2
+- name: amazon/aws-efs-csi-driver
+  newName: amazon/aws-efs-csi-driver
+  newTag: latest
+- name: quay.io/k8scsi/csi-attacher
+  newName: quay.io/k8scsi/csi-attacher
+  newTag: v0.4.2

--- a/aws/aws-fsx-csi-driver/base/csi-attacher-cluster-role-binding.yaml
+++ b/aws/aws-fsx-csi-driver/base/csi-attacher-cluster-role-binding.yaml
@@ -1,0 +1,12 @@
+kind: ClusterRoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: fsx-csi-external-attacher-clusterrole-binding
+subjects:
+  - kind: ServiceAccount
+    name: fsx-csi-controller-sa
+    namespace: kubeflow
+roleRef:
+  kind: ClusterRole
+  name: fsx-csi-external-attacher-clusterrole
+  apiGroup: rbac.authorization.k8s.io

--- a/aws/aws-fsx-csi-driver/base/csi-attacher-cluster-role.yaml
+++ b/aws/aws-fsx-csi-driver/base/csi-attacher-cluster-role.yaml
@@ -1,0 +1,14 @@
+kind: ClusterRole
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: fsx-csi-external-attacher-clusterrole
+rules:
+  - apiGroups: [""]
+    resources: ["persistentvolumes"]
+    verbs: ["get", "list", "watch", "update"]
+  - apiGroups: [""]
+    resources: ["nodes"]
+    verbs: ["get", "list", "watch"]
+  - apiGroups: ["storage.k8s.io"]
+    resources: ["volumeattachments"]
+    verbs: ["get", "list", "watch", "update"]

--- a/aws/aws-fsx-csi-driver/base/csi-controller-cluster-role-binding.yaml
+++ b/aws/aws-fsx-csi-driver/base/csi-controller-cluster-role-binding.yaml
@@ -1,0 +1,12 @@
+kind: ClusterRoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: csi-provisioner-binding
+subjects:
+  - kind: ServiceAccount
+    name: csi-controller-sa
+    namespace: kubeflow
+roleRef:
+  kind: ClusterRole
+  name: external-provisioner-role
+  apiGroup: rbac.authorization.k8s.io

--- a/aws/aws-fsx-csi-driver/base/csi-controller-cluster-role.yaml
+++ b/aws/aws-fsx-csi-driver/base/csi-controller-cluster-role.yaml
@@ -1,0 +1,17 @@
+kind: ClusterRole
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: external-provisioner-role
+rules:
+  - apiGroups: [""]
+    resources: ["persistentvolumes"]
+    verbs: ["get", "list", "watch", "create", "delete"]
+  - apiGroups: [""]
+    resources: ["persistentvolumeclaims"]
+    verbs: ["get", "list", "watch", "update"]
+  - apiGroups: ["storage.k8s.io"]
+    resources: ["storageclasses"]
+    verbs: ["get", "list", "watch"]
+  - apiGroups: [""]
+    resources: ["events"]
+    verbs: ["get", "list", "watch", "create", "update", "patch"]

--- a/aws/aws-fsx-csi-driver/base/csi-controller-sa.yaml
+++ b/aws/aws-fsx-csi-driver/base/csi-controller-sa.yaml
@@ -1,0 +1,4 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: fsx-csi-controller-sa

--- a/aws/aws-fsx-csi-driver/base/csi-controller-stateful-set.yaml
+++ b/aws/aws-fsx-csi-driver/base/csi-controller-stateful-set.yaml
@@ -1,0 +1,57 @@
+kind: StatefulSet
+apiVersion: apps/v1beta1
+metadata:
+  name: fsx-csi-controller
+spec:
+  serviceName: fsx-csi-controller
+  replicas: 1
+  template:
+    metadata:
+      labels:
+        app: fsx-csi-controller
+    spec:
+      serviceAccount: fsx-csi-controller-sa
+#      priorityClassName: system-cluster-critical
+      tolerations:
+        - key: CriticalAddonsOnly
+          operator: Exists
+      containers:
+        - name: fsx-plugin
+          image: amazon/aws-fsx-csi-driver:latest
+          args :
+            - --endpoint=$(CSI_ENDPOINT)
+            - --logtostderr
+            - --v=5
+          env:
+            - name: CSI_ENDPOINT
+              value: unix:///var/lib/csi/sockets/pluginproxy/csi.sock
+          volumeMounts:
+            - name: socket-dir
+              mountPath: /var/lib/csi/sockets/pluginproxy/
+        - name: csi-provisioner
+          image: quay.io/k8scsi/csi-provisioner:v0.4.2
+          args:
+            - --provisioner=fsx.csi.aws.com
+            - --csi-address=$(ADDRESS)
+            - --connection-timeout=5m
+            - --v=5
+          env:
+            - name: ADDRESS
+              value: /var/lib/csi/sockets/pluginproxy/csi.sock
+          volumeMounts:
+            - name: socket-dir
+              mountPath: /var/lib/csi/sockets/pluginproxy/
+        - name: csi-attacher
+          image: quay.io/k8scsi/csi-attacher:v0.4.2
+          args:
+            - --csi-address=$(ADDRESS)
+            - --v=5
+          env:
+            - name: ADDRESS
+              value: /var/lib/csi/sockets/pluginproxy/csi.sock
+          volumeMounts:
+            - name: socket-dir
+              mountPath: /var/lib/csi/sockets/pluginproxy/
+      volumes:
+        - name: socket-dir
+          emptyDir: {}

--- a/aws/aws-fsx-csi-driver/base/csi-default-storage.yaml
+++ b/aws/aws-fsx-csi-driver/base/csi-default-storage.yaml
@@ -1,0 +1,5 @@
+apiVersion: storage.k8s.io/v1
+kind: StorageClass
+metadata:
+  name: fsx-default
+provisioner: fsx.csi.aws.com

--- a/aws/aws-fsx-csi-driver/base/csi-node-cluster-role-binding.yaml
+++ b/aws/aws-fsx-csi-driver/base/csi-node-cluster-role-binding.yaml
@@ -1,0 +1,12 @@
+kind: ClusterRoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: fsx-csi-node-clusterrole-binding
+subjects:
+  - kind: ServiceAccount
+    name: fsx-csi-node-sa
+    namespace: kubeflow
+roleRef:
+  kind: ClusterRole
+  name: fsx-csi-node-clusterrole
+  apiGroup: rbac.authorization.k8s.io

--- a/aws/aws-fsx-csi-driver/base/csi-node-cluster-role.yaml
+++ b/aws/aws-fsx-csi-driver/base/csi-node-cluster-role.yaml
@@ -1,0 +1,23 @@
+kind: ClusterRole
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: fsx-csi-node-clusterrole
+rules:
+  - apiGroups: [""]
+    resources: ["secrets"]
+    verbs: ["get", "list"]
+  - apiGroups: [""]
+    resources: ["nodes"]
+    verbs: ["get", "list", "update"]
+  - apiGroups: [""]
+    resources: ["namespaces"]
+    verbs: ["get", "list"]
+  - apiGroups: [""]
+    resources: ["persistentvolumes"]
+    verbs: ["get", "list", "watch", "update"]
+  - apiGroups: ["storage.k8s.io"]
+    resources: ["volumeattachments"]
+    verbs: ["get", "list", "watch", "update"]
+  - apiGroups: ["csi.storage.k8s.io"]
+    resources: ["csinodeinfos"]
+    verbs: ["get", "list", "watch", "update"]

--- a/aws/aws-fsx-csi-driver/base/csi-node-daemonset.yaml
+++ b/aws/aws-fsx-csi-driver/base/csi-node-daemonset.yaml
@@ -1,0 +1,75 @@
+kind: DaemonSet
+apiVersion: apps/v1beta2
+metadata:
+  name: fsx-csi-node-ds
+spec:
+  selector:
+    matchLabels:
+      app: fsx-csi-node
+  template:
+    metadata:
+      labels:
+        app: fsx-csi-node
+    spec:
+      serviceAccount: fsx-csi-node-sa
+      hostNetwork: true
+      containers:
+        - name: fsx-plugin
+          securityContext:
+            privileged: true
+          image: amazon/aws-fsx-csi-driver:latest
+          args:
+            - --endpoint=$(CSI_ENDPOINT)
+            - --logtostderr
+            - --v=5
+          env:
+            - name: CSI_ENDPOINT
+              value: unix:/csi/csi.sock
+          volumeMounts:
+            - name: kubelet-dir
+              mountPath: /var/lib/kubelet
+              mountPropagation: "Bidirectional"
+            - name: plugin-dir
+              mountPath: /csi
+            - name: device-dir
+              mountPath: /dev
+        - name: csi-driver-registrar
+          image: quay.io/k8scsi/driver-registrar:v0.4.2
+          args:
+            - --csi-address=$(ADDRESS)
+            - --mode=node-register
+            - --driver-requires-attachment=true
+            - --pod-info-mount-version="v1"
+            - --kubelet-registration-path=$(DRIVER_REG_SOCK_PATH)
+            - --v=5
+          env:
+            - name: ADDRESS
+              value: /csi/csi.sock
+            - name: DRIVER_REG_SOCK_PATH
+              value: /var/lib/kubelet/plugins/fsx.csi.aws.com/csi.sock
+            - name: KUBE_NODE_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: spec.nodeName
+          volumeMounts:
+            - name: plugin-dir
+              mountPath: /csi
+            - name: registration-dir
+              mountPath: /registration
+      volumes:
+        - name: kubelet-dir
+          hostPath:
+            path: /var/lib/kubelet
+            type: Directory
+        - name: plugin-dir
+          hostPath:
+            path: /var/lib/kubelet/plugins/fsx.csi.aws.com/
+            type: DirectoryOrCreate
+        - name: registration-dir
+          hostPath:
+            path: /var/lib/kubelet/plugins/
+            type: Directory
+        - name: device-dir
+          hostPath:
+            path: /dev
+            type: Directory

--- a/aws/aws-fsx-csi-driver/base/csi-node-sa.yaml
+++ b/aws/aws-fsx-csi-driver/base/csi-node-sa.yaml
@@ -1,0 +1,4 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: fsx-csi-node-sa

--- a/aws/aws-fsx-csi-driver/base/csi-provisioner-cluster-role-binding.yaml
+++ b/aws/aws-fsx-csi-driver/base/csi-provisioner-cluster-role-binding.yaml
@@ -1,0 +1,12 @@
+kind: ClusterRoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: fsx-csi-provisioner-clusterrole-binding
+subjects:
+  - kind: ServiceAccount
+    name: fsx-csi-controller-sa
+    namespace: kubeflow
+roleRef:
+  kind: ClusterRole
+  name: fsx-external-provisioner-clusterrole
+  apiGroup: rbac.authorization.k8s.io

--- a/aws/aws-fsx-csi-driver/base/csi-provisioner-cluster-role.yaml
+++ b/aws/aws-fsx-csi-driver/base/csi-provisioner-cluster-role.yaml
@@ -1,0 +1,17 @@
+kind: ClusterRole
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: fsx-external-provisioner-clusterrole
+rules:
+  - apiGroups: [""]
+    resources: ["persistentvolumes"]
+    verbs: ["get", "list", "watch", "create", "delete"]
+  - apiGroups: [""]
+    resources: ["persistentvolumeclaims"]
+    verbs: ["get", "list", "watch", "update"]
+  - apiGroups: ["storage.k8s.io"]
+    resources: ["storageclasses"]
+    verbs: ["get", "list", "watch"]
+  - apiGroups: [""]
+    resources: ["events"]
+    verbs: ["get", "list", "watch", "create", "update", "patch"]

--- a/aws/aws-fsx-csi-driver/base/kustomization.yaml
+++ b/aws/aws-fsx-csi-driver/base/kustomization.yaml
@@ -1,0 +1,29 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+namespace: kubeflow
+resources:
+- csi-controller-stateful-set.yaml
+- csi-attacher-cluster-role.yaml
+- csi-attacher-cluster-role-binding.yaml
+- csi-controller-cluster-role.yaml
+- csi-controller-cluster-role-binding.yaml
+- csi-controller-sa.yaml
+- csi-node-cluster-role.yaml
+- csi-node-cluster-role-binding.yaml
+- csi-node-daemonset.yaml
+- csi-node-sa.yaml
+- csi-provisioner-cluster-role.yaml
+- csi-provisioner-cluster-role-binding.yaml
+- csi-default-storage.yaml
+generatorOptions:
+  disableNameSuffixHash: true
+images:
+- name: amazon/aws-fsx-csi-driver
+  newName: amazon/aws-fsx-csi-driver
+  newTag: latest
+- name: quay.io/k8scsi/driver-registrar
+  newName: quay.io/k8scsi/driver-registrar
+  newTag: v0.4.2
+- name: quay.io/k8scsi/csi-provisioner
+  newName: quay.io/k8scsi/csi-provisioner
+  newTag: v0.4.2

--- a/aws/fluentd-cloud-watch/base/cluster-role-binding.yaml
+++ b/aws/fluentd-cloud-watch/base/cluster-role-binding.yaml
@@ -1,0 +1,12 @@
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: ClusterRoleBinding
+metadata:
+  name: fluentd
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: fluentd
+subjects:
+  - kind: ServiceAccount
+    name: fluentd
+    namespace: kube-system

--- a/aws/fluentd-cloud-watch/base/cluster-role.yaml
+++ b/aws/fluentd-cloud-watch/base/cluster-role.yaml
@@ -1,0 +1,10 @@
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: ClusterRole
+metadata:
+  name: fluentd
+rules:
+  - apiGroups: [""]
+    resources:
+      - namespaces
+      - pods
+    verbs: ["get", "list", "watch"]

--- a/aws/fluentd-cloud-watch/base/configmap.yaml
+++ b/aws/fluentd-cloud-watch/base/configmap.yaml
@@ -1,0 +1,122 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: fluentd-config
+  labels:
+    k8s-app: fluentd-cloudwatch
+data:
+  fluent.conf: |
+    @include containers.conf
+    @include systemd.conf
+    <match fluent.**>
+      @type null
+    </match>
+  containers.conf: |
+    <source>
+      @type tail
+      @id in_tail_container_logs
+      @label @containers
+      path /var/log/containers/*.log
+      pos_file /var/log/fluentd-containers.log.pos
+      tag *
+      read_from_head true
+      <parse>
+        @type json
+        time_format %Y-%m-%dT%H:%M:%S.%NZ
+      </parse>
+    </source>
+    <label @containers>
+      <filter **>
+        @type kubernetes_metadata
+        @id filter_kube_metadata
+      </filter>
+      <filter **>
+        @type record_transformer
+        @id filter_containers_stream_transformer
+        <record>
+          stream_name ${tag_parts[3]}
+        </record>
+      </filter>
+      <match **>
+        @type cloudwatch_logs
+        @id out_cloudwatch_logs_containers
+        region "#{ENV.fetch('REGION')}"
+        log_group_name "/eks/#{ENV.fetch('CLUSTER_NAME')}/containers"
+        log_stream_name_key stream_name
+        remove_log_stream_name_key true
+        auto_create_stream true
+        <buffer>
+          flush_interval 5
+          chunk_limit_size 2m
+          queued_chunks_limit_size 32
+          retry_forever true
+        </buffer>
+      </match>
+    </label>
+  systemd.conf: |
+    <source>
+      @type systemd
+      @id in_systemd_kubelet
+      @label @systemd
+      filters [{ "_SYSTEMD_UNIT": "kubelet.service" }]
+      <entry>
+        field_map {"MESSAGE": "message", "_HOSTNAME": "hostname", "_SYSTEMD_UNIT": "systemd_unit"}
+        field_map_strict true
+      </entry>
+      path /run/log/journal
+      pos_file /var/log/fluentd-journald-kubelet.pos
+      read_from_head true
+      tag kubelet.service
+    </source>
+    <source>
+      @type systemd
+      @id in_systemd_kubeproxy
+      @label @systemd
+      filters [{ "_SYSTEMD_UNIT": "kubeproxy.service" }]
+      <entry>
+        field_map {"MESSAGE": "message", "_HOSTNAME": "hostname", "_SYSTEMD_UNIT": "systemd_unit"}
+        field_map_strict true
+      </entry>
+      path /run/log/journal
+      pos_file /var/log/fluentd-journald-kubeproxy.pos
+      read_from_head true
+      tag kubeproxy.service
+    </source>
+    <source>
+      @type systemd
+      @id in_systemd_docker
+      @label @systemd
+      filters [{ "_SYSTEMD_UNIT": "docker.service" }]
+      <entry>
+        field_map {"MESSAGE": "message", "_HOSTNAME": "hostname", "_SYSTEMD_UNIT": "systemd_unit"}
+        field_map_strict true
+      </entry>
+      path /run/log/journal
+      pos_file /var/log/fluentd-journald-docker.pos
+      read_from_head true
+      tag docker.service
+    </source>
+    <label @systemd>
+      <filter **>
+        @type record_transformer
+        @id filter_systemd_stream_transformer
+        <record>
+          stream_name ${tag}-${record["hostname"]}
+        </record>
+      </filter>
+      <match **>
+        @type cloudwatch_logs
+        @id out_cloudwatch_logs_systemd
+        region "#{ENV.fetch('REGION')}"
+        log_group_name "/eks/#{ENV.fetch('CLUSTER_NAME')}/systemd"
+        log_stream_name_key stream_name
+        auto_create_stream true
+        remove_log_stream_name_key true
+        <buffer>
+          flush_interval 5
+          chunk_limit_size 2m
+          queued_chunks_limit_size 32
+          retry_forever true
+        </buffer>
+      </match>
+    </label>

--- a/aws/fluentd-cloud-watch/base/daemonset.yaml
+++ b/aws/fluentd-cloud-watch/base/daemonset.yaml
@@ -1,0 +1,68 @@
+apiVersion: extensions/v1beta1
+kind: DaemonSet
+metadata:
+  name: fluentd-cloudwatch
+  labels:
+    k8s-app: fluentd-cloudwatch
+spec:
+  template:
+    metadata:
+      labels:
+        k8s-app: fluentd-cloudwatch
+    spec:
+      serviceAccountName: fluentd
+      terminationGracePeriodSeconds: 30
+      # Because the image's entrypoint requires to write on /fluentd/etc but we mount configmap there which is read-only,
+      # this initContainers workaround or other is needed.
+      # See https://github.com/fluent/fluentd-kubernetes-daemonset/issues/90
+      initContainers:
+        - name: copy-fluentd-config
+          image: busybox
+          command: ['sh', '-c', 'cp /config-volume/..data/* /fluentd/etc']
+          volumeMounts:
+            - name: config-volume
+              mountPath: /config-volume
+            - name: fluentdconf
+              mountPath: /fluentd/etc
+      containers:
+        - name: fluentd-cloudwatch
+          image: fluent/fluentd-kubernetes-daemonset:v1.1-debian-cloudwatch
+          env:
+            - name: REGION
+              value: $(REGION)
+            - name: CLUSTER_NAME
+              value: $(CLUSTER_NAME)
+          resources:
+            limits:
+              memory: 200Mi
+            requests:
+              cpu: 100m
+              memory: 200Mi
+          volumeMounts:
+            - name: config-volume
+              mountPath: /config-volume
+            - name: fluentdconf
+              mountPath: /fluentd/etc
+            - name: varlog
+              mountPath: /var/log
+            - name: varlibdockercontainers
+              mountPath: /var/lib/docker/containers
+              readOnly: true
+            - name: runlogjournal
+              mountPath: /run/log/journal
+              readOnly: true
+      volumes:
+        - name: config-volume
+          configMap:
+            name: fluentd-config
+        - name: fluentdconf
+          emptyDir: {}
+        - name: varlog
+          hostPath:
+            path: /var/log
+        - name: varlibdockercontainers
+          hostPath:
+            path: /var/lib/docker/containers
+        - name: runlogjournal
+          hostPath:
+            path: /run/log/journal

--- a/aws/fluentd-cloud-watch/base/kustomization.yaml
+++ b/aws/fluentd-cloud-watch/base/kustomization.yaml
@@ -1,0 +1,35 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+namespace: kube-system
+resources:
+- cluster-role.yaml
+- cluster-role-binding.yaml
+- configmap.yaml
+- daemonset.yaml
+- service-account.yaml
+commonLabels:
+  kustomize.component: fluentd-cloud-watch
+generatorOptions:
+  disableNameSuffixHash: true
+images:
+- name: fluent/fluentd-kubernetes-daemonset
+  newName: fluent/fluentd-kubernetes-daemonset
+  newTag: v1.1-debian-cloudwatch
+configMapGenerator:
+- name: fluentd-cloud-watch-parameters
+  env: params.env
+vars:
+- name: CLUSTER_NAME
+  objref:
+    kind: ConfigMap
+    name: fluentd-cloud-watch-parameters
+    apiVersion: v1
+  fieldref:
+    fieldpath: data.clusterName
+- name: REGION
+  objref:
+    kind: ConfigMap
+    name: fluentd-cloud-watch-parameters
+    apiVersion: v1
+  fieldref:
+    fieldpath: data.region

--- a/aws/fluentd-cloud-watch/base/params.env
+++ b/aws/fluentd-cloud-watch/base/params.env
@@ -1,0 +1,2 @@
+region=us-west-2
+clusterName=

--- a/aws/fluentd-cloud-watch/base/service-account.yaml
+++ b/aws/fluentd-cloud-watch/base/service-account.yaml
@@ -1,0 +1,4 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: fluentd

--- a/aws/istio-ingress/base/ingress.yaml
+++ b/aws/istio-ingress/base/ingress.yaml
@@ -1,0 +1,16 @@
+apiVersion: extensions/v1beta1
+kind: Ingress
+metadata:
+  annotations:
+    kubernetes.io/ingress.class: alb
+    alb.ingress.kubernetes.io/scheme: internet-facing
+    alb.ingress.kubernetes.io/listen-ports: '[{"HTTP": 80}]'
+  name: istio-ingress
+spec:
+  rules:
+    - http:
+        paths:
+          - backend:
+              serviceName: istio-ingressgateway
+              servicePort: 80
+            path: /*

--- a/aws/istio-ingress/base/istio-gateway.yaml
+++ b/aws/istio-ingress/base/istio-gateway.yaml
@@ -1,0 +1,15 @@
+apiVersion: networking.istio.io/v1alpha3
+kind: Gateway
+metadata:
+  name: kubeflow-gateway
+  namespace: kubeflow
+spec:
+  selector:
+    istio: ingressgateway
+  servers:
+  - hosts:
+    - '*'
+    port:
+      name: http
+      number: 80
+      protocol: HTTP

--- a/aws/istio-ingress/base/istio-policy.yaml
+++ b/aws/istio-ingress/base/istio-policy.yaml
@@ -1,0 +1,20 @@
+# TODO: AWS has not enable this yet
+
+apiVersion: authentication.istio.io/v1alpha1
+kind: Policy
+metadata:
+  name: istio-jwt
+  namespace: istio-system
+spec:
+  targets:
+    - name: istio-ingressgateway
+      ports:
+        - number: 80
+  origins:
+    - jwt:
+        audiences:
+          - cognito_app_client_id
+        issuer: "testing@secure.istio.io"
+        jwksUri: "https://raw.githubusercontent.com/istio/istio/release-1.2/security/tools/jwt/samples/jwks.json"
+        jwtHeaders: x-amzn-cognito-jwt-assertion
+  principalBinding: USE_ORIGIN

--- a/aws/istio-ingress/base/istio-virutal-service.yaml
+++ b/aws/istio-ingress/base/istio-virutal-service.yaml
@@ -1,0 +1,19 @@
+apiVersion: networking.istio.io/v1alpha3
+kind: VirtualService
+metadata:
+  name: kubeflow-routes
+  namespace: kubeflow
+spec:
+  gateways:
+    - kubeflow-gateway
+  hosts:
+    - '*'
+  http:
+    - match:
+      - uri:
+        prefix: /
+      route:
+      - destination:
+          host: ambassador
+          port:
+            number: 80

--- a/aws/istio-ingress/base/kustomization.yaml
+++ b/aws/istio-ingress/base/kustomization.yaml
@@ -1,0 +1,8 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+- ingress.yaml
+- istio-gateway.yaml
+#- istio-virtual-service.yaml
+commonLabels:
+  kustomize.component: istio-ingress

--- a/aws/istio-ingress/overlays/cognito/ingress.yaml
+++ b/aws/istio-ingress/overlays/cognito/ingress.yaml
@@ -1,0 +1,11 @@
+apiVersion: extensions/v1beta1
+kind: Ingress
+metadata:
+  name: istio-ingress
+  annotations:
+    kubernetes.io/ingress.class: alb
+    alb.ingress.kubernetes.io/scheme: internet-facing
+    alb.ingress.kubernetes.io/auth-type: cognito
+    alb.ingress.kubernetes.io/auth-idp-cognito: '{"UserPoolArn":"$(CognitoUserPoolArn)","UserPoolClientId":"$(CognitoAppClientId)", "UserPoolDomain":"$(CognitoUserPoolDomain)"}'
+    alb.ingress.kubernetes.io/certificate-arn: $(certArn)
+    alb.ingress.kubernetes.io/listen-ports: '[{"HTTPS":443}]'

--- a/aws/istio-ingress/overlays/cognito/kustomization.yaml
+++ b/aws/istio-ingress/overlays/cognito/kustomization.yaml
@@ -1,0 +1,38 @@
+bases:
+- ../../base
+patchesStrategicMerge:
+- ingress.yaml
+configMapGenerator:
+- name: istio-ingress-cognito-parameters
+  env: params.env
+vars:
+- name: CognitoUserPoolArn
+  objref:
+    kind: ConfigMap
+    name: istio-ingress-cognito-parameters
+    apiVersion: v1
+  fieldref:
+    fieldpath: data.CognitoUserPoolArn
+- name: CognitoAppClientId
+  objref:
+    kind: ConfigMap
+    name: istio-ingress-cognito-parameters
+    apiVersion: v1
+  fieldref:
+    fieldpath: data.CognitoAppClientId
+- name: CognitoUserPoolDomain
+  objref:
+    kind: ConfigMap
+    name: istio-ingress-cognito-parameters
+    apiVersion: v1
+  fieldref:
+    fieldpath: data.CognitoUserPoolDomain
+- name: certArn
+  objref:
+    kind: ConfigMap
+    name: istio-ingress-cognito-parameters
+    apiVersion: v1
+  fieldref:
+    fieldpath: data.certArn
+configurations:
+- params.yaml

--- a/aws/istio-ingress/overlays/cognito/params.env
+++ b/aws/istio-ingress/overlays/cognito/params.env
@@ -1,0 +1,4 @@
+CognitoUserPoolArn=
+CognitoAppClientId=
+CognitoUserPoolDomain=
+certArn=

--- a/aws/istio-ingress/overlays/cognito/params.yaml
+++ b/aws/istio-ingress/overlays/cognito/params.yaml
@@ -1,0 +1,3 @@
+varReference:
+- path: metadata/annotations
+  kind: Ingress

--- a/aws/istio-ingress/overlays/oidc/ingress.yaml
+++ b/aws/istio-ingress/overlays/oidc/ingress.yaml
@@ -1,0 +1,11 @@
+apiVersion: extensions/v1beta1
+kind: Ingress
+metadata:
+  name: istio-ingress
+  annotations:
+    kubernetes.io/ingress.class: alb
+    alb.ingress.kubernetes.io/scheme: internet-facing
+    alb.ingress.kubernetes.io/auth-type: oidc
+    alb.ingress.kubernetes.io/auth-idp-cognito: '{"Issuer":"$(oidcIssuer)","AuthorizationEndpoint":"$(oidcAuthorizationEndpoint)","TokenEndpoint":"$(oidcTokenEndpoint)","UserInfoEndpoint":"$(oidcUserInfoEndpoint)","SecretName":"$(oidcSecretName)"}'
+    alb.ingress.kubernetes.io/certificate-arn: $(certArn)
+    alb.ingress.kubernetes.io/listen-ports: '[{"HTTPS":443}]'

--- a/aws/istio-ingress/overlays/oidc/kustomization.yaml
+++ b/aws/istio-ingress/overlays/oidc/kustomization.yaml
@@ -1,0 +1,57 @@
+bases:
+- ../../base
+patchesStrategicMerge:
+- ingress.yaml
+#- oidc-secret.yaml
+secretGenerator:
+- name: istio-oidc-secret
+  env: secrets.env
+  namespace: istio-system
+configMapGenerator:
+- name: istio-ingress-oidc-parameters
+  env: params.env
+vars:
+- name: oidcIssuer
+  objref:
+    kind: ConfigMap
+    name: istio-ingress-oidc-parameters
+    apiVersion: v1
+  fieldref:
+    fieldpath: data.oidcIssuer
+- name: oidcAuthorizationEndpoint
+  objref:
+    kind: ConfigMap
+    name: istio-ingress-oidc-parameters
+    apiVersion: v1
+  fieldref:
+    fieldpath: data.oidcAuthorizationEndpoint
+- name: oidcTokenEndpoint
+  objref:
+    kind: ConfigMap
+    name: istio-ingress-oidc-parameters
+    apiVersion: v1
+  fieldref:
+    fieldpath: data.oidcTokenEndpoint
+- name: oidcUserInfoEndpoint
+  objref:
+    kind: ConfigMap
+    name: istio-ingress-oidc-parameters
+    apiVersion: v1
+  fieldref:
+    fieldpath: data.oidcUserInfoEndpoint
+- name: oidcSecretName
+  objref:
+    kind: ConfigMap
+    name: istio-ingress-oidc-parameters
+    apiVersion: v1
+  fieldref:
+    fieldpath: data.oidcSecretName
+- name: certArn
+  objref:
+    kind: ConfigMap
+    name: istio-ingress-oidc-parameters
+    apiVersion: v1
+  fieldref:
+    fieldpath: data.certArn
+configurations:
+- params.yaml

--- a/aws/istio-ingress/overlays/oidc/oidc-secret.yaml
+++ b/aws/istio-ingress/overlays/oidc/oidc-secret.yaml
@@ -1,0 +1,8 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: istio-oidc-secret
+  namespace: istio-system
+data:
+  clientId: $(oidc_client_id)
+  clientSecret: $(oidc_client_secret)

--- a/aws/istio-ingress/overlays/oidc/params.env
+++ b/aws/istio-ingress/overlays/oidc/params.env
@@ -1,0 +1,6 @@
+oidcIssuer=
+oidcAuthorizationEndpoint=
+oidcTokenEndpoint=
+oidcUserInfoEndpoint=
+oidcSecretName=istio-oidc-secret
+certArn=

--- a/aws/istio-ingress/overlays/oidc/params.yaml
+++ b/aws/istio-ingress/overlays/oidc/params.yaml
@@ -1,0 +1,4 @@
+varReference:
+- path: metadata/annotations
+  kind: Ingress
+

--- a/aws/istio-ingress/overlays/oidc/secrets.env
+++ b/aws/istio-ingress/overlays/oidc/secrets.env
@@ -1,0 +1,2 @@
+clientId=
+clientSecret=

--- a/aws/nvidia-device-plugin/base/daemonset.yaml
+++ b/aws/nvidia-device-plugin/base/daemonset.yaml
@@ -1,0 +1,37 @@
+apiVersion: extensions/v1beta1
+kind: DaemonSet
+metadata:
+  name: nvidia-device-plugin-daemonset
+spec:
+  updateStrategy:
+    type: RollingUpdate
+  template:
+    metadata:
+      # Mark this pod as a critical add-on; when enabled, the critical add-on scheduler
+      # reserves resources for critical add-on pods so that they can be rescheduled after
+      # a failure.  This annotation works in tandem with the toleration below.
+      annotations:
+        scheduler.alpha.kubernetes.io/critical-pod: ""
+    spec:
+      tolerations:
+        # Allow this pod to be rescheduled while the node is in "critical add-ons only" mode.
+        # This, along with the annotation above marks this pod as a critical add-on.
+        - key: CriticalAddonsOnly
+          operator: Exists
+        - key: nvidia.com/gpu
+          operator: Exists
+          effect: NoSchedule
+      containers:
+        - image: nvidia/k8s-device-plugin:1.0.0-beta
+          name: nvidia-device-plugin-ctr
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop: ["ALL"]
+          volumeMounts:
+            - name: device-plugin
+              mountPath: /var/lib/kubelet/device-plugins
+      volumes:
+        - name: device-plugin
+          hostPath:
+            path: /var/lib/kubelet/device-plugins

--- a/aws/nvidia-device-plugin/base/kustomization.yaml
+++ b/aws/nvidia-device-plugin/base/kustomization.yaml
@@ -1,0 +1,11 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+namespace: kube-system
+resources:
+- daemonset.yaml
+commonLabels:
+  kustomize.component: nvidia-device-plugin
+images:
+- name: nvidia/k8s-device-plugin
+  newName: nvidia/k8s-device-plugin
+  newTag: 1.0.0-beta

--- a/hack/gen-test-target.sh
+++ b/hack/gen-test-target.sh
@@ -41,7 +41,7 @@ gen-target-start() {
 gen-target-middle() {
   local directory=$1
 
-  for i in $(echo $(cat $directory/kustomization.yaml | grep '^- .*yaml$' | sed 's/^- //') $(cat $directory/kustomization.yaml | grep '  path: ' | sed 's/^.*: \(.*\)$/\1/') params.env kustomization.yaml | sed 's/ /\\n/g' | sort | uniq | awk '{gsub(/\\n/,"\n")}1'); do
+  for i in $(echo $(cat $directory/kustomization.yaml | grep '^- .*yaml$' | sed 's/^- //') $(cat $directory/kustomization.yaml | grep '  path: ' | sed 's/^.*: \(.*\)$/\1/') params.env secrets.env kustomization.yaml | sed 's/ /\\n/g' | sort | uniq | awk '{gsub(/\\n/,"\n")}1'); do
     file=$i
     if [[ -f $directory/$file ]]; then
       case $file in
@@ -52,6 +52,9 @@ gen-target-middle() {
           gen-target-resource $file $directory
           ;;
         params.env)
+          gen-target-resource $file $directory
+          ;;
+        secrets.env)
           gen-target-resource $file $directory
           ;;
         *) ;;

--- a/istio/istio/base/kustomization.yaml
+++ b/istio/istio/base/kustomization.yaml
@@ -15,4 +15,4 @@ vars:
   fieldref:
     fieldpath: data.clusterRbacConfig
 configurations:
- - params.yaml
+- params.yaml

--- a/tests/aws-alb-ingress-controller-base_test.go
+++ b/tests/aws-alb-ingress-controller-base_test.go
@@ -1,0 +1,182 @@
+package tests_test
+
+import (
+	"sigs.k8s.io/kustomize/k8sdeps/kunstruct"
+	"sigs.k8s.io/kustomize/k8sdeps/transformer"
+	"sigs.k8s.io/kustomize/pkg/fs"
+	"sigs.k8s.io/kustomize/pkg/loader"
+	"sigs.k8s.io/kustomize/pkg/resmap"
+	"sigs.k8s.io/kustomize/pkg/resource"
+	"sigs.k8s.io/kustomize/pkg/target"
+	"testing"
+)
+
+func writeAwsAlbIngressControllerBase(th *KustTestHarness) {
+	th.writeF("/manifests/aws/aws-alb-ingress-controller/base/cluster-role.yaml", `
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: alb-ingress-controller
+rules:
+  - apiGroups:
+      - ""
+      - extensions
+    resources:
+      - configmaps
+      - endpoints
+      - events
+      - ingresses
+      - ingresses/status
+      - services
+    verbs:
+      - create
+      - get
+      - list
+      - update
+      - watch
+      - patch
+  - apiGroups:
+      - ""
+      - extensions
+    resources:
+      - nodes
+      - pods
+      - secrets
+      - services
+      - namespaces
+    verbs:
+      - get
+      - list
+      - watch
+`)
+	th.writeF("/manifests/aws/aws-alb-ingress-controller/base/cluster-role-binding.yaml", `
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: alb-ingress-controller
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: alb-ingress-controller
+subjects:
+  - kind: ServiceAccount
+    name: alb-ingress-controller
+`)
+	th.writeF("/manifests/aws/aws-alb-ingress-controller/base/deployment.yaml", `
+# Application Load Balancer (ALB) Ingress Controller Deployment Manifest.
+# This manifest details sensible defaults for deploying an ALB Ingress Controller.
+# GitHub: https://github.com/kubernetes-sigs/aws-alb-ingress-controller
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: alb-ingress-controller
+  # Namespace the ALB Ingress Controller should run in. Does not impact which
+  # namespaces it's able to resolve ingress resource for. For limiting ingress
+  # namespace scope, see --watch-namespace.
+#  namespace: kubeflow
+spec:
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: alb-ingress-controller
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: alb-ingress-controller
+    spec:
+      containers:
+        - name: alb-ingress-controller
+          args:
+            # Limit the namespace where this ALB Ingress Controller deployment will
+            # resolve ingress resources. If left commented, all namespaces are used.
+            # - --watch-namespace=your-k8s-namespace
+
+            # Setting the ingress-class flag below ensures that only ingress resources with the
+            # annotation kubernetes.io/ingress.class: "alb" are respected by the controller. You may
+            # choose any class you'd like for this controller to respect.
+            - --ingress-class=alb
+
+            # REQUIRED
+            # Name of your cluster. Used when naming resources created
+            # by the ALB Ingress Controller, providing distinction between
+            # clusters.
+#            - --cluster-name=$(CLUSTER_NAME)
+            - --cluster-name=$(CLUSTER_NAME)
+
+            # AWS VPC ID this ingress controller will use to create AWS resources.
+            # If unspecified, it will be discovered from ec2metadata.
+            # - --aws-vpc-id=vpc-xxxxxx
+
+            # AWS region this ingress controller will operate in.
+            # If unspecified, it will be discovered from ec2metadata.
+            # List of regions: http://docs.aws.amazon.com/general/latest/gr/rande.html#vpc_region
+            # - --aws-region=us-west-1
+          # Repository location of the ALB Ingress Controller.
+          image: docker.io/amazon/aws-alb-ingress-controller:v1.1.2
+          imagePullPolicy: Always
+      serviceAccountName: alb-ingress-controller
+`)
+	th.writeF("/manifests/aws/aws-alb-ingress-controller/base/service-account.yaml", `
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: alb-ingress-controller
+`)
+	th.writeF("/manifests/aws/aws-alb-ingress-controller/base/params.env", `
+clusterName=
+`)
+	th.writeK("/manifests/aws/aws-alb-ingress-controller/base", `
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+namespace: kubeflow
+resources:
+- cluster-role.yaml
+- cluster-role-binding.yaml
+- deployment.yaml
+- service-account.yaml
+commonLabels:
+  kustomize.component: aws-alb-ingress-controller
+generatorOptions:
+  disableNameSuffixHash: true
+images:
+- name: docker.io/amazon/aws-alb-ingress-controller
+  newName: docker.io/amazon/aws-alb-ingress-controller
+  newTag: v1.1.2
+configMapGenerator:
+- name: alb-ingress-controller-parameters
+  env: params.env
+vars:
+- name: CLUSTER_NAME
+  objref:
+    kind: ConfigMap
+    name: alb-ingress-controller-parameters
+    apiVersion: v1
+  fieldref:
+    fieldpath: data.clusterName
+`)
+}
+
+func TestAwsAlbIngressControllerBase(t *testing.T) {
+	th := NewKustTestHarness(t, "/manifests/aws/aws-alb-ingress-controller/base")
+	writeAwsAlbIngressControllerBase(th)
+	m, err := th.makeKustTarget().MakeCustomizedResMap()
+	if err != nil {
+		t.Fatalf("Err: %v", err)
+	}
+	targetPath := "../aws/aws-alb-ingress-controller/base"
+	fsys := fs.MakeRealFS()
+	_loader, loaderErr := loader.NewLoader(targetPath, fsys)
+	if loaderErr != nil {
+		t.Fatalf("could not load kustomize loader: %v", loaderErr)
+	}
+	rf := resmap.NewFactory(resource.NewFactory(kunstruct.NewKunstructuredFactoryImpl()))
+	kt, err := target.NewKustTarget(_loader, rf, transformer.NewFactoryImpl())
+	if err != nil {
+		th.t.Fatalf("Unexpected construction error %v", err)
+	}
+	n, err := kt.MakeCustomizedResMap()
+	if err != nil {
+		t.Fatalf("Err: %v", err)
+	}
+	expected, err := n.EncodeAsYaml()
+	th.assertActualEqualsExpected(m, string(expected))
+}

--- a/tests/aws-alb-ingress-controller-overlays-vpc_test.go
+++ b/tests/aws-alb-ingress-controller-overlays-vpc_test.go
@@ -1,0 +1,231 @@
+package tests_test
+
+import (
+	"sigs.k8s.io/kustomize/k8sdeps/kunstruct"
+	"sigs.k8s.io/kustomize/k8sdeps/transformer"
+	"sigs.k8s.io/kustomize/pkg/fs"
+	"sigs.k8s.io/kustomize/pkg/loader"
+	"sigs.k8s.io/kustomize/pkg/resmap"
+	"sigs.k8s.io/kustomize/pkg/resource"
+	"sigs.k8s.io/kustomize/pkg/target"
+	"testing"
+)
+
+func writeAwsAlbIngressControllerOverlaysVpc(th *KustTestHarness) {
+	th.writeF("/manifests/aws/aws-alb-ingress-controller/overlays/vpc/vpc.yaml", `
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: alb-ingress-controller
+spec:
+  template:
+    spec:
+      containers:
+        - name: alb-ingress-controller
+          args:
+            # AWS VPC ID this ingress controller will use to create AWS resources.
+            # If unspecified, it will be discovered from ec2metadata.
+            - --aws-vpc-id=$(VPC_ID)
+
+            # AWS region this ingress controller will operate in.
+            # If unspecified, it will be discovered from ec2metadata.
+            # List of regions: http://docs.aws.amazon.com/general/latest/gr/rande.html#vpc_region
+            - --aws-region=$(REGION)
+`)
+	th.writeF("/manifests/aws/aws-alb-ingress-controller/overlays/vpc/params.env", `
+vpcId=
+region=us-west-2
+`)
+	th.writeK("/manifests/aws/aws-alb-ingress-controller/overlays/vpc", `
+bases:
+- ../../base
+resources:
+- vpc.yaml
+configMapGenerator:
+- name: alb-ingress-controller-parameters
+  behavior: merge
+  env: params.env
+vars:
+- name: VPC_ID
+  objref:
+    kind: ConfigMap
+    name: alb-ingress-controller-parameters
+    apiVersion: v1
+  fieldref:
+    fieldpath: data.vpcId
+- name: REGION
+  objref:
+    kind: ConfigMap
+    name: alb-ingress-controller-parameters
+    apiVersion: v1
+  fieldref:
+    fieldpath: data.region
+`)
+	th.writeF("/manifests/aws/aws-alb-ingress-controller/base/cluster-role.yaml", `
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: alb-ingress-controller
+rules:
+  - apiGroups:
+      - ""
+      - extensions
+    resources:
+      - configmaps
+      - endpoints
+      - events
+      - ingresses
+      - ingresses/status
+      - services
+    verbs:
+      - create
+      - get
+      - list
+      - update
+      - watch
+      - patch
+  - apiGroups:
+      - ""
+      - extensions
+    resources:
+      - nodes
+      - pods
+      - secrets
+      - services
+      - namespaces
+    verbs:
+      - get
+      - list
+      - watch
+`)
+	th.writeF("/manifests/aws/aws-alb-ingress-controller/base/cluster-role-binding.yaml", `
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: alb-ingress-controller
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: alb-ingress-controller
+subjects:
+  - kind: ServiceAccount
+    name: alb-ingress-controller
+`)
+	th.writeF("/manifests/aws/aws-alb-ingress-controller/base/deployment.yaml", `
+# Application Load Balancer (ALB) Ingress Controller Deployment Manifest.
+# This manifest details sensible defaults for deploying an ALB Ingress Controller.
+# GitHub: https://github.com/kubernetes-sigs/aws-alb-ingress-controller
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: alb-ingress-controller
+  # Namespace the ALB Ingress Controller should run in. Does not impact which
+  # namespaces it's able to resolve ingress resource for. For limiting ingress
+  # namespace scope, see --watch-namespace.
+#  namespace: kubeflow
+spec:
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: alb-ingress-controller
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: alb-ingress-controller
+    spec:
+      containers:
+        - name: alb-ingress-controller
+          args:
+            # Limit the namespace where this ALB Ingress Controller deployment will
+            # resolve ingress resources. If left commented, all namespaces are used.
+            # - --watch-namespace=your-k8s-namespace
+
+            # Setting the ingress-class flag below ensures that only ingress resources with the
+            # annotation kubernetes.io/ingress.class: "alb" are respected by the controller. You may
+            # choose any class you'd like for this controller to respect.
+            - --ingress-class=alb
+
+            # REQUIRED
+            # Name of your cluster. Used when naming resources created
+            # by the ALB Ingress Controller, providing distinction between
+            # clusters.
+#            - --cluster-name=$(CLUSTER_NAME)
+            - --cluster-name=$(CLUSTER_NAME)
+
+            # AWS VPC ID this ingress controller will use to create AWS resources.
+            # If unspecified, it will be discovered from ec2metadata.
+            # - --aws-vpc-id=vpc-xxxxxx
+
+            # AWS region this ingress controller will operate in.
+            # If unspecified, it will be discovered from ec2metadata.
+            # List of regions: http://docs.aws.amazon.com/general/latest/gr/rande.html#vpc_region
+            # - --aws-region=us-west-1
+          # Repository location of the ALB Ingress Controller.
+          image: docker.io/amazon/aws-alb-ingress-controller:v1.1.2
+          imagePullPolicy: Always
+      serviceAccountName: alb-ingress-controller
+`)
+	th.writeF("/manifests/aws/aws-alb-ingress-controller/base/service-account.yaml", `
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: alb-ingress-controller
+`)
+	th.writeF("/manifests/aws/aws-alb-ingress-controller/base/params.env", `
+clusterName=
+`)
+	th.writeK("/manifests/aws/aws-alb-ingress-controller/base", `
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+namespace: kubeflow
+resources:
+- cluster-role.yaml
+- cluster-role-binding.yaml
+- deployment.yaml
+- service-account.yaml
+commonLabels:
+  kustomize.component: aws-alb-ingress-controller
+generatorOptions:
+  disableNameSuffixHash: true
+images:
+- name: docker.io/amazon/aws-alb-ingress-controller
+  newName: docker.io/amazon/aws-alb-ingress-controller
+  newTag: v1.1.2
+configMapGenerator:
+- name: alb-ingress-controller-parameters
+  env: params.env
+vars:
+- name: CLUSTER_NAME
+  objref:
+    kind: ConfigMap
+    name: alb-ingress-controller-parameters
+    apiVersion: v1
+  fieldref:
+    fieldpath: data.clusterName
+`)
+}
+
+func TestAwsAlbIngressControllerOverlaysVpc(t *testing.T) {
+	th := NewKustTestHarness(t, "/manifests/aws/aws-alb-ingress-controller/overlays/vpc")
+	writeAwsAlbIngressControllerOverlaysVpc(th)
+	m, err := th.makeKustTarget().MakeCustomizedResMap()
+	if err != nil {
+		t.Fatalf("Err: %v", err)
+	}
+	targetPath := "../aws/aws-alb-ingress-controller/overlays/vpc"
+	fsys := fs.MakeRealFS()
+	_loader, loaderErr := loader.NewLoader(targetPath, fsys)
+	if loaderErr != nil {
+		t.Fatalf("could not load kustomize loader: %v", loaderErr)
+	}
+	rf := resmap.NewFactory(resource.NewFactory(kunstruct.NewKunstructuredFactoryImpl()))
+	kt, err := target.NewKustTarget(_loader, rf, transformer.NewFactoryImpl())
+	if err != nil {
+		th.t.Fatalf("Unexpected construction error %v", err)
+	}
+	n, err := kt.MakeCustomizedResMap()
+	if err != nil {
+		t.Fatalf("Err: %v", err)
+	}
+	expected, err := n.EncodeAsYaml()
+	th.assertActualEqualsExpected(m, string(expected))
+}

--- a/tests/aws-efs-csi-driver-base_test.go
+++ b/tests/aws-efs-csi-driver-base_test.go
@@ -1,0 +1,283 @@
+package tests_test
+
+import (
+	"sigs.k8s.io/kustomize/k8sdeps/kunstruct"
+	"sigs.k8s.io/kustomize/k8sdeps/transformer"
+	"sigs.k8s.io/kustomize/pkg/fs"
+	"sigs.k8s.io/kustomize/pkg/loader"
+	"sigs.k8s.io/kustomize/pkg/resmap"
+	"sigs.k8s.io/kustomize/pkg/resource"
+	"sigs.k8s.io/kustomize/pkg/target"
+	"testing"
+)
+
+func writeAwsEfsCsiDriverBase(th *KustTestHarness) {
+	th.writeF("/manifests/aws/aws-efs-csi-driver/base/csi-controller-stateful-set.yaml", `
+kind: StatefulSet
+apiVersion: apps/v1beta1
+metadata:
+  name: efs-csi-controller
+spec:
+  serviceName: efs-csi-controller
+  replicas: 1
+  template:
+    metadata:
+      labels:
+        app: efs-csi-controller
+    spec:
+      serviceAccount: efs-csi-controller-sa
+      #priorityClassName: system-cluster-critical
+      tolerations:
+        - key: CriticalAddonsOnly
+          operator: Exists
+      containers:
+        - name: efs-plugin
+          image: amazon/aws-efs-csi-driver:latest
+          imagePullPolicy: Always
+          args :
+            - --endpoint=$(CSI_ENDPOINT)
+            - --logtostderr
+            - --v=5
+          env:
+            - name: CSI_ENDPOINT
+              value: unix:///var/lib/csi/sockets/pluginproxy/csi.sock
+          volumeMounts:
+            - name: socket-dir
+              mountPath: /var/lib/csi/sockets/pluginproxy/
+        - name: csi-attacher
+          image: quay.io/k8scsi/csi-attacher:v0.4.2
+          imagePullPolicy: Always
+          args:
+            - --csi-address=$(ADDRESS)
+            - --v=5
+          env:
+            - name: ADDRESS
+              value: /var/lib/csi/sockets/pluginproxy/csi.sock
+          volumeMounts:
+            - name: socket-dir
+              mountPath: /var/lib/csi/sockets/pluginproxy/
+      volumes:
+        - name: socket-dir
+          emptyDir: {}
+`)
+	th.writeF("/manifests/aws/aws-efs-csi-driver/base/csi-attacher-cluster-role.yaml", `
+kind: ClusterRole
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: efs-csi-external-attacher-clusterrole
+rules:
+  - apiGroups: [""]
+    resources: ["persistentvolumes"]
+    verbs: ["get", "list", "watch", "update"]
+  - apiGroups: [""]
+    resources: ["nodes"]
+    verbs: ["get", "list", "watch"]
+  - apiGroups: ["storage.k8s.io"]
+    resources: ["volumeattachments"]
+    verbs: ["get", "list", "watch", "update"]
+`)
+	th.writeF("/manifests/aws/aws-efs-csi-driver/base/csi-attacher-cluster-role-binding.yaml", `
+kind: ClusterRoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: efs-csi-external-attacher-clusterrole-binding
+subjects:
+  - kind: ServiceAccount
+    name: efs-csi-controller-sa
+    namespace: kubeflow
+roleRef:
+  kind: ClusterRole
+  name: efs-csi-external-attacher-clusterrole
+  apiGroup: rbac.authorization.k8s.io
+`)
+	th.writeF("/manifests/aws/aws-efs-csi-driver/base/csi-controller-sa.yaml", `
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: efs-csi-controller-sa
+`)
+	th.writeF("/manifests/aws/aws-efs-csi-driver/base/csi-node-cluster-role.yaml", `
+kind: ClusterRole
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: efs-csi-node-clusterrole
+rules:
+  - apiGroups: [""]
+    resources: ["secrets"]
+    verbs: ["get", "list"]
+  - apiGroups: [""]
+    resources: ["nodes"]
+    verbs: ["get", "list", "update"]
+  - apiGroups: [""]
+    resources: ["namespaces"]
+    verbs: ["get", "list"]
+  - apiGroups: [""]
+    resources: ["persistentvolumes"]
+    verbs: ["get", "list", "watch", "update"]
+  - apiGroups: ["storage.k8s.io"]
+    resources: ["volumeattachments"]
+    verbs: ["get", "list", "watch", "update"]
+  - apiGroups: ["csi.storage.k8s.io"]
+    resources: ["csinodeinfos"]
+    verbs: ["get", "list", "watch", "update"]
+`)
+	th.writeF("/manifests/aws/aws-efs-csi-driver/base/csi-node-cluster-role-binding.yaml", `
+kind: ClusterRoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: efs-csi-node-clusterole-binding
+subjects:
+  - kind: ServiceAccount
+    name: efs-csi-node-sa
+    namespace: kubeflow
+roleRef:
+  kind: ClusterRole
+  name: efs-csi-node-clusterrole
+  apiGroup: rbac.authorization.k8s.io
+`)
+	th.writeF("/manifests/aws/aws-efs-csi-driver/base/csi-node-daemon-set.yaml", `
+kind: DaemonSet
+apiVersion: apps/v1beta2
+metadata:
+  name: efs-csi-node
+spec:
+  selector:
+    matchLabels:
+      app: efs-csi-node
+  template:
+    metadata:
+      labels:
+        app: efs-csi-node
+    spec:
+      serviceAccount: efs-csi-node-sa
+      hostNetwork: true
+      containers:
+        - name: efs-plugin
+          securityContext:
+            privileged: true
+          image: amazon/aws-efs-csi-driver:latest
+          imagePullPolicy: Always
+          args:
+            - --endpoint=$(CSI_ENDPOINT)
+            - --logtostderr
+            - --v=5
+          env:
+            - name: CSI_ENDPOINT
+              value: unix:/csi/csi.sock
+          volumeMounts:
+            - name: kubelet-dir
+              mountPath: /var/lib/kubelet
+              mountPropagation: "Bidirectional"
+            - name: plugin-dir
+              mountPath: /csi
+            - name: device-dir
+              mountPath: /dev
+        - name: csi-driver-registrar
+          image: quay.io/k8scsi/driver-registrar:v0.4.2
+          imagePullPolicy: Always
+          args:
+            - --csi-address=$(ADDRESS)
+            - --mode=node-register
+            - --driver-requires-attachment=true
+            - --pod-info-mount-version="v1"
+            - --kubelet-registration-path=$(DRIVER_REG_SOCK_PATH)
+            - --v=5
+          env:
+            - name: ADDRESS
+              value: /csi/csi.sock
+            - name: DRIVER_REG_SOCK_PATH
+              value: /var/lib/kubelet/plugins/efs.csi.aws.com/csi.sock
+            - name: KUBE_NODE_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: spec.nodeName
+          volumeMounts:
+            - name: plugin-dir
+              mountPath: /csi
+            - name: registration-dir
+              mountPath: /registration
+      volumes:
+        - name: kubelet-dir
+          hostPath:
+            path: /var/lib/kubelet
+            type: Directory
+        - name: plugin-dir
+          hostPath:
+            path: /var/lib/kubelet/plugins/efs.csi.aws.com/
+            type: DirectoryOrCreate
+        - name: registration-dir
+          hostPath:
+            path: /var/lib/kubelet/plugins/
+            type: Directory
+        - name: device-dir
+          hostPath:
+            path: /dev
+            type: Directory
+`)
+	th.writeF("/manifests/aws/aws-efs-csi-driver/base/csi-node-sa.yaml", `
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: efs-csi-node-sa
+`)
+	th.writeF("/manifests/aws/aws-efs-csi-driver/base/csi-default-storage.yaml", `
+apiVersion: storage.k8s.io/v1
+kind: StorageClass
+metadata:
+  name: efs-default
+provisioner: efs.csi.aws.com
+`)
+	th.writeK("/manifests/aws/aws-efs-csi-driver/base", `
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+namespace: kubeflow
+resources:
+- csi-controller-stateful-set.yaml
+- csi-attacher-cluster-role.yaml
+- csi-attacher-cluster-role-binding.yaml
+- csi-controller-sa.yaml
+- csi-node-cluster-role.yaml
+- csi-node-cluster-role-binding.yaml
+- csi-node-daemon-set.yaml
+- csi-node-sa.yaml
+- csi-default-storage.yaml
+generatorOptions:
+  disableNameSuffixHash: true
+images:
+- name: quay.io/k8scsi/driver-registrar
+  newName: quay.io/k8scsi/driver-registrar
+  newTag: v0.4.2
+- name: amazon/aws-efs-csi-driver
+  newName: amazon/aws-efs-csi-driver
+  newTag: latest
+- name: quay.io/k8scsi/csi-attacher
+  newName: quay.io/k8scsi/csi-attacher
+  newTag: v0.4.2
+`)
+}
+
+func TestAwsEfsCsiDriverBase(t *testing.T) {
+	th := NewKustTestHarness(t, "/manifests/aws/aws-efs-csi-driver/base")
+	writeAwsEfsCsiDriverBase(th)
+	m, err := th.makeKustTarget().MakeCustomizedResMap()
+	if err != nil {
+		t.Fatalf("Err: %v", err)
+	}
+	targetPath := "../aws/aws-efs-csi-driver/base"
+	fsys := fs.MakeRealFS()
+	_loader, loaderErr := loader.NewLoader(targetPath, fsys)
+	if loaderErr != nil {
+		t.Fatalf("could not load kustomize loader: %v", loaderErr)
+	}
+	rf := resmap.NewFactory(resource.NewFactory(kunstruct.NewKunstructuredFactoryImpl()))
+	kt, err := target.NewKustTarget(_loader, rf, transformer.NewFactoryImpl())
+	if err != nil {
+		th.t.Fatalf("Unexpected construction error %v", err)
+	}
+	n, err := kt.MakeCustomizedResMap()
+	if err != nil {
+		t.Fatalf("Err: %v", err)
+	}
+	expected, err := n.EncodeAsYaml()
+	th.assertActualEqualsExpected(m, string(expected))
+}

--- a/tests/aws-fsx-csi-driver-base_test.go
+++ b/tests/aws-fsx-csi-driver-base_test.go
@@ -1,0 +1,362 @@
+package tests_test
+
+import (
+	"sigs.k8s.io/kustomize/k8sdeps/kunstruct"
+	"sigs.k8s.io/kustomize/k8sdeps/transformer"
+	"sigs.k8s.io/kustomize/pkg/fs"
+	"sigs.k8s.io/kustomize/pkg/loader"
+	"sigs.k8s.io/kustomize/pkg/resmap"
+	"sigs.k8s.io/kustomize/pkg/resource"
+	"sigs.k8s.io/kustomize/pkg/target"
+	"testing"
+)
+
+func writeAwsFsxCsiDriverBase(th *KustTestHarness) {
+	th.writeF("/manifests/aws/aws-fsx-csi-driver/base/csi-controller-stateful-set.yaml", `
+kind: StatefulSet
+apiVersion: apps/v1beta1
+metadata:
+  name: fsx-csi-controller
+spec:
+  serviceName: fsx-csi-controller
+  replicas: 1
+  template:
+    metadata:
+      labels:
+        app: fsx-csi-controller
+    spec:
+      serviceAccount: fsx-csi-controller-sa
+#      priorityClassName: system-cluster-critical
+      tolerations:
+        - key: CriticalAddonsOnly
+          operator: Exists
+      containers:
+        - name: fsx-plugin
+          image: amazon/aws-fsx-csi-driver:latest
+          args :
+            - --endpoint=$(CSI_ENDPOINT)
+            - --logtostderr
+            - --v=5
+          env:
+            - name: CSI_ENDPOINT
+              value: unix:///var/lib/csi/sockets/pluginproxy/csi.sock
+          volumeMounts:
+            - name: socket-dir
+              mountPath: /var/lib/csi/sockets/pluginproxy/
+        - name: csi-provisioner
+          image: quay.io/k8scsi/csi-provisioner:v0.4.2
+          args:
+            - --provisioner=fsx.csi.aws.com
+            - --csi-address=$(ADDRESS)
+            - --connection-timeout=5m
+            - --v=5
+          env:
+            - name: ADDRESS
+              value: /var/lib/csi/sockets/pluginproxy/csi.sock
+          volumeMounts:
+            - name: socket-dir
+              mountPath: /var/lib/csi/sockets/pluginproxy/
+        - name: csi-attacher
+          image: quay.io/k8scsi/csi-attacher:v0.4.2
+          args:
+            - --csi-address=$(ADDRESS)
+            - --v=5
+          env:
+            - name: ADDRESS
+              value: /var/lib/csi/sockets/pluginproxy/csi.sock
+          volumeMounts:
+            - name: socket-dir
+              mountPath: /var/lib/csi/sockets/pluginproxy/
+      volumes:
+        - name: socket-dir
+          emptyDir: {}
+`)
+	th.writeF("/manifests/aws/aws-fsx-csi-driver/base/csi-attacher-cluster-role.yaml", `
+kind: ClusterRole
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: fsx-csi-external-attacher-clusterrole
+rules:
+  - apiGroups: [""]
+    resources: ["persistentvolumes"]
+    verbs: ["get", "list", "watch", "update"]
+  - apiGroups: [""]
+    resources: ["nodes"]
+    verbs: ["get", "list", "watch"]
+  - apiGroups: ["storage.k8s.io"]
+    resources: ["volumeattachments"]
+    verbs: ["get", "list", "watch", "update"]
+`)
+	th.writeF("/manifests/aws/aws-fsx-csi-driver/base/csi-attacher-cluster-role-binding.yaml", `
+kind: ClusterRoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: fsx-csi-external-attacher-clusterrole-binding
+subjects:
+  - kind: ServiceAccount
+    name: fsx-csi-controller-sa
+    namespace: kubeflow
+roleRef:
+  kind: ClusterRole
+  name: fsx-csi-external-attacher-clusterrole
+  apiGroup: rbac.authorization.k8s.io
+`)
+	th.writeF("/manifests/aws/aws-fsx-csi-driver/base/csi-controller-cluster-role.yaml", `
+kind: ClusterRole
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: external-provisioner-role
+rules:
+  - apiGroups: [""]
+    resources: ["persistentvolumes"]
+    verbs: ["get", "list", "watch", "create", "delete"]
+  - apiGroups: [""]
+    resources: ["persistentvolumeclaims"]
+    verbs: ["get", "list", "watch", "update"]
+  - apiGroups: ["storage.k8s.io"]
+    resources: ["storageclasses"]
+    verbs: ["get", "list", "watch"]
+  - apiGroups: [""]
+    resources: ["events"]
+    verbs: ["get", "list", "watch", "create", "update", "patch"]
+`)
+	th.writeF("/manifests/aws/aws-fsx-csi-driver/base/csi-controller-cluster-role-binding.yaml", `
+kind: ClusterRoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: csi-provisioner-binding
+subjects:
+  - kind: ServiceAccount
+    name: csi-controller-sa
+    namespace: kubeflow
+roleRef:
+  kind: ClusterRole
+  name: external-provisioner-role
+  apiGroup: rbac.authorization.k8s.io
+`)
+	th.writeF("/manifests/aws/aws-fsx-csi-driver/base/csi-controller-sa.yaml", `
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: fsx-csi-controller-sa
+`)
+	th.writeF("/manifests/aws/aws-fsx-csi-driver/base/csi-node-cluster-role.yaml", `
+kind: ClusterRole
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: fsx-csi-node-clusterrole
+rules:
+  - apiGroups: [""]
+    resources: ["secrets"]
+    verbs: ["get", "list"]
+  - apiGroups: [""]
+    resources: ["nodes"]
+    verbs: ["get", "list", "update"]
+  - apiGroups: [""]
+    resources: ["namespaces"]
+    verbs: ["get", "list"]
+  - apiGroups: [""]
+    resources: ["persistentvolumes"]
+    verbs: ["get", "list", "watch", "update"]
+  - apiGroups: ["storage.k8s.io"]
+    resources: ["volumeattachments"]
+    verbs: ["get", "list", "watch", "update"]
+  - apiGroups: ["csi.storage.k8s.io"]
+    resources: ["csinodeinfos"]
+    verbs: ["get", "list", "watch", "update"]
+`)
+	th.writeF("/manifests/aws/aws-fsx-csi-driver/base/csi-node-cluster-role-binding.yaml", `
+kind: ClusterRoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: fsx-csi-node-clusterrole-binding
+subjects:
+  - kind: ServiceAccount
+    name: fsx-csi-node-sa
+    namespace: kubeflow
+roleRef:
+  kind: ClusterRole
+  name: fsx-csi-node-clusterrole
+  apiGroup: rbac.authorization.k8s.io
+`)
+	th.writeF("/manifests/aws/aws-fsx-csi-driver/base/csi-node-daemonset.yaml", `
+kind: DaemonSet
+apiVersion: apps/v1beta2
+metadata:
+  name: fsx-csi-node-ds
+spec:
+  selector:
+    matchLabels:
+      app: fsx-csi-node
+  template:
+    metadata:
+      labels:
+        app: fsx-csi-node
+    spec:
+      serviceAccount: fsx-csi-node-sa
+      hostNetwork: true
+      containers:
+        - name: fsx-plugin
+          securityContext:
+            privileged: true
+          image: amazon/aws-fsx-csi-driver:latest
+          args:
+            - --endpoint=$(CSI_ENDPOINT)
+            - --logtostderr
+            - --v=5
+          env:
+            - name: CSI_ENDPOINT
+              value: unix:/csi/csi.sock
+          volumeMounts:
+            - name: kubelet-dir
+              mountPath: /var/lib/kubelet
+              mountPropagation: "Bidirectional"
+            - name: plugin-dir
+              mountPath: /csi
+            - name: device-dir
+              mountPath: /dev
+        - name: csi-driver-registrar
+          image: quay.io/k8scsi/driver-registrar:v0.4.2
+          args:
+            - --csi-address=$(ADDRESS)
+            - --mode=node-register
+            - --driver-requires-attachment=true
+            - --pod-info-mount-version="v1"
+            - --kubelet-registration-path=$(DRIVER_REG_SOCK_PATH)
+            - --v=5
+          env:
+            - name: ADDRESS
+              value: /csi/csi.sock
+            - name: DRIVER_REG_SOCK_PATH
+              value: /var/lib/kubelet/plugins/fsx.csi.aws.com/csi.sock
+            - name: KUBE_NODE_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: spec.nodeName
+          volumeMounts:
+            - name: plugin-dir
+              mountPath: /csi
+            - name: registration-dir
+              mountPath: /registration
+      volumes:
+        - name: kubelet-dir
+          hostPath:
+            path: /var/lib/kubelet
+            type: Directory
+        - name: plugin-dir
+          hostPath:
+            path: /var/lib/kubelet/plugins/fsx.csi.aws.com/
+            type: DirectoryOrCreate
+        - name: registration-dir
+          hostPath:
+            path: /var/lib/kubelet/plugins/
+            type: Directory
+        - name: device-dir
+          hostPath:
+            path: /dev
+            type: Directory
+`)
+	th.writeF("/manifests/aws/aws-fsx-csi-driver/base/csi-node-sa.yaml", `
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: fsx-csi-node-sa
+`)
+	th.writeF("/manifests/aws/aws-fsx-csi-driver/base/csi-provisioner-cluster-role.yaml", `
+kind: ClusterRole
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: fsx-external-provisioner-clusterrole
+rules:
+  - apiGroups: [""]
+    resources: ["persistentvolumes"]
+    verbs: ["get", "list", "watch", "create", "delete"]
+  - apiGroups: [""]
+    resources: ["persistentvolumeclaims"]
+    verbs: ["get", "list", "watch", "update"]
+  - apiGroups: ["storage.k8s.io"]
+    resources: ["storageclasses"]
+    verbs: ["get", "list", "watch"]
+  - apiGroups: [""]
+    resources: ["events"]
+    verbs: ["get", "list", "watch", "create", "update", "patch"]
+`)
+	th.writeF("/manifests/aws/aws-fsx-csi-driver/base/csi-provisioner-cluster-role-binding.yaml", `
+kind: ClusterRoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: fsx-csi-provisioner-clusterrole-binding
+subjects:
+  - kind: ServiceAccount
+    name: fsx-csi-controller-sa
+    namespace: kubeflow
+roleRef:
+  kind: ClusterRole
+  name: fsx-external-provisioner-clusterrole
+  apiGroup: rbac.authorization.k8s.io
+`)
+	th.writeF("/manifests/aws/aws-fsx-csi-driver/base/csi-default-storage.yaml", `
+apiVersion: storage.k8s.io/v1
+kind: StorageClass
+metadata:
+  name: fsx-default
+provisioner: fsx.csi.aws.com
+`)
+	th.writeK("/manifests/aws/aws-fsx-csi-driver/base", `
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+namespace: kubeflow
+resources:
+- csi-controller-stateful-set.yaml
+- csi-attacher-cluster-role.yaml
+- csi-attacher-cluster-role-binding.yaml
+- csi-controller-cluster-role.yaml
+- csi-controller-cluster-role-binding.yaml
+- csi-controller-sa.yaml
+- csi-node-cluster-role.yaml
+- csi-node-cluster-role-binding.yaml
+- csi-node-daemonset.yaml
+- csi-node-sa.yaml
+- csi-provisioner-cluster-role.yaml
+- csi-provisioner-cluster-role-binding.yaml
+- csi-default-storage.yaml
+generatorOptions:
+  disableNameSuffixHash: true
+images:
+- name: amazon/aws-fsx-csi-driver
+  newName: amazon/aws-fsx-csi-driver
+  newTag: latest
+- name: quay.io/k8scsi/driver-registrar
+  newName: quay.io/k8scsi/driver-registrar
+  newTag: v0.4.2
+- name: quay.io/k8scsi/csi-provisioner
+  newName: quay.io/k8scsi/csi-provisioner
+  newTag: v0.4.2
+`)
+}
+
+func TestAwsFsxCsiDriverBase(t *testing.T) {
+	th := NewKustTestHarness(t, "/manifests/aws/aws-fsx-csi-driver/base")
+	writeAwsFsxCsiDriverBase(th)
+	m, err := th.makeKustTarget().MakeCustomizedResMap()
+	if err != nil {
+		t.Fatalf("Err: %v", err)
+	}
+	targetPath := "../aws/aws-fsx-csi-driver/base"
+	fsys := fs.MakeRealFS()
+	_loader, loaderErr := loader.NewLoader(targetPath, fsys)
+	if loaderErr != nil {
+		t.Fatalf("could not load kustomize loader: %v", loaderErr)
+	}
+	rf := resmap.NewFactory(resource.NewFactory(kunstruct.NewKunstructuredFactoryImpl()))
+	kt, err := target.NewKustTarget(_loader, rf, transformer.NewFactoryImpl())
+	if err != nil {
+		th.t.Fatalf("Unexpected construction error %v", err)
+	}
+	n, err := kt.MakeCustomizedResMap()
+	if err != nil {
+		t.Fatalf("Err: %v", err)
+	}
+	expected, err := n.EncodeAsYaml()
+	th.assertActualEqualsExpected(m, string(expected))
+}

--- a/tests/fluentd-cloud-watch-base_test.go
+++ b/tests/fluentd-cloud-watch-base_test.go
@@ -1,0 +1,308 @@
+package tests_test
+
+import (
+	"sigs.k8s.io/kustomize/k8sdeps/kunstruct"
+	"sigs.k8s.io/kustomize/k8sdeps/transformer"
+	"sigs.k8s.io/kustomize/pkg/fs"
+	"sigs.k8s.io/kustomize/pkg/loader"
+	"sigs.k8s.io/kustomize/pkg/resmap"
+	"sigs.k8s.io/kustomize/pkg/resource"
+	"sigs.k8s.io/kustomize/pkg/target"
+	"testing"
+)
+
+func writeFluentdCloudWatchBase(th *KustTestHarness) {
+	th.writeF("/manifests/aws/fluentd-cloud-watch/base/cluster-role.yaml", `
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: ClusterRole
+metadata:
+  name: fluentd
+rules:
+  - apiGroups: [""]
+    resources:
+      - namespaces
+      - pods
+    verbs: ["get", "list", "watch"]
+`)
+	th.writeF("/manifests/aws/fluentd-cloud-watch/base/cluster-role-binding.yaml", `
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: ClusterRoleBinding
+metadata:
+  name: fluentd
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: fluentd
+subjects:
+  - kind: ServiceAccount
+    name: fluentd
+    namespace: kube-system
+`)
+	th.writeF("/manifests/aws/fluentd-cloud-watch/base/configmap.yaml", `
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: fluentd-config
+  labels:
+    k8s-app: fluentd-cloudwatch
+data:
+  fluent.conf: |
+    @include containers.conf
+    @include systemd.conf
+    <match fluent.**>
+      @type null
+    </match>
+  containers.conf: |
+    <source>
+      @type tail
+      @id in_tail_container_logs
+      @label @containers
+      path /var/log/containers/*.log
+      pos_file /var/log/fluentd-containers.log.pos
+      tag *
+      read_from_head true
+      <parse>
+        @type json
+        time_format %Y-%m-%dT%H:%M:%S.%NZ
+      </parse>
+    </source>
+    <label @containers>
+      <filter **>
+        @type kubernetes_metadata
+        @id filter_kube_metadata
+      </filter>
+      <filter **>
+        @type record_transformer
+        @id filter_containers_stream_transformer
+        <record>
+          stream_name ${tag_parts[3]}
+        </record>
+      </filter>
+      <match **>
+        @type cloudwatch_logs
+        @id out_cloudwatch_logs_containers
+        region "#{ENV.fetch('REGION')}"
+        log_group_name "/eks/#{ENV.fetch('CLUSTER_NAME')}/containers"
+        log_stream_name_key stream_name
+        remove_log_stream_name_key true
+        auto_create_stream true
+        <buffer>
+          flush_interval 5
+          chunk_limit_size 2m
+          queued_chunks_limit_size 32
+          retry_forever true
+        </buffer>
+      </match>
+    </label>
+  systemd.conf: |
+    <source>
+      @type systemd
+      @id in_systemd_kubelet
+      @label @systemd
+      filters [{ "_SYSTEMD_UNIT": "kubelet.service" }]
+      <entry>
+        field_map {"MESSAGE": "message", "_HOSTNAME": "hostname", "_SYSTEMD_UNIT": "systemd_unit"}
+        field_map_strict true
+      </entry>
+      path /run/log/journal
+      pos_file /var/log/fluentd-journald-kubelet.pos
+      read_from_head true
+      tag kubelet.service
+    </source>
+    <source>
+      @type systemd
+      @id in_systemd_kubeproxy
+      @label @systemd
+      filters [{ "_SYSTEMD_UNIT": "kubeproxy.service" }]
+      <entry>
+        field_map {"MESSAGE": "message", "_HOSTNAME": "hostname", "_SYSTEMD_UNIT": "systemd_unit"}
+        field_map_strict true
+      </entry>
+      path /run/log/journal
+      pos_file /var/log/fluentd-journald-kubeproxy.pos
+      read_from_head true
+      tag kubeproxy.service
+    </source>
+    <source>
+      @type systemd
+      @id in_systemd_docker
+      @label @systemd
+      filters [{ "_SYSTEMD_UNIT": "docker.service" }]
+      <entry>
+        field_map {"MESSAGE": "message", "_HOSTNAME": "hostname", "_SYSTEMD_UNIT": "systemd_unit"}
+        field_map_strict true
+      </entry>
+      path /run/log/journal
+      pos_file /var/log/fluentd-journald-docker.pos
+      read_from_head true
+      tag docker.service
+    </source>
+    <label @systemd>
+      <filter **>
+        @type record_transformer
+        @id filter_systemd_stream_transformer
+        <record>
+          stream_name ${tag}-${record["hostname"]}
+        </record>
+      </filter>
+      <match **>
+        @type cloudwatch_logs
+        @id out_cloudwatch_logs_systemd
+        region "#{ENV.fetch('REGION')}"
+        log_group_name "/eks/#{ENV.fetch('CLUSTER_NAME')}/systemd"
+        log_stream_name_key stream_name
+        auto_create_stream true
+        remove_log_stream_name_key true
+        <buffer>
+          flush_interval 5
+          chunk_limit_size 2m
+          queued_chunks_limit_size 32
+          retry_forever true
+        </buffer>
+      </match>
+    </label>
+`)
+	th.writeF("/manifests/aws/fluentd-cloud-watch/base/daemonset.yaml", `
+apiVersion: extensions/v1beta1
+kind: DaemonSet
+metadata:
+  name: fluentd-cloudwatch
+  labels:
+    k8s-app: fluentd-cloudwatch
+spec:
+  template:
+    metadata:
+      labels:
+        k8s-app: fluentd-cloudwatch
+    spec:
+      serviceAccountName: fluentd
+      terminationGracePeriodSeconds: 30
+      # Because the image's entrypoint requires to write on /fluentd/etc but we mount configmap there which is read-only,
+      # this initContainers workaround or other is needed.
+      # See https://github.com/fluent/fluentd-kubernetes-daemonset/issues/90
+      initContainers:
+        - name: copy-fluentd-config
+          image: busybox
+          command: ['sh', '-c', 'cp /config-volume/..data/* /fluentd/etc']
+          volumeMounts:
+            - name: config-volume
+              mountPath: /config-volume
+            - name: fluentdconf
+              mountPath: /fluentd/etc
+      containers:
+        - name: fluentd-cloudwatch
+          image: fluent/fluentd-kubernetes-daemonset:v1.1-debian-cloudwatch
+          env:
+            - name: REGION
+              value: $(REGION)
+            - name: CLUSTER_NAME
+              value: $(CLUSTER_NAME)
+          resources:
+            limits:
+              memory: 200Mi
+            requests:
+              cpu: 100m
+              memory: 200Mi
+          volumeMounts:
+            - name: config-volume
+              mountPath: /config-volume
+            - name: fluentdconf
+              mountPath: /fluentd/etc
+            - name: varlog
+              mountPath: /var/log
+            - name: varlibdockercontainers
+              mountPath: /var/lib/docker/containers
+              readOnly: true
+            - name: runlogjournal
+              mountPath: /run/log/journal
+              readOnly: true
+      volumes:
+        - name: config-volume
+          configMap:
+            name: fluentd-config
+        - name: fluentdconf
+          emptyDir: {}
+        - name: varlog
+          hostPath:
+            path: /var/log
+        - name: varlibdockercontainers
+          hostPath:
+            path: /var/lib/docker/containers
+        - name: runlogjournal
+          hostPath:
+            path: /run/log/journal
+`)
+	th.writeF("/manifests/aws/fluentd-cloud-watch/base/service-account.yaml", `
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: fluentd
+`)
+	th.writeF("/manifests/aws/fluentd-cloud-watch/base/params.env", `
+region=us-west-2
+clusterName=
+`)
+	th.writeK("/manifests/aws/fluentd-cloud-watch/base", `
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+namespace: kube-system
+resources:
+- cluster-role.yaml
+- cluster-role-binding.yaml
+- configmap.yaml
+- daemonset.yaml
+- service-account.yaml
+commonLabels:
+  kustomize.component: fluentd-cloud-watch
+generatorOptions:
+  disableNameSuffixHash: true
+images:
+- name: fluent/fluentd-kubernetes-daemonset
+  newName: fluent/fluentd-kubernetes-daemonset
+  newTag: v1.1-debian-cloudwatch
+configMapGenerator:
+- name: fluentd-cloud-watch-parameters
+  env: params.env
+vars:
+- name: CLUSTER_NAME
+  objref:
+    kind: ConfigMap
+    name: fluentd-cloud-watch-parameters
+    apiVersion: v1
+  fieldref:
+    fieldpath: data.clusterName
+- name: REGION
+  objref:
+    kind: ConfigMap
+    name: fluentd-cloud-watch-parameters
+    apiVersion: v1
+  fieldref:
+    fieldpath: data.region
+`)
+}
+
+func TestFluentdCloudWatchBase(t *testing.T) {
+	th := NewKustTestHarness(t, "/manifests/aws/fluentd-cloud-watch/base")
+	writeFluentdCloudWatchBase(th)
+	m, err := th.makeKustTarget().MakeCustomizedResMap()
+	if err != nil {
+		t.Fatalf("Err: %v", err)
+	}
+	targetPath := "../aws/fluentd-cloud-watch/base"
+	fsys := fs.MakeRealFS()
+	_loader, loaderErr := loader.NewLoader(targetPath, fsys)
+	if loaderErr != nil {
+		t.Fatalf("could not load kustomize loader: %v", loaderErr)
+	}
+	rf := resmap.NewFactory(resource.NewFactory(kunstruct.NewKunstructuredFactoryImpl()))
+	kt, err := target.NewKustTarget(_loader, rf, transformer.NewFactoryImpl())
+	if err != nil {
+		th.t.Fatalf("Unexpected construction error %v", err)
+	}
+	n, err := kt.MakeCustomizedResMap()
+	if err != nil {
+		t.Fatalf("Err: %v", err)
+	}
+	expected, err := n.EncodeAsYaml()
+	th.assertActualEqualsExpected(m, string(expected))
+}

--- a/tests/istio-base_test.go
+++ b/tests/istio-base_test.go
@@ -124,13 +124,13 @@ metadata:
 spec:
   mode: $(clusterRbacConfig)
 `)
-	th.writeF("/manifests/istio/istio/base/params.env", `
-clusterRbacConfig=ON
-`)
 	th.writeF("/manifests/istio/istio/base/params.yaml", `
 varReference:
 - path: spec/mode
   kind: ClusterRbacConfig
+`)
+	th.writeF("/manifests/istio/istio/base/params.env", `
+clusterRbacConfig=ON
 `)
 	th.writeK("/manifests/istio/istio/base", `
 apiVersion: kustomize.config.k8s.io/v1beta1
@@ -150,7 +150,7 @@ vars:
   fieldref:
     fieldpath: data.clusterRbacConfig
 configurations:
- - params.yaml
+- params.yaml
 `)
 }
 

--- a/tests/istio-ingress-base_test.go
+++ b/tests/istio-ingress-base_test.go
@@ -1,0 +1,86 @@
+package tests_test
+
+import (
+	"sigs.k8s.io/kustomize/k8sdeps/kunstruct"
+	"sigs.k8s.io/kustomize/k8sdeps/transformer"
+	"sigs.k8s.io/kustomize/pkg/fs"
+	"sigs.k8s.io/kustomize/pkg/loader"
+	"sigs.k8s.io/kustomize/pkg/resmap"
+	"sigs.k8s.io/kustomize/pkg/resource"
+	"sigs.k8s.io/kustomize/pkg/target"
+	"testing"
+)
+
+func writeIstioIngressBase(th *KustTestHarness) {
+	th.writeF("/manifests/aws/istio-ingress/base/ingress.yaml", `
+apiVersion: extensions/v1beta1
+kind: Ingress
+metadata:
+  annotations:
+    kubernetes.io/ingress.class: alb
+    alb.ingress.kubernetes.io/scheme: internet-facing
+    alb.ingress.kubernetes.io/listen-ports: '[{"HTTP": 80}]'
+  name: istio-ingress
+spec:
+  rules:
+    - http:
+        paths:
+          - backend:
+              serviceName: istio-ingressgateway
+              servicePort: 80
+            path: /*
+`)
+	th.writeF("/manifests/aws/istio-ingress/base/istio-gateway.yaml", `
+apiVersion: networking.istio.io/v1alpha3
+kind: Gateway
+metadata:
+  name: kubeflow-gateway
+  namespace: kubeflow
+spec:
+  selector:
+    istio: ingressgateway
+  servers:
+  - hosts:
+    - '*'
+    port:
+      name: http
+      number: 80
+      protocol: HTTP
+`)
+	th.writeK("/manifests/aws/istio-ingress/base", `
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+- ingress.yaml
+- istio-gateway.yaml
+#- istio-virtual-service.yaml
+commonLabels:
+  kustomize.component: istio-ingress
+`)
+}
+
+func TestIstioIngressBase(t *testing.T) {
+	th := NewKustTestHarness(t, "/manifests/aws/istio-ingress/base")
+	writeIstioIngressBase(th)
+	m, err := th.makeKustTarget().MakeCustomizedResMap()
+	if err != nil {
+		t.Fatalf("Err: %v", err)
+	}
+	targetPath := "../aws/istio-ingress/base"
+	fsys := fs.MakeRealFS()
+	_loader, loaderErr := loader.NewLoader(targetPath, fsys)
+	if loaderErr != nil {
+		t.Fatalf("could not load kustomize loader: %v", loaderErr)
+	}
+	rf := resmap.NewFactory(resource.NewFactory(kunstruct.NewKunstructuredFactoryImpl()))
+	kt, err := target.NewKustTarget(_loader, rf, transformer.NewFactoryImpl())
+	if err != nil {
+		th.t.Fatalf("Unexpected construction error %v", err)
+	}
+	n, err := kt.MakeCustomizedResMap()
+	if err != nil {
+		t.Fatalf("Err: %v", err)
+	}
+	expected, err := n.EncodeAsYaml()
+	th.assertActualEqualsExpected(m, string(expected))
+}

--- a/tests/istio-ingress-overlays-cognito_test.go
+++ b/tests/istio-ingress-overlays-cognito_test.go
@@ -1,0 +1,149 @@
+package tests_test
+
+import (
+	"sigs.k8s.io/kustomize/k8sdeps/kunstruct"
+	"sigs.k8s.io/kustomize/k8sdeps/transformer"
+	"sigs.k8s.io/kustomize/pkg/fs"
+	"sigs.k8s.io/kustomize/pkg/loader"
+	"sigs.k8s.io/kustomize/pkg/resmap"
+	"sigs.k8s.io/kustomize/pkg/resource"
+	"sigs.k8s.io/kustomize/pkg/target"
+	"testing"
+)
+
+func writeIstioIngressOverlaysCognito(th *KustTestHarness) {
+	th.writeF("/manifests/aws/istio-ingress/overlays/cognito/ingress.yaml", `
+apiVersion: extensions/v1beta1
+kind: Ingress
+metadata:
+  name: istio-ingress
+  annotations:
+    kubernetes.io/ingress.class: alb
+    alb.ingress.kubernetes.io/scheme: internet-facing
+    alb.ingress.kubernetes.io/auth-type: cognito
+    alb.ingress.kubernetes.io/auth-idp-cognito: '{"UserPoolArn":"$(CognitoUserPoolArn)","UserPoolClientId":"$(CognitoAppClientId)", "UserPoolDomain":"$(CognitoUserPoolDomain)"}'
+    alb.ingress.kubernetes.io/certificate-arn: $(certArn)
+    alb.ingress.kubernetes.io/listen-ports: '[{"HTTPS":443}]'
+`)
+	th.writeF("/manifests/aws/istio-ingress/overlays/cognito/params.yaml", `
+varReference:
+- path: metadata/annotations
+  kind: Ingress
+`)
+	th.writeF("/manifests/aws/istio-ingress/overlays/cognito/params.env", `
+CognitoUserPoolArn=
+CognitoAppClientId=
+CognitoUserPoolDomain=
+certArn=
+`)
+	th.writeK("/manifests/aws/istio-ingress/overlays/cognito", `
+bases:
+- ../../base
+patchesStrategicMerge:
+- ingress.yaml
+configMapGenerator:
+- name: istio-ingress-cognito-parameters
+  env: params.env
+vars:
+- name: CognitoUserPoolArn
+  objref:
+    kind: ConfigMap
+    name: istio-ingress-cognito-parameters
+    apiVersion: v1
+  fieldref:
+    fieldpath: data.CognitoUserPoolArn
+- name: CognitoAppClientId
+  objref:
+    kind: ConfigMap
+    name: istio-ingress-cognito-parameters
+    apiVersion: v1
+  fieldref:
+    fieldpath: data.CognitoAppClientId
+- name: CognitoUserPoolDomain
+  objref:
+    kind: ConfigMap
+    name: istio-ingress-cognito-parameters
+    apiVersion: v1
+  fieldref:
+    fieldpath: data.CognitoUserPoolDomain
+- name: certArn
+  objref:
+    kind: ConfigMap
+    name: istio-ingress-cognito-parameters
+    apiVersion: v1
+  fieldref:
+    fieldpath: data.certArn
+configurations:
+- params.yaml`)
+	th.writeF("/manifests/aws/istio-ingress/base/ingress.yaml", `
+apiVersion: extensions/v1beta1
+kind: Ingress
+metadata:
+  annotations:
+    kubernetes.io/ingress.class: alb
+    alb.ingress.kubernetes.io/scheme: internet-facing
+    alb.ingress.kubernetes.io/listen-ports: '[{"HTTP": 80}]'
+  name: istio-ingress
+spec:
+  rules:
+    - http:
+        paths:
+          - backend:
+              serviceName: istio-ingressgateway
+              servicePort: 80
+            path: /*
+`)
+	th.writeF("/manifests/aws/istio-ingress/base/istio-gateway.yaml", `
+apiVersion: networking.istio.io/v1alpha3
+kind: Gateway
+metadata:
+  name: kubeflow-gateway
+  namespace: kubeflow
+spec:
+  selector:
+    istio: ingressgateway
+  servers:
+  - hosts:
+    - '*'
+    port:
+      name: http
+      number: 80
+      protocol: HTTP
+`)
+	th.writeK("/manifests/aws/istio-ingress/base", `
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+- ingress.yaml
+- istio-gateway.yaml
+#- istio-virtual-service.yaml
+commonLabels:
+  kustomize.component: istio-ingress
+`)
+}
+
+func TestIstioIngressOverlaysCognito(t *testing.T) {
+	th := NewKustTestHarness(t, "/manifests/aws/istio-ingress/overlays/cognito")
+	writeIstioIngressOverlaysCognito(th)
+	m, err := th.makeKustTarget().MakeCustomizedResMap()
+	if err != nil {
+		t.Fatalf("Err: %v", err)
+	}
+	targetPath := "../aws/istio-ingress/overlays/cognito"
+	fsys := fs.MakeRealFS()
+	_loader, loaderErr := loader.NewLoader(targetPath, fsys)
+	if loaderErr != nil {
+		t.Fatalf("could not load kustomize loader: %v", loaderErr)
+	}
+	rf := resmap.NewFactory(resource.NewFactory(kunstruct.NewKunstructuredFactoryImpl()))
+	kt, err := target.NewKustTarget(_loader, rf, transformer.NewFactoryImpl())
+	if err != nil {
+		th.t.Fatalf("Unexpected construction error %v", err)
+	}
+	n, err := kt.MakeCustomizedResMap()
+	if err != nil {
+		t.Fatalf("Err: %v", err)
+	}
+	expected, err := n.EncodeAsYaml()
+	th.assertActualEqualsExpected(m, string(expected))
+}

--- a/tests/istio-ingress-overlays-oidc_test.go
+++ b/tests/istio-ingress-overlays-oidc_test.go
@@ -1,0 +1,175 @@
+package tests_test
+
+import (
+	"sigs.k8s.io/kustomize/k8sdeps/kunstruct"
+	"sigs.k8s.io/kustomize/k8sdeps/transformer"
+	"sigs.k8s.io/kustomize/pkg/fs"
+	"sigs.k8s.io/kustomize/pkg/loader"
+	"sigs.k8s.io/kustomize/pkg/resmap"
+	"sigs.k8s.io/kustomize/pkg/resource"
+	"sigs.k8s.io/kustomize/pkg/target"
+	"testing"
+)
+
+func writeIstioIngressOverlaysOidc(th *KustTestHarness) {
+	th.writeF("/manifests/aws/istio-ingress/overlays/oidc/ingress.yaml", `
+apiVersion: extensions/v1beta1
+kind: Ingress
+metadata:
+  name: istio-ingress
+  annotations:
+    kubernetes.io/ingress.class: alb
+    alb.ingress.kubernetes.io/scheme: internet-facing
+    alb.ingress.kubernetes.io/auth-type: oidc
+    alb.ingress.kubernetes.io/auth-idp-cognito: '{"Issuer":"$(oidcIssuer)","AuthorizationEndpoint":"$(oidcAuthorizationEndpoint)","TokenEndpoint":"$(oidcTokenEndpoint)","UserInfoEndpoint":"$(oidcUserInfoEndpoint)","SecretName":"$(oidcSecretName)"}'
+    alb.ingress.kubernetes.io/certificate-arn: $(certArn)
+    alb.ingress.kubernetes.io/listen-ports: '[{"HTTPS":443}]'
+`)
+	th.writeF("/manifests/aws/istio-ingress/overlays/oidc/params.yaml", `
+varReference:
+- path: metadata/annotations
+  kind: Ingress
+
+`)
+	th.writeF("/manifests/aws/istio-ingress/overlays/oidc/params.env", `
+oidcIssuer=
+oidcAuthorizationEndpoint=
+oidcTokenEndpoint=
+oidcUserInfoEndpoint=
+oidcSecretName=istio-oidc-secret
+certArn=
+`)
+	th.writeF("/manifests/aws/istio-ingress/overlays/oidc/secrets.env", `
+clientId=
+clientSecret=
+`)
+	th.writeK("/manifests/aws/istio-ingress/overlays/oidc", `
+bases:
+- ../../base
+patchesStrategicMerge:
+- ingress.yaml
+#- oidc-secret.yaml
+secretGenerator:
+- name: istio-oidc-secret
+  env: secrets.env
+  namespace: istio-system
+configMapGenerator:
+- name: istio-ingress-oidc-parameters
+  env: params.env
+vars:
+- name: oidcIssuer
+  objref:
+    kind: ConfigMap
+    name: istio-ingress-oidc-parameters
+    apiVersion: v1
+  fieldref:
+    fieldpath: data.oidcIssuer
+- name: oidcAuthorizationEndpoint
+  objref:
+    kind: ConfigMap
+    name: istio-ingress-oidc-parameters
+    apiVersion: v1
+  fieldref:
+    fieldpath: data.oidcAuthorizationEndpoint
+- name: oidcTokenEndpoint
+  objref:
+    kind: ConfigMap
+    name: istio-ingress-oidc-parameters
+    apiVersion: v1
+  fieldref:
+    fieldpath: data.oidcTokenEndpoint
+- name: oidcUserInfoEndpoint
+  objref:
+    kind: ConfigMap
+    name: istio-ingress-oidc-parameters
+    apiVersion: v1
+  fieldref:
+    fieldpath: data.oidcUserInfoEndpoint
+- name: oidcSecretName
+  objref:
+    kind: ConfigMap
+    name: istio-ingress-oidc-parameters
+    apiVersion: v1
+  fieldref:
+    fieldpath: data.oidcSecretName
+- name: certArn
+  objref:
+    kind: ConfigMap
+    name: istio-ingress-oidc-parameters
+    apiVersion: v1
+  fieldref:
+    fieldpath: data.certArn
+configurations:
+- params.yaml`)
+	th.writeF("/manifests/aws/istio-ingress/base/ingress.yaml", `
+apiVersion: extensions/v1beta1
+kind: Ingress
+metadata:
+  annotations:
+    kubernetes.io/ingress.class: alb
+    alb.ingress.kubernetes.io/scheme: internet-facing
+    alb.ingress.kubernetes.io/listen-ports: '[{"HTTP": 80}]'
+  name: istio-ingress
+spec:
+  rules:
+    - http:
+        paths:
+          - backend:
+              serviceName: istio-ingressgateway
+              servicePort: 80
+            path: /*
+`)
+	th.writeF("/manifests/aws/istio-ingress/base/istio-gateway.yaml", `
+apiVersion: networking.istio.io/v1alpha3
+kind: Gateway
+metadata:
+  name: kubeflow-gateway
+  namespace: kubeflow
+spec:
+  selector:
+    istio: ingressgateway
+  servers:
+  - hosts:
+    - '*'
+    port:
+      name: http
+      number: 80
+      protocol: HTTP
+`)
+	th.writeK("/manifests/aws/istio-ingress/base", `
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+- ingress.yaml
+- istio-gateway.yaml
+#- istio-virtual-service.yaml
+commonLabels:
+  kustomize.component: istio-ingress
+`)
+}
+
+func TestIstioIngressOverlaysOidc(t *testing.T) {
+	th := NewKustTestHarness(t, "/manifests/aws/istio-ingress/overlays/oidc")
+	writeIstioIngressOverlaysOidc(th)
+	m, err := th.makeKustTarget().MakeCustomizedResMap()
+	if err != nil {
+		t.Fatalf("Err: %v", err)
+	}
+	targetPath := "../aws/istio-ingress/overlays/oidc"
+	fsys := fs.MakeRealFS()
+	_loader, loaderErr := loader.NewLoader(targetPath, fsys)
+	if loaderErr != nil {
+		t.Fatalf("could not load kustomize loader: %v", loaderErr)
+	}
+	rf := resmap.NewFactory(resource.NewFactory(kunstruct.NewKunstructuredFactoryImpl()))
+	kt, err := target.NewKustTarget(_loader, rf, transformer.NewFactoryImpl())
+	if err != nil {
+		th.t.Fatalf("Unexpected construction error %v", err)
+	}
+	n, err := kt.MakeCustomizedResMap()
+	if err != nil {
+		t.Fatalf("Err: %v", err)
+	}
+	expected, err := n.EncodeAsYaml()
+	th.assertActualEqualsExpected(m, string(expected))
+}

--- a/tests/nvidia-device-plugin-base_test.go
+++ b/tests/nvidia-device-plugin-base_test.go
@@ -1,0 +1,93 @@
+package tests_test
+
+import (
+	"sigs.k8s.io/kustomize/k8sdeps/kunstruct"
+	"sigs.k8s.io/kustomize/k8sdeps/transformer"
+	"sigs.k8s.io/kustomize/pkg/fs"
+	"sigs.k8s.io/kustomize/pkg/loader"
+	"sigs.k8s.io/kustomize/pkg/resmap"
+	"sigs.k8s.io/kustomize/pkg/resource"
+	"sigs.k8s.io/kustomize/pkg/target"
+	"testing"
+)
+
+func writeNvidiaDevicePluginBase(th *KustTestHarness) {
+	th.writeF("/manifests/aws/nvidia-device-plugin/base/daemonset.yaml", `
+apiVersion: extensions/v1beta1
+kind: DaemonSet
+metadata:
+  name: nvidia-device-plugin-daemonset
+spec:
+  updateStrategy:
+    type: RollingUpdate
+  template:
+    metadata:
+      # Mark this pod as a critical add-on; when enabled, the critical add-on scheduler
+      # reserves resources for critical add-on pods so that they can be rescheduled after
+      # a failure.  This annotation works in tandem with the toleration below.
+      annotations:
+        scheduler.alpha.kubernetes.io/critical-pod: ""
+    spec:
+      tolerations:
+        # Allow this pod to be rescheduled while the node is in "critical add-ons only" mode.
+        # This, along with the annotation above marks this pod as a critical add-on.
+        - key: CriticalAddonsOnly
+          operator: Exists
+        - key: nvidia.com/gpu
+          operator: Exists
+          effect: NoSchedule
+      containers:
+        - image: nvidia/k8s-device-plugin:1.0.0-beta
+          name: nvidia-device-plugin-ctr
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop: ["ALL"]
+          volumeMounts:
+            - name: device-plugin
+              mountPath: /var/lib/kubelet/device-plugins
+      volumes:
+        - name: device-plugin
+          hostPath:
+            path: /var/lib/kubelet/device-plugins
+`)
+	th.writeK("/manifests/aws/nvidia-device-plugin/base", `
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+namespace: kube-system
+resources:
+- daemonset.yaml
+commonLabels:
+  kustomize.component: nvidia-device-plugin
+images:
+- name: nvidia/k8s-device-plugin
+  newName: nvidia/k8s-device-plugin
+  newTag: 1.0.0-beta
+`)
+}
+
+func TestNvidiaDevicePluginBase(t *testing.T) {
+	th := NewKustTestHarness(t, "/manifests/aws/nvidia-device-plugin/base")
+	writeNvidiaDevicePluginBase(th)
+	m, err := th.makeKustTarget().MakeCustomizedResMap()
+	if err != nil {
+		t.Fatalf("Err: %v", err)
+	}
+	targetPath := "../aws/nvidia-device-plugin/base"
+	fsys := fs.MakeRealFS()
+	_loader, loaderErr := loader.NewLoader(targetPath, fsys)
+	if loaderErr != nil {
+		t.Fatalf("could not load kustomize loader: %v", loaderErr)
+	}
+	rf := resmap.NewFactory(resource.NewFactory(kunstruct.NewKunstructuredFactoryImpl()))
+	kt, err := target.NewKustTarget(_loader, rf, transformer.NewFactoryImpl())
+	if err != nil {
+		th.t.Fatalf("Unexpected construction error %v", err)
+	}
+	n, err := kt.MakeCustomizedResMap()
+	if err != nil {
+		t.Fatalf("Err: %v", err)
+	}
+	expected, err := n.EncodeAsYaml()
+	th.assertActualEqualsExpected(m, string(expected))
+}


### PR DESCRIPTION
This is a cherry-pick of #221 

**Which issue is resolved by this Pull Request:**
Resolves https://github.com/kubeflow/kubeflow/issues/4057

**Description of your changes:**
Once we use 0.6 tags in kubeflow configs, notice aws components are not in 0.6-branch. Need to cherry-pick entire aws folder. 

**Checklist:**
- [x] Unit tests have been rebuilt: 
    1. `cd manifests/tests`
    2. `make generate`
    3. `make test`

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/manifests/360)
<!-- Reviewable:end -->
