### PR TITLE
add instance label to jupyter-web-app, selector to Application

### DIFF
--- a/jupyter/jupyter-web-app/overlays/application/application.yaml
+++ b/jupyter/jupyter-web-app/overlays/application/application.yaml
@@ -6,11 +6,11 @@ spec:
   selector:
     matchLabels:
       app.kubernetes.io/name: jupyter-web-app
-      app.kubernetes.io/instance: jupyter-web-app
+      app.kubernetes.io/instance: jupyter-web-app-v0.6.2
       app.kubernetes.io/managed-by: kfctl
-      app.kubernetes.io/component: jupyter
+      app.kubernetes.io/component: jupyter-web-app
       app.kubernetes.io/part-of: kubeflow
-      app.kubernetes.io/version: v0.6
+      app.kubernetes.io/version: v0.6.2
   componentKinds:
   - group: core
     kind: ConfigMap
@@ -22,6 +22,8 @@ spec:
     kind: Role
   - group: core
     kind: ServiceAccount
+  - group: core
+    kind: Service
   - group: networking.istio.io
     kind: VirtualService
   descriptor:

--- a/jupyter/jupyter-web-app/overlays/application/kustomization.yaml
+++ b/jupyter/jupyter-web-app/overlays/application/kustomization.yaml
@@ -6,8 +6,8 @@ resources:
 - application.yaml
 commonLabels:
   app.kubernetes.io/name: jupyter-web-app
-  app.kubernetes.io/instance: jupyter-web-app
+  app.kubernetes.io/instance: jupyter-web-app-v0.6.2
   app.kubernetes.io/managed-by: kfctl
-  app.kubernetes.io/component: jupyter
+  app.kubernetes.io/component: jupyter-web-app
   app.kubernetes.io/part-of: kubeflow
-  app.kubernetes.io/version: v0.6
+  app.kubernetes.io/version: v0.6.2

--- a/tests/aws-alb-ingress-controller-base_test.go
+++ b/tests/aws-alb-ingress-controller-base_test.go
@@ -63,7 +63,8 @@ roleRef:
   name: alb-ingress-controller
 subjects:
   - kind: ServiceAccount
-    name: alb-ingress-controller`)
+    name: alb-ingress-controller
+`)
 	th.writeF("/manifests/aws/aws-alb-ingress-controller/base/deployment.yaml", `
 # Application Load Balancer (ALB) Ingress Controller Deployment Manifest.
 # This manifest details sensible defaults for deploying an ALB Ingress Controller.
@@ -115,14 +116,17 @@ spec:
           # Repository location of the ALB Ingress Controller.
           image: docker.io/amazon/aws-alb-ingress-controller:v1.1.2
           imagePullPolicy: Always
-      serviceAccountName: alb-ingress-controller`)
+      serviceAccountName: alb-ingress-controller
+`)
 	th.writeF("/manifests/aws/aws-alb-ingress-controller/base/service-account.yaml", `
 apiVersion: v1
 kind: ServiceAccount
 metadata:
-  name: alb-ingress-controller`)
+  name: alb-ingress-controller
+`)
 	th.writeF("/manifests/aws/aws-alb-ingress-controller/base/params.env", `
-clusterName=`)
+clusterName=
+`)
 	th.writeK("/manifests/aws/aws-alb-ingress-controller/base", `
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization

--- a/tests/aws-alb-ingress-controller-overlays-vpc_test.go
+++ b/tests/aws-alb-ingress-controller-overlays-vpc_test.go
@@ -44,7 +44,8 @@ spec:
 `)
 	th.writeF("/manifests/aws/aws-alb-ingress-controller/overlays/vpc/params.env", `
 vpcId=
-region=us-west-2`)
+region=us-west-2
+`)
 	th.writeK("/manifests/aws/aws-alb-ingress-controller/overlays/vpc", `
 bases:
 - ../../base
@@ -119,7 +120,8 @@ roleRef:
   name: alb-ingress-controller
 subjects:
   - kind: ServiceAccount
-    name: alb-ingress-controller`)
+    name: alb-ingress-controller
+`)
 	th.writeF("/manifests/aws/aws-alb-ingress-controller/base/deployment.yaml", `
 # Application Load Balancer (ALB) Ingress Controller Deployment Manifest.
 # This manifest details sensible defaults for deploying an ALB Ingress Controller.
@@ -171,14 +173,17 @@ spec:
           # Repository location of the ALB Ingress Controller.
           image: docker.io/amazon/aws-alb-ingress-controller:v1.1.2
           imagePullPolicy: Always
-      serviceAccountName: alb-ingress-controller`)
+      serviceAccountName: alb-ingress-controller
+`)
 	th.writeF("/manifests/aws/aws-alb-ingress-controller/base/service-account.yaml", `
 apiVersion: v1
 kind: ServiceAccount
 metadata:
-  name: alb-ingress-controller`)
+  name: alb-ingress-controller
+`)
 	th.writeF("/manifests/aws/aws-alb-ingress-controller/base/params.env", `
-clusterName=`)
+clusterName=
+`)
 	th.writeK("/manifests/aws/aws-alb-ingress-controller/base", `
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization

--- a/tests/aws-efs-csi-driver-base_test.go
+++ b/tests/aws-efs-csi-driver-base_test.go
@@ -79,7 +79,8 @@ rules:
     verbs: ["get", "list", "watch"]
   - apiGroups: ["storage.k8s.io"]
     resources: ["volumeattachments"]
-    verbs: ["get", "list", "watch", "update"]`)
+    verbs: ["get", "list", "watch", "update"]
+`)
 	th.writeF("/manifests/aws/aws-efs-csi-driver/base/csi-attacher-cluster-role-binding.yaml", `
 kind: ClusterRoleBinding
 apiVersion: rbac.authorization.k8s.io/v1
@@ -92,12 +93,14 @@ subjects:
 roleRef:
   kind: ClusterRole
   name: efs-csi-external-attacher-clusterrole
-  apiGroup: rbac.authorization.k8s.io`)
+  apiGroup: rbac.authorization.k8s.io
+`)
 	th.writeF("/manifests/aws/aws-efs-csi-driver/base/csi-controller-sa.yaml", `
 apiVersion: v1
 kind: ServiceAccount
 metadata:
-  name: efs-csi-controller-sa`)
+  name: efs-csi-controller-sa
+`)
 	th.writeF("/manifests/aws/aws-efs-csi-driver/base/csi-node-cluster-role.yaml", `
 kind: ClusterRole
 apiVersion: rbac.authorization.k8s.io/v1
@@ -121,7 +124,8 @@ rules:
     verbs: ["get", "list", "watch", "update"]
   - apiGroups: ["csi.storage.k8s.io"]
     resources: ["csinodeinfos"]
-    verbs: ["get", "list", "watch", "update"]`)
+    verbs: ["get", "list", "watch", "update"]
+`)
 	th.writeF("/manifests/aws/aws-efs-csi-driver/base/csi-node-cluster-role-binding.yaml", `
 kind: ClusterRoleBinding
 apiVersion: rbac.authorization.k8s.io/v1
@@ -134,7 +138,8 @@ subjects:
 roleRef:
   kind: ClusterRole
   name: efs-csi-node-clusterrole
-  apiGroup: rbac.authorization.k8s.io`)
+  apiGroup: rbac.authorization.k8s.io
+`)
 	th.writeF("/manifests/aws/aws-efs-csi-driver/base/csi-node-daemon-set.yaml", `
 kind: DaemonSet
 apiVersion: apps/v1
@@ -218,13 +223,15 @@ spec:
 apiVersion: v1
 kind: ServiceAccount
 metadata:
-  name: efs-csi-node-sa`)
+  name: efs-csi-node-sa
+`)
 	th.writeF("/manifests/aws/aws-efs-csi-driver/base/csi-default-storage.yaml", `
 apiVersion: storage.k8s.io/v1
 kind: StorageClass
 metadata:
   name: efs-default
-provisioner: efs.csi.aws.com`)
+provisioner: efs.csi.aws.com
+`)
 	th.writeK("/manifests/aws/aws-efs-csi-driver/base", `
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization

--- a/tests/aws-fsx-csi-driver-base_test.go
+++ b/tests/aws-fsx-csi-driver-base_test.go
@@ -90,7 +90,8 @@ rules:
     verbs: ["get", "list", "watch"]
   - apiGroups: ["storage.k8s.io"]
     resources: ["volumeattachments"]
-    verbs: ["get", "list", "watch", "update"]`)
+    verbs: ["get", "list", "watch", "update"]
+`)
 	th.writeF("/manifests/aws/aws-fsx-csi-driver/base/csi-attacher-cluster-role-binding.yaml", `
 kind: ClusterRoleBinding
 apiVersion: rbac.authorization.k8s.io/v1
@@ -103,7 +104,8 @@ subjects:
 roleRef:
   kind: ClusterRole
   name: fsx-csi-external-attacher-clusterrole
-  apiGroup: rbac.authorization.k8s.io`)
+  apiGroup: rbac.authorization.k8s.io
+`)
 	th.writeF("/manifests/aws/aws-fsx-csi-driver/base/csi-controller-cluster-role.yaml", `
 kind: ClusterRole
 apiVersion: rbac.authorization.k8s.io/v1
@@ -121,7 +123,8 @@ rules:
     verbs: ["get", "list", "watch"]
   - apiGroups: [""]
     resources: ["events"]
-    verbs: ["get", "list", "watch", "create", "update", "patch"]`)
+    verbs: ["get", "list", "watch", "create", "update", "patch"]
+`)
 	th.writeF("/manifests/aws/aws-fsx-csi-driver/base/csi-controller-cluster-role-binding.yaml", `
 kind: ClusterRoleBinding
 apiVersion: rbac.authorization.k8s.io/v1
@@ -134,7 +137,8 @@ subjects:
 roleRef:
   kind: ClusterRole
   name: external-provisioner-role
-  apiGroup: rbac.authorization.k8s.io`)
+  apiGroup: rbac.authorization.k8s.io
+`)
 	th.writeF("/manifests/aws/aws-fsx-csi-driver/base/csi-controller-sa.yaml", `
 apiVersion: v1
 kind: ServiceAccount
@@ -178,7 +182,8 @@ subjects:
 roleRef:
   kind: ClusterRole
   name: fsx-csi-node-clusterrole
-  apiGroup: rbac.authorization.k8s.io`)
+  apiGroup: rbac.authorization.k8s.io
+`)
 	th.writeF("/manifests/aws/aws-fsx-csi-driver/base/csi-node-daemonset.yaml", `
 kind: DaemonSet
 apiVersion: apps/v1
@@ -279,7 +284,8 @@ rules:
     verbs: ["get", "list", "watch"]
   - apiGroups: [""]
     resources: ["events"]
-    verbs: ["get", "list", "watch", "create", "update", "patch"]`)
+    verbs: ["get", "list", "watch", "create", "update", "patch"]
+`)
 	th.writeF("/manifests/aws/aws-fsx-csi-driver/base/csi-provisioner-cluster-role-binding.yaml", `
 kind: ClusterRoleBinding
 apiVersion: rbac.authorization.k8s.io/v1
@@ -292,13 +298,15 @@ subjects:
 roleRef:
   kind: ClusterRole
   name: fsx-external-provisioner-clusterrole
-  apiGroup: rbac.authorization.k8s.io`)
+  apiGroup: rbac.authorization.k8s.io
+`)
 	th.writeF("/manifests/aws/aws-fsx-csi-driver/base/csi-default-storage.yaml", `
 apiVersion: storage.k8s.io/v1
 kind: StorageClass
 metadata:
   name: fsx-default
-provisioner: fsx.csi.aws.com`)
+provisioner: fsx.csi.aws.com
+`)
 	th.writeK("/manifests/aws/aws-fsx-csi-driver/base", `
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization

--- a/tests/basic-auth-ingress-overlays-certmanager_test.go
+++ b/tests/basic-auth-ingress-overlays-certmanager_test.go
@@ -77,7 +77,8 @@ resources:
 - certificate.yaml
 namespace: kubeflow
 commonLabels:
-  kustomize.component: basic-auth-ingress`)
+  kustomize.component: basic-auth-ingress
+`)
 	th.writeF("/manifests/gcp/basic-auth-ingress/base/cloud-endpoint.yaml", `
 apiVersion: ctl.isla.solutions/v1
 kind: CloudEndpoint

--- a/tests/basic-auth-ingress-overlays-gcp-credentials_test.go
+++ b/tests/basic-auth-ingress-overlays-gcp-credentials_test.go
@@ -43,7 +43,8 @@ kind: Kustomization
 bases:
 - ../../base
 patchesStrategicMerge:
-- gcp-credentials-patch.yaml`)
+- gcp-credentials-patch.yaml
+`)
 	th.writeF("/manifests/gcp/basic-auth-ingress/base/cloud-endpoint.yaml", `
 apiVersion: ctl.isla.solutions/v1
 kind: CloudEndpoint

--- a/tests/basic-auth-ingress-overlays-managed-cert_test.go
+++ b/tests/basic-auth-ingress-overlays-managed-cert_test.go
@@ -21,7 +21,8 @@ metadata:
   name: gke-certificate
 spec:
   domains:
-  - $(hostname)`)
+  - $(hostname)
+`)
 	th.writeK("/manifests/gcp/basic-auth-ingress/overlays/managed-cert", `
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
@@ -31,7 +32,8 @@ resources:
 - cert.yaml
 namespace: kubeflow
 commonLabels:
-  kustomize.component: basic-auth-ingress`)
+  kustomize.component: basic-auth-ingress
+`)
 	th.writeF("/manifests/gcp/basic-auth-ingress/base/cloud-endpoint.yaml", `
 apiVersion: ctl.isla.solutions/v1
 kind: CloudEndpoint

--- a/tests/centraldashboard-base_test.go
+++ b/tests/centraldashboard-base_test.go
@@ -166,11 +166,13 @@ varReference:
 - path: spec/template/spec/containers/0/env/0/value
   kind: Deployment
 - path: spec/template/spec/containers/0/env/1/value
-  kind: Deployment`)
+  kind: Deployment
+`)
 	th.writeF("/manifests/common/centraldashboard/base/params.env", `
 clusterDomain=cluster.local
 userid-header=
-userid-prefix=`)
+userid-prefix=
+`)
 	th.writeK("/manifests/common/centraldashboard/base", `
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization

--- a/tests/centraldashboard-overlays-application_test.go
+++ b/tests/centraldashboard-overlays-application_test.go
@@ -235,11 +235,13 @@ varReference:
 - path: spec/template/spec/containers/0/env/0/value
   kind: Deployment
 - path: spec/template/spec/containers/0/env/1/value
-  kind: Deployment`)
+  kind: Deployment
+`)
 	th.writeF("/manifests/common/centraldashboard/base/params.env", `
 clusterDomain=cluster.local
 userid-header=
-userid-prefix=`)
+userid-prefix=
+`)
 	th.writeK("/manifests/common/centraldashboard/base", `
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization

--- a/tests/centraldashboard-overlays-istio_test.go
+++ b/tests/centraldashboard-overlays-istio_test.go
@@ -204,11 +204,13 @@ varReference:
 - path: spec/template/spec/containers/0/env/0/value
   kind: Deployment
 - path: spec/template/spec/containers/0/env/1/value
-  kind: Deployment`)
+  kind: Deployment
+`)
 	th.writeF("/manifests/common/centraldashboard/base/params.env", `
 clusterDomain=cluster.local
 userid-header=
-userid-prefix=`)
+userid-prefix=
+`)
 	th.writeK("/manifests/common/centraldashboard/base", `
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization

--- a/tests/cloud-endpoints-overlays-gcp-credentials_test.go
+++ b/tests/cloud-endpoints-overlays-gcp-credentials_test.go
@@ -43,7 +43,8 @@ kind: Kustomization
 bases:
 - ../../base
 patchesStrategicMerge:
-- gcp-credentials-patch.yaml`)
+- gcp-credentials-patch.yaml
+`)
 	th.writeF("/manifests/gcp/cloud-endpoints/base/cluster-role-binding.yaml", `
 apiVersion: rbac.authorization.k8s.io/v1beta1
 kind: ClusterRoleBinding

--- a/tests/fluentd-cloud-watch-base_test.go
+++ b/tests/fluentd-cloud-watch-base_test.go
@@ -24,7 +24,8 @@ rules:
     resources:
       - namespaces
       - pods
-    verbs: ["get", "list", "watch"]`)
+    verbs: ["get", "list", "watch"]
+`)
 	th.writeF("/manifests/aws/fluentd-cloud-watch/base/cluster-role-binding.yaml", `
 apiVersion: rbac.authorization.k8s.io/v1beta1
 kind: ClusterRoleBinding
@@ -37,7 +38,8 @@ roleRef:
 subjects:
   - kind: ServiceAccount
     name: fluentd
-    namespace: kube-system`)
+    namespace: kube-system
+`)
 	th.writeF("/manifests/aws/fluentd-cloud-watch/base/configmap.yaml", `
 apiVersion: v1
 kind: ConfigMap
@@ -160,7 +162,8 @@ data:
           retry_forever true
         </buffer>
       </match>
-    </label>`)
+    </label>
+`)
 	th.writeF("/manifests/aws/fluentd-cloud-watch/base/daemonset.yaml", `
 apiVersion: apps/v1
 kind: DaemonSet
@@ -235,7 +238,8 @@ spec:
 apiVersion: v1
 kind: ServiceAccount
 metadata:
-  name: fluentd`)
+  name: fluentd
+`)
 	th.writeF("/manifests/aws/fluentd-cloud-watch/base/params.env", `
 region=us-west-2
 clusterName=

--- a/tests/iap-ingress-base_test.go
+++ b/tests/iap-ingress-base_test.go
@@ -545,7 +545,8 @@ varReference:
 - path: data/healthcheck_route.yaml
   kind: ConfigMap
 - path: spec/domains
-  kind: ManagedCertificate`)
+  kind: ManagedCertificate
+`)
 	th.writeF("/manifests/gcp/iap-ingress/base/params.env", `
 namespace=kubeflow
 appName=kubeflow
@@ -557,7 +558,8 @@ oauthSecretName=kubeflow-oauth
 project=
 adminSaSecretName=admin-gcp-sa
 tlsSecretName=envoy-ingress-tls
-istioNamespace=istio-system`)
+istioNamespace=istio-system
+`)
 	th.writeK("/manifests/gcp/iap-ingress/base", `
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
@@ -670,7 +672,8 @@ vars:
   fieldref:
     fieldpath: data.istioNamespace
 configurations:
-- params.yaml`)
+- params.yaml
+`)
 }
 
 func TestIapIngressBase(t *testing.T) {

--- a/tests/iap-ingress-overlays-certmanager_test.go
+++ b/tests/iap-ingress-overlays-certmanager_test.go
@@ -622,7 +622,8 @@ varReference:
 - path: data/healthcheck_route.yaml
   kind: ConfigMap
 - path: spec/domains
-  kind: ManagedCertificate`)
+  kind: ManagedCertificate
+`)
 	th.writeF("/manifests/gcp/iap-ingress/base/params.env", `
 namespace=kubeflow
 appName=kubeflow
@@ -634,7 +635,8 @@ oauthSecretName=kubeflow-oauth
 project=
 adminSaSecretName=admin-gcp-sa
 tlsSecretName=envoy-ingress-tls
-istioNamespace=istio-system`)
+istioNamespace=istio-system
+`)
 	th.writeK("/manifests/gcp/iap-ingress/base", `
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
@@ -747,7 +749,8 @@ vars:
   fieldref:
     fieldpath: data.istioNamespace
 configurations:
-- params.yaml`)
+- params.yaml
+`)
 }
 
 func TestIapIngressOverlaysCertmanager(t *testing.T) {

--- a/tests/iap-ingress-overlays-gcp-credentials_test.go
+++ b/tests/iap-ingress-overlays-gcp-credentials_test.go
@@ -600,7 +600,8 @@ varReference:
 - path: data/healthcheck_route.yaml
   kind: ConfigMap
 - path: spec/domains
-  kind: ManagedCertificate`)
+  kind: ManagedCertificate
+`)
 	th.writeF("/manifests/gcp/iap-ingress/base/params.env", `
 namespace=kubeflow
 appName=kubeflow
@@ -612,7 +613,8 @@ oauthSecretName=kubeflow-oauth
 project=
 adminSaSecretName=admin-gcp-sa
 tlsSecretName=envoy-ingress-tls
-istioNamespace=istio-system`)
+istioNamespace=istio-system
+`)
 	th.writeK("/manifests/gcp/iap-ingress/base", `
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
@@ -725,7 +727,8 @@ vars:
   fieldref:
     fieldpath: data.istioNamespace
 configurations:
-- params.yaml`)
+- params.yaml
+`)
 }
 
 func TestIapIngressOverlaysGcpCredentials(t *testing.T) {

--- a/tests/iap-ingress-overlays-managed-cert_test.go
+++ b/tests/iap-ingress-overlays-managed-cert_test.go
@@ -565,7 +565,8 @@ varReference:
 - path: data/healthcheck_route.yaml
   kind: ConfigMap
 - path: spec/domains
-  kind: ManagedCertificate`)
+  kind: ManagedCertificate
+`)
 	th.writeF("/manifests/gcp/iap-ingress/base/params.env", `
 namespace=kubeflow
 appName=kubeflow
@@ -577,7 +578,8 @@ oauthSecretName=kubeflow-oauth
 project=
 adminSaSecretName=admin-gcp-sa
 tlsSecretName=envoy-ingress-tls
-istioNamespace=istio-system`)
+istioNamespace=istio-system
+`)
 	th.writeK("/manifests/gcp/iap-ingress/base", `
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
@@ -690,7 +692,8 @@ vars:
   fieldref:
     fieldpath: data.istioNamespace
 configurations:
-- params.yaml`)
+- params.yaml
+`)
 }
 
 func TestIapIngressOverlaysManagedCert(t *testing.T) {

--- a/tests/istio-base_test.go
+++ b/tests/istio-base_test.go
@@ -184,10 +184,12 @@ varReference:
 - path: spec/mode
   kind: ClusterRbacConfig
 - path: spec/selector
-  kind: Gateway`)
+  kind: Gateway
+`)
 	th.writeF("/manifests/istio/istio/base/params.env", `
 clusterRbacConfig=ON
-gatewaySelector=ingressgateway`)
+gatewaySelector=ingressgateway
+`)
 	th.writeK("/manifests/istio/istio/base", `
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization

--- a/tests/istio-ingress-base_test.go
+++ b/tests/istio-ingress-base_test.go
@@ -47,7 +47,8 @@ spec:
     port:
       name: http
       number: 80
-      protocol: HTTP`)
+      protocol: HTTP
+`)
 	th.writeK("/manifests/aws/istio-ingress/base", `
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization

--- a/tests/istio-ingress-overlays-cognito_test.go
+++ b/tests/istio-ingress-overlays-cognito_test.go
@@ -30,12 +30,14 @@ metadata:
 	th.writeF("/manifests/aws/istio-ingress/overlays/cognito/params.yaml", `
 varReference:
 - path: metadata/annotations
-  kind: Ingress`)
+  kind: Ingress
+`)
 	th.writeF("/manifests/aws/istio-ingress/overlays/cognito/params.env", `
 CognitoUserPoolArn=
 CognitoAppClientId=
 CognitoUserPoolDomain=
-certArn=`)
+certArn=
+`)
 	th.writeK("/manifests/aws/istio-ingress/overlays/cognito", `
 bases:
 - ../../base
@@ -74,7 +76,8 @@ vars:
   fieldref:
     fieldpath: data.certArn
 configurations:
-- params.yaml`)
+- params.yaml
+`)
 	th.writeF("/manifests/aws/istio-ingress/base/ingress.yaml", `
 apiVersion: extensions/v1beta1 # networking.k8s.io/v1beta1
 kind: Ingress
@@ -108,7 +111,8 @@ spec:
     port:
       name: http
       number: 80
-      protocol: HTTP`)
+      protocol: HTTP
+`)
 	th.writeK("/manifests/aws/istio-ingress/base", `
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization

--- a/tests/istio-ingress-overlays-oidc_test.go
+++ b/tests/istio-ingress-overlays-oidc_test.go
@@ -39,7 +39,8 @@ oidcAuthorizationEndpoint=
 oidcTokenEndpoint=
 oidcUserInfoEndpoint=
 oidcSecretName=istio-oidc-secret
-certArn=`)
+certArn=
+`)
 	th.writeF("/manifests/aws/istio-ingress/overlays/oidc/secrets.env", `
 clientId=
 clientSecret=
@@ -101,7 +102,8 @@ vars:
   fieldref:
     fieldpath: data.certArn
 configurations:
-- params.yaml`)
+- params.yaml
+`)
 	th.writeF("/manifests/aws/istio-ingress/base/ingress.yaml", `
 apiVersion: extensions/v1beta1 # networking.k8s.io/v1beta1
 kind: Ingress
@@ -135,7 +137,8 @@ spec:
     port:
       name: http
       number: 80
-      protocol: HTTP`)
+      protocol: HTTP
+`)
 	th.writeK("/manifests/aws/istio-ingress/base", `
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization

--- a/tests/jupyter-web-app-base_test.go
+++ b/tests/jupyter-web-app-base_test.go
@@ -328,7 +328,8 @@ varReference:
 - path: spec/template/spec/containers/0/env/2/value
   kind: Deployment
 - path: spec/template/spec/containers/0/env/3/value
-  kind: Deployment`)
+  kind: Deployment
+`)
 	th.writeF("/manifests/jupyter/jupyter-web-app/base/params.env", `
 UI=default
 ROK_SECRET_NAME=secret-rok-{username}
@@ -336,7 +337,8 @@ policy=Always
 prefix=jupyter
 clusterDomain=cluster.local
 userid-header=
-userid-prefix=`)
+userid-prefix=
+`)
 	th.writeK("/manifests/jupyter/jupyter-web-app/base", `
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization

--- a/tests/jupyter-web-app-overlays-application_test.go
+++ b/tests/jupyter-web-app-overlays-application_test.go
@@ -23,11 +23,11 @@ spec:
   selector:
     matchLabels:
       app.kubernetes.io/name: jupyter-web-app
-      app.kubernetes.io/instance: jupyter-web-app
+      app.kubernetes.io/instance: jupyter-web-app-v0.6.2
       app.kubernetes.io/managed-by: kfctl
-      app.kubernetes.io/component: jupyter
+      app.kubernetes.io/component: jupyter-web-app
       app.kubernetes.io/part-of: kubeflow
-      app.kubernetes.io/version: v0.6
+      app.kubernetes.io/version: v0.6.2
   componentKinds:
   - group: core
     kind: ConfigMap
@@ -39,6 +39,8 @@ spec:
     kind: Role
   - group: core
     kind: ServiceAccount
+  - group: core
+    kind: Service
   - group: networking.istio.io
     kind: VirtualService
   descriptor:
@@ -72,11 +74,11 @@ resources:
 - application.yaml
 commonLabels:
   app.kubernetes.io/name: jupyter-web-app
-  app.kubernetes.io/instance: jupyter-web-app
+  app.kubernetes.io/instance: jupyter-web-app-v0.6.2
   app.kubernetes.io/managed-by: kfctl
-  app.kubernetes.io/component: jupyter
+  app.kubernetes.io/component: jupyter-web-app
   app.kubernetes.io/part-of: kubeflow
-  app.kubernetes.io/version: v0.6
+  app.kubernetes.io/version: v0.6.2
 `)
 	th.writeF("/manifests/jupyter/jupyter-web-app/base/cluster-role-binding.yaml", `
 apiVersion: rbac.authorization.k8s.io/v1
@@ -392,7 +394,8 @@ varReference:
 - path: spec/template/spec/containers/0/env/2/value
   kind: Deployment
 - path: spec/template/spec/containers/0/env/3/value
-  kind: Deployment`)
+  kind: Deployment
+`)
 	th.writeF("/manifests/jupyter/jupyter-web-app/base/params.env", `
 UI=default
 ROK_SECRET_NAME=secret-rok-{username}
@@ -400,7 +403,8 @@ policy=Always
 prefix=jupyter
 clusterDomain=cluster.local
 userid-header=
-userid-prefix=`)
+userid-prefix=
+`)
 	th.writeK("/manifests/jupyter/jupyter-web-app/base", `
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization

--- a/tests/jupyter-web-app-overlays-istio_test.go
+++ b/tests/jupyter-web-app-overlays-istio_test.go
@@ -367,7 +367,8 @@ varReference:
 - path: spec/template/spec/containers/0/env/2/value
   kind: Deployment
 - path: spec/template/spec/containers/0/env/3/value
-  kind: Deployment`)
+  kind: Deployment
+`)
 	th.writeF("/manifests/jupyter/jupyter-web-app/base/params.env", `
 UI=default
 ROK_SECRET_NAME=secret-rok-{username}
@@ -375,7 +376,8 @@ policy=Always
 prefix=jupyter
 clusterDomain=cluster.local
 userid-header=
-userid-prefix=`)
+userid-prefix=
+`)
 	th.writeK("/manifests/jupyter/jupyter-web-app/base", `
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization

--- a/tests/metadata-base_test.go
+++ b/tests/metadata-base_test.go
@@ -394,7 +394,8 @@ vars:
     name: envoy-service
     apiVersion: v1
   fieldref:
-    fieldpath: metadata.name`)
+    fieldpath: metadata.name
+`)
 }
 
 func TestMetadataBase(t *testing.T) {

--- a/tests/metadata-overlays-application_test.go
+++ b/tests/metadata-overlays-application_test.go
@@ -451,7 +451,8 @@ vars:
     name: envoy-service
     apiVersion: v1
   fieldref:
-    fieldpath: metadata.name`)
+    fieldpath: metadata.name
+`)
 }
 
 func TestMetadataOverlaysApplication(t *testing.T) {

--- a/tests/metadata-overlays-istio_test.go
+++ b/tests/metadata-overlays-istio_test.go
@@ -456,7 +456,8 @@ vars:
     name: envoy-service
     apiVersion: v1
   fieldref:
-    fieldpath: metadata.name`)
+    fieldpath: metadata.name
+`)
 }
 
 func TestMetadataOverlaysIstio(t *testing.T) {

--- a/tests/minio-base_test.go
+++ b/tests/minio-base_test.go
@@ -86,9 +86,11 @@ varReference:
 - path: spec/template/spec/volumes/persistentVolumeClaim/claimName
   kind: Deployment
 - path: metadata/name
-  kind: PersistentVolumeClaim`)
+  kind: PersistentVolumeClaim
+`)
 	th.writeF("/manifests/pipeline/minio/base/params.env", `
-minioPvcName=`)
+minioPvcName=
+`)
 	th.writeK("/manifests/pipeline/minio/base", `
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization

--- a/tests/minio-overlays-minioPd_test.go
+++ b/tests/minio-overlays-minioPd_test.go
@@ -35,7 +35,8 @@ metadata:
   name: $(minioPvcName)
 spec:
   volumeName: $(minioPvName)
-  storageClassName: ""`)
+  storageClassName: ""
+`)
 	th.writeF("/manifests/pipeline/minio/overlays/minioPd/params.yaml", `
 varReference:
 - path: spec/gcePersistentDisk/pdName
@@ -156,9 +157,11 @@ varReference:
 - path: spec/template/spec/volumes/persistentVolumeClaim/claimName
   kind: Deployment
 - path: metadata/name
-  kind: PersistentVolumeClaim`)
+  kind: PersistentVolumeClaim
+`)
 	th.writeF("/manifests/pipeline/minio/base/params.env", `
-minioPvcName=`)
+minioPvcName=
+`)
 	th.writeK("/manifests/pipeline/minio/base", `
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization

--- a/tests/mxnet-operator-base_test.go
+++ b/tests/mxnet-operator-base_test.go
@@ -27,7 +27,8 @@ roleRef:
   name: mxnet-operator
 subjects:
 - kind: ServiceAccount
-  name: mxnet-operator`)
+  name: mxnet-operator
+`)
 	th.writeF("/manifests/mxnet-job/mxnet-operator/base/cluster-role.yaml", `
 apiVersion: rbac.authorization.k8s.io/v1beta1
 kind: ClusterRole
@@ -77,7 +78,8 @@ rules:
   resources:
   - deployments
   verbs:
-  - '*'`)
+  - '*'
+`)
 	th.writeF("/manifests/mxnet-job/mxnet-operator/base/crd.yaml", `
 apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
@@ -129,7 +131,8 @@ kind: ServiceAccount
 metadata:
   labels:
     app: mxnet-operator
-  name: mxnet-operator`)
+  name: mxnet-operator
+`)
 	th.writeK("/manifests/mxnet-job/mxnet-operator/base", `
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization

--- a/tests/mxnet-operator-overlays-application_test.go
+++ b/tests/mxnet-operator-overlays-application_test.go
@@ -82,7 +82,8 @@ roleRef:
   name: mxnet-operator
 subjects:
 - kind: ServiceAccount
-  name: mxnet-operator`)
+  name: mxnet-operator
+`)
 	th.writeF("/manifests/mxnet-job/mxnet-operator/base/cluster-role.yaml", `
 apiVersion: rbac.authorization.k8s.io/v1beta1
 kind: ClusterRole
@@ -132,7 +133,8 @@ rules:
   resources:
   - deployments
   verbs:
-  - '*'`)
+  - '*'
+`)
 	th.writeF("/manifests/mxnet-job/mxnet-operator/base/crd.yaml", `
 apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
@@ -184,7 +186,8 @@ kind: ServiceAccount
 metadata:
   labels:
     app: mxnet-operator
-  name: mxnet-operator`)
+  name: mxnet-operator
+`)
 	th.writeK("/manifests/mxnet-job/mxnet-operator/base", `
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization

--- a/tests/mysql-base_test.go
+++ b/tests/mysql-base_test.go
@@ -60,13 +60,15 @@ spec:
   - ReadWriteOnce
   resources:
     requests:
-      storage: 20Gi`)
+      storage: 20Gi
+`)
 	th.writeF("/manifests/pipeline/mysql/base/params.yaml", `
 varReference:
 - path: spec/template/spec/volumes/persistentVolumeClaim/claimName
   kind: Deployment
 - path: metadata/name
-  kind: PersistentVolumeClaim`)
+  kind: PersistentVolumeClaim
+`)
 	th.writeF("/manifests/pipeline/mysql/base/params.env", `
 mysqlPvcName=
 `)

--- a/tests/mysql-overlays-mysqlPd_test.go
+++ b/tests/mysql-overlays-mysqlPd_test.go
@@ -131,13 +131,15 @@ spec:
   - ReadWriteOnce
   resources:
     requests:
-      storage: 20Gi`)
+      storage: 20Gi
+`)
 	th.writeF("/manifests/pipeline/mysql/base/params.yaml", `
 varReference:
 - path: spec/template/spec/volumes/persistentVolumeClaim/claimName
   kind: Deployment
 - path: metadata/name
-  kind: PersistentVolumeClaim`)
+  kind: PersistentVolumeClaim
+`)
 	th.writeF("/manifests/pipeline/mysql/base/params.env", `
 mysqlPvcName=
 `)

--- a/tests/profiles-base_test.go
+++ b/tests/profiles-base_test.go
@@ -127,7 +127,8 @@ metadata:
   name: kfam
 spec:
   ports:
-    - port: 8081`)
+    - port: 8081
+`)
 	th.writeF("/manifests/profiles/base/deployment.yaml", `
 apiVersion: apps/v1
 kind: Deployment
@@ -172,7 +173,8 @@ varReference:
 - path: spec/template/spec/containers/1/args/3
   kind: Deployment
 - path: spec/template/spec/containers/1/args/5
-  kind: Deployment`)
+  kind: Deployment
+`)
 	th.writeF("/manifests/profiles/base/params.env", `
 admin=
 userid-header=

--- a/tests/profiles-overlays-debug_test.go
+++ b/tests/profiles-overlays-debug_test.go
@@ -182,7 +182,8 @@ metadata:
   name: kfam
 spec:
   ports:
-    - port: 8081`)
+    - port: 8081
+`)
 	th.writeF("/manifests/profiles/base/deployment.yaml", `
 apiVersion: apps/v1
 kind: Deployment
@@ -227,7 +228,8 @@ varReference:
 - path: spec/template/spec/containers/1/args/3
   kind: Deployment
 - path: spec/template/spec/containers/1/args/5
-  kind: Deployment`)
+  kind: Deployment
+`)
 	th.writeF("/manifests/profiles/base/params.env", `
 admin=
 userid-header=

--- a/tests/profiles-overlays-devices_test.go
+++ b/tests/profiles-overlays-devices_test.go
@@ -153,7 +153,8 @@ metadata:
   name: kfam
 spec:
   ports:
-    - port: 8081`)
+    - port: 8081
+`)
 	th.writeF("/manifests/profiles/base/deployment.yaml", `
 apiVersion: apps/v1
 kind: Deployment
@@ -198,7 +199,8 @@ varReference:
 - path: spec/template/spec/containers/1/args/3
   kind: Deployment
 - path: spec/template/spec/containers/1/args/5
-  kind: Deployment`)
+  kind: Deployment
+`)
 	th.writeF("/manifests/profiles/base/params.env", `
 admin=
 userid-header=

--- a/tests/profiles-overlays-istio_test.go
+++ b/tests/profiles-overlays-istio_test.go
@@ -168,7 +168,8 @@ metadata:
   name: kfam
 spec:
   ports:
-    - port: 8081`)
+    - port: 8081
+`)
 	th.writeF("/manifests/profiles/base/deployment.yaml", `
 apiVersion: apps/v1
 kind: Deployment
@@ -213,7 +214,8 @@ varReference:
 - path: spec/template/spec/containers/1/args/3
   kind: Deployment
 - path: spec/template/spec/containers/1/args/5
-  kind: Deployment`)
+  kind: Deployment
+`)
 	th.writeF("/manifests/profiles/base/params.env", `
 admin=
 userid-header=

--- a/tests/prometheus-base_test.go
+++ b/tests/prometheus-base_test.go
@@ -298,7 +298,8 @@ varReference:
 	th.writeF("/manifests/gcp/prometheus/base/params.env", `
 projectId=
 clusterName=
-zone=`)
+zone=
+`)
 	th.writeK("/manifests/gcp/prometheus/base", `
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization

--- a/tests/seldon-core-operator-base_test.go
+++ b/tests/seldon-core-operator-base_test.go
@@ -3635,7 +3635,8 @@ resources:
 - seldon-operator-manager-rolebinding-crb.yaml
 - seldon-operator-webhook-server-secret-secret.yaml
 - seldondeployments.machinelearning.seldon.io-crd.yaml
-- webhook-server-service-svc.yaml`)
+- webhook-server-service-svc.yaml
+`)
 }
 
 func TestSeldonCoreOperatorBase(t *testing.T) {

--- a/tests/seldon-core-operator-overlays-application_test.go
+++ b/tests/seldon-core-operator-overlays-application_test.go
@@ -3684,7 +3684,8 @@ resources:
 - seldon-operator-manager-rolebinding-crb.yaml
 - seldon-operator-webhook-server-secret-secret.yaml
 - seldondeployments.machinelearning.seldon.io-crd.yaml
-- webhook-server-service-svc.yaml`)
+- webhook-server-service-svc.yaml
+`)
 }
 
 func TestSeldonCoreOperatorOverlaysApplication(t *testing.T) {


### PR DESCRIPTION
**Which issue is resolved by this Pull Request:**
Resolves #445

**Description of your changes:**
commonLabels include an instance label (for upgrade) are added to all resources.
The application overlay is included in all config files


NOTE most of the generated go files can be ignored and showed differences after running `make generate; make test`

**Checklist:**
- [x] Unit tests have been rebuilt: 
    1. `cd manifests/tests`
    2. `make generate`
    3. `make test`

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/manifests/446)
<!-- Reviewable:end -->
