### PR TITLE
Remove istio overlay in tf-job-operator

### DIFF
--- a/kfdef/kfctl_anthos.yaml
+++ b/kfdef/kfctl_anthos.yaml
@@ -162,8 +162,6 @@ spec:
         path: tf-training/tf-job-crds
     name: tf-job-crds
   - kustomizeConfig:
-      overlays:
-      - istio
       repoRef:
         name: manifests
         path: tf-training/tf-job-operator

--- a/kfdef/kfctl_aws.yaml
+++ b/kfdef/kfctl_aws.yaml
@@ -149,7 +149,6 @@ spec:
       name: tf-job-crds
     - kustomizeConfig:
         overlays:
-          - istio
           - application
         repoRef:
           name: manifests

--- a/kfdef/kfctl_aws_cognito.yaml
+++ b/kfdef/kfctl_aws_cognito.yaml
@@ -149,7 +149,6 @@ spec:
       name: tf-job-crds
     - kustomizeConfig:
         overlays:
-          - istio
           - application
         repoRef:
           name: manifests

--- a/kfdef/kfctl_existing_arrikto.yaml
+++ b/kfdef/kfctl_existing_arrikto.yaml
@@ -130,7 +130,6 @@ spec:
     name: tf-job-crds
   - kustomizeConfig:
       overlays:
-      - istio
       - application
       repoRef:
         name: manifests

--- a/kfdef/kfctl_gcp_basic_auth.yaml
+++ b/kfdef/kfctl_gcp_basic_auth.yaml
@@ -188,7 +188,6 @@ spec:
     name: tf-job-crds
   - kustomizeConfig:
       overlays:
-      - istio
       - application
       repoRef:
         name: manifests

--- a/kfdef/kfctl_gcp_iap.yaml
+++ b/kfdef/kfctl_gcp_iap.yaml
@@ -194,7 +194,6 @@ spec:
     name: tf-job-crds
   - kustomizeConfig:
       overlays:
-      - istio
       - application
       repoRef:
         name: manifests

--- a/kfdef/kfctl_k8s_istio.yaml
+++ b/kfdef/kfctl_k8s_istio.yaml
@@ -176,8 +176,6 @@ spec:
         path: tf-training/tf-job-crds
     name: tf-job-crds
   - kustomizeConfig:
-      overlays:
-      - istio
       repoRef:
         name: manifests
         path: tf-training/tf-job-operator


### PR DESCRIPTION
As istio overlay has been removed in #432 , corresponding entry from config files are removed

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/manifests/433)
<!-- Reviewable:end -->
