### PR TITLE
add kfserving to existing_arrikto

### DIFF
--- a/kfdef/kfctl_anthos.yaml
+++ b/kfdef/kfctl_anthos.yaml
@@ -95,6 +95,32 @@ spec:
         path: metadata
     name: metadata
   - kustomizeConfig:
+      parameters:
+      - name: namespace
+        value: knative-serving
+      repoRef:
+        name: manifests
+        path: knative/knative-serving-crds
+    name: knative-crds
+  - kustomizeConfig:
+      parameters:
+      - name: namespace
+        value: knative-serving
+      repoRef:
+        name: manifests
+        path: knative/knative-serving-install
+    name: knative-install
+  - kustomizeConfig:
+      repoRef:
+        name: manifests
+        path: kfserving/kfserving-crds
+    name: kfserving-crds
+  - kustomizeConfig:
+      repoRef:
+        name: manifests
+        path: kfserving/kfserving-install
+    name: kfserving-install
+  - kustomizeConfig:
       overlays:
       - istio
       - application

--- a/kfdef/kfctl_anthos.yaml
+++ b/kfdef/kfctl_anthos.yaml
@@ -95,32 +95,6 @@ spec:
         path: metadata
     name: metadata
   - kustomizeConfig:
-      parameters:
-      - name: namespace
-        value: knative-serving
-      repoRef:
-        name: manifests
-        path: knative/knative-serving-crds
-    name: knative-crds
-  - kustomizeConfig:
-      parameters:
-      - name: namespace
-        value: knative-serving
-      repoRef:
-        name: manifests
-        path: knative/knative-serving-install
-    name: knative-install
-  - kustomizeConfig:
-      repoRef:
-        name: manifests
-        path: kfserving/kfserving-crds
-    name: kfserving-crds
-  - kustomizeConfig:
-      repoRef:
-        name: manifests
-        path: kfserving/kfserving-install
-    name: kfserving-install
-  - kustomizeConfig:
       overlays:
       - istio
       - application

--- a/kfdef/kfctl_istio_dex.yaml
+++ b/kfdef/kfctl_istio_dex.yaml
@@ -176,6 +176,40 @@ spec:
     name: metadata
   - kustomizeConfig:
       overlays:
+      - application
+      parameters:
+      - name: namespace
+        value: knative-serving
+      repoRef:
+        name: manifests
+        path: knative/knative-serving-crds
+    name: knative-crds
+  - kustomizeConfig:
+      overlays:
+      - application
+      parameters:
+      - name: namespace
+        value: knative-serving
+      repoRef:
+        name: manifests
+        path: knative/knative-serving-install
+    name: knative-install
+  - kustomizeConfig:
+      overlays:
+      - application
+      repoRef:
+        name: manifests
+        path: kfserving/kfserving-crds
+    name: kfserving-crds
+  - kustomizeConfig:
+      overlays:
+      - application
+      repoRef:
+        name: manifests
+        path: kfserving/kfserving-install
+    name: kfserving-install
+  - kustomizeConfig:
+      overlays:
       - istio
       - application
       repoRef:


### PR DESCRIPTION
existing_arrikto wasn't included in https://github.com/kubeflow/kubeflow/pull/3953 but kfserving can be used with the rest of the existing_arrikto setup

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/manifests/447)
<!-- Reviewable:end -->
