### PR TITLE
Update pipelines manifest to ship 0.1.31

### DIFF
--- a/kfdef/kfctl_aws.yaml
+++ b/kfdef/kfctl_aws.yaml
@@ -203,6 +203,11 @@ spec:
           path: pipeline/scheduledworkflow
       name: scheduledworkflow
     - kustomizeConfig:
+        repoRef:
+          name: manifests
+          path: pipeline/pipeline-visualization-service
+      name: pipeline-visualization-service
+    - kustomizeConfig:
         overlays:
           - istio
         repoRef:
@@ -247,8 +252,6 @@ spec:
   enableApplications: true
   packageManager: kustomize
   repos:
-    - name: kubeflow
-      uri: https://github.com/kubeflow/kubeflow/archive/master.tar.gz
     - name: manifests
       root: manifests-master
       uri: https://github.com/kubeflow/manifests/archive/master.tar.gz

--- a/kfdef/kfctl_aws_cognito.yaml
+++ b/kfdef/kfctl_aws_cognito.yaml
@@ -207,6 +207,11 @@ spec:
           path: pipeline/scheduledworkflow
       name: scheduledworkflow
     - kustomizeConfig:
+        repoRef:
+          name: manifests
+          path: pipeline/pipeline-visualization-service
+      name: pipeline-visualization-service
+    - kustomizeConfig:
         overlays:
           - istio
         repoRef:

--- a/kfdef/kfctl_existing_arrikto.yaml
+++ b/kfdef/kfctl_existing_arrikto.yaml
@@ -179,6 +179,11 @@ spec:
         path: pipeline/scheduledworkflow
     name: scheduledworkflow
   - kustomizeConfig:
+      repoRef:
+        name: manifests
+        path: pipeline/pipeline-visualization-service
+    name: pipeline-visualization-service
+  - kustomizeConfig:
       parameters:
       - name: userid-header
         value: kubeflow-userid

--- a/kfdef/kfctl_gcp_basic_auth.yaml
+++ b/kfdef/kfctl_gcp_basic_auth.yaml
@@ -254,6 +254,11 @@ spec:
         path: pipeline/scheduledworkflow
     name: scheduledworkflow
   - kustomizeConfig:
+      repoRef:
+        name: manifests
+        path: pipeline/pipeline-visualization-service
+    name: pipeline-visualization-service
+  - kustomizeConfig:
       parameters:
       - initRequired: true
         name: ipName

--- a/kfdef/kfctl_gcp_iap.yaml
+++ b/kfdef/kfctl_gcp_iap.yaml
@@ -262,6 +262,11 @@ spec:
   - kustomizeConfig:
       repoRef:
         name: manifests
+        path: pipeline/pipeline-visualization-service
+    name: pipeline-visualization-service
+  - kustomizeConfig:
+      repoRef:
+        name: manifests
         path: gcp/cloud-endpoints
     name: cloud-endpoints
   - kustomizeConfig:

--- a/kfdef/kfctl_k8s_istio.yaml
+++ b/kfdef/kfctl_k8s_istio.yaml
@@ -229,6 +229,11 @@ spec:
         path: pipeline/scheduledworkflow
     name: scheduledworkflow
   - kustomizeConfig:
+      repoRef:
+        name: manifests
+        path: pipeline/pipeline-visualization-service
+    name: pipeline-visualization-service
+  - kustomizeConfig:
       overlays:
       - istio
       parameters:

--- a/pipeline/api-service/base/config-map.yaml
+++ b/pipeline/api-service/base/config-map.yaml
@@ -1,0 +1,25 @@
+# The configuration for the ML pipelines APIServer
+# Based on https://github.com/kubeflow/pipelines/blob/master/backend/src/apiserver/config/config.json
+apiVersion: v1
+data:
+  # apiserver assumes the config is named config.json
+  config.json: |
+    {
+      "DBConfig": {
+        "DriverName": "mysql",
+        "DataSourceName": "",
+        "DBName": "mlpipeline"
+      },
+      "ObjectStoreConfig":{
+        "AccessKey": "minio",
+        "SecretAccessKey": "minio123",
+        "BucketName": "mlpipeline"
+      },
+      "InitConnectionTimeout": "6m",
+      "DefaultPipelineRunnerServiceAccount": "pipeline-runner",
+      "ML_PIPELINE_VISUALIZATIONSERVER_SERVICE_HOST": "ml-pipeline-ml-pipeline-visualizationserver",
+      "ML_PIPELINE_VISUALIZATIONSERVER_SERVICE_PORT": 8888
+    }
+kind: ConfigMap
+metadata:
+  name: ml-pipeline-config

--- a/pipeline/api-service/base/deployment.yaml
+++ b/pipeline/api-service/base/deployment.yaml
@@ -12,9 +12,21 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: metadata.namespace
-        image: gcr.io/ml-pipeline/api-server:0.1.23
+        image: gcr.io/ml-pipeline/api-server
         imagePullPolicy: IfNotPresent
+        command:
+          - apiserver 
+          - --config=/etc/ml-pipeline-config
+          - --sampleconfig=/config/sample_config.json 
+          - -logtostderr=true
         ports:
         - containerPort: 8888
         - containerPort: 8887
-      serviceAccountName: ml-pipeline
+        volumeMounts:
+        - name: config-volume
+          mountPath: /etc/ml-pipeline-config
+      serviceAccountName: ml-pipeline      
+      volumes:
+        - name: config-volume
+          configMap:
+            name: ml-pipeline-config

--- a/pipeline/api-service/base/kustomization.yaml
+++ b/pipeline/api-service/base/kustomization.yaml
@@ -3,6 +3,7 @@ kind: Kustomization
 commonLabels:
   app: ml-pipeline
 resources:
+- config-map.yaml
 - deployment.yaml
 - role-binding.yaml
 - role.yaml
@@ -10,4 +11,4 @@ resources:
 - service.yaml
 images:
 - name: gcr.io/ml-pipeline/api-server
-  newTag: '0.1.23'
+  newTag: '0.1.31'

--- a/pipeline/persistent-agent/base/deployment.yaml
+++ b/pipeline/persistent-agent/base/deployment.yaml
@@ -12,6 +12,6 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: metadata.namespace
-        image: gcr.io/ml-pipeline/persistenceagent:0.1.23
+        image: gcr.io/ml-pipeline/persistenceagent
         imagePullPolicy: IfNotPresent
       serviceAccountName: ml-pipeline-persistenceagent

--- a/pipeline/persistent-agent/base/kustomization.yaml
+++ b/pipeline/persistent-agent/base/kustomization.yaml
@@ -10,4 +10,4 @@ resources:
 - service-account.yaml
 images:
 - name: gcr.io/ml-pipeline/persistenceagent
-  newTag: '0.1.23'
+  newTag: '0.1.31'

--- a/pipeline/pipeline-visualization-service/base/kustomization.yaml
+++ b/pipeline/pipeline-visualization-service/base/kustomization.yaml
@@ -4,6 +4,7 @@ nameprefix: ml-pipeline-
 commonLabels:
   app: ml-pipeline-visualizationserver
 resources:
+- deployment.yaml
 - service.yaml
 images:
 - name: gcr.io/ml-pipeline/visualization-server

--- a/pipeline/pipelines-ui/base/deployment.yaml
+++ b/pipeline/pipelines-ui/base/deployment.yaml
@@ -15,7 +15,7 @@ spec:
     spec:
       containers:
       - name: ml-pipeline-ui
-        image: gcr.io/ml-pipeline/frontend:0.1.23
+        image: gcr.io/ml-pipeline/frontend
         imagePullPolicy: IfNotPresent
         ports:
         - containerPort: 3000

--- a/pipeline/pipelines-ui/base/kustomization.yaml
+++ b/pipeline/pipelines-ui/base/kustomization.yaml
@@ -12,7 +12,7 @@ configMapGenerator:
   env: params.env
 images:
 - name: gcr.io/ml-pipeline/frontend
-  newTag: '0.1.23'
+  newTag: '0.1.31'
 vars:
 - name: ui-namespace
   objref:

--- a/pipeline/pipelines-viewer/base/deployment.yaml
+++ b/pipeline/pipelines-viewer/base/deployment.yaml
@@ -11,7 +11,7 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: metadata.namespace
-        image: gcr.io/ml-pipeline/viewer-crd-controller:0.1.23
+        image: gcr.io/ml-pipeline/viewer-crd-controller:0.1.31
         imagePullPolicy: Always
         name: ml-pipeline-viewer-controller
       serviceAccountName: crd-service-account

--- a/pipeline/pipelines-viewer/base/kustomization.yaml
+++ b/pipeline/pipelines-viewer/base/kustomization.yaml
@@ -12,4 +12,4 @@ resources:
 - service-account.yaml
 images:
 - name: gcr.io/ml-pipeline/viewer-crd-controller
-  newTag: '0.1.23'
+  newTag: '0.1.31'

--- a/pipeline/scheduledworkflow/base/deployment.yaml
+++ b/pipeline/scheduledworkflow/base/deployment.yaml
@@ -12,6 +12,6 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: metadata.namespace
-        image: gcr.io/ml-pipeline/scheduledworkflow:0.1.23
+        image: gcr.io/ml-pipeline/scheduledworkflow
         imagePullPolicy: IfNotPresent
       serviceAccountName: ml-pipeline-scheduledworkflow

--- a/pipeline/scheduledworkflow/base/kustomization.yaml
+++ b/pipeline/scheduledworkflow/base/kustomization.yaml
@@ -12,4 +12,4 @@ resources:
 - service-account.yaml
 images:
 - name: gcr.io/ml-pipeline/scheduledworkflow
-  newTag: '0.1.23'
+  newTag: '0.1.31'

--- a/tests/persistent-agent-base_test.go
+++ b/tests/persistent-agent-base_test.go
@@ -65,7 +65,7 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: metadata.namespace
-        image: gcr.io/ml-pipeline/persistenceagent:0.1.23
+        image: gcr.io/ml-pipeline/persistenceagent
         imagePullPolicy: IfNotPresent
       serviceAccountName: ml-pipeline-persistenceagent
 `)
@@ -88,7 +88,7 @@ resources:
 - service-account.yaml
 images:
 - name: gcr.io/ml-pipeline/persistenceagent
-  newTag: '0.1.23'
+  newTag: '0.1.31'
 `)
 }
 

--- a/tests/pipeline-visualization-service-base_test.go
+++ b/tests/pipeline-visualization-service-base_test.go
@@ -14,6 +14,29 @@ import (
 )
 
 func writePipelineVisualizationServiceBase(th *KustTestHarness) {
+	th.writeF("/manifests/pipeline/pipeline-visualization-service/base/deployment.yaml", `
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  labels:
+    app: ml-pipeline-visualizationserver
+  name: ml-pipeline-visualizationserver
+spec:
+  selector:
+    matchLabels:
+      app: ml-pipeline-visualizationserver
+  template:
+    metadata:
+      labels:
+        app: ml-pipeline-visualizationserver
+    spec:
+      containers:
+      - image: gcr.io/ml-pipeline/visualization-server
+        imagePullPolicy: IfNotPresent
+        name: ml-pipeline-visualizationserver
+        ports:
+        - containerPort: 8888
+`)
 	th.writeF("/manifests/pipeline/pipeline-visualization-service/base/service.yaml", `
 apiVersion: v1
 kind: Service
@@ -35,6 +58,7 @@ nameprefix: ml-pipeline-
 commonLabels:
   app: ml-pipeline-visualizationserver
 resources:
+- deployment.yaml
 - service.yaml
 images:
 - name: gcr.io/ml-pipeline/visualization-server

--- a/tests/pipelines-ui-base_test.go
+++ b/tests/pipelines-ui-base_test.go
@@ -32,7 +32,7 @@ spec:
     spec:
       containers:
       - name: ml-pipeline-ui
-        image: gcr.io/ml-pipeline/frontend:0.1.23
+        image: gcr.io/ml-pipeline/frontend
         imagePullPolicy: IfNotPresent
         ports:
         - containerPort: 3000
@@ -160,7 +160,7 @@ configMapGenerator:
   env: params.env
 images:
 - name: gcr.io/ml-pipeline/frontend
-  newTag: '0.1.23'
+  newTag: '0.1.31'
 vars:
 - name: ui-namespace
   objref:

--- a/tests/pipelines-ui-overlays-istio_test.go
+++ b/tests/pipelines-ui-overlays-istio_test.go
@@ -92,7 +92,7 @@ spec:
     spec:
       containers:
       - name: ml-pipeline-ui
-        image: gcr.io/ml-pipeline/frontend:0.1.23
+        image: gcr.io/ml-pipeline/frontend
         imagePullPolicy: IfNotPresent
         ports:
         - containerPort: 3000
@@ -220,7 +220,7 @@ configMapGenerator:
   env: params.env
 images:
 - name: gcr.io/ml-pipeline/frontend
-  newTag: '0.1.23'
+  newTag: '0.1.31'
 vars:
 - name: ui-namespace
   objref:

--- a/tests/pipelines-viewer-base_test.go
+++ b/tests/pipelines-viewer-base_test.go
@@ -149,7 +149,7 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: metadata.namespace
-        image: gcr.io/ml-pipeline/viewer-crd-controller:0.1.23
+        image: gcr.io/ml-pipeline/viewer-crd-controller:0.1.31
         imagePullPolicy: Always
         name: ml-pipeline-viewer-controller
       serviceAccountName: crd-service-account
@@ -175,7 +175,7 @@ resources:
 - service-account.yaml
 images:
 - name: gcr.io/ml-pipeline/viewer-crd-controller
-  newTag: '0.1.23'
+  newTag: '0.1.31'
 `)
 }
 

--- a/tests/scheduledworkflow-base_test.go
+++ b/tests/scheduledworkflow-base_test.go
@@ -106,66 +106,9 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: metadata.namespace
-        image: gcr.io/ml-pipeline/scheduledworkflow:0.1.23
+        image: gcr.io/ml-pipeline/scheduledworkflow
         imagePullPolicy: IfNotPresent
       serviceAccountName: ml-pipeline-scheduledworkflow
-`)
-	th.writeF("/manifests/pipeline/scheduledworkflow/base/cluster-role.yaml", `
----
-
-apiVersion: rbac.authorization.k8s.io/v1
-kind: ClusterRole
-metadata:
-  name: kubeflow-scheduledworkflows-admin
-  labels:
-    rbac.authorization.kubeflow.org/aggregate-to-kubeflow-admin: "true"
-aggregationRule:
-  clusterRoleSelectors:
-  - matchLabels:
-      rbac.authorization.kubeflow.org/aggregate-to-kubeflow-scheduledworkflows-admin: "true"
-rules: null
-
----
-
-apiVersion: rbac.authorization.k8s.io/v1
-kind: ClusterRole
-metadata:
-  name: kubeflow-scheduledworkflows-edit
-  labels:
-    rbac.authorization.kubeflow.org/aggregate-to-kubeflow-edit: "true"
-    rbac.authorization.kubeflow.org/aggregate-to-kubeflow-scheduledworkflows-admin: "true"
-rules:
-- apiGroups:
-  - kubeflow.org
-  resources:
-  - scheduledworkflows
-  verbs:
-  - get
-  - list
-  - watch
-  - create
-  - delete
-  - deletecollection
-  - patch
-  - update
-
----
-
-apiVersion: rbac.authorization.k8s.io/v1
-kind: ClusterRole
-metadata:
-  name: kubeflow-scheduledworkflows-view
-  labels:
-    rbac.authorization.kubeflow.org/aggregate-to-kubeflow-view: "true"
-rules:
-- apiGroups:
-  - kubeflow.org
-  resources:
-  - scheduledworkflows
-  verbs:
-  - get
-  - list
-  - watch
 `)
 	th.writeF("/manifests/pipeline/scheduledworkflow/base/role-binding.yaml", `
 apiVersion: rbac.authorization.k8s.io/v1beta1
@@ -232,7 +175,7 @@ resources:
 - service-account.yaml
 images:
 - name: gcr.io/ml-pipeline/scheduledworkflow
-  newTag: '0.1.23'
+  newTag: '0.1.31'
 `)
 }
 


### PR DESCRIPTION
* Update the images to 0.1.31

* We need to include the pipeline-visualization-service

Related to kubeflow/pipelines#2239

Use a config map to specify the config for the ml-pipeline backend server
  * Currently it is hardcoded to a config file baked into the docker image.
  * Hardcoding a config into the dockerfile generally doesn't seem like a good
    idea since its not easy to configure.

  * Per kubeflow/pipelines#2101 the hard coded config is actually broken it
    is not specifying the hostname and port of the visualization server.

**Which issue is resolved by th

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/manifests/392)
<!-- Reviewable:end -->
