### PR TITLE
error when deploying istio #420

### DIFF
--- a/gcp/cloud-endpoints/overlays/application/params.yaml
+++ b/gcp/cloud-endpoints/overlays/application/params.yaml
@@ -3,6 +3,8 @@ varReference:
   kind: Application
 - path: spec/selector/matchLabels/app.kubernetes.io\/instance
   kind: Application
+- path: spec/selector/app.kubernetes.io\/instance
+  kind: Service
 - path: spec/selector/matchLabels/app.kubernetes.io\/instance
   kind: Deployment
 - path: spec/template/metadata/labels/app.kubernetes.io\/instance

--- a/gcp/iap-ingress/overlays/application/params.yaml
+++ b/gcp/iap-ingress/overlays/application/params.yaml
@@ -3,6 +3,12 @@ varReference:
   kind: Application
 - path: spec/selector/matchLabels/app.kubernetes.io\/instance
   kind: Application
+- path: spec/selector/app.kubernetes.io\/instance
+  kind: Service
+- path: spec/selector/matchLabels/app.kubernetes.io\/instance
+  kind: Deployment
+- path: spec/template/metadata/labels/app.kubernetes.io\/instance
+  kind: Deployment
 - path: spec/selector/matchLabels/app.kubernetes.io\/instance
   kind: StatefulSet
 - path: spec/template/metadata/labels/app.kubernetes.io\/instance

--- a/gcp/iap-ingress/overlays/application/params.yaml
+++ b/gcp/iap-ingress/overlays/application/params.yaml
@@ -7,3 +7,5 @@ varReference:
   kind: StatefulSet
 - path: spec/template/metadata/labels/app.kubernetes.io\/instance
   kind: StatefulSet
+- path: spec/template/metadata/labels/app.kubernetes.io\/instance
+  kind: Job

--- a/istio/istio-install/overlays/application/params.yaml
+++ b/istio/istio-install/overlays/application/params.yaml
@@ -9,3 +9,7 @@ varReference:
   kind: Deployment
 - path: spec/template/metadata/labels/app.kubernetes.io\/instance
   kind: Deployment
+- path: spec/selector/matchLabels/app.kubernetes.io\/instance
+  kind: PodDisruptionBudget
+- path: spec/template/metadata/labels/app.kubernetes.io\/instance
+  kind: Job

--- a/kfdef/kfctl_anthos.yaml
+++ b/kfdef/kfctl_anthos.yaml
@@ -206,8 +206,6 @@ spec:
       parameters:
       - name: generateName
         value: knative-serving-crds-
-      - name: namespace
-        value: knative-serving
       repoRef:
         name: manifests
         path: knative/knative-serving-crds

--- a/kfdef/kfctl_anthos.yaml
+++ b/kfdef/kfctl_anthos.yaml
@@ -211,11 +211,7 @@ spec:
         path: knative/knative-serving-crds
     name: knative-crds
   - kustomizeConfig:
-      overlays:
-      - application
       parameters:
-      - name: generateName
-        value: knative-serving-install-
       - name: namespace
         value: knative-serving
       repoRef:

--- a/kfdef/kfctl_anthos.yaml
+++ b/kfdef/kfctl_anthos.yaml
@@ -201,11 +201,6 @@ spec:
         path: pytorch-job/pytorch-operator
     name: pytorch-operator
   - kustomizeConfig:
-      overlays:
-      - application
-      parameters:
-      - name: generateName
-        value: knative-serving-crds-
       repoRef:
         name: manifests
         path: knative/knative-serving-crds

--- a/kfdef/kfctl_aws.yaml
+++ b/kfdef/kfctl_aws.yaml
@@ -7,6 +7,11 @@ spec:
   platform: aws
   applications:
     - kustomizeConfig:
+        repoRef:
+          name: manifests
+          path: application/application-crds
+      name: application-crds
+    - kustomizeConfig:
         overlays:
           - application
         parameters:
@@ -36,11 +41,6 @@ spec:
           name: manifests
           path: istio/istio
       name: istio
-    - kustomizeConfig:
-        repoRef:
-          name: manifests
-          path: application/application-crds
-      name: application-crds
     - kustomizeConfig:
         overlays:
           - application

--- a/kfdef/kfctl_aws.yaml
+++ b/kfdef/kfctl_aws.yaml
@@ -17,11 +17,7 @@ spec:
           path: istio/istio-crds
       name: istio-crds
     - kustomizeConfig:
-        overlays:
-          - application
         parameters:
-          - name: generateName
-            value: istio-install-
           - name: namespace
             value: istio-system
         repoRef:

--- a/kfdef/kfctl_aws.yaml
+++ b/kfdef/kfctl_aws.yaml
@@ -12,8 +12,6 @@ spec:
         parameters:
           - name: generateName
             value: istio-crds-
-          - name: namespace
-            value: istio-system
         repoRef:
           name: manifests
           path: istio/istio-crds

--- a/kfdef/kfctl_aws_cognito.yaml
+++ b/kfdef/kfctl_aws_cognito.yaml
@@ -7,6 +7,11 @@ spec:
   platform: aws
   applications:
     - kustomizeConfig:
+        repoRef:
+          name: manifests
+          path: application/application-crds
+      name: application-crds
+    - kustomizeConfig:
         overlays:
           - application
         parameters:
@@ -36,11 +41,6 @@ spec:
           name: manifests
           path: istio/istio
       name: istio
-    - kustomizeConfig:
-        repoRef:
-          name: manifests
-          path: application/application-crds
-      name: application-crds
     - kustomizeConfig:
         overlays:
           - application

--- a/kfdef/kfctl_aws_cognito.yaml
+++ b/kfdef/kfctl_aws_cognito.yaml
@@ -17,11 +17,7 @@ spec:
           path: istio/istio-crds
       name: istio-crds
     - kustomizeConfig:
-        overlays:
-          - application
         parameters:
-          - name: generateName
-            value: istio-install-
           - name: namespace
             value: istio-system
         repoRef:

--- a/kfdef/kfctl_aws_cognito.yaml
+++ b/kfdef/kfctl_aws_cognito.yaml
@@ -12,8 +12,6 @@ spec:
         parameters:
           - name: generateName
             value: istio-crds-
-          - name: namespace
-            value: istio-system
         repoRef:
           name: manifests
           path: istio/istio-crds

--- a/kfdef/kfctl_gcp_basic_auth.yaml
+++ b/kfdef/kfctl_gcp_basic_auth.yaml
@@ -18,6 +18,11 @@ spec:
   appdir: /tmp/myapp2
   applications:
   - kustomizeConfig:
+      repoRef:
+        name: manifests
+        path: application/application-crds
+    name: application-crds
+  - kustomizeConfig:
       overlays:
       - application
       parameters:
@@ -47,11 +52,6 @@ spec:
         name: manifests
         path: istio/istio
     name: istio
-  - kustomizeConfig:
-      repoRef:
-        name: manifests
-        path: application/application-crds
-    name: application-crds
   - kustomizeConfig:
       overlays:
       - application

--- a/kfdef/kfctl_gcp_basic_auth.yaml
+++ b/kfdef/kfctl_gcp_basic_auth.yaml
@@ -239,11 +239,7 @@ spec:
         path: knative/knative-serving-crds
     name: knative-crds
   - kustomizeConfig:
-      overlays:
-      - application
       parameters:
-      - name: generateName
-        value: knative-serving-install-
       - name: namespace
         value: knative-serving
       repoRef:

--- a/kfdef/kfctl_gcp_basic_auth.yaml
+++ b/kfdef/kfctl_gcp_basic_auth.yaml
@@ -28,11 +28,7 @@ spec:
         path: istio/istio-crds
     name: istio-crds
   - kustomizeConfig:
-      overlays:
-      - application
       parameters:
-      - name: generateName
-        value: istio-install-
       - name: namespace
         value: istio-system
       repoRef:

--- a/kfdef/kfctl_gcp_basic_auth.yaml
+++ b/kfdef/kfctl_gcp_basic_auth.yaml
@@ -229,11 +229,6 @@ spec:
         path: pytorch-job/pytorch-operator
     name: pytorch-operator
   - kustomizeConfig:
-      overlays:
-      - application
-      parameters:
-      - name: generateName
-        value: knative-serving-crds-
       repoRef:
         name: manifests
         path: knative/knative-serving-crds

--- a/kfdef/kfctl_gcp_basic_auth.yaml
+++ b/kfdef/kfctl_gcp_basic_auth.yaml
@@ -234,8 +234,6 @@ spec:
       parameters:
       - name: generateName
         value: knative-serving-crds-
-      - name: namespace
-        value: knative-serving
       repoRef:
         name: manifests
         path: knative/knative-serving-crds

--- a/kfdef/kfctl_gcp_basic_auth.yaml
+++ b/kfdef/kfctl_gcp_basic_auth.yaml
@@ -23,8 +23,6 @@ spec:
       parameters:
       - name: generateName
         value: istio-crds-
-      - name: namespace
-        value: istio-system
       repoRef:
         name: manifests
         path: istio/istio-crds

--- a/kfdef/kfctl_gcp_iap.yaml
+++ b/kfdef/kfctl_gcp_iap.yaml
@@ -238,11 +238,6 @@ spec:
         path: pytorch-job/pytorch-operator
     name: pytorch-operator
   - kustomizeConfig:
-      overlays:
-      - application
-      parameters:
-      - name: generateName
-        value: knative-serving-crds-
       repoRef:
         name: manifests
         path: knative/knative-serving-crds

--- a/kfdef/kfctl_gcp_iap.yaml
+++ b/kfdef/kfctl_gcp_iap.yaml
@@ -243,8 +243,6 @@ spec:
       parameters:
       - name: generateName
         value: knative-serving-crds-
-      - name: namespace
-        value: knative-serving
       repoRef:
         name: manifests
         path: knative/knative-serving-crds

--- a/kfdef/kfctl_gcp_iap.yaml
+++ b/kfdef/kfctl_gcp_iap.yaml
@@ -8,7 +8,8 @@ metadata:
 spec:
   repos:
   - name: manifests
-    uri: https://github.com/kubeflow/manifests/archive/pull/342/head.tar.gz
+    root: manifests-master
+    uri: https://github.com/kubeflow/manifests/archive/master.tar.gz
     # To get manifest at a PR:
     #uri: https://github.com/kubeflow/manifests/archive/pull/235/head.tar.gz
   appdir: /tmp/myapp2
@@ -24,11 +25,7 @@ spec:
         path: istio/istio-crds
     name: istio-crds
   - kustomizeConfig:
-      overlays:
-      - application
       parameters:
-      - name: generateName
-        value: istio-install-
       - name: namespace
         value: istio-system
       repoRef:

--- a/kfdef/kfctl_gcp_iap.yaml
+++ b/kfdef/kfctl_gcp_iap.yaml
@@ -19,8 +19,6 @@ spec:
       parameters:
       - name: generateName
         value: istio-crds-
-      - name: namespace
-        value: istio-system
       repoRef:
         name: manifests
         path: istio/istio-crds

--- a/kfdef/kfctl_gcp_iap.yaml
+++ b/kfdef/kfctl_gcp_iap.yaml
@@ -248,11 +248,7 @@ spec:
         path: knative/knative-serving-crds
     name: knative-crds
   - kustomizeConfig:
-      overlays:
-      - application
       parameters:
-      - name: generateName
-        value: knative-serving-install-
       - name: namespace
         value: knative-serving
       repoRef:

--- a/kfdef/kfctl_gcp_iap.yaml
+++ b/kfdef/kfctl_gcp_iap.yaml
@@ -15,6 +15,11 @@ spec:
   appdir: /tmp/myapp2
   applications:
   - kustomizeConfig:
+      repoRef:
+        name: manifests
+        path: application/application-crds
+    name: application-crds
+  - kustomizeConfig:
       overlays:
       - application
       parameters:
@@ -44,11 +49,6 @@ spec:
         name: manifests
         path: istio/istio
     name: istio
-  - kustomizeConfig:
-      repoRef:
-        name: manifests
-        path: application/application-crds
-    name: application-crds
   - kustomizeConfig:
       overlays:
       - application

--- a/kfdef/kfctl_k8s_istio.yaml
+++ b/kfdef/kfctl_k8s_istio.yaml
@@ -227,8 +227,6 @@ spec:
       parameters:
       - name: generateName
         value: knative-serving-crds-
-      - name: namespace
-        value: knative-serving
       repoRef:
         name: manifests
         path: knative/knative-serving-crds

--- a/kfdef/kfctl_k8s_istio.yaml
+++ b/kfdef/kfctl_k8s_istio.yaml
@@ -24,11 +24,7 @@ spec:
         path: istio/istio-crds
     name: istio-crds
   - kustomizeConfig:
-      overlays:
-      - application
       parameters:
-      - name: generateName
-        value: istio-install-
       - name: namespace
         value: istio-system
       repoRef:

--- a/kfdef/kfctl_k8s_istio.yaml
+++ b/kfdef/kfctl_k8s_istio.yaml
@@ -232,11 +232,7 @@ spec:
         path: knative/knative-serving-crds
     name: knative-crds
   - kustomizeConfig:
-      overlays:
-      - application
       parameters:
-      - name: generateName
-        value: knative-serving-install-
       - name: namespace
         value: knative-serving
       repoRef:

--- a/kfdef/kfctl_k8s_istio.yaml
+++ b/kfdef/kfctl_k8s_istio.yaml
@@ -19,8 +19,6 @@ spec:
       parameters:
       - name: generateName
         value: istio-crds-
-      - name: namespace
-        value: istio-system
       repoRef:
         name: manifests
         path: istio/istio-crds

--- a/kfdef/kfctl_k8s_istio.yaml
+++ b/kfdef/kfctl_k8s_istio.yaml
@@ -14,6 +14,11 @@ spec:
   applications:
   # Istio install. If not needed, comment out istio-crds and istio-install.
   - kustomizeConfig:
+      repoRef:
+        name: manifests
+        path: application/application-crds
+    name: application-crds
+  - kustomizeConfig:
       overlays:
       - application
       parameters:
@@ -44,11 +49,6 @@ spec:
         name: manifests
         path: istio/istio
     name: istio
-  - kustomizeConfig:
-      repoRef:
-        name: manifests
-        path: application/application-crds
-    name: application-crds
   - kustomizeConfig:
       overlays:
       - application

--- a/kfdef/kfctl_k8s_istio.yaml
+++ b/kfdef/kfctl_k8s_istio.yaml
@@ -222,11 +222,6 @@ spec:
         path: pytorch-job/pytorch-operator
     name: pytorch-operator
   - kustomizeConfig:
-      overlays:
-      - application
-      parameters:
-      - name: generateName
-        value: knative-serving-crds-
       repoRef:
         name: manifests
         path: knative/knative-serving-crds

--- a/spark/spark-operator/overlays/application/params.yaml
+++ b/spark/spark-operator/overlays/application/params.yaml
@@ -9,3 +9,5 @@ varReference:
   kind: StatefulSet
 - path: spec/template/metadata/labels/app.kubernetes.io\/instance
   kind: StatefulSet
+- path: spec/template/metadata/labels/app.kubernetes.io\/instance
+  kind: Job

--- a/tests/aws-alb-ingress-controller-base_test.go
+++ b/tests/aws-alb-ingress-controller-base_test.go
@@ -63,7 +63,8 @@ roleRef:
   name: alb-ingress-controller
 subjects:
   - kind: ServiceAccount
-    name: alb-ingress-controller`)
+    name: alb-ingress-controller
+`)
 	th.writeF("/manifests/aws/aws-alb-ingress-controller/base/deployment.yaml", `
 # Application Load Balancer (ALB) Ingress Controller Deployment Manifest.
 # This manifest details sensible defaults for deploying an ALB Ingress Controller.
@@ -115,14 +116,17 @@ spec:
           # Repository location of the ALB Ingress Controller.
           image: docker.io/amazon/aws-alb-ingress-controller:v1.1.2
           imagePullPolicy: Always
-      serviceAccountName: alb-ingress-controller`)
+      serviceAccountName: alb-ingress-controller
+`)
 	th.writeF("/manifests/aws/aws-alb-ingress-controller/base/service-account.yaml", `
 apiVersion: v1
 kind: ServiceAccount
 metadata:
-  name: alb-ingress-controller`)
+  name: alb-ingress-controller
+`)
 	th.writeF("/manifests/aws/aws-alb-ingress-controller/base/params.env", `
-clusterName=`)
+clusterName=
+`)
 	th.writeK("/manifests/aws/aws-alb-ingress-controller/base", `
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization

--- a/tests/aws-alb-ingress-controller-overlays-vpc_test.go
+++ b/tests/aws-alb-ingress-controller-overlays-vpc_test.go
@@ -44,7 +44,8 @@ spec:
 `)
 	th.writeF("/manifests/aws/aws-alb-ingress-controller/overlays/vpc/params.env", `
 vpcId=
-region=us-west-2`)
+region=us-west-2
+`)
 	th.writeK("/manifests/aws/aws-alb-ingress-controller/overlays/vpc", `
 bases:
 - ../../base
@@ -119,7 +120,8 @@ roleRef:
   name: alb-ingress-controller
 subjects:
   - kind: ServiceAccount
-    name: alb-ingress-controller`)
+    name: alb-ingress-controller
+`)
 	th.writeF("/manifests/aws/aws-alb-ingress-controller/base/deployment.yaml", `
 # Application Load Balancer (ALB) Ingress Controller Deployment Manifest.
 # This manifest details sensible defaults for deploying an ALB Ingress Controller.
@@ -171,14 +173,17 @@ spec:
           # Repository location of the ALB Ingress Controller.
           image: docker.io/amazon/aws-alb-ingress-controller:v1.1.2
           imagePullPolicy: Always
-      serviceAccountName: alb-ingress-controller`)
+      serviceAccountName: alb-ingress-controller
+`)
 	th.writeF("/manifests/aws/aws-alb-ingress-controller/base/service-account.yaml", `
 apiVersion: v1
 kind: ServiceAccount
 metadata:
-  name: alb-ingress-controller`)
+  name: alb-ingress-controller
+`)
 	th.writeF("/manifests/aws/aws-alb-ingress-controller/base/params.env", `
-clusterName=`)
+clusterName=
+`)
 	th.writeK("/manifests/aws/aws-alb-ingress-controller/base", `
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization

--- a/tests/aws-efs-csi-driver-base_test.go
+++ b/tests/aws-efs-csi-driver-base_test.go
@@ -79,7 +79,8 @@ rules:
     verbs: ["get", "list", "watch"]
   - apiGroups: ["storage.k8s.io"]
     resources: ["volumeattachments"]
-    verbs: ["get", "list", "watch", "update"]`)
+    verbs: ["get", "list", "watch", "update"]
+`)
 	th.writeF("/manifests/aws/aws-efs-csi-driver/base/csi-attacher-cluster-role-binding.yaml", `
 kind: ClusterRoleBinding
 apiVersion: rbac.authorization.k8s.io/v1
@@ -92,12 +93,14 @@ subjects:
 roleRef:
   kind: ClusterRole
   name: efs-csi-external-attacher-clusterrole
-  apiGroup: rbac.authorization.k8s.io`)
+  apiGroup: rbac.authorization.k8s.io
+`)
 	th.writeF("/manifests/aws/aws-efs-csi-driver/base/csi-controller-sa.yaml", `
 apiVersion: v1
 kind: ServiceAccount
 metadata:
-  name: efs-csi-controller-sa`)
+  name: efs-csi-controller-sa
+`)
 	th.writeF("/manifests/aws/aws-efs-csi-driver/base/csi-node-cluster-role.yaml", `
 kind: ClusterRole
 apiVersion: rbac.authorization.k8s.io/v1
@@ -121,7 +124,8 @@ rules:
     verbs: ["get", "list", "watch", "update"]
   - apiGroups: ["csi.storage.k8s.io"]
     resources: ["csinodeinfos"]
-    verbs: ["get", "list", "watch", "update"]`)
+    verbs: ["get", "list", "watch", "update"]
+`)
 	th.writeF("/manifests/aws/aws-efs-csi-driver/base/csi-node-cluster-role-binding.yaml", `
 kind: ClusterRoleBinding
 apiVersion: rbac.authorization.k8s.io/v1
@@ -134,7 +138,8 @@ subjects:
 roleRef:
   kind: ClusterRole
   name: efs-csi-node-clusterrole
-  apiGroup: rbac.authorization.k8s.io`)
+  apiGroup: rbac.authorization.k8s.io
+`)
 	th.writeF("/manifests/aws/aws-efs-csi-driver/base/csi-node-daemon-set.yaml", `
 kind: DaemonSet
 apiVersion: apps/v1
@@ -218,13 +223,15 @@ spec:
 apiVersion: v1
 kind: ServiceAccount
 metadata:
-  name: efs-csi-node-sa`)
+  name: efs-csi-node-sa
+`)
 	th.writeF("/manifests/aws/aws-efs-csi-driver/base/csi-default-storage.yaml", `
 apiVersion: storage.k8s.io/v1
 kind: StorageClass
 metadata:
   name: efs-default
-provisioner: efs.csi.aws.com`)
+provisioner: efs.csi.aws.com
+`)
 	th.writeK("/manifests/aws/aws-efs-csi-driver/base", `
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization

--- a/tests/aws-fsx-csi-driver-base_test.go
+++ b/tests/aws-fsx-csi-driver-base_test.go
@@ -90,7 +90,8 @@ rules:
     verbs: ["get", "list", "watch"]
   - apiGroups: ["storage.k8s.io"]
     resources: ["volumeattachments"]
-    verbs: ["get", "list", "watch", "update"]`)
+    verbs: ["get", "list", "watch", "update"]
+`)
 	th.writeF("/manifests/aws/aws-fsx-csi-driver/base/csi-attacher-cluster-role-binding.yaml", `
 kind: ClusterRoleBinding
 apiVersion: rbac.authorization.k8s.io/v1
@@ -103,7 +104,8 @@ subjects:
 roleRef:
   kind: ClusterRole
   name: fsx-csi-external-attacher-clusterrole
-  apiGroup: rbac.authorization.k8s.io`)
+  apiGroup: rbac.authorization.k8s.io
+`)
 	th.writeF("/manifests/aws/aws-fsx-csi-driver/base/csi-controller-cluster-role.yaml", `
 kind: ClusterRole
 apiVersion: rbac.authorization.k8s.io/v1
@@ -121,7 +123,8 @@ rules:
     verbs: ["get", "list", "watch"]
   - apiGroups: [""]
     resources: ["events"]
-    verbs: ["get", "list", "watch", "create", "update", "patch"]`)
+    verbs: ["get", "list", "watch", "create", "update", "patch"]
+`)
 	th.writeF("/manifests/aws/aws-fsx-csi-driver/base/csi-controller-cluster-role-binding.yaml", `
 kind: ClusterRoleBinding
 apiVersion: rbac.authorization.k8s.io/v1
@@ -134,7 +137,8 @@ subjects:
 roleRef:
   kind: ClusterRole
   name: external-provisioner-role
-  apiGroup: rbac.authorization.k8s.io`)
+  apiGroup: rbac.authorization.k8s.io
+`)
 	th.writeF("/manifests/aws/aws-fsx-csi-driver/base/csi-controller-sa.yaml", `
 apiVersion: v1
 kind: ServiceAccount
@@ -178,7 +182,8 @@ subjects:
 roleRef:
   kind: ClusterRole
   name: fsx-csi-node-clusterrole
-  apiGroup: rbac.authorization.k8s.io`)
+  apiGroup: rbac.authorization.k8s.io
+`)
 	th.writeF("/manifests/aws/aws-fsx-csi-driver/base/csi-node-daemonset.yaml", `
 kind: DaemonSet
 apiVersion: apps/v1
@@ -279,7 +284,8 @@ rules:
     verbs: ["get", "list", "watch"]
   - apiGroups: [""]
     resources: ["events"]
-    verbs: ["get", "list", "watch", "create", "update", "patch"]`)
+    verbs: ["get", "list", "watch", "create", "update", "patch"]
+`)
 	th.writeF("/manifests/aws/aws-fsx-csi-driver/base/csi-provisioner-cluster-role-binding.yaml", `
 kind: ClusterRoleBinding
 apiVersion: rbac.authorization.k8s.io/v1
@@ -292,13 +298,15 @@ subjects:
 roleRef:
   kind: ClusterRole
   name: fsx-external-provisioner-clusterrole
-  apiGroup: rbac.authorization.k8s.io`)
+  apiGroup: rbac.authorization.k8s.io
+`)
 	th.writeF("/manifests/aws/aws-fsx-csi-driver/base/csi-default-storage.yaml", `
 apiVersion: storage.k8s.io/v1
 kind: StorageClass
 metadata:
   name: fsx-default
-provisioner: fsx.csi.aws.com`)
+provisioner: fsx.csi.aws.com
+`)
 	th.writeK("/manifests/aws/aws-fsx-csi-driver/base", `
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization

--- a/tests/basic-auth-ingress-overlays-managed-cert_test.go
+++ b/tests/basic-auth-ingress-overlays-managed-cert_test.go
@@ -21,7 +21,8 @@ metadata:
   name: gke-certificate
 spec:
   domains:
-  - $(hostname)`)
+  - $(hostname)
+`)
 	th.writeK("/manifests/gcp/basic-auth-ingress/overlays/managed-cert", `
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization

--- a/tests/centraldashboard-base_test.go
+++ b/tests/centraldashboard-base_test.go
@@ -166,11 +166,13 @@ varReference:
 - path: spec/template/spec/containers/0/env/0/value
   kind: Deployment
 - path: spec/template/spec/containers/0/env/1/value
-  kind: Deployment`)
+  kind: Deployment
+`)
 	th.writeF("/manifests/common/centraldashboard/base/params.env", `
 clusterDomain=cluster.local
 userid-header=
-userid-prefix=`)
+userid-prefix=
+`)
 	th.writeK("/manifests/common/centraldashboard/base", `
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization

--- a/tests/centraldashboard-overlays-application_test.go
+++ b/tests/centraldashboard-overlays-application_test.go
@@ -259,11 +259,13 @@ varReference:
 - path: spec/template/spec/containers/0/env/0/value
   kind: Deployment
 - path: spec/template/spec/containers/0/env/1/value
-  kind: Deployment`)
+  kind: Deployment
+`)
 	th.writeF("/manifests/common/centraldashboard/base/params.env", `
 clusterDomain=cluster.local
 userid-header=
-userid-prefix=`)
+userid-prefix=
+`)
 	th.writeK("/manifests/common/centraldashboard/base", `
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization

--- a/tests/centraldashboard-overlays-istio_test.go
+++ b/tests/centraldashboard-overlays-istio_test.go
@@ -204,11 +204,13 @@ varReference:
 - path: spec/template/spec/containers/0/env/0/value
   kind: Deployment
 - path: spec/template/spec/containers/0/env/1/value
-  kind: Deployment`)
+  kind: Deployment
+`)
 	th.writeF("/manifests/common/centraldashboard/base/params.env", `
 clusterDomain=cluster.local
 userid-header=
-userid-prefix=`)
+userid-prefix=
+`)
 	th.writeK("/manifests/common/centraldashboard/base", `
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization

--- a/tests/cloud-endpoints-overlays-application_test.go
+++ b/tests/cloud-endpoints-overlays-application_test.go
@@ -49,6 +49,8 @@ varReference:
   kind: Application
 - path: spec/selector/matchLabels/app.kubernetes.io\/instance
   kind: Application
+- path: spec/selector/app.kubernetes.io\/instance
+  kind: Service
 - path: spec/selector/matchLabels/app.kubernetes.io\/instance
   kind: Deployment
 - path: spec/template/metadata/labels/app.kubernetes.io\/instance

--- a/tests/fluentd-cloud-watch-base_test.go
+++ b/tests/fluentd-cloud-watch-base_test.go
@@ -24,7 +24,8 @@ rules:
     resources:
       - namespaces
       - pods
-    verbs: ["get", "list", "watch"]`)
+    verbs: ["get", "list", "watch"]
+`)
 	th.writeF("/manifests/aws/fluentd-cloud-watch/base/cluster-role-binding.yaml", `
 apiVersion: rbac.authorization.k8s.io/v1beta1
 kind: ClusterRoleBinding
@@ -37,7 +38,8 @@ roleRef:
 subjects:
   - kind: ServiceAccount
     name: fluentd
-    namespace: kube-system`)
+    namespace: kube-system
+`)
 	th.writeF("/manifests/aws/fluentd-cloud-watch/base/configmap.yaml", `
 apiVersion: v1
 kind: ConfigMap
@@ -160,7 +162,8 @@ data:
           retry_forever true
         </buffer>
       </match>
-    </label>`)
+    </label>
+`)
 	th.writeF("/manifests/aws/fluentd-cloud-watch/base/daemonset.yaml", `
 apiVersion: apps/v1
 kind: DaemonSet
@@ -235,7 +238,8 @@ spec:
 apiVersion: v1
 kind: ServiceAccount
 metadata:
-  name: fluentd`)
+  name: fluentd
+`)
 	th.writeF("/manifests/aws/fluentd-cloud-watch/base/params.env", `
 region=us-west-2
 clusterName=

--- a/tests/iap-ingress-base_test.go
+++ b/tests/iap-ingress-base_test.go
@@ -545,7 +545,8 @@ varReference:
 - path: data/healthcheck_route.yaml
   kind: ConfigMap
 - path: spec/domains
-  kind: ManagedCertificate`)
+  kind: ManagedCertificate
+`)
 	th.writeF("/manifests/gcp/iap-ingress/base/params.env", `
 namespace=kubeflow
 appName=kubeflow
@@ -557,7 +558,8 @@ oauthSecretName=kubeflow-oauth
 project=
 adminSaSecretName=admin-gcp-sa
 tlsSecretName=envoy-ingress-tls
-istioNamespace=istio-system`)
+istioNamespace=istio-system
+`)
 	th.writeK("/manifests/gcp/iap-ingress/base", `
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization

--- a/tests/iap-ingress-overlays-application_test.go
+++ b/tests/iap-ingress-overlays-application_test.go
@@ -57,6 +57,12 @@ varReference:
   kind: Application
 - path: spec/selector/matchLabels/app.kubernetes.io\/instance
   kind: Application
+- path: spec/selector/app.kubernetes.io\/instance
+  kind: Service
+- path: spec/selector/matchLabels/app.kubernetes.io\/instance
+  kind: Deployment
+- path: spec/template/metadata/labels/app.kubernetes.io\/instance
+  kind: Deployment
 - path: spec/selector/matchLabels/app.kubernetes.io\/instance
   kind: StatefulSet
 - path: spec/template/metadata/labels/app.kubernetes.io\/instance

--- a/tests/iap-ingress-overlays-application_test.go
+++ b/tests/iap-ingress-overlays-application_test.go
@@ -61,6 +61,8 @@ varReference:
   kind: StatefulSet
 - path: spec/template/metadata/labels/app.kubernetes.io\/instance
   kind: StatefulSet
+- path: spec/template/metadata/labels/app.kubernetes.io\/instance
+  kind: Job
 `)
 	th.writeF("/manifests/gcp/iap-ingress/overlays/application/params.env", `
 generateName=
@@ -624,7 +626,8 @@ varReference:
 - path: data/healthcheck_route.yaml
   kind: ConfigMap
 - path: spec/domains
-  kind: ManagedCertificate`)
+  kind: ManagedCertificate
+`)
 	th.writeF("/manifests/gcp/iap-ingress/base/params.env", `
 namespace=kubeflow
 appName=kubeflow
@@ -636,7 +639,8 @@ oauthSecretName=kubeflow-oauth
 project=
 adminSaSecretName=admin-gcp-sa
 tlsSecretName=envoy-ingress-tls
-istioNamespace=istio-system`)
+istioNamespace=istio-system
+`)
 	th.writeK("/manifests/gcp/iap-ingress/base", `
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization

--- a/tests/iap-ingress-overlays-certmanager_test.go
+++ b/tests/iap-ingress-overlays-certmanager_test.go
@@ -626,7 +626,8 @@ varReference:
 - path: data/healthcheck_route.yaml
   kind: ConfigMap
 - path: spec/domains
-  kind: ManagedCertificate`)
+  kind: ManagedCertificate
+`)
 	th.writeF("/manifests/gcp/iap-ingress/base/params.env", `
 namespace=kubeflow
 appName=kubeflow
@@ -638,7 +639,8 @@ oauthSecretName=kubeflow-oauth
 project=
 adminSaSecretName=admin-gcp-sa
 tlsSecretName=envoy-ingress-tls
-istioNamespace=istio-system`)
+istioNamespace=istio-system
+`)
 	th.writeK("/manifests/gcp/iap-ingress/base", `
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization

--- a/tests/iap-ingress-overlays-gcp-credentials_test.go
+++ b/tests/iap-ingress-overlays-gcp-credentials_test.go
@@ -600,7 +600,8 @@ varReference:
 - path: data/healthcheck_route.yaml
   kind: ConfigMap
 - path: spec/domains
-  kind: ManagedCertificate`)
+  kind: ManagedCertificate
+`)
 	th.writeF("/manifests/gcp/iap-ingress/base/params.env", `
 namespace=kubeflow
 appName=kubeflow
@@ -612,7 +613,8 @@ oauthSecretName=kubeflow-oauth
 project=
 adminSaSecretName=admin-gcp-sa
 tlsSecretName=envoy-ingress-tls
-istioNamespace=istio-system`)
+istioNamespace=istio-system
+`)
 	th.writeK("/manifests/gcp/iap-ingress/base", `
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization

--- a/tests/iap-ingress-overlays-managed-cert_test.go
+++ b/tests/iap-ingress-overlays-managed-cert_test.go
@@ -565,7 +565,8 @@ varReference:
 - path: data/healthcheck_route.yaml
   kind: ConfigMap
 - path: spec/domains
-  kind: ManagedCertificate`)
+  kind: ManagedCertificate
+`)
 	th.writeF("/manifests/gcp/iap-ingress/base/params.env", `
 namespace=kubeflow
 appName=kubeflow
@@ -577,7 +578,8 @@ oauthSecretName=kubeflow-oauth
 project=
 adminSaSecretName=admin-gcp-sa
 tlsSecretName=envoy-ingress-tls
-istioNamespace=istio-system`)
+istioNamespace=istio-system
+`)
 	th.writeK("/manifests/gcp/iap-ingress/base", `
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization

--- a/tests/istio-base_test.go
+++ b/tests/istio-base_test.go
@@ -184,10 +184,12 @@ varReference:
 - path: spec/mode
   kind: ClusterRbacConfig
 - path: spec/selector
-  kind: Gateway`)
+  kind: Gateway
+`)
 	th.writeF("/manifests/istio/istio/base/params.env", `
 clusterRbacConfig=ON
-gatewaySelector=ingressgateway`)
+gatewaySelector=ingressgateway
+`)
 	th.writeK("/manifests/istio/istio/base", `
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization

--- a/tests/istio-ingress-base_test.go
+++ b/tests/istio-ingress-base_test.go
@@ -47,7 +47,8 @@ spec:
     port:
       name: http
       number: 80
-      protocol: HTTP`)
+      protocol: HTTP
+`)
 	th.writeK("/manifests/aws/istio-ingress/base", `
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization

--- a/tests/istio-ingress-overlays-cognito_test.go
+++ b/tests/istio-ingress-overlays-cognito_test.go
@@ -30,12 +30,14 @@ metadata:
 	th.writeF("/manifests/aws/istio-ingress/overlays/cognito/params.yaml", `
 varReference:
 - path: metadata/annotations
-  kind: Ingress`)
+  kind: Ingress
+`)
 	th.writeF("/manifests/aws/istio-ingress/overlays/cognito/params.env", `
 CognitoUserPoolArn=
 CognitoAppClientId=
 CognitoUserPoolDomain=
-certArn=`)
+certArn=
+`)
 	th.writeK("/manifests/aws/istio-ingress/overlays/cognito", `
 bases:
 - ../../base
@@ -109,7 +111,8 @@ spec:
     port:
       name: http
       number: 80
-      protocol: HTTP`)
+      protocol: HTTP
+`)
 	th.writeK("/manifests/aws/istio-ingress/base", `
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization

--- a/tests/istio-ingress-overlays-oidc_test.go
+++ b/tests/istio-ingress-overlays-oidc_test.go
@@ -39,7 +39,8 @@ oidcAuthorizationEndpoint=
 oidcTokenEndpoint=
 oidcUserInfoEndpoint=
 oidcSecretName=istio-oidc-secret
-certArn=`)
+certArn=
+`)
 	th.writeF("/manifests/aws/istio-ingress/overlays/oidc/secrets.env", `
 clientId=
 clientSecret=
@@ -136,7 +137,8 @@ spec:
     port:
       name: http
       number: 80
-      protocol: HTTP`)
+      protocol: HTTP
+`)
 	th.writeK("/manifests/aws/istio-ingress/base", `
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization

--- a/tests/istio-install-overlays-application_test.go
+++ b/tests/istio-install-overlays-application_test.go
@@ -59,6 +59,10 @@ varReference:
   kind: Deployment
 - path: spec/template/metadata/labels/app.kubernetes.io\/instance
   kind: Deployment
+- path: spec/selector/matchLabels/app.kubernetes.io\/instance
+  kind: PodDisruptionBudget
+- path: spec/template/metadata/labels/app.kubernetes.io\/instance
+  kind: Job
 `)
 	th.writeF("/manifests/istio/istio-install/overlays/application/params.env", `
 generateName=

--- a/tests/istio-overlays-application_test.go
+++ b/tests/istio-overlays-application_test.go
@@ -251,10 +251,12 @@ varReference:
 - path: spec/mode
   kind: ClusterRbacConfig
 - path: spec/selector
-  kind: Gateway`)
+  kind: Gateway
+`)
 	th.writeF("/manifests/istio/istio/base/params.env", `
 clusterRbacConfig=ON
-gatewaySelector=ingressgateway`)
+gatewaySelector=ingressgateway
+`)
 	th.writeK("/manifests/istio/istio/base", `
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization

--- a/tests/jupyter-web-app-base_test.go
+++ b/tests/jupyter-web-app-base_test.go
@@ -328,7 +328,8 @@ varReference:
 - path: spec/template/spec/containers/0/env/2/value
   kind: Deployment
 - path: spec/template/spec/containers/0/env/3/value
-  kind: Deployment`)
+  kind: Deployment
+`)
 	th.writeF("/manifests/jupyter/jupyter-web-app/base/params.env", `
 UI=default
 ROK_SECRET_NAME=secret-rok-{username}
@@ -336,7 +337,8 @@ policy=Always
 prefix=jupyter
 clusterDomain=cluster.local
 userid-header=
-userid-prefix=`)
+userid-prefix=
+`)
 	th.writeK("/manifests/jupyter/jupyter-web-app/base", `
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization

--- a/tests/jupyter-web-app-overlays-application_test.go
+++ b/tests/jupyter-web-app-overlays-application_test.go
@@ -416,7 +416,8 @@ varReference:
 - path: spec/template/spec/containers/0/env/2/value
   kind: Deployment
 - path: spec/template/spec/containers/0/env/3/value
-  kind: Deployment`)
+  kind: Deployment
+`)
 	th.writeF("/manifests/jupyter/jupyter-web-app/base/params.env", `
 UI=default
 ROK_SECRET_NAME=secret-rok-{username}
@@ -424,7 +425,8 @@ policy=Always
 prefix=jupyter
 clusterDomain=cluster.local
 userid-header=
-userid-prefix=`)
+userid-prefix=
+`)
 	th.writeK("/manifests/jupyter/jupyter-web-app/base", `
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization

--- a/tests/jupyter-web-app-overlays-istio_test.go
+++ b/tests/jupyter-web-app-overlays-istio_test.go
@@ -367,7 +367,8 @@ varReference:
 - path: spec/template/spec/containers/0/env/2/value
   kind: Deployment
 - path: spec/template/spec/containers/0/env/3/value
-  kind: Deployment`)
+  kind: Deployment
+`)
 	th.writeF("/manifests/jupyter/jupyter-web-app/base/params.env", `
 UI=default
 ROK_SECRET_NAME=secret-rok-{username}
@@ -375,7 +376,8 @@ policy=Always
 prefix=jupyter
 clusterDomain=cluster.local
 userid-header=
-userid-prefix=`)
+userid-prefix=
+`)
 	th.writeK("/manifests/jupyter/jupyter-web-app/base", `
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization

--- a/tests/minio-base_test.go
+++ b/tests/minio-base_test.go
@@ -86,9 +86,11 @@ varReference:
 - path: spec/template/spec/volumes/persistentVolumeClaim/claimName
   kind: Deployment
 - path: metadata/name
-  kind: PersistentVolumeClaim`)
+  kind: PersistentVolumeClaim
+`)
 	th.writeF("/manifests/pipeline/minio/base/params.env", `
-minioPvcName=`)
+minioPvcName=
+`)
 	th.writeK("/manifests/pipeline/minio/base", `
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization

--- a/tests/minio-overlays-application_test.go
+++ b/tests/minio-overlays-application_test.go
@@ -158,9 +158,11 @@ varReference:
 - path: spec/template/spec/volumes/persistentVolumeClaim/claimName
   kind: Deployment
 - path: metadata/name
-  kind: PersistentVolumeClaim`)
+  kind: PersistentVolumeClaim
+`)
 	th.writeF("/manifests/pipeline/minio/base/params.env", `
-minioPvcName=`)
+minioPvcName=
+`)
 	th.writeK("/manifests/pipeline/minio/base", `
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization

--- a/tests/minio-overlays-minioPd_test.go
+++ b/tests/minio-overlays-minioPd_test.go
@@ -35,7 +35,8 @@ metadata:
   name: $(minioPvcName)
 spec:
   volumeName: $(minioPvName)
-  storageClassName: ""`)
+  storageClassName: ""
+`)
 	th.writeF("/manifests/pipeline/minio/overlays/minioPd/params.yaml", `
 varReference:
 - path: spec/gcePersistentDisk/pdName
@@ -156,9 +157,11 @@ varReference:
 - path: spec/template/spec/volumes/persistentVolumeClaim/claimName
   kind: Deployment
 - path: metadata/name
-  kind: PersistentVolumeClaim`)
+  kind: PersistentVolumeClaim
+`)
 	th.writeF("/manifests/pipeline/minio/base/params.env", `
-minioPvcName=`)
+minioPvcName=
+`)
 	th.writeK("/manifests/pipeline/minio/base", `
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization

--- a/tests/mxnet-operator-base_test.go
+++ b/tests/mxnet-operator-base_test.go
@@ -27,7 +27,8 @@ roleRef:
   name: mxnet-operator
 subjects:
 - kind: ServiceAccount
-  name: mxnet-operator`)
+  name: mxnet-operator
+`)
 	th.writeF("/manifests/mxnet-job/mxnet-operator/base/cluster-role.yaml", `
 apiVersion: rbac.authorization.k8s.io/v1beta1
 kind: ClusterRole
@@ -77,7 +78,8 @@ rules:
   resources:
   - deployments
   verbs:
-  - '*'`)
+  - '*'
+`)
 	th.writeF("/manifests/mxnet-job/mxnet-operator/base/crd.yaml", `
 apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
@@ -129,7 +131,8 @@ kind: ServiceAccount
 metadata:
   labels:
     app: mxnet-operator
-  name: mxnet-operator`)
+  name: mxnet-operator
+`)
 	th.writeK("/manifests/mxnet-job/mxnet-operator/base", `
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization

--- a/tests/mxnet-operator-overlays-application_test.go
+++ b/tests/mxnet-operator-overlays-application_test.go
@@ -106,7 +106,8 @@ roleRef:
   name: mxnet-operator
 subjects:
 - kind: ServiceAccount
-  name: mxnet-operator`)
+  name: mxnet-operator
+`)
 	th.writeF("/manifests/mxnet-job/mxnet-operator/base/cluster-role.yaml", `
 apiVersion: rbac.authorization.k8s.io/v1beta1
 kind: ClusterRole
@@ -156,7 +157,8 @@ rules:
   resources:
   - deployments
   verbs:
-  - '*'`)
+  - '*'
+`)
 	th.writeF("/manifests/mxnet-job/mxnet-operator/base/crd.yaml", `
 apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
@@ -208,7 +210,8 @@ kind: ServiceAccount
 metadata:
   labels:
     app: mxnet-operator
-  name: mxnet-operator`)
+  name: mxnet-operator
+`)
 	th.writeK("/manifests/mxnet-job/mxnet-operator/base", `
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization

--- a/tests/mysql-base_test.go
+++ b/tests/mysql-base_test.go
@@ -60,13 +60,15 @@ spec:
   - ReadWriteOnce
   resources:
     requests:
-      storage: 20Gi`)
+      storage: 20Gi
+`)
 	th.writeF("/manifests/pipeline/mysql/base/params.yaml", `
 varReference:
 - path: spec/template/spec/volumes/persistentVolumeClaim/claimName
   kind: Deployment
 - path: metadata/name
-  kind: PersistentVolumeClaim`)
+  kind: PersistentVolumeClaim
+`)
 	th.writeF("/manifests/pipeline/mysql/base/params.env", `
 mysqlPvcName=
 `)

--- a/tests/mysql-overlays-application_test.go
+++ b/tests/mysql-overlays-application_test.go
@@ -131,13 +131,15 @@ spec:
   - ReadWriteOnce
   resources:
     requests:
-      storage: 20Gi`)
+      storage: 20Gi
+`)
 	th.writeF("/manifests/pipeline/mysql/base/params.yaml", `
 varReference:
 - path: spec/template/spec/volumes/persistentVolumeClaim/claimName
   kind: Deployment
 - path: metadata/name
-  kind: PersistentVolumeClaim`)
+  kind: PersistentVolumeClaim
+`)
 	th.writeF("/manifests/pipeline/mysql/base/params.env", `
 mysqlPvcName=
 `)

--- a/tests/mysql-overlays-mysqlPd_test.go
+++ b/tests/mysql-overlays-mysqlPd_test.go
@@ -131,13 +131,15 @@ spec:
   - ReadWriteOnce
   resources:
     requests:
-      storage: 20Gi`)
+      storage: 20Gi
+`)
 	th.writeF("/manifests/pipeline/mysql/base/params.yaml", `
 varReference:
 - path: spec/template/spec/volumes/persistentVolumeClaim/claimName
   kind: Deployment
 - path: metadata/name
-  kind: PersistentVolumeClaim`)
+  kind: PersistentVolumeClaim
+`)
 	th.writeF("/manifests/pipeline/mysql/base/params.env", `
 mysqlPvcName=
 `)

--- a/tests/profiles-base_test.go
+++ b/tests/profiles-base_test.go
@@ -127,7 +127,8 @@ metadata:
   name: kfam
 spec:
   ports:
-    - port: 8081`)
+    - port: 8081
+`)
 	th.writeF("/manifests/profiles/base/deployment.yaml", `
 apiVersion: apps/v1
 kind: Deployment
@@ -172,7 +173,8 @@ varReference:
 - path: spec/template/spec/containers/1/args/3
   kind: Deployment
 - path: spec/template/spec/containers/1/args/5
-  kind: Deployment`)
+  kind: Deployment
+`)
 	th.writeF("/manifests/profiles/base/params.env", `
 admin=
 userid-header=

--- a/tests/profiles-overlays-application_test.go
+++ b/tests/profiles-overlays-application_test.go
@@ -201,7 +201,8 @@ metadata:
   name: kfam
 spec:
   ports:
-    - port: 8081`)
+    - port: 8081
+`)
 	th.writeF("/manifests/profiles/base/deployment.yaml", `
 apiVersion: apps/v1
 kind: Deployment
@@ -246,7 +247,8 @@ varReference:
 - path: spec/template/spec/containers/1/args/3
   kind: Deployment
 - path: spec/template/spec/containers/1/args/5
-  kind: Deployment`)
+  kind: Deployment
+`)
 	th.writeF("/manifests/profiles/base/params.env", `
 admin=
 userid-header=

--- a/tests/profiles-overlays-debug_test.go
+++ b/tests/profiles-overlays-debug_test.go
@@ -186,7 +186,8 @@ metadata:
   name: kfam
 spec:
   ports:
-    - port: 8081`)
+    - port: 8081
+`)
 	th.writeF("/manifests/profiles/base/deployment.yaml", `
 apiVersion: apps/v1
 kind: Deployment
@@ -231,7 +232,8 @@ varReference:
 - path: spec/template/spec/containers/1/args/3
   kind: Deployment
 - path: spec/template/spec/containers/1/args/5
-  kind: Deployment`)
+  kind: Deployment
+`)
 	th.writeF("/manifests/profiles/base/params.env", `
 admin=
 userid-header=

--- a/tests/profiles-overlays-devices_test.go
+++ b/tests/profiles-overlays-devices_test.go
@@ -153,7 +153,8 @@ metadata:
   name: kfam
 spec:
   ports:
-    - port: 8081`)
+    - port: 8081
+`)
 	th.writeF("/manifests/profiles/base/deployment.yaml", `
 apiVersion: apps/v1
 kind: Deployment
@@ -198,7 +199,8 @@ varReference:
 - path: spec/template/spec/containers/1/args/3
   kind: Deployment
 - path: spec/template/spec/containers/1/args/5
-  kind: Deployment`)
+  kind: Deployment
+`)
 	th.writeF("/manifests/profiles/base/params.env", `
 admin=
 userid-header=

--- a/tests/profiles-overlays-istio_test.go
+++ b/tests/profiles-overlays-istio_test.go
@@ -168,7 +168,8 @@ metadata:
   name: kfam
 spec:
   ports:
-    - port: 8081`)
+    - port: 8081
+`)
 	th.writeF("/manifests/profiles/base/deployment.yaml", `
 apiVersion: apps/v1
 kind: Deployment
@@ -213,7 +214,8 @@ varReference:
 - path: spec/template/spec/containers/1/args/3
   kind: Deployment
 - path: spec/template/spec/containers/1/args/5
-  kind: Deployment`)
+  kind: Deployment
+`)
 	th.writeF("/manifests/profiles/base/params.env", `
 admin=
 userid-header=

--- a/tests/prometheus-base_test.go
+++ b/tests/prometheus-base_test.go
@@ -298,7 +298,8 @@ varReference:
 	th.writeF("/manifests/gcp/prometheus/base/params.env", `
 projectId=
 clusterName=
-zone=`)
+zone=
+`)
 	th.writeK("/manifests/gcp/prometheus/base", `
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization

--- a/tests/spark-operator-overlays-application_test.go
+++ b/tests/spark-operator-overlays-application_test.go
@@ -60,6 +60,8 @@ varReference:
   kind: StatefulSet
 - path: spec/template/metadata/labels/app.kubernetes.io\/instance
   kind: StatefulSet
+- path: spec/template/metadata/labels/app.kubernetes.io\/instance
+  kind: Job
 `)
 	th.writeF("/manifests/spark/spark-operator/overlays/application/params.env", `
 generateName=


### PR DESCRIPTION
**Which issue is resolved by this Pull Request:**
Resolves #420

**Description of your changes:**
setting the namespace parameter for istio-crds to istio-system causes it to try and put the application CR and related configmap in the istio-system namespace which hasn't been created yet

adding the application overlay to istio-install adds selectors to istio deployments. Istio attempts to do sidecar injections which generate selector patches to these deployments. Selectors are [immutable](https://github.com/kubernetes/kubernetes/pull/50719#) so these operations fail.  

**Checklist:**
- [ ] Unit tests have been rebuilt: 
    1. `cd manifests/tests`
    2. `make generate`
    3. `make test`

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/manifests/421)
<!-- Reviewable:end -->
