### PR TITLE
document istio workaround for 'Internal error occurred: failed calling admission webhook "pilot.validation.istio.io"'

### DIFF
--- a/istio/istio-install/base/istio-noauth.yaml
+++ b/istio/istio-install/base/istio-noauth.yaml
@@ -14332,6 +14332,7 @@ spec:
           - /etc/config/validatingwebhookconfiguration.yaml
           - --monitoringPort=15014
           - --log_output_level=default:info
+          # see  https://github.com/istio/istio/issues/15352
           - --enable-validation=true
           volumeMounts:
           - name: certs

--- a/tests/istio-install-base_test.go
+++ b/tests/istio-install-base_test.go
@@ -14349,6 +14349,7 @@ spec:
           - /etc/config/validatingwebhookconfiguration.yaml
           - --monitoringPort=15014
           - --log_output_level=default:info
+          # see  https://github.com/istio/istio/issues/15352
           - --enable-validation=true
           volumeMounts:
           - name: certs


### PR DESCRIPTION
**Which issue is resolved by this Pull Request:**
Resolves #495

**Description of your changes:**
>> Documentation only <<
added 
```
          # see  https://github.com/istio/istio/issues/15352
          - --enable-validation=true
```

**Checklist:**
- [x] Unit tests have been rebuilt: 
    1. `cd manifests/tests`
    2. `make generate`
    3. `make test`

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/manifests/496)
<!-- Reviewable:end -->
