### PR TITLE
app.kubernetes.io labels for kfserving

### DIFF
--- a/kfserving/kfserving-install/overlays/application/application.yaml
+++ b/kfserving/kfserving-install/overlays/application/application.yaml
@@ -3,6 +3,15 @@ kind: Application
 metadata:
   name: "kfserving"
 spec:
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: kfserving
+      app.kubernetes.io/instance: kfserving
+      app.kubernetes.io/managed-by: kfctl
+      app.kubernetes.io/component: kfserving
+      app.kubernetes.io/part-of: kubeflow
+      app.kubernetes.io/version: v0.7
+spec:
   type: "kfserving"
   componentKinds:
     - group: apps/v1
@@ -24,6 +33,8 @@ spec:
   owners:
     - name: Johnu George
       email: johnugeo@cisco.com
+    - name: AnimeshSingh
+      email: singhan@us.ibm.com   
   keywords:
    - "kfserving"
    - "inference"


### PR DESCRIPTION
adding app.kubernetes.io labels  as its mentioned as a v0.7 requirement

Every resource that is part of the application should include the labels recommended by Kubernetes, currently:
app.kubernetes.io/name
app.kubernetes.io/instance
app.kubernetes.io/version
app.kubernetes.io/component
app.kubernetes.io/part-of
app.kubernetes.io/managed-by

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/manifests/439)
<!-- Reviewable:end -->
