### PR TITLE
Solve identation issue in new spark operator overlay.

### DIFF
--- a/spark/spark-operator/overlays/application/application.yaml
+++ b/spark/spark-operator/overlays/application/application.yaml
@@ -11,7 +11,7 @@ spec:
       app.kubernetes.io/component: sppark-operator
       app.kubernetes.io/part-of: kubeflow
       app.kubernetes.io/version: v0.6 
-componentKinds:
+  componentKinds:
   - group: core
     kind: Service
   - group: apps

--- a/tests/aws-alb-ingress-controller-base_test.go
+++ b/tests/aws-alb-ingress-controller-base_test.go
@@ -47,8 +47,7 @@ rules:
     verbs:
       - get
       - list
-      - watch
-`)
+      - watch`)
 	th.writeF("/manifests/aws/aws-alb-ingress-controller/base/cluster-role-binding.yaml", `
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
@@ -60,8 +59,7 @@ roleRef:
   name: alb-ingress-controller
 subjects:
   - kind: ServiceAccount
-    name: alb-ingress-controller
-`)
+    name: alb-ingress-controller`)
 	th.writeF("/manifests/aws/aws-alb-ingress-controller/base/deployment.yaml", `
 # Application Load Balancer (ALB) Ingress Controller Deployment Manifest.
 # This manifest details sensible defaults for deploying an ALB Ingress Controller.
@@ -113,17 +111,14 @@ spec:
           # Repository location of the ALB Ingress Controller.
           image: docker.io/amazon/aws-alb-ingress-controller:v1.1.2
           imagePullPolicy: Always
-      serviceAccountName: alb-ingress-controller
-`)
+      serviceAccountName: alb-ingress-controller`)
 	th.writeF("/manifests/aws/aws-alb-ingress-controller/base/service-account.yaml", `
 apiVersion: v1
 kind: ServiceAccount
 metadata:
-  name: alb-ingress-controller
-`)
+  name: alb-ingress-controller`)
 	th.writeF("/manifests/aws/aws-alb-ingress-controller/base/params.env", `
-clusterName=
-`)
+clusterName=`)
 	th.writeK("/manifests/aws/aws-alb-ingress-controller/base", `
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization

--- a/tests/aws-alb-ingress-controller-overlays-vpc_test.go
+++ b/tests/aws-alb-ingress-controller-overlays-vpc_test.go
@@ -34,8 +34,7 @@ spec:
 `)
 	th.writeF("/manifests/aws/aws-alb-ingress-controller/overlays/vpc/params.env", `
 vpcId=
-region=us-west-2
-`)
+region=us-west-2`)
 	th.writeK("/manifests/aws/aws-alb-ingress-controller/overlays/vpc", `
 bases:
 - ../../base
@@ -96,8 +95,7 @@ rules:
     verbs:
       - get
       - list
-      - watch
-`)
+      - watch`)
 	th.writeF("/manifests/aws/aws-alb-ingress-controller/base/cluster-role-binding.yaml", `
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
@@ -109,8 +107,7 @@ roleRef:
   name: alb-ingress-controller
 subjects:
   - kind: ServiceAccount
-    name: alb-ingress-controller
-`)
+    name: alb-ingress-controller`)
 	th.writeF("/manifests/aws/aws-alb-ingress-controller/base/deployment.yaml", `
 # Application Load Balancer (ALB) Ingress Controller Deployment Manifest.
 # This manifest details sensible defaults for deploying an ALB Ingress Controller.
@@ -162,17 +159,14 @@ spec:
           # Repository location of the ALB Ingress Controller.
           image: docker.io/amazon/aws-alb-ingress-controller:v1.1.2
           imagePullPolicy: Always
-      serviceAccountName: alb-ingress-controller
-`)
+      serviceAccountName: alb-ingress-controller`)
 	th.writeF("/manifests/aws/aws-alb-ingress-controller/base/service-account.yaml", `
 apiVersion: v1
 kind: ServiceAccount
 metadata:
-  name: alb-ingress-controller
-`)
+  name: alb-ingress-controller`)
 	th.writeF("/manifests/aws/aws-alb-ingress-controller/base/params.env", `
-clusterName=
-`)
+clusterName=`)
 	th.writeK("/manifests/aws/aws-alb-ingress-controller/base", `
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization

--- a/tests/aws-efs-csi-driver-base_test.go
+++ b/tests/aws-efs-csi-driver-base_test.go
@@ -58,8 +58,7 @@ spec:
               mountPath: /var/lib/csi/sockets/pluginproxy/
       volumes:
         - name: socket-dir
-          emptyDir: {}
-`)
+          emptyDir: {}`)
 	th.writeF("/manifests/aws/aws-efs-csi-driver/base/csi-attacher-cluster-role.yaml", `
 kind: ClusterRole
 apiVersion: rbac.authorization.k8s.io/v1
@@ -74,8 +73,7 @@ rules:
     verbs: ["get", "list", "watch"]
   - apiGroups: ["storage.k8s.io"]
     resources: ["volumeattachments"]
-    verbs: ["get", "list", "watch", "update"]
-`)
+    verbs: ["get", "list", "watch", "update"]`)
 	th.writeF("/manifests/aws/aws-efs-csi-driver/base/csi-attacher-cluster-role-binding.yaml", `
 kind: ClusterRoleBinding
 apiVersion: rbac.authorization.k8s.io/v1
@@ -88,14 +86,12 @@ subjects:
 roleRef:
   kind: ClusterRole
   name: efs-csi-external-attacher-clusterrole
-  apiGroup: rbac.authorization.k8s.io
-`)
+  apiGroup: rbac.authorization.k8s.io`)
 	th.writeF("/manifests/aws/aws-efs-csi-driver/base/csi-controller-sa.yaml", `
 apiVersion: v1
 kind: ServiceAccount
 metadata:
-  name: efs-csi-controller-sa
-`)
+  name: efs-csi-controller-sa`)
 	th.writeF("/manifests/aws/aws-efs-csi-driver/base/csi-node-cluster-role.yaml", `
 kind: ClusterRole
 apiVersion: rbac.authorization.k8s.io/v1
@@ -119,8 +115,7 @@ rules:
     verbs: ["get", "list", "watch", "update"]
   - apiGroups: ["csi.storage.k8s.io"]
     resources: ["csinodeinfos"]
-    verbs: ["get", "list", "watch", "update"]
-`)
+    verbs: ["get", "list", "watch", "update"]`)
 	th.writeF("/manifests/aws/aws-efs-csi-driver/base/csi-node-cluster-role-binding.yaml", `
 kind: ClusterRoleBinding
 apiVersion: rbac.authorization.k8s.io/v1
@@ -133,8 +128,7 @@ subjects:
 roleRef:
   kind: ClusterRole
   name: efs-csi-node-clusterrole
-  apiGroup: rbac.authorization.k8s.io
-`)
+  apiGroup: rbac.authorization.k8s.io`)
 	th.writeF("/manifests/aws/aws-efs-csi-driver/base/csi-node-daemon-set.yaml", `
 kind: DaemonSet
 apiVersion: apps/v1beta2
@@ -218,15 +212,13 @@ spec:
 apiVersion: v1
 kind: ServiceAccount
 metadata:
-  name: efs-csi-node-sa
-`)
+  name: efs-csi-node-sa`)
 	th.writeF("/manifests/aws/aws-efs-csi-driver/base/csi-default-storage.yaml", `
 apiVersion: storage.k8s.io/v1
 kind: StorageClass
 metadata:
   name: efs-default
-provisioner: efs.csi.aws.com
-`)
+provisioner: efs.csi.aws.com`)
 	th.writeK("/manifests/aws/aws-efs-csi-driver/base", `
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization

--- a/tests/aws-fsx-csi-driver-base_test.go
+++ b/tests/aws-fsx-csi-driver-base_test.go
@@ -69,8 +69,7 @@ spec:
               mountPath: /var/lib/csi/sockets/pluginproxy/
       volumes:
         - name: socket-dir
-          emptyDir: {}
-`)
+          emptyDir: {}`)
 	th.writeF("/manifests/aws/aws-fsx-csi-driver/base/csi-attacher-cluster-role.yaml", `
 kind: ClusterRole
 apiVersion: rbac.authorization.k8s.io/v1
@@ -85,8 +84,7 @@ rules:
     verbs: ["get", "list", "watch"]
   - apiGroups: ["storage.k8s.io"]
     resources: ["volumeattachments"]
-    verbs: ["get", "list", "watch", "update"]
-`)
+    verbs: ["get", "list", "watch", "update"]`)
 	th.writeF("/manifests/aws/aws-fsx-csi-driver/base/csi-attacher-cluster-role-binding.yaml", `
 kind: ClusterRoleBinding
 apiVersion: rbac.authorization.k8s.io/v1
@@ -99,8 +97,7 @@ subjects:
 roleRef:
   kind: ClusterRole
   name: fsx-csi-external-attacher-clusterrole
-  apiGroup: rbac.authorization.k8s.io
-`)
+  apiGroup: rbac.authorization.k8s.io`)
 	th.writeF("/manifests/aws/aws-fsx-csi-driver/base/csi-controller-cluster-role.yaml", `
 kind: ClusterRole
 apiVersion: rbac.authorization.k8s.io/v1
@@ -118,8 +115,7 @@ rules:
     verbs: ["get", "list", "watch"]
   - apiGroups: [""]
     resources: ["events"]
-    verbs: ["get", "list", "watch", "create", "update", "patch"]
-`)
+    verbs: ["get", "list", "watch", "create", "update", "patch"]`)
 	th.writeF("/manifests/aws/aws-fsx-csi-driver/base/csi-controller-cluster-role-binding.yaml", `
 kind: ClusterRoleBinding
 apiVersion: rbac.authorization.k8s.io/v1
@@ -132,8 +128,7 @@ subjects:
 roleRef:
   kind: ClusterRole
   name: external-provisioner-role
-  apiGroup: rbac.authorization.k8s.io
-`)
+  apiGroup: rbac.authorization.k8s.io`)
 	th.writeF("/manifests/aws/aws-fsx-csi-driver/base/csi-controller-sa.yaml", `
 apiVersion: v1
 kind: ServiceAccount
@@ -177,8 +172,7 @@ subjects:
 roleRef:
   kind: ClusterRole
   name: fsx-csi-node-clusterrole
-  apiGroup: rbac.authorization.k8s.io
-`)
+  apiGroup: rbac.authorization.k8s.io`)
 	th.writeF("/manifests/aws/aws-fsx-csi-driver/base/csi-node-daemonset.yaml", `
 kind: DaemonSet
 apiVersion: apps/v1beta2
@@ -279,8 +273,7 @@ rules:
     verbs: ["get", "list", "watch"]
   - apiGroups: [""]
     resources: ["events"]
-    verbs: ["get", "list", "watch", "create", "update", "patch"]
-`)
+    verbs: ["get", "list", "watch", "create", "update", "patch"]`)
 	th.writeF("/manifests/aws/aws-fsx-csi-driver/base/csi-provisioner-cluster-role-binding.yaml", `
 kind: ClusterRoleBinding
 apiVersion: rbac.authorization.k8s.io/v1
@@ -293,15 +286,13 @@ subjects:
 roleRef:
   kind: ClusterRole
   name: fsx-external-provisioner-clusterrole
-  apiGroup: rbac.authorization.k8s.io
-`)
+  apiGroup: rbac.authorization.k8s.io`)
 	th.writeF("/manifests/aws/aws-fsx-csi-driver/base/csi-default-storage.yaml", `
 apiVersion: storage.k8s.io/v1
 kind: StorageClass
 metadata:
   name: fsx-default
-provisioner: fsx.csi.aws.com
-`)
+provisioner: fsx.csi.aws.com`)
 	th.writeK("/manifests/aws/aws-fsx-csi-driver/base", `
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization

--- a/tests/basic-auth-ingress-overlays-certmanager_test.go
+++ b/tests/basic-auth-ingress-overlays-certmanager_test.go
@@ -75,8 +75,7 @@ resources:
 - certificate.yaml
 namespace: kubeflow
 commonLabels:
-  kustomize.component: basic-auth-ingress
-`)
+  kustomize.component: basic-auth-ingress`)
 	th.writeF("/manifests/gcp/basic-auth-ingress/base/cloud-endpoint.yaml", `
 apiVersion: ctl.isla.solutions/v1
 kind: CloudEndpoint

--- a/tests/basic-auth-ingress-overlays-gcp-credentials_test.go
+++ b/tests/basic-auth-ingress-overlays-gcp-credentials_test.go
@@ -33,16 +33,14 @@ spec:
       volumes:
       - name: sa-key
         secret:
-          secretName: admin-gcp-sa
-`)
+          secretName: admin-gcp-sa`)
 	th.writeK("/manifests/gcp/basic-auth-ingress/overlays/gcp-credentials", `
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 bases:
 - ../../base
 patchesStrategicMerge:
-- gcp-credentials-patch.yaml
-`)
+- gcp-credentials-patch.yaml`)
 	th.writeF("/manifests/gcp/basic-auth-ingress/base/cloud-endpoint.yaml", `
 apiVersion: ctl.isla.solutions/v1
 kind: CloudEndpoint

--- a/tests/basic-auth-ingress-overlays-managed-cert_test.go
+++ b/tests/basic-auth-ingress-overlays-managed-cert_test.go
@@ -19,8 +19,7 @@ metadata:
   name: gke-certificate
 spec:
   domains:
-  - $(hostname)
-`)
+  - $(hostname)`)
 	th.writeK("/manifests/gcp/basic-auth-ingress/overlays/managed-cert", `
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
@@ -30,8 +29,7 @@ resources:
 - cert.yaml
 namespace: kubeflow
 commonLabels:
-  kustomize.component: basic-auth-ingress
-`)
+  kustomize.component: basic-auth-ingress`)
 	th.writeF("/manifests/gcp/basic-auth-ingress/base/cloud-endpoint.yaml", `
 apiVersion: ctl.isla.solutions/v1
 kind: CloudEndpoint

--- a/tests/centraldashboard-base_test.go
+++ b/tests/centraldashboard-base_test.go
@@ -164,13 +164,11 @@ varReference:
 - path: spec/template/spec/containers/0/env/0/value
   kind: Deployment
 - path: spec/template/spec/containers/0/env/1/value
-  kind: Deployment
-`)
+  kind: Deployment`)
 	th.writeF("/manifests/common/centraldashboard/base/params.env", `
 clusterDomain=cluster.local
 userid-header=
-userid-prefix=
-`)
+userid-prefix=`)
 	th.writeK("/manifests/common/centraldashboard/base", `
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization

--- a/tests/centraldashboard-overlays-application_test.go
+++ b/tests/centraldashboard-overlays-application_test.go
@@ -233,13 +233,11 @@ varReference:
 - path: spec/template/spec/containers/0/env/0/value
   kind: Deployment
 - path: spec/template/spec/containers/0/env/1/value
-  kind: Deployment
-`)
+  kind: Deployment`)
 	th.writeF("/manifests/common/centraldashboard/base/params.env", `
 clusterDomain=cluster.local
 userid-header=
-userid-prefix=
-`)
+userid-prefix=`)
 	th.writeK("/manifests/common/centraldashboard/base", `
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization

--- a/tests/centraldashboard-overlays-istio_test.go
+++ b/tests/centraldashboard-overlays-istio_test.go
@@ -202,13 +202,11 @@ varReference:
 - path: spec/template/spec/containers/0/env/0/value
   kind: Deployment
 - path: spec/template/spec/containers/0/env/1/value
-  kind: Deployment
-`)
+  kind: Deployment`)
 	th.writeF("/manifests/common/centraldashboard/base/params.env", `
 clusterDomain=cluster.local
 userid-header=
-userid-prefix=
-`)
+userid-prefix=`)
 	th.writeK("/manifests/common/centraldashboard/base", `
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization

--- a/tests/cloud-endpoints-overlays-gcp-credentials_test.go
+++ b/tests/cloud-endpoints-overlays-gcp-credentials_test.go
@@ -33,16 +33,14 @@ spec:
       volumes:
       - name: sa-key
         secret:
-          secretName: admin-gcp-sa
-`)
+          secretName: admin-gcp-sa`)
 	th.writeK("/manifests/gcp/cloud-endpoints/overlays/gcp-credentials", `
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 bases:
 - ../../base
 patchesStrategicMerge:
-- gcp-credentials-patch.yaml
-`)
+- gcp-credentials-patch.yaml`)
 	th.writeF("/manifests/gcp/cloud-endpoints/base/cluster-role-binding.yaml", `
 apiVersion: rbac.authorization.k8s.io/v1beta1
 kind: ClusterRoleBinding

--- a/tests/fluentd-cloud-watch-base_test.go
+++ b/tests/fluentd-cloud-watch-base_test.go
@@ -22,8 +22,7 @@ rules:
     resources:
       - namespaces
       - pods
-    verbs: ["get", "list", "watch"]
-`)
+    verbs: ["get", "list", "watch"]`)
 	th.writeF("/manifests/aws/fluentd-cloud-watch/base/cluster-role-binding.yaml", `
 apiVersion: rbac.authorization.k8s.io/v1beta1
 kind: ClusterRoleBinding
@@ -36,8 +35,7 @@ roleRef:
 subjects:
   - kind: ServiceAccount
     name: fluentd
-    namespace: kube-system
-`)
+    namespace: kube-system`)
 	th.writeF("/manifests/aws/fluentd-cloud-watch/base/configmap.yaml", `
 apiVersion: v1
 kind: ConfigMap
@@ -160,8 +158,7 @@ data:
           retry_forever true
         </buffer>
       </match>
-    </label>
-`)
+    </label>`)
 	th.writeF("/manifests/aws/fluentd-cloud-watch/base/daemonset.yaml", `
 apiVersion: extensions/v1beta1
 kind: DaemonSet
@@ -230,14 +227,12 @@ spec:
             path: /var/lib/docker/containers
         - name: runlogjournal
           hostPath:
-            path: /run/log/journal
-`)
+            path: /run/log/journal`)
 	th.writeF("/manifests/aws/fluentd-cloud-watch/base/service-account.yaml", `
 apiVersion: v1
 kind: ServiceAccount
 metadata:
-  name: fluentd
-`)
+  name: fluentd`)
 	th.writeF("/manifests/aws/fluentd-cloud-watch/base/params.env", `
 region=us-west-2
 clusterName=

--- a/tests/iap-ingress-base_test.go
+++ b/tests/iap-ingress-base_test.go
@@ -542,8 +542,7 @@ varReference:
 - path: data/healthcheck_route.yaml
   kind: ConfigMap
 - path: spec/domains
-  kind: ManagedCertificate
-`)
+  kind: ManagedCertificate`)
 	th.writeF("/manifests/gcp/iap-ingress/base/params.env", `
 namespace=kubeflow
 appName=kubeflow
@@ -555,8 +554,7 @@ oauthSecretName=kubeflow-oauth
 project=
 adminSaSecretName=admin-gcp-sa
 tlsSecretName=envoy-ingress-tls
-istioNamespace=istio-system
-`)
+istioNamespace=istio-system`)
 	th.writeK("/manifests/gcp/iap-ingress/base", `
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
@@ -669,8 +667,7 @@ vars:
   fieldref:
     fieldpath: data.istioNamespace
 configurations:
-- params.yaml
-`)
+- params.yaml`)
 }
 
 func TestIapIngressBase(t *testing.T) {

--- a/tests/iap-ingress-overlays-certmanager_test.go
+++ b/tests/iap-ingress-overlays-certmanager_test.go
@@ -619,8 +619,7 @@ varReference:
 - path: data/healthcheck_route.yaml
   kind: ConfigMap
 - path: spec/domains
-  kind: ManagedCertificate
-`)
+  kind: ManagedCertificate`)
 	th.writeF("/manifests/gcp/iap-ingress/base/params.env", `
 namespace=kubeflow
 appName=kubeflow
@@ -632,8 +631,7 @@ oauthSecretName=kubeflow-oauth
 project=
 adminSaSecretName=admin-gcp-sa
 tlsSecretName=envoy-ingress-tls
-istioNamespace=istio-system
-`)
+istioNamespace=istio-system`)
 	th.writeK("/manifests/gcp/iap-ingress/base", `
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
@@ -746,8 +744,7 @@ vars:
   fieldref:
     fieldpath: data.istioNamespace
 configurations:
-- params.yaml
-`)
+- params.yaml`)
 }
 
 func TestIapIngressOverlaysCertmanager(t *testing.T) {

--- a/tests/iap-ingress-overlays-gcp-credentials_test.go
+++ b/tests/iap-ingress-overlays-gcp-credentials_test.go
@@ -597,8 +597,7 @@ varReference:
 - path: data/healthcheck_route.yaml
   kind: ConfigMap
 - path: spec/domains
-  kind: ManagedCertificate
-`)
+  kind: ManagedCertificate`)
 	th.writeF("/manifests/gcp/iap-ingress/base/params.env", `
 namespace=kubeflow
 appName=kubeflow
@@ -610,8 +609,7 @@ oauthSecretName=kubeflow-oauth
 project=
 adminSaSecretName=admin-gcp-sa
 tlsSecretName=envoy-ingress-tls
-istioNamespace=istio-system
-`)
+istioNamespace=istio-system`)
 	th.writeK("/manifests/gcp/iap-ingress/base", `
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
@@ -724,8 +722,7 @@ vars:
   fieldref:
     fieldpath: data.istioNamespace
 configurations:
-- params.yaml
-`)
+- params.yaml`)
 }
 
 func TestIapIngressOverlaysGcpCredentials(t *testing.T) {

--- a/tests/iap-ingress-overlays-managed-cert_test.go
+++ b/tests/iap-ingress-overlays-managed-cert_test.go
@@ -562,8 +562,7 @@ varReference:
 - path: data/healthcheck_route.yaml
   kind: ConfigMap
 - path: spec/domains
-  kind: ManagedCertificate
-`)
+  kind: ManagedCertificate`)
 	th.writeF("/manifests/gcp/iap-ingress/base/params.env", `
 namespace=kubeflow
 appName=kubeflow
@@ -575,8 +574,7 @@ oauthSecretName=kubeflow-oauth
 project=
 adminSaSecretName=admin-gcp-sa
 tlsSecretName=envoy-ingress-tls
-istioNamespace=istio-system
-`)
+istioNamespace=istio-system`)
 	th.writeK("/manifests/gcp/iap-ingress/base", `
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
@@ -689,8 +687,7 @@ vars:
   fieldref:
     fieldpath: data.istioNamespace
 configurations:
-- params.yaml
-`)
+- params.yaml`)
 }
 
 func TestIapIngressOverlaysManagedCert(t *testing.T) {

--- a/tests/istio-ingress-base_test.go
+++ b/tests/istio-ingress-base_test.go
@@ -28,8 +28,7 @@ spec:
           - backend:
               serviceName: istio-ingressgateway
               servicePort: 80
-            path: /*
-`)
+            path: /*`)
 	th.writeF("/manifests/aws/istio-ingress/base/istio-gateway.yaml", `
 apiVersion: networking.istio.io/v1alpha3
 kind: Gateway
@@ -45,8 +44,7 @@ spec:
     port:
       name: http
       number: 80
-      protocol: HTTP
-`)
+      protocol: HTTP`)
 	th.writeK("/manifests/aws/istio-ingress/base", `
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization

--- a/tests/istio-ingress-overlays-cognito_test.go
+++ b/tests/istio-ingress-overlays-cognito_test.go
@@ -23,19 +23,16 @@ metadata:
     alb.ingress.kubernetes.io/auth-type: cognito
     alb.ingress.kubernetes.io/auth-idp-cognito: '{"UserPoolArn":"$(CognitoUserPoolArn)","UserPoolClientId":"$(CognitoAppClientId)", "UserPoolDomain":"$(CognitoUserPoolDomain)"}'
     alb.ingress.kubernetes.io/certificate-arn: $(certArn)
-    alb.ingress.kubernetes.io/listen-ports: '[{"HTTPS":443}]'
-`)
+    alb.ingress.kubernetes.io/listen-ports: '[{"HTTPS":443}]'`)
 	th.writeF("/manifests/aws/istio-ingress/overlays/cognito/params.yaml", `
 varReference:
 - path: metadata/annotations
-  kind: Ingress
-`)
+  kind: Ingress`)
 	th.writeF("/manifests/aws/istio-ingress/overlays/cognito/params.env", `
 CognitoUserPoolArn=
 CognitoAppClientId=
 CognitoUserPoolDomain=
-certArn=
-`)
+certArn=`)
 	th.writeK("/manifests/aws/istio-ingress/overlays/cognito", `
 bases:
 - ../../base
@@ -74,8 +71,7 @@ vars:
   fieldref:
     fieldpath: data.certArn
 configurations:
-- params.yaml
-`)
+- params.yaml`)
 	th.writeF("/manifests/aws/istio-ingress/base/ingress.yaml", `
 apiVersion: extensions/v1beta1
 kind: Ingress
@@ -92,8 +88,7 @@ spec:
           - backend:
               serviceName: istio-ingressgateway
               servicePort: 80
-            path: /*
-`)
+            path: /*`)
 	th.writeF("/manifests/aws/istio-ingress/base/istio-gateway.yaml", `
 apiVersion: networking.istio.io/v1alpha3
 kind: Gateway
@@ -109,8 +104,7 @@ spec:
     port:
       name: http
       number: 80
-      protocol: HTTP
-`)
+      protocol: HTTP`)
 	th.writeK("/manifests/aws/istio-ingress/base", `
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization

--- a/tests/istio-ingress-overlays-oidc_test.go
+++ b/tests/istio-ingress-overlays-oidc_test.go
@@ -23,8 +23,7 @@ metadata:
     alb.ingress.kubernetes.io/auth-type: oidc
     alb.ingress.kubernetes.io/auth-idp-cognito: '{"Issuer":"$(oidcIssuer)","AuthorizationEndpoint":"$(oidcAuthorizationEndpoint)","TokenEndpoint":"$(oidcTokenEndpoint)","UserInfoEndpoint":"$(oidcUserInfoEndpoint)","SecretName":"$(oidcSecretName)"}'
     alb.ingress.kubernetes.io/certificate-arn: $(certArn)
-    alb.ingress.kubernetes.io/listen-ports: '[{"HTTPS":443}]'
-`)
+    alb.ingress.kubernetes.io/listen-ports: '[{"HTTPS":443}]'`)
 	th.writeF("/manifests/aws/istio-ingress/overlays/oidc/params.yaml", `
 varReference:
 - path: metadata/annotations
@@ -37,8 +36,7 @@ oidcAuthorizationEndpoint=
 oidcTokenEndpoint=
 oidcUserInfoEndpoint=
 oidcSecretName=istio-oidc-secret
-certArn=
-`)
+certArn=`)
 	th.writeF("/manifests/aws/istio-ingress/overlays/oidc/secrets.env", `
 clientId=
 clientSecret=
@@ -100,8 +98,7 @@ vars:
   fieldref:
     fieldpath: data.certArn
 configurations:
-- params.yaml
-`)
+- params.yaml`)
 	th.writeF("/manifests/aws/istio-ingress/base/ingress.yaml", `
 apiVersion: extensions/v1beta1
 kind: Ingress
@@ -118,8 +115,7 @@ spec:
           - backend:
               serviceName: istio-ingressgateway
               servicePort: 80
-            path: /*
-`)
+            path: /*`)
 	th.writeF("/manifests/aws/istio-ingress/base/istio-gateway.yaml", `
 apiVersion: networking.istio.io/v1alpha3
 kind: Gateway
@@ -135,8 +131,7 @@ spec:
     port:
       name: http
       number: 80
-      protocol: HTTP
-`)
+      protocol: HTTP`)
 	th.writeK("/manifests/aws/istio-ingress/base", `
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization

--- a/tests/jupyter-web-app-base_test.go
+++ b/tests/jupyter-web-app-base_test.go
@@ -342,8 +342,7 @@ varReference:
 - path: spec/template/spec/containers/0/env/2/value
   kind: Deployment
 - path: spec/template/spec/containers/0/env/3/value
-  kind: Deployment
-`)
+  kind: Deployment`)
 	th.writeF("/manifests/jupyter/jupyter-web-app/base/params.env", `
 UI=default
 ROK_SECRET_NAME=secret-rok-{username}
@@ -351,8 +350,7 @@ policy=Always
 prefix=jupyter
 clusterDomain=cluster.local
 userid-header=
-userid-prefix=
-`)
+userid-prefix=`)
 	th.writeK("/manifests/jupyter/jupyter-web-app/base", `
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization

--- a/tests/jupyter-web-app-overlays-application_test.go
+++ b/tests/jupyter-web-app-overlays-application_test.go
@@ -406,8 +406,7 @@ varReference:
 - path: spec/template/spec/containers/0/env/2/value
   kind: Deployment
 - path: spec/template/spec/containers/0/env/3/value
-  kind: Deployment
-`)
+  kind: Deployment`)
 	th.writeF("/manifests/jupyter/jupyter-web-app/base/params.env", `
 UI=default
 ROK_SECRET_NAME=secret-rok-{username}
@@ -415,8 +414,7 @@ policy=Always
 prefix=jupyter
 clusterDomain=cluster.local
 userid-header=
-userid-prefix=
-`)
+userid-prefix=`)
 	th.writeK("/manifests/jupyter/jupyter-web-app/base", `
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization

--- a/tests/jupyter-web-app-overlays-istio_test.go
+++ b/tests/jupyter-web-app-overlays-istio_test.go
@@ -381,8 +381,7 @@ varReference:
 - path: spec/template/spec/containers/0/env/2/value
   kind: Deployment
 - path: spec/template/spec/containers/0/env/3/value
-  kind: Deployment
-`)
+  kind: Deployment`)
 	th.writeF("/manifests/jupyter/jupyter-web-app/base/params.env", `
 UI=default
 ROK_SECRET_NAME=secret-rok-{username}
@@ -390,8 +389,7 @@ policy=Always
 prefix=jupyter
 clusterDomain=cluster.local
 userid-header=
-userid-prefix=
-`)
+userid-prefix=`)
 	th.writeK("/manifests/jupyter/jupyter-web-app/base", `
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization

--- a/tests/metadata-base_test.go
+++ b/tests/metadata-base_test.go
@@ -289,8 +289,7 @@ vars:
     name: ui
     apiVersion: v1
   fieldref:
-    fieldpath: metadata.name
-`)
+    fieldpath: metadata.name`)
 }
 
 func TestMetadataBase(t *testing.T) {

--- a/tests/metadata-overlays-application_test.go
+++ b/tests/metadata-overlays-application_test.go
@@ -346,8 +346,7 @@ vars:
     name: ui
     apiVersion: v1
   fieldref:
-    fieldpath: metadata.name
-`)
+    fieldpath: metadata.name`)
 }
 
 func TestMetadataOverlaysApplication(t *testing.T) {

--- a/tests/metadata-overlays-istio_test.go
+++ b/tests/metadata-overlays-istio_test.go
@@ -327,8 +327,7 @@ vars:
     name: ui
     apiVersion: v1
   fieldref:
-    fieldpath: metadata.name
-`)
+    fieldpath: metadata.name`)
 }
 
 func TestMetadataOverlaysIstio(t *testing.T) {

--- a/tests/minio-base_test.go
+++ b/tests/minio-base_test.go
@@ -84,11 +84,9 @@ varReference:
 - path: spec/template/spec/volumes/persistentVolumeClaim/claimName
   kind: Deployment
 - path: metadata/name
-  kind: PersistentVolumeClaim
-`)
+  kind: PersistentVolumeClaim`)
 	th.writeF("/manifests/pipeline/minio/base/params.env", `
-minioPvcName=
-`)
+minioPvcName=`)
 	th.writeK("/manifests/pipeline/minio/base", `
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization

--- a/tests/minio-overlays-minioPd_test.go
+++ b/tests/minio-overlays-minioPd_test.go
@@ -33,8 +33,7 @@ metadata:
   name: $(minioPvcName)
 spec:
   volumeName: $(minioPvName)
-  storageClassName: ""
-`)
+  storageClassName: ""`)
 	th.writeF("/manifests/pipeline/minio/overlays/minioPd/params.yaml", `
 varReference:
 - path: spec/gcePersistentDisk/pdName
@@ -155,11 +154,9 @@ varReference:
 - path: spec/template/spec/volumes/persistentVolumeClaim/claimName
   kind: Deployment
 - path: metadata/name
-  kind: PersistentVolumeClaim
-`)
+  kind: PersistentVolumeClaim`)
 	th.writeF("/manifests/pipeline/minio/base/params.env", `
-minioPvcName=
-`)
+minioPvcName=`)
 	th.writeK("/manifests/pipeline/minio/base", `
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization

--- a/tests/mxnet-operator-base_test.go
+++ b/tests/mxnet-operator-base_test.go
@@ -25,8 +25,7 @@ roleRef:
   name: mxnet-operator
 subjects:
 - kind: ServiceAccount
-  name: mxnet-operator
-`)
+  name: mxnet-operator`)
 	th.writeF("/manifests/mxnet-job/mxnet-operator/base/cluster-role.yaml", `
 apiVersion: rbac.authorization.k8s.io/v1beta1
 kind: ClusterRole
@@ -76,8 +75,7 @@ rules:
   resources:
   - deployments
   verbs:
-  - '*'
-`)
+  - '*'`)
 	th.writeF("/manifests/mxnet-job/mxnet-operator/base/crd.yaml", `
 apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
@@ -129,8 +127,7 @@ kind: ServiceAccount
 metadata:
   labels:
     app: mxnet-operator
-  name: mxnet-operator
-`)
+  name: mxnet-operator`)
 	th.writeK("/manifests/mxnet-job/mxnet-operator/base", `
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization

--- a/tests/mxnet-operator-overlays-application_test.go
+++ b/tests/mxnet-operator-overlays-application_test.go
@@ -80,8 +80,7 @@ roleRef:
   name: mxnet-operator
 subjects:
 - kind: ServiceAccount
-  name: mxnet-operator
-`)
+  name: mxnet-operator`)
 	th.writeF("/manifests/mxnet-job/mxnet-operator/base/cluster-role.yaml", `
 apiVersion: rbac.authorization.k8s.io/v1beta1
 kind: ClusterRole
@@ -131,8 +130,7 @@ rules:
   resources:
   - deployments
   verbs:
-  - '*'
-`)
+  - '*'`)
 	th.writeF("/manifests/mxnet-job/mxnet-operator/base/crd.yaml", `
 apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
@@ -184,8 +182,7 @@ kind: ServiceAccount
 metadata:
   labels:
     app: mxnet-operator
-  name: mxnet-operator
-`)
+  name: mxnet-operator`)
 	th.writeK("/manifests/mxnet-job/mxnet-operator/base", `
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization

--- a/tests/mysql-base_test.go
+++ b/tests/mysql-base_test.go
@@ -58,15 +58,13 @@ spec:
   - ReadWriteOnce
   resources:
     requests:
-      storage: 20Gi
-`)
+      storage: 20Gi`)
 	th.writeF("/manifests/pipeline/mysql/base/params.yaml", `
 varReference:
 - path: spec/template/spec/volumes/persistentVolumeClaim/claimName
   kind: Deployment
 - path: metadata/name
-  kind: PersistentVolumeClaim
-`)
+  kind: PersistentVolumeClaim`)
 	th.writeF("/manifests/pipeline/mysql/base/params.env", `
 mysqlPvcName=
 `)

--- a/tests/mysql-overlays-mysqlPd_test.go
+++ b/tests/mysql-overlays-mysqlPd_test.go
@@ -129,15 +129,13 @@ spec:
   - ReadWriteOnce
   resources:
     requests:
-      storage: 20Gi
-`)
+      storage: 20Gi`)
 	th.writeF("/manifests/pipeline/mysql/base/params.yaml", `
 varReference:
 - path: spec/template/spec/volumes/persistentVolumeClaim/claimName
   kind: Deployment
 - path: metadata/name
-  kind: PersistentVolumeClaim
-`)
+  kind: PersistentVolumeClaim`)
 	th.writeF("/manifests/pipeline/mysql/base/params.env", `
 mysqlPvcName=
 `)

--- a/tests/nvidia-device-plugin-base_test.go
+++ b/tests/nvidia-device-plugin-base_test.go
@@ -49,8 +49,7 @@ spec:
       volumes:
         - name: device-plugin
           hostPath:
-            path: /var/lib/kubelet/device-plugins
-`)
+            path: /var/lib/kubelet/device-plugins`)
 	th.writeK("/manifests/aws/nvidia-device-plugin/base", `
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization

--- a/tests/profiles-base_test.go
+++ b/tests/profiles-base_test.go
@@ -125,8 +125,7 @@ metadata:
   name: kfam
 spec:
   ports:
-    - port: 8081
-`)
+    - port: 8081`)
 	th.writeF("/manifests/profiles/base/deployment.yaml", `
 apiVersion: apps/v1
 kind: Deployment
@@ -171,8 +170,7 @@ varReference:
 - path: spec/template/spec/containers/1/args/3
   kind: Deployment
 - path: spec/template/spec/containers/1/args/5
-  kind: Deployment
-`)
+  kind: Deployment`)
 	th.writeF("/manifests/profiles/base/params.env", `
 admin=
 userid-header=

--- a/tests/profiles-overlays-debug_test.go
+++ b/tests/profiles-overlays-debug_test.go
@@ -180,8 +180,7 @@ metadata:
   name: kfam
 spec:
   ports:
-    - port: 8081
-`)
+    - port: 8081`)
 	th.writeF("/manifests/profiles/base/deployment.yaml", `
 apiVersion: apps/v1
 kind: Deployment
@@ -226,8 +225,7 @@ varReference:
 - path: spec/template/spec/containers/1/args/3
   kind: Deployment
 - path: spec/template/spec/containers/1/args/5
-  kind: Deployment
-`)
+  kind: Deployment`)
 	th.writeF("/manifests/profiles/base/params.env", `
 admin=
 userid-header=

--- a/tests/profiles-overlays-devices_test.go
+++ b/tests/profiles-overlays-devices_test.go
@@ -151,8 +151,7 @@ metadata:
   name: kfam
 spec:
   ports:
-    - port: 8081
-`)
+    - port: 8081`)
 	th.writeF("/manifests/profiles/base/deployment.yaml", `
 apiVersion: apps/v1
 kind: Deployment
@@ -197,8 +196,7 @@ varReference:
 - path: spec/template/spec/containers/1/args/3
   kind: Deployment
 - path: spec/template/spec/containers/1/args/5
-  kind: Deployment
-`)
+  kind: Deployment`)
 	th.writeF("/manifests/profiles/base/params.env", `
 admin=
 userid-header=

--- a/tests/profiles-overlays-istio_test.go
+++ b/tests/profiles-overlays-istio_test.go
@@ -166,8 +166,7 @@ metadata:
   name: kfam
 spec:
   ports:
-    - port: 8081
-`)
+    - port: 8081`)
 	th.writeF("/manifests/profiles/base/deployment.yaml", `
 apiVersion: apps/v1
 kind: Deployment
@@ -212,8 +211,7 @@ varReference:
 - path: spec/template/spec/containers/1/args/3
   kind: Deployment
 - path: spec/template/spec/containers/1/args/5
-  kind: Deployment
-`)
+  kind: Deployment`)
 	th.writeF("/manifests/profiles/base/params.env", `
 admin=
 userid-header=

--- a/tests/prometheus-base_test.go
+++ b/tests/prometheus-base_test.go
@@ -295,8 +295,7 @@ varReference:
 	th.writeF("/manifests/gcp/prometheus/base/params.env", `
 projectId=
 clusterName=
-zone=
-`)
+zone=`)
 	th.writeK("/manifests/gcp/prometheus/base", `
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization

--- a/tests/seldon-core-operator-base_test.go
+++ b/tests/seldon-core-operator-base_test.go
@@ -3629,8 +3629,7 @@ resources:
 - seldon-operator-manager-rolebinding-crb.yaml
 - seldon-operator-webhook-server-secret-secret.yaml
 - seldondeployments.machinelearning.seldon.io-crd.yaml
-- webhook-server-service-svc.yaml
-`)
+- webhook-server-service-svc.yaml`)
 }
 
 func TestSeldonCoreOperatorBase(t *testing.T) {

--- a/tests/seldon-core-operator-overlays-application_test.go
+++ b/tests/seldon-core-operator-overlays-application_test.go
@@ -3678,8 +3678,7 @@ resources:
 - seldon-operator-manager-rolebinding-crb.yaml
 - seldon-operator-webhook-server-secret-secret.yaml
 - seldondeployments.machinelearning.seldon.io-crd.yaml
-- webhook-server-service-svc.yaml
-`)
+- webhook-server-service-svc.yaml`)
 }
 
 func TestSeldonCoreOperatorOverlaysApplication(t *testing.T) {

--- a/tests/spark-operator-overlays-application_test.go
+++ b/tests/spark-operator-overlays-application_test.go
@@ -11,7 +11,61 @@ import (
 	"testing"
 )
 
-func writeSparkOperatorBase(th *KustTestHarness) {
+func writeSparkOperatorOverlaysApplication(th *KustTestHarness) {
+	th.writeF("/manifests/spark/spark-operator/overlays/application/application.yaml", `
+apiVersion: app.k8s.io/v1beta1
+kind: Application
+metadata:
+  name: spark-operator
+spec:
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: sparkoperator
+      app.kubernetes.io/instance: spark-operator
+      app.kubernetes.io/managed-by: kfctl
+      app.kubernetes.io/component: sppark-operator
+      app.kubernetes.io/part-of: kubeflow
+      app.kubernetes.io/version: v0.6 
+  componentKinds:
+  - group: core
+    kind: Service
+  - group: apps
+    kind: Deployment
+  - group: core
+    kind: ConfigMap
+  - group: core
+    kind: ServiceAccount
+  - group: kubeflow.org
+    kind: SparkOperator
+  descriptor:
+    type: "spark-operator"
+    version: "v1"
+    description: "Spark-operator allows users to create and manage the \"SparkApplication\" custom resource."
+    maintainers:
+    - name: Holden Karau
+      email: holden@pigscanfly.ca
+    owners:
+    - name: Holden Karau
+      email: holden@pigscanfly.ca
+    keywords:
+    - "spark"
+  addOwnerRef: true
+`)
+	th.writeK("/manifests/spark/spark-operator/overlays/application", `
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+bases:
+- ../../base
+resources:
+- application.yaml
+commonLabels:
+  app.kubernetes.io/name: sparkoperator
+  app.kubernetes.io/instance: spark-operator
+  app.kubernetes.io/managed-by: kfctl
+  app.kubernetes.io/component: spark-operator
+  app.kubernetes.io/part-of: kubeflow
+  app.kubernetes.io/version: v0.6
+`)
 	th.writeF("/manifests/spark/spark-operator/base/spark-sa.yaml", `
 apiVersion: v1
 kind: ServiceAccount
@@ -215,9 +269,9 @@ resources:
 `)
 }
 
-func TestSparkOperatorBase(t *testing.T) {
-	th := NewKustTestHarness(t, "/manifests/spark/spark-operator/base")
-	writeSparkOperatorBase(th)
+func TestSparkOperatorOverlaysApplication(t *testing.T) {
+	th := NewKustTestHarness(t, "/manifests/spark/spark-operator/overlays/application")
+	writeSparkOperatorOverlaysApplication(th)
 	m, err := th.makeKustTarget().MakeCustomizedResMap()
 	if err != nil {
 		t.Fatalf("Err: %v", err)
@@ -226,7 +280,7 @@ func TestSparkOperatorBase(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Err: %v", err)
 	}
-	targetPath := "../spark/spark-operator/base"
+	targetPath := "../spark/spark-operator/overlays/application"
 	fsys := fs.MakeRealFS()
 	_loader, loaderErr := loader.NewLoader(targetPath, fsys)
 	if loaderErr != nil {


### PR DESCRIPTION
**Which issue is resolved by this Pull Request:**
Resolves #
The indentation issue prevents make test to work since the yaml syntax is incorrect.

**Description of your changes:**

- Add two spaces in the spark/overlays/application.yaml
- rerun make generate.
- rerun make test

**Checklist:**
- [x] Unit tests have been rebuilt: 
    1. `cd manifests/tests`
    2. `make generate`
    3. `make test`

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/manifests/377)
<!-- Reviewable:end -->
