### PR TITLE
Minor changes to Katib manifests

### DIFF
--- a/katib/katib-controller/base/katib-manager-deployment.yaml
+++ b/katib/katib-controller/base/katib-manager-deployment.yaml
@@ -43,3 +43,5 @@ spec:
           exec:
             command: ["/bin/grpc_health_probe", "-addr=:6789"]
           initialDelaySeconds: 10
+          periodSeconds: 60
+          failureThreshold: 5

--- a/katib/katib-crds/base/trial-crd.yaml
+++ b/katib/katib-crds/base/trial-crd.yaml
@@ -5,6 +5,9 @@ metadata:
 spec:
   additionalPrinterColumns:
   - JSONPath: .status.conditions[-1:].type
+    name: Type
+    type: string
+  - JSONPath: .status.conditions[-1:].status
     name: Status
     type: string
   - JSONPath: .metadata.creationTimestamp

--- a/tests/katib-controller-base_test.go
+++ b/tests/katib-controller-base_test.go
@@ -345,6 +345,8 @@ spec:
           exec:
             command: ["/bin/grpc_health_probe", "-addr=:6789"]
           initialDelaySeconds: 10
+          periodSeconds: 60
+          failureThreshold: 5
 `)
 	th.writeF("/manifests/katib/katib-controller/base/katib-manager-rest-deployment.yaml", `
 apiVersion: apps/v1

--- a/tests/katib-controller-overlays-application_test.go
+++ b/tests/katib-controller-overlays-application_test.go
@@ -424,6 +424,8 @@ spec:
           exec:
             command: ["/bin/grpc_health_probe", "-addr=:6789"]
           initialDelaySeconds: 10
+          periodSeconds: 60
+          failureThreshold: 5
 `)
 	th.writeF("/manifests/katib/katib-controller/base/katib-manager-rest-deployment.yaml", `
 apiVersion: apps/v1

--- a/tests/katib-controller-overlays-istio_test.go
+++ b/tests/katib-controller-overlays-istio_test.go
@@ -382,6 +382,8 @@ spec:
           exec:
             command: ["/bin/grpc_health_probe", "-addr=:6789"]
           initialDelaySeconds: 10
+          periodSeconds: 60
+          failureThreshold: 5
 `)
 	th.writeF("/manifests/katib/katib-controller/base/katib-manager-rest-deployment.yaml", `
 apiVersion: apps/v1

--- a/tests/katib-crds-base_test.go
+++ b/tests/katib-crds-base_test.go
@@ -85,6 +85,9 @@ metadata:
 spec:
   additionalPrinterColumns:
   - JSONPath: .status.conditions[-1:].type
+    name: Type
+    type: string
+  - JSONPath: .status.conditions[-1:].status
     name: Status
     type: string
   - JSONPath: .metadata.creationTimestamp


### PR DESCRIPTION
Related: https://github.com/kubeflow/katib/pull/851, https://github.com/kubeflow/katib/pull/864

**Checklist:**
- [x] Unit tests have been rebuilt: 
    1. `cd manifests/tests`
    2. `make generate`
    3. `make test`

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/manifests/457)
<!-- Reviewable:end -->
