### PR TITLE
Restore Metadata fix (#424)

### DIFF
--- a/metadata/base/kustomization.yaml
+++ b/metadata/base/kustomization.yaml
@@ -43,3 +43,10 @@ vars:
     apiVersion: v1
   fieldref:
     fieldpath: metadata.name
+- name: metadata-envoy-service
+  objref:
+    kind: Service
+    name: envoy-service
+    apiVersion: v1
+  fieldref:
+    fieldpath: metadata.name

--- a/metadata/base/metadata-envoy-deployment.yaml
+++ b/metadata/base/metadata-envoy-deployment.yaml
@@ -16,7 +16,7 @@ spec:
     spec:
       containers:
       - name: container
-        image: gcr.io/ml-pipeline/envoy:initial
+        image: gcr.io/ml-pipeline/envoy:metadata-grpc
         ports:
         - name: md-envoy
           containerPort: 9090

--- a/metadata/overlays/istio/kustomization.yaml
+++ b/metadata/overlays/istio/kustomization.yaml
@@ -4,5 +4,6 @@ bases:
 - ../../base
 resources:
 - virtual-service.yaml
+- virtual-service-metadata-grpc.yaml
 configurations:
 - params.yaml

--- a/metadata/overlays/istio/virtual-service-metadata-grpc.yaml
+++ b/metadata/overlays/istio/virtual-service-metadata-grpc.yaml
@@ -1,0 +1,21 @@
+apiVersion: networking.istio.io/v1alpha3
+kind: VirtualService
+metadata:
+  name: metadata-grpc
+spec:
+  gateways:
+  - kubeflow-gateway
+  hosts:
+  - '*'
+  http:
+  - match:
+    - uri:
+        prefix: /ml_metadata
+    rewrite:
+      uri: /ml_metadata
+    route:
+    - destination:
+        host: $(metadata-envoy-service).$(ui-namespace).svc.$(ui-clusterDomain)
+        port:
+          number: 80
+    timeout: 300s

--- a/metadata/overlays/istio/virtual-service-metadata-grpc.yaml
+++ b/metadata/overlays/istio/virtual-service-metadata-grpc.yaml
@@ -17,5 +17,5 @@ spec:
     - destination:
         host: $(metadata-envoy-service).$(ui-namespace).svc.$(ui-clusterDomain)
         port:
-          number: 80
+          number: 9090
     timeout: 300s

--- a/tests/metadata-base_test.go
+++ b/tests/metadata-base_test.go
@@ -316,7 +316,7 @@ spec:
     spec:
       containers:
       - name: container
-        image: gcr.io/ml-pipeline/envoy:initial
+        image: gcr.io/ml-pipeline/envoy:metadata-grpc
         ports:
         - name: md-envoy
           containerPort: 9090
@@ -385,6 +385,13 @@ vars:
   objref:
     kind: Service
     name: ui
+    apiVersion: v1
+  fieldref:
+    fieldpath: metadata.name
+- name: metadata-envoy-service
+  objref:
+    kind: Service
+    name: envoy-service
     apiVersion: v1
   fieldref:
     fieldpath: metadata.name`)

--- a/tests/metadata-overlays-application_test.go
+++ b/tests/metadata-overlays-application_test.go
@@ -373,7 +373,7 @@ spec:
     spec:
       containers:
       - name: container
-        image: gcr.io/ml-pipeline/envoy:initial
+        image: gcr.io/ml-pipeline/envoy:metadata-grpc
         ports:
         - name: md-envoy
           containerPort: 9090
@@ -442,6 +442,13 @@ vars:
   objref:
     kind: Service
     name: ui
+    apiVersion: v1
+  fieldref:
+    fieldpath: metadata.name
+- name: metadata-envoy-service
+  objref:
+    kind: Service
+    name: envoy-service
     apiVersion: v1
   fieldref:
     fieldpath: metadata.name`)

--- a/tests/metadata-overlays-istio_test.go
+++ b/tests/metadata-overlays-istio_test.go
@@ -37,6 +37,29 @@ spec:
           number: 80
     timeout: 300s
 `)
+	th.writeF("/manifests/metadata/overlays/istio/virtual-service-metadata-grpc.yaml", `
+apiVersion: networking.istio.io/v1alpha3
+kind: VirtualService
+metadata:
+  name: metadata-grpc
+spec:
+  gateways:
+  - kubeflow-gateway
+  hosts:
+  - '*'
+  http:
+  - match:
+    - uri:
+        prefix: /ml_metadata
+    rewrite:
+      uri: /ml_metadata
+    route:
+    - destination:
+        host: $(metadata-envoy-service).$(ui-namespace).svc.$(ui-clusterDomain)
+        port:
+          number: 9090
+    timeout: 300s
+`)
 	th.writeF("/manifests/metadata/overlays/istio/params.yaml", `
 varReference:
 - path: spec/http/route/destination/host
@@ -49,6 +72,7 @@ bases:
 - ../../base
 resources:
 - virtual-service.yaml
+- virtual-service-metadata-grpc.yaml
 configurations:
 - params.yaml
 `)

--- a/tests/metadata-overlays-istio_test.go
+++ b/tests/metadata-overlays-istio_test.go
@@ -354,7 +354,7 @@ spec:
     spec:
       containers:
       - name: container
-        image: gcr.io/ml-pipeline/envoy:initial
+        image: gcr.io/ml-pipeline/envoy:metadata-grpc
         ports:
         - name: md-envoy
           containerPort: 9090
@@ -423,6 +423,13 @@ vars:
   objref:
     kind: Service
     name: ui
+    apiVersion: v1
+  fieldref:
+    fieldpath: metadata.name
+- name: metadata-envoy-service
+  objref:
+    kind: Service
+    name: envoy-service
     apiVersion: v1
   fieldref:
     fieldpath: metadata.name`)


### PR DESCRIPTION
* Fix metadata deployment for KFP's UI

* Only update metadata test files

* This PR was originally committed as #424 but it got rolled back in #429
  in order to fix master.

  * This PR is rolling it forward.

  * Related to #426

* Changes not in the original PR

   * New virtual service needs to be listed in kustomization.yaml
   * Port for the virtual service should be 9090 not 80

* Related to kubeflow/pipelines#2239 - update KFP to 0.31 for KF 0.7

**Which issue is resolved by this Pull Request:**
Resolves #

**Description of your changes:**


**Checklist:**
- [ ] Unit tests have been rebuilt: 
    1. `cd manifests/tests`
    2. `make generate`
    3. `make test`

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/manifests/430)
<!-- Reviewable:end -->
