### PR TITLE
Metadata fix

### DIFF
--- a/metadata/base/kustomization.yaml
+++ b/metadata/base/kustomization.yaml
@@ -43,6 +43,13 @@ vars:
     apiVersion: v1
   fieldref:
     fieldpath: metadata.name
+- name: metadata-envoy-service
+  objref:
+    kind: Service
+    name: envoy-service
+    apiVersion: v1
+  fieldref:
+    fieldpath: metadata.name
 images:
 - name: mysql
   newName: mysql

--- a/metadata/base/metadata-envoy-deployment.yaml
+++ b/metadata/base/metadata-envoy-deployment.yaml
@@ -16,7 +16,7 @@ spec:
     spec:
       containers:
       - name: container
-        image: gcr.io/ml-pipeline/envoy:initial
+        image: gcr.io/ml-pipeline/envoy:metadata-grpc
         ports:
         - name: md-envoy
           containerPort: 9090

--- a/metadata/overlays/istio/virtual-service-metadata-grpc.yaml
+++ b/metadata/overlays/istio/virtual-service-metadata-grpc.yaml
@@ -1,0 +1,21 @@
+apiVersion: networking.istio.io/v1alpha3
+kind: VirtualService
+metadata:
+  name: metadata-grpc
+spec:
+  gateways:
+  - kubeflow-gateway
+  hosts:
+  - '*'
+  http:
+  - match:
+    - uri:
+        prefix: /ml_metadata
+    rewrite:
+      uri: /ml_metadata
+    route:
+    - destination:
+        host: $(metadata-envoy-service).$(ui-namespace).svc.$(ui-clusterDomain)
+        port:
+          number: 80
+    timeout: 300s

--- a/tests/metadata-base_test.go
+++ b/tests/metadata-base_test.go
@@ -316,7 +316,7 @@ spec:
     spec:
       containers:
       - name: container
-        image: gcr.io/ml-pipeline/envoy:initial
+        image: gcr.io/ml-pipeline/envoy:metadata-grpc
         ports:
         - name: md-envoy
           containerPort: 9090
@@ -385,6 +385,13 @@ vars:
   objref:
     kind: Service
     name: ui
+    apiVersion: v1
+  fieldref:
+    fieldpath: metadata.name
+- name: metadata-envoy-service
+  objref:
+    kind: Service
+    name: envoy-service
     apiVersion: v1
   fieldref:
     fieldpath: metadata.name

--- a/tests/metadata-overlays-application_test.go
+++ b/tests/metadata-overlays-application_test.go
@@ -397,7 +397,7 @@ spec:
     spec:
       containers:
       - name: container
-        image: gcr.io/ml-pipeline/envoy:initial
+        image: gcr.io/ml-pipeline/envoy:metadata-grpc
         ports:
         - name: md-envoy
           containerPort: 9090
@@ -466,6 +466,13 @@ vars:
   objref:
     kind: Service
     name: ui
+    apiVersion: v1
+  fieldref:
+    fieldpath: metadata.name
+- name: metadata-envoy-service
+  objref:
+    kind: Service
+    name: envoy-service
     apiVersion: v1
   fieldref:
     fieldpath: metadata.name

--- a/tests/metadata-overlays-istio_test.go
+++ b/tests/metadata-overlays-istio_test.go
@@ -354,7 +354,7 @@ spec:
     spec:
       containers:
       - name: container
-        image: gcr.io/ml-pipeline/envoy:initial
+        image: gcr.io/ml-pipeline/envoy:metadata-grpc
         ports:
         - name: md-envoy
           containerPort: 9090
@@ -423,6 +423,13 @@ vars:
   objref:
     kind: Service
     name: ui
+    apiVersion: v1
+  fieldref:
+    fieldpath: metadata.name
+- name: metadata-envoy-service
+  objref:
+    kind: Service
+    name: envoy-service
     apiVersion: v1
   fieldref:
     fieldpath: metadata.name


### PR DESCRIPTION
**Which issue is resolved by this Pull Request:**
Partially resolves kubeflow/pipelines#2239

**Description of your changes:**
Add virtual service for metadata grpc server and point mlmd grpc deployment to newer image with the right service name for the deployed grpc server.

**Checklist:**
- [X] Unit tests have been rebuilt: 
    1. `cd manifests/tests`
    2. `make generate`
    3. `make test`

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/manifests/424)
<!-- Reviewable:end -->
