### PR TITLE
Workaround workload identity bug and fix node autoprovisioning.

### DIFF
--- a/gcp/deployment_manager_configs/cluster-kubeflow.yaml
+++ b/gcp/deployment_manager_configs/cluster-kubeflow.yaml
@@ -31,7 +31,9 @@ resources:
     zone: SET_THE_ZONE
     # "1.X": picks the highest valid patch+gke.N patch in the 1.X version
     # https://cloud.google.com/kubernetes-engine/docs/reference/rest/v1/projects.zones.clusters
-    cluster-version: "1.14"
+    # TODO(https://github.com/kubeflow/kfctl/issues/48): This is a short term
+    # work around. We should unpin once 1.14.6-gke.14 is available.
+    cluster-version: "1.14.6-gke.2"
     # Set this to v1beta1 to use beta features such as private clusterss
     # and the Kubernetes stackdriver agents.
     gkeApiVersion: SET_GKE_API_VERSION

--- a/gcp/deployment_manager_configs/cluster.jinja
+++ b/gcp/deployment_manager_configs/cluster.jinja
@@ -96,6 +96,10 @@ resources:
       {% if properties['gkeApiVersion'] == 'v1beta1' and properties['autoprovisioning-config']['enabled'] %}
       autoscaling:
         enableNodeAutoprovisioning: true
+        autoprovisioningNodePoolDefaults:
+          # oauthScopes can't be set with service account
+          serviceAccount: {{ KF_VM_SA_NAME }}@{{ env['project'] }}.iam.gserviceaccount.com
+          
         resourceLimits:
         - resourceType: 'cpu'
           maximum: {{ properties['autoprovisioning-config']['max-cpu'] }}


### PR DESCRIPTION
* See https://github.com/kubeflow/kfctl/issues/48 1.14.6-gke-13 has
  a bug with workload identity so to work around it we temporarily
  pin to 1.14.6-gke-2.

* Fix node autoprovisioning defaults (kubeflow/kubeflow#4259) we need to set
  the default service account otherwise we won't be able to
  pull images from private GCR.

  * Note: We can't set both service account and scopes so we only set
    the service account.

**Which issue is resolved by this Pull Request:**
Resolves #

**Description of your changes:**


**Checklist:**
- [ ] Unit tests have been rebuilt: 
    1. `cd manifests/tests`
    2. `make generate`
    3. `make test`

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/manifests/498)
<!-- Reviewable:end -->
