### PR TITLE
Remove tiller and helm related labels from K8s manifests

### DIFF
--- a/istio/istio-crds/base/crds.yaml
+++ b/istio/istio-crds/base/crds.yaml
@@ -6,7 +6,6 @@ metadata:
   labels:
     app: istio-pilot
     chart: istio
-    heritage: Tiller
     release: istio
   annotations:
     "helm.sh/resource-policy": keep
@@ -48,7 +47,6 @@ metadata:
   labels:
     app: istio-pilot
     chart: istio
-    heritage: Tiller
     release: istio
   annotations:
     "helm.sh/resource-policy": keep
@@ -86,7 +84,6 @@ metadata:
   labels:
     app: istio-pilot
     chart: istio
-    heritage: Tiller
     release: istio
   annotations:
     "helm.sh/resource-policy": keep
@@ -132,7 +129,6 @@ metadata:
   labels:
     app: istio-pilot
     chart: istio
-    heritage: Tiller
     release: istio
   annotations:
     "helm.sh/resource-policy": keep
@@ -157,7 +153,6 @@ metadata:
   labels:
     app: istio-pilot
     chart: istio
-    heritage: Tiller
     release: istio
   annotations:
     "helm.sh/resource-policy": keep
@@ -180,7 +175,6 @@ metadata:
   labels:
     app: istio-pilot
     istio: rbac
-    heritage: Tiller
     release: istio
   annotations:
     "helm.sh/resource-policy": keep
@@ -203,7 +197,6 @@ metadata:
   labels:
     app: istio-citadel
     chart: istio
-    heritage: Tiller
     release: istio
   annotations:
     "helm.sh/resource-policy": keep
@@ -226,7 +219,6 @@ metadata:
   labels:
     app: istio-citadel
     chart: istio
-    heritage: Tiller
     release: istio
   annotations:
     "helm.sh/resource-policy": keep
@@ -250,7 +242,6 @@ metadata:
   labels:
     app: istio-mixer
     chart: istio
-    heritage: Tiller
     release: istio
   annotations:
     "helm.sh/resource-policy": keep
@@ -273,7 +264,6 @@ metadata:
   labels:
     app: istio-mixer
     chart: istio
-    heritage: Tiller
     release: istio
   annotations:
     "helm.sh/resource-policy": keep
@@ -296,7 +286,6 @@ metadata:
   labels:
     app: istio-mixer
     chart: istio
-    heritage: Tiller
     release: istio
   annotations:
     "helm.sh/resource-policy": keep
@@ -319,7 +308,6 @@ metadata:
   labels:
     app: istio-mixer
     chart: istio
-    heritage: Tiller
     release: istio
   annotations:
     "helm.sh/resource-policy": keep
@@ -344,7 +332,6 @@ metadata:
     package: istio.io.mixer
     istio: core
     chart: istio
-    heritage: Tiller
     release: istio
   annotations:
     "helm.sh/resource-policy": keep
@@ -369,7 +356,6 @@ metadata:
     package: istio.io.mixer
     istio: core
     chart: istio
-    heritage: Tiller
     release: istio
   annotations:
     "helm.sh/resource-policy": keep
@@ -394,7 +380,6 @@ metadata:
     package: bypass
     istio: mixer-adapter
     chart: istio
-    heritage: Tiller
     release: istio
   annotations:
     "helm.sh/resource-policy": keep
@@ -419,7 +404,6 @@ metadata:
     package: circonus
     istio: mixer-adapter
     chart: istio
-    heritage: Tiller
     release: istio
   annotations:
     "helm.sh/resource-policy": keep
@@ -444,7 +428,6 @@ metadata:
     package: denier
     istio: mixer-adapter
     chart: istio
-    heritage: Tiller
     release: istio
   annotations:
     "helm.sh/resource-policy": keep
@@ -469,7 +452,6 @@ metadata:
     package: fluentd
     istio: mixer-adapter
     chart: istio
-    heritage: Tiller
     release: istio
   annotations:
     "helm.sh/resource-policy": keep
@@ -494,7 +476,6 @@ metadata:
     package: kubernetesenv
     istio: mixer-adapter
     chart: istio
-    heritage: Tiller
     release: istio
   annotations:
     "helm.sh/resource-policy": keep
@@ -519,7 +500,6 @@ metadata:
     package: listchecker
     istio: mixer-adapter
     chart: istio
-    heritage: Tiller
     release: istio
   annotations:
     "helm.sh/resource-policy": keep
@@ -544,7 +524,6 @@ metadata:
     package: memquota
     istio: mixer-adapter
     chart: istio
-    heritage: Tiller
     release: istio
   annotations:
     "helm.sh/resource-policy": keep
@@ -569,7 +548,6 @@ metadata:
     package: noop
     istio: mixer-adapter
     chart: istio
-    heritage: Tiller
     release: istio
   annotations:
     "helm.sh/resource-policy": keep
@@ -594,7 +572,6 @@ metadata:
     package: opa
     istio: mixer-adapter
     chart: istio
-    heritage: Tiller
     release: istio
   annotations:
     "helm.sh/resource-policy": keep
@@ -619,7 +596,6 @@ metadata:
     package: prometheus
     istio: mixer-adapter
     chart: istio
-    heritage: Tiller
     release: istio
   annotations:
     "helm.sh/resource-policy": keep
@@ -644,7 +620,6 @@ metadata:
     package: rbac
     istio: mixer-adapter
     chart: istio
-    heritage: Tiller
     release: istio
   annotations:
     "helm.sh/resource-policy": keep
@@ -669,7 +644,6 @@ metadata:
     package: redisquota
     istio: mixer-adapter
     chart: istio
-    heritage: Tiller
     release: istio
   annotations:
     "helm.sh/resource-policy": keep
@@ -691,7 +665,6 @@ metadata:
     package: signalfx
     istio: mixer-adapter
     chart: istio
-    heritage: Tiller
     release: istio
   annotations:
     "helm.sh/resource-policy": keep
@@ -716,7 +689,6 @@ metadata:
     package: solarwinds
     istio: mixer-adapter
     chart: istio
-    heritage: Tiller
     release: istio
   annotations:
     "helm.sh/resource-policy": keep
@@ -741,7 +713,6 @@ metadata:
     package: stackdriver
     istio: mixer-adapter
     chart: istio
-    heritage: Tiller
     release: istio
   annotations:
     "helm.sh/resource-policy": keep
@@ -766,7 +737,6 @@ metadata:
     package: statsd
     istio: mixer-adapter
     chart: istio
-    heritage: Tiller
     release: istio
   annotations:
     "helm.sh/resource-policy": keep
@@ -791,7 +761,6 @@ metadata:
     package: stdio
     istio: mixer-adapter
     chart: istio
-    heritage: Tiller
     release: istio
   annotations:
     "helm.sh/resource-policy": keep
@@ -816,7 +785,6 @@ metadata:
     package: apikey
     istio: mixer-instance
     chart: istio
-    heritage: Tiller
     release: istio
   annotations:
     "helm.sh/resource-policy": keep
@@ -841,7 +809,6 @@ metadata:
     package: authorization
     istio: mixer-instance
     chart: istio
-    heritage: Tiller
     release: istio
   annotations:
     "helm.sh/resource-policy": keep
@@ -866,7 +833,6 @@ metadata:
     package: checknothing
     istio: mixer-instance
     chart: istio
-    heritage: Tiller
     release: istio
   annotations:
     "helm.sh/resource-policy": keep
@@ -891,7 +857,6 @@ metadata:
     package: adapter.template.kubernetes
     istio: mixer-instance
     chart: istio
-    heritage: Tiller
     release: istio
   annotations:
     "helm.sh/resource-policy": keep
@@ -916,7 +881,6 @@ metadata:
     package: listentry
     istio: mixer-instance
     chart: istio
-    heritage: Tiller
     release: istio
   annotations:
     "helm.sh/resource-policy": keep
@@ -941,7 +905,6 @@ metadata:
     package: logentry
     istio: mixer-instance
     chart: istio
-    heritage: Tiller
     release: istio
   annotations:
     "helm.sh/resource-policy": keep
@@ -986,7 +949,6 @@ metadata:
     package: edge
     istio: mixer-instance
     chart: istio
-    heritage: Tiller
     release: istio
   annotations:
     "helm.sh/resource-policy": keep
@@ -1011,7 +973,6 @@ metadata:
     package: metric
     istio: mixer-instance
     chart: istio
-    heritage: Tiller
     release: istio
   annotations:
     "helm.sh/resource-policy": keep
@@ -1036,7 +997,6 @@ metadata:
     package: quota
     istio: mixer-instance
     chart: istio
-    heritage: Tiller
     release: istio
   annotations:
     "helm.sh/resource-policy": keep
@@ -1061,7 +1021,6 @@ metadata:
     package: reportnothing
     istio: mixer-instance
     chart: istio
-    heritage: Tiller
     release: istio
   annotations:
     "helm.sh/resource-policy": keep
@@ -1086,7 +1045,6 @@ metadata:
     package: tracespan
     istio: mixer-instance
     chart: istio
-    heritage: Tiller
     release: istio
   annotations:
     "helm.sh/resource-policy": keep
@@ -1111,7 +1069,6 @@ metadata:
     package: istio.io.mixer
     istio: rbac
     chart: istio
-    heritage: Tiller
     release: istio
   annotations:
     "helm.sh/resource-policy": keep
@@ -1136,7 +1093,6 @@ metadata:
     package: istio.io.mixer
     istio: rbac
     chart: istio
-    heritage: Tiller
     release: istio
   annotations:
     "helm.sh/resource-policy": keep
@@ -1161,7 +1117,6 @@ metadata:
     package: istio.io.mixer
     istio: rbac
     chart: istio
-    heritage: Tiller
     release: istio
   annotations:
     "helm.sh/resource-policy": keep
@@ -1198,7 +1153,6 @@ metadata:
     package: adapter
     istio: mixer-adapter
     chart: istio
-    heritage: Tiller
     release: istio
   annotations:
     "helm.sh/resource-policy": keep
@@ -1223,7 +1177,6 @@ metadata:
     package: instance
     istio: mixer-instance
     chart: istio
-    heritage: Tiller
     release: istio
   annotations:
     "helm.sh/resource-policy": keep
@@ -1248,7 +1201,6 @@ metadata:
     package: template
     istio: mixer-template
     chart: istio
-    heritage: Tiller
     release: istio
   annotations:
     "helm.sh/resource-policy": keep
@@ -1273,7 +1225,6 @@ metadata:
     package: handler
     istio: mixer-handler
     chart: istio
-    heritage: Tiller
     release: istio
   annotations:
     "helm.sh/resource-policy": keep
@@ -1340,7 +1291,6 @@ metadata:
   labels:
     app: istio-pilot
     chart: istio
-    heritage: Tiller
     release: istio
   annotations:
     "helm.sh/resource-policy": keep
@@ -1385,7 +1335,6 @@ metadata:
   labels:
     app: certmanager
     chart: certmanager
-    heritage: Tiller
     release: istio
   annotations:
     "helm.sh/resource-policy": keep
@@ -1404,7 +1353,6 @@ metadata:
   labels:
     app: certmanager
     chart: certmanager
-    heritage: Tiller
     release: istio
   annotations:
     "helm.sh/resource-policy": keep
@@ -1423,7 +1371,6 @@ metadata:
   labels:
     app: certmanager
     chart: certmanager
-    heritage: Tiller
     release: istio
   annotations:
     "helm.sh/resource-policy": keep
@@ -1467,7 +1414,6 @@ metadata:
   labels:
     app: certmanager
     chart: certmanager
-    heritage: Tiller
     release: istio
   annotations:
     "helm.sh/resource-policy": keep
@@ -1505,7 +1451,6 @@ metadata:
   labels:
     app: certmanager
     chart: certmanager
-    heritage: Tiller
     release: istio
   annotations:
     "helm.sh/resource-policy": keep

--- a/istio/istio-crds/base/crds.yaml
+++ b/istio/istio-crds/base/crds.yaml
@@ -5,7 +5,6 @@ metadata:
   name: virtualservices.networking.istio.io
   labels:
     app: istio-pilot
-    chart: istio
     release: istio
   annotations:
     "helm.sh/resource-policy": keep
@@ -46,7 +45,6 @@ metadata:
   name: destinationrules.networking.istio.io
   labels:
     app: istio-pilot
-    chart: istio
     release: istio
   annotations:
     "helm.sh/resource-policy": keep
@@ -83,7 +81,6 @@ metadata:
   name: serviceentries.networking.istio.io
   labels:
     app: istio-pilot
-    chart: istio
     release: istio
   annotations:
     "helm.sh/resource-policy": keep
@@ -128,7 +125,6 @@ metadata:
   name: gateways.networking.istio.io
   labels:
     app: istio-pilot
-    chart: istio
     release: istio
   annotations:
     "helm.sh/resource-policy": keep
@@ -152,7 +148,6 @@ metadata:
   name: envoyfilters.networking.istio.io
   labels:
     app: istio-pilot
-    chart: istio
     release: istio
   annotations:
     "helm.sh/resource-policy": keep
@@ -196,7 +191,6 @@ metadata:
   name: policies.authentication.istio.io
   labels:
     app: istio-citadel
-    chart: istio
     release: istio
   annotations:
     "helm.sh/resource-policy": keep
@@ -218,7 +212,6 @@ metadata:
   name: meshpolicies.authentication.istio.io
   labels:
     app: istio-citadel
-    chart: istio
     release: istio
   annotations:
     "helm.sh/resource-policy": keep
@@ -241,7 +234,6 @@ metadata:
   name: httpapispecbindings.config.istio.io
   labels:
     app: istio-mixer
-    chart: istio
     release: istio
   annotations:
     "helm.sh/resource-policy": keep
@@ -263,7 +255,6 @@ metadata:
   name: httpapispecs.config.istio.io
   labels:
     app: istio-mixer
-    chart: istio
     release: istio
   annotations:
     "helm.sh/resource-policy": keep
@@ -285,7 +276,6 @@ metadata:
   name: quotaspecbindings.config.istio.io
   labels:
     app: istio-mixer
-    chart: istio
     release: istio
   annotations:
     "helm.sh/resource-policy": keep
@@ -307,7 +297,6 @@ metadata:
   name: quotaspecs.config.istio.io
   labels:
     app: istio-mixer
-    chart: istio
     release: istio
   annotations:
     "helm.sh/resource-policy": keep
@@ -331,7 +320,6 @@ metadata:
     app: mixer
     package: istio.io.mixer
     istio: core
-    chart: istio
     release: istio
   annotations:
     "helm.sh/resource-policy": keep
@@ -355,7 +343,6 @@ metadata:
     app: mixer
     package: istio.io.mixer
     istio: core
-    chart: istio
     release: istio
   annotations:
     "helm.sh/resource-policy": keep
@@ -379,7 +366,6 @@ metadata:
     app: mixer
     package: bypass
     istio: mixer-adapter
-    chart: istio
     release: istio
   annotations:
     "helm.sh/resource-policy": keep
@@ -403,7 +389,6 @@ metadata:
     app: mixer
     package: circonus
     istio: mixer-adapter
-    chart: istio
     release: istio
   annotations:
     "helm.sh/resource-policy": keep
@@ -427,7 +412,6 @@ metadata:
     app: mixer
     package: denier
     istio: mixer-adapter
-    chart: istio
     release: istio
   annotations:
     "helm.sh/resource-policy": keep
@@ -451,7 +435,6 @@ metadata:
     app: mixer
     package: fluentd
     istio: mixer-adapter
-    chart: istio
     release: istio
   annotations:
     "helm.sh/resource-policy": keep
@@ -475,7 +458,6 @@ metadata:
     app: mixer
     package: kubernetesenv
     istio: mixer-adapter
-    chart: istio
     release: istio
   annotations:
     "helm.sh/resource-policy": keep
@@ -499,7 +481,6 @@ metadata:
     app: mixer
     package: listchecker
     istio: mixer-adapter
-    chart: istio
     release: istio
   annotations:
     "helm.sh/resource-policy": keep
@@ -523,7 +504,6 @@ metadata:
     app: mixer
     package: memquota
     istio: mixer-adapter
-    chart: istio
     release: istio
   annotations:
     "helm.sh/resource-policy": keep
@@ -547,7 +527,6 @@ metadata:
     app: mixer
     package: noop
     istio: mixer-adapter
-    chart: istio
     release: istio
   annotations:
     "helm.sh/resource-policy": keep
@@ -571,7 +550,6 @@ metadata:
     app: mixer
     package: opa
     istio: mixer-adapter
-    chart: istio
     release: istio
   annotations:
     "helm.sh/resource-policy": keep
@@ -595,7 +573,6 @@ metadata:
     app: mixer
     package: prometheus
     istio: mixer-adapter
-    chart: istio
     release: istio
   annotations:
     "helm.sh/resource-policy": keep
@@ -619,7 +596,6 @@ metadata:
     app: mixer
     package: rbac
     istio: mixer-adapter
-    chart: istio
     release: istio
   annotations:
     "helm.sh/resource-policy": keep
@@ -643,7 +619,6 @@ metadata:
     app: mixer
     package: redisquota
     istio: mixer-adapter
-    chart: istio
     release: istio
   annotations:
     "helm.sh/resource-policy": keep
@@ -664,7 +639,6 @@ metadata:
     app: mixer
     package: signalfx
     istio: mixer-adapter
-    chart: istio
     release: istio
   annotations:
     "helm.sh/resource-policy": keep
@@ -688,7 +662,6 @@ metadata:
     app: mixer
     package: solarwinds
     istio: mixer-adapter
-    chart: istio
     release: istio
   annotations:
     "helm.sh/resource-policy": keep
@@ -712,7 +685,6 @@ metadata:
     app: mixer
     package: stackdriver
     istio: mixer-adapter
-    chart: istio
     release: istio
   annotations:
     "helm.sh/resource-policy": keep
@@ -736,7 +708,6 @@ metadata:
     app: mixer
     package: statsd
     istio: mixer-adapter
-    chart: istio
     release: istio
   annotations:
     "helm.sh/resource-policy": keep
@@ -760,7 +731,6 @@ metadata:
     app: mixer
     package: stdio
     istio: mixer-adapter
-    chart: istio
     release: istio
   annotations:
     "helm.sh/resource-policy": keep
@@ -784,7 +754,6 @@ metadata:
     app: mixer
     package: apikey
     istio: mixer-instance
-    chart: istio
     release: istio
   annotations:
     "helm.sh/resource-policy": keep
@@ -808,7 +777,6 @@ metadata:
     app: mixer
     package: authorization
     istio: mixer-instance
-    chart: istio
     release: istio
   annotations:
     "helm.sh/resource-policy": keep
@@ -832,7 +800,6 @@ metadata:
     app: mixer
     package: checknothing
     istio: mixer-instance
-    chart: istio
     release: istio
   annotations:
     "helm.sh/resource-policy": keep
@@ -856,7 +823,6 @@ metadata:
     app: mixer
     package: adapter.template.kubernetes
     istio: mixer-instance
-    chart: istio
     release: istio
   annotations:
     "helm.sh/resource-policy": keep
@@ -880,7 +846,6 @@ metadata:
     app: mixer
     package: listentry
     istio: mixer-instance
-    chart: istio
     release: istio
   annotations:
     "helm.sh/resource-policy": keep
@@ -904,7 +869,6 @@ metadata:
     app: mixer
     package: logentry
     istio: mixer-instance
-    chart: istio
     release: istio
   annotations:
     "helm.sh/resource-policy": keep
@@ -948,7 +912,6 @@ metadata:
     app: mixer
     package: edge
     istio: mixer-instance
-    chart: istio
     release: istio
   annotations:
     "helm.sh/resource-policy": keep
@@ -972,7 +935,6 @@ metadata:
     app: mixer
     package: metric
     istio: mixer-instance
-    chart: istio
     release: istio
   annotations:
     "helm.sh/resource-policy": keep
@@ -996,7 +958,6 @@ metadata:
     app: mixer
     package: quota
     istio: mixer-instance
-    chart: istio
     release: istio
   annotations:
     "helm.sh/resource-policy": keep
@@ -1020,7 +981,6 @@ metadata:
     app: mixer
     package: reportnothing
     istio: mixer-instance
-    chart: istio
     release: istio
   annotations:
     "helm.sh/resource-policy": keep
@@ -1044,7 +1004,6 @@ metadata:
     app: mixer
     package: tracespan
     istio: mixer-instance
-    chart: istio
     release: istio
   annotations:
     "helm.sh/resource-policy": keep
@@ -1068,7 +1027,6 @@ metadata:
     app: mixer
     package: istio.io.mixer
     istio: rbac
-    chart: istio
     release: istio
   annotations:
     "helm.sh/resource-policy": keep
@@ -1092,7 +1050,6 @@ metadata:
     app: mixer
     package: istio.io.mixer
     istio: rbac
-    chart: istio
     release: istio
   annotations:
     "helm.sh/resource-policy": keep
@@ -1116,7 +1073,6 @@ metadata:
     app: mixer
     package: istio.io.mixer
     istio: rbac
-    chart: istio
     release: istio
   annotations:
     "helm.sh/resource-policy": keep
@@ -1152,7 +1108,6 @@ metadata:
     app: mixer
     package: adapter
     istio: mixer-adapter
-    chart: istio
     release: istio
   annotations:
     "helm.sh/resource-policy": keep
@@ -1176,7 +1131,6 @@ metadata:
     app: mixer
     package: instance
     istio: mixer-instance
-    chart: istio
     release: istio
   annotations:
     "helm.sh/resource-policy": keep
@@ -1200,7 +1154,6 @@ metadata:
     app: mixer
     package: template
     istio: mixer-template
-    chart: istio
     release: istio
   annotations:
     "helm.sh/resource-policy": keep
@@ -1224,7 +1177,6 @@ metadata:
     app: mixer
     package: handler
     istio: mixer-handler
-    chart: istio
     release: istio
   annotations:
     "helm.sh/resource-policy": keep
@@ -1290,7 +1242,6 @@ metadata:
   name: sidecars.networking.istio.io
   labels:
     app: istio-pilot
-    chart: istio
     release: istio
   annotations:
     "helm.sh/resource-policy": keep
@@ -1334,7 +1285,6 @@ metadata:
   name: clusterissuers.certmanager.k8s.io
   labels:
     app: certmanager
-    chart: certmanager
     release: istio
   annotations:
     "helm.sh/resource-policy": keep
@@ -1352,7 +1302,6 @@ metadata:
   name: issuers.certmanager.k8s.io
   labels:
     app: certmanager
-    chart: certmanager
     release: istio
   annotations:
     "helm.sh/resource-policy": keep
@@ -1370,7 +1319,6 @@ metadata:
   name: certificates.certmanager.k8s.io
   labels:
     app: certmanager
-    chart: certmanager
     release: istio
   annotations:
     "helm.sh/resource-policy": keep
@@ -1413,7 +1361,6 @@ metadata:
   name: orders.certmanager.k8s.io
   labels:
     app: certmanager
-    chart: certmanager
     release: istio
   annotations:
     "helm.sh/resource-policy": keep
@@ -1450,7 +1397,6 @@ metadata:
   name: challenges.certmanager.k8s.io
   labels:
     app: certmanager
-    chart: certmanager
     release: istio
   annotations:
     "helm.sh/resource-policy": keep

--- a/istio/istio-install/base/istio-noauth.yaml
+++ b/istio/istio-install/base/istio-noauth.yaml
@@ -14,7 +14,6 @@ metadata:
   labels:
     app: kiali
     chart: kiali
-    heritage: Tiller
     release: istio
 type: Opaque
 data:
@@ -30,7 +29,6 @@ metadata:
   labels:
     app: galley
     chart: galley
-    heritage: Tiller
     release: istio
     istio: galley
 data:
@@ -43,7 +41,6 @@ data:
       labels:
         app: galley
         chart: galley
-        heritage: Tiller
         release: istio
         istio: galley
     webhooks:
@@ -154,7 +151,6 @@ metadata:
   labels:
     app: grafana
     chart: grafana
-    heritage: Tiller
     release: istio
     istio: grafana
 data:
@@ -167,7 +163,6 @@ data:
       labels:
         app: grafana
         chart: grafana
-        heritage: Tiller
         release: istio
     spec:
       targets:
@@ -217,7 +212,6 @@ metadata:
   labels:
     app: grafana
     chart: grafana
-    heritage: Tiller
     release: istio
     istio: grafana
 data:
@@ -2049,7 +2043,6 @@ metadata:
   labels:
     app: grafana
     chart: grafana
-    heritage: Tiller
     release: istio
     istio: grafana
 data:
@@ -3015,7 +3008,6 @@ metadata:
   labels:
     app: grafana
     chart: grafana
-    heritage: Tiller
     release: istio
     istio: grafana
 data:
@@ -3645,7 +3637,6 @@ metadata:
   labels:
     app: grafana
     chart: grafana
-    heritage: Tiller
     release: istio
     istio: grafana
 data:
@@ -6259,7 +6250,6 @@ metadata:
   labels:
     app: grafana
     chart: grafana
-    heritage: Tiller
     release: istio
     istio: grafana
 data:
@@ -8575,7 +8565,6 @@ metadata:
   labels:
     app: grafana
     chart: grafana
-    heritage: Tiller
     release: istio
     istio: grafana
 data:
@@ -10396,7 +10385,6 @@ metadata:
   labels:
     app: grafana
     chart: grafana
-    heritage: Tiller
     release: istio
     istio: grafana
 data:
@@ -12007,7 +11995,6 @@ metadata:
   labels:
     app: grafana
     chart: grafana
-    heritage: Tiller
     release: istio
     istio: grafana
 data:
@@ -12044,7 +12031,6 @@ metadata:
   labels:
     app: kiali
     chart: kiali
-    heritage: Tiller
     release: istio
 data:
   config.yaml: |
@@ -12068,7 +12054,6 @@ metadata:
   labels:
     app: prometheus
     chart: prometheus
-    heritage: Tiller
     release: istio
 data:
   prometheus.yml: |-
@@ -12382,7 +12367,6 @@ metadata:
   labels:	
     app: security	
     chart: security	
-    heritage: Tiller	
     release: istio	
     istio: citadel	
 data:	
@@ -12395,7 +12379,6 @@ data:
       labels:
         app: security
         chart: security
-        heritage: Tiller
         release: istio
     spec:
       peers:
@@ -12444,7 +12427,6 @@ metadata:
   labels:
     app: istio
     chart: istio
-    heritage: Tiller
     release: istio
 data:
   mesh: |-
@@ -12588,7 +12570,6 @@ metadata:
   labels:
     app: istio
     chart: istio
-    heritage: Tiller
     release: istio
     istio: sidecar-injector
 data:
@@ -12806,7 +12787,6 @@ metadata:
   labels:
     app: galley
     chart: galley
-    heritage: Tiller
     release: istio
 
 ---
@@ -12819,7 +12799,6 @@ metadata:
   labels:
     app: istio-egressgateway
     chart: gateways
-    heritage: Tiller
     release: istio
 ---
 apiVersion: v1
@@ -12829,7 +12808,6 @@ metadata:
   labels:
     app: istio-ingressgateway
     chart: gateways
-    heritage: Tiller
     release: istio
 ---
 
@@ -12843,7 +12821,6 @@ metadata:
   labels:
     app: grafana
     chart: grafana
-    heritage: Tiller
     release: istio
 ---
 apiVersion: rbac.authorization.k8s.io/v1
@@ -12853,7 +12830,6 @@ metadata:
   labels:
     app: grafana
     chart: grafana
-    heritage: Tiller
     release: istio
 rules:
 - apiGroups: ["authentication.istio.io"] # needed to create default authn policy
@@ -12867,7 +12843,6 @@ metadata:
   labels:
     app: grafana
     chart: grafana
-    heritage: Tiller
     release: istio
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -12888,7 +12863,6 @@ metadata:
   labels:
     app: grafana
     chart: grafana
-    heritage: Tiller
     release: istio
 spec:
   template:
@@ -12897,7 +12871,6 @@ spec:
       labels:
         app: istio-grafana
         chart: grafana
-        heritage: Tiller
         release: istio
     spec:
       serviceAccountName: istio-grafana-post-install-account
@@ -12956,7 +12929,6 @@ metadata:
   labels:
     app: kiali
     chart: kiali
-    heritage: Tiller
     release: istio
 
 ---
@@ -12969,7 +12941,6 @@ metadata:
   labels:
     app: mixer
     chart: mixer
-    heritage: Tiller
     release: istio
 
 ---
@@ -12981,7 +12952,6 @@ metadata:
   labels:
     app: pilot
     chart: pilot
-    heritage: Tiller
     release: istio
 
 ---
@@ -12993,7 +12963,6 @@ metadata:
   labels:
     app: prometheus
     chart: prometheus
-    heritage: Tiller
     release: istio
 
 ---
@@ -13018,7 +12987,6 @@ metadata:
   labels:
     app: security
     chart: security
-    heritage: Tiller
     release: istio
 ---
 apiVersion: rbac.authorization.k8s.io/v1
@@ -13032,7 +13000,6 @@ metadata:
   labels:
     app: security
     chart: security
-    heritage: Tiller
     release: istio
 rules:
 - apiGroups: [""]
@@ -13050,7 +13017,6 @@ metadata:
   labels:
     app: security
     chart: security
-    heritage: Tiller
     release: istio
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -13072,7 +13038,6 @@ metadata:
   labels:
     app: security
     chart: security
-    heritage: Tiller
     release: istio
 spec:
   template:
@@ -13081,7 +13046,6 @@ spec:
       labels:
         app: security
         chart: security
-        heritage: Tiller
         release: istio
     spec:
       serviceAccountName: istio-cleanup-secrets-service-account
@@ -13143,7 +13107,6 @@ metadata:
   labels:	
     app: security	
     chart: security	
-    heritage: Tiller	
     release: istio	
 ---
 apiVersion: rbac.authorization.k8s.io/v1beta1	
@@ -13153,7 +13116,6 @@ metadata:
   labels:	
     app: security	
     chart: security	
-    heritage: Tiller	
     release: istio	
 rules:	
 - apiGroups: ["authentication.istio.io"] # needed to create default authn policy	
@@ -13176,7 +13138,6 @@ metadata:
   labels:	
     app: security	
     chart: security	
-    heritage: Tiller	
     release: istio	
 roleRef:	
   apiGroup: rbac.authorization.k8s.io	
@@ -13197,7 +13158,6 @@ metadata:
   labels:	
     app: security	
     chart: security	
-    heritage: Tiller	
     release: istio	
 spec:	
   template:	
@@ -13206,7 +13166,6 @@ spec:
       labels:	
         app: security	
         chart: security	
-        heritage: Tiller	
         release: istio	
     spec:	
       serviceAccountName: istio-security-post-install-account	
@@ -13266,7 +13225,6 @@ metadata:
   labels:
     app: security
     chart: security
-    heritage: Tiller
     release: istio
 
 ---
@@ -13278,7 +13236,6 @@ metadata:
   labels:
     app: sidecarInjectorWebhook
     chart: sidecarInjectorWebhook
-    heritage: Tiller
     release: istio
     istio: sidecar-injector
 
@@ -13298,7 +13255,6 @@ metadata:
   labels:
     app: galley
     chart: galley
-    heritage: Tiller
     release: istio
 rules:
 - apiGroups: ["admissionregistration.k8s.io"]
@@ -13341,7 +13297,6 @@ metadata:
   labels:
     app: egressgateway
     chart: gateways
-    heritage: Tiller
     release: istio
 rules:
 - apiGroups: ["networking.istio.io"]
@@ -13355,7 +13310,6 @@ metadata:
   labels:
     app: ingressgateway
     chart: gateways
-    heritage: Tiller
     release: istio
 rules:
 - apiGroups: ["networking.istio.io"]
@@ -13372,7 +13326,6 @@ metadata:
   labels:
     app: kiali
     chart: kiali
-    heritage: Tiller
     release: istio
 rules:
 - apiGroups: [""]
@@ -13497,7 +13450,6 @@ metadata:
   labels:
     app: kiali
     chart: kiali
-    heritage: Tiller
     release: istio
 rules:
 - apiGroups: [""]
@@ -13615,7 +13567,6 @@ metadata:
   labels:
     app: mixer
     chart: mixer
-    heritage: Tiller
     release: istio
 rules:
 - apiGroups: ["config.istio.io"] # istio CRD watcher
@@ -13640,7 +13591,6 @@ metadata:
   labels:
     app: pilot
     chart: pilot
-    heritage: Tiller
     release: istio
 rules:
 - apiGroups: ["config.istio.io"]
@@ -13677,7 +13627,6 @@ metadata:
   labels:
     app: prometheus
     chart: prometheus
-    heritage: Tiller
     release: istio
 rules:
 - apiGroups: [""]
@@ -13704,7 +13653,6 @@ metadata:
   labels:
     app: security
     chart: security
-    heritage: Tiller
     release: istio
 rules:
 - apiGroups: [""]
@@ -13729,7 +13677,6 @@ metadata:
   labels:
     app: sidecarInjectorWebhook
     chart: sidecarInjectorWebhook
-    heritage: Tiller
     release: istio
     istio: sidecar-injector
 rules:
@@ -13763,7 +13710,6 @@ metadata:
   labels:
     app: galley
     chart: galley
-    heritage: Tiller
     release: istio
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -13784,7 +13730,6 @@ metadata:
   labels:
     app: egressgateway
     chart: gateways
-    heritage: Tiller
     release: istio
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -13801,7 +13746,6 @@ metadata:
   labels:
     app: ingressgateway
     chart: gateways
-    heritage: Tiller
     release: istio
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -13821,7 +13765,6 @@ metadata:
   labels:
     app: kiali
     chart: kiali
-    heritage: Tiller
     release: istio
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -13841,7 +13784,6 @@ metadata:
   labels:
     app: mixer
     chart: mixer
-    heritage: Tiller
     release: istio
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -13861,7 +13803,6 @@ metadata:
   labels:
     app: pilot
     chart: pilot
-    heritage: Tiller
     release: istio
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -13881,7 +13822,6 @@ metadata:
   labels:
     app: prometheus
     chart: prometheus
-    heritage: Tiller
     release: istio
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -13900,7 +13840,6 @@ metadata:
   labels:
     app: security
     chart: security
-    heritage: Tiller
     release: istio
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -13920,7 +13859,6 @@ metadata:
   labels:
     app: sidecarInjectorWebhook
     chart: sidecarInjectorWebhook
-    heritage: Tiller
     release: istio
     istio: sidecar-injector
 roleRef:
@@ -13986,7 +13924,6 @@ metadata:
   labels:
     app: galley
     chart: galley
-    heritage: Tiller
     release: istio
     istio: galley
 spec:
@@ -14009,7 +13946,6 @@ metadata:
   name: istio-egressgateway
   labels:
     chart: gateways
-    heritage: Tiller
     release: istio
     app: istio-egressgateway
     istio: egressgateway
@@ -14039,7 +13975,6 @@ metadata:
     beta.cloud.google.com/backend-config: '{"ports": {"http2":"iap-backendconfig"}}'
   labels:
     chart: gateways
-    heritage: Tiller
     release: istio
     app: istio-ingressgateway
     istio: ingressgateway
@@ -14098,7 +14033,6 @@ metadata:
   labels:
     app: grafana
     chart: grafana
-    heritage: Tiller
     release: istio
 spec:
   type: ClusterIP
@@ -14119,7 +14053,6 @@ metadata:
   labels:
     app: kiali
     chart: kiali
-    heritage: Tiller
     release: istio
 spec:
   ports:
@@ -14141,7 +14074,6 @@ metadata:
   labels:
     app: mixer
     chart: mixer
-    heritage: Tiller
     release: istio
     istio: mixer
 spec:
@@ -14165,7 +14097,6 @@ metadata:
   labels:
     app: mixer
     chart: mixer
-    heritage: Tiller
     release: istio
     istio: mixer
 spec:
@@ -14193,7 +14124,6 @@ metadata:
   labels:
     app: pilot
     chart: pilot
-    heritage: Tiller
     release: istio
     istio: pilot
 spec:
@@ -14220,7 +14150,6 @@ metadata:
   labels:
     app: prometheus
     chart: prometheus
-    heritage: Tiller
     release: istio
 spec:
   selector:
@@ -14241,7 +14170,6 @@ metadata:
   labels:
     app: security
     chart: security
-    heritage: Tiller
     release: istio
     istio: citadel
 spec:
@@ -14264,7 +14192,6 @@ metadata:
   labels:
     app: sidecarInjectorWebhook
     chart: sidecarInjectorWebhook
-    heritage: Tiller
     release: istio
     istio: sidecar-injector
 spec:
@@ -14282,7 +14209,6 @@ metadata:
   labels:
     app: galley
     chart: galley
-    heritage: Tiller
     release: istio
     istio: galley
 spec:
@@ -14295,7 +14221,6 @@ spec:
     matchLabels:
       app: galley
       chart: galley
-      heritage: Tiller
       release: istio      
       istio: galley
   template:
@@ -14303,7 +14228,6 @@ spec:
       labels:
         app: galley
         chart: galley
-        heritage: Tiller
         release: istio      
         istio: galley
       annotations:
@@ -14417,7 +14341,6 @@ metadata:
   name: istio-egressgateway
   labels:
     chart: gateways
-    heritage: Tiller
     release: istio
     app: istio-egressgateway
     istio: egressgateway
@@ -14425,7 +14348,6 @@ spec:
   selector:
     matchLabels:
       chart: gateways
-      heritage: Tiller
       release: istio
       app: istio-egressgateway
       istio: egressgateway
@@ -14433,7 +14355,6 @@ spec:
     metadata:
       labels:
         chart: gateways
-        heritage: Tiller
         release: istio
         app: istio-egressgateway
         istio: egressgateway
@@ -14589,7 +14510,6 @@ metadata:
   name: istio-ingressgateway
   labels:
     chart: gateways
-    heritage: Tiller
     release: istio
     app: istio-ingressgateway
     istio: ingressgateway
@@ -14597,7 +14517,6 @@ spec:
   selector:
     matchLabels:
       chart: gateways
-      heritage: Tiller
       release: istio
       app: istio-ingressgateway
       istio: ingressgateway
@@ -14605,7 +14524,6 @@ spec:
     metadata:
       labels:
         chart: gateways
-        heritage: Tiller
         release: istio
         app: istio-ingressgateway
         istio: ingressgateway
@@ -14771,7 +14689,6 @@ metadata:
   labels:
     app: grafana
     chart: grafana
-    heritage: Tiller
     release: istio
 spec:
   replicas: 1
@@ -14779,14 +14696,12 @@ spec:
     matchLabels:
       app: grafana
       chart: grafana
-      heritage: Tiller
       release: istio
   template:
     metadata:
       labels:
         app: grafana
         chart: grafana
-        heritage: Tiller
         release: istio
       annotations:
         sidecar.istio.io/inject: "false"
@@ -14926,7 +14841,6 @@ metadata:
   labels:
     app: kiali
     chart: kiali
-    heritage: Tiller
     release: istio
 spec:
   replicas: 1
@@ -14939,7 +14853,6 @@ spec:
       labels:
         app: kiali
         chart: kiali
-        heritage: Tiller
         release: istio
       annotations:
         sidecar.istio.io/inject: "false"
@@ -15027,7 +14940,6 @@ metadata:
   labels:
     app: istio-mixer
     chart: mixer
-    heritage: Tiller
     release: istio
     istio: mixer
 spec:
@@ -15044,7 +14956,6 @@ spec:
       labels:
         app: policy
         chart: mixer
-        heritage: Tiller
         release: istio
         istio: mixer
         istio-mixer-type: policy
@@ -15198,7 +15109,6 @@ metadata:
   labels:
     app: istio-mixer
     chart: mixer
-    heritage: Tiller
     release: istio
     istio: mixer
 spec:
@@ -15215,7 +15125,6 @@ spec:
       labels:
         app: telemetry
         chart: mixer
-        heritage: Tiller
         release: istio
         istio: mixer
         istio-mixer-type: telemetry
@@ -15377,7 +15286,6 @@ metadata:
   labels:
     app: pilot
     chart: pilot
-    heritage: Tiller
     release: istio
     istio: pilot
   annotations:
@@ -15395,7 +15303,6 @@ spec:
       labels:
         app: pilot
         chart: pilot
-        heritage: Tiller
         release: istio
         istio: pilot
       annotations:
@@ -15557,7 +15464,6 @@ metadata:
   labels:
     app: prometheus
     chart: prometheus
-    heritage: Tiller
     release: istio
 spec:
   replicas: 1
@@ -15569,7 +15475,6 @@ spec:
       labels:
         app: prometheus
         chart: prometheus
-        heritage: Tiller
         release: istio
       annotations:
         sidecar.istio.io/inject: "false"
@@ -15654,7 +15559,6 @@ metadata:
   labels:
     app: security
     chart: security
-    heritage: Tiller
     release: istio
     istio: citadel
 spec:
@@ -15667,7 +15571,6 @@ spec:
     matchLabels:
       app: security
       chart: security
-      heritage: Tiller
       release: istio
       istio: citadel
   template:
@@ -15675,7 +15578,6 @@ spec:
       labels:
         app: security
         chart: security
-        heritage: Tiller
         release: istio
         istio: citadel
       annotations:
@@ -15747,7 +15649,6 @@ metadata:
   labels:
     app: sidecarInjectorWebhook
     chart: sidecarInjectorWebhook
-    heritage: Tiller
     release: istio
     istio: sidecar-injector
 spec:
@@ -15760,7 +15661,6 @@ spec:
     matchLabels:
       app: sidecarInjectorWebhook
       chart: sidecarInjectorWebhook
-      heritage: Tiller
       release: istio
       istio: sidecar-injector
   template:
@@ -15768,7 +15668,6 @@ spec:
       labels:
         app: sidecarInjectorWebhook
         chart: sidecarInjectorWebhook
-        heritage: Tiller
         release: istio
         istio: sidecar-injector
       annotations:
@@ -15877,21 +15776,18 @@ metadata:
   labels:
     app: jaeger
     chart: tracing
-    heritage: Tiller
     release: istio
 spec:
   selector:
     matchLabels:
       app: jaeger
       chart: tracing
-      heritage: Tiller
       release: istio
   template:
     metadata:
       labels:
         app: jaeger
         chart: tracing
-        heritage: Tiller
         release: istio
       annotations:
         sidecar.istio.io/inject: "false"
@@ -15981,7 +15877,6 @@ metadata:
   labels:
     app: egressgateway
     chart: gateways
-    heritage: Tiller
     release: istio
 spec:
   maxReplicas: 5
@@ -16003,7 +15898,6 @@ metadata:
   labels:
     app: ingressgateway
     chart: gateways
-    heritage: Tiller
     release: istio
 spec:
   maxReplicas: 5
@@ -16029,7 +15923,6 @@ metadata:
   labels:
     app: mixer
     chart: mixer
-    heritage: Tiller
     release: istio
 spec:
     maxReplicas: 5
@@ -16051,7 +15944,6 @@ metadata:
   labels:
     app: mixer
     chart: mixer
-    heritage: Tiller
     release: istio
 spec:
     maxReplicas: 5
@@ -16077,7 +15969,6 @@ metadata:
   labels:
     app: pilot
     chart: pilot
-    heritage: Tiller
     release: istio
 spec:
   maxReplicas: 5
@@ -16105,7 +15996,6 @@ metadata:
     app: jaeger
     jaeger-infra: jaeger-service
     chart: tracing
-    heritage: Tiller
     release: istio
 spec:
   ports:
@@ -16126,7 +16016,6 @@ metadata:
     app: jaeger
     jaeger-infra: collector-service
     chart: tracing
-    heritage: Tiller
     release: istio
 spec:
   ports:
@@ -16150,7 +16039,6 @@ metadata:
     app: jaeger
     jaeger-infra: agent-service
     chart: tracing
-    heritage: Tiller
     release: istio
 spec:
   ports:
@@ -16181,7 +16069,6 @@ metadata:
   labels:
     app: jaeger
     chart: tracing
-    heritage: Tiller
     release: istio
 spec:
   type: ClusterIP
@@ -16201,7 +16088,6 @@ metadata:
   labels:
     app: jaeger
     chart: tracing
-    heritage: Tiller
     release: istio
 spec:
   ports:
@@ -16223,7 +16109,6 @@ metadata:
   labels:
     app: sidecarInjectorWebhook
     chart: sidecarInjectorWebhook
-    heritage: Tiller
     release: istio
 webhooks:
   - name: sidecar-injector.istio.io
@@ -16254,7 +16139,6 @@ metadata:
   labels:
     app: galley
     chart: galley
-    heritage: Tiller
     release: istio
     istio: galley
 spec:
@@ -16275,7 +16159,6 @@ metadata:
   name: istio-egressgateway
   labels:
     chart: gateways
-    heritage: Tiller
     release: istio
     app: istio-egressgateway
     istio: egressgateway
@@ -16294,7 +16177,6 @@ metadata:
   name: istio-ingressgateway
   labels:
     chart: gateways
-    heritage: Tiller
     release: istio
     app: istio-ingressgateway
     istio: ingressgateway
@@ -16318,7 +16200,6 @@ metadata:
   labels:
     app: policy
     chart: mixer
-    heritage: Tiller
     release: istio
     version: 1.1.0
     istio: mixer
@@ -16340,7 +16221,6 @@ metadata:
   labels:
     app: telemetry
     chart: mixer
-    heritage: Tiller
     release: istio
     version: 1.1.0
     istio: mixer
@@ -16364,7 +16244,6 @@ metadata:
   labels:
     app: pilot
     chart: pilot
-    heritage: Tiller
     release: istio
     istio: pilot
 spec:
@@ -16384,7 +16263,6 @@ metadata:
   labels:
     app: mixer
     chart: mixer
-    heritage: Tiller
     release: istio
 spec:
   attributes:
@@ -16524,7 +16402,6 @@ metadata:
   labels:
     app: mixer
     chart: mixer
-    heritage: Tiller
     release: istio
 spec:
   attributes:
@@ -16588,7 +16465,6 @@ metadata:
   labels:
     app: mixer
     chart: mixer
-    heritage: Tiller
     release: istio
 spec:
   compiledAdapter: stdio
@@ -16602,7 +16478,6 @@ metadata:
   labels:
     app: mixer
     chart: mixer
-    heritage: Tiller
     release: istio
 spec:
   severity: '"Info"'
@@ -16658,7 +16533,6 @@ metadata:
   labels:
     app: mixer
     chart: mixer
-    heritage: Tiller
     release: istio
 spec:
   severity: '"Info"'
@@ -16699,7 +16573,6 @@ metadata:
   labels:
     app: mixer
     chart: mixer
-    heritage: Tiller
     release: istio
 spec:
   match: context.protocol == "http" || context.protocol == "grpc"
@@ -16715,7 +16588,6 @@ metadata:
   labels:
     app: mixer
     chart: mixer
-    heritage: Tiller
     release: istio
 spec:
   match: context.protocol == "tcp"
@@ -16731,7 +16603,6 @@ metadata:
   labels:
     app: mixer
     chart: mixer
-    heritage: Tiller
     release: istio
 spec:
   value: "1"
@@ -16765,7 +16636,6 @@ metadata:
   labels:
     app: mixer
     chart: mixer
-    heritage: Tiller
     release: istio
 spec:
   value: response.duration | "0ms"
@@ -16799,7 +16669,6 @@ metadata:
   labels:
     app: mixer
     chart: mixer
-    heritage: Tiller
     release: istio
 spec:
   value: request.size | 0
@@ -16833,7 +16702,6 @@ metadata:
   labels:
     app: mixer
     chart: mixer
-    heritage: Tiller
     release: istio
 spec:
   value: response.size | 0
@@ -16867,7 +16735,6 @@ metadata:
   labels:
     app: mixer
     chart: mixer
-    heritage: Tiller
     release: istio
 spec:
   value: connection.sent.bytes | 0
@@ -16897,7 +16764,6 @@ metadata:
   labels:
     app: mixer
     chart: mixer
-    heritage: Tiller
     release: istio
 spec:
   value: connection.received.bytes | 0
@@ -16927,7 +16793,6 @@ metadata:
   labels:
     app: mixer
     chart: mixer
-    heritage: Tiller
     release: istio
 spec:
   value: "1"
@@ -16957,7 +16822,6 @@ metadata:
   labels:
     app: mixer
     chart: mixer
-    heritage: Tiller
     release: istio
 spec:
   value: "1"
@@ -16987,7 +16851,6 @@ metadata:
   labels:
     app: mixer
     chart: mixer
-    heritage: Tiller
     release: istio
 spec:
   compiledAdapter: prometheus
@@ -17192,7 +17055,6 @@ metadata:
   labels:
     app: mixer
     chart: mixer
-    heritage: Tiller
     release: istio
 spec:
   match: (context.protocol == "http" || context.protocol == "grpc") && (match((request.useragent | "-"), "kube-probe*") == false)
@@ -17211,7 +17073,6 @@ metadata:
   labels:
     app: mixer
     chart: mixer
-    heritage: Tiller
     release: istio
 spec:
   match: context.protocol == "tcp"
@@ -17228,7 +17089,6 @@ metadata:
   labels:
     app: mixer
     chart: mixer
-    heritage: Tiller
     release: istio
 spec:
   match: context.protocol == "tcp" && ((connection.event | "na") == "open")
@@ -17244,7 +17104,6 @@ metadata:
   labels:
     app: mixer
     chart: mixer
-    heritage: Tiller
     release: istio
 spec:
   match: context.protocol == "tcp" && ((connection.event | "na") == "close")
@@ -17260,7 +17119,6 @@ metadata:
   labels:
     app: mixer
     chart: mixer
-    heritage: Tiller
     release: istio
 spec:
   compiledAdapter: kubernetesenv
@@ -17280,7 +17138,6 @@ metadata:
   labels:
     app: mixer
     chart: mixer
-    heritage: Tiller
     release: istio
 spec:
   actions:
@@ -17295,7 +17152,6 @@ metadata:
   labels:
     app: mixer
     chart: mixer
-    heritage: Tiller
     release: istio
 spec:
   match: context.protocol == "tcp"
@@ -17311,7 +17167,6 @@ metadata:
   labels:
     app: mixer
     chart: mixer
-    heritage: Tiller
     release: istio
 spec:
   # Pass the required attribute data to the adapter
@@ -17354,7 +17209,6 @@ metadata:
   labels:
     app: mixer
     chart: mixer
-    heritage: Tiller
     release: istio
 spec:
   host: istio-policy.istio-system.svc.cluster.local
@@ -17371,7 +17225,6 @@ metadata:
   labels:
     app: mixer
     chart: mixer
-    heritage: Tiller
     release: istio
 spec:
   host: istio-telemetry.istio-system.svc.cluster.local

--- a/istio/istio-install/base/istio-noauth.yaml
+++ b/istio/istio-install/base/istio-noauth.yaml
@@ -13,7 +13,6 @@ metadata:
   name: kiali
   labels:
     app: kiali
-    chart: kiali
     release: istio
 type: Opaque
 data:
@@ -28,7 +27,6 @@ metadata:
   name: istio-galley-configuration
   labels:
     app: galley
-    chart: galley
     release: istio
     istio: galley
 data:
@@ -40,7 +38,6 @@ data:
       namespace: istio-system
       labels:
         app: galley
-        chart: galley
         release: istio
         istio: galley
     webhooks:
@@ -150,7 +147,6 @@ metadata:
   name: istio-grafana-custom-resources
   labels:
     app: grafana
-    chart: grafana
     release: istio
     istio: grafana
 data:
@@ -162,7 +158,6 @@ data:
       namespace: istio-system
       labels:
         app: grafana
-        chart: grafana
         release: istio
     spec:
       targets:
@@ -211,7 +206,6 @@ metadata:
   name: istio-grafana-configuration-dashboards-galley-dashboard
   labels:
     app: grafana
-    chart: grafana
     release: istio
     istio: grafana
 data:
@@ -2042,7 +2036,6 @@ metadata:
   name: istio-grafana-configuration-dashboards-istio-mesh-dashboard
   labels:
     app: grafana
-    chart: grafana
     release: istio
     istio: grafana
 data:
@@ -3007,7 +3000,6 @@ metadata:
   name: istio-grafana-configuration-dashboards-istio-performance-dashboard
   labels:
     app: grafana
-    chart: grafana
     release: istio
     istio: grafana
 data:
@@ -3636,7 +3628,6 @@ metadata:
   name: istio-grafana-configuration-dashboards-istio-service-dashboard
   labels:
     app: grafana
-    chart: grafana
     release: istio
     istio: grafana
 data:
@@ -6249,7 +6240,6 @@ metadata:
   name: istio-grafana-configuration-dashboards-istio-workload-dashboard
   labels:
     app: grafana
-    chart: grafana
     release: istio
     istio: grafana
 data:
@@ -8564,7 +8554,6 @@ metadata:
   name: istio-grafana-configuration-dashboards-mixer-dashboard
   labels:
     app: grafana
-    chart: grafana
     release: istio
     istio: grafana
 data:
@@ -10384,7 +10373,6 @@ metadata:
   name: istio-grafana-configuration-dashboards-pilot-dashboard
   labels:
     app: grafana
-    chart: grafana
     release: istio
     istio: grafana
 data:
@@ -11994,7 +11982,6 @@ metadata:
   name: istio-grafana
   labels:
     app: grafana
-    chart: grafana
     release: istio
     istio: grafana
 data:
@@ -12030,7 +12017,6 @@ metadata:
   name: kiali
   labels:
     app: kiali
-    chart: kiali
     release: istio
 data:
   config.yaml: |
@@ -12053,7 +12039,6 @@ metadata:
   name: prometheus
   labels:
     app: prometheus
-    chart: prometheus
     release: istio
 data:
   prometheus.yml: |-
@@ -12366,7 +12351,6 @@ metadata:
   name: istio-security-custom-resources	
   labels:	
     app: security	
-    chart: security	
     release: istio	
     istio: citadel	
 data:	
@@ -12378,7 +12362,6 @@ data:
       name: "default"
       labels:
         app: security
-        chart: security
         release: istio
     spec:
       peers:
@@ -12426,7 +12409,6 @@ metadata:
   name: istio
   labels:
     app: istio
-    chart: istio
     release: istio
 data:
   mesh: |-
@@ -12569,7 +12551,6 @@ metadata:
   name: istio-sidecar-injector
   labels:
     app: istio
-    chart: istio
     release: istio
     istio: sidecar-injector
 data:
@@ -12786,7 +12767,6 @@ metadata:
   name: istio-galley-service-account
   labels:
     app: galley
-    chart: galley
     release: istio
 
 ---
@@ -12798,7 +12778,6 @@ metadata:
   name: istio-egressgateway-service-account
   labels:
     app: istio-egressgateway
-    chart: gateways
     release: istio
 ---
 apiVersion: v1
@@ -12807,7 +12786,6 @@ metadata:
   name: istio-ingressgateway-service-account
   labels:
     app: istio-ingressgateway
-    chart: gateways
     release: istio
 ---
 
@@ -12820,7 +12798,6 @@ metadata:
   name: istio-grafana-post-install-account
   labels:
     app: grafana
-    chart: grafana
     release: istio
 ---
 apiVersion: rbac.authorization.k8s.io/v1
@@ -12829,7 +12806,6 @@ metadata:
   name: istio-grafana-post-install-istio-system
   labels:
     app: grafana
-    chart: grafana
     release: istio
 rules:
 - apiGroups: ["authentication.istio.io"] # needed to create default authn policy
@@ -12842,7 +12818,6 @@ metadata:
   name: istio-grafana-post-install-role-binding-istio-system
   labels:
     app: grafana
-    chart: grafana
     release: istio
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -12862,7 +12837,6 @@ metadata:
     "helm.sh/hook-delete-policy": hook-succeeded
   labels:
     app: grafana
-    chart: grafana
     release: istio
 spec:
   template:
@@ -12870,7 +12844,6 @@ spec:
       name: istio-grafana-post-install
       labels:
         app: istio-grafana
-        chart: grafana
         release: istio
     spec:
       serviceAccountName: istio-grafana-post-install-account
@@ -12928,7 +12901,6 @@ metadata:
   name: kiali-service-account
   labels:
     app: kiali
-    chart: kiali
     release: istio
 
 ---
@@ -12940,7 +12912,6 @@ metadata:
   name: istio-mixer-service-account
   labels:
     app: mixer
-    chart: mixer
     release: istio
 
 ---
@@ -12951,7 +12922,6 @@ metadata:
   name: istio-pilot-service-account
   labels:
     app: pilot
-    chart: pilot
     release: istio
 
 ---
@@ -12962,7 +12932,6 @@ metadata:
   name: prometheus
   labels:
     app: prometheus
-    chart: prometheus
     release: istio
 
 ---
@@ -12986,7 +12955,6 @@ metadata:
     "helm.sh/hook-weight": "1"
   labels:
     app: security
-    chart: security
     release: istio
 ---
 apiVersion: rbac.authorization.k8s.io/v1
@@ -12999,7 +12967,6 @@ metadata:
     "helm.sh/hook-weight": "1"
   labels:
     app: security
-    chart: security
     release: istio
 rules:
 - apiGroups: [""]
@@ -13016,7 +12983,6 @@ metadata:
     "helm.sh/hook-weight": "2"
   labels:
     app: security
-    chart: security
     release: istio
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -13037,7 +13003,6 @@ metadata:
     "helm.sh/hook-weight": "3"
   labels:
     app: security
-    chart: security
     release: istio
 spec:
   template:
@@ -13045,7 +13010,6 @@ spec:
       name: istio-cleanup-secrets
       labels:
         app: security
-        chart: security
         release: istio
     spec:
       serviceAccountName: istio-cleanup-secrets-service-account
@@ -13106,7 +13070,6 @@ metadata:
   name: istio-security-post-install-account	
   labels:	
     app: security	
-    chart: security	
     release: istio	
 ---
 apiVersion: rbac.authorization.k8s.io/v1beta1	
@@ -13115,7 +13078,6 @@ metadata:
   name: istio-security-post-install-istio-system	
   labels:	
     app: security	
-    chart: security	
     release: istio	
 rules:	
 - apiGroups: ["authentication.istio.io"] # needed to create default authn policy	
@@ -13137,7 +13099,6 @@ metadata:
   name: istio-security-post-install-role-binding-istio-system	
   labels:	
     app: security	
-    chart: security	
     release: istio	
 roleRef:	
   apiGroup: rbac.authorization.k8s.io	
@@ -13157,7 +13118,6 @@ metadata:
     "helm.sh/hook-delete-policy": hook-succeeded	
   labels:	
     app: security	
-    chart: security	
     release: istio	
 spec:	
   template:	
@@ -13165,7 +13125,6 @@ spec:
       name: istio-security-post-install	
       labels:	
         app: security	
-        chart: security	
         release: istio	
     spec:	
       serviceAccountName: istio-security-post-install-account	
@@ -13224,7 +13183,6 @@ metadata:
   name: istio-citadel-service-account
   labels:
     app: security
-    chart: security
     release: istio
 
 ---
@@ -13235,7 +13193,6 @@ metadata:
   name: istio-sidecar-injector-service-account
   labels:
     app: sidecarInjectorWebhook
-    chart: sidecarInjectorWebhook
     release: istio
     istio: sidecar-injector
 
@@ -13254,7 +13211,6 @@ metadata:
   name: istio-galley-istio-system
   labels:
     app: galley
-    chart: galley
     release: istio
 rules:
 - apiGroups: ["admissionregistration.k8s.io"]
@@ -13296,7 +13252,6 @@ metadata:
   name: istio-egressgateway-istio-system
   labels:
     app: egressgateway
-    chart: gateways
     release: istio
 rules:
 - apiGroups: ["networking.istio.io"]
@@ -13309,7 +13264,6 @@ metadata:
   name: istio-ingressgateway-istio-system
   labels:
     app: ingressgateway
-    chart: gateways
     release: istio
 rules:
 - apiGroups: ["networking.istio.io"]
@@ -13325,7 +13279,6 @@ metadata:
   name: kiali
   labels:
     app: kiali
-    chart: kiali
     release: istio
 rules:
 - apiGroups: [""]
@@ -13449,7 +13402,6 @@ metadata:
   name: kiali-viewer
   labels:
     app: kiali
-    chart: kiali
     release: istio
 rules:
 - apiGroups: [""]
@@ -13566,7 +13518,6 @@ metadata:
   name: istio-mixer-istio-system
   labels:
     app: mixer
-    chart: mixer
     release: istio
 rules:
 - apiGroups: ["config.istio.io"] # istio CRD watcher
@@ -13590,7 +13541,6 @@ metadata:
   name: istio-pilot-istio-system
   labels:
     app: pilot
-    chart: pilot
     release: istio
 rules:
 - apiGroups: ["config.istio.io"]
@@ -13626,7 +13576,6 @@ metadata:
   name: prometheus-istio-system
   labels:
     app: prometheus
-    chart: prometheus
     release: istio
 rules:
 - apiGroups: [""]
@@ -13652,7 +13601,6 @@ metadata:
   name: istio-citadel-istio-system
   labels:
     app: security
-    chart: security
     release: istio
 rules:
 - apiGroups: [""]
@@ -13676,7 +13624,6 @@ metadata:
   name: istio-sidecar-injector-istio-system
   labels:
     app: sidecarInjectorWebhook
-    chart: sidecarInjectorWebhook
     release: istio
     istio: sidecar-injector
 rules:
@@ -13709,7 +13656,6 @@ metadata:
   name: istio-galley-admin-role-binding-istio-system
   labels:
     app: galley
-    chart: galley
     release: istio
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -13729,7 +13675,6 @@ metadata:
   name: istio-egressgateway-istio-system
   labels:
     app: egressgateway
-    chart: gateways
     release: istio
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -13745,7 +13690,6 @@ metadata:
   name: istio-ingressgateway-istio-system
   labels:
     app: ingressgateway
-    chart: gateways
     release: istio
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -13764,7 +13708,6 @@ metadata:
   name: istio-kiali-admin-role-binding-istio-system
   labels:
     app: kiali
-    chart: kiali
     release: istio
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -13783,7 +13726,6 @@ metadata:
   name: istio-mixer-admin-role-binding-istio-system
   labels:
     app: mixer
-    chart: mixer
     release: istio
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -13802,7 +13744,6 @@ metadata:
   name: istio-pilot-istio-system
   labels:
     app: pilot
-    chart: pilot
     release: istio
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -13821,7 +13762,6 @@ metadata:
   name: prometheus-istio-system
   labels:
     app: prometheus
-    chart: prometheus
     release: istio
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -13839,7 +13779,6 @@ metadata:
   name: istio-citadel-istio-system
   labels:
     app: security
-    chart: security
     release: istio
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -13858,7 +13797,6 @@ metadata:
   name: istio-sidecar-injector-admin-role-binding-istio-system
   labels:
     app: sidecarInjectorWebhook
-    chart: sidecarInjectorWebhook
     release: istio
     istio: sidecar-injector
 roleRef:
@@ -13877,7 +13815,6 @@ kind: ClusterRoleBinding
 metadata:
   name: istio-multi
   labels:
-    chart: istio-1.1.0
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
@@ -13923,7 +13860,6 @@ metadata:
   name: istio-galley
   labels:
     app: galley
-    chart: galley
     release: istio
     istio: galley
 spec:
@@ -13945,7 +13881,6 @@ kind: Service
 metadata:
   name: istio-egressgateway
   labels:
-    chart: gateways
     release: istio
     app: istio-egressgateway
     istio: egressgateway
@@ -13974,7 +13909,6 @@ metadata:
   annotations:
     beta.cloud.google.com/backend-config: '{"ports": {"http2":"iap-backendconfig"}}'
   labels:
-    chart: gateways
     release: istio
     app: istio-ingressgateway
     istio: ingressgateway
@@ -14032,7 +13966,6 @@ metadata:
   name: grafana
   labels:
     app: grafana
-    chart: grafana
     release: istio
 spec:
   type: ClusterIP
@@ -14052,7 +13985,6 @@ metadata:
   name: kiali
   labels:
     app: kiali
-    chart: kiali
     release: istio
 spec:
   ports:
@@ -14073,7 +14005,6 @@ metadata:
    networking.istio.io/exportTo: "*"
   labels:
     app: mixer
-    chart: mixer
     release: istio
     istio: mixer
 spec:
@@ -14096,7 +14027,6 @@ metadata:
    networking.istio.io/exportTo: "*"
   labels:
     app: mixer
-    chart: mixer
     release: istio
     istio: mixer
 spec:
@@ -14123,7 +14053,6 @@ metadata:
   name: istio-pilot
   labels:
     app: pilot
-    chart: pilot
     release: istio
     istio: pilot
 spec:
@@ -14149,7 +14078,6 @@ metadata:
     prometheus.io/scrape: 'true'
   labels:
     app: prometheus
-    chart: prometheus
     release: istio
 spec:
   selector:
@@ -14169,7 +14097,6 @@ metadata:
   name: istio-citadel
   labels:
     app: security
-    chart: security
     release: istio
     istio: citadel
 spec:
@@ -14191,7 +14118,6 @@ metadata:
   name: istio-sidecar-injector
   labels:
     app: sidecarInjectorWebhook
-    chart: sidecarInjectorWebhook
     release: istio
     istio: sidecar-injector
 spec:
@@ -14208,7 +14134,6 @@ metadata:
   name: istio-galley
   labels:
     app: galley
-    chart: galley
     release: istio
     istio: galley
 spec:
@@ -14220,14 +14145,12 @@ spec:
   selector:
     matchLabels:
       app: galley
-      chart: galley
       release: istio      
       istio: galley
   template:
     metadata:
       labels:
         app: galley
-        chart: galley
         release: istio      
         istio: galley
       annotations:
@@ -14340,21 +14263,18 @@ kind: Deployment
 metadata:
   name: istio-egressgateway
   labels:
-    chart: gateways
     release: istio
     app: istio-egressgateway
     istio: egressgateway
 spec:
   selector:
     matchLabels:
-      chart: gateways
       release: istio
       app: istio-egressgateway
       istio: egressgateway
   template:
     metadata:
       labels:
-        chart: gateways
         release: istio
         app: istio-egressgateway
         istio: egressgateway
@@ -14509,21 +14429,18 @@ kind: Deployment
 metadata:
   name: istio-ingressgateway
   labels:
-    chart: gateways
     release: istio
     app: istio-ingressgateway
     istio: ingressgateway
 spec:
   selector:
     matchLabels:
-      chart: gateways
       release: istio
       app: istio-ingressgateway
       istio: ingressgateway
   template:
     metadata:
       labels:
-        chart: gateways
         release: istio
         app: istio-ingressgateway
         istio: ingressgateway
@@ -14688,20 +14605,17 @@ metadata:
   name: grafana
   labels:
     app: grafana
-    chart: grafana
     release: istio
 spec:
   replicas: 1
   selector:
     matchLabels:
       app: grafana
-      chart: grafana
       release: istio
   template:
     metadata:
       labels:
         app: grafana
-        chart: grafana
         release: istio
       annotations:
         sidecar.istio.io/inject: "false"
@@ -14840,7 +14754,6 @@ metadata:
   name: kiali
   labels:
     app: kiali
-    chart: kiali
     release: istio
 spec:
   replicas: 1
@@ -14852,7 +14765,6 @@ spec:
       name: kiali
       labels:
         app: kiali
-        chart: kiali
         release: istio
       annotations:
         sidecar.istio.io/inject: "false"
@@ -14939,7 +14851,6 @@ metadata:
   name: istio-policy
   labels:
     app: istio-mixer
-    chart: mixer
     release: istio
     istio: mixer
 spec:
@@ -14955,7 +14866,6 @@ spec:
     metadata:
       labels:
         app: policy
-        chart: mixer
         release: istio
         istio: mixer
         istio-mixer-type: policy
@@ -15108,7 +15018,6 @@ metadata:
   name: istio-telemetry
   labels:
     app: istio-mixer
-    chart: mixer
     release: istio
     istio: mixer
 spec:
@@ -15124,7 +15033,6 @@ spec:
     metadata:
       labels:
         app: telemetry
-        chart: mixer
         release: istio
         istio: mixer
         istio-mixer-type: telemetry
@@ -15285,7 +15193,6 @@ metadata:
   # TODO: default template doesn't have this, which one is right ?
   labels:
     app: pilot
-    chart: pilot
     release: istio
     istio: pilot
   annotations:
@@ -15302,7 +15209,6 @@ spec:
     metadata:
       labels:
         app: pilot
-        chart: pilot
         release: istio
         istio: pilot
       annotations:
@@ -15463,7 +15369,6 @@ metadata:
   name: prometheus
   labels:
     app: prometheus
-    chart: prometheus
     release: istio
 spec:
   replicas: 1
@@ -15474,7 +15379,6 @@ spec:
     metadata:
       labels:
         app: prometheus
-        chart: prometheus
         release: istio
       annotations:
         sidecar.istio.io/inject: "false"
@@ -15558,7 +15462,6 @@ metadata:
   name: istio-citadel
   labels:
     app: security
-    chart: security
     release: istio
     istio: citadel
 spec:
@@ -15570,14 +15473,12 @@ spec:
   selector:
     matchLabels:
       app: security
-      chart: security
       release: istio
       istio: citadel
   template:
     metadata:
       labels:
         app: security
-        chart: security
         release: istio
         istio: citadel
       annotations:
@@ -15648,7 +15549,6 @@ metadata:
   name: istio-sidecar-injector
   labels:
     app: sidecarInjectorWebhook
-    chart: sidecarInjectorWebhook
     release: istio
     istio: sidecar-injector
 spec:
@@ -15660,14 +15560,12 @@ spec:
   selector:
     matchLabels:
       app: sidecarInjectorWebhook
-      chart: sidecarInjectorWebhook
       release: istio
       istio: sidecar-injector
   template:
     metadata:
       labels:
         app: sidecarInjectorWebhook
-        chart: sidecarInjectorWebhook
         release: istio
         istio: sidecar-injector
       annotations:
@@ -15775,19 +15673,16 @@ metadata:
   name: istio-tracing
   labels:
     app: jaeger
-    chart: tracing
     release: istio
 spec:
   selector:
     matchLabels:
       app: jaeger
-      chart: tracing
       release: istio
   template:
     metadata:
       labels:
         app: jaeger
-        chart: tracing
         release: istio
       annotations:
         sidecar.istio.io/inject: "false"
@@ -15876,7 +15771,6 @@ metadata:
   name: istio-egressgateway
   labels:
     app: egressgateway
-    chart: gateways
     release: istio
 spec:
   maxReplicas: 5
@@ -15897,7 +15791,6 @@ metadata:
   name: istio-ingressgateway
   labels:
     app: ingressgateway
-    chart: gateways
     release: istio
 spec:
   maxReplicas: 5
@@ -15922,7 +15815,6 @@ metadata:
   name: istio-policy
   labels:
     app: mixer
-    chart: mixer
     release: istio
 spec:
     maxReplicas: 5
@@ -15943,7 +15835,6 @@ metadata:
   name: istio-telemetry
   labels:
     app: mixer
-    chart: mixer
     release: istio
 spec:
     maxReplicas: 5
@@ -15968,7 +15859,6 @@ metadata:
   name: istio-pilot
   labels:
     app: pilot
-    chart: pilot
     release: istio
 spec:
   maxReplicas: 5
@@ -15995,7 +15885,6 @@ metadata:
   labels:
     app: jaeger
     jaeger-infra: jaeger-service
-    chart: tracing
     release: istio
 spec:
   ports:
@@ -16015,7 +15904,6 @@ metadata:
   labels:
     app: jaeger
     jaeger-infra: collector-service
-    chart: tracing
     release: istio
 spec:
   ports:
@@ -16038,7 +15926,6 @@ metadata:
   labels:
     app: jaeger
     jaeger-infra: agent-service
-    chart: tracing
     release: istio
 spec:
   ports:
@@ -16068,7 +15955,6 @@ metadata:
   name: zipkin
   labels:
     app: jaeger
-    chart: tracing
     release: istio
 spec:
   type: ClusterIP
@@ -16087,7 +15973,6 @@ metadata:
   annotations:
   labels:
     app: jaeger
-    chart: tracing
     release: istio
 spec:
   ports:
@@ -16108,7 +15993,6 @@ metadata:
   name: istio-sidecar-injector
   labels:
     app: sidecarInjectorWebhook
-    chart: sidecarInjectorWebhook
     release: istio
 webhooks:
   - name: sidecar-injector.istio.io
@@ -16138,7 +16022,6 @@ metadata:
   name: istio-galley
   labels:
     app: galley
-    chart: galley
     release: istio
     istio: galley
 spec:
@@ -16158,7 +16041,6 @@ kind: PodDisruptionBudget
 metadata:
   name: istio-egressgateway
   labels:
-    chart: gateways
     release: istio
     app: istio-egressgateway
     istio: egressgateway
@@ -16176,7 +16058,6 @@ kind: PodDisruptionBudget
 metadata:
   name: istio-ingressgateway
   labels:
-    chart: gateways
     release: istio
     app: istio-ingressgateway
     istio: ingressgateway
@@ -16199,7 +16080,6 @@ metadata:
   name: istio-policy
   labels:
     app: policy
-    chart: mixer
     release: istio
     version: 1.1.0
     istio: mixer
@@ -16220,7 +16100,6 @@ metadata:
   name: istio-telemetry
   labels:
     app: telemetry
-    chart: mixer
     release: istio
     version: 1.1.0
     istio: mixer
@@ -16243,7 +16122,6 @@ metadata:
   name: istio-pilot
   labels:
     app: pilot
-    chart: pilot
     release: istio
     istio: pilot
 spec:
@@ -16262,7 +16140,6 @@ metadata:
   name: istioproxy
   labels:
     app: mixer
-    chart: mixer
     release: istio
 spec:
   attributes:
@@ -16401,7 +16278,6 @@ metadata:
   name: kubernetes
   labels:
     app: mixer
-    chart: mixer
     release: istio
 spec:
   attributes:
@@ -16464,7 +16340,6 @@ metadata:
   name: stdio
   labels:
     app: mixer
-    chart: mixer
     release: istio
 spec:
   compiledAdapter: stdio
@@ -16477,7 +16352,6 @@ metadata:
   name: accesslog
   labels:
     app: mixer
-    chart: mixer
     release: istio
 spec:
   severity: '"Info"'
@@ -16532,7 +16406,6 @@ metadata:
   name: tcpaccesslog
   labels:
     app: mixer
-    chart: mixer
     release: istio
 spec:
   severity: '"Info"'
@@ -16572,7 +16445,6 @@ metadata:
   name: stdio
   labels:
     app: mixer
-    chart: mixer
     release: istio
 spec:
   match: context.protocol == "http" || context.protocol == "grpc"
@@ -16587,7 +16459,6 @@ metadata:
   name: stdiotcp
   labels:
     app: mixer
-    chart: mixer
     release: istio
 spec:
   match: context.protocol == "tcp"
@@ -16602,7 +16473,6 @@ metadata:
   name: requestcount
   labels:
     app: mixer
-    chart: mixer
     release: istio
 spec:
   value: "1"
@@ -16635,7 +16505,6 @@ metadata:
   name: requestduration
   labels:
     app: mixer
-    chart: mixer
     release: istio
 spec:
   value: response.duration | "0ms"
@@ -16668,7 +16537,6 @@ metadata:
   name: requestsize
   labels:
     app: mixer
-    chart: mixer
     release: istio
 spec:
   value: request.size | 0
@@ -16701,7 +16569,6 @@ metadata:
   name: responsesize
   labels:
     app: mixer
-    chart: mixer
     release: istio
 spec:
   value: response.size | 0
@@ -16734,7 +16601,6 @@ metadata:
   name: tcpbytesent
   labels:
     app: mixer
-    chart: mixer
     release: istio
 spec:
   value: connection.sent.bytes | 0
@@ -16763,7 +16629,6 @@ metadata:
   name: tcpbytereceived
   labels:
     app: mixer
-    chart: mixer
     release: istio
 spec:
   value: connection.received.bytes | 0
@@ -16792,7 +16657,6 @@ metadata:
   name: tcpconnectionsopened
   labels:
     app: mixer
-    chart: mixer
     release: istio
 spec:
   value: "1"
@@ -16821,7 +16685,6 @@ metadata:
   name: tcpconnectionsclosed
   labels:
     app: mixer
-    chart: mixer
     release: istio
 spec:
   value: "1"
@@ -16850,7 +16713,6 @@ metadata:
   name: prometheus
   labels:
     app: mixer
-    chart: mixer
     release: istio
 spec:
   compiledAdapter: prometheus
@@ -17054,7 +16916,6 @@ metadata:
   name: promhttp
   labels:
     app: mixer
-    chart: mixer
     release: istio
 spec:
   match: (context.protocol == "http" || context.protocol == "grpc") && (match((request.useragent | "-"), "kube-probe*") == false)
@@ -17072,7 +16933,6 @@ metadata:
   name: promtcp
   labels:
     app: mixer
-    chart: mixer
     release: istio
 spec:
   match: context.protocol == "tcp"
@@ -17088,7 +16948,6 @@ metadata:
   name: promtcpconnectionopen
   labels:
     app: mixer
-    chart: mixer
     release: istio
 spec:
   match: context.protocol == "tcp" && ((connection.event | "na") == "open")
@@ -17103,7 +16962,6 @@ metadata:
   name: promtcpconnectionclosed
   labels:
     app: mixer
-    chart: mixer
     release: istio
 spec:
   match: context.protocol == "tcp" && ((connection.event | "na") == "close")
@@ -17118,7 +16976,6 @@ metadata:
   name: kubernetesenv
   labels:
     app: mixer
-    chart: mixer
     release: istio
 spec:
   compiledAdapter: kubernetesenv
@@ -17137,7 +16994,6 @@ metadata:
   name: kubeattrgenrulerule
   labels:
     app: mixer
-    chart: mixer
     release: istio
 spec:
   actions:
@@ -17151,7 +17007,6 @@ metadata:
   name: tcpkubeattrgenrulerule
   labels:
     app: mixer
-    chart: mixer
     release: istio
 spec:
   match: context.protocol == "tcp"
@@ -17166,7 +17021,6 @@ metadata:
   name: attributes
   labels:
     app: mixer
-    chart: mixer
     release: istio
 spec:
   # Pass the required attribute data to the adapter
@@ -17208,7 +17062,6 @@ metadata:
   name: istio-policy
   labels:
     app: mixer
-    chart: mixer
     release: istio
 spec:
   host: istio-policy.istio-system.svc.cluster.local
@@ -17224,7 +17077,6 @@ metadata:
   name: istio-telemetry
   labels:
     app: mixer
-    chart: mixer
     release: istio
 spec:
   host: istio-telemetry.istio-system.svc.cluster.local

--- a/kfdef/generic/istio/crds.yaml
+++ b/kfdef/generic/istio/crds.yaml
@@ -5,7 +5,6 @@ metadata:
   labels:
     app: istio-pilot
     chart: istio
-    heritage: Tiller
     release: istio
   annotations:
     "helm.sh/resource-policy": keep
@@ -47,7 +46,6 @@ metadata:
   labels:
     app: istio-pilot
     chart: istio
-    heritage: Tiller
     release: istio
   annotations:
     "helm.sh/resource-policy": keep
@@ -85,7 +83,6 @@ metadata:
   labels:
     app: istio-pilot
     chart: istio
-    heritage: Tiller
     release: istio
   annotations:
     "helm.sh/resource-policy": keep
@@ -131,7 +128,6 @@ metadata:
   labels:
     app: istio-pilot
     chart: istio
-    heritage: Tiller
     release: istio
   annotations:
     "helm.sh/resource-policy": keep
@@ -156,7 +152,6 @@ metadata:
   labels:
     app: istio-pilot
     chart: istio
-    heritage: Tiller
     release: istio
   annotations:
     "helm.sh/resource-policy": keep
@@ -179,7 +174,6 @@ metadata:
   labels:
     app: istio-pilot
     istio: rbac
-    heritage: Tiller
     release: istio
   annotations:
     "helm.sh/resource-policy": keep
@@ -202,7 +196,6 @@ metadata:
   labels:
     app: istio-citadel
     chart: istio
-    heritage: Tiller
     release: istio
   annotations:
     "helm.sh/resource-policy": keep
@@ -225,7 +218,6 @@ metadata:
   labels:
     app: istio-citadel
     chart: istio
-    heritage: Tiller
     release: istio
   annotations:
     "helm.sh/resource-policy": keep
@@ -249,7 +241,6 @@ metadata:
   labels:
     app: istio-mixer
     chart: istio
-    heritage: Tiller
     release: istio
   annotations:
     "helm.sh/resource-policy": keep
@@ -272,7 +263,6 @@ metadata:
   labels:
     app: istio-mixer
     chart: istio
-    heritage: Tiller
     release: istio
   annotations:
     "helm.sh/resource-policy": keep
@@ -295,7 +285,6 @@ metadata:
   labels:
     app: istio-mixer
     chart: istio
-    heritage: Tiller
     release: istio
   annotations:
     "helm.sh/resource-policy": keep
@@ -318,7 +307,6 @@ metadata:
   labels:
     app: istio-mixer
     chart: istio
-    heritage: Tiller
     release: istio
   annotations:
     "helm.sh/resource-policy": keep
@@ -343,7 +331,6 @@ metadata:
     package: istio.io.mixer
     istio: core
     chart: istio
-    heritage: Tiller
     release: istio
   annotations:
     "helm.sh/resource-policy": keep
@@ -368,7 +355,6 @@ metadata:
     package: istio.io.mixer
     istio: core
     chart: istio
-    heritage: Tiller
     release: istio
   annotations:
     "helm.sh/resource-policy": keep
@@ -393,7 +379,6 @@ metadata:
     package: bypass
     istio: mixer-adapter
     chart: istio
-    heritage: Tiller
     release: istio
   annotations:
     "helm.sh/resource-policy": keep
@@ -418,7 +403,6 @@ metadata:
     package: circonus
     istio: mixer-adapter
     chart: istio
-    heritage: Tiller
     release: istio
   annotations:
     "helm.sh/resource-policy": keep
@@ -443,7 +427,6 @@ metadata:
     package: denier
     istio: mixer-adapter
     chart: istio
-    heritage: Tiller
     release: istio
   annotations:
     "helm.sh/resource-policy": keep
@@ -468,7 +451,6 @@ metadata:
     package: fluentd
     istio: mixer-adapter
     chart: istio
-    heritage: Tiller
     release: istio
   annotations:
     "helm.sh/resource-policy": keep
@@ -493,7 +475,6 @@ metadata:
     package: kubernetesenv
     istio: mixer-adapter
     chart: istio
-    heritage: Tiller
     release: istio
   annotations:
     "helm.sh/resource-policy": keep
@@ -518,7 +499,6 @@ metadata:
     package: listchecker
     istio: mixer-adapter
     chart: istio
-    heritage: Tiller
     release: istio
   annotations:
     "helm.sh/resource-policy": keep
@@ -543,7 +523,6 @@ metadata:
     package: memquota
     istio: mixer-adapter
     chart: istio
-    heritage: Tiller
     release: istio
   annotations:
     "helm.sh/resource-policy": keep
@@ -568,7 +547,6 @@ metadata:
     package: noop
     istio: mixer-adapter
     chart: istio
-    heritage: Tiller
     release: istio
   annotations:
     "helm.sh/resource-policy": keep
@@ -593,7 +571,6 @@ metadata:
     package: opa
     istio: mixer-adapter
     chart: istio
-    heritage: Tiller
     release: istio
   annotations:
     "helm.sh/resource-policy": keep
@@ -618,7 +595,6 @@ metadata:
     package: prometheus
     istio: mixer-adapter
     chart: istio
-    heritage: Tiller
     release: istio
   annotations:
     "helm.sh/resource-policy": keep
@@ -643,7 +619,6 @@ metadata:
     package: rbac
     istio: mixer-adapter
     chart: istio
-    heritage: Tiller
     release: istio
   annotations:
     "helm.sh/resource-policy": keep
@@ -668,7 +643,6 @@ metadata:
     package: redisquota
     istio: mixer-adapter
     chart: istio
-    heritage: Tiller
     release: istio
   annotations:
     "helm.sh/resource-policy": keep
@@ -690,7 +664,6 @@ metadata:
     package: signalfx
     istio: mixer-adapter
     chart: istio
-    heritage: Tiller
     release: istio
   annotations:
     "helm.sh/resource-policy": keep
@@ -715,7 +688,6 @@ metadata:
     package: solarwinds
     istio: mixer-adapter
     chart: istio
-    heritage: Tiller
     release: istio
   annotations:
     "helm.sh/resource-policy": keep
@@ -740,7 +712,6 @@ metadata:
     package: stackdriver
     istio: mixer-adapter
     chart: istio
-    heritage: Tiller
     release: istio
   annotations:
     "helm.sh/resource-policy": keep
@@ -765,7 +736,6 @@ metadata:
     package: statsd
     istio: mixer-adapter
     chart: istio
-    heritage: Tiller
     release: istio
   annotations:
     "helm.sh/resource-policy": keep
@@ -790,7 +760,6 @@ metadata:
     package: stdio
     istio: mixer-adapter
     chart: istio
-    heritage: Tiller
     release: istio
   annotations:
     "helm.sh/resource-policy": keep
@@ -815,7 +784,6 @@ metadata:
     package: apikey
     istio: mixer-instance
     chart: istio
-    heritage: Tiller
     release: istio
   annotations:
     "helm.sh/resource-policy": keep
@@ -840,7 +808,6 @@ metadata:
     package: authorization
     istio: mixer-instance
     chart: istio
-    heritage: Tiller
     release: istio
   annotations:
     "helm.sh/resource-policy": keep
@@ -865,7 +832,6 @@ metadata:
     package: checknothing
     istio: mixer-instance
     chart: istio
-    heritage: Tiller
     release: istio
   annotations:
     "helm.sh/resource-policy": keep
@@ -890,7 +856,6 @@ metadata:
     package: adapter.template.kubernetes
     istio: mixer-instance
     chart: istio
-    heritage: Tiller
     release: istio
   annotations:
     "helm.sh/resource-policy": keep
@@ -915,7 +880,6 @@ metadata:
     package: listentry
     istio: mixer-instance
     chart: istio
-    heritage: Tiller
     release: istio
   annotations:
     "helm.sh/resource-policy": keep
@@ -940,7 +904,6 @@ metadata:
     package: logentry
     istio: mixer-instance
     chart: istio
-    heritage: Tiller
     release: istio
   annotations:
     "helm.sh/resource-policy": keep
@@ -985,7 +948,6 @@ metadata:
     package: edge
     istio: mixer-instance
     chart: istio
-    heritage: Tiller
     release: istio
   annotations:
     "helm.sh/resource-policy": keep
@@ -1010,7 +972,6 @@ metadata:
     package: metric
     istio: mixer-instance
     chart: istio
-    heritage: Tiller
     release: istio
   annotations:
     "helm.sh/resource-policy": keep
@@ -1035,7 +996,6 @@ metadata:
     package: quota
     istio: mixer-instance
     chart: istio
-    heritage: Tiller
     release: istio
   annotations:
     "helm.sh/resource-policy": keep
@@ -1060,7 +1020,6 @@ metadata:
     package: reportnothing
     istio: mixer-instance
     chart: istio
-    heritage: Tiller
     release: istio
   annotations:
     "helm.sh/resource-policy": keep
@@ -1085,7 +1044,6 @@ metadata:
     package: tracespan
     istio: mixer-instance
     chart: istio
-    heritage: Tiller
     release: istio
   annotations:
     "helm.sh/resource-policy": keep
@@ -1110,7 +1068,6 @@ metadata:
     package: istio.io.mixer
     istio: rbac
     chart: istio
-    heritage: Tiller
     release: istio
   annotations:
     "helm.sh/resource-policy": keep
@@ -1135,7 +1092,6 @@ metadata:
     package: istio.io.mixer
     istio: rbac
     chart: istio
-    heritage: Tiller
     release: istio
   annotations:
     "helm.sh/resource-policy": keep
@@ -1160,7 +1116,6 @@ metadata:
     package: istio.io.mixer
     istio: rbac
     chart: istio
-    heritage: Tiller
     release: istio
   annotations:
     "helm.sh/resource-policy": keep
@@ -1197,7 +1152,6 @@ metadata:
     package: adapter
     istio: mixer-adapter
     chart: istio
-    heritage: Tiller
     release: istio
   annotations:
     "helm.sh/resource-policy": keep
@@ -1222,7 +1176,6 @@ metadata:
     package: instance
     istio: mixer-instance
     chart: istio
-    heritage: Tiller
     release: istio
   annotations:
     "helm.sh/resource-policy": keep
@@ -1247,7 +1200,6 @@ metadata:
     package: template
     istio: mixer-template
     chart: istio
-    heritage: Tiller
     release: istio
   annotations:
     "helm.sh/resource-policy": keep
@@ -1272,7 +1224,6 @@ metadata:
     package: handler
     istio: mixer-handler
     chart: istio
-    heritage: Tiller
     release: istio
   annotations:
     "helm.sh/resource-policy": keep
@@ -1339,7 +1290,6 @@ metadata:
   labels:
     app: istio-pilot
     chart: istio
-    heritage: Tiller
     release: istio
   annotations:
     "helm.sh/resource-policy": keep
@@ -1384,7 +1334,6 @@ metadata:
   labels:
     app: certmanager
     chart: certmanager
-    heritage: Tiller
     release: istio
   annotations:
     "helm.sh/resource-policy": keep
@@ -1403,7 +1352,6 @@ metadata:
   labels:
     app: certmanager
     chart: certmanager
-    heritage: Tiller
     release: istio
   annotations:
     "helm.sh/resource-policy": keep
@@ -1422,7 +1370,6 @@ metadata:
   labels:
     app: certmanager
     chart: certmanager
-    heritage: Tiller
     release: istio
   annotations:
     "helm.sh/resource-policy": keep
@@ -1466,7 +1413,6 @@ metadata:
   labels:
     app: certmanager
     chart: certmanager
-    heritage: Tiller
     release: istio
   annotations:
     "helm.sh/resource-policy": keep
@@ -1504,7 +1450,6 @@ metadata:
   labels:
     app: certmanager
     chart: certmanager
-    heritage: Tiller
     release: istio
   annotations:
     "helm.sh/resource-policy": keep

--- a/kfdef/generic/istio/crds.yaml
+++ b/kfdef/generic/istio/crds.yaml
@@ -4,7 +4,6 @@ metadata:
   name: virtualservices.networking.istio.io
   labels:
     app: istio-pilot
-    chart: istio
     release: istio
   annotations:
     "helm.sh/resource-policy": keep
@@ -45,7 +44,6 @@ metadata:
   name: destinationrules.networking.istio.io
   labels:
     app: istio-pilot
-    chart: istio
     release: istio
   annotations:
     "helm.sh/resource-policy": keep
@@ -82,7 +80,6 @@ metadata:
   name: serviceentries.networking.istio.io
   labels:
     app: istio-pilot
-    chart: istio
     release: istio
   annotations:
     "helm.sh/resource-policy": keep
@@ -127,7 +124,6 @@ metadata:
   name: gateways.networking.istio.io
   labels:
     app: istio-pilot
-    chart: istio
     release: istio
   annotations:
     "helm.sh/resource-policy": keep
@@ -151,7 +147,6 @@ metadata:
   name: envoyfilters.networking.istio.io
   labels:
     app: istio-pilot
-    chart: istio
     release: istio
   annotations:
     "helm.sh/resource-policy": keep
@@ -195,7 +190,6 @@ metadata:
   name: policies.authentication.istio.io
   labels:
     app: istio-citadel
-    chart: istio
     release: istio
   annotations:
     "helm.sh/resource-policy": keep
@@ -217,7 +211,6 @@ metadata:
   name: meshpolicies.authentication.istio.io
   labels:
     app: istio-citadel
-    chart: istio
     release: istio
   annotations:
     "helm.sh/resource-policy": keep
@@ -240,7 +233,6 @@ metadata:
   name: httpapispecbindings.config.istio.io
   labels:
     app: istio-mixer
-    chart: istio
     release: istio
   annotations:
     "helm.sh/resource-policy": keep
@@ -262,7 +254,6 @@ metadata:
   name: httpapispecs.config.istio.io
   labels:
     app: istio-mixer
-    chart: istio
     release: istio
   annotations:
     "helm.sh/resource-policy": keep
@@ -284,7 +275,6 @@ metadata:
   name: quotaspecbindings.config.istio.io
   labels:
     app: istio-mixer
-    chart: istio
     release: istio
   annotations:
     "helm.sh/resource-policy": keep
@@ -306,7 +296,6 @@ metadata:
   name: quotaspecs.config.istio.io
   labels:
     app: istio-mixer
-    chart: istio
     release: istio
   annotations:
     "helm.sh/resource-policy": keep
@@ -330,7 +319,6 @@ metadata:
     app: mixer
     package: istio.io.mixer
     istio: core
-    chart: istio
     release: istio
   annotations:
     "helm.sh/resource-policy": keep
@@ -354,7 +342,6 @@ metadata:
     app: mixer
     package: istio.io.mixer
     istio: core
-    chart: istio
     release: istio
   annotations:
     "helm.sh/resource-policy": keep
@@ -378,7 +365,6 @@ metadata:
     app: mixer
     package: bypass
     istio: mixer-adapter
-    chart: istio
     release: istio
   annotations:
     "helm.sh/resource-policy": keep
@@ -402,7 +388,6 @@ metadata:
     app: mixer
     package: circonus
     istio: mixer-adapter
-    chart: istio
     release: istio
   annotations:
     "helm.sh/resource-policy": keep
@@ -426,7 +411,6 @@ metadata:
     app: mixer
     package: denier
     istio: mixer-adapter
-    chart: istio
     release: istio
   annotations:
     "helm.sh/resource-policy": keep
@@ -450,7 +434,6 @@ metadata:
     app: mixer
     package: fluentd
     istio: mixer-adapter
-    chart: istio
     release: istio
   annotations:
     "helm.sh/resource-policy": keep
@@ -474,7 +457,6 @@ metadata:
     app: mixer
     package: kubernetesenv
     istio: mixer-adapter
-    chart: istio
     release: istio
   annotations:
     "helm.sh/resource-policy": keep
@@ -498,7 +480,6 @@ metadata:
     app: mixer
     package: listchecker
     istio: mixer-adapter
-    chart: istio
     release: istio
   annotations:
     "helm.sh/resource-policy": keep
@@ -522,7 +503,6 @@ metadata:
     app: mixer
     package: memquota
     istio: mixer-adapter
-    chart: istio
     release: istio
   annotations:
     "helm.sh/resource-policy": keep
@@ -546,7 +526,6 @@ metadata:
     app: mixer
     package: noop
     istio: mixer-adapter
-    chart: istio
     release: istio
   annotations:
     "helm.sh/resource-policy": keep
@@ -570,7 +549,6 @@ metadata:
     app: mixer
     package: opa
     istio: mixer-adapter
-    chart: istio
     release: istio
   annotations:
     "helm.sh/resource-policy": keep
@@ -594,7 +572,6 @@ metadata:
     app: mixer
     package: prometheus
     istio: mixer-adapter
-    chart: istio
     release: istio
   annotations:
     "helm.sh/resource-policy": keep
@@ -618,7 +595,6 @@ metadata:
     app: mixer
     package: rbac
     istio: mixer-adapter
-    chart: istio
     release: istio
   annotations:
     "helm.sh/resource-policy": keep
@@ -642,7 +618,6 @@ metadata:
     app: mixer
     package: redisquota
     istio: mixer-adapter
-    chart: istio
     release: istio
   annotations:
     "helm.sh/resource-policy": keep
@@ -663,7 +638,6 @@ metadata:
     app: mixer
     package: signalfx
     istio: mixer-adapter
-    chart: istio
     release: istio
   annotations:
     "helm.sh/resource-policy": keep
@@ -687,7 +661,6 @@ metadata:
     app: mixer
     package: solarwinds
     istio: mixer-adapter
-    chart: istio
     release: istio
   annotations:
     "helm.sh/resource-policy": keep
@@ -711,7 +684,6 @@ metadata:
     app: mixer
     package: stackdriver
     istio: mixer-adapter
-    chart: istio
     release: istio
   annotations:
     "helm.sh/resource-policy": keep
@@ -735,7 +707,6 @@ metadata:
     app: mixer
     package: statsd
     istio: mixer-adapter
-    chart: istio
     release: istio
   annotations:
     "helm.sh/resource-policy": keep
@@ -759,7 +730,6 @@ metadata:
     app: mixer
     package: stdio
     istio: mixer-adapter
-    chart: istio
     release: istio
   annotations:
     "helm.sh/resource-policy": keep
@@ -783,7 +753,6 @@ metadata:
     app: mixer
     package: apikey
     istio: mixer-instance
-    chart: istio
     release: istio
   annotations:
     "helm.sh/resource-policy": keep
@@ -807,7 +776,6 @@ metadata:
     app: mixer
     package: authorization
     istio: mixer-instance
-    chart: istio
     release: istio
   annotations:
     "helm.sh/resource-policy": keep
@@ -831,7 +799,6 @@ metadata:
     app: mixer
     package: checknothing
     istio: mixer-instance
-    chart: istio
     release: istio
   annotations:
     "helm.sh/resource-policy": keep
@@ -855,7 +822,6 @@ metadata:
     app: mixer
     package: adapter.template.kubernetes
     istio: mixer-instance
-    chart: istio
     release: istio
   annotations:
     "helm.sh/resource-policy": keep
@@ -879,7 +845,6 @@ metadata:
     app: mixer
     package: listentry
     istio: mixer-instance
-    chart: istio
     release: istio
   annotations:
     "helm.sh/resource-policy": keep
@@ -903,7 +868,6 @@ metadata:
     app: mixer
     package: logentry
     istio: mixer-instance
-    chart: istio
     release: istio
   annotations:
     "helm.sh/resource-policy": keep
@@ -947,7 +911,6 @@ metadata:
     app: mixer
     package: edge
     istio: mixer-instance
-    chart: istio
     release: istio
   annotations:
     "helm.sh/resource-policy": keep
@@ -971,7 +934,6 @@ metadata:
     app: mixer
     package: metric
     istio: mixer-instance
-    chart: istio
     release: istio
   annotations:
     "helm.sh/resource-policy": keep
@@ -995,7 +957,6 @@ metadata:
     app: mixer
     package: quota
     istio: mixer-instance
-    chart: istio
     release: istio
   annotations:
     "helm.sh/resource-policy": keep
@@ -1019,7 +980,6 @@ metadata:
     app: mixer
     package: reportnothing
     istio: mixer-instance
-    chart: istio
     release: istio
   annotations:
     "helm.sh/resource-policy": keep
@@ -1043,7 +1003,6 @@ metadata:
     app: mixer
     package: tracespan
     istio: mixer-instance
-    chart: istio
     release: istio
   annotations:
     "helm.sh/resource-policy": keep
@@ -1067,7 +1026,6 @@ metadata:
     app: mixer
     package: istio.io.mixer
     istio: rbac
-    chart: istio
     release: istio
   annotations:
     "helm.sh/resource-policy": keep
@@ -1091,7 +1049,6 @@ metadata:
     app: mixer
     package: istio.io.mixer
     istio: rbac
-    chart: istio
     release: istio
   annotations:
     "helm.sh/resource-policy": keep
@@ -1115,7 +1072,6 @@ metadata:
     app: mixer
     package: istio.io.mixer
     istio: rbac
-    chart: istio
     release: istio
   annotations:
     "helm.sh/resource-policy": keep
@@ -1151,7 +1107,6 @@ metadata:
     app: mixer
     package: adapter
     istio: mixer-adapter
-    chart: istio
     release: istio
   annotations:
     "helm.sh/resource-policy": keep
@@ -1175,7 +1130,6 @@ metadata:
     app: mixer
     package: instance
     istio: mixer-instance
-    chart: istio
     release: istio
   annotations:
     "helm.sh/resource-policy": keep
@@ -1199,7 +1153,6 @@ metadata:
     app: mixer
     package: template
     istio: mixer-template
-    chart: istio
     release: istio
   annotations:
     "helm.sh/resource-policy": keep
@@ -1223,7 +1176,6 @@ metadata:
     app: mixer
     package: handler
     istio: mixer-handler
-    chart: istio
     release: istio
   annotations:
     "helm.sh/resource-policy": keep
@@ -1289,7 +1241,6 @@ metadata:
   name: sidecars.networking.istio.io
   labels:
     app: istio-pilot
-    chart: istio
     release: istio
   annotations:
     "helm.sh/resource-policy": keep
@@ -1333,7 +1284,6 @@ metadata:
   name: clusterissuers.certmanager.k8s.io
   labels:
     app: certmanager
-    chart: certmanager
     release: istio
   annotations:
     "helm.sh/resource-policy": keep
@@ -1351,7 +1301,6 @@ metadata:
   name: issuers.certmanager.k8s.io
   labels:
     app: certmanager
-    chart: certmanager
     release: istio
   annotations:
     "helm.sh/resource-policy": keep
@@ -1369,7 +1318,6 @@ metadata:
   name: certificates.certmanager.k8s.io
   labels:
     app: certmanager
-    chart: certmanager
     release: istio
   annotations:
     "helm.sh/resource-policy": keep
@@ -1412,7 +1360,6 @@ metadata:
   name: orders.certmanager.k8s.io
   labels:
     app: certmanager
-    chart: certmanager
     release: istio
   annotations:
     "helm.sh/resource-policy": keep
@@ -1449,7 +1396,6 @@ metadata:
   name: challenges.certmanager.k8s.io
   labels:
     app: certmanager
-    chart: certmanager
     release: istio
   annotations:
     "helm.sh/resource-policy": keep

--- a/kfdef/generic/istio/istio-noauth.yaml
+++ b/kfdef/generic/istio/istio-noauth.yaml
@@ -11,7 +11,6 @@ metadata:
   name: virtualservices.networking.istio.io
   labels:
     app: istio-pilot
-    chart: istio
     release: istio
   annotations:
     "helm.sh/resource-policy": keep
@@ -52,7 +51,6 @@ metadata:
   name: destinationrules.networking.istio.io
   labels:
     app: istio-pilot
-    chart: istio
     release: istio
   annotations:
     "helm.sh/resource-policy": keep
@@ -89,7 +87,6 @@ metadata:
   name: serviceentries.networking.istio.io
   labels:
     app: istio-pilot
-    chart: istio
     release: istio
   annotations:
     "helm.sh/resource-policy": keep
@@ -134,7 +131,6 @@ metadata:
   name: gateways.networking.istio.io
   labels:
     app: istio-pilot
-    chart: istio
     release: istio
   annotations:
     "helm.sh/resource-policy": keep
@@ -158,7 +154,6 @@ metadata:
   name: envoyfilters.networking.istio.io
   labels:
     app: istio-pilot
-    chart: istio
     release: istio
   annotations:
     "helm.sh/resource-policy": keep
@@ -202,7 +197,6 @@ metadata:
   name: policies.authentication.istio.io
   labels:
     app: istio-citadel
-    chart: istio
     release: istio
   annotations:
     "helm.sh/resource-policy": keep
@@ -224,7 +218,6 @@ metadata:
   name: meshpolicies.authentication.istio.io
   labels:
     app: istio-citadel
-    chart: istio
     release: istio
   annotations:
     "helm.sh/resource-policy": keep
@@ -247,7 +240,6 @@ metadata:
   name: httpapispecbindings.config.istio.io
   labels:
     app: istio-mixer
-    chart: istio
     release: istio
   annotations:
     "helm.sh/resource-policy": keep
@@ -269,7 +261,6 @@ metadata:
   name: httpapispecs.config.istio.io
   labels:
     app: istio-mixer
-    chart: istio
     release: istio
   annotations:
     "helm.sh/resource-policy": keep
@@ -291,7 +282,6 @@ metadata:
   name: quotaspecbindings.config.istio.io
   labels:
     app: istio-mixer
-    chart: istio
     release: istio
   annotations:
     "helm.sh/resource-policy": keep
@@ -313,7 +303,6 @@ metadata:
   name: quotaspecs.config.istio.io
   labels:
     app: istio-mixer
-    chart: istio
     release: istio
   annotations:
     "helm.sh/resource-policy": keep
@@ -337,7 +326,6 @@ metadata:
     app: mixer
     package: istio.io.mixer
     istio: core
-    chart: istio
     release: istio
   annotations:
     "helm.sh/resource-policy": keep
@@ -361,7 +349,6 @@ metadata:
     app: mixer
     package: istio.io.mixer
     istio: core
-    chart: istio
     release: istio
   annotations:
     "helm.sh/resource-policy": keep
@@ -385,7 +372,6 @@ metadata:
     app: mixer
     package: bypass
     istio: mixer-adapter
-    chart: istio
     release: istio
   annotations:
     "helm.sh/resource-policy": keep
@@ -409,7 +395,6 @@ metadata:
     app: mixer
     package: circonus
     istio: mixer-adapter
-    chart: istio
     release: istio
   annotations:
     "helm.sh/resource-policy": keep
@@ -433,7 +418,6 @@ metadata:
     app: mixer
     package: denier
     istio: mixer-adapter
-    chart: istio
     release: istio
   annotations:
     "helm.sh/resource-policy": keep
@@ -457,7 +441,6 @@ metadata:
     app: mixer
     package: fluentd
     istio: mixer-adapter
-    chart: istio
     release: istio
   annotations:
     "helm.sh/resource-policy": keep
@@ -481,7 +464,6 @@ metadata:
     app: mixer
     package: kubernetesenv
     istio: mixer-adapter
-    chart: istio
     release: istio
   annotations:
     "helm.sh/resource-policy": keep
@@ -505,7 +487,6 @@ metadata:
     app: mixer
     package: listchecker
     istio: mixer-adapter
-    chart: istio
     release: istio
   annotations:
     "helm.sh/resource-policy": keep
@@ -529,7 +510,6 @@ metadata:
     app: mixer
     package: memquota
     istio: mixer-adapter
-    chart: istio
     release: istio
   annotations:
     "helm.sh/resource-policy": keep
@@ -553,7 +533,6 @@ metadata:
     app: mixer
     package: noop
     istio: mixer-adapter
-    chart: istio
     release: istio
   annotations:
     "helm.sh/resource-policy": keep
@@ -577,7 +556,6 @@ metadata:
     app: mixer
     package: opa
     istio: mixer-adapter
-    chart: istio
     release: istio
   annotations:
     "helm.sh/resource-policy": keep
@@ -601,7 +579,6 @@ metadata:
     app: mixer
     package: prometheus
     istio: mixer-adapter
-    chart: istio
     release: istio
   annotations:
     "helm.sh/resource-policy": keep
@@ -625,7 +602,6 @@ metadata:
     app: mixer
     package: rbac
     istio: mixer-adapter
-    chart: istio
     release: istio
   annotations:
     "helm.sh/resource-policy": keep
@@ -649,7 +625,6 @@ metadata:
     app: mixer
     package: redisquota
     istio: mixer-adapter
-    chart: istio
     release: istio
   annotations:
     "helm.sh/resource-policy": keep
@@ -670,7 +645,6 @@ metadata:
     app: mixer
     package: signalfx
     istio: mixer-adapter
-    chart: istio
     release: istio
   annotations:
     "helm.sh/resource-policy": keep
@@ -694,7 +668,6 @@ metadata:
     app: mixer
     package: solarwinds
     istio: mixer-adapter
-    chart: istio
     release: istio
   annotations:
     "helm.sh/resource-policy": keep
@@ -718,7 +691,6 @@ metadata:
     app: mixer
     package: stackdriver
     istio: mixer-adapter
-    chart: istio
     release: istio
   annotations:
     "helm.sh/resource-policy": keep
@@ -742,7 +714,6 @@ metadata:
     app: mixer
     package: statsd
     istio: mixer-adapter
-    chart: istio
     release: istio
   annotations:
     "helm.sh/resource-policy": keep
@@ -766,7 +737,6 @@ metadata:
     app: mixer
     package: stdio
     istio: mixer-adapter
-    chart: istio
     release: istio
   annotations:
     "helm.sh/resource-policy": keep
@@ -790,7 +760,6 @@ metadata:
     app: mixer
     package: apikey
     istio: mixer-instance
-    chart: istio
     release: istio
   annotations:
     "helm.sh/resource-policy": keep
@@ -814,7 +783,6 @@ metadata:
     app: mixer
     package: authorization
     istio: mixer-instance
-    chart: istio
     release: istio
   annotations:
     "helm.sh/resource-policy": keep
@@ -838,7 +806,6 @@ metadata:
     app: mixer
     package: checknothing
     istio: mixer-instance
-    chart: istio
     release: istio
   annotations:
     "helm.sh/resource-policy": keep
@@ -862,7 +829,6 @@ metadata:
     app: mixer
     package: adapter.template.kubernetes
     istio: mixer-instance
-    chart: istio
     release: istio
   annotations:
     "helm.sh/resource-policy": keep
@@ -886,7 +852,6 @@ metadata:
     app: mixer
     package: listentry
     istio: mixer-instance
-    chart: istio
     release: istio
   annotations:
     "helm.sh/resource-policy": keep
@@ -910,7 +875,6 @@ metadata:
     app: mixer
     package: logentry
     istio: mixer-instance
-    chart: istio
     release: istio
   annotations:
     "helm.sh/resource-policy": keep
@@ -954,7 +918,6 @@ metadata:
     app: mixer
     package: edge
     istio: mixer-instance
-    chart: istio
     release: istio
   annotations:
     "helm.sh/resource-policy": keep
@@ -978,7 +941,6 @@ metadata:
     app: mixer
     package: metric
     istio: mixer-instance
-    chart: istio
     release: istio
   annotations:
     "helm.sh/resource-policy": keep
@@ -1002,7 +964,6 @@ metadata:
     app: mixer
     package: quota
     istio: mixer-instance
-    chart: istio
     release: istio
   annotations:
     "helm.sh/resource-policy": keep
@@ -1026,7 +987,6 @@ metadata:
     app: mixer
     package: reportnothing
     istio: mixer-instance
-    chart: istio
     release: istio
   annotations:
     "helm.sh/resource-policy": keep
@@ -1050,7 +1010,6 @@ metadata:
     app: mixer
     package: tracespan
     istio: mixer-instance
-    chart: istio
     release: istio
   annotations:
     "helm.sh/resource-policy": keep
@@ -1074,7 +1033,6 @@ metadata:
     app: mixer
     package: istio.io.mixer
     istio: rbac
-    chart: istio
     release: istio
   annotations:
     "helm.sh/resource-policy": keep
@@ -1098,7 +1056,6 @@ metadata:
     app: mixer
     package: istio.io.mixer
     istio: rbac
-    chart: istio
     release: istio
   annotations:
     "helm.sh/resource-policy": keep
@@ -1122,7 +1079,6 @@ metadata:
     app: mixer
     package: istio.io.mixer
     istio: rbac
-    chart: istio
     release: istio
   annotations:
     "helm.sh/resource-policy": keep
@@ -1158,7 +1114,6 @@ metadata:
     app: mixer
     package: adapter
     istio: mixer-adapter
-    chart: istio
     release: istio
   annotations:
     "helm.sh/resource-policy": keep
@@ -1182,7 +1137,6 @@ metadata:
     app: mixer
     package: instance
     istio: mixer-instance
-    chart: istio
     release: istio
   annotations:
     "helm.sh/resource-policy": keep
@@ -1206,7 +1160,6 @@ metadata:
     app: mixer
     package: template
     istio: mixer-template
-    chart: istio
     release: istio
   annotations:
     "helm.sh/resource-policy": keep
@@ -1230,7 +1183,6 @@ metadata:
     app: mixer
     package: handler
     istio: mixer-handler
-    chart: istio
     release: istio
   annotations:
     "helm.sh/resource-policy": keep
@@ -1296,7 +1248,6 @@ metadata:
   name: sidecars.networking.istio.io
   labels:
     app: istio-pilot
-    chart: istio
     release: istio
   annotations:
     "helm.sh/resource-policy": keep
@@ -1340,7 +1291,6 @@ metadata:
   name: clusterissuers.certmanager.k8s.io
   labels:
     app: certmanager
-    chart: certmanager
     release: istio
   annotations:
     "helm.sh/resource-policy": keep
@@ -1358,7 +1308,6 @@ metadata:
   name: issuers.certmanager.k8s.io
   labels:
     app: certmanager
-    chart: certmanager
     release: istio
   annotations:
     "helm.sh/resource-policy": keep
@@ -1376,7 +1325,6 @@ metadata:
   name: certificates.certmanager.k8s.io
   labels:
     app: certmanager
-    chart: certmanager
     release: istio
   annotations:
     "helm.sh/resource-policy": keep
@@ -1418,7 +1366,6 @@ metadata:
   name: orders.certmanager.k8s.io
   labels:
     app: certmanager
-    chart: certmanager
     release: istio
   annotations:
     "helm.sh/resource-policy": keep
@@ -1455,7 +1402,6 @@ metadata:
   name: challenges.certmanager.k8s.io
   labels:
     app: certmanager
-    chart: certmanager
     release: istio
   annotations:
     "helm.sh/resource-policy": keep
@@ -1493,7 +1439,6 @@ metadata:
   namespace: istio-system
   labels:
     app: kiali
-    chart: kiali
     release: istio
 type: Opaque
 data:
@@ -1509,7 +1454,6 @@ metadata:
   namespace: istio-system
   labels:
     app: galley
-    chart: galley
     release: istio
     istio: galley
 data:
@@ -1521,7 +1465,6 @@ data:
       namespace: istio-system
       labels:
         app: galley
-        chart: galley
         release: istio
         istio: galley
     webhooks:
@@ -1632,7 +1575,6 @@ metadata:
   namespace: istio-system
   labels:
     app: grafana
-    chart: grafana
     release: istio
     istio: grafana
 data:
@@ -1644,7 +1586,6 @@ data:
       namespace: istio-system
       labels:
         app: grafana
-        chart: grafana
         release: istio
     spec:
       targets:
@@ -1694,7 +1635,6 @@ metadata:
   namespace: istio-system
   labels:
     app: grafana
-    chart: grafana
     release: istio
     istio: grafana
 data:
@@ -3526,7 +3466,6 @@ metadata:
   namespace: istio-system
   labels:
     app: grafana
-    chart: grafana
     release: istio
     istio: grafana
 data:
@@ -4492,7 +4431,6 @@ metadata:
   namespace: istio-system
   labels:
     app: grafana
-    chart: grafana
     release: istio
     istio: grafana
 data:
@@ -5122,7 +5060,6 @@ metadata:
   namespace: istio-system
   labels:
     app: grafana
-    chart: grafana
     release: istio
     istio: grafana
 data:
@@ -7736,7 +7673,6 @@ metadata:
   namespace: istio-system
   labels:
     app: grafana
-    chart: grafana
     release: istio
     istio: grafana
 data:
@@ -10052,7 +9988,6 @@ metadata:
   namespace: istio-system
   labels:
     app: grafana
-    chart: grafana
     release: istio
     istio: grafana
 data:
@@ -11873,7 +11808,6 @@ metadata:
   namespace: istio-system
   labels:
     app: grafana
-    chart: grafana
     release: istio
     istio: grafana
 data:
@@ -13484,7 +13418,6 @@ metadata:
   namespace: istio-system
   labels:
     app: grafana
-    chart: grafana
     release: istio
     istio: grafana
 data:
@@ -13521,7 +13454,6 @@ metadata:
   namespace: istio-system
   labels:
     app: kiali
-    chart: kiali
     release: istio
 data:
   config.yaml: |
@@ -13545,7 +13477,6 @@ metadata:
   namespace: istio-system
   labels:
     app: prometheus
-    chart: prometheus
     release: istio
 data:
   prometheus.yml: |-
@@ -13859,7 +13790,6 @@ metadata:
   namespace: istio-system	
   labels:	
     app: security	
-    chart: security	
     release: istio	
     istio: citadel	
 data:	
@@ -13871,7 +13801,6 @@ data:
       name: "default"
       labels:
         app: security
-        chart: security
         release: istio
     spec:
       peers:
@@ -13920,7 +13849,6 @@ metadata:
   namespace: istio-system
   labels:
     app: istio
-    chart: istio
     release: istio
 data:
   mesh: |-
@@ -14064,7 +13992,6 @@ metadata:
   namespace: istio-system
   labels:
     app: istio
-    chart: istio
     release: istio
     istio: sidecar-injector
 data:
@@ -14282,7 +14209,6 @@ metadata:
   namespace: istio-system
   labels:
     app: galley
-    chart: galley
     release: istio
 
 ---
@@ -14295,7 +14221,6 @@ metadata:
   namespace: istio-system
   labels:
     app: istio-egressgateway
-    chart: gateways
     release: istio
 ---
 apiVersion: v1
@@ -14305,7 +14230,6 @@ metadata:
   namespace: istio-system
   labels:
     app: istio-ingressgateway
-    chart: gateways
     release: istio
 ---
 
@@ -14319,7 +14243,6 @@ metadata:
   namespace: istio-system
   labels:
     app: grafana
-    chart: grafana
     release: istio
 ---
 apiVersion: rbac.authorization.k8s.io/v1
@@ -14328,7 +14251,6 @@ metadata:
   name: istio-grafana-post-install-istio-system
   labels:
     app: grafana
-    chart: grafana
     release: istio
 rules:
 - apiGroups: ["authentication.istio.io"] # needed to create default authn policy
@@ -14341,7 +14263,6 @@ metadata:
   name: istio-grafana-post-install-role-binding-istio-system
   labels:
     app: grafana
-    chart: grafana
     release: istio
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -14362,7 +14283,6 @@ metadata:
     "helm.sh/hook-delete-policy": hook-succeeded
   labels:
     app: grafana
-    chart: grafana
     release: istio
 spec:
   template:
@@ -14370,7 +14290,6 @@ spec:
       name: istio-grafana-post-install
       labels:
         app: istio-grafana
-        chart: grafana
         release: istio
     spec:
       serviceAccountName: istio-grafana-post-install-account
@@ -14429,7 +14348,6 @@ metadata:
   namespace: istio-system
   labels:
     app: kiali
-    chart: kiali
     release: istio
 
 ---
@@ -14442,7 +14360,6 @@ metadata:
   namespace: istio-system
   labels:
     app: mixer
-    chart: mixer
     release: istio
 
 ---
@@ -14454,7 +14371,6 @@ metadata:
   namespace: istio-system
   labels:
     app: pilot
-    chart: pilot
     release: istio
 
 ---
@@ -14466,7 +14382,6 @@ metadata:
   namespace: istio-system
   labels:
     app: prometheus
-    chart: prometheus
     release: istio
 
 ---
@@ -14491,7 +14406,6 @@ metadata:
     "helm.sh/hook-weight": "1"
   labels:
     app: security
-    chart: security
     release: istio
 ---
 apiVersion: rbac.authorization.k8s.io/v1
@@ -14504,7 +14418,6 @@ metadata:
     "helm.sh/hook-weight": "1"
   labels:
     app: security
-    chart: security
     release: istio
 rules:
 - apiGroups: [""]
@@ -14521,7 +14434,6 @@ metadata:
     "helm.sh/hook-weight": "2"
   labels:
     app: security
-    chart: security
     release: istio
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -14543,7 +14455,6 @@ metadata:
     "helm.sh/hook-weight": "3"
   labels:
     app: security
-    chart: security
     release: istio
 spec:
   template:
@@ -14551,7 +14462,6 @@ spec:
       name: istio-cleanup-secrets
       labels:
         app: security
-        chart: security
         release: istio
     spec:
       serviceAccountName: istio-cleanup-secrets-service-account
@@ -14613,7 +14523,6 @@ metadata:
   namespace: istio-system	
   labels:	
     app: security	
-    chart: security	
     release: istio	
 ---
 apiVersion: rbac.authorization.k8s.io/v1beta1	
@@ -14622,7 +14531,6 @@ metadata:
   name: istio-security-post-install-istio-system	
   labels:	
     app: security	
-    chart: security	
     release: istio	
 rules:	
 - apiGroups: ["authentication.istio.io"] # needed to create default authn policy	
@@ -14644,7 +14552,6 @@ metadata:
   name: istio-security-post-install-role-binding-istio-system	
   labels:	
     app: security	
-    chart: security	
     release: istio	
 roleRef:	
   apiGroup: rbac.authorization.k8s.io	
@@ -14665,7 +14572,6 @@ metadata:
     "helm.sh/hook-delete-policy": hook-succeeded	
   labels:	
     app: security	
-    chart: security	
     release: istio	
 spec:	
   template:	
@@ -14673,7 +14579,6 @@ spec:
       name: istio-security-post-install	
       labels:	
         app: security	
-        chart: security	
         release: istio	
     spec:	
       serviceAccountName: istio-security-post-install-account	
@@ -14733,7 +14638,6 @@ metadata:
   namespace: istio-system
   labels:
     app: security
-    chart: security
     release: istio
 
 ---
@@ -14745,7 +14649,6 @@ metadata:
   namespace: istio-system
   labels:
     app: sidecarInjectorWebhook
-    chart: sidecarInjectorWebhook
     release: istio
     istio: sidecar-injector
 
@@ -14765,7 +14668,6 @@ metadata:
   name: istio-galley-istio-system
   labels:
     app: galley
-    chart: galley
     release: istio
 rules:
 - apiGroups: ["admissionregistration.k8s.io"]
@@ -14807,7 +14709,6 @@ metadata:
   name: istio-egressgateway-istio-system
   labels:
     app: egressgateway
-    chart: gateways
     release: istio
 rules:
 - apiGroups: ["networking.istio.io"]
@@ -14820,7 +14721,6 @@ metadata:
   name: istio-ingressgateway-istio-system
   labels:
     app: ingressgateway
-    chart: gateways
     release: istio
 rules:
 - apiGroups: ["networking.istio.io"]
@@ -14836,7 +14736,6 @@ metadata:
   name: kiali
   labels:
     app: kiali
-    chart: kiali
     release: istio
 rules:
 - apiGroups: [""]
@@ -14960,7 +14859,6 @@ metadata:
   name: kiali-viewer
   labels:
     app: kiali
-    chart: kiali
     release: istio
 rules:
 - apiGroups: [""]
@@ -15077,7 +14975,6 @@ metadata:
   name: istio-mixer-istio-system
   labels:
     app: mixer
-    chart: mixer
     release: istio
 rules:
 - apiGroups: ["config.istio.io"] # istio CRD watcher
@@ -15101,7 +14998,6 @@ metadata:
   name: istio-pilot-istio-system
   labels:
     app: pilot
-    chart: pilot
     release: istio
 rules:
 - apiGroups: ["config.istio.io"]
@@ -15137,7 +15033,6 @@ metadata:
   name: prometheus-istio-system
   labels:
     app: prometheus
-    chart: prometheus
     release: istio
 rules:
 - apiGroups: [""]
@@ -15163,7 +15058,6 @@ metadata:
   name: istio-citadel-istio-system
   labels:
     app: security
-    chart: security
     release: istio
 rules:
 - apiGroups: [""]
@@ -15187,7 +15081,6 @@ metadata:
   name: istio-sidecar-injector-istio-system
   labels:
     app: sidecarInjectorWebhook
-    chart: sidecarInjectorWebhook
     release: istio
     istio: sidecar-injector
 rules:
@@ -15220,7 +15113,6 @@ metadata:
   name: istio-galley-admin-role-binding-istio-system
   labels:
     app: galley
-    chart: galley
     release: istio
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -15240,7 +15132,6 @@ metadata:
   name: istio-egressgateway-istio-system
   labels:
     app: egressgateway
-    chart: gateways
     release: istio
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -15257,7 +15148,6 @@ metadata:
   name: istio-ingressgateway-istio-system
   labels:
     app: ingressgateway
-    chart: gateways
     release: istio
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -15277,7 +15167,6 @@ metadata:
   name: istio-kiali-admin-role-binding-istio-system
   labels:
     app: kiali
-    chart: kiali
     release: istio
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -15297,7 +15186,6 @@ metadata:
   name: istio-mixer-admin-role-binding-istio-system
   labels:
     app: mixer
-    chart: mixer
     release: istio
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -15316,7 +15204,6 @@ metadata:
   name: istio-pilot-istio-system
   labels:
     app: pilot
-    chart: pilot
     release: istio
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -15335,7 +15222,6 @@ metadata:
   name: prometheus-istio-system
   labels:
     app: prometheus
-    chart: prometheus
     release: istio
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -15354,7 +15240,6 @@ metadata:
   name: istio-citadel-istio-system
   labels:
     app: security
-    chart: security
     release: istio
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -15373,7 +15258,6 @@ metadata:
   name: istio-sidecar-injector-admin-role-binding-istio-system
   labels:
     app: sidecarInjectorWebhook
-    chart: sidecarInjectorWebhook
     release: istio
     istio: sidecar-injector
 roleRef:
@@ -15392,7 +15276,6 @@ kind: ClusterRoleBinding
 metadata:
   name: istio-multi
   labels:
-    chart: istio-1.1.0
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
@@ -15442,7 +15325,6 @@ metadata:
   namespace: istio-system
   labels:
     app: galley
-    chart: galley
     release: istio
     istio: galley
 spec:
@@ -15465,7 +15347,6 @@ metadata:
   name: istio-egressgateway
   namespace: istio-system
   labels:
-    chart: gateways
     release: istio
     app: istio-egressgateway
     istio: egressgateway
@@ -15495,7 +15376,6 @@ metadata:
   annotations:
     beta.cloud.google.com/backend-config: '{"ports": {"http2":"iap-backendconfig"}}'
   labels:
-    chart: gateways
     release: istio
     app: istio-ingressgateway
     istio: ingressgateway
@@ -15558,7 +15438,6 @@ metadata:
   namespace: istio-system
   labels:
     app: grafana
-    chart: grafana
     release: istio
 spec:
   type: ClusterIP
@@ -15579,7 +15458,6 @@ metadata:
   namespace: istio-system
   labels:
     app: kiali
-    chart: kiali
     release: istio
 spec:
   ports:
@@ -15601,7 +15479,6 @@ metadata:
    networking.istio.io/exportTo: "*"
   labels:
     app: mixer
-    chart: mixer
     release: istio
     istio: mixer
 spec:
@@ -15625,7 +15502,6 @@ metadata:
    networking.istio.io/exportTo: "*"
   labels:
     app: mixer
-    chart: mixer
     release: istio
     istio: mixer
 spec:
@@ -15653,7 +15529,6 @@ metadata:
   namespace: istio-system
   labels:
     app: pilot
-    chart: pilot
     release: istio
     istio: pilot
 spec:
@@ -15680,7 +15555,6 @@ metadata:
     prometheus.io/scrape: 'true'
   labels:
     app: prometheus
-    chart: prometheus
     release: istio
 spec:
   selector:
@@ -15701,7 +15575,6 @@ metadata:
   namespace: istio-system
   labels:
     app: security
-    chart: security
     release: istio
     istio: citadel
 spec:
@@ -15724,7 +15597,6 @@ metadata:
   namespace: istio-system
   labels:
     app: sidecarInjectorWebhook
-    chart: sidecarInjectorWebhook
     release: istio
     istio: sidecar-injector
 spec:
@@ -15742,7 +15614,6 @@ metadata:
   namespace: istio-system
   labels:
     app: galley
-    chart: galley
     release: istio
     istio: galley
 spec:
@@ -15754,14 +15625,12 @@ spec:
   selector:
     matchLabels:
       app: galley
-      chart: galley
       release: istio      
       istio: galley
   template:
     metadata:
       labels:
         app: galley
-        chart: galley
         release: istio      
         istio: galley
       annotations:
@@ -15875,7 +15744,6 @@ metadata:
   name: istio-egressgateway
   namespace: istio-system
   labels:
-    chart: gateways
     release: istio
     app: istio-egressgateway
     istio: egressgateway
@@ -15883,7 +15751,6 @@ spec:
   template:
     metadata:
       labels:
-        chart: gateways
         release: istio
         app: istio-egressgateway
         istio: egressgateway
@@ -16039,7 +15906,6 @@ metadata:
   name: istio-ingressgateway
   namespace: istio-system
   labels:
-    chart: gateways
     release: istio
     app: istio-ingressgateway
     istio: ingressgateway
@@ -16047,7 +15913,6 @@ spec:
   template:
     metadata:
       labels:
-        chart: gateways
         release: istio
         app: istio-ingressgateway
         istio: ingressgateway
@@ -16213,7 +16078,6 @@ metadata:
   namespace: istio-system
   labels:
     app: grafana
-    chart: grafana
     release: istio
 spec:
   replicas: 1
@@ -16221,7 +16085,6 @@ spec:
     metadata:
       labels:
         app: grafana
-        chart: grafana
         release: istio
       annotations:
         sidecar.istio.io/inject: "false"
@@ -16361,7 +16224,6 @@ metadata:
   namespace: istio-system
   labels:
     app: kiali
-    chart: kiali
     release: istio
 spec:
   replicas: 1
@@ -16373,7 +16235,6 @@ spec:
       name: kiali
       labels:
         app: kiali
-        chart: kiali
         release: istio
       annotations:
         sidecar.istio.io/inject: "false"
@@ -16461,7 +16322,6 @@ metadata:
   namespace: istio-system
   labels:
     app: istio-mixer
-    chart: mixer
     release: istio
     istio: mixer
 spec:
@@ -16477,7 +16337,6 @@ spec:
     metadata:
       labels:
         app: policy
-        chart: mixer
         release: istio
         istio: mixer
         istio-mixer-type: policy
@@ -16631,7 +16490,6 @@ metadata:
   namespace: istio-system
   labels:
     app: istio-mixer
-    chart: mixer
     release: istio
     istio: mixer
 spec:
@@ -16647,7 +16505,6 @@ spec:
     metadata:
       labels:
         app: telemetry
-        chart: mixer
         release: istio
         istio: mixer
         istio-mixer-type: telemetry
@@ -16809,7 +16666,6 @@ metadata:
   # TODO: default template doesn't have this, which one is right ?
   labels:
     app: pilot
-    chart: pilot
     release: istio
     istio: pilot
   annotations:
@@ -16826,7 +16682,6 @@ spec:
     metadata:
       labels:
         app: pilot
-        chart: pilot
         release: istio
         istio: pilot
       annotations:
@@ -16988,7 +16843,6 @@ metadata:
   namespace: istio-system
   labels:
     app: prometheus
-    chart: prometheus
     release: istio
 spec:
   replicas: 1
@@ -16999,7 +16853,6 @@ spec:
     metadata:
       labels:
         app: prometheus
-        chart: prometheus
         release: istio
       annotations:
         sidecar.istio.io/inject: "false"
@@ -17084,7 +16937,6 @@ metadata:
   namespace: istio-system
   labels:
     app: security
-    chart: security
     release: istio
     istio: citadel
 spec:
@@ -17097,7 +16949,6 @@ spec:
     metadata:
       labels:
         app: security
-        chart: security
         release: istio
         istio: citadel
       annotations:
@@ -17169,7 +17020,6 @@ metadata:
   namespace: istio-system
   labels:
     app: sidecarInjectorWebhook
-    chart: sidecarInjectorWebhook
     release: istio
     istio: sidecar-injector
 spec:
@@ -17182,7 +17032,6 @@ spec:
     metadata:
       labels:
         app: sidecarInjectorWebhook
-        chart: sidecarInjectorWebhook
         release: istio
         istio: sidecar-injector
       annotations:
@@ -17291,14 +17140,12 @@ metadata:
   namespace: istio-system
   labels:
     app: jaeger
-    chart: tracing
     release: istio
 spec:
   template:
     metadata:
       labels:
         app: jaeger
-        chart: tracing
         release: istio
       annotations:
         sidecar.istio.io/inject: "false"
@@ -17388,7 +17235,6 @@ metadata:
   namespace: istio-system
   labels:
     app: egressgateway
-    chart: gateways
     release: istio
 spec:
   maxReplicas: 5
@@ -17410,7 +17256,6 @@ metadata:
   namespace: istio-system
   labels:
     app: ingressgateway
-    chart: gateways
     release: istio
 spec:
   maxReplicas: 5
@@ -17436,7 +17281,6 @@ metadata:
   namespace: istio-system
   labels:
     app: mixer
-    chart: mixer
     release: istio
 spec:
     maxReplicas: 5
@@ -17458,7 +17302,6 @@ metadata:
   namespace: istio-system
   labels:
     app: mixer
-    chart: mixer
     release: istio
 spec:
     maxReplicas: 5
@@ -17484,7 +17327,6 @@ metadata:
   namespace: istio-system
   labels:
     app: pilot
-    chart: pilot
     release: istio
 spec:
   maxReplicas: 5
@@ -17512,7 +17354,6 @@ metadata:
   labels:
     app: jaeger
     jaeger-infra: jaeger-service
-    chart: tracing
     release: istio
 spec:
   ports:
@@ -17533,7 +17374,6 @@ metadata:
   labels:
     app: jaeger
     jaeger-infra: collector-service
-    chart: tracing
     release: istio
 spec:
   ports:
@@ -17557,7 +17397,6 @@ metadata:
   labels:
     app: jaeger
     jaeger-infra: agent-service
-    chart: tracing
     release: istio
 spec:
   ports:
@@ -17588,7 +17427,6 @@ metadata:
   namespace: istio-system
   labels:
     app: jaeger
-    chart: tracing
     release: istio
 spec:
   type: ClusterIP
@@ -17608,7 +17446,6 @@ metadata:
   annotations:
   labels:
     app: jaeger
-    chart: tracing
     release: istio
 spec:
   ports:
@@ -17630,7 +17467,6 @@ metadata:
   namespace: istio-system
   labels:
     app: sidecarInjectorWebhook
-    chart: sidecarInjectorWebhook
     release: istio
 webhooks:
   - name: sidecar-injector.istio.io
@@ -17661,7 +17497,6 @@ metadata:
   namespace: istio-system
   labels:
     app: galley
-    chart: galley
     release: istio
     istio: galley
 spec:
@@ -17682,7 +17517,6 @@ metadata:
   name: istio-egressgateway
   namespace: istio-system
   labels:
-    chart: gateways
     release: istio
     app: istio-egressgateway
     istio: egressgateway
@@ -17701,7 +17535,6 @@ metadata:
   name: istio-ingressgateway
   namespace: istio-system
   labels:
-    chart: gateways
     release: istio
     app: istio-ingressgateway
     istio: ingressgateway
@@ -17725,7 +17558,6 @@ metadata:
   namespace: istio-system
   labels:
     app: policy
-    chart: mixer
     release: istio
     version: 1.1.0
     istio: mixer
@@ -17747,7 +17579,6 @@ metadata:
   namespace: istio-system
   labels:
     app: telemetry
-    chart: mixer
     release: istio
     version: 1.1.0
     istio: mixer
@@ -17773,7 +17604,6 @@ metadata:
   namespace: istio-system
   labels:
     app: pilot
-    chart: pilot
     release: istio
     istio: pilot
 spec:
@@ -17794,7 +17624,6 @@ metadata:
   namespace: istio-system
   labels:
     app: mixer
-    chart: mixer
     release: istio
 spec:
   attributes:
@@ -17934,7 +17763,6 @@ metadata:
   namespace: istio-system
   labels:
     app: mixer
-    chart: mixer
     release: istio
 spec:
   attributes:
@@ -17998,7 +17826,6 @@ metadata:
   namespace: istio-system
   labels:
     app: mixer
-    chart: mixer
     release: istio
 spec:
   compiledAdapter: stdio
@@ -18012,7 +17839,6 @@ metadata:
   namespace: istio-system
   labels:
     app: mixer
-    chart: mixer
     release: istio
 spec:
   severity: '"Info"'
@@ -18068,7 +17894,6 @@ metadata:
   namespace: istio-system
   labels:
     app: mixer
-    chart: mixer
     release: istio
 spec:
   severity: '"Info"'
@@ -18109,7 +17934,6 @@ metadata:
   namespace: istio-system
   labels:
     app: mixer
-    chart: mixer
     release: istio
 spec:
   match: context.protocol == "http" || context.protocol == "grpc"
@@ -18125,7 +17949,6 @@ metadata:
   namespace: istio-system
   labels:
     app: mixer
-    chart: mixer
     release: istio
 spec:
   match: context.protocol == "tcp"
@@ -18141,7 +17964,6 @@ metadata:
   namespace: istio-system
   labels:
     app: mixer
-    chart: mixer
     release: istio
 spec:
   value: "1"
@@ -18175,7 +17997,6 @@ metadata:
   namespace: istio-system
   labels:
     app: mixer
-    chart: mixer
     release: istio
 spec:
   value: response.duration | "0ms"
@@ -18209,7 +18030,6 @@ metadata:
   namespace: istio-system
   labels:
     app: mixer
-    chart: mixer
     release: istio
 spec:
   value: request.size | 0
@@ -18243,7 +18063,6 @@ metadata:
   namespace: istio-system
   labels:
     app: mixer
-    chart: mixer
     release: istio
 spec:
   value: response.size | 0
@@ -18277,7 +18096,6 @@ metadata:
   namespace: istio-system
   labels:
     app: mixer
-    chart: mixer
     release: istio
 spec:
   value: connection.sent.bytes | 0
@@ -18307,7 +18125,6 @@ metadata:
   namespace: istio-system
   labels:
     app: mixer
-    chart: mixer
     release: istio
 spec:
   value: connection.received.bytes | 0
@@ -18337,7 +18154,6 @@ metadata:
   namespace: istio-system
   labels:
     app: mixer
-    chart: mixer
     release: istio
 spec:
   value: "1"
@@ -18367,7 +18183,6 @@ metadata:
   namespace: istio-system
   labels:
     app: mixer
-    chart: mixer
     release: istio
 spec:
   value: "1"
@@ -18397,7 +18212,6 @@ metadata:
   namespace: istio-system
   labels:
     app: mixer
-    chart: mixer
     release: istio
 spec:
   compiledAdapter: prometheus
@@ -18602,7 +18416,6 @@ metadata:
   namespace: istio-system
   labels:
     app: mixer
-    chart: mixer
     release: istio
 spec:
   match: (context.protocol == "http" || context.protocol == "grpc") && (match((request.useragent | "-"), "kube-probe*") == false)
@@ -18621,7 +18434,6 @@ metadata:
   namespace: istio-system
   labels:
     app: mixer
-    chart: mixer
     release: istio
 spec:
   match: context.protocol == "tcp"
@@ -18638,7 +18450,6 @@ metadata:
   namespace: istio-system
   labels:
     app: mixer
-    chart: mixer
     release: istio
 spec:
   match: context.protocol == "tcp" && ((connection.event | "na") == "open")
@@ -18654,7 +18465,6 @@ metadata:
   namespace: istio-system
   labels:
     app: mixer
-    chart: mixer
     release: istio
 spec:
   match: context.protocol == "tcp" && ((connection.event | "na") == "close")
@@ -18670,7 +18480,6 @@ metadata:
   namespace: istio-system
   labels:
     app: mixer
-    chart: mixer
     release: istio
 spec:
   compiledAdapter: kubernetesenv
@@ -18690,7 +18499,6 @@ metadata:
   namespace: istio-system
   labels:
     app: mixer
-    chart: mixer
     release: istio
 spec:
   actions:
@@ -18705,7 +18513,6 @@ metadata:
   namespace: istio-system
   labels:
     app: mixer
-    chart: mixer
     release: istio
 spec:
   match: context.protocol == "tcp"
@@ -18721,7 +18528,6 @@ metadata:
   namespace: istio-system
   labels:
     app: mixer
-    chart: mixer
     release: istio
 spec:
   # Pass the required attribute data to the adapter
@@ -18764,7 +18570,6 @@ metadata:
   namespace: istio-system
   labels:
     app: mixer
-    chart: mixer
     release: istio
 spec:
   host: istio-policy.istio-system.svc.cluster.local
@@ -18781,7 +18586,6 @@ metadata:
   namespace: istio-system
   labels:
     app: mixer
-    chart: mixer
     release: istio
 spec:
   host: istio-telemetry.istio-system.svc.cluster.local

--- a/kfdef/generic/istio/istio-noauth.yaml
+++ b/kfdef/generic/istio/istio-noauth.yaml
@@ -12,7 +12,6 @@ metadata:
   labels:
     app: istio-pilot
     chart: istio
-    heritage: Tiller
     release: istio
   annotations:
     "helm.sh/resource-policy": keep
@@ -54,7 +53,6 @@ metadata:
   labels:
     app: istio-pilot
     chart: istio
-    heritage: Tiller
     release: istio
   annotations:
     "helm.sh/resource-policy": keep
@@ -92,7 +90,6 @@ metadata:
   labels:
     app: istio-pilot
     chart: istio
-    heritage: Tiller
     release: istio
   annotations:
     "helm.sh/resource-policy": keep
@@ -138,7 +135,6 @@ metadata:
   labels:
     app: istio-pilot
     chart: istio
-    heritage: Tiller
     release: istio
   annotations:
     "helm.sh/resource-policy": keep
@@ -163,7 +159,6 @@ metadata:
   labels:
     app: istio-pilot
     chart: istio
-    heritage: Tiller
     release: istio
   annotations:
     "helm.sh/resource-policy": keep
@@ -186,7 +181,6 @@ metadata:
   labels:
     app: istio-pilot
     istio: rbac
-    heritage: Tiller
     release: istio
   annotations:
     "helm.sh/resource-policy": keep
@@ -209,7 +203,6 @@ metadata:
   labels:
     app: istio-citadel
     chart: istio
-    heritage: Tiller
     release: istio
   annotations:
     "helm.sh/resource-policy": keep
@@ -232,7 +225,6 @@ metadata:
   labels:
     app: istio-citadel
     chart: istio
-    heritage: Tiller
     release: istio
   annotations:
     "helm.sh/resource-policy": keep
@@ -256,7 +248,6 @@ metadata:
   labels:
     app: istio-mixer
     chart: istio
-    heritage: Tiller
     release: istio
   annotations:
     "helm.sh/resource-policy": keep
@@ -279,7 +270,6 @@ metadata:
   labels:
     app: istio-mixer
     chart: istio
-    heritage: Tiller
     release: istio
   annotations:
     "helm.sh/resource-policy": keep
@@ -302,7 +292,6 @@ metadata:
   labels:
     app: istio-mixer
     chart: istio
-    heritage: Tiller
     release: istio
   annotations:
     "helm.sh/resource-policy": keep
@@ -325,7 +314,6 @@ metadata:
   labels:
     app: istio-mixer
     chart: istio
-    heritage: Tiller
     release: istio
   annotations:
     "helm.sh/resource-policy": keep
@@ -350,7 +338,6 @@ metadata:
     package: istio.io.mixer
     istio: core
     chart: istio
-    heritage: Tiller
     release: istio
   annotations:
     "helm.sh/resource-policy": keep
@@ -375,7 +362,6 @@ metadata:
     package: istio.io.mixer
     istio: core
     chart: istio
-    heritage: Tiller
     release: istio
   annotations:
     "helm.sh/resource-policy": keep
@@ -400,7 +386,6 @@ metadata:
     package: bypass
     istio: mixer-adapter
     chart: istio
-    heritage: Tiller
     release: istio
   annotations:
     "helm.sh/resource-policy": keep
@@ -425,7 +410,6 @@ metadata:
     package: circonus
     istio: mixer-adapter
     chart: istio
-    heritage: Tiller
     release: istio
   annotations:
     "helm.sh/resource-policy": keep
@@ -450,7 +434,6 @@ metadata:
     package: denier
     istio: mixer-adapter
     chart: istio
-    heritage: Tiller
     release: istio
   annotations:
     "helm.sh/resource-policy": keep
@@ -475,7 +458,6 @@ metadata:
     package: fluentd
     istio: mixer-adapter
     chart: istio
-    heritage: Tiller
     release: istio
   annotations:
     "helm.sh/resource-policy": keep
@@ -500,7 +482,6 @@ metadata:
     package: kubernetesenv
     istio: mixer-adapter
     chart: istio
-    heritage: Tiller
     release: istio
   annotations:
     "helm.sh/resource-policy": keep
@@ -525,7 +506,6 @@ metadata:
     package: listchecker
     istio: mixer-adapter
     chart: istio
-    heritage: Tiller
     release: istio
   annotations:
     "helm.sh/resource-policy": keep
@@ -550,7 +530,6 @@ metadata:
     package: memquota
     istio: mixer-adapter
     chart: istio
-    heritage: Tiller
     release: istio
   annotations:
     "helm.sh/resource-policy": keep
@@ -575,7 +554,6 @@ metadata:
     package: noop
     istio: mixer-adapter
     chart: istio
-    heritage: Tiller
     release: istio
   annotations:
     "helm.sh/resource-policy": keep
@@ -600,7 +578,6 @@ metadata:
     package: opa
     istio: mixer-adapter
     chart: istio
-    heritage: Tiller
     release: istio
   annotations:
     "helm.sh/resource-policy": keep
@@ -625,7 +602,6 @@ metadata:
     package: prometheus
     istio: mixer-adapter
     chart: istio
-    heritage: Tiller
     release: istio
   annotations:
     "helm.sh/resource-policy": keep
@@ -650,7 +626,6 @@ metadata:
     package: rbac
     istio: mixer-adapter
     chart: istio
-    heritage: Tiller
     release: istio
   annotations:
     "helm.sh/resource-policy": keep
@@ -675,7 +650,6 @@ metadata:
     package: redisquota
     istio: mixer-adapter
     chart: istio
-    heritage: Tiller
     release: istio
   annotations:
     "helm.sh/resource-policy": keep
@@ -697,7 +671,6 @@ metadata:
     package: signalfx
     istio: mixer-adapter
     chart: istio
-    heritage: Tiller
     release: istio
   annotations:
     "helm.sh/resource-policy": keep
@@ -722,7 +695,6 @@ metadata:
     package: solarwinds
     istio: mixer-adapter
     chart: istio
-    heritage: Tiller
     release: istio
   annotations:
     "helm.sh/resource-policy": keep
@@ -747,7 +719,6 @@ metadata:
     package: stackdriver
     istio: mixer-adapter
     chart: istio
-    heritage: Tiller
     release: istio
   annotations:
     "helm.sh/resource-policy": keep
@@ -772,7 +743,6 @@ metadata:
     package: statsd
     istio: mixer-adapter
     chart: istio
-    heritage: Tiller
     release: istio
   annotations:
     "helm.sh/resource-policy": keep
@@ -797,7 +767,6 @@ metadata:
     package: stdio
     istio: mixer-adapter
     chart: istio
-    heritage: Tiller
     release: istio
   annotations:
     "helm.sh/resource-policy": keep
@@ -822,7 +791,6 @@ metadata:
     package: apikey
     istio: mixer-instance
     chart: istio
-    heritage: Tiller
     release: istio
   annotations:
     "helm.sh/resource-policy": keep
@@ -847,7 +815,6 @@ metadata:
     package: authorization
     istio: mixer-instance
     chart: istio
-    heritage: Tiller
     release: istio
   annotations:
     "helm.sh/resource-policy": keep
@@ -872,7 +839,6 @@ metadata:
     package: checknothing
     istio: mixer-instance
     chart: istio
-    heritage: Tiller
     release: istio
   annotations:
     "helm.sh/resource-policy": keep
@@ -897,7 +863,6 @@ metadata:
     package: adapter.template.kubernetes
     istio: mixer-instance
     chart: istio
-    heritage: Tiller
     release: istio
   annotations:
     "helm.sh/resource-policy": keep
@@ -922,7 +887,6 @@ metadata:
     package: listentry
     istio: mixer-instance
     chart: istio
-    heritage: Tiller
     release: istio
   annotations:
     "helm.sh/resource-policy": keep
@@ -947,7 +911,6 @@ metadata:
     package: logentry
     istio: mixer-instance
     chart: istio
-    heritage: Tiller
     release: istio
   annotations:
     "helm.sh/resource-policy": keep
@@ -992,7 +955,6 @@ metadata:
     package: edge
     istio: mixer-instance
     chart: istio
-    heritage: Tiller
     release: istio
   annotations:
     "helm.sh/resource-policy": keep
@@ -1017,7 +979,6 @@ metadata:
     package: metric
     istio: mixer-instance
     chart: istio
-    heritage: Tiller
     release: istio
   annotations:
     "helm.sh/resource-policy": keep
@@ -1042,7 +1003,6 @@ metadata:
     package: quota
     istio: mixer-instance
     chart: istio
-    heritage: Tiller
     release: istio
   annotations:
     "helm.sh/resource-policy": keep
@@ -1067,7 +1027,6 @@ metadata:
     package: reportnothing
     istio: mixer-instance
     chart: istio
-    heritage: Tiller
     release: istio
   annotations:
     "helm.sh/resource-policy": keep
@@ -1092,7 +1051,6 @@ metadata:
     package: tracespan
     istio: mixer-instance
     chart: istio
-    heritage: Tiller
     release: istio
   annotations:
     "helm.sh/resource-policy": keep
@@ -1117,7 +1075,6 @@ metadata:
     package: istio.io.mixer
     istio: rbac
     chart: istio
-    heritage: Tiller
     release: istio
   annotations:
     "helm.sh/resource-policy": keep
@@ -1142,7 +1099,6 @@ metadata:
     package: istio.io.mixer
     istio: rbac
     chart: istio
-    heritage: Tiller
     release: istio
   annotations:
     "helm.sh/resource-policy": keep
@@ -1167,7 +1123,6 @@ metadata:
     package: istio.io.mixer
     istio: rbac
     chart: istio
-    heritage: Tiller
     release: istio
   annotations:
     "helm.sh/resource-policy": keep
@@ -1204,7 +1159,6 @@ metadata:
     package: adapter
     istio: mixer-adapter
     chart: istio
-    heritage: Tiller
     release: istio
   annotations:
     "helm.sh/resource-policy": keep
@@ -1229,7 +1183,6 @@ metadata:
     package: instance
     istio: mixer-instance
     chart: istio
-    heritage: Tiller
     release: istio
   annotations:
     "helm.sh/resource-policy": keep
@@ -1254,7 +1207,6 @@ metadata:
     package: template
     istio: mixer-template
     chart: istio
-    heritage: Tiller
     release: istio
   annotations:
     "helm.sh/resource-policy": keep
@@ -1279,7 +1231,6 @@ metadata:
     package: handler
     istio: mixer-handler
     chart: istio
-    heritage: Tiller
     release: istio
   annotations:
     "helm.sh/resource-policy": keep
@@ -1346,7 +1297,6 @@ metadata:
   labels:
     app: istio-pilot
     chart: istio
-    heritage: Tiller
     release: istio
   annotations:
     "helm.sh/resource-policy": keep
@@ -1391,7 +1341,6 @@ metadata:
   labels:
     app: certmanager
     chart: certmanager
-    heritage: Tiller
     release: istio
   annotations:
     "helm.sh/resource-policy": keep
@@ -1410,7 +1359,6 @@ metadata:
   labels:
     app: certmanager
     chart: certmanager
-    heritage: Tiller
     release: istio
   annotations:
     "helm.sh/resource-policy": keep
@@ -1429,7 +1377,6 @@ metadata:
   labels:
     app: certmanager
     chart: certmanager
-    heritage: Tiller
     release: istio
   annotations:
     "helm.sh/resource-policy": keep
@@ -1472,7 +1419,6 @@ metadata:
   labels:
     app: certmanager
     chart: certmanager
-    heritage: Tiller
     release: istio
   annotations:
     "helm.sh/resource-policy": keep
@@ -1510,7 +1456,6 @@ metadata:
   labels:
     app: certmanager
     chart: certmanager
-    heritage: Tiller
     release: istio
   annotations:
     "helm.sh/resource-policy": keep
@@ -1549,7 +1494,6 @@ metadata:
   labels:
     app: kiali
     chart: kiali
-    heritage: Tiller
     release: istio
 type: Opaque
 data:
@@ -1566,7 +1510,6 @@ metadata:
   labels:
     app: galley
     chart: galley
-    heritage: Tiller
     release: istio
     istio: galley
 data:
@@ -1579,7 +1522,6 @@ data:
       labels:
         app: galley
         chart: galley
-        heritage: Tiller
         release: istio
         istio: galley
     webhooks:
@@ -1691,7 +1633,6 @@ metadata:
   labels:
     app: grafana
     chart: grafana
-    heritage: Tiller
     release: istio
     istio: grafana
 data:
@@ -1704,7 +1645,6 @@ data:
       labels:
         app: grafana
         chart: grafana
-        heritage: Tiller
         release: istio
     spec:
       targets:
@@ -1755,7 +1695,6 @@ metadata:
   labels:
     app: grafana
     chart: grafana
-    heritage: Tiller
     release: istio
     istio: grafana
 data:
@@ -3588,7 +3527,6 @@ metadata:
   labels:
     app: grafana
     chart: grafana
-    heritage: Tiller
     release: istio
     istio: grafana
 data:
@@ -4555,7 +4493,6 @@ metadata:
   labels:
     app: grafana
     chart: grafana
-    heritage: Tiller
     release: istio
     istio: grafana
 data:
@@ -5186,7 +5123,6 @@ metadata:
   labels:
     app: grafana
     chart: grafana
-    heritage: Tiller
     release: istio
     istio: grafana
 data:
@@ -7801,7 +7737,6 @@ metadata:
   labels:
     app: grafana
     chart: grafana
-    heritage: Tiller
     release: istio
     istio: grafana
 data:
@@ -10118,7 +10053,6 @@ metadata:
   labels:
     app: grafana
     chart: grafana
-    heritage: Tiller
     release: istio
     istio: grafana
 data:
@@ -11940,7 +11874,6 @@ metadata:
   labels:
     app: grafana
     chart: grafana
-    heritage: Tiller
     release: istio
     istio: grafana
 data:
@@ -13552,7 +13485,6 @@ metadata:
   labels:
     app: grafana
     chart: grafana
-    heritage: Tiller
     release: istio
     istio: grafana
 data:
@@ -13590,7 +13522,6 @@ metadata:
   labels:
     app: kiali
     chart: kiali
-    heritage: Tiller
     release: istio
 data:
   config.yaml: |
@@ -13615,7 +13546,6 @@ metadata:
   labels:
     app: prometheus
     chart: prometheus
-    heritage: Tiller
     release: istio
 data:
   prometheus.yml: |-
@@ -13930,7 +13860,6 @@ metadata:
   labels:	
     app: security	
     chart: security	
-    heritage: Tiller	
     release: istio	
     istio: citadel	
 data:	
@@ -13943,7 +13872,6 @@ data:
       labels:
         app: security
         chart: security
-        heritage: Tiller
         release: istio
     spec:
       peers:
@@ -13993,7 +13921,6 @@ metadata:
   labels:
     app: istio
     chart: istio
-    heritage: Tiller
     release: istio
 data:
   mesh: |-
@@ -14138,7 +14065,6 @@ metadata:
   labels:
     app: istio
     chart: istio
-    heritage: Tiller
     release: istio
     istio: sidecar-injector
 data:
@@ -14357,7 +14283,6 @@ metadata:
   labels:
     app: galley
     chart: galley
-    heritage: Tiller
     release: istio
 
 ---
@@ -14371,7 +14296,6 @@ metadata:
   labels:
     app: istio-egressgateway
     chart: gateways
-    heritage: Tiller
     release: istio
 ---
 apiVersion: v1
@@ -14382,7 +14306,6 @@ metadata:
   labels:
     app: istio-ingressgateway
     chart: gateways
-    heritage: Tiller
     release: istio
 ---
 
@@ -14397,7 +14320,6 @@ metadata:
   labels:
     app: grafana
     chart: grafana
-    heritage: Tiller
     release: istio
 ---
 apiVersion: rbac.authorization.k8s.io/v1
@@ -14407,7 +14329,6 @@ metadata:
   labels:
     app: grafana
     chart: grafana
-    heritage: Tiller
     release: istio
 rules:
 - apiGroups: ["authentication.istio.io"] # needed to create default authn policy
@@ -14421,7 +14342,6 @@ metadata:
   labels:
     app: grafana
     chart: grafana
-    heritage: Tiller
     release: istio
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -14443,7 +14363,6 @@ metadata:
   labels:
     app: grafana
     chart: grafana
-    heritage: Tiller
     release: istio
 spec:
   template:
@@ -14452,7 +14371,6 @@ spec:
       labels:
         app: istio-grafana
         chart: grafana
-        heritage: Tiller
         release: istio
     spec:
       serviceAccountName: istio-grafana-post-install-account
@@ -14512,7 +14430,6 @@ metadata:
   labels:
     app: kiali
     chart: kiali
-    heritage: Tiller
     release: istio
 
 ---
@@ -14526,7 +14443,6 @@ metadata:
   labels:
     app: mixer
     chart: mixer
-    heritage: Tiller
     release: istio
 
 ---
@@ -14539,7 +14455,6 @@ metadata:
   labels:
     app: pilot
     chart: pilot
-    heritage: Tiller
     release: istio
 
 ---
@@ -14552,7 +14467,6 @@ metadata:
   labels:
     app: prometheus
     chart: prometheus
-    heritage: Tiller
     release: istio
 
 ---
@@ -14578,7 +14492,6 @@ metadata:
   labels:
     app: security
     chart: security
-    heritage: Tiller
     release: istio
 ---
 apiVersion: rbac.authorization.k8s.io/v1
@@ -14592,7 +14505,6 @@ metadata:
   labels:
     app: security
     chart: security
-    heritage: Tiller
     release: istio
 rules:
 - apiGroups: [""]
@@ -14610,7 +14522,6 @@ metadata:
   labels:
     app: security
     chart: security
-    heritage: Tiller
     release: istio
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -14633,7 +14544,6 @@ metadata:
   labels:
     app: security
     chart: security
-    heritage: Tiller
     release: istio
 spec:
   template:
@@ -14642,7 +14552,6 @@ spec:
       labels:
         app: security
         chart: security
-        heritage: Tiller
         release: istio
     spec:
       serviceAccountName: istio-cleanup-secrets-service-account
@@ -14705,7 +14614,6 @@ metadata:
   labels:	
     app: security	
     chart: security	
-    heritage: Tiller	
     release: istio	
 ---
 apiVersion: rbac.authorization.k8s.io/v1beta1	
@@ -14715,7 +14623,6 @@ metadata:
   labels:	
     app: security	
     chart: security	
-    heritage: Tiller	
     release: istio	
 rules:	
 - apiGroups: ["authentication.istio.io"] # needed to create default authn policy	
@@ -14738,7 +14645,6 @@ metadata:
   labels:	
     app: security	
     chart: security	
-    heritage: Tiller	
     release: istio	
 roleRef:	
   apiGroup: rbac.authorization.k8s.io	
@@ -14760,7 +14666,6 @@ metadata:
   labels:	
     app: security	
     chart: security	
-    heritage: Tiller	
     release: istio	
 spec:	
   template:	
@@ -14769,7 +14674,6 @@ spec:
       labels:	
         app: security	
         chart: security	
-        heritage: Tiller	
         release: istio	
     spec:	
       serviceAccountName: istio-security-post-install-account	
@@ -14830,7 +14734,6 @@ metadata:
   labels:
     app: security
     chart: security
-    heritage: Tiller
     release: istio
 
 ---
@@ -14843,7 +14746,6 @@ metadata:
   labels:
     app: sidecarInjectorWebhook
     chart: sidecarInjectorWebhook
-    heritage: Tiller
     release: istio
     istio: sidecar-injector
 
@@ -14864,7 +14766,6 @@ metadata:
   labels:
     app: galley
     chart: galley
-    heritage: Tiller
     release: istio
 rules:
 - apiGroups: ["admissionregistration.k8s.io"]
@@ -14907,7 +14808,6 @@ metadata:
   labels:
     app: egressgateway
     chart: gateways
-    heritage: Tiller
     release: istio
 rules:
 - apiGroups: ["networking.istio.io"]
@@ -14921,7 +14821,6 @@ metadata:
   labels:
     app: ingressgateway
     chart: gateways
-    heritage: Tiller
     release: istio
 rules:
 - apiGroups: ["networking.istio.io"]
@@ -14938,7 +14837,6 @@ metadata:
   labels:
     app: kiali
     chart: kiali
-    heritage: Tiller
     release: istio
 rules:
 - apiGroups: [""]
@@ -15063,7 +14961,6 @@ metadata:
   labels:
     app: kiali
     chart: kiali
-    heritage: Tiller
     release: istio
 rules:
 - apiGroups: [""]
@@ -15181,7 +15078,6 @@ metadata:
   labels:
     app: mixer
     chart: mixer
-    heritage: Tiller
     release: istio
 rules:
 - apiGroups: ["config.istio.io"] # istio CRD watcher
@@ -15206,7 +15102,6 @@ metadata:
   labels:
     app: pilot
     chart: pilot
-    heritage: Tiller
     release: istio
 rules:
 - apiGroups: ["config.istio.io"]
@@ -15243,7 +15138,6 @@ metadata:
   labels:
     app: prometheus
     chart: prometheus
-    heritage: Tiller
     release: istio
 rules:
 - apiGroups: [""]
@@ -15270,7 +15164,6 @@ metadata:
   labels:
     app: security
     chart: security
-    heritage: Tiller
     release: istio
 rules:
 - apiGroups: [""]
@@ -15295,7 +15188,6 @@ metadata:
   labels:
     app: sidecarInjectorWebhook
     chart: sidecarInjectorWebhook
-    heritage: Tiller
     release: istio
     istio: sidecar-injector
 rules:
@@ -15329,7 +15221,6 @@ metadata:
   labels:
     app: galley
     chart: galley
-    heritage: Tiller
     release: istio
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -15350,7 +15241,6 @@ metadata:
   labels:
     app: egressgateway
     chart: gateways
-    heritage: Tiller
     release: istio
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -15368,7 +15258,6 @@ metadata:
   labels:
     app: ingressgateway
     chart: gateways
-    heritage: Tiller
     release: istio
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -15389,7 +15278,6 @@ metadata:
   labels:
     app: kiali
     chart: kiali
-    heritage: Tiller
     release: istio
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -15410,7 +15298,6 @@ metadata:
   labels:
     app: mixer
     chart: mixer
-    heritage: Tiller
     release: istio
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -15430,7 +15317,6 @@ metadata:
   labels:
     app: pilot
     chart: pilot
-    heritage: Tiller
     release: istio
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -15450,7 +15336,6 @@ metadata:
   labels:
     app: prometheus
     chart: prometheus
-    heritage: Tiller
     release: istio
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -15470,7 +15355,6 @@ metadata:
   labels:
     app: security
     chart: security
-    heritage: Tiller
     release: istio
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -15490,7 +15374,6 @@ metadata:
   labels:
     app: sidecarInjectorWebhook
     chart: sidecarInjectorWebhook
-    heritage: Tiller
     release: istio
     istio: sidecar-injector
 roleRef:
@@ -15560,7 +15443,6 @@ metadata:
   labels:
     app: galley
     chart: galley
-    heritage: Tiller
     release: istio
     istio: galley
 spec:
@@ -15584,7 +15466,6 @@ metadata:
   namespace: istio-system
   labels:
     chart: gateways
-    heritage: Tiller
     release: istio
     app: istio-egressgateway
     istio: egressgateway
@@ -15615,7 +15496,6 @@ metadata:
     beta.cloud.google.com/backend-config: '{"ports": {"http2":"iap-backendconfig"}}'
   labels:
     chart: gateways
-    heritage: Tiller
     release: istio
     app: istio-ingressgateway
     istio: ingressgateway
@@ -15679,7 +15559,6 @@ metadata:
   labels:
     app: grafana
     chart: grafana
-    heritage: Tiller
     release: istio
 spec:
   type: ClusterIP
@@ -15701,7 +15580,6 @@ metadata:
   labels:
     app: kiali
     chart: kiali
-    heritage: Tiller
     release: istio
 spec:
   ports:
@@ -15724,7 +15602,6 @@ metadata:
   labels:
     app: mixer
     chart: mixer
-    heritage: Tiller
     release: istio
     istio: mixer
 spec:
@@ -15749,7 +15626,6 @@ metadata:
   labels:
     app: mixer
     chart: mixer
-    heritage: Tiller
     release: istio
     istio: mixer
 spec:
@@ -15778,7 +15654,6 @@ metadata:
   labels:
     app: pilot
     chart: pilot
-    heritage: Tiller
     release: istio
     istio: pilot
 spec:
@@ -15806,7 +15681,6 @@ metadata:
   labels:
     app: prometheus
     chart: prometheus
-    heritage: Tiller
     release: istio
 spec:
   selector:
@@ -15828,7 +15702,6 @@ metadata:
   labels:
     app: security
     chart: security
-    heritage: Tiller
     release: istio
     istio: citadel
 spec:
@@ -15852,7 +15725,6 @@ metadata:
   labels:
     app: sidecarInjectorWebhook
     chart: sidecarInjectorWebhook
-    heritage: Tiller
     release: istio
     istio: sidecar-injector
 spec:
@@ -15871,7 +15743,6 @@ metadata:
   labels:
     app: galley
     chart: galley
-    heritage: Tiller
     release: istio
     istio: galley
 spec:
@@ -15884,7 +15755,6 @@ spec:
     matchLabels:
       app: galley
       chart: galley
-      heritage: Tiller
       release: istio      
       istio: galley
   template:
@@ -15892,7 +15762,6 @@ spec:
       labels:
         app: galley
         chart: galley
-        heritage: Tiller
         release: istio      
         istio: galley
       annotations:
@@ -16007,7 +15876,6 @@ metadata:
   namespace: istio-system
   labels:
     chart: gateways
-    heritage: Tiller
     release: istio
     app: istio-egressgateway
     istio: egressgateway
@@ -16016,7 +15884,6 @@ spec:
     metadata:
       labels:
         chart: gateways
-        heritage: Tiller
         release: istio
         app: istio-egressgateway
         istio: egressgateway
@@ -16173,7 +16040,6 @@ metadata:
   namespace: istio-system
   labels:
     chart: gateways
-    heritage: Tiller
     release: istio
     app: istio-ingressgateway
     istio: ingressgateway
@@ -16182,7 +16048,6 @@ spec:
     metadata:
       labels:
         chart: gateways
-        heritage: Tiller
         release: istio
         app: istio-ingressgateway
         istio: ingressgateway
@@ -16349,7 +16214,6 @@ metadata:
   labels:
     app: grafana
     chart: grafana
-    heritage: Tiller
     release: istio
 spec:
   replicas: 1
@@ -16358,7 +16222,6 @@ spec:
       labels:
         app: grafana
         chart: grafana
-        heritage: Tiller
         release: istio
       annotations:
         sidecar.istio.io/inject: "false"
@@ -16499,7 +16362,6 @@ metadata:
   labels:
     app: kiali
     chart: kiali
-    heritage: Tiller
     release: istio
 spec:
   replicas: 1
@@ -16512,7 +16374,6 @@ spec:
       labels:
         app: kiali
         chart: kiali
-        heritage: Tiller
         release: istio
       annotations:
         sidecar.istio.io/inject: "false"
@@ -16601,7 +16462,6 @@ metadata:
   labels:
     app: istio-mixer
     chart: mixer
-    heritage: Tiller
     release: istio
     istio: mixer
 spec:
@@ -16618,7 +16478,6 @@ spec:
       labels:
         app: policy
         chart: mixer
-        heritage: Tiller
         release: istio
         istio: mixer
         istio-mixer-type: policy
@@ -16773,7 +16632,6 @@ metadata:
   labels:
     app: istio-mixer
     chart: mixer
-    heritage: Tiller
     release: istio
     istio: mixer
 spec:
@@ -16790,7 +16648,6 @@ spec:
       labels:
         app: telemetry
         chart: mixer
-        heritage: Tiller
         release: istio
         istio: mixer
         istio-mixer-type: telemetry
@@ -16953,7 +16810,6 @@ metadata:
   labels:
     app: pilot
     chart: pilot
-    heritage: Tiller
     release: istio
     istio: pilot
   annotations:
@@ -16971,7 +16827,6 @@ spec:
       labels:
         app: pilot
         chart: pilot
-        heritage: Tiller
         release: istio
         istio: pilot
       annotations:
@@ -17134,7 +16989,6 @@ metadata:
   labels:
     app: prometheus
     chart: prometheus
-    heritage: Tiller
     release: istio
 spec:
   replicas: 1
@@ -17146,7 +17000,6 @@ spec:
       labels:
         app: prometheus
         chart: prometheus
-        heritage: Tiller
         release: istio
       annotations:
         sidecar.istio.io/inject: "false"
@@ -17232,7 +17085,6 @@ metadata:
   labels:
     app: security
     chart: security
-    heritage: Tiller
     release: istio
     istio: citadel
 spec:
@@ -17246,7 +17098,6 @@ spec:
       labels:
         app: security
         chart: security
-        heritage: Tiller
         release: istio
         istio: citadel
       annotations:
@@ -17319,7 +17170,6 @@ metadata:
   labels:
     app: sidecarInjectorWebhook
     chart: sidecarInjectorWebhook
-    heritage: Tiller
     release: istio
     istio: sidecar-injector
 spec:
@@ -17333,7 +17183,6 @@ spec:
       labels:
         app: sidecarInjectorWebhook
         chart: sidecarInjectorWebhook
-        heritage: Tiller
         release: istio
         istio: sidecar-injector
       annotations:
@@ -17443,7 +17292,6 @@ metadata:
   labels:
     app: jaeger
     chart: tracing
-    heritage: Tiller
     release: istio
 spec:
   template:
@@ -17451,7 +17299,6 @@ spec:
       labels:
         app: jaeger
         chart: tracing
-        heritage: Tiller
         release: istio
       annotations:
         sidecar.istio.io/inject: "false"
@@ -17542,7 +17389,6 @@ metadata:
   labels:
     app: egressgateway
     chart: gateways
-    heritage: Tiller
     release: istio
 spec:
   maxReplicas: 5
@@ -17565,7 +17411,6 @@ metadata:
   labels:
     app: ingressgateway
     chart: gateways
-    heritage: Tiller
     release: istio
 spec:
   maxReplicas: 5
@@ -17592,7 +17437,6 @@ metadata:
   labels:
     app: mixer
     chart: mixer
-    heritage: Tiller
     release: istio
 spec:
     maxReplicas: 5
@@ -17615,7 +17459,6 @@ metadata:
   labels:
     app: mixer
     chart: mixer
-    heritage: Tiller
     release: istio
 spec:
     maxReplicas: 5
@@ -17642,7 +17485,6 @@ metadata:
   labels:
     app: pilot
     chart: pilot
-    heritage: Tiller
     release: istio
 spec:
   maxReplicas: 5
@@ -17671,7 +17513,6 @@ metadata:
     app: jaeger
     jaeger-infra: jaeger-service
     chart: tracing
-    heritage: Tiller
     release: istio
 spec:
   ports:
@@ -17693,7 +17534,6 @@ metadata:
     app: jaeger
     jaeger-infra: collector-service
     chart: tracing
-    heritage: Tiller
     release: istio
 spec:
   ports:
@@ -17718,7 +17558,6 @@ metadata:
     app: jaeger
     jaeger-infra: agent-service
     chart: tracing
-    heritage: Tiller
     release: istio
 spec:
   ports:
@@ -17750,7 +17589,6 @@ metadata:
   labels:
     app: jaeger
     chart: tracing
-    heritage: Tiller
     release: istio
 spec:
   type: ClusterIP
@@ -17771,7 +17609,6 @@ metadata:
   labels:
     app: jaeger
     chart: tracing
-    heritage: Tiller
     release: istio
 spec:
   ports:
@@ -17794,7 +17631,6 @@ metadata:
   labels:
     app: sidecarInjectorWebhook
     chart: sidecarInjectorWebhook
-    heritage: Tiller
     release: istio
 webhooks:
   - name: sidecar-injector.istio.io
@@ -17826,7 +17662,6 @@ metadata:
   labels:
     app: galley
     chart: galley
-    heritage: Tiller
     release: istio
     istio: galley
 spec:
@@ -17848,7 +17683,6 @@ metadata:
   namespace: istio-system
   labels:
     chart: gateways
-    heritage: Tiller
     release: istio
     app: istio-egressgateway
     istio: egressgateway
@@ -17868,7 +17702,6 @@ metadata:
   namespace: istio-system
   labels:
     chart: gateways
-    heritage: Tiller
     release: istio
     app: istio-ingressgateway
     istio: ingressgateway
@@ -17893,7 +17726,6 @@ metadata:
   labels:
     app: policy
     chart: mixer
-    heritage: Tiller
     release: istio
     version: 1.1.0
     istio: mixer
@@ -17916,7 +17748,6 @@ metadata:
   labels:
     app: telemetry
     chart: mixer
-    heritage: Tiller
     release: istio
     version: 1.1.0
     istio: mixer
@@ -17943,7 +17774,6 @@ metadata:
   labels:
     app: pilot
     chart: pilot
-    heritage: Tiller
     release: istio
     istio: pilot
 spec:
@@ -17965,7 +17795,6 @@ metadata:
   labels:
     app: mixer
     chart: mixer
-    heritage: Tiller
     release: istio
 spec:
   attributes:
@@ -18106,7 +17935,6 @@ metadata:
   labels:
     app: mixer
     chart: mixer
-    heritage: Tiller
     release: istio
 spec:
   attributes:
@@ -18171,7 +17999,6 @@ metadata:
   labels:
     app: mixer
     chart: mixer
-    heritage: Tiller
     release: istio
 spec:
   compiledAdapter: stdio
@@ -18186,7 +18013,6 @@ metadata:
   labels:
     app: mixer
     chart: mixer
-    heritage: Tiller
     release: istio
 spec:
   severity: '"Info"'
@@ -18243,7 +18069,6 @@ metadata:
   labels:
     app: mixer
     chart: mixer
-    heritage: Tiller
     release: istio
 spec:
   severity: '"Info"'
@@ -18285,7 +18110,6 @@ metadata:
   labels:
     app: mixer
     chart: mixer
-    heritage: Tiller
     release: istio
 spec:
   match: context.protocol == "http" || context.protocol == "grpc"
@@ -18302,7 +18126,6 @@ metadata:
   labels:
     app: mixer
     chart: mixer
-    heritage: Tiller
     release: istio
 spec:
   match: context.protocol == "tcp"
@@ -18319,7 +18142,6 @@ metadata:
   labels:
     app: mixer
     chart: mixer
-    heritage: Tiller
     release: istio
 spec:
   value: "1"
@@ -18354,7 +18176,6 @@ metadata:
   labels:
     app: mixer
     chart: mixer
-    heritage: Tiller
     release: istio
 spec:
   value: response.duration | "0ms"
@@ -18389,7 +18210,6 @@ metadata:
   labels:
     app: mixer
     chart: mixer
-    heritage: Tiller
     release: istio
 spec:
   value: request.size | 0
@@ -18424,7 +18244,6 @@ metadata:
   labels:
     app: mixer
     chart: mixer
-    heritage: Tiller
     release: istio
 spec:
   value: response.size | 0
@@ -18459,7 +18278,6 @@ metadata:
   labels:
     app: mixer
     chart: mixer
-    heritage: Tiller
     release: istio
 spec:
   value: connection.sent.bytes | 0
@@ -18490,7 +18308,6 @@ metadata:
   labels:
     app: mixer
     chart: mixer
-    heritage: Tiller
     release: istio
 spec:
   value: connection.received.bytes | 0
@@ -18521,7 +18338,6 @@ metadata:
   labels:
     app: mixer
     chart: mixer
-    heritage: Tiller
     release: istio
 spec:
   value: "1"
@@ -18552,7 +18368,6 @@ metadata:
   labels:
     app: mixer
     chart: mixer
-    heritage: Tiller
     release: istio
 spec:
   value: "1"
@@ -18583,7 +18398,6 @@ metadata:
   labels:
     app: mixer
     chart: mixer
-    heritage: Tiller
     release: istio
 spec:
   compiledAdapter: prometheus
@@ -18789,7 +18603,6 @@ metadata:
   labels:
     app: mixer
     chart: mixer
-    heritage: Tiller
     release: istio
 spec:
   match: (context.protocol == "http" || context.protocol == "grpc") && (match((request.useragent | "-"), "kube-probe*") == false)
@@ -18809,7 +18622,6 @@ metadata:
   labels:
     app: mixer
     chart: mixer
-    heritage: Tiller
     release: istio
 spec:
   match: context.protocol == "tcp"
@@ -18827,7 +18639,6 @@ metadata:
   labels:
     app: mixer
     chart: mixer
-    heritage: Tiller
     release: istio
 spec:
   match: context.protocol == "tcp" && ((connection.event | "na") == "open")
@@ -18844,7 +18655,6 @@ metadata:
   labels:
     app: mixer
     chart: mixer
-    heritage: Tiller
     release: istio
 spec:
   match: context.protocol == "tcp" && ((connection.event | "na") == "close")
@@ -18861,7 +18671,6 @@ metadata:
   labels:
     app: mixer
     chart: mixer
-    heritage: Tiller
     release: istio
 spec:
   compiledAdapter: kubernetesenv
@@ -18882,7 +18691,6 @@ metadata:
   labels:
     app: mixer
     chart: mixer
-    heritage: Tiller
     release: istio
 spec:
   actions:
@@ -18898,7 +18706,6 @@ metadata:
   labels:
     app: mixer
     chart: mixer
-    heritage: Tiller
     release: istio
 spec:
   match: context.protocol == "tcp"
@@ -18915,7 +18722,6 @@ metadata:
   labels:
     app: mixer
     chart: mixer
-    heritage: Tiller
     release: istio
 spec:
   # Pass the required attribute data to the adapter
@@ -18959,7 +18765,6 @@ metadata:
   labels:
     app: mixer
     chart: mixer
-    heritage: Tiller
     release: istio
 spec:
   host: istio-policy.istio-system.svc.cluster.local
@@ -18977,7 +18782,6 @@ metadata:
   labels:
     app: mixer
     chart: mixer
-    heritage: Tiller
     release: istio
 spec:
   host: istio-telemetry.istio-system.svc.cluster.local

--- a/seldon/seldon-core-operator/base/seldon-config-cm.yaml
+++ b/seldon/seldon-core-operator/base/seldon-config-cm.yaml
@@ -15,6 +15,5 @@ metadata:
   labels:
     app.kubernetes.io/instance: seldon-core-operator
     app.kubernetes.io/name: seldon-core-operator
-    helm.sh/chart: seldon-core-operator-0.4.0
   name: seldon-config
   namespace: kubeflow

--- a/seldon/seldon-core-operator/base/seldon-config-cm.yaml
+++ b/seldon/seldon-core-operator/base/seldon-config-cm.yaml
@@ -14,7 +14,6 @@ kind: ConfigMap
 metadata:
   labels:
     app.kubernetes.io/instance: seldon-core-operator
-    app.kubernetes.io/managed-by: Tiller
     app.kubernetes.io/name: seldon-core-operator
     helm.sh/chart: seldon-core-operator-0.4.0
   name: seldon-config

--- a/seldon/seldon-core-operator/base/seldon-manager-sa.yaml
+++ b/seldon/seldon-core-operator/base/seldon-manager-sa.yaml
@@ -4,6 +4,5 @@ metadata:
   labels:
     app.kubernetes.io/instance: seldon-core-operator
     app.kubernetes.io/name: seldon-core-operator
-    helm.sh/chart: seldon-core-operator-0.4.0
   name: seldon-manager
   namespace: kubeflow

--- a/seldon/seldon-core-operator/base/seldon-manager-sa.yaml
+++ b/seldon/seldon-core-operator/base/seldon-manager-sa.yaml
@@ -3,7 +3,6 @@ kind: ServiceAccount
 metadata:
   labels:
     app.kubernetes.io/instance: seldon-core-operator
-    app.kubernetes.io/managed-by: Tiller
     app.kubernetes.io/name: seldon-core-operator
     helm.sh/chart: seldon-core-operator-0.4.0
   name: seldon-manager

--- a/seldon/seldon-core-operator/base/seldon-operator-controller-manager-service-svc.yaml
+++ b/seldon/seldon-core-operator/base/seldon-operator-controller-manager-service-svc.yaml
@@ -3,7 +3,6 @@ kind: Service
 metadata:
   labels:
     app.kubernetes.io/instance: seldon-core-operator
-    app.kubernetes.io/managed-by: Tiller
     app.kubernetes.io/name: seldon-core-operator
     control-plane: seldon-controller-manager
     controller-tools.k8s.io: "1.0"

--- a/seldon/seldon-core-operator/base/seldon-operator-controller-manager-service-svc.yaml
+++ b/seldon/seldon-core-operator/base/seldon-operator-controller-manager-service-svc.yaml
@@ -6,7 +6,6 @@ metadata:
     app.kubernetes.io/name: seldon-core-operator
     control-plane: seldon-controller-manager
     controller-tools.k8s.io: "1.0"
-    helm.sh/chart: seldon-core-operator-0.4.0
   name: seldon-operator-controller-manager-service
   namespace: kubeflow
 spec:

--- a/seldon/seldon-core-operator/base/seldon-operator-controller-manager-statefulset.yaml
+++ b/seldon/seldon-core-operator/base/seldon-operator-controller-manager-statefulset.yaml
@@ -6,7 +6,6 @@ metadata:
     app.kubernetes.io/name: seldon-core-operator
     control-plane: seldon-controller-manager
     controller-tools.k8s.io: "1.0"
-    helm.sh/chart: seldon-core-operator-0.4.0
   name: seldon-operator-controller-manager
   namespace: kubeflow
 spec:

--- a/seldon/seldon-core-operator/base/seldon-operator-controller-manager-statefulset.yaml
+++ b/seldon/seldon-core-operator/base/seldon-operator-controller-manager-statefulset.yaml
@@ -3,7 +3,6 @@ kind: StatefulSet
 metadata:
   labels:
     app.kubernetes.io/instance: seldon-core-operator
-    app.kubernetes.io/managed-by: Tiller
     app.kubernetes.io/name: seldon-core-operator
     control-plane: seldon-controller-manager
     controller-tools.k8s.io: "1.0"

--- a/seldon/seldon-core-operator/base/seldon-operator-manager-role-clusterrole.yaml
+++ b/seldon/seldon-core-operator/base/seldon-operator-manager-role-clusterrole.yaml
@@ -3,7 +3,6 @@ kind: ClusterRole
 metadata:
   labels:
     app.kubernetes.io/instance: seldon-core-operator
-    app.kubernetes.io/managed-by: Tiller
     app.kubernetes.io/name: seldon-core-operator
     helm.sh/chart: seldon-core-operator-0.4.0
   name: seldon-operator-manager-role

--- a/seldon/seldon-core-operator/base/seldon-operator-manager-role-clusterrole.yaml
+++ b/seldon/seldon-core-operator/base/seldon-operator-manager-role-clusterrole.yaml
@@ -4,7 +4,6 @@ metadata:
   labels:
     app.kubernetes.io/instance: seldon-core-operator
     app.kubernetes.io/name: seldon-core-operator
-    helm.sh/chart: seldon-core-operator-0.4.0
   name: seldon-operator-manager-role
 rules:
 - apiGroups:

--- a/seldon/seldon-core-operator/base/seldon-operator-manager-rolebinding-crb.yaml
+++ b/seldon/seldon-core-operator/base/seldon-operator-manager-rolebinding-crb.yaml
@@ -4,7 +4,6 @@ metadata:
   labels:
     app.kubernetes.io/instance: seldon-core-operator
     app.kubernetes.io/name: seldon-core-operator
-    helm.sh/chart: seldon-core-operator-0.4.0
   name: seldon-operator-manager-rolebinding
 roleRef:
   apiGroup: rbac.authorization.k8s.io

--- a/seldon/seldon-core-operator/base/seldon-operator-manager-rolebinding-crb.yaml
+++ b/seldon/seldon-core-operator/base/seldon-operator-manager-rolebinding-crb.yaml
@@ -3,7 +3,6 @@ kind: ClusterRoleBinding
 metadata:
   labels:
     app.kubernetes.io/instance: seldon-core-operator
-    app.kubernetes.io/managed-by: Tiller
     app.kubernetes.io/name: seldon-core-operator
     helm.sh/chart: seldon-core-operator-0.4.0
   name: seldon-operator-manager-rolebinding

--- a/seldon/seldon-core-operator/base/webhook-server-service-svc.yaml
+++ b/seldon/seldon-core-operator/base/webhook-server-service-svc.yaml
@@ -3,7 +3,6 @@ kind: Service
 metadata:
   labels:
     app.kubernetes.io/instance: seldon-core-operator
-    app.kubernetes.io/managed-by: Tiller
     app.kubernetes.io/name: seldon-core-operator
     control-plane: seldon-controller-manager
     controller-tools.k8s.io: "1.0"

--- a/seldon/seldon-core-operator/base/webhook-server-service-svc.yaml
+++ b/seldon/seldon-core-operator/base/webhook-server-service-svc.yaml
@@ -6,7 +6,6 @@ metadata:
     app.kubernetes.io/name: seldon-core-operator
     control-plane: seldon-controller-manager
     controller-tools.k8s.io: "1.0"
-    helm.sh/chart: seldon-core-operator-0.4.0
   name: webhook-server-service
   namespace: kubeflow
 spec:

--- a/tests/istio-crds-base_test.go
+++ b/tests/istio-crds-base_test.go
@@ -22,7 +22,6 @@ metadata:
   name: virtualservices.networking.istio.io
   labels:
     app: istio-pilot
-    chart: istio
     release: istio
   annotations:
     "helm.sh/resource-policy": keep
@@ -63,7 +62,6 @@ metadata:
   name: destinationrules.networking.istio.io
   labels:
     app: istio-pilot
-    chart: istio
     release: istio
   annotations:
     "helm.sh/resource-policy": keep
@@ -100,7 +98,6 @@ metadata:
   name: serviceentries.networking.istio.io
   labels:
     app: istio-pilot
-    chart: istio
     release: istio
   annotations:
     "helm.sh/resource-policy": keep
@@ -145,7 +142,6 @@ metadata:
   name: gateways.networking.istio.io
   labels:
     app: istio-pilot
-    chart: istio
     release: istio
   annotations:
     "helm.sh/resource-policy": keep
@@ -169,7 +165,6 @@ metadata:
   name: envoyfilters.networking.istio.io
   labels:
     app: istio-pilot
-    chart: istio
     release: istio
   annotations:
     "helm.sh/resource-policy": keep
@@ -213,7 +208,6 @@ metadata:
   name: policies.authentication.istio.io
   labels:
     app: istio-citadel
-    chart: istio
     release: istio
   annotations:
     "helm.sh/resource-policy": keep
@@ -235,7 +229,6 @@ metadata:
   name: meshpolicies.authentication.istio.io
   labels:
     app: istio-citadel
-    chart: istio
     release: istio
   annotations:
     "helm.sh/resource-policy": keep
@@ -258,7 +251,6 @@ metadata:
   name: httpapispecbindings.config.istio.io
   labels:
     app: istio-mixer
-    chart: istio
     release: istio
   annotations:
     "helm.sh/resource-policy": keep
@@ -280,7 +272,6 @@ metadata:
   name: httpapispecs.config.istio.io
   labels:
     app: istio-mixer
-    chart: istio
     release: istio
   annotations:
     "helm.sh/resource-policy": keep
@@ -302,7 +293,6 @@ metadata:
   name: quotaspecbindings.config.istio.io
   labels:
     app: istio-mixer
-    chart: istio
     release: istio
   annotations:
     "helm.sh/resource-policy": keep
@@ -324,7 +314,6 @@ metadata:
   name: quotaspecs.config.istio.io
   labels:
     app: istio-mixer
-    chart: istio
     release: istio
   annotations:
     "helm.sh/resource-policy": keep
@@ -348,7 +337,6 @@ metadata:
     app: mixer
     package: istio.io.mixer
     istio: core
-    chart: istio
     release: istio
   annotations:
     "helm.sh/resource-policy": keep
@@ -372,7 +360,6 @@ metadata:
     app: mixer
     package: istio.io.mixer
     istio: core
-    chart: istio
     release: istio
   annotations:
     "helm.sh/resource-policy": keep
@@ -396,7 +383,6 @@ metadata:
     app: mixer
     package: bypass
     istio: mixer-adapter
-    chart: istio
     release: istio
   annotations:
     "helm.sh/resource-policy": keep
@@ -420,7 +406,6 @@ metadata:
     app: mixer
     package: circonus
     istio: mixer-adapter
-    chart: istio
     release: istio
   annotations:
     "helm.sh/resource-policy": keep
@@ -444,7 +429,6 @@ metadata:
     app: mixer
     package: denier
     istio: mixer-adapter
-    chart: istio
     release: istio
   annotations:
     "helm.sh/resource-policy": keep
@@ -468,7 +452,6 @@ metadata:
     app: mixer
     package: fluentd
     istio: mixer-adapter
-    chart: istio
     release: istio
   annotations:
     "helm.sh/resource-policy": keep
@@ -492,7 +475,6 @@ metadata:
     app: mixer
     package: kubernetesenv
     istio: mixer-adapter
-    chart: istio
     release: istio
   annotations:
     "helm.sh/resource-policy": keep
@@ -516,7 +498,6 @@ metadata:
     app: mixer
     package: listchecker
     istio: mixer-adapter
-    chart: istio
     release: istio
   annotations:
     "helm.sh/resource-policy": keep
@@ -540,7 +521,6 @@ metadata:
     app: mixer
     package: memquota
     istio: mixer-adapter
-    chart: istio
     release: istio
   annotations:
     "helm.sh/resource-policy": keep
@@ -564,7 +544,6 @@ metadata:
     app: mixer
     package: noop
     istio: mixer-adapter
-    chart: istio
     release: istio
   annotations:
     "helm.sh/resource-policy": keep
@@ -588,7 +567,6 @@ metadata:
     app: mixer
     package: opa
     istio: mixer-adapter
-    chart: istio
     release: istio
   annotations:
     "helm.sh/resource-policy": keep
@@ -612,7 +590,6 @@ metadata:
     app: mixer
     package: prometheus
     istio: mixer-adapter
-    chart: istio
     release: istio
   annotations:
     "helm.sh/resource-policy": keep
@@ -636,7 +613,6 @@ metadata:
     app: mixer
     package: rbac
     istio: mixer-adapter
-    chart: istio
     release: istio
   annotations:
     "helm.sh/resource-policy": keep
@@ -660,7 +636,6 @@ metadata:
     app: mixer
     package: redisquota
     istio: mixer-adapter
-    chart: istio
     release: istio
   annotations:
     "helm.sh/resource-policy": keep
@@ -681,7 +656,6 @@ metadata:
     app: mixer
     package: signalfx
     istio: mixer-adapter
-    chart: istio
     release: istio
   annotations:
     "helm.sh/resource-policy": keep
@@ -705,7 +679,6 @@ metadata:
     app: mixer
     package: solarwinds
     istio: mixer-adapter
-    chart: istio
     release: istio
   annotations:
     "helm.sh/resource-policy": keep
@@ -729,7 +702,6 @@ metadata:
     app: mixer
     package: stackdriver
     istio: mixer-adapter
-    chart: istio
     release: istio
   annotations:
     "helm.sh/resource-policy": keep
@@ -753,7 +725,6 @@ metadata:
     app: mixer
     package: statsd
     istio: mixer-adapter
-    chart: istio
     release: istio
   annotations:
     "helm.sh/resource-policy": keep
@@ -777,7 +748,6 @@ metadata:
     app: mixer
     package: stdio
     istio: mixer-adapter
-    chart: istio
     release: istio
   annotations:
     "helm.sh/resource-policy": keep
@@ -801,7 +771,6 @@ metadata:
     app: mixer
     package: apikey
     istio: mixer-instance
-    chart: istio
     release: istio
   annotations:
     "helm.sh/resource-policy": keep
@@ -825,7 +794,6 @@ metadata:
     app: mixer
     package: authorization
     istio: mixer-instance
-    chart: istio
     release: istio
   annotations:
     "helm.sh/resource-policy": keep
@@ -849,7 +817,6 @@ metadata:
     app: mixer
     package: checknothing
     istio: mixer-instance
-    chart: istio
     release: istio
   annotations:
     "helm.sh/resource-policy": keep
@@ -873,7 +840,6 @@ metadata:
     app: mixer
     package: adapter.template.kubernetes
     istio: mixer-instance
-    chart: istio
     release: istio
   annotations:
     "helm.sh/resource-policy": keep
@@ -897,7 +863,6 @@ metadata:
     app: mixer
     package: listentry
     istio: mixer-instance
-    chart: istio
     release: istio
   annotations:
     "helm.sh/resource-policy": keep
@@ -921,7 +886,6 @@ metadata:
     app: mixer
     package: logentry
     istio: mixer-instance
-    chart: istio
     release: istio
   annotations:
     "helm.sh/resource-policy": keep
@@ -965,7 +929,6 @@ metadata:
     app: mixer
     package: edge
     istio: mixer-instance
-    chart: istio
     release: istio
   annotations:
     "helm.sh/resource-policy": keep
@@ -989,7 +952,6 @@ metadata:
     app: mixer
     package: metric
     istio: mixer-instance
-    chart: istio
     release: istio
   annotations:
     "helm.sh/resource-policy": keep
@@ -1013,7 +975,6 @@ metadata:
     app: mixer
     package: quota
     istio: mixer-instance
-    chart: istio
     release: istio
   annotations:
     "helm.sh/resource-policy": keep
@@ -1037,7 +998,6 @@ metadata:
     app: mixer
     package: reportnothing
     istio: mixer-instance
-    chart: istio
     release: istio
   annotations:
     "helm.sh/resource-policy": keep
@@ -1061,7 +1021,6 @@ metadata:
     app: mixer
     package: tracespan
     istio: mixer-instance
-    chart: istio
     release: istio
   annotations:
     "helm.sh/resource-policy": keep
@@ -1085,7 +1044,6 @@ metadata:
     app: mixer
     package: istio.io.mixer
     istio: rbac
-    chart: istio
     release: istio
   annotations:
     "helm.sh/resource-policy": keep
@@ -1109,7 +1067,6 @@ metadata:
     app: mixer
     package: istio.io.mixer
     istio: rbac
-    chart: istio
     release: istio
   annotations:
     "helm.sh/resource-policy": keep
@@ -1133,7 +1090,6 @@ metadata:
     app: mixer
     package: istio.io.mixer
     istio: rbac
-    chart: istio
     release: istio
   annotations:
     "helm.sh/resource-policy": keep
@@ -1169,7 +1125,6 @@ metadata:
     app: mixer
     package: adapter
     istio: mixer-adapter
-    chart: istio
     release: istio
   annotations:
     "helm.sh/resource-policy": keep
@@ -1193,7 +1148,6 @@ metadata:
     app: mixer
     package: instance
     istio: mixer-instance
-    chart: istio
     release: istio
   annotations:
     "helm.sh/resource-policy": keep
@@ -1217,7 +1171,6 @@ metadata:
     app: mixer
     package: template
     istio: mixer-template
-    chart: istio
     release: istio
   annotations:
     "helm.sh/resource-policy": keep
@@ -1241,7 +1194,6 @@ metadata:
     app: mixer
     package: handler
     istio: mixer-handler
-    chart: istio
     release: istio
   annotations:
     "helm.sh/resource-policy": keep
@@ -1307,7 +1259,6 @@ metadata:
   name: sidecars.networking.istio.io
   labels:
     app: istio-pilot
-    chart: istio
     release: istio
   annotations:
     "helm.sh/resource-policy": keep
@@ -1351,7 +1302,6 @@ metadata:
   name: clusterissuers.certmanager.k8s.io
   labels:
     app: certmanager
-    chart: certmanager
     release: istio
   annotations:
     "helm.sh/resource-policy": keep
@@ -1369,7 +1319,6 @@ metadata:
   name: issuers.certmanager.k8s.io
   labels:
     app: certmanager
-    chart: certmanager
     release: istio
   annotations:
     "helm.sh/resource-policy": keep
@@ -1387,7 +1336,6 @@ metadata:
   name: certificates.certmanager.k8s.io
   labels:
     app: certmanager
-    chart: certmanager
     release: istio
   annotations:
     "helm.sh/resource-policy": keep
@@ -1430,7 +1378,6 @@ metadata:
   name: orders.certmanager.k8s.io
   labels:
     app: certmanager
-    chart: certmanager
     release: istio
   annotations:
     "helm.sh/resource-policy": keep
@@ -1467,7 +1414,6 @@ metadata:
   name: challenges.certmanager.k8s.io
   labels:
     app: certmanager
-    chart: certmanager
     release: istio
   annotations:
     "helm.sh/resource-policy": keep

--- a/tests/istio-crds-base_test.go
+++ b/tests/istio-crds-base_test.go
@@ -23,7 +23,6 @@ metadata:
   labels:
     app: istio-pilot
     chart: istio
-    heritage: Tiller
     release: istio
   annotations:
     "helm.sh/resource-policy": keep
@@ -65,7 +64,6 @@ metadata:
   labels:
     app: istio-pilot
     chart: istio
-    heritage: Tiller
     release: istio
   annotations:
     "helm.sh/resource-policy": keep
@@ -103,7 +101,6 @@ metadata:
   labels:
     app: istio-pilot
     chart: istio
-    heritage: Tiller
     release: istio
   annotations:
     "helm.sh/resource-policy": keep
@@ -149,7 +146,6 @@ metadata:
   labels:
     app: istio-pilot
     chart: istio
-    heritage: Tiller
     release: istio
   annotations:
     "helm.sh/resource-policy": keep
@@ -174,7 +170,6 @@ metadata:
   labels:
     app: istio-pilot
     chart: istio
-    heritage: Tiller
     release: istio
   annotations:
     "helm.sh/resource-policy": keep
@@ -197,7 +192,6 @@ metadata:
   labels:
     app: istio-pilot
     istio: rbac
-    heritage: Tiller
     release: istio
   annotations:
     "helm.sh/resource-policy": keep
@@ -220,7 +214,6 @@ metadata:
   labels:
     app: istio-citadel
     chart: istio
-    heritage: Tiller
     release: istio
   annotations:
     "helm.sh/resource-policy": keep
@@ -243,7 +236,6 @@ metadata:
   labels:
     app: istio-citadel
     chart: istio
-    heritage: Tiller
     release: istio
   annotations:
     "helm.sh/resource-policy": keep
@@ -267,7 +259,6 @@ metadata:
   labels:
     app: istio-mixer
     chart: istio
-    heritage: Tiller
     release: istio
   annotations:
     "helm.sh/resource-policy": keep
@@ -290,7 +281,6 @@ metadata:
   labels:
     app: istio-mixer
     chart: istio
-    heritage: Tiller
     release: istio
   annotations:
     "helm.sh/resource-policy": keep
@@ -313,7 +303,6 @@ metadata:
   labels:
     app: istio-mixer
     chart: istio
-    heritage: Tiller
     release: istio
   annotations:
     "helm.sh/resource-policy": keep
@@ -336,7 +325,6 @@ metadata:
   labels:
     app: istio-mixer
     chart: istio
-    heritage: Tiller
     release: istio
   annotations:
     "helm.sh/resource-policy": keep
@@ -361,7 +349,6 @@ metadata:
     package: istio.io.mixer
     istio: core
     chart: istio
-    heritage: Tiller
     release: istio
   annotations:
     "helm.sh/resource-policy": keep
@@ -386,7 +373,6 @@ metadata:
     package: istio.io.mixer
     istio: core
     chart: istio
-    heritage: Tiller
     release: istio
   annotations:
     "helm.sh/resource-policy": keep
@@ -411,7 +397,6 @@ metadata:
     package: bypass
     istio: mixer-adapter
     chart: istio
-    heritage: Tiller
     release: istio
   annotations:
     "helm.sh/resource-policy": keep
@@ -436,7 +421,6 @@ metadata:
     package: circonus
     istio: mixer-adapter
     chart: istio
-    heritage: Tiller
     release: istio
   annotations:
     "helm.sh/resource-policy": keep
@@ -461,7 +445,6 @@ metadata:
     package: denier
     istio: mixer-adapter
     chart: istio
-    heritage: Tiller
     release: istio
   annotations:
     "helm.sh/resource-policy": keep
@@ -486,7 +469,6 @@ metadata:
     package: fluentd
     istio: mixer-adapter
     chart: istio
-    heritage: Tiller
     release: istio
   annotations:
     "helm.sh/resource-policy": keep
@@ -511,7 +493,6 @@ metadata:
     package: kubernetesenv
     istio: mixer-adapter
     chart: istio
-    heritage: Tiller
     release: istio
   annotations:
     "helm.sh/resource-policy": keep
@@ -536,7 +517,6 @@ metadata:
     package: listchecker
     istio: mixer-adapter
     chart: istio
-    heritage: Tiller
     release: istio
   annotations:
     "helm.sh/resource-policy": keep
@@ -561,7 +541,6 @@ metadata:
     package: memquota
     istio: mixer-adapter
     chart: istio
-    heritage: Tiller
     release: istio
   annotations:
     "helm.sh/resource-policy": keep
@@ -586,7 +565,6 @@ metadata:
     package: noop
     istio: mixer-adapter
     chart: istio
-    heritage: Tiller
     release: istio
   annotations:
     "helm.sh/resource-policy": keep
@@ -611,7 +589,6 @@ metadata:
     package: opa
     istio: mixer-adapter
     chart: istio
-    heritage: Tiller
     release: istio
   annotations:
     "helm.sh/resource-policy": keep
@@ -636,7 +613,6 @@ metadata:
     package: prometheus
     istio: mixer-adapter
     chart: istio
-    heritage: Tiller
     release: istio
   annotations:
     "helm.sh/resource-policy": keep
@@ -661,7 +637,6 @@ metadata:
     package: rbac
     istio: mixer-adapter
     chart: istio
-    heritage: Tiller
     release: istio
   annotations:
     "helm.sh/resource-policy": keep
@@ -686,7 +661,6 @@ metadata:
     package: redisquota
     istio: mixer-adapter
     chart: istio
-    heritage: Tiller
     release: istio
   annotations:
     "helm.sh/resource-policy": keep
@@ -708,7 +682,6 @@ metadata:
     package: signalfx
     istio: mixer-adapter
     chart: istio
-    heritage: Tiller
     release: istio
   annotations:
     "helm.sh/resource-policy": keep
@@ -733,7 +706,6 @@ metadata:
     package: solarwinds
     istio: mixer-adapter
     chart: istio
-    heritage: Tiller
     release: istio
   annotations:
     "helm.sh/resource-policy": keep
@@ -758,7 +730,6 @@ metadata:
     package: stackdriver
     istio: mixer-adapter
     chart: istio
-    heritage: Tiller
     release: istio
   annotations:
     "helm.sh/resource-policy": keep
@@ -783,7 +754,6 @@ metadata:
     package: statsd
     istio: mixer-adapter
     chart: istio
-    heritage: Tiller
     release: istio
   annotations:
     "helm.sh/resource-policy": keep
@@ -808,7 +778,6 @@ metadata:
     package: stdio
     istio: mixer-adapter
     chart: istio
-    heritage: Tiller
     release: istio
   annotations:
     "helm.sh/resource-policy": keep
@@ -833,7 +802,6 @@ metadata:
     package: apikey
     istio: mixer-instance
     chart: istio
-    heritage: Tiller
     release: istio
   annotations:
     "helm.sh/resource-policy": keep
@@ -858,7 +826,6 @@ metadata:
     package: authorization
     istio: mixer-instance
     chart: istio
-    heritage: Tiller
     release: istio
   annotations:
     "helm.sh/resource-policy": keep
@@ -883,7 +850,6 @@ metadata:
     package: checknothing
     istio: mixer-instance
     chart: istio
-    heritage: Tiller
     release: istio
   annotations:
     "helm.sh/resource-policy": keep
@@ -908,7 +874,6 @@ metadata:
     package: adapter.template.kubernetes
     istio: mixer-instance
     chart: istio
-    heritage: Tiller
     release: istio
   annotations:
     "helm.sh/resource-policy": keep
@@ -933,7 +898,6 @@ metadata:
     package: listentry
     istio: mixer-instance
     chart: istio
-    heritage: Tiller
     release: istio
   annotations:
     "helm.sh/resource-policy": keep
@@ -958,7 +922,6 @@ metadata:
     package: logentry
     istio: mixer-instance
     chart: istio
-    heritage: Tiller
     release: istio
   annotations:
     "helm.sh/resource-policy": keep
@@ -1003,7 +966,6 @@ metadata:
     package: edge
     istio: mixer-instance
     chart: istio
-    heritage: Tiller
     release: istio
   annotations:
     "helm.sh/resource-policy": keep
@@ -1028,7 +990,6 @@ metadata:
     package: metric
     istio: mixer-instance
     chart: istio
-    heritage: Tiller
     release: istio
   annotations:
     "helm.sh/resource-policy": keep
@@ -1053,7 +1014,6 @@ metadata:
     package: quota
     istio: mixer-instance
     chart: istio
-    heritage: Tiller
     release: istio
   annotations:
     "helm.sh/resource-policy": keep
@@ -1078,7 +1038,6 @@ metadata:
     package: reportnothing
     istio: mixer-instance
     chart: istio
-    heritage: Tiller
     release: istio
   annotations:
     "helm.sh/resource-policy": keep
@@ -1103,7 +1062,6 @@ metadata:
     package: tracespan
     istio: mixer-instance
     chart: istio
-    heritage: Tiller
     release: istio
   annotations:
     "helm.sh/resource-policy": keep
@@ -1128,7 +1086,6 @@ metadata:
     package: istio.io.mixer
     istio: rbac
     chart: istio
-    heritage: Tiller
     release: istio
   annotations:
     "helm.sh/resource-policy": keep
@@ -1153,7 +1110,6 @@ metadata:
     package: istio.io.mixer
     istio: rbac
     chart: istio
-    heritage: Tiller
     release: istio
   annotations:
     "helm.sh/resource-policy": keep
@@ -1178,7 +1134,6 @@ metadata:
     package: istio.io.mixer
     istio: rbac
     chart: istio
-    heritage: Tiller
     release: istio
   annotations:
     "helm.sh/resource-policy": keep
@@ -1215,7 +1170,6 @@ metadata:
     package: adapter
     istio: mixer-adapter
     chart: istio
-    heritage: Tiller
     release: istio
   annotations:
     "helm.sh/resource-policy": keep
@@ -1240,7 +1194,6 @@ metadata:
     package: instance
     istio: mixer-instance
     chart: istio
-    heritage: Tiller
     release: istio
   annotations:
     "helm.sh/resource-policy": keep
@@ -1265,7 +1218,6 @@ metadata:
     package: template
     istio: mixer-template
     chart: istio
-    heritage: Tiller
     release: istio
   annotations:
     "helm.sh/resource-policy": keep
@@ -1290,7 +1242,6 @@ metadata:
     package: handler
     istio: mixer-handler
     chart: istio
-    heritage: Tiller
     release: istio
   annotations:
     "helm.sh/resource-policy": keep
@@ -1357,7 +1308,6 @@ metadata:
   labels:
     app: istio-pilot
     chart: istio
-    heritage: Tiller
     release: istio
   annotations:
     "helm.sh/resource-policy": keep
@@ -1402,7 +1352,6 @@ metadata:
   labels:
     app: certmanager
     chart: certmanager
-    heritage: Tiller
     release: istio
   annotations:
     "helm.sh/resource-policy": keep
@@ -1421,7 +1370,6 @@ metadata:
   labels:
     app: certmanager
     chart: certmanager
-    heritage: Tiller
     release: istio
   annotations:
     "helm.sh/resource-policy": keep
@@ -1440,7 +1388,6 @@ metadata:
   labels:
     app: certmanager
     chart: certmanager
-    heritage: Tiller
     release: istio
   annotations:
     "helm.sh/resource-policy": keep
@@ -1484,7 +1431,6 @@ metadata:
   labels:
     app: certmanager
     chart: certmanager
-    heritage: Tiller
     release: istio
   annotations:
     "helm.sh/resource-policy": keep
@@ -1522,7 +1468,6 @@ metadata:
   labels:
     app: certmanager
     chart: certmanager
-    heritage: Tiller
     release: istio
   annotations:
     "helm.sh/resource-policy": keep

--- a/tests/istio-install-base_test.go
+++ b/tests/istio-install-base_test.go
@@ -30,7 +30,6 @@ metadata:
   name: kiali
   labels:
     app: kiali
-    chart: kiali
     release: istio
 type: Opaque
 data:
@@ -45,7 +44,6 @@ metadata:
   name: istio-galley-configuration
   labels:
     app: galley
-    chart: galley
     release: istio
     istio: galley
 data:
@@ -57,7 +55,6 @@ data:
       namespace: istio-system
       labels:
         app: galley
-        chart: galley
         release: istio
         istio: galley
     webhooks:
@@ -167,7 +164,6 @@ metadata:
   name: istio-grafana-custom-resources
   labels:
     app: grafana
-    chart: grafana
     release: istio
     istio: grafana
 data:
@@ -179,7 +175,6 @@ data:
       namespace: istio-system
       labels:
         app: grafana
-        chart: grafana
         release: istio
     spec:
       targets:
@@ -228,7 +223,6 @@ metadata:
   name: istio-grafana-configuration-dashboards-galley-dashboard
   labels:
     app: grafana
-    chart: grafana
     release: istio
     istio: grafana
 data:
@@ -2059,7 +2053,6 @@ metadata:
   name: istio-grafana-configuration-dashboards-istio-mesh-dashboard
   labels:
     app: grafana
-    chart: grafana
     release: istio
     istio: grafana
 data:
@@ -3024,7 +3017,6 @@ metadata:
   name: istio-grafana-configuration-dashboards-istio-performance-dashboard
   labels:
     app: grafana
-    chart: grafana
     release: istio
     istio: grafana
 data:
@@ -3653,7 +3645,6 @@ metadata:
   name: istio-grafana-configuration-dashboards-istio-service-dashboard
   labels:
     app: grafana
-    chart: grafana
     release: istio
     istio: grafana
 data:
@@ -6266,7 +6257,6 @@ metadata:
   name: istio-grafana-configuration-dashboards-istio-workload-dashboard
   labels:
     app: grafana
-    chart: grafana
     release: istio
     istio: grafana
 data:
@@ -8581,7 +8571,6 @@ metadata:
   name: istio-grafana-configuration-dashboards-mixer-dashboard
   labels:
     app: grafana
-    chart: grafana
     release: istio
     istio: grafana
 data:
@@ -10401,7 +10390,6 @@ metadata:
   name: istio-grafana-configuration-dashboards-pilot-dashboard
   labels:
     app: grafana
-    chart: grafana
     release: istio
     istio: grafana
 data:
@@ -12011,7 +11999,6 @@ metadata:
   name: istio-grafana
   labels:
     app: grafana
-    chart: grafana
     release: istio
     istio: grafana
 data:
@@ -12047,7 +12034,6 @@ metadata:
   name: kiali
   labels:
     app: kiali
-    chart: kiali
     release: istio
 data:
   config.yaml: |
@@ -12070,7 +12056,6 @@ metadata:
   name: prometheus
   labels:
     app: prometheus
-    chart: prometheus
     release: istio
 data:
   prometheus.yml: |-
@@ -12383,7 +12368,6 @@ metadata:
   name: istio-security-custom-resources	
   labels:	
     app: security	
-    chart: security	
     release: istio	
     istio: citadel	
 data:	
@@ -12395,7 +12379,6 @@ data:
       name: "default"
       labels:
         app: security
-        chart: security
         release: istio
     spec:
       peers:
@@ -12443,7 +12426,6 @@ metadata:
   name: istio
   labels:
     app: istio
-    chart: istio
     release: istio
 data:
   mesh: |-
@@ -12586,7 +12568,6 @@ metadata:
   name: istio-sidecar-injector
   labels:
     app: istio
-    chart: istio
     release: istio
     istio: sidecar-injector
 data:
@@ -12803,7 +12784,6 @@ metadata:
   name: istio-galley-service-account
   labels:
     app: galley
-    chart: galley
     release: istio
 
 ---
@@ -12815,7 +12795,6 @@ metadata:
   name: istio-egressgateway-service-account
   labels:
     app: istio-egressgateway
-    chart: gateways
     release: istio
 ---
 apiVersion: v1
@@ -12824,7 +12803,6 @@ metadata:
   name: istio-ingressgateway-service-account
   labels:
     app: istio-ingressgateway
-    chart: gateways
     release: istio
 ---
 
@@ -12837,7 +12815,6 @@ metadata:
   name: istio-grafana-post-install-account
   labels:
     app: grafana
-    chart: grafana
     release: istio
 ---
 apiVersion: rbac.authorization.k8s.io/v1
@@ -12846,7 +12823,6 @@ metadata:
   name: istio-grafana-post-install-istio-system
   labels:
     app: grafana
-    chart: grafana
     release: istio
 rules:
 - apiGroups: ["authentication.istio.io"] # needed to create default authn policy
@@ -12859,7 +12835,6 @@ metadata:
   name: istio-grafana-post-install-role-binding-istio-system
   labels:
     app: grafana
-    chart: grafana
     release: istio
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -12879,7 +12854,6 @@ metadata:
     "helm.sh/hook-delete-policy": hook-succeeded
   labels:
     app: grafana
-    chart: grafana
     release: istio
 spec:
   template:
@@ -12887,7 +12861,6 @@ spec:
       name: istio-grafana-post-install
       labels:
         app: istio-grafana
-        chart: grafana
         release: istio
     spec:
       serviceAccountName: istio-grafana-post-install-account
@@ -12945,7 +12918,6 @@ metadata:
   name: kiali-service-account
   labels:
     app: kiali
-    chart: kiali
     release: istio
 
 ---
@@ -12957,7 +12929,6 @@ metadata:
   name: istio-mixer-service-account
   labels:
     app: mixer
-    chart: mixer
     release: istio
 
 ---
@@ -12968,7 +12939,6 @@ metadata:
   name: istio-pilot-service-account
   labels:
     app: pilot
-    chart: pilot
     release: istio
 
 ---
@@ -12979,7 +12949,6 @@ metadata:
   name: prometheus
   labels:
     app: prometheus
-    chart: prometheus
     release: istio
 
 ---
@@ -13003,7 +12972,6 @@ metadata:
     "helm.sh/hook-weight": "1"
   labels:
     app: security
-    chart: security
     release: istio
 ---
 apiVersion: rbac.authorization.k8s.io/v1
@@ -13016,7 +12984,6 @@ metadata:
     "helm.sh/hook-weight": "1"
   labels:
     app: security
-    chart: security
     release: istio
 rules:
 - apiGroups: [""]
@@ -13033,7 +13000,6 @@ metadata:
     "helm.sh/hook-weight": "2"
   labels:
     app: security
-    chart: security
     release: istio
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -13054,7 +13020,6 @@ metadata:
     "helm.sh/hook-weight": "3"
   labels:
     app: security
-    chart: security
     release: istio
 spec:
   template:
@@ -13062,7 +13027,6 @@ spec:
       name: istio-cleanup-secrets
       labels:
         app: security
-        chart: security
         release: istio
     spec:
       serviceAccountName: istio-cleanup-secrets-service-account
@@ -13123,7 +13087,6 @@ metadata:
   name: istio-security-post-install-account	
   labels:	
     app: security	
-    chart: security	
     release: istio	
 ---
 apiVersion: rbac.authorization.k8s.io/v1beta1	
@@ -13132,7 +13095,6 @@ metadata:
   name: istio-security-post-install-istio-system	
   labels:	
     app: security	
-    chart: security	
     release: istio	
 rules:	
 - apiGroups: ["authentication.istio.io"] # needed to create default authn policy	
@@ -13154,7 +13116,6 @@ metadata:
   name: istio-security-post-install-role-binding-istio-system	
   labels:	
     app: security	
-    chart: security	
     release: istio	
 roleRef:	
   apiGroup: rbac.authorization.k8s.io	
@@ -13174,7 +13135,6 @@ metadata:
     "helm.sh/hook-delete-policy": hook-succeeded	
   labels:	
     app: security	
-    chart: security	
     release: istio	
 spec:	
   template:	
@@ -13182,7 +13142,6 @@ spec:
       name: istio-security-post-install	
       labels:	
         app: security	
-        chart: security	
         release: istio	
     spec:	
       serviceAccountName: istio-security-post-install-account	
@@ -13241,7 +13200,6 @@ metadata:
   name: istio-citadel-service-account
   labels:
     app: security
-    chart: security
     release: istio
 
 ---
@@ -13252,7 +13210,6 @@ metadata:
   name: istio-sidecar-injector-service-account
   labels:
     app: sidecarInjectorWebhook
-    chart: sidecarInjectorWebhook
     release: istio
     istio: sidecar-injector
 
@@ -13271,7 +13228,6 @@ metadata:
   name: istio-galley-istio-system
   labels:
     app: galley
-    chart: galley
     release: istio
 rules:
 - apiGroups: ["admissionregistration.k8s.io"]
@@ -13313,7 +13269,6 @@ metadata:
   name: istio-egressgateway-istio-system
   labels:
     app: egressgateway
-    chart: gateways
     release: istio
 rules:
 - apiGroups: ["networking.istio.io"]
@@ -13326,7 +13281,6 @@ metadata:
   name: istio-ingressgateway-istio-system
   labels:
     app: ingressgateway
-    chart: gateways
     release: istio
 rules:
 - apiGroups: ["networking.istio.io"]
@@ -13342,7 +13296,6 @@ metadata:
   name: kiali
   labels:
     app: kiali
-    chart: kiali
     release: istio
 rules:
 - apiGroups: [""]
@@ -13466,7 +13419,6 @@ metadata:
   name: kiali-viewer
   labels:
     app: kiali
-    chart: kiali
     release: istio
 rules:
 - apiGroups: [""]
@@ -13583,7 +13535,6 @@ metadata:
   name: istio-mixer-istio-system
   labels:
     app: mixer
-    chart: mixer
     release: istio
 rules:
 - apiGroups: ["config.istio.io"] # istio CRD watcher
@@ -13607,7 +13558,6 @@ metadata:
   name: istio-pilot-istio-system
   labels:
     app: pilot
-    chart: pilot
     release: istio
 rules:
 - apiGroups: ["config.istio.io"]
@@ -13643,7 +13593,6 @@ metadata:
   name: prometheus-istio-system
   labels:
     app: prometheus
-    chart: prometheus
     release: istio
 rules:
 - apiGroups: [""]
@@ -13669,7 +13618,6 @@ metadata:
   name: istio-citadel-istio-system
   labels:
     app: security
-    chart: security
     release: istio
 rules:
 - apiGroups: [""]
@@ -13693,7 +13641,6 @@ metadata:
   name: istio-sidecar-injector-istio-system
   labels:
     app: sidecarInjectorWebhook
-    chart: sidecarInjectorWebhook
     release: istio
     istio: sidecar-injector
 rules:
@@ -13726,7 +13673,6 @@ metadata:
   name: istio-galley-admin-role-binding-istio-system
   labels:
     app: galley
-    chart: galley
     release: istio
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -13746,7 +13692,6 @@ metadata:
   name: istio-egressgateway-istio-system
   labels:
     app: egressgateway
-    chart: gateways
     release: istio
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -13762,7 +13707,6 @@ metadata:
   name: istio-ingressgateway-istio-system
   labels:
     app: ingressgateway
-    chart: gateways
     release: istio
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -13781,7 +13725,6 @@ metadata:
   name: istio-kiali-admin-role-binding-istio-system
   labels:
     app: kiali
-    chart: kiali
     release: istio
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -13800,7 +13743,6 @@ metadata:
   name: istio-mixer-admin-role-binding-istio-system
   labels:
     app: mixer
-    chart: mixer
     release: istio
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -13819,7 +13761,6 @@ metadata:
   name: istio-pilot-istio-system
   labels:
     app: pilot
-    chart: pilot
     release: istio
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -13838,7 +13779,6 @@ metadata:
   name: prometheus-istio-system
   labels:
     app: prometheus
-    chart: prometheus
     release: istio
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -13856,7 +13796,6 @@ metadata:
   name: istio-citadel-istio-system
   labels:
     app: security
-    chart: security
     release: istio
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -13875,7 +13814,6 @@ metadata:
   name: istio-sidecar-injector-admin-role-binding-istio-system
   labels:
     app: sidecarInjectorWebhook
-    chart: sidecarInjectorWebhook
     release: istio
     istio: sidecar-injector
 roleRef:
@@ -13894,7 +13832,6 @@ kind: ClusterRoleBinding
 metadata:
   name: istio-multi
   labels:
-    chart: istio-1.1.0
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
@@ -13940,7 +13877,6 @@ metadata:
   name: istio-galley
   labels:
     app: galley
-    chart: galley
     release: istio
     istio: galley
 spec:
@@ -13962,7 +13898,6 @@ kind: Service
 metadata:
   name: istio-egressgateway
   labels:
-    chart: gateways
     release: istio
     app: istio-egressgateway
     istio: egressgateway
@@ -13991,7 +13926,6 @@ metadata:
   annotations:
     beta.cloud.google.com/backend-config: '{"ports": {"http2":"iap-backendconfig"}}'
   labels:
-    chart: gateways
     release: istio
     app: istio-ingressgateway
     istio: ingressgateway
@@ -14049,7 +13983,6 @@ metadata:
   name: grafana
   labels:
     app: grafana
-    chart: grafana
     release: istio
 spec:
   type: ClusterIP
@@ -14069,7 +14002,6 @@ metadata:
   name: kiali
   labels:
     app: kiali
-    chart: kiali
     release: istio
 spec:
   ports:
@@ -14090,7 +14022,6 @@ metadata:
    networking.istio.io/exportTo: "*"
   labels:
     app: mixer
-    chart: mixer
     release: istio
     istio: mixer
 spec:
@@ -14113,7 +14044,6 @@ metadata:
    networking.istio.io/exportTo: "*"
   labels:
     app: mixer
-    chart: mixer
     release: istio
     istio: mixer
 spec:
@@ -14140,7 +14070,6 @@ metadata:
   name: istio-pilot
   labels:
     app: pilot
-    chart: pilot
     release: istio
     istio: pilot
 spec:
@@ -14166,7 +14095,6 @@ metadata:
     prometheus.io/scrape: 'true'
   labels:
     app: prometheus
-    chart: prometheus
     release: istio
 spec:
   selector:
@@ -14186,7 +14114,6 @@ metadata:
   name: istio-citadel
   labels:
     app: security
-    chart: security
     release: istio
     istio: citadel
 spec:
@@ -14208,7 +14135,6 @@ metadata:
   name: istio-sidecar-injector
   labels:
     app: sidecarInjectorWebhook
-    chart: sidecarInjectorWebhook
     release: istio
     istio: sidecar-injector
 spec:
@@ -14225,7 +14151,6 @@ metadata:
   name: istio-galley
   labels:
     app: galley
-    chart: galley
     release: istio
     istio: galley
 spec:
@@ -14237,14 +14162,12 @@ spec:
   selector:
     matchLabels:
       app: galley
-      chart: galley
       release: istio      
       istio: galley
   template:
     metadata:
       labels:
         app: galley
-        chart: galley
         release: istio      
         istio: galley
       annotations:
@@ -14357,21 +14280,18 @@ kind: Deployment
 metadata:
   name: istio-egressgateway
   labels:
-    chart: gateways
     release: istio
     app: istio-egressgateway
     istio: egressgateway
 spec:
   selector:
     matchLabels:
-      chart: gateways
       release: istio
       app: istio-egressgateway
       istio: egressgateway
   template:
     metadata:
       labels:
-        chart: gateways
         release: istio
         app: istio-egressgateway
         istio: egressgateway
@@ -14526,21 +14446,18 @@ kind: Deployment
 metadata:
   name: istio-ingressgateway
   labels:
-    chart: gateways
     release: istio
     app: istio-ingressgateway
     istio: ingressgateway
 spec:
   selector:
     matchLabels:
-      chart: gateways
       release: istio
       app: istio-ingressgateway
       istio: ingressgateway
   template:
     metadata:
       labels:
-        chart: gateways
         release: istio
         app: istio-ingressgateway
         istio: ingressgateway
@@ -14705,20 +14622,17 @@ metadata:
   name: grafana
   labels:
     app: grafana
-    chart: grafana
     release: istio
 spec:
   replicas: 1
   selector:
     matchLabels:
       app: grafana
-      chart: grafana
       release: istio
   template:
     metadata:
       labels:
         app: grafana
-        chart: grafana
         release: istio
       annotations:
         sidecar.istio.io/inject: "false"
@@ -14857,7 +14771,6 @@ metadata:
   name: kiali
   labels:
     app: kiali
-    chart: kiali
     release: istio
 spec:
   replicas: 1
@@ -14869,7 +14782,6 @@ spec:
       name: kiali
       labels:
         app: kiali
-        chart: kiali
         release: istio
       annotations:
         sidecar.istio.io/inject: "false"
@@ -14956,7 +14868,6 @@ metadata:
   name: istio-policy
   labels:
     app: istio-mixer
-    chart: mixer
     release: istio
     istio: mixer
 spec:
@@ -14972,7 +14883,6 @@ spec:
     metadata:
       labels:
         app: policy
-        chart: mixer
         release: istio
         istio: mixer
         istio-mixer-type: policy
@@ -15125,7 +15035,6 @@ metadata:
   name: istio-telemetry
   labels:
     app: istio-mixer
-    chart: mixer
     release: istio
     istio: mixer
 spec:
@@ -15141,7 +15050,6 @@ spec:
     metadata:
       labels:
         app: telemetry
-        chart: mixer
         release: istio
         istio: mixer
         istio-mixer-type: telemetry
@@ -15302,7 +15210,6 @@ metadata:
   # TODO: default template doesn't have this, which one is right ?
   labels:
     app: pilot
-    chart: pilot
     release: istio
     istio: pilot
   annotations:
@@ -15319,7 +15226,6 @@ spec:
     metadata:
       labels:
         app: pilot
-        chart: pilot
         release: istio
         istio: pilot
       annotations:
@@ -15480,7 +15386,6 @@ metadata:
   name: prometheus
   labels:
     app: prometheus
-    chart: prometheus
     release: istio
 spec:
   replicas: 1
@@ -15491,7 +15396,6 @@ spec:
     metadata:
       labels:
         app: prometheus
-        chart: prometheus
         release: istio
       annotations:
         sidecar.istio.io/inject: "false"
@@ -15575,7 +15479,6 @@ metadata:
   name: istio-citadel
   labels:
     app: security
-    chart: security
     release: istio
     istio: citadel
 spec:
@@ -15587,14 +15490,12 @@ spec:
   selector:
     matchLabels:
       app: security
-      chart: security
       release: istio
       istio: citadel
   template:
     metadata:
       labels:
         app: security
-        chart: security
         release: istio
         istio: citadel
       annotations:
@@ -15665,7 +15566,6 @@ metadata:
   name: istio-sidecar-injector
   labels:
     app: sidecarInjectorWebhook
-    chart: sidecarInjectorWebhook
     release: istio
     istio: sidecar-injector
 spec:
@@ -15677,14 +15577,12 @@ spec:
   selector:
     matchLabels:
       app: sidecarInjectorWebhook
-      chart: sidecarInjectorWebhook
       release: istio
       istio: sidecar-injector
   template:
     metadata:
       labels:
         app: sidecarInjectorWebhook
-        chart: sidecarInjectorWebhook
         release: istio
         istio: sidecar-injector
       annotations:
@@ -15792,19 +15690,16 @@ metadata:
   name: istio-tracing
   labels:
     app: jaeger
-    chart: tracing
     release: istio
 spec:
   selector:
     matchLabels:
       app: jaeger
-      chart: tracing
       release: istio
   template:
     metadata:
       labels:
         app: jaeger
-        chart: tracing
         release: istio
       annotations:
         sidecar.istio.io/inject: "false"
@@ -15893,7 +15788,6 @@ metadata:
   name: istio-egressgateway
   labels:
     app: egressgateway
-    chart: gateways
     release: istio
 spec:
   maxReplicas: 5
@@ -15914,7 +15808,6 @@ metadata:
   name: istio-ingressgateway
   labels:
     app: ingressgateway
-    chart: gateways
     release: istio
 spec:
   maxReplicas: 5
@@ -15939,7 +15832,6 @@ metadata:
   name: istio-policy
   labels:
     app: mixer
-    chart: mixer
     release: istio
 spec:
     maxReplicas: 5
@@ -15960,7 +15852,6 @@ metadata:
   name: istio-telemetry
   labels:
     app: mixer
-    chart: mixer
     release: istio
 spec:
     maxReplicas: 5
@@ -15985,7 +15876,6 @@ metadata:
   name: istio-pilot
   labels:
     app: pilot
-    chart: pilot
     release: istio
 spec:
   maxReplicas: 5
@@ -16012,7 +15902,6 @@ metadata:
   labels:
     app: jaeger
     jaeger-infra: jaeger-service
-    chart: tracing
     release: istio
 spec:
   ports:
@@ -16032,7 +15921,6 @@ metadata:
   labels:
     app: jaeger
     jaeger-infra: collector-service
-    chart: tracing
     release: istio
 spec:
   ports:
@@ -16055,7 +15943,6 @@ metadata:
   labels:
     app: jaeger
     jaeger-infra: agent-service
-    chart: tracing
     release: istio
 spec:
   ports:
@@ -16085,7 +15972,6 @@ metadata:
   name: zipkin
   labels:
     app: jaeger
-    chart: tracing
     release: istio
 spec:
   type: ClusterIP
@@ -16104,7 +15990,6 @@ metadata:
   annotations:
   labels:
     app: jaeger
-    chart: tracing
     release: istio
 spec:
   ports:
@@ -16125,7 +16010,6 @@ metadata:
   name: istio-sidecar-injector
   labels:
     app: sidecarInjectorWebhook
-    chart: sidecarInjectorWebhook
     release: istio
 webhooks:
   - name: sidecar-injector.istio.io
@@ -16155,7 +16039,6 @@ metadata:
   name: istio-galley
   labels:
     app: galley
-    chart: galley
     release: istio
     istio: galley
 spec:
@@ -16175,7 +16058,6 @@ kind: PodDisruptionBudget
 metadata:
   name: istio-egressgateway
   labels:
-    chart: gateways
     release: istio
     app: istio-egressgateway
     istio: egressgateway
@@ -16193,7 +16075,6 @@ kind: PodDisruptionBudget
 metadata:
   name: istio-ingressgateway
   labels:
-    chart: gateways
     release: istio
     app: istio-ingressgateway
     istio: ingressgateway
@@ -16216,7 +16097,6 @@ metadata:
   name: istio-policy
   labels:
     app: policy
-    chart: mixer
     release: istio
     version: 1.1.0
     istio: mixer
@@ -16237,7 +16117,6 @@ metadata:
   name: istio-telemetry
   labels:
     app: telemetry
-    chart: mixer
     release: istio
     version: 1.1.0
     istio: mixer
@@ -16260,7 +16139,6 @@ metadata:
   name: istio-pilot
   labels:
     app: pilot
-    chart: pilot
     release: istio
     istio: pilot
 spec:
@@ -16279,7 +16157,6 @@ metadata:
   name: istioproxy
   labels:
     app: mixer
-    chart: mixer
     release: istio
 spec:
   attributes:
@@ -16418,7 +16295,6 @@ metadata:
   name: kubernetes
   labels:
     app: mixer
-    chart: mixer
     release: istio
 spec:
   attributes:
@@ -16481,7 +16357,6 @@ metadata:
   name: stdio
   labels:
     app: mixer
-    chart: mixer
     release: istio
 spec:
   compiledAdapter: stdio
@@ -16494,7 +16369,6 @@ metadata:
   name: accesslog
   labels:
     app: mixer
-    chart: mixer
     release: istio
 spec:
   severity: '"Info"'
@@ -16549,7 +16423,6 @@ metadata:
   name: tcpaccesslog
   labels:
     app: mixer
-    chart: mixer
     release: istio
 spec:
   severity: '"Info"'
@@ -16589,7 +16462,6 @@ metadata:
   name: stdio
   labels:
     app: mixer
-    chart: mixer
     release: istio
 spec:
   match: context.protocol == "http" || context.protocol == "grpc"
@@ -16604,7 +16476,6 @@ metadata:
   name: stdiotcp
   labels:
     app: mixer
-    chart: mixer
     release: istio
 spec:
   match: context.protocol == "tcp"
@@ -16619,7 +16490,6 @@ metadata:
   name: requestcount
   labels:
     app: mixer
-    chart: mixer
     release: istio
 spec:
   value: "1"
@@ -16652,7 +16522,6 @@ metadata:
   name: requestduration
   labels:
     app: mixer
-    chart: mixer
     release: istio
 spec:
   value: response.duration | "0ms"
@@ -16685,7 +16554,6 @@ metadata:
   name: requestsize
   labels:
     app: mixer
-    chart: mixer
     release: istio
 spec:
   value: request.size | 0
@@ -16718,7 +16586,6 @@ metadata:
   name: responsesize
   labels:
     app: mixer
-    chart: mixer
     release: istio
 spec:
   value: response.size | 0
@@ -16751,7 +16618,6 @@ metadata:
   name: tcpbytesent
   labels:
     app: mixer
-    chart: mixer
     release: istio
 spec:
   value: connection.sent.bytes | 0
@@ -16780,7 +16646,6 @@ metadata:
   name: tcpbytereceived
   labels:
     app: mixer
-    chart: mixer
     release: istio
 spec:
   value: connection.received.bytes | 0
@@ -16809,7 +16674,6 @@ metadata:
   name: tcpconnectionsopened
   labels:
     app: mixer
-    chart: mixer
     release: istio
 spec:
   value: "1"
@@ -16838,7 +16702,6 @@ metadata:
   name: tcpconnectionsclosed
   labels:
     app: mixer
-    chart: mixer
     release: istio
 spec:
   value: "1"
@@ -16867,7 +16730,6 @@ metadata:
   name: prometheus
   labels:
     app: mixer
-    chart: mixer
     release: istio
 spec:
   compiledAdapter: prometheus
@@ -17071,7 +16933,6 @@ metadata:
   name: promhttp
   labels:
     app: mixer
-    chart: mixer
     release: istio
 spec:
   match: (context.protocol == "http" || context.protocol == "grpc") && (match((request.useragent | "-"), "kube-probe*") == false)
@@ -17089,7 +16950,6 @@ metadata:
   name: promtcp
   labels:
     app: mixer
-    chart: mixer
     release: istio
 spec:
   match: context.protocol == "tcp"
@@ -17105,7 +16965,6 @@ metadata:
   name: promtcpconnectionopen
   labels:
     app: mixer
-    chart: mixer
     release: istio
 spec:
   match: context.protocol == "tcp" && ((connection.event | "na") == "open")
@@ -17120,7 +16979,6 @@ metadata:
   name: promtcpconnectionclosed
   labels:
     app: mixer
-    chart: mixer
     release: istio
 spec:
   match: context.protocol == "tcp" && ((connection.event | "na") == "close")
@@ -17135,7 +16993,6 @@ metadata:
   name: kubernetesenv
   labels:
     app: mixer
-    chart: mixer
     release: istio
 spec:
   compiledAdapter: kubernetesenv
@@ -17154,7 +17011,6 @@ metadata:
   name: kubeattrgenrulerule
   labels:
     app: mixer
-    chart: mixer
     release: istio
 spec:
   actions:
@@ -17168,7 +17024,6 @@ metadata:
   name: tcpkubeattrgenrulerule
   labels:
     app: mixer
-    chart: mixer
     release: istio
 spec:
   match: context.protocol == "tcp"
@@ -17183,7 +17038,6 @@ metadata:
   name: attributes
   labels:
     app: mixer
-    chart: mixer
     release: istio
 spec:
   # Pass the required attribute data to the adapter
@@ -17225,7 +17079,6 @@ metadata:
   name: istio-policy
   labels:
     app: mixer
-    chart: mixer
     release: istio
 spec:
   host: istio-policy.istio-system.svc.cluster.local
@@ -17241,7 +17094,6 @@ metadata:
   name: istio-telemetry
   labels:
     app: mixer
-    chart: mixer
     release: istio
 spec:
   host: istio-telemetry.istio-system.svc.cluster.local

--- a/tests/istio-install-base_test.go
+++ b/tests/istio-install-base_test.go
@@ -31,7 +31,6 @@ metadata:
   labels:
     app: kiali
     chart: kiali
-    heritage: Tiller
     release: istio
 type: Opaque
 data:
@@ -47,7 +46,6 @@ metadata:
   labels:
     app: galley
     chart: galley
-    heritage: Tiller
     release: istio
     istio: galley
 data:
@@ -60,7 +58,6 @@ data:
       labels:
         app: galley
         chart: galley
-        heritage: Tiller
         release: istio
         istio: galley
     webhooks:
@@ -171,7 +168,6 @@ metadata:
   labels:
     app: grafana
     chart: grafana
-    heritage: Tiller
     release: istio
     istio: grafana
 data:
@@ -184,7 +180,6 @@ data:
       labels:
         app: grafana
         chart: grafana
-        heritage: Tiller
         release: istio
     spec:
       targets:
@@ -234,7 +229,6 @@ metadata:
   labels:
     app: grafana
     chart: grafana
-    heritage: Tiller
     release: istio
     istio: grafana
 data:
@@ -2066,7 +2060,6 @@ metadata:
   labels:
     app: grafana
     chart: grafana
-    heritage: Tiller
     release: istio
     istio: grafana
 data:
@@ -3032,7 +3025,6 @@ metadata:
   labels:
     app: grafana
     chart: grafana
-    heritage: Tiller
     release: istio
     istio: grafana
 data:
@@ -3662,7 +3654,6 @@ metadata:
   labels:
     app: grafana
     chart: grafana
-    heritage: Tiller
     release: istio
     istio: grafana
 data:
@@ -6276,7 +6267,6 @@ metadata:
   labels:
     app: grafana
     chart: grafana
-    heritage: Tiller
     release: istio
     istio: grafana
 data:
@@ -8592,7 +8582,6 @@ metadata:
   labels:
     app: grafana
     chart: grafana
-    heritage: Tiller
     release: istio
     istio: grafana
 data:
@@ -10413,7 +10402,6 @@ metadata:
   labels:
     app: grafana
     chart: grafana
-    heritage: Tiller
     release: istio
     istio: grafana
 data:
@@ -12024,7 +12012,6 @@ metadata:
   labels:
     app: grafana
     chart: grafana
-    heritage: Tiller
     release: istio
     istio: grafana
 data:
@@ -12061,7 +12048,6 @@ metadata:
   labels:
     app: kiali
     chart: kiali
-    heritage: Tiller
     release: istio
 data:
   config.yaml: |
@@ -12085,7 +12071,6 @@ metadata:
   labels:
     app: prometheus
     chart: prometheus
-    heritage: Tiller
     release: istio
 data:
   prometheus.yml: |-
@@ -12399,7 +12384,6 @@ metadata:
   labels:	
     app: security	
     chart: security	
-    heritage: Tiller	
     release: istio	
     istio: citadel	
 data:	
@@ -12412,7 +12396,6 @@ data:
       labels:
         app: security
         chart: security
-        heritage: Tiller
         release: istio
     spec:
       peers:
@@ -12461,7 +12444,6 @@ metadata:
   labels:
     app: istio
     chart: istio
-    heritage: Tiller
     release: istio
 data:
   mesh: |-
@@ -12605,7 +12587,6 @@ metadata:
   labels:
     app: istio
     chart: istio
-    heritage: Tiller
     release: istio
     istio: sidecar-injector
 data:
@@ -12823,7 +12804,6 @@ metadata:
   labels:
     app: galley
     chart: galley
-    heritage: Tiller
     release: istio
 
 ---
@@ -12836,7 +12816,6 @@ metadata:
   labels:
     app: istio-egressgateway
     chart: gateways
-    heritage: Tiller
     release: istio
 ---
 apiVersion: v1
@@ -12846,7 +12825,6 @@ metadata:
   labels:
     app: istio-ingressgateway
     chart: gateways
-    heritage: Tiller
     release: istio
 ---
 
@@ -12860,7 +12838,6 @@ metadata:
   labels:
     app: grafana
     chart: grafana
-    heritage: Tiller
     release: istio
 ---
 apiVersion: rbac.authorization.k8s.io/v1
@@ -12870,7 +12847,6 @@ metadata:
   labels:
     app: grafana
     chart: grafana
-    heritage: Tiller
     release: istio
 rules:
 - apiGroups: ["authentication.istio.io"] # needed to create default authn policy
@@ -12884,7 +12860,6 @@ metadata:
   labels:
     app: grafana
     chart: grafana
-    heritage: Tiller
     release: istio
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -12905,7 +12880,6 @@ metadata:
   labels:
     app: grafana
     chart: grafana
-    heritage: Tiller
     release: istio
 spec:
   template:
@@ -12914,7 +12888,6 @@ spec:
       labels:
         app: istio-grafana
         chart: grafana
-        heritage: Tiller
         release: istio
     spec:
       serviceAccountName: istio-grafana-post-install-account
@@ -12973,7 +12946,6 @@ metadata:
   labels:
     app: kiali
     chart: kiali
-    heritage: Tiller
     release: istio
 
 ---
@@ -12986,7 +12958,6 @@ metadata:
   labels:
     app: mixer
     chart: mixer
-    heritage: Tiller
     release: istio
 
 ---
@@ -12998,7 +12969,6 @@ metadata:
   labels:
     app: pilot
     chart: pilot
-    heritage: Tiller
     release: istio
 
 ---
@@ -13010,7 +12980,6 @@ metadata:
   labels:
     app: prometheus
     chart: prometheus
-    heritage: Tiller
     release: istio
 
 ---
@@ -13035,7 +13004,6 @@ metadata:
   labels:
     app: security
     chart: security
-    heritage: Tiller
     release: istio
 ---
 apiVersion: rbac.authorization.k8s.io/v1
@@ -13049,7 +13017,6 @@ metadata:
   labels:
     app: security
     chart: security
-    heritage: Tiller
     release: istio
 rules:
 - apiGroups: [""]
@@ -13067,7 +13034,6 @@ metadata:
   labels:
     app: security
     chart: security
-    heritage: Tiller
     release: istio
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -13089,7 +13055,6 @@ metadata:
   labels:
     app: security
     chart: security
-    heritage: Tiller
     release: istio
 spec:
   template:
@@ -13098,7 +13063,6 @@ spec:
       labels:
         app: security
         chart: security
-        heritage: Tiller
         release: istio
     spec:
       serviceAccountName: istio-cleanup-secrets-service-account
@@ -13160,7 +13124,6 @@ metadata:
   labels:	
     app: security	
     chart: security	
-    heritage: Tiller	
     release: istio	
 ---
 apiVersion: rbac.authorization.k8s.io/v1beta1	
@@ -13170,7 +13133,6 @@ metadata:
   labels:	
     app: security	
     chart: security	
-    heritage: Tiller	
     release: istio	
 rules:	
 - apiGroups: ["authentication.istio.io"] # needed to create default authn policy	
@@ -13193,7 +13155,6 @@ metadata:
   labels:	
     app: security	
     chart: security	
-    heritage: Tiller	
     release: istio	
 roleRef:	
   apiGroup: rbac.authorization.k8s.io	
@@ -13214,7 +13175,6 @@ metadata:
   labels:	
     app: security	
     chart: security	
-    heritage: Tiller	
     release: istio	
 spec:	
   template:	
@@ -13223,7 +13183,6 @@ spec:
       labels:	
         app: security	
         chart: security	
-        heritage: Tiller	
         release: istio	
     spec:	
       serviceAccountName: istio-security-post-install-account	
@@ -13283,7 +13242,6 @@ metadata:
   labels:
     app: security
     chart: security
-    heritage: Tiller
     release: istio
 
 ---
@@ -13295,7 +13253,6 @@ metadata:
   labels:
     app: sidecarInjectorWebhook
     chart: sidecarInjectorWebhook
-    heritage: Tiller
     release: istio
     istio: sidecar-injector
 
@@ -13315,7 +13272,6 @@ metadata:
   labels:
     app: galley
     chart: galley
-    heritage: Tiller
     release: istio
 rules:
 - apiGroups: ["admissionregistration.k8s.io"]
@@ -13358,7 +13314,6 @@ metadata:
   labels:
     app: egressgateway
     chart: gateways
-    heritage: Tiller
     release: istio
 rules:
 - apiGroups: ["networking.istio.io"]
@@ -13372,7 +13327,6 @@ metadata:
   labels:
     app: ingressgateway
     chart: gateways
-    heritage: Tiller
     release: istio
 rules:
 - apiGroups: ["networking.istio.io"]
@@ -13389,7 +13343,6 @@ metadata:
   labels:
     app: kiali
     chart: kiali
-    heritage: Tiller
     release: istio
 rules:
 - apiGroups: [""]
@@ -13514,7 +13467,6 @@ metadata:
   labels:
     app: kiali
     chart: kiali
-    heritage: Tiller
     release: istio
 rules:
 - apiGroups: [""]
@@ -13632,7 +13584,6 @@ metadata:
   labels:
     app: mixer
     chart: mixer
-    heritage: Tiller
     release: istio
 rules:
 - apiGroups: ["config.istio.io"] # istio CRD watcher
@@ -13657,7 +13608,6 @@ metadata:
   labels:
     app: pilot
     chart: pilot
-    heritage: Tiller
     release: istio
 rules:
 - apiGroups: ["config.istio.io"]
@@ -13694,7 +13644,6 @@ metadata:
   labels:
     app: prometheus
     chart: prometheus
-    heritage: Tiller
     release: istio
 rules:
 - apiGroups: [""]
@@ -13721,7 +13670,6 @@ metadata:
   labels:
     app: security
     chart: security
-    heritage: Tiller
     release: istio
 rules:
 - apiGroups: [""]
@@ -13746,7 +13694,6 @@ metadata:
   labels:
     app: sidecarInjectorWebhook
     chart: sidecarInjectorWebhook
-    heritage: Tiller
     release: istio
     istio: sidecar-injector
 rules:
@@ -13780,7 +13727,6 @@ metadata:
   labels:
     app: galley
     chart: galley
-    heritage: Tiller
     release: istio
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -13801,7 +13747,6 @@ metadata:
   labels:
     app: egressgateway
     chart: gateways
-    heritage: Tiller
     release: istio
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -13818,7 +13763,6 @@ metadata:
   labels:
     app: ingressgateway
     chart: gateways
-    heritage: Tiller
     release: istio
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -13838,7 +13782,6 @@ metadata:
   labels:
     app: kiali
     chart: kiali
-    heritage: Tiller
     release: istio
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -13858,7 +13801,6 @@ metadata:
   labels:
     app: mixer
     chart: mixer
-    heritage: Tiller
     release: istio
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -13878,7 +13820,6 @@ metadata:
   labels:
     app: pilot
     chart: pilot
-    heritage: Tiller
     release: istio
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -13898,7 +13839,6 @@ metadata:
   labels:
     app: prometheus
     chart: prometheus
-    heritage: Tiller
     release: istio
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -13917,7 +13857,6 @@ metadata:
   labels:
     app: security
     chart: security
-    heritage: Tiller
     release: istio
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -13937,7 +13876,6 @@ metadata:
   labels:
     app: sidecarInjectorWebhook
     chart: sidecarInjectorWebhook
-    heritage: Tiller
     release: istio
     istio: sidecar-injector
 roleRef:
@@ -14003,7 +13941,6 @@ metadata:
   labels:
     app: galley
     chart: galley
-    heritage: Tiller
     release: istio
     istio: galley
 spec:
@@ -14026,7 +13963,6 @@ metadata:
   name: istio-egressgateway
   labels:
     chart: gateways
-    heritage: Tiller
     release: istio
     app: istio-egressgateway
     istio: egressgateway
@@ -14056,7 +13992,6 @@ metadata:
     beta.cloud.google.com/backend-config: '{"ports": {"http2":"iap-backendconfig"}}'
   labels:
     chart: gateways
-    heritage: Tiller
     release: istio
     app: istio-ingressgateway
     istio: ingressgateway
@@ -14115,7 +14050,6 @@ metadata:
   labels:
     app: grafana
     chart: grafana
-    heritage: Tiller
     release: istio
 spec:
   type: ClusterIP
@@ -14136,7 +14070,6 @@ metadata:
   labels:
     app: kiali
     chart: kiali
-    heritage: Tiller
     release: istio
 spec:
   ports:
@@ -14158,7 +14091,6 @@ metadata:
   labels:
     app: mixer
     chart: mixer
-    heritage: Tiller
     release: istio
     istio: mixer
 spec:
@@ -14182,7 +14114,6 @@ metadata:
   labels:
     app: mixer
     chart: mixer
-    heritage: Tiller
     release: istio
     istio: mixer
 spec:
@@ -14210,7 +14141,6 @@ metadata:
   labels:
     app: pilot
     chart: pilot
-    heritage: Tiller
     release: istio
     istio: pilot
 spec:
@@ -14237,7 +14167,6 @@ metadata:
   labels:
     app: prometheus
     chart: prometheus
-    heritage: Tiller
     release: istio
 spec:
   selector:
@@ -14258,7 +14187,6 @@ metadata:
   labels:
     app: security
     chart: security
-    heritage: Tiller
     release: istio
     istio: citadel
 spec:
@@ -14281,7 +14209,6 @@ metadata:
   labels:
     app: sidecarInjectorWebhook
     chart: sidecarInjectorWebhook
-    heritage: Tiller
     release: istio
     istio: sidecar-injector
 spec:
@@ -14299,7 +14226,6 @@ metadata:
   labels:
     app: galley
     chart: galley
-    heritage: Tiller
     release: istio
     istio: galley
 spec:
@@ -14312,7 +14238,6 @@ spec:
     matchLabels:
       app: galley
       chart: galley
-      heritage: Tiller
       release: istio      
       istio: galley
   template:
@@ -14320,7 +14245,6 @@ spec:
       labels:
         app: galley
         chart: galley
-        heritage: Tiller
         release: istio      
         istio: galley
       annotations:
@@ -14434,7 +14358,6 @@ metadata:
   name: istio-egressgateway
   labels:
     chart: gateways
-    heritage: Tiller
     release: istio
     app: istio-egressgateway
     istio: egressgateway
@@ -14442,7 +14365,6 @@ spec:
   selector:
     matchLabels:
       chart: gateways
-      heritage: Tiller
       release: istio
       app: istio-egressgateway
       istio: egressgateway
@@ -14450,7 +14372,6 @@ spec:
     metadata:
       labels:
         chart: gateways
-        heritage: Tiller
         release: istio
         app: istio-egressgateway
         istio: egressgateway
@@ -14606,7 +14527,6 @@ metadata:
   name: istio-ingressgateway
   labels:
     chart: gateways
-    heritage: Tiller
     release: istio
     app: istio-ingressgateway
     istio: ingressgateway
@@ -14614,7 +14534,6 @@ spec:
   selector:
     matchLabels:
       chart: gateways
-      heritage: Tiller
       release: istio
       app: istio-ingressgateway
       istio: ingressgateway
@@ -14622,7 +14541,6 @@ spec:
     metadata:
       labels:
         chart: gateways
-        heritage: Tiller
         release: istio
         app: istio-ingressgateway
         istio: ingressgateway
@@ -14788,7 +14706,6 @@ metadata:
   labels:
     app: grafana
     chart: grafana
-    heritage: Tiller
     release: istio
 spec:
   replicas: 1
@@ -14796,14 +14713,12 @@ spec:
     matchLabels:
       app: grafana
       chart: grafana
-      heritage: Tiller
       release: istio
   template:
     metadata:
       labels:
         app: grafana
         chart: grafana
-        heritage: Tiller
         release: istio
       annotations:
         sidecar.istio.io/inject: "false"
@@ -14943,7 +14858,6 @@ metadata:
   labels:
     app: kiali
     chart: kiali
-    heritage: Tiller
     release: istio
 spec:
   replicas: 1
@@ -14956,7 +14870,6 @@ spec:
       labels:
         app: kiali
         chart: kiali
-        heritage: Tiller
         release: istio
       annotations:
         sidecar.istio.io/inject: "false"
@@ -15044,7 +14957,6 @@ metadata:
   labels:
     app: istio-mixer
     chart: mixer
-    heritage: Tiller
     release: istio
     istio: mixer
 spec:
@@ -15061,7 +14973,6 @@ spec:
       labels:
         app: policy
         chart: mixer
-        heritage: Tiller
         release: istio
         istio: mixer
         istio-mixer-type: policy
@@ -15215,7 +15126,6 @@ metadata:
   labels:
     app: istio-mixer
     chart: mixer
-    heritage: Tiller
     release: istio
     istio: mixer
 spec:
@@ -15232,7 +15142,6 @@ spec:
       labels:
         app: telemetry
         chart: mixer
-        heritage: Tiller
         release: istio
         istio: mixer
         istio-mixer-type: telemetry
@@ -15394,7 +15303,6 @@ metadata:
   labels:
     app: pilot
     chart: pilot
-    heritage: Tiller
     release: istio
     istio: pilot
   annotations:
@@ -15412,7 +15320,6 @@ spec:
       labels:
         app: pilot
         chart: pilot
-        heritage: Tiller
         release: istio
         istio: pilot
       annotations:
@@ -15574,7 +15481,6 @@ metadata:
   labels:
     app: prometheus
     chart: prometheus
-    heritage: Tiller
     release: istio
 spec:
   replicas: 1
@@ -15586,7 +15492,6 @@ spec:
       labels:
         app: prometheus
         chart: prometheus
-        heritage: Tiller
         release: istio
       annotations:
         sidecar.istio.io/inject: "false"
@@ -15671,7 +15576,6 @@ metadata:
   labels:
     app: security
     chart: security
-    heritage: Tiller
     release: istio
     istio: citadel
 spec:
@@ -15684,7 +15588,6 @@ spec:
     matchLabels:
       app: security
       chart: security
-      heritage: Tiller
       release: istio
       istio: citadel
   template:
@@ -15692,7 +15595,6 @@ spec:
       labels:
         app: security
         chart: security
-        heritage: Tiller
         release: istio
         istio: citadel
       annotations:
@@ -15764,7 +15666,6 @@ metadata:
   labels:
     app: sidecarInjectorWebhook
     chart: sidecarInjectorWebhook
-    heritage: Tiller
     release: istio
     istio: sidecar-injector
 spec:
@@ -15777,7 +15678,6 @@ spec:
     matchLabels:
       app: sidecarInjectorWebhook
       chart: sidecarInjectorWebhook
-      heritage: Tiller
       release: istio
       istio: sidecar-injector
   template:
@@ -15785,7 +15685,6 @@ spec:
       labels:
         app: sidecarInjectorWebhook
         chart: sidecarInjectorWebhook
-        heritage: Tiller
         release: istio
         istio: sidecar-injector
       annotations:
@@ -15894,21 +15793,18 @@ metadata:
   labels:
     app: jaeger
     chart: tracing
-    heritage: Tiller
     release: istio
 spec:
   selector:
     matchLabels:
       app: jaeger
       chart: tracing
-      heritage: Tiller
       release: istio
   template:
     metadata:
       labels:
         app: jaeger
         chart: tracing
-        heritage: Tiller
         release: istio
       annotations:
         sidecar.istio.io/inject: "false"
@@ -15998,7 +15894,6 @@ metadata:
   labels:
     app: egressgateway
     chart: gateways
-    heritage: Tiller
     release: istio
 spec:
   maxReplicas: 5
@@ -16020,7 +15915,6 @@ metadata:
   labels:
     app: ingressgateway
     chart: gateways
-    heritage: Tiller
     release: istio
 spec:
   maxReplicas: 5
@@ -16046,7 +15940,6 @@ metadata:
   labels:
     app: mixer
     chart: mixer
-    heritage: Tiller
     release: istio
 spec:
     maxReplicas: 5
@@ -16068,7 +15961,6 @@ metadata:
   labels:
     app: mixer
     chart: mixer
-    heritage: Tiller
     release: istio
 spec:
     maxReplicas: 5
@@ -16094,7 +15986,6 @@ metadata:
   labels:
     app: pilot
     chart: pilot
-    heritage: Tiller
     release: istio
 spec:
   maxReplicas: 5
@@ -16122,7 +16013,6 @@ metadata:
     app: jaeger
     jaeger-infra: jaeger-service
     chart: tracing
-    heritage: Tiller
     release: istio
 spec:
   ports:
@@ -16143,7 +16033,6 @@ metadata:
     app: jaeger
     jaeger-infra: collector-service
     chart: tracing
-    heritage: Tiller
     release: istio
 spec:
   ports:
@@ -16167,7 +16056,6 @@ metadata:
     app: jaeger
     jaeger-infra: agent-service
     chart: tracing
-    heritage: Tiller
     release: istio
 spec:
   ports:
@@ -16198,7 +16086,6 @@ metadata:
   labels:
     app: jaeger
     chart: tracing
-    heritage: Tiller
     release: istio
 spec:
   type: ClusterIP
@@ -16218,7 +16105,6 @@ metadata:
   labels:
     app: jaeger
     chart: tracing
-    heritage: Tiller
     release: istio
 spec:
   ports:
@@ -16240,7 +16126,6 @@ metadata:
   labels:
     app: sidecarInjectorWebhook
     chart: sidecarInjectorWebhook
-    heritage: Tiller
     release: istio
 webhooks:
   - name: sidecar-injector.istio.io
@@ -16271,7 +16156,6 @@ metadata:
   labels:
     app: galley
     chart: galley
-    heritage: Tiller
     release: istio
     istio: galley
 spec:
@@ -16292,7 +16176,6 @@ metadata:
   name: istio-egressgateway
   labels:
     chart: gateways
-    heritage: Tiller
     release: istio
     app: istio-egressgateway
     istio: egressgateway
@@ -16311,7 +16194,6 @@ metadata:
   name: istio-ingressgateway
   labels:
     chart: gateways
-    heritage: Tiller
     release: istio
     app: istio-ingressgateway
     istio: ingressgateway
@@ -16335,7 +16217,6 @@ metadata:
   labels:
     app: policy
     chart: mixer
-    heritage: Tiller
     release: istio
     version: 1.1.0
     istio: mixer
@@ -16357,7 +16238,6 @@ metadata:
   labels:
     app: telemetry
     chart: mixer
-    heritage: Tiller
     release: istio
     version: 1.1.0
     istio: mixer
@@ -16381,7 +16261,6 @@ metadata:
   labels:
     app: pilot
     chart: pilot
-    heritage: Tiller
     release: istio
     istio: pilot
 spec:
@@ -16401,7 +16280,6 @@ metadata:
   labels:
     app: mixer
     chart: mixer
-    heritage: Tiller
     release: istio
 spec:
   attributes:
@@ -16541,7 +16419,6 @@ metadata:
   labels:
     app: mixer
     chart: mixer
-    heritage: Tiller
     release: istio
 spec:
   attributes:
@@ -16605,7 +16482,6 @@ metadata:
   labels:
     app: mixer
     chart: mixer
-    heritage: Tiller
     release: istio
 spec:
   compiledAdapter: stdio
@@ -16619,7 +16495,6 @@ metadata:
   labels:
     app: mixer
     chart: mixer
-    heritage: Tiller
     release: istio
 spec:
   severity: '"Info"'
@@ -16675,7 +16550,6 @@ metadata:
   labels:
     app: mixer
     chart: mixer
-    heritage: Tiller
     release: istio
 spec:
   severity: '"Info"'
@@ -16716,7 +16590,6 @@ metadata:
   labels:
     app: mixer
     chart: mixer
-    heritage: Tiller
     release: istio
 spec:
   match: context.protocol == "http" || context.protocol == "grpc"
@@ -16732,7 +16605,6 @@ metadata:
   labels:
     app: mixer
     chart: mixer
-    heritage: Tiller
     release: istio
 spec:
   match: context.protocol == "tcp"
@@ -16748,7 +16620,6 @@ metadata:
   labels:
     app: mixer
     chart: mixer
-    heritage: Tiller
     release: istio
 spec:
   value: "1"
@@ -16782,7 +16653,6 @@ metadata:
   labels:
     app: mixer
     chart: mixer
-    heritage: Tiller
     release: istio
 spec:
   value: response.duration | "0ms"
@@ -16816,7 +16686,6 @@ metadata:
   labels:
     app: mixer
     chart: mixer
-    heritage: Tiller
     release: istio
 spec:
   value: request.size | 0
@@ -16850,7 +16719,6 @@ metadata:
   labels:
     app: mixer
     chart: mixer
-    heritage: Tiller
     release: istio
 spec:
   value: response.size | 0
@@ -16884,7 +16752,6 @@ metadata:
   labels:
     app: mixer
     chart: mixer
-    heritage: Tiller
     release: istio
 spec:
   value: connection.sent.bytes | 0
@@ -16914,7 +16781,6 @@ metadata:
   labels:
     app: mixer
     chart: mixer
-    heritage: Tiller
     release: istio
 spec:
   value: connection.received.bytes | 0
@@ -16944,7 +16810,6 @@ metadata:
   labels:
     app: mixer
     chart: mixer
-    heritage: Tiller
     release: istio
 spec:
   value: "1"
@@ -16974,7 +16839,6 @@ metadata:
   labels:
     app: mixer
     chart: mixer
-    heritage: Tiller
     release: istio
 spec:
   value: "1"
@@ -17004,7 +16868,6 @@ metadata:
   labels:
     app: mixer
     chart: mixer
-    heritage: Tiller
     release: istio
 spec:
   compiledAdapter: prometheus
@@ -17209,7 +17072,6 @@ metadata:
   labels:
     app: mixer
     chart: mixer
-    heritage: Tiller
     release: istio
 spec:
   match: (context.protocol == "http" || context.protocol == "grpc") && (match((request.useragent | "-"), "kube-probe*") == false)
@@ -17228,7 +17090,6 @@ metadata:
   labels:
     app: mixer
     chart: mixer
-    heritage: Tiller
     release: istio
 spec:
   match: context.protocol == "tcp"
@@ -17245,7 +17106,6 @@ metadata:
   labels:
     app: mixer
     chart: mixer
-    heritage: Tiller
     release: istio
 spec:
   match: context.protocol == "tcp" && ((connection.event | "na") == "open")
@@ -17261,7 +17121,6 @@ metadata:
   labels:
     app: mixer
     chart: mixer
-    heritage: Tiller
     release: istio
 spec:
   match: context.protocol == "tcp" && ((connection.event | "na") == "close")
@@ -17277,7 +17136,6 @@ metadata:
   labels:
     app: mixer
     chart: mixer
-    heritage: Tiller
     release: istio
 spec:
   compiledAdapter: kubernetesenv
@@ -17297,7 +17155,6 @@ metadata:
   labels:
     app: mixer
     chart: mixer
-    heritage: Tiller
     release: istio
 spec:
   actions:
@@ -17312,7 +17169,6 @@ metadata:
   labels:
     app: mixer
     chart: mixer
-    heritage: Tiller
     release: istio
 spec:
   match: context.protocol == "tcp"
@@ -17328,7 +17184,6 @@ metadata:
   labels:
     app: mixer
     chart: mixer
-    heritage: Tiller
     release: istio
 spec:
   # Pass the required attribute data to the adapter
@@ -17371,7 +17226,6 @@ metadata:
   labels:
     app: mixer
     chart: mixer
-    heritage: Tiller
     release: istio
 spec:
   host: istio-policy.istio-system.svc.cluster.local
@@ -17388,7 +17242,6 @@ metadata:
   labels:
     app: mixer
     chart: mixer
-    heritage: Tiller
     release: istio
 spec:
   host: istio-telemetry.istio-system.svc.cluster.local

--- a/tests/seldon-core-operator-base_test.go
+++ b/tests/seldon-core-operator-base_test.go
@@ -32,7 +32,6 @@ metadata:
   labels:
     app.kubernetes.io/instance: seldon-core-operator
     app.kubernetes.io/name: seldon-core-operator
-    helm.sh/chart: seldon-core-operator-0.4.0
   name: seldon-config
   namespace: kubeflow
 `)
@@ -43,7 +42,6 @@ metadata:
   labels:
     app.kubernetes.io/instance: seldon-core-operator
     app.kubernetes.io/name: seldon-core-operator
-    helm.sh/chart: seldon-core-operator-0.4.0
   name: seldon-manager
   namespace: kubeflow
 `)
@@ -56,7 +54,6 @@ metadata:
     app.kubernetes.io/name: seldon-core-operator
     control-plane: seldon-controller-manager
     controller-tools.k8s.io: "1.0"
-    helm.sh/chart: seldon-core-operator-0.4.0
   name: seldon-operator-controller-manager-service
   namespace: kubeflow
 spec:
@@ -75,7 +72,6 @@ metadata:
     app.kubernetes.io/name: seldon-core-operator
     control-plane: seldon-controller-manager
     controller-tools.k8s.io: "1.0"
-    helm.sh/chart: seldon-core-operator-0.4.0
   name: seldon-operator-controller-manager
   namespace: kubeflow
 spec:
@@ -166,7 +162,6 @@ metadata:
   labels:
     app.kubernetes.io/instance: seldon-core-operator
     app.kubernetes.io/name: seldon-core-operator
-    helm.sh/chart: seldon-core-operator-0.4.0
   name: seldon-operator-manager-role
 rules:
 - apiGroups:
@@ -358,7 +353,6 @@ metadata:
   labels:
     app.kubernetes.io/instance: seldon-core-operator
     app.kubernetes.io/name: seldon-core-operator
-    helm.sh/chart: seldon-core-operator-0.4.0
   name: seldon-operator-manager-rolebinding
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -3602,7 +3596,6 @@ metadata:
     app.kubernetes.io/name: seldon-core-operator
     control-plane: seldon-controller-manager
     controller-tools.k8s.io: "1.0"
-    helm.sh/chart: seldon-core-operator-0.4.0
   name: webhook-server-service
   namespace: kubeflow
 spec:

--- a/tests/seldon-core-operator-base_test.go
+++ b/tests/seldon-core-operator-base_test.go
@@ -31,7 +31,6 @@ kind: ConfigMap
 metadata:
   labels:
     app.kubernetes.io/instance: seldon-core-operator
-    app.kubernetes.io/managed-by: Tiller
     app.kubernetes.io/name: seldon-core-operator
     helm.sh/chart: seldon-core-operator-0.4.0
   name: seldon-config
@@ -43,7 +42,6 @@ kind: ServiceAccount
 metadata:
   labels:
     app.kubernetes.io/instance: seldon-core-operator
-    app.kubernetes.io/managed-by: Tiller
     app.kubernetes.io/name: seldon-core-operator
     helm.sh/chart: seldon-core-operator-0.4.0
   name: seldon-manager
@@ -55,7 +53,6 @@ kind: Service
 metadata:
   labels:
     app.kubernetes.io/instance: seldon-core-operator
-    app.kubernetes.io/managed-by: Tiller
     app.kubernetes.io/name: seldon-core-operator
     control-plane: seldon-controller-manager
     controller-tools.k8s.io: "1.0"
@@ -75,7 +72,6 @@ kind: StatefulSet
 metadata:
   labels:
     app.kubernetes.io/instance: seldon-core-operator
-    app.kubernetes.io/managed-by: Tiller
     app.kubernetes.io/name: seldon-core-operator
     control-plane: seldon-controller-manager
     controller-tools.k8s.io: "1.0"
@@ -169,7 +165,6 @@ kind: ClusterRole
 metadata:
   labels:
     app.kubernetes.io/instance: seldon-core-operator
-    app.kubernetes.io/managed-by: Tiller
     app.kubernetes.io/name: seldon-core-operator
     helm.sh/chart: seldon-core-operator-0.4.0
   name: seldon-operator-manager-role
@@ -362,7 +357,6 @@ kind: ClusterRoleBinding
 metadata:
   labels:
     app.kubernetes.io/instance: seldon-core-operator
-    app.kubernetes.io/managed-by: Tiller
     app.kubernetes.io/name: seldon-core-operator
     helm.sh/chart: seldon-core-operator-0.4.0
   name: seldon-operator-manager-rolebinding
@@ -3605,7 +3599,6 @@ kind: Service
 metadata:
   labels:
     app.kubernetes.io/instance: seldon-core-operator
-    app.kubernetes.io/managed-by: Tiller
     app.kubernetes.io/name: seldon-core-operator
     control-plane: seldon-controller-manager
     controller-tools.k8s.io: "1.0"

--- a/tests/seldon-core-operator-overlays-application_test.go
+++ b/tests/seldon-core-operator-overlays-application_test.go
@@ -80,7 +80,6 @@ kind: ConfigMap
 metadata:
   labels:
     app.kubernetes.io/instance: seldon-core-operator
-    app.kubernetes.io/managed-by: Tiller
     app.kubernetes.io/name: seldon-core-operator
     helm.sh/chart: seldon-core-operator-0.4.0
   name: seldon-config
@@ -92,7 +91,6 @@ kind: ServiceAccount
 metadata:
   labels:
     app.kubernetes.io/instance: seldon-core-operator
-    app.kubernetes.io/managed-by: Tiller
     app.kubernetes.io/name: seldon-core-operator
     helm.sh/chart: seldon-core-operator-0.4.0
   name: seldon-manager
@@ -104,7 +102,6 @@ kind: Service
 metadata:
   labels:
     app.kubernetes.io/instance: seldon-core-operator
-    app.kubernetes.io/managed-by: Tiller
     app.kubernetes.io/name: seldon-core-operator
     control-plane: seldon-controller-manager
     controller-tools.k8s.io: "1.0"
@@ -124,7 +121,6 @@ kind: StatefulSet
 metadata:
   labels:
     app.kubernetes.io/instance: seldon-core-operator
-    app.kubernetes.io/managed-by: Tiller
     app.kubernetes.io/name: seldon-core-operator
     control-plane: seldon-controller-manager
     controller-tools.k8s.io: "1.0"
@@ -218,7 +214,6 @@ kind: ClusterRole
 metadata:
   labels:
     app.kubernetes.io/instance: seldon-core-operator
-    app.kubernetes.io/managed-by: Tiller
     app.kubernetes.io/name: seldon-core-operator
     helm.sh/chart: seldon-core-operator-0.4.0
   name: seldon-operator-manager-role
@@ -411,7 +406,6 @@ kind: ClusterRoleBinding
 metadata:
   labels:
     app.kubernetes.io/instance: seldon-core-operator
-    app.kubernetes.io/managed-by: Tiller
     app.kubernetes.io/name: seldon-core-operator
     helm.sh/chart: seldon-core-operator-0.4.0
   name: seldon-operator-manager-rolebinding
@@ -3654,7 +3648,6 @@ kind: Service
 metadata:
   labels:
     app.kubernetes.io/instance: seldon-core-operator
-    app.kubernetes.io/managed-by: Tiller
     app.kubernetes.io/name: seldon-core-operator
     control-plane: seldon-controller-manager
     controller-tools.k8s.io: "1.0"

--- a/tests/seldon-core-operator-overlays-application_test.go
+++ b/tests/seldon-core-operator-overlays-application_test.go
@@ -81,7 +81,6 @@ metadata:
   labels:
     app.kubernetes.io/instance: seldon-core-operator
     app.kubernetes.io/name: seldon-core-operator
-    helm.sh/chart: seldon-core-operator-0.4.0
   name: seldon-config
   namespace: kubeflow
 `)
@@ -92,7 +91,6 @@ metadata:
   labels:
     app.kubernetes.io/instance: seldon-core-operator
     app.kubernetes.io/name: seldon-core-operator
-    helm.sh/chart: seldon-core-operator-0.4.0
   name: seldon-manager
   namespace: kubeflow
 `)
@@ -105,7 +103,6 @@ metadata:
     app.kubernetes.io/name: seldon-core-operator
     control-plane: seldon-controller-manager
     controller-tools.k8s.io: "1.0"
-    helm.sh/chart: seldon-core-operator-0.4.0
   name: seldon-operator-controller-manager-service
   namespace: kubeflow
 spec:
@@ -124,7 +121,6 @@ metadata:
     app.kubernetes.io/name: seldon-core-operator
     control-plane: seldon-controller-manager
     controller-tools.k8s.io: "1.0"
-    helm.sh/chart: seldon-core-operator-0.4.0
   name: seldon-operator-controller-manager
   namespace: kubeflow
 spec:
@@ -215,7 +211,6 @@ metadata:
   labels:
     app.kubernetes.io/instance: seldon-core-operator
     app.kubernetes.io/name: seldon-core-operator
-    helm.sh/chart: seldon-core-operator-0.4.0
   name: seldon-operator-manager-role
 rules:
 - apiGroups:
@@ -407,7 +402,6 @@ metadata:
   labels:
     app.kubernetes.io/instance: seldon-core-operator
     app.kubernetes.io/name: seldon-core-operator
-    helm.sh/chart: seldon-core-operator-0.4.0
   name: seldon-operator-manager-rolebinding
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -3651,7 +3645,6 @@ metadata:
     app.kubernetes.io/name: seldon-core-operator
     control-plane: seldon-controller-manager
     controller-tools.k8s.io: "1.0"
-    helm.sh/chart: seldon-core-operator-0.4.0
   name: webhook-server-service
   namespace: kubeflow
 spec:


### PR DESCRIPTION
**Which issue is resolved by this Pull Request:**

- Builds on top of the Kubernetes 1.16 PR.
- Remove Tiller labels from deployment files since those files are not deployed by Tiller.
- Will rebase this PR once the Kubernetes 1.16 is merged or will abandon the Kubernetes 1.16 PR if this PR is merged.

**Description of your changes:**

simple "grep -v" on Tiller.

**Checklist:**
- [x] Unit tests have been rebuilt: 
    1. `cd manifests/tests`
    2. `make generate`
    3. `make test`

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/manifests/378)
<!-- Reviewable:end -->
