### PR TITLE
Reorder katib manifests

### DIFF
--- a/kfdef/kfctl_anthos.yaml
+++ b/kfdef/kfctl_anthos.yaml
@@ -74,19 +74,6 @@ spec:
         path: jupyter/jupyter-web-app
     name: jupyter-web-app
   - kustomizeConfig:
-      repoRef:
-        name: manifests
-        path: katib/katib-crds
-    name: katib-crds
-  - kustomizeConfig:
-      overlays:
-      - application
-      - istio
-      repoRef:
-        name: manifests
-        path: katib/katib-controller
-    name: katib-controller
-  - kustomizeConfig:
       overlays:
       - istio
       repoRef:
@@ -168,6 +155,19 @@ spec:
         name: manifests
         path: tf-training/tf-job-operator
     name: tf-job-operator
+  - kustomizeConfig:
+      repoRef:
+        name: manifests
+        path: katib/katib-crds
+    name: katib-crds
+  - kustomizeConfig:
+      overlays:
+      - application
+      - istio
+      repoRef:
+        name: manifests
+        path: katib/katib-controller
+    name: katib-controller
   - kustomizeConfig:
       repoRef:
         name: manifests

--- a/kfdef/kfctl_aws.yaml
+++ b/kfdef/kfctl_aws.yaml
@@ -84,19 +84,6 @@ spec:
           path: jupyter/jupyter-web-app
       name: jupyter-web-app
     - kustomizeConfig:
-        repoRef:
-          name: manifests
-          path: katib/katib-crds
-      name: katib-crds
-    - kustomizeConfig:
-        overlays:
-        - application
-        - istio
-        repoRef:
-          name: manifests
-          path: katib/katib-controller
-      name: katib-controller
-    - kustomizeConfig:
         overlays:
           - istio
         repoRef:
@@ -155,6 +142,19 @@ spec:
           name: manifests
           path: tf-training/tf-job-operator
       name: tf-job-operator
+    - kustomizeConfig:
+        repoRef:
+          name: manifests
+          path: katib/katib-crds
+      name: katib-crds
+    - kustomizeConfig:
+        overlays:
+        - application
+        - istio
+        repoRef:
+          name: manifests
+          path: katib/katib-controller
+      name: katib-controller
     - kustomizeConfig:
         repoRef:
           name: manifests

--- a/kfdef/kfctl_aws_cognito.yaml
+++ b/kfdef/kfctl_aws_cognito.yaml
@@ -84,19 +84,6 @@ spec:
           path: jupyter/jupyter-web-app
       name: jupyter-web-app
     - kustomizeConfig:
-        repoRef:
-          name: manifests
-          path: katib/katib-crds
-      name: katib-crds
-    - kustomizeConfig:
-        overlays:
-        - application
-        - istio
-        repoRef:
-          name: manifests
-          path: katib/katib-controller
-      name: katib-controller
-    - kustomizeConfig:
         overlays:
           - istio
         repoRef:
@@ -155,6 +142,19 @@ spec:
           name: manifests
           path: tf-training/tf-job-operator
       name: tf-job-operator
+    - kustomizeConfig:
+        repoRef:
+          name: manifests
+          path: katib/katib-crds
+      name: katib-crds
+    - kustomizeConfig:
+        overlays:
+        - application
+        - istio
+        repoRef:
+          name: manifests
+          path: katib/katib-controller
+      name: katib-controller
     - kustomizeConfig:
         repoRef:
           name: manifests

--- a/kfdef/kfctl_existing_arrikto.yaml
+++ b/kfdef/kfctl_existing_arrikto.yaml
@@ -67,19 +67,6 @@ spec:
         path: jupyter/jupyter-web-app
     name: jupyter-web-app
   - kustomizeConfig:
-      repoRef:
-        name: manifests
-        path: katib/katib-crds
-    name: katib-crds
-  - kustomizeConfig:
-      overlays:
-      - application
-      - istio
-      repoRef:
-        name: manifests
-        path: katib/katib-controller
-    name: katib-controller
-  - kustomizeConfig:
       overlays:
       - istio
       repoRef:
@@ -136,6 +123,19 @@ spec:
         name: manifests
         path: tf-training/tf-job-operator
     name: tf-job-operator
+  - kustomizeConfig:
+      repoRef:
+        name: manifests
+        path: katib/katib-crds
+    name: katib-crds
+  - kustomizeConfig:
+      overlays:
+      - application
+      - istio
+      repoRef:
+        name: manifests
+        path: katib/katib-controller
+    name: katib-controller
   - kustomizeConfig:
       repoRef:
         name: manifests

--- a/kfdef/kfctl_gcp_basic_auth.yaml
+++ b/kfdef/kfctl_gcp_basic_auth.yaml
@@ -94,19 +94,6 @@ spec:
         path: jupyter/jupyter-web-app
     name: jupyter-web-app
   - kustomizeConfig:
-      repoRef:
-        name: manifests
-        path: katib/katib-crds
-    name: katib-crds
-  - kustomizeConfig:
-      overlays:
-      - application
-      - istio
-      repoRef:
-        name: manifests
-        path: katib/katib-controller
-    name: katib-controller
-  - kustomizeConfig:
       overlays:
       - istio
       repoRef:
@@ -194,6 +181,19 @@ spec:
         name: manifests
         path: tf-training/tf-job-operator
     name: tf-job-operator
+  - kustomizeConfig:
+      repoRef:
+        name: manifests
+        path: katib/katib-crds
+    name: katib-crds
+  - kustomizeConfig:
+      overlays:
+      - application
+      - istio
+      repoRef:
+        name: manifests
+        path: katib/katib-controller
+    name: katib-controller
   - kustomizeConfig:
       repoRef:
         name: manifests

--- a/kfdef/kfctl_gcp_iap.yaml
+++ b/kfdef/kfctl_gcp_iap.yaml
@@ -100,19 +100,6 @@ spec:
         path: jupyter/jupyter-web-app
     name: jupyter-web-app
   - kustomizeConfig:
-      repoRef:
-        name: manifests
-        path: katib/katib-crds
-    name: katib-crds
-  - kustomizeConfig:
-      overlays:
-      - application
-      - istio
-      repoRef:
-        name: manifests
-        path: katib/katib-controller
-    name: katib-controller
-  - kustomizeConfig:
       overlays:
       - istio
       repoRef:
@@ -200,6 +187,19 @@ spec:
         name: manifests
         path: tf-training/tf-job-operator
     name: tf-job-operator
+  - kustomizeConfig:
+      repoRef:
+        name: manifests
+        path: katib/katib-crds
+    name: katib-crds
+  - kustomizeConfig:
+      overlays:
+      - application
+      - istio
+      repoRef:
+        name: manifests
+        path: katib/katib-controller
+    name: katib-controller
   - kustomizeConfig:
       repoRef:
         name: manifests

--- a/kfdef/kfctl_k8s_istio.yaml
+++ b/kfdef/kfctl_k8s_istio.yaml
@@ -88,19 +88,6 @@ spec:
         path: jupyter/jupyter-web-app
     name: jupyter-web-app
   - kustomizeConfig:
-      repoRef:
-        name: manifests
-        path: katib/katib-crds
-    name: katib-crds
-  - kustomizeConfig:
-      overlays:
-      - application
-      - istio
-      repoRef:
-        name: manifests
-        path: katib/katib-controller
-    name: katib-controller
-  - kustomizeConfig:
       overlays:
       - istio
       repoRef:
@@ -182,6 +169,19 @@ spec:
         name: manifests
         path: tf-training/tf-job-operator
     name: tf-job-operator
+  - kustomizeConfig:
+      repoRef:
+        name: manifests
+        path: katib/katib-crds
+    name: katib-crds
+  - kustomizeConfig:
+      overlays:
+      - application
+      - istio
+      repoRef:
+        name: manifests
+        path: katib/katib-controller
+    name: katib-controller
   - kustomizeConfig:
       repoRef:
         name: manifests


### PR DESCRIPTION
Katib installation is moved after job operators installation.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/manifests/434)
<!-- Reviewable:end -->
