### PR TITLE
kfdef: existing_arrikto: remove metacontroller application

### DIFF
--- a/kfdef/kfctl_existing_arrikto.yaml
+++ b/kfdef/kfctl_existing_arrikto.yaml
@@ -21,11 +21,6 @@ spec:
         path: application/application
     name: application
   - kustomizeConfig:
-      repoRef:
-        name: manifests
-        path: metacontroller
-    name: metacontroller
-  - kustomizeConfig:
       overlays:
       - istio
       repoRef:


### PR DESCRIPTION
Remove the metacontroller application from the existing_arrikto
config as it is no longer used.

Signed-off-by: Yannis Zarkadas <yanniszark@arrikto.com>

**Checklist:**
- [X] Unit tests have been rebuilt: 
    1. `cd manifests/tests`
    2. `make generate`
    3. `make test`

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/manifests/404)
<!-- Reviewable:end -->
