### PR TITLE
Fix presubmits; pythonpath needs to include kubeflow/kubeflow/py

### DIFF
--- a/tests/workflows/components/kfctl_go_test.jsonnet
+++ b/tests/workflows/components/kfctl_go_test.jsonnet
@@ -101,7 +101,7 @@ local buildTemplate(step_name, command, working_dir=null, env_vars=[], sidecars=
       {
         // Add the source directories to the python path.
         name: "PYTHONPATH",
-        value: kubeflowPy + ":" + kubeflowTestingPy,
+        value: kubeflowPy + ":" + kubeflowPy + "/py:" + kubeflowTestingPy,
       },
       {
         name: "GOOGLE_APPLICATION_CREDENTIALS",


### PR DESCRIPTION
* This is a quick fix for the failing presubmits #436
* A better fix would be to use E2E workflow as defined in kubeflow/kubeflow
  rather than maintaining a separate copy of it.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/manifests/437)
<!-- Reviewable:end -->
