### PR TITLE
update jwt excluded_paths

### DIFF
--- a/gcp/iap-ingress/base/policy.yaml
+++ b/gcp/iap-ingress/base/policy.yaml
@@ -13,7 +13,7 @@ spec:
       - x-goog-iap-jwt-assertion
       trigger_rules:
       - excluded_paths:
-        - exact: /healthz
+        - exact: /healthz/ready
         - prefix: /.well-known/acme-challenge
   principalBinding: USE_ORIGIN
   targets:

--- a/tests/iap-ingress-base_test.go
+++ b/tests/iap-ingress-base_test.go
@@ -1,8 +1,6 @@
 package tests_test
 
 import (
-	"testing"
-
 	"sigs.k8s.io/kustomize/v3/k8sdeps/kunstruct"
 	"sigs.k8s.io/kustomize/v3/k8sdeps/transformer"
 	"sigs.k8s.io/kustomize/v3/pkg/fs"
@@ -12,7 +10,9 @@ import (
 	"sigs.k8s.io/kustomize/v3/pkg/resource"
 	"sigs.k8s.io/kustomize/v3/pkg/target"
 	"sigs.k8s.io/kustomize/v3/pkg/validators"
+	"testing"
 )
+
 
 func writeIapIngressBase(th *KustTestHarness) {
 	th.writeF("/manifests/gcp/iap-ingress/base/backend-config.yaml", `

--- a/tests/iap-ingress-base_test.go
+++ b/tests/iap-ingress-base_test.go
@@ -429,7 +429,7 @@ spec:
       - x-goog-iap-jwt-assertion
       trigger_rules:
       - excluded_paths:
-        - exact: /healthz
+        - exact: /healthz/ready
         - prefix: /.well-known/acme-challenge
   principalBinding: USE_ORIGIN
   targets:
@@ -545,8 +545,7 @@ varReference:
 - path: data/healthcheck_route.yaml
   kind: ConfigMap
 - path: spec/domains
-  kind: ManagedCertificate
-`)
+  kind: ManagedCertificate`)
 	th.writeF("/manifests/gcp/iap-ingress/base/params.env", `
 namespace=kubeflow
 appName=kubeflow
@@ -558,8 +557,7 @@ oauthSecretName=kubeflow-oauth
 project=
 adminSaSecretName=admin-gcp-sa
 tlsSecretName=envoy-ingress-tls
-istioNamespace=istio-system
-`)
+istioNamespace=istio-system`)
 	th.writeK("/manifests/gcp/iap-ingress/base", `
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization

--- a/tests/iap-ingress-base_test.go
+++ b/tests/iap-ingress-base_test.go
@@ -1,6 +1,8 @@
 package tests_test
 
 import (
+	"testing"
+
 	"sigs.k8s.io/kustomize/v3/k8sdeps/kunstruct"
 	"sigs.k8s.io/kustomize/v3/k8sdeps/transformer"
 	"sigs.k8s.io/kustomize/v3/pkg/fs"
@@ -10,7 +12,6 @@ import (
 	"sigs.k8s.io/kustomize/v3/pkg/resource"
 	"sigs.k8s.io/kustomize/v3/pkg/target"
 	"sigs.k8s.io/kustomize/v3/pkg/validators"
-	"testing"
 )
 
 func writeIapIngressBase(th *KustTestHarness) {
@@ -429,7 +430,7 @@ spec:
       - x-goog-iap-jwt-assertion
       trigger_rules:
       - excluded_paths:
-        - exact: /healthz
+        - exact: /healthz/ready
         - prefix: /.well-known/acme-challenge
   principalBinding: USE_ORIGIN
   targets:

--- a/tests/iap-ingress-base_test.go
+++ b/tests/iap-ingress-base_test.go
@@ -429,7 +429,7 @@ spec:
       - x-goog-iap-jwt-assertion
       trigger_rules:
       - excluded_paths:
-        - exact: /healthz/ready
+        - exact: /healthz
         - prefix: /.well-known/acme-challenge
   principalBinding: USE_ORIGIN
   targets:
@@ -545,7 +545,8 @@ varReference:
 - path: data/healthcheck_route.yaml
   kind: ConfigMap
 - path: spec/domains
-  kind: ManagedCertificate`)
+  kind: ManagedCertificate
+`)
 	th.writeF("/manifests/gcp/iap-ingress/base/params.env", `
 namespace=kubeflow
 appName=kubeflow
@@ -557,7 +558,8 @@ oauthSecretName=kubeflow-oauth
 project=
 adminSaSecretName=admin-gcp-sa
 tlsSecretName=envoy-ingress-tls
-istioNamespace=istio-system`)
+istioNamespace=istio-system
+`)
 	th.writeK("/manifests/gcp/iap-ingress/base", `
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization

--- a/tests/iap-ingress-overlays-application_test.go
+++ b/tests/iap-ingress-overlays-application_test.go
@@ -1,21 +1,20 @@
 package tests_test
 
 import (
-	"testing"
-
-	"sigs.k8s.io/kustomize/v3/k8sdeps/kunstruct"
-	"sigs.k8s.io/kustomize/v3/k8sdeps/transformer"
-	"sigs.k8s.io/kustomize/v3/pkg/fs"
-	"sigs.k8s.io/kustomize/v3/pkg/loader"
-	"sigs.k8s.io/kustomize/v3/pkg/plugins"
-	"sigs.k8s.io/kustomize/v3/pkg/resmap"
-	"sigs.k8s.io/kustomize/v3/pkg/resource"
-	"sigs.k8s.io/kustomize/v3/pkg/target"
-	"sigs.k8s.io/kustomize/v3/pkg/validators"
+  "sigs.k8s.io/kustomize/v3/k8sdeps/kunstruct"
+  "sigs.k8s.io/kustomize/v3/k8sdeps/transformer"
+  "sigs.k8s.io/kustomize/v3/pkg/fs"
+  "sigs.k8s.io/kustomize/v3/pkg/loader"
+  "sigs.k8s.io/kustomize/v3/pkg/plugins"
+  "sigs.k8s.io/kustomize/v3/pkg/resmap"
+  "sigs.k8s.io/kustomize/v3/pkg/resource"
+  "sigs.k8s.io/kustomize/v3/pkg/target"
+  "sigs.k8s.io/kustomize/v3/pkg/validators"
+  "testing"
 )
 
 func writeIapIngressOverlaysApplication(th *KustTestHarness) {
-	th.writeF("/manifests/gcp/iap-ingress/overlays/application/application.yaml", `
+  th.writeF("/manifests/gcp/iap-ingress/overlays/application/application.yaml", `
 apiVersion: app.k8s.io/v1beta1
 kind: Application
 metadata:
@@ -48,7 +47,7 @@ spec:
       url: ""
   addOwnerRef: true
 `)
-	th.writeK("/manifests/gcp/iap-ingress/overlays/application", `
+  th.writeK("/manifests/gcp/iap-ingress/overlays/application", `
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 bases:
@@ -63,7 +62,7 @@ commonLabels:
   app.kubernetes.io/part-of: kubeflow
   app.kubernetes.io/version: v0.7.0
 `)
-	th.writeF("/manifests/gcp/iap-ingress/base/backend-config.yaml", `
+  th.writeF("/manifests/gcp/iap-ingress/base/backend-config.yaml", `
 apiVersion: cloud.google.com/v1beta1
 kind: BackendConfig
 metadata:
@@ -74,7 +73,7 @@ spec:
     oauthclientCredentials:
       secretName: $(oauthSecretName)
 `)
-	th.writeF("/manifests/gcp/iap-ingress/base/cloud-endpoint.yaml", `
+  th.writeF("/manifests/gcp/iap-ingress/base/cloud-endpoint.yaml", `
 apiVersion: ctl.isla.solutions/v1
 kind: CloudEndpoint
 metadata:
@@ -85,7 +84,7 @@ spec:
     name: $(ingressName)
     namespace: $(istioNamespace)
 `)
-	th.writeF("/manifests/gcp/iap-ingress/base/cluster-role-binding.yaml", `
+  th.writeF("/manifests/gcp/iap-ingress/base/cluster-role-binding.yaml", `
 apiVersion: rbac.authorization.k8s.io/v1beta1
 kind: ClusterRoleBinding
 metadata:
@@ -98,7 +97,7 @@ subjects:
 - kind: ServiceAccount
   name: kf-admin
 `)
-	th.writeF("/manifests/gcp/iap-ingress/base/cluster-role.yaml", `
+  th.writeF("/manifests/gcp/iap-ingress/base/cluster-role.yaml", `
 apiVersion: rbac.authorization.k8s.io/v1beta1
 kind: ClusterRole
 metadata:
@@ -139,7 +138,7 @@ rules:
   verbs:
   - '*'
 `)
-	th.writeF("/manifests/gcp/iap-ingress/base/config-map.yaml", `
+  th.writeF("/manifests/gcp/iap-ingress/base/config-map.yaml", `
 ---
 apiVersion: v1
 data:
@@ -372,7 +371,7 @@ metadata:
   name: ingress-bootstrap-config
 ---
 `)
-	th.writeF("/manifests/gcp/iap-ingress/base/deployment.yaml", `
+  th.writeF("/manifests/gcp/iap-ingress/base/deployment.yaml", `
 ---
 apiVersion: apps/v1
 kind: Deployment
@@ -441,7 +440,7 @@ spec:
           name: envoy-config
         name: config-volume
 `)
-	th.writeF("/manifests/gcp/iap-ingress/base/ingress.yaml", `
+  th.writeF("/manifests/gcp/iap-ingress/base/ingress.yaml", `
 apiVersion: extensions/v1beta1 # networking.k8s.io/v1beta1
 kind: Ingress
 metadata:
@@ -462,7 +461,7 @@ spec:
           servicePort: 80
         path: /*
 `)
-	th.writeF("/manifests/gcp/iap-ingress/base/policy.yaml", `
+  th.writeF("/manifests/gcp/iap-ingress/base/policy.yaml", `
 apiVersion: authentication.istio.io/v1alpha1
 kind: Policy
 metadata:
@@ -486,13 +485,13 @@ spec:
     ports:
     - number: 80
 `)
-	th.writeF("/manifests/gcp/iap-ingress/base/service-account.yaml", `
+  th.writeF("/manifests/gcp/iap-ingress/base/service-account.yaml", `
 apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: kf-admin
 `)
-	th.writeF("/manifests/gcp/iap-ingress/base/service.yaml", `
+  th.writeF("/manifests/gcp/iap-ingress/base/service.yaml", `
 apiVersion: v1
 kind: Service
 metadata:
@@ -507,7 +506,7 @@ spec:
     app: whoami
   type: ClusterIP
 `)
-	th.writeF("/manifests/gcp/iap-ingress/base/stateful-set.yaml", `
+  th.writeF("/manifests/gcp/iap-ingress/base/stateful-set.yaml", `
 apiVersion: apps/v1
 kind: StatefulSet
 metadata:
@@ -549,7 +548,7 @@ spec:
         name: config-volume
   volumeClaimTemplates: []
 `)
-	th.writeF("/manifests/gcp/iap-ingress/base/params.yaml", `
+  th.writeF("/manifests/gcp/iap-ingress/base/params.yaml", `
 varReference:
 - path: metadata/name
   kind: Certificate
@@ -596,7 +595,7 @@ varReference:
 - path: spec/domains
   kind: ManagedCertificate
 `)
-	th.writeF("/manifests/gcp/iap-ingress/base/params.env", `
+  th.writeF("/manifests/gcp/iap-ingress/base/params.env", `
 namespace=kubeflow
 appName=kubeflow
 hostname=
@@ -609,7 +608,7 @@ adminSaSecretName=admin-gcp-sa
 tlsSecretName=envoy-ingress-tls
 istioNamespace=istio-system
 `)
-	th.writeK("/manifests/gcp/iap-ingress/base", `
+  th.writeK("/manifests/gcp/iap-ingress/base", `
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
@@ -726,32 +725,32 @@ configurations:
 }
 
 func TestIapIngressOverlaysApplication(t *testing.T) {
-	th := NewKustTestHarness(t, "/manifests/gcp/iap-ingress/overlays/application")
-	writeIapIngressOverlaysApplication(th)
-	m, err := th.makeKustTarget().MakeCustomizedResMap()
-	if err != nil {
-		t.Fatalf("Err: %v", err)
-	}
-	expected, err := m.AsYaml()
-	if err != nil {
-		t.Fatalf("Err: %v", err)
-	}
-	targetPath := "../gcp/iap-ingress/overlays/application"
-	fsys := fs.MakeRealFS()
-	lrc := loader.RestrictionRootOnly
-	_loader, loaderErr := loader.NewLoader(lrc, validators.MakeFakeValidator(), targetPath, fsys)
-	if loaderErr != nil {
-		t.Fatalf("could not load kustomize loader: %v", loaderErr)
-	}
-	rf := resmap.NewFactory(resource.NewFactory(kunstruct.NewKunstructuredFactoryImpl()), transformer.NewFactoryImpl())
-	pc := plugins.DefaultPluginConfig()
-	kt, err := target.NewKustTarget(_loader, rf, transformer.NewFactoryImpl(), plugins.NewLoader(pc, rf))
-	if err != nil {
-		th.t.Fatalf("Unexpected construction error %v", err)
-	}
-	actual, err := kt.MakeCustomizedResMap()
-	if err != nil {
-		t.Fatalf("Err: %v", err)
-	}
-	th.assertActualEqualsExpected(actual, string(expected))
+  th := NewKustTestHarness(t, "/manifests/gcp/iap-ingress/overlays/application")
+  writeIapIngressOverlaysApplication(th)
+  m, err := th.makeKustTarget().MakeCustomizedResMap()
+  if err != nil {
+    t.Fatalf("Err: %v", err)
+  }
+  expected, err := m.AsYaml()
+  if err != nil {
+    t.Fatalf("Err: %v", err)
+  }
+  targetPath := "../gcp/iap-ingress/overlays/application"
+  fsys := fs.MakeRealFS()
+  lrc := loader.RestrictionRootOnly
+  _loader, loaderErr := loader.NewLoader(lrc, validators.MakeFakeValidator(), targetPath, fsys)
+  if loaderErr != nil {
+    t.Fatalf("could not load kustomize loader: %v", loaderErr)
+  }
+  rf := resmap.NewFactory(resource.NewFactory(kunstruct.NewKunstructuredFactoryImpl()), transformer.NewFactoryImpl())
+  pc := plugins.DefaultPluginConfig()
+  kt, err := target.NewKustTarget(_loader, rf, transformer.NewFactoryImpl(), plugins.NewLoader(pc, rf))
+  if err != nil {
+    th.t.Fatalf("Unexpected construction error %v", err)
+  }
+  actual, err := kt.MakeCustomizedResMap()
+  if err != nil {
+    t.Fatalf("Err: %v", err)
+  }
+  th.assertActualEqualsExpected(actual, string(expected))
 }

--- a/tests/iap-ingress-overlays-application_test.go
+++ b/tests/iap-ingress-overlays-application_test.go
@@ -1,20 +1,21 @@
 package tests_test
 
 import (
-  "sigs.k8s.io/kustomize/v3/k8sdeps/kunstruct"
-  "sigs.k8s.io/kustomize/v3/k8sdeps/transformer"
-  "sigs.k8s.io/kustomize/v3/pkg/fs"
-  "sigs.k8s.io/kustomize/v3/pkg/loader"
-  "sigs.k8s.io/kustomize/v3/pkg/plugins"
-  "sigs.k8s.io/kustomize/v3/pkg/resmap"
-  "sigs.k8s.io/kustomize/v3/pkg/resource"
-  "sigs.k8s.io/kustomize/v3/pkg/target"
-  "sigs.k8s.io/kustomize/v3/pkg/validators"
-  "testing"
+	"testing"
+
+	"sigs.k8s.io/kustomize/v3/k8sdeps/kunstruct"
+	"sigs.k8s.io/kustomize/v3/k8sdeps/transformer"
+	"sigs.k8s.io/kustomize/v3/pkg/fs"
+	"sigs.k8s.io/kustomize/v3/pkg/loader"
+	"sigs.k8s.io/kustomize/v3/pkg/plugins"
+	"sigs.k8s.io/kustomize/v3/pkg/resmap"
+	"sigs.k8s.io/kustomize/v3/pkg/resource"
+	"sigs.k8s.io/kustomize/v3/pkg/target"
+	"sigs.k8s.io/kustomize/v3/pkg/validators"
 )
 
 func writeIapIngressOverlaysApplication(th *KustTestHarness) {
-  th.writeF("/manifests/gcp/iap-ingress/overlays/application/application.yaml", `
+	th.writeF("/manifests/gcp/iap-ingress/overlays/application/application.yaml", `
 apiVersion: app.k8s.io/v1beta1
 kind: Application
 metadata:
@@ -47,7 +48,7 @@ spec:
       url: ""
   addOwnerRef: true
 `)
-  th.writeK("/manifests/gcp/iap-ingress/overlays/application", `
+	th.writeK("/manifests/gcp/iap-ingress/overlays/application", `
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 bases:
@@ -62,7 +63,7 @@ commonLabels:
   app.kubernetes.io/part-of: kubeflow
   app.kubernetes.io/version: v0.7.0
 `)
-  th.writeF("/manifests/gcp/iap-ingress/base/backend-config.yaml", `
+	th.writeF("/manifests/gcp/iap-ingress/base/backend-config.yaml", `
 apiVersion: cloud.google.com/v1beta1
 kind: BackendConfig
 metadata:
@@ -73,7 +74,7 @@ spec:
     oauthclientCredentials:
       secretName: $(oauthSecretName)
 `)
-  th.writeF("/manifests/gcp/iap-ingress/base/cloud-endpoint.yaml", `
+	th.writeF("/manifests/gcp/iap-ingress/base/cloud-endpoint.yaml", `
 apiVersion: ctl.isla.solutions/v1
 kind: CloudEndpoint
 metadata:
@@ -84,7 +85,7 @@ spec:
     name: $(ingressName)
     namespace: $(istioNamespace)
 `)
-  th.writeF("/manifests/gcp/iap-ingress/base/cluster-role-binding.yaml", `
+	th.writeF("/manifests/gcp/iap-ingress/base/cluster-role-binding.yaml", `
 apiVersion: rbac.authorization.k8s.io/v1beta1
 kind: ClusterRoleBinding
 metadata:
@@ -97,7 +98,7 @@ subjects:
 - kind: ServiceAccount
   name: kf-admin
 `)
-  th.writeF("/manifests/gcp/iap-ingress/base/cluster-role.yaml", `
+	th.writeF("/manifests/gcp/iap-ingress/base/cluster-role.yaml", `
 apiVersion: rbac.authorization.k8s.io/v1beta1
 kind: ClusterRole
 metadata:
@@ -138,7 +139,7 @@ rules:
   verbs:
   - '*'
 `)
-  th.writeF("/manifests/gcp/iap-ingress/base/config-map.yaml", `
+	th.writeF("/manifests/gcp/iap-ingress/base/config-map.yaml", `
 ---
 apiVersion: v1
 data:
@@ -371,7 +372,7 @@ metadata:
   name: ingress-bootstrap-config
 ---
 `)
-  th.writeF("/manifests/gcp/iap-ingress/base/deployment.yaml", `
+	th.writeF("/manifests/gcp/iap-ingress/base/deployment.yaml", `
 ---
 apiVersion: apps/v1
 kind: Deployment
@@ -440,7 +441,7 @@ spec:
           name: envoy-config
         name: config-volume
 `)
-  th.writeF("/manifests/gcp/iap-ingress/base/ingress.yaml", `
+	th.writeF("/manifests/gcp/iap-ingress/base/ingress.yaml", `
 apiVersion: extensions/v1beta1 # networking.k8s.io/v1beta1
 kind: Ingress
 metadata:
@@ -461,7 +462,7 @@ spec:
           servicePort: 80
         path: /*
 `)
-  th.writeF("/manifests/gcp/iap-ingress/base/policy.yaml", `
+	th.writeF("/manifests/gcp/iap-ingress/base/policy.yaml", `
 apiVersion: authentication.istio.io/v1alpha1
 kind: Policy
 metadata:
@@ -477,7 +478,7 @@ spec:
       - x-goog-iap-jwt-assertion
       trigger_rules:
       - excluded_paths:
-        - exact: /healthz
+        - exact: /healthz/ready
         - prefix: /.well-known/acme-challenge
   principalBinding: USE_ORIGIN
   targets:
@@ -485,13 +486,13 @@ spec:
     ports:
     - number: 80
 `)
-  th.writeF("/manifests/gcp/iap-ingress/base/service-account.yaml", `
+	th.writeF("/manifests/gcp/iap-ingress/base/service-account.yaml", `
 apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: kf-admin
 `)
-  th.writeF("/manifests/gcp/iap-ingress/base/service.yaml", `
+	th.writeF("/manifests/gcp/iap-ingress/base/service.yaml", `
 apiVersion: v1
 kind: Service
 metadata:
@@ -506,7 +507,7 @@ spec:
     app: whoami
   type: ClusterIP
 `)
-  th.writeF("/manifests/gcp/iap-ingress/base/stateful-set.yaml", `
+	th.writeF("/manifests/gcp/iap-ingress/base/stateful-set.yaml", `
 apiVersion: apps/v1
 kind: StatefulSet
 metadata:
@@ -548,7 +549,7 @@ spec:
         name: config-volume
   volumeClaimTemplates: []
 `)
-  th.writeF("/manifests/gcp/iap-ingress/base/params.yaml", `
+	th.writeF("/manifests/gcp/iap-ingress/base/params.yaml", `
 varReference:
 - path: metadata/name
   kind: Certificate
@@ -595,7 +596,7 @@ varReference:
 - path: spec/domains
   kind: ManagedCertificate
 `)
-  th.writeF("/manifests/gcp/iap-ingress/base/params.env", `
+	th.writeF("/manifests/gcp/iap-ingress/base/params.env", `
 namespace=kubeflow
 appName=kubeflow
 hostname=
@@ -608,7 +609,7 @@ adminSaSecretName=admin-gcp-sa
 tlsSecretName=envoy-ingress-tls
 istioNamespace=istio-system
 `)
-  th.writeK("/manifests/gcp/iap-ingress/base", `
+	th.writeK("/manifests/gcp/iap-ingress/base", `
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
@@ -725,32 +726,32 @@ configurations:
 }
 
 func TestIapIngressOverlaysApplication(t *testing.T) {
-  th := NewKustTestHarness(t, "/manifests/gcp/iap-ingress/overlays/application")
-  writeIapIngressOverlaysApplication(th)
-  m, err := th.makeKustTarget().MakeCustomizedResMap()
-  if err != nil {
-    t.Fatalf("Err: %v", err)
-  }
-  expected, err := m.AsYaml()
-  if err != nil {
-    t.Fatalf("Err: %v", err)
-  }
-  targetPath := "../gcp/iap-ingress/overlays/application"
-  fsys := fs.MakeRealFS()
-  lrc := loader.RestrictionRootOnly
-  _loader, loaderErr := loader.NewLoader(lrc, validators.MakeFakeValidator(), targetPath, fsys)
-  if loaderErr != nil {
-    t.Fatalf("could not load kustomize loader: %v", loaderErr)
-  }
-  rf := resmap.NewFactory(resource.NewFactory(kunstruct.NewKunstructuredFactoryImpl()), transformer.NewFactoryImpl())
-  pc := plugins.DefaultPluginConfig()
-  kt, err := target.NewKustTarget(_loader, rf, transformer.NewFactoryImpl(), plugins.NewLoader(pc, rf))
-  if err != nil {
-    th.t.Fatalf("Unexpected construction error %v", err)
-  }
-  actual, err := kt.MakeCustomizedResMap()
-  if err != nil {
-    t.Fatalf("Err: %v", err)
-  }
-  th.assertActualEqualsExpected(actual, string(expected))
+	th := NewKustTestHarness(t, "/manifests/gcp/iap-ingress/overlays/application")
+	writeIapIngressOverlaysApplication(th)
+	m, err := th.makeKustTarget().MakeCustomizedResMap()
+	if err != nil {
+		t.Fatalf("Err: %v", err)
+	}
+	expected, err := m.AsYaml()
+	if err != nil {
+		t.Fatalf("Err: %v", err)
+	}
+	targetPath := "../gcp/iap-ingress/overlays/application"
+	fsys := fs.MakeRealFS()
+	lrc := loader.RestrictionRootOnly
+	_loader, loaderErr := loader.NewLoader(lrc, validators.MakeFakeValidator(), targetPath, fsys)
+	if loaderErr != nil {
+		t.Fatalf("could not load kustomize loader: %v", loaderErr)
+	}
+	rf := resmap.NewFactory(resource.NewFactory(kunstruct.NewKunstructuredFactoryImpl()), transformer.NewFactoryImpl())
+	pc := plugins.DefaultPluginConfig()
+	kt, err := target.NewKustTarget(_loader, rf, transformer.NewFactoryImpl(), plugins.NewLoader(pc, rf))
+	if err != nil {
+		th.t.Fatalf("Unexpected construction error %v", err)
+	}
+	actual, err := kt.MakeCustomizedResMap()
+	if err != nil {
+		t.Fatalf("Err: %v", err)
+	}
+	th.assertActualEqualsExpected(actual, string(expected))
 }

--- a/tests/iap-ingress-overlays-certmanager_test.go
+++ b/tests/iap-ingress-overlays-certmanager_test.go
@@ -1,8 +1,6 @@
 package tests_test
 
 import (
-	"testing"
-
 	"sigs.k8s.io/kustomize/v3/k8sdeps/kunstruct"
 	"sigs.k8s.io/kustomize/v3/k8sdeps/transformer"
 	"sigs.k8s.io/kustomize/v3/pkg/fs"
@@ -12,6 +10,7 @@ import (
 	"sigs.k8s.io/kustomize/v3/pkg/resource"
 	"sigs.k8s.io/kustomize/v3/pkg/target"
 	"sigs.k8s.io/kustomize/v3/pkg/validators"
+	"testing"
 )
 
 func writeIapIngressOverlaysCertmanager(th *KustTestHarness) {

--- a/tests/iap-ingress-overlays-certmanager_test.go
+++ b/tests/iap-ingress-overlays-certmanager_test.go
@@ -1,6 +1,8 @@
 package tests_test
 
 import (
+	"testing"
+
 	"sigs.k8s.io/kustomize/v3/k8sdeps/kunstruct"
 	"sigs.k8s.io/kustomize/v3/k8sdeps/transformer"
 	"sigs.k8s.io/kustomize/v3/pkg/fs"
@@ -10,7 +12,6 @@ import (
 	"sigs.k8s.io/kustomize/v3/pkg/resource"
 	"sigs.k8s.io/kustomize/v3/pkg/target"
 	"sigs.k8s.io/kustomize/v3/pkg/validators"
-	"testing"
 )
 
 func writeIapIngressOverlaysCertmanager(th *KustTestHarness) {
@@ -510,7 +511,7 @@ spec:
       - x-goog-iap-jwt-assertion
       trigger_rules:
       - excluded_paths:
-        - exact: /healthz
+        - exact: /healthz/ready
         - prefix: /.well-known/acme-challenge
   principalBinding: USE_ORIGIN
   targets:

--- a/tests/iap-ingress-overlays-gcp-credentials_test.go
+++ b/tests/iap-ingress-overlays-gcp-credentials_test.go
@@ -1,6 +1,8 @@
 package tests_test
 
 import (
+	"testing"
+
 	"sigs.k8s.io/kustomize/v3/k8sdeps/kunstruct"
 	"sigs.k8s.io/kustomize/v3/k8sdeps/transformer"
 	"sigs.k8s.io/kustomize/v3/pkg/fs"
@@ -10,7 +12,6 @@ import (
 	"sigs.k8s.io/kustomize/v3/pkg/resource"
 	"sigs.k8s.io/kustomize/v3/pkg/target"
 	"sigs.k8s.io/kustomize/v3/pkg/validators"
-	"testing"
 )
 
 func writeIapIngressOverlaysGcpCredentials(th *KustTestHarness) {
@@ -484,7 +485,7 @@ spec:
       - x-goog-iap-jwt-assertion
       trigger_rules:
       - excluded_paths:
-        - exact: /healthz
+        - exact: /healthz/ready
         - prefix: /.well-known/acme-challenge
   principalBinding: USE_ORIGIN
   targets:

--- a/tests/iap-ingress-overlays-gcp-credentials_test.go
+++ b/tests/iap-ingress-overlays-gcp-credentials_test.go
@@ -1,8 +1,6 @@
 package tests_test
 
 import (
-	"testing"
-
 	"sigs.k8s.io/kustomize/v3/k8sdeps/kunstruct"
 	"sigs.k8s.io/kustomize/v3/k8sdeps/transformer"
 	"sigs.k8s.io/kustomize/v3/pkg/fs"
@@ -12,6 +10,7 @@ import (
 	"sigs.k8s.io/kustomize/v3/pkg/resource"
 	"sigs.k8s.io/kustomize/v3/pkg/target"
 	"sigs.k8s.io/kustomize/v3/pkg/validators"
+	"testing"
 )
 
 func writeIapIngressOverlaysGcpCredentials(th *KustTestHarness) {

--- a/tests/iap-ingress-overlays-managed-cert_test.go
+++ b/tests/iap-ingress-overlays-managed-cert_test.go
@@ -1,6 +1,8 @@
 package tests_test
 
 import (
+	"testing"
+
 	"sigs.k8s.io/kustomize/v3/k8sdeps/kunstruct"
 	"sigs.k8s.io/kustomize/v3/k8sdeps/transformer"
 	"sigs.k8s.io/kustomize/v3/pkg/fs"
@@ -10,7 +12,6 @@ import (
 	"sigs.k8s.io/kustomize/v3/pkg/resource"
 	"sigs.k8s.io/kustomize/v3/pkg/target"
 	"sigs.k8s.io/kustomize/v3/pkg/validators"
-	"testing"
 )
 
 func writeIapIngressOverlaysManagedCert(th *KustTestHarness) {
@@ -449,7 +450,7 @@ spec:
       - x-goog-iap-jwt-assertion
       trigger_rules:
       - excluded_paths:
-        - exact: /healthz
+        - exact: /healthz/ready
         - prefix: /.well-known/acme-challenge
   principalBinding: USE_ORIGIN
   targets:

--- a/tests/iap-ingress-overlays-managed-cert_test.go
+++ b/tests/iap-ingress-overlays-managed-cert_test.go
@@ -1,8 +1,6 @@
 package tests_test
 
 import (
-	"testing"
-
 	"sigs.k8s.io/kustomize/v3/k8sdeps/kunstruct"
 	"sigs.k8s.io/kustomize/v3/k8sdeps/transformer"
 	"sigs.k8s.io/kustomize/v3/pkg/fs"
@@ -12,6 +10,7 @@ import (
 	"sigs.k8s.io/kustomize/v3/pkg/resource"
 	"sigs.k8s.io/kustomize/v3/pkg/target"
 	"sigs.k8s.io/kustomize/v3/pkg/validators"
+	"testing"
 )
 
 func writeIapIngressOverlaysManagedCert(th *KustTestHarness) {


### PR DESCRIPTION
Issue: https://github.com/kubeflow/kubeflow/issues/4266

this path should match below two places
1. istio health check path - https://github.com/istio/istio/blob/master/pilot/cmd/pilot-agent/status/server.go#L43
2. configured hc path for ingress - 
https://github.com/kubeflow/manifests/blob/master/gcp/iap-ingress/base/config-map.yaml#L186

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/manifests/491)
<!-- Reviewable:end -->
