### PR TITLE
kfdef: generic: revert #376 

### DIFF
--- a/kfdef/generic/istio/istio-noauth.yaml
+++ b/kfdef/generic/istio/istio-noauth.yaml
@@ -14889,10 +14889,10 @@ rules:
 - apiGroups: [""]
   resources: ["pods", "nodes", "services", "endpoints"]
   verbs: ["get", "list", "watch"]
-- apiGroups: ["extensions", "networking.k8s.io"]
+- apiGroups: ["extensions"]
   resources: ["ingresses"]
   verbs: ["get", "list", "watch"]
-- apiGroups: ["extensions", "apps"]
+- apiGroups: ["extensions"]
   resources: ["deployments/finalizers"]
   resourceNames: ["istio-galley"]
   verbs: ["update"]
@@ -15224,7 +15224,7 @@ rules:
 - apiGroups: ["apiextensions.k8s.io"]
   resources: ["customresourcedefinitions"]
   verbs: ["*"]
-- apiGroups: ["extensions", "networking.k8s.io"]
+- apiGroups: ["extensions"]
   resources: ["ingresses", "ingresses/status"]
   verbs: ["*"]
 - apiGroups: [""]
@@ -15863,7 +15863,7 @@ spec:
 
 ---
 # Source: istio/charts/galley/templates/deployment.yaml
-apiVersion: apps/v1
+apiVersion: extensions/v1beta1
 kind: Deployment
 metadata:
   name: istio-galley
@@ -15880,13 +15880,6 @@ spec:
     rollingUpdate:
       maxSurge: 1
       maxUnavailable: 0
-  selector:
-    matchLabels:
-      app: galley
-      chart: galley
-      heritage: Tiller
-      release: istio      
-      istio: galley
   template:
     metadata:
       labels:
@@ -16000,7 +15993,7 @@ spec:
 ---
 # Source: istio/charts/gateways/templates/deployment.yaml
 
-apiVersion: apps/v1
+apiVersion: extensions/v1beta1
 kind: Deployment
 metadata:
   name: istio-egressgateway
@@ -16166,7 +16159,7 @@ spec:
                 values:
                 - s390x      
 ---
-apiVersion: apps/v1
+apiVersion: extensions/v1beta1
 kind: Deployment
 metadata:
   name: istio-ingressgateway
@@ -16341,7 +16334,7 @@ spec:
 
 ---
 # Source: istio/charts/grafana/templates/deployment.yaml
-apiVersion: apps/v1
+apiVersion: extensions/v1beta1
 kind: Deployment
 metadata:
   name: grafana
@@ -16491,7 +16484,7 @@ spec:
 
 ---
 # Source: istio/charts/kiali/templates/deployment.yaml
-apiVersion: apps/v1
+apiVersion: extensions/v1beta1
 kind: Deployment
 metadata:
   name: kiali
@@ -16593,7 +16586,7 @@ spec:
 ---
 # Source: istio/charts/mixer/templates/deployment.yaml
 
-apiVersion: apps/v1
+apiVersion: extensions/v1beta1
 kind: Deployment
 metadata:
   name: istio-policy
@@ -16765,7 +16758,7 @@ spec:
           readOnly: true
 
 ---
-apiVersion: apps/v1
+apiVersion: extensions/v1beta1
 kind: Deployment
 metadata:
   name: istio-telemetry
@@ -16944,7 +16937,7 @@ spec:
 
 ---
 # Source: istio/charts/pilot/templates/deployment.yaml
-apiVersion: apps/v1
+apiVersion: extensions/v1beta1
 kind: Deployment
 metadata:
   name: istio-pilot
@@ -17126,7 +17119,7 @@ spec:
 ---
 # Source: istio/charts/prometheus/templates/deployment.yaml
 # TODO: the original template has service account, roles, etc
-apiVersion: apps/v1
+apiVersion: extensions/v1beta1
 kind: Deployment
 metadata:
   name: prometheus
@@ -17224,7 +17217,7 @@ spec:
 ---
 # Source: istio/charts/security/templates/deployment.yaml
 # istio CA watching all namespaces
-apiVersion: apps/v1
+apiVersion: extensions/v1beta1
 kind: Deployment
 metadata:
   name: istio-citadel
@@ -17311,7 +17304,7 @@ spec:
 
 ---
 # Source: istio/charts/sidecarInjectorWebhook/templates/deployment.yaml
-apiVersion: apps/v1
+apiVersion: extensions/v1beta1
 kind: Deployment
 metadata:
   name: istio-sidecar-injector
@@ -17435,7 +17428,7 @@ spec:
 # Source: istio/charts/tracing/templates/deployment-jaeger.yaml
 
 
-apiVersion: apps/v1
+apiVersion: extensions/v1beta1
 kind: Deployment
 metadata:
   name: istio-tracing
@@ -17548,7 +17541,7 @@ spec:
   maxReplicas: 5
   minReplicas: 1
   scaleTargetRef:
-    apiVersion: apps/v1
+    apiVersion: apps/v1beta1
     kind: Deployment
     name: istio-egressgateway
   metrics:
@@ -17571,7 +17564,7 @@ spec:
   maxReplicas: 5
   minReplicas: 1
   scaleTargetRef:
-    apiVersion: apps/v1
+    apiVersion: apps/v1beta1
     kind: Deployment
     name: istio-ingressgateway
   metrics:
@@ -17598,7 +17591,7 @@ spec:
     maxReplicas: 5
     minReplicas: 1
     scaleTargetRef:
-      apiVersion: apps/v1
+      apiVersion: apps/v1beta1
       kind: Deployment
       name: istio-policy
     metrics:
@@ -17621,7 +17614,7 @@ spec:
     maxReplicas: 5
     minReplicas: 1
     scaleTargetRef:
-      apiVersion: apps/v1
+      apiVersion: apps/v1beta1
       kind: Deployment
       name: istio-telemetry
     metrics:
@@ -17648,7 +17641,7 @@ spec:
   maxReplicas: 5
   minReplicas: 1
   scaleTargetRef:
-    apiVersion: apps/v1
+    apiVersion: apps/v1beta1
     kind: Deployment
     name: istio-pilot
   metrics:


### PR DESCRIPTION
**Description of your changes:**
PR #376 introduced changes that broke the kfdef/generic/istio package and consequently the kfctl_existing_arrikto config on master. (istio-egressgateway selector doesn't match labels).
This PR reverts the changes to kfdef/generic.

/cc @jlewi @jbrette 

**Checklist:**
- [X] Unit tests have been rebuilt: 
    1. `cd manifests/tests`
    2. `make generate`
    3. `make test`

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/manifests/383)
<!-- Reviewable:end -->
