### PR TITLE
Enable workload identity in our KFDef specs.

### DIFF
--- a/kfdef/kfctl_gcp_basic_auth.yaml
+++ b/kfdef/kfctl_gcp_basic_auth.yaml
@@ -269,11 +269,7 @@ spec:
         path: pipeline/scheduledworkflow
     name: scheduledworkflow
   - kustomizeConfig:
-      overlays:
-      - gcp-credentials
       parameters:
-      - name: secretName
-        value: admin-gcp-sa
       - initRequired: true
         name: ipName
         value: ipName
@@ -326,7 +322,6 @@ spec:
     name: basic-auth
   - kustomizeConfig:
       overlays:
-      - gcp-credentials
       - managed-cert
       parameters:
       - name: namespace

--- a/kfdef/kfctl_gcp_basic_auth.yaml
+++ b/kfdef/kfctl_gcp_basic_auth.yaml
@@ -365,6 +365,7 @@ spec:
         repoRef:
           name: manifests
           path: gcp/deployment_manager_configs
+      enableWorkloadIdentity: true
   skipInitProject: true
   useBasicAuth: true
   useIstio: true

--- a/kfdef/kfctl_gcp_iap.yaml
+++ b/kfdef/kfctl_gcp_iap.yaml
@@ -275,11 +275,6 @@ spec:
         path: pipeline/scheduledworkflow
     name: scheduledworkflow
   - kustomizeConfig:
-      overlays:
-      - gcp-credentials
-      parameters:
-      - name: secretName
-        value: admin-gcp-sa
       repoRef:
         name: manifests
         path: gcp/cloud-endpoints
@@ -306,7 +301,6 @@ spec:
     name: gpu-driver
   - kustomizeConfig:
       overlays:
-      - gcp-credentials
       - managed-cert
       parameters:
       - name: namespace

--- a/kfdef/kfctl_gcp_iap.yaml
+++ b/kfdef/kfctl_gcp_iap.yaml
@@ -345,6 +345,7 @@ spec:
         repoRef:
           name: manifests
           path: gcp/deployment_manager_configs
+      enableWorkloadIdentity: true
   skipInitProject: true
   useBasicAuth: false
   useIstio: true


### PR DESCRIPTION
Update the GCP KFDef specs to enable workload identity

* Related to kubeflow/kubeflow#3638

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/manifests/390)
<!-- Reviewable:end -->
