### PR TITLE
Missing images details for newName and newTag kustomization in kustom…

### DIFF
--- a/istio/istio-install/base/kustomization.yaml
+++ b/istio/istio-install/base/kustomization.yaml
@@ -3,3 +3,40 @@ kind: Kustomization
 resources:
 - istio-noauth.yaml
 namespace: kubeflow
+images:
+- name: docker.io/istio/citadel
+  newName: docker.io/istio/citadel
+  newTag: 1.1.6
+- name: docker.io/istio/galley
+  newName: docker.io/istio/kubectl
+  newTag: 1.1.6
+- name: docker.io/istio/kubectl
+  newName: docker.io/istio/kubectl
+  newTag: 1.1.6
+- name: docker.io/istio/mixer
+  newName: docker.io/istio/mixer
+  newTag: 1.1.6
+- name: docker.io/istio/pilot
+  newName: docker.io/istio/pilot
+  newTag: 1.1.6
+- name: docker.io/istio/proxy_init
+  newName: docker.io/istio/proxy_init
+  newTag: 1.1.6
+- name: docker.io/istio/proxyv2
+  newName: docker.io/istio/proxyv2
+  newTag: 1.1.6
+- name: docker.io/istio/sidecar_injector
+  newName: docker.io/istio/sidecar_injector
+  newTag: 1.1.6
+- name: docker.io/jaegertracing/all-in-one
+  newName: docker.io/jaegertracing/all-in-one
+  newTag: "1.9"
+- name: docker.io/kiali/kiali
+  newName: docker.io/kiali/kiali
+  newTag: v0.16
+- name: docker.io/prom/prometheus
+  newName: docker.io/prom/prometheus
+  newTag: v2.3.1
+- name: grafana/grafana
+  newName: grafana/grafana
+  newTag: 6.0.2

--- a/katib-v1alpha2/katib-controller/base/kustomization.yaml
+++ b/katib-v1alpha2/katib-controller/base/kustomization.yaml
@@ -10,5 +10,6 @@ resources:
 generatorOptions:
   disableNameSuffixHash: true
 images:
-  - name: gcr.io/kubeflow-images-public/katib/v1alpha2/katib-controller
-    newTag: v0.6.0-rc.0
+- name: gcr.io/kubeflow-images-public/katib/v1alpha2/katib-controller
+  newName: gcr.io/kubeflow-images-public/katib/v1alpha2/katib-controller
+  newTag: v0.6.0-rc.0

--- a/katib-v1alpha2/katib-db/base/kustomization.yaml
+++ b/katib-v1alpha2/katib-db/base/kustomization.yaml
@@ -7,5 +7,6 @@ resources:
 generatorOptions:
   disableNameSuffixHash: true
 images:
-  - name: mysql
-    newTag: 8.0.3
+- name: mysql
+  newName: mysql
+  newTag: 8.0.3

--- a/katib-v1alpha2/katib-ui/base/kustomization.yaml
+++ b/katib-v1alpha2/katib-ui/base/kustomization.yaml
@@ -9,8 +9,9 @@ configMapGenerator:
 generatorOptions:
   disableNameSuffixHash: true
 images:
-  - name: gcr.io/kubeflow-images-public/katib/v1alpha2/katib-ui
-    newTag: v0.6.0-rc.0
+- name: gcr.io/kubeflow-images-public/katib/v1alpha2/katib-ui
+  newName: gcr.io/kubeflow-images-public/katib/v1alpha2/katib-ui
+  newTag: v0.6.0-rc.0
 vars:
 - name: clusterDomain
   objref:

--- a/katib-v1alpha2/metrics-collector/base/kustomization.yaml
+++ b/katib-v1alpha2/metrics-collector/base/kustomization.yaml
@@ -5,5 +5,6 @@ resources:
 generatorOptions:
   disableNameSuffixHash: true
 images:
-  - name: gcr.io/kubeflow-images-public/katib/v1alpha2/metrics-collector
-    newTag: v0.6.0-rc.0
+- name: gcr.io/kubeflow-images-public/katib/v1alpha2/metrics-collector
+  newName: gcr.io/kubeflow-images-public/katib/v1alpha2/metrics-collector
+  newTag: v0.6.0-rc.0

--- a/katib-v1alpha2/suggestion/base/kustomization.yaml
+++ b/katib-v1alpha2/suggestion/base/kustomization.yaml
@@ -14,12 +14,17 @@ generatorOptions:
   disableNameSuffixHash: true
 images:
   - name: gcr.io/kubeflow-images-public/katib/v1alpha2/suggestion-hyperband
+    newName: gcr.io/kubeflow-images-public/katib/v1alpha2/suggestion-hyperband
     newTag: v0.6.0-rc.0
   - name: gcr.io/kubeflow-images-public/katib/v1alpha2/suggestion-bayesianoptimization
+    newName: gcr.io/kubeflow-images-public/katib/v1alpha2/suggestion-bayesianoptimization
     newTag: v0.6.0-rc.0
   - name: gcr.io/kubeflow-images-public/katib/v1alpha2/suggestion-grid
+    newName: gcr.io/kubeflow-images-public/katib/v1alpha2/suggestion-grid
     newTag: v0.6.0-rc.0
   - name: gcr.io/kubeflow-images-public/katib/v1alpha2/suggestion-random
+    newName: gcr.io/kubeflow-images-public/katib/v1alpha2/suggestion-random
     newTag: v0.6.0-rc.0
   - name: gcr.io/kubeflow-images-public/katib/v1alpha2/suggestion-nasrl
+    newName: gcr.io/kubeflow-images-public/katib/v1alpha2/suggestion-nasrl
     newTag: v0.6.0-rc.0

--- a/kfserving/kfserving-install/base/kustomization.yaml
+++ b/kfserving/kfserving-install/base/kustomization.yaml
@@ -23,3 +23,10 @@ vars:
       fieldpath: data.registry
 configurations:
 - params.yaml
+images:
+- name: gcr.io/kfserving/kfserving-controller
+  newName: gcr.io/kfserving/kfserving-controller
+  newTag: v0.1.1
+- name: gcr.io/kubebuilder/kube-rbac-proxy
+  newName: gcr.io/kubebuilder/kube-rbac-proxy
+  newTag: v0.4.0

--- a/knative/knative-serving-install/base/kustomization.yaml
+++ b/knative/knative-serving-install/base/kustomization.yaml
@@ -18,3 +18,25 @@ resources:
 - hpa.yaml
 commonLabels:
   kustomize.component: knative
+images:
+- newTag: 88d864eb3c47881cf7ac058479d1c735cc3cf4f07a11aad0621cd36dcd9ae3c6
+  name: gcr.io/knative-releases/knative.dev/serving/cmd/activator@sha256
+  newName: gcr.io/knative-releases/knative.dev/serving/cmd/activator@sha256
+- newTag: a7801c3cf4edecfa51b7bd2068f97941f6714f7922cb4806245377c2b336b723
+  name: gcr.io/knative-releases/knative.dev/serving/cmd/autoscaler-hpa@sha256
+  newName: gcr.io/knative-releases/knative.dev/serving/cmd/autoscaler-hpa@sha256
+- newTag: aeaacec4feedee309293ac21da13e71a05a2ad84b1d5fcc01ffecfa6cfbb2870
+  name: gcr.io/knative-releases/knative.dev/serving/cmd/autoscaler@sha256
+  newName: gcr.io/knative-releases/knative.dev/serving/cmd/autoscaler@sha256
+- newTag: 3b096e55fa907cff53d37dadc5d20c29cea9bb18ed9e921a588fee17beb937df
+  name: gcr.io/knative-releases/knative.dev/serving/cmd/controller@sha256
+  newName: gcr.io/knative-releases/knative.dev/serving/cmd/controller@sha256
+- newTag: 057c999bccfe32e9889616b571dc8d389c742ff66f0b5516bad651f05459b7bc
+  name: gcr.io/knative-releases/knative.dev/serving/cmd/networking/istio@sha256
+  newName: gcr.io/knative-releases/knative.dev/serving/cmd/networking/istio@sha256
+- newTag: e0654305370cf3bbbd0f56f97789c92cf5215f752b70902eba5d5fc0e88c5aca
+  name: gcr.io/knative-releases/knative.dev/serving/cmd/queue@sha256
+  newName: gcr.io/knative-releases/knative.dev/serving/cmd/queue@sha256
+- newTag: c2076674618933df53e90cf9ddd17f5ddbad513b8c95e955e45e37be7ca9e0e8
+  name: gcr.io/knative-releases/knative.dev/serving/cmd/webhook@sha256
+  newName: gcr.io/knative-releases/knative.dev/serving/cmd/webhook@sha256

--- a/metadata/base/kustomization.yaml
+++ b/metadata/base/kustomization.yaml
@@ -43,3 +43,13 @@ vars:
     apiVersion: v1
   fieldref:
     fieldpath: metadata.name
+images:
+- name: gcr.io/kubeflow-images-public/metadata
+  newName: gcr.io/kubeflow-images-public/metadata
+  newTag: v0.1.8
+- name: gcr.io/kubeflow-images-public/metadata-frontend
+  newName: gcr.io/kubeflow-images-public/metadata-frontend
+  newTag: v0.1.8
+- name: mysql
+  newName: mysql
+  newTag: 8.0.3

--- a/pipeline/api-service/base/kustomization.yaml
+++ b/pipeline/api-service/base/kustomization.yaml
@@ -10,4 +10,5 @@ resources:
 - service.yaml
 images:
 - name: gcr.io/ml-pipeline/api-server
-  newTag: '0.1.23'
+  newName: gcr.io/ml-pipeline/api-server
+  newTag: 0.1.23

--- a/pipeline/minio/base/kustomization.yaml
+++ b/pipeline/minio/base/kustomization.yaml
@@ -22,6 +22,7 @@ vars:
     fieldpath: data.minioPvcName
 images:
 - name: minio/minio
+  newName: minio/minio
   newTag: RELEASE.2018-02-09T22-40-05Z
 configurations:
 - params.yaml

--- a/pipeline/mysql/base/kustomization.yaml
+++ b/pipeline/mysql/base/kustomization.yaml
@@ -21,6 +21,7 @@ vars:
     fieldpath: data.mysqlPvcName
 images:
 - name: mysql
+  newName: mysql
   newTag: '5.6'
 configurations:
 - params.yaml

--- a/pipeline/persistent-agent/base/kustomization.yaml
+++ b/pipeline/persistent-agent/base/kustomization.yaml
@@ -10,4 +10,5 @@ resources:
 - service-account.yaml
 images:
 - name: gcr.io/ml-pipeline/persistenceagent
+  newName: gcr.io/ml-pipeline/persistenceagent
   newTag: '0.1.23'

--- a/pipeline/pipelines-ui/base/kustomization.yaml
+++ b/pipeline/pipelines-ui/base/kustomization.yaml
@@ -12,6 +12,7 @@ configMapGenerator:
   env: params.env
 images:
 - name: gcr.io/ml-pipeline/frontend
+  newName: gcr.io/ml-pipeline/frontend
   newTag: '0.1.23'
 vars:
 - name: ui-namespace

--- a/pipeline/pipelines-viewer/base/kustomization.yaml
+++ b/pipeline/pipelines-viewer/base/kustomization.yaml
@@ -12,4 +12,5 @@ resources:
 - service-account.yaml
 images:
 - name: gcr.io/ml-pipeline/viewer-crd-controller
+  newName: gcr.io/ml-pipeline/viewer-crd-controller
   newTag: '0.1.23'

--- a/pipeline/scheduledworkflow/base/kustomization.yaml
+++ b/pipeline/scheduledworkflow/base/kustomization.yaml
@@ -11,4 +11,5 @@ resources:
 - service-account.yaml
 images:
 - name: gcr.io/ml-pipeline/scheduledworkflow
+  newName: gcr.io/ml-pipeline/scheduledworkflow
   newTag: '0.1.23'

--- a/profiles/base/kustomization.yaml
+++ b/profiles/base/kustomization.yaml
@@ -16,9 +16,12 @@ configMapGenerator:
   - name: profiles-parameters
     env: params.env
 images:
-  - name: gcr.io/kubeflow-images-public/profile-controller
-    newName: gcr.io/kubeflow-images-public/profile-controller
-    newTag: v20190619-v0-219-gbd3daa8c-dirty-1ced0e
+- name: gcr.io/kubeflow-images-public/kfam
+  newName: gcr.io/kubeflow-images-public/kfam
+  newTag: v20190612-v0-170-ga06cdb79-dirty-a33ee4
+- name: gcr.io/kubeflow-images-public/profile-controller
+  newName: gcr.io/kubeflow-images-public/profile-controller
+  newTag: v20190619-v0-219-gbd3daa8c-dirty-1ced0e
 vars:
   - name: admin
     objref:

--- a/seldon/seldon-core-operator/base/kustomization.yaml
+++ b/seldon/seldon-core-operator/base/kustomization.yaml
@@ -10,3 +10,7 @@ resources:
 - seldon-operator-webhook-server-secret-secret.yaml
 - seldondeployments.machinelearning.seldon.io-crd.yaml
 - webhook-server-service-svc.yaml
+images:
+- name: docker.io/seldonio/seldon-core-operator
+  newName: docker.io/seldonio/seldon-core-operator
+  newTag: 0.4.0

--- a/tensorboard/base/kustomization.yaml
+++ b/tensorboard/base/kustomization.yaml
@@ -26,3 +26,7 @@ vars:
     fieldpath: data.clusterDomain
 configurations:
 - params.yaml
+images:
+- name: tensorflow/tensorflow
+  newName: tensorflow/tensorflow
+  newTag: 1.8.0

--- a/tf-training/tf-job-operator/base/kustomization.yaml
+++ b/tf-training/tf-job-operator/base/kustomization.yaml
@@ -34,3 +34,7 @@ vars:
     fieldpath: data.clusterDomain
 configurations:
 - params.yaml
+images:
+- name: gcr.io/kubeflow-images-public/tf_operator
+  newName: gcr.io/kubeflow-images-public/tf_operator
+  newTag: v0.6.0.rc0


### PR DESCRIPTION
…ization.yaml files

**Which issue is resolved by this Pull Request:**
Resolves #
Many of the application kustomization.yaml files doesn't option to specify the images: 
while some have.
it would be easier to replace the registry in the newName if all application have their images configurable in the kustomization.yaml so that we could determine and retain the container name and the tag version and replacing the registry e.g. docker.io to any custom registry through the shell script.
This shell script could be called before the kfctl apply or can be handled with the kfctl build stage.

**Description of your changes:**
Ran "kustomize edit set image" on all the missing applications to add the entry in the kustomization.yaml
Many already existing. 

**Checklist:**
- [ ] Unit tests have been rebuilt: 
    1. `cd manifests/tests`
    2. `make generate`
    3. `make test`

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/manifests/363)
<!-- Reviewable:end -->
