### PR TITLE
KFDef specs should no longer be checking out the kubeflow repo.

### DIFF
--- a/kfdef/kfctl_aws_cognito.yaml
+++ b/kfdef/kfctl_aws_cognito.yaml
@@ -268,8 +268,6 @@ spec:
   enableApplications: true
   packageManager: kustomize
   repos:
-    - name: kubeflow
-      uri: https://github.com/kubeflow/kubeflow/archive/master.tar.gz
     - name: manifests
       root: manifests-master
       uri: https://github.com/kubeflow/manifests/archive/master.tar.gz

--- a/kfdef/kfctl_existing_arrikto.yaml
+++ b/kfdef/kfctl_existing_arrikto.yaml
@@ -220,6 +220,3 @@ spec:
   - name: manifests
     root: manifests-master
     uri: https://github.com/kubeflow/manifests/archive/master.tar.gz
-  - name: kubeflow
-    root: kubeflow-master
-    uri: https://github.com/kubeflow/kubeflow/archive/master.tar.gz

--- a/kfdef/kfctl_k8s_istio.yaml
+++ b/kfdef/kfctl_k8s_istio.yaml
@@ -11,9 +11,6 @@ spec:
   - name: manifests
     root: manifests-master
     uri: https://github.com/kubeflow/manifests/archive/master.tar.gz
-  - name: kubeflow
-    root: kubeflow-master
-    uri: https://github.com/kubeflow/kubeflow/archive/master.tar.gz
   applications:
   # Istio install. If not needed, comment out istio-crds and istio-install.
   - kustomizeConfig:


### PR DESCRIPTION
* All the config/manifest files should now be in kubeflow/manifests

* kubeflow/kubeflow#4121 updated kfctl to change the hard coding of the
  extra config files to kubeflow/manifests

* Fix #373 - Stop checking out kubeflow/kubeflow in KFDef

* Related to kubeflow/manifests#241 move configs to kubeflow/manifests

**Which issue is resolved by this Pull Request:**
Resolves #

**Description of your changes:**


**Checklist:**
- [ ] Unit tests have been rebuilt: 
    1. `cd manifests/tests`
    2. `make generate`
    3. `make test`

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/manifests/379)
<!-- Reviewable:end -->
