### PR TITLE
Replaces null values at ClusterRoles with [] - for kubectl CLI compatibility

### DIFF
--- a/admission-webhook/webhook/base/cluster-role.yaml
+++ b/admission-webhook/webhook/base/cluster-role.yaml
@@ -28,7 +28,7 @@ aggregationRule:
   clusterRoleSelectors:
   - matchLabels:
       rbac.authorization.kubeflow.org/aggregate-to-kubeflow-poddefaults-admin: "true"
-rules: null
+rules: []
 
 ---
 
@@ -42,7 +42,7 @@ aggregationRule:
   clusterRoleSelectors:
   - matchLabels:
       rbac.authorization.kubeflow.org/aggregate-to-kubeflow-poddefaults-edit: "true"
-rules: null
+rules: []
 
 ---
 

--- a/jupyter/notebook-controller/base/cluster-role.yaml
+++ b/jupyter/notebook-controller/base/cluster-role.yaml
@@ -50,7 +50,7 @@ aggregationRule:
   clusterRoleSelectors:
   - matchLabels:
       rbac.authorization.kubeflow.org/aggregate-to-kubeflow-notebooks-admin: "true"
-rules: null
+rules: []
 
 ---
 

--- a/kfserving/kfserving-install/base/cluster-role.yaml
+++ b/kfserving/kfserving-install/base/cluster-role.yaml
@@ -156,7 +156,7 @@ aggregationRule:
   clusterRoleSelectors:
   - matchLabels:
       rbac.authorization.kubeflow.org/aggregate-to-kubeflow-kfserving-admin: "true"
-rules: null
+rules: []
 
 ---
 

--- a/kubeflow-roles/base/cluster-roles.yaml
+++ b/kubeflow-roles/base/cluster-roles.yaml
@@ -8,7 +8,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   name: kubeflow-admin
-rules: null
+rules: []
 
 ---
 
@@ -22,7 +22,7 @@ metadata:
   name: kubeflow-edit
   labels:
     rbac.authorization.kubeflow.org/aggregate-to-kubeflow-admin: "true"
-rules: null
+rules: []
 
 ---
 
@@ -36,7 +36,7 @@ metadata:
   name: kubeflow-view
   labels:
     rbac.authorization.kubeflow.org/aggregate-to-kubeflow-edit: "true"
-rules: null
+rules: []
 
 ---
 

--- a/pipeline/pipelines-viewer/base/cluster-role.yaml
+++ b/pipeline/pipelines-viewer/base/cluster-role.yaml
@@ -41,7 +41,7 @@ aggregationRule:
   clusterRoleSelectors:
   - matchLabels:
       rbac.authorization.kubeflow.org/aggregate-to-kubeflow-pipeline-viewers-admin: "true"
-rules: null
+rules: []
 
 ---
 

--- a/pipeline/scheduledworkflow/base/cluster-role.yaml
+++ b/pipeline/scheduledworkflow/base/cluster-role.yaml
@@ -10,7 +10,7 @@ aggregationRule:
   clusterRoleSelectors:
   - matchLabels:
       rbac.authorization.kubeflow.org/aggregate-to-kubeflow-scheduledworkflows-admin: "true"
-rules: null
+rules: []
 
 ---
 

--- a/pytorch-job/pytorch-operator/base/cluster-role.yaml
+++ b/pytorch-job/pytorch-operator/base/cluster-role.yaml
@@ -39,7 +39,7 @@ aggregationRule:
   clusterRoleSelectors:
   - matchLabels:
       rbac.authorization.kubeflow.org/aggregate-to-kubeflow-pytorchjobs-admin: "true"
-rules: null
+rules: []
 
 ---
 

--- a/tests/kfserving-install-base_test.go
+++ b/tests/kfserving-install-base_test.go
@@ -200,7 +200,7 @@ aggregationRule:
   clusterRoleSelectors:
   - matchLabels:
       rbac.authorization.kubeflow.org/aggregate-to-kubeflow-kfserving-admin: "true"
-rules: null
+rules: []
 
 ---
 

--- a/tests/kfserving-install-overlays-application_test.go
+++ b/tests/kfserving-install-overlays-application_test.go
@@ -249,7 +249,7 @@ aggregationRule:
   clusterRoleSelectors:
   - matchLabels:
       rbac.authorization.kubeflow.org/aggregate-to-kubeflow-kfserving-admin: "true"
-rules: null
+rules: []
 
 ---
 

--- a/tests/kubeflow-roles-base_test.go
+++ b/tests/kubeflow-roles-base_test.go
@@ -25,7 +25,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   name: kubeflow-admin
-rules: null
+rules: []
 
 ---
 
@@ -39,7 +39,7 @@ metadata:
   name: kubeflow-edit
   labels:
     rbac.authorization.kubeflow.org/aggregate-to-kubeflow-admin: "true"
-rules: null
+rules: []
 
 ---
 
@@ -53,7 +53,7 @@ metadata:
   name: kubeflow-view
   labels:
     rbac.authorization.kubeflow.org/aggregate-to-kubeflow-edit: "true"
-rules: null
+rules: []
 
 ---
 

--- a/tests/notebook-controller-base_test.go
+++ b/tests/notebook-controller-base_test.go
@@ -80,7 +80,7 @@ aggregationRule:
   clusterRoleSelectors:
   - matchLabels:
       rbac.authorization.kubeflow.org/aggregate-to-kubeflow-notebooks-admin: "true"
-rules: null
+rules: []
 
 ---
 

--- a/tests/notebook-controller-overlays-application_test.go
+++ b/tests/notebook-controller-overlays-application_test.go
@@ -35,7 +35,7 @@ spec:
       kind: Deployment
     - group: core
       kind: ServiceAccount
-  descriptor: 
+  descriptor:
     type: notebook-controller
     version: v1beta1
     description: Notebooks controller allows users to create a custom resource \"Notebook\" (jupyter notebook).
@@ -49,7 +49,7 @@ spec:
      - jupyter
      - notebook
      - notebook-controller
-     - jupyterhub  
+     - jupyterhub
     links:
     - description: About
       url: "https://github.com/kubeflow/kubeflow/tree/master/components/notebook-controller"
@@ -136,7 +136,7 @@ aggregationRule:
   clusterRoleSelectors:
   - matchLabels:
       rbac.authorization.kubeflow.org/aggregate-to-kubeflow-notebooks-admin: "true"
-rules: null
+rules: []
 
 ---
 

--- a/tests/notebook-controller-overlays-istio_test.go
+++ b/tests/notebook-controller-overlays-istio_test.go
@@ -111,7 +111,7 @@ aggregationRule:
   clusterRoleSelectors:
   - matchLabels:
       rbac.authorization.kubeflow.org/aggregate-to-kubeflow-notebooks-admin: "true"
-rules: null
+rules: []
 
 ---
 

--- a/tests/pipelines-viewer-base_test.go
+++ b/tests/pipelines-viewer-base_test.go
@@ -91,7 +91,7 @@ aggregationRule:
   clusterRoleSelectors:
   - matchLabels:
       rbac.authorization.kubeflow.org/aggregate-to-kubeflow-pipeline-viewers-admin: "true"
-rules: null
+rules: []
 
 ---
 

--- a/tests/pytorch-operator-base_test.go
+++ b/tests/pytorch-operator-base_test.go
@@ -71,7 +71,7 @@ aggregationRule:
   clusterRoleSelectors:
   - matchLabels:
       rbac.authorization.kubeflow.org/aggregate-to-kubeflow-pytorchjobs-admin: "true"
-rules: null
+rules: []
 
 ---
 

--- a/tests/pytorch-operator-overlays-application_test.go
+++ b/tests/pytorch-operator-overlays-application_test.go
@@ -132,7 +132,7 @@ aggregationRule:
   clusterRoleSelectors:
   - matchLabels:
       rbac.authorization.kubeflow.org/aggregate-to-kubeflow-pytorchjobs-admin: "true"
-rules: null
+rules: []
 
 ---
 

--- a/tests/scheduledworkflow-base_test.go
+++ b/tests/scheduledworkflow-base_test.go
@@ -27,7 +27,7 @@ aggregationRule:
   clusterRoleSelectors:
   - matchLabels:
       rbac.authorization.kubeflow.org/aggregate-to-kubeflow-scheduledworkflows-admin: "true"
-rules: null
+rules: []
 
 ---
 

--- a/tests/tf-job-operator-base_test.go
+++ b/tests/tf-job-operator-base_test.go
@@ -81,7 +81,7 @@ aggregationRule:
   clusterRoleSelectors:
   - matchLabels:
       rbac.authorization.kubeflow.org/aggregate-to-kubeflow-tfjobs-admin: "true"
-rules: null
+rules: []
 
 ---
 

--- a/tests/tf-job-operator-overlays-application_test.go
+++ b/tests/tf-job-operator-overlays-application_test.go
@@ -27,7 +27,7 @@ spec:
       app.kubernetes.io/managed-by: kfctl
       app.kubernetes.io/component: tfjob
       app.kubernetes.io/part-of: kubeflow
-      app.kubernetes.io/version: v0.6 
+      app.kubernetes.io/version: v0.6
   componentKinds:
   - group: core
     kind: Service
@@ -140,7 +140,7 @@ aggregationRule:
   clusterRoleSelectors:
   - matchLabels:
       rbac.authorization.kubeflow.org/aggregate-to-kubeflow-tfjobs-admin: "true"
-rules: null
+rules: []
 
 ---
 

--- a/tests/webhook-base_test.go
+++ b/tests/webhook-base_test.go
@@ -58,7 +58,7 @@ aggregationRule:
   clusterRoleSelectors:
   - matchLabels:
       rbac.authorization.kubeflow.org/aggregate-to-kubeflow-poddefaults-admin: "true"
-rules: null
+rules: []
 
 ---
 
@@ -72,7 +72,7 @@ aggregationRule:
   clusterRoleSelectors:
   - matchLabels:
       rbac.authorization.kubeflow.org/aggregate-to-kubeflow-poddefaults-edit: "true"
-rules: null
+rules: []
 
 ---
 
@@ -113,7 +113,7 @@ spec:
       - name: webhook-cert
         secret:
           secretName: webhook-certs
-      serviceAccountName: service-account    
+      serviceAccountName: service-account
 `)
 	th.writeF("/manifests/admission-webhook/webhook/base/mutating-webhook-configuration.yaml", `
 apiVersion: admissionregistration.k8s.io/v1beta1

--- a/tests/webhook-overlays-application_test.go
+++ b/tests/webhook-overlays-application_test.go
@@ -45,7 +45,7 @@ spec:
     description: injects volume, volume mounts, env vars into PodDefault
     maintainers: []
     owners: []
-    keywords: 
+    keywords:
      - admission-webhook
      - kubeflow
     links:
@@ -113,7 +113,7 @@ aggregationRule:
   clusterRoleSelectors:
   - matchLabels:
       rbac.authorization.kubeflow.org/aggregate-to-kubeflow-poddefaults-admin: "true"
-rules: null
+rules: []
 
 ---
 
@@ -127,7 +127,7 @@ aggregationRule:
   clusterRoleSelectors:
   - matchLabels:
       rbac.authorization.kubeflow.org/aggregate-to-kubeflow-poddefaults-edit: "true"
-rules: null
+rules: []
 
 ---
 
@@ -168,7 +168,7 @@ spec:
       - name: webhook-cert
         secret:
           secretName: webhook-certs
-      serviceAccountName: service-account    
+      serviceAccountName: service-account
 `)
 	th.writeF("/manifests/admission-webhook/webhook/base/mutating-webhook-configuration.yaml", `
 apiVersion: admissionregistration.k8s.io/v1beta1

--- a/tf-training/tf-job-operator/base/cluster-role.yaml
+++ b/tf-training/tf-job-operator/base/cluster-role.yaml
@@ -48,7 +48,7 @@ aggregationRule:
   clusterRoleSelectors:
   - matchLabels:
       rbac.authorization.kubeflow.org/aggregate-to-kubeflow-tfjobs-admin: "true"
-rules: null
+rules: []
 
 ---
 


### PR DESCRIPTION
**Description of your changes:**
Kustomize CLI manifest application, for e.g. `kustomize build . | kubectl apply -f -` fails with:
```
error validating "STDIN": error validating data: ValidationError(ClusterRole): missing required field "rules" in io.k8s.api.rbac.v1.ClusterRole; if you choose to ignore these errors, turn validation off with --validate=false
```

This seems to be a kubectl client-side validation bug as mentioned in this [comment](https://github.com/kubernetes/kubernetes/issues/73050#issuecomment-457068012)

Another problem is with `make test`, which warns about:
```
nil value at `rules.resourceNames` ignored in mutation attempt
```


**Checklist:**
- [x] Unit tests have been rebuilt: 
    1. `cd manifests/tests`
    2. `make generate`
    3. `make test`

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/manifests/462)
<!-- Reviewable:end -->
