### PR TITLE
[3945] Configurable Istio Gateway for Notebook Controller

### DIFF
--- a/jupyter/notebook-controller/base/kustomization.yaml
+++ b/jupyter/notebook-controller/base/kustomization.yaml
@@ -36,3 +36,10 @@ vars:
     apiVersion: v1
   fieldref:
     fieldpath: data.USE_ISTIO
+- name: ISTIO_GATEWAY
+  objref:
+    kind: ConfigMap
+    name: parameters
+    apiVersion: v1
+  fieldref:
+    fieldpath: data.ISTIO_GATEWAY

--- a/jupyter/notebook-controller/base/params.env
+++ b/jupyter/notebook-controller/base/params.env
@@ -1,2 +1,3 @@
 POD_LABELS=gcp-cred-secret=user-gcp-sa,gcp-cred-secret-filename=user-gcp-sa.json
 USE_ISTIO=false
+ISTIO_GATEWAY=kubeflow/kubeflow-gateway

--- a/jupyter/notebook-controller/overlays/istio/deployment.yaml
+++ b/jupyter/notebook-controller/overlays/istio/deployment.yaml
@@ -10,3 +10,5 @@ spec:
         env:
           - name: USE_ISTIO
             value: $(USE_ISTIO)
+          - name: ISTIO_GATEWAY
+            value: $(ISTIO_GATEWAY)

--- a/jupyter/notebook-controller/overlays/istio/params.env
+++ b/jupyter/notebook-controller/overlays/istio/params.env
@@ -1,1 +1,2 @@
 USE_ISTIO=true
+ISTIO_GATEWAY=kubeflow/kubeflow-gateway

--- a/tests/notebook-controller-base_test.go
+++ b/tests/notebook-controller-base_test.go
@@ -235,6 +235,7 @@ spec:
 	th.writeF("/manifests/jupyter/notebook-controller/base/params.env", `
 POD_LABELS=gcp-cred-secret=user-gcp-sa,gcp-cred-secret-filename=user-gcp-sa.json
 USE_ISTIO=false
+ISTIO_GATEWAY=kubeflow/kubeflow-gateway
 `)
 	th.writeK("/manifests/jupyter/notebook-controller/base", `
 apiVersion: kustomize.config.k8s.io/v1beta1
@@ -275,6 +276,13 @@ vars:
     apiVersion: v1
   fieldref:
     fieldpath: data.USE_ISTIO
+- name: ISTIO_GATEWAY
+  objref:
+    kind: ConfigMap
+    name: parameters
+    apiVersion: v1
+  fieldref:
+    fieldpath: data.ISTIO_GATEWAY
 `)
 }
 

--- a/tests/notebook-controller-overlays-application_test.go
+++ b/tests/notebook-controller-overlays-application_test.go
@@ -291,6 +291,7 @@ spec:
 	th.writeF("/manifests/jupyter/notebook-controller/base/params.env", `
 POD_LABELS=gcp-cred-secret=user-gcp-sa,gcp-cred-secret-filename=user-gcp-sa.json
 USE_ISTIO=false
+ISTIO_GATEWAY=kubeflow/kubeflow-gateway
 `)
 	th.writeK("/manifests/jupyter/notebook-controller/base", `
 apiVersion: kustomize.config.k8s.io/v1beta1
@@ -331,6 +332,13 @@ vars:
     apiVersion: v1
   fieldref:
     fieldpath: data.USE_ISTIO
+- name: ISTIO_GATEWAY
+  objref:
+    kind: ConfigMap
+    name: parameters
+    apiVersion: v1
+  fieldref:
+    fieldpath: data.ISTIO_GATEWAY
 `)
 }
 

--- a/tests/notebook-controller-overlays-istio_test.go
+++ b/tests/notebook-controller-overlays-istio_test.go
@@ -27,9 +27,12 @@ spec:
         env:
           - name: USE_ISTIO
             value: $(USE_ISTIO)
+          - name: ISTIO_GATEWAY
+            value: $(ISTIO_GATEWAY)
 `)
 	th.writeF("/manifests/jupyter/notebook-controller/overlays/istio/params.env", `
 USE_ISTIO=true
+ISTIO_GATEWAY=kubeflow/kubeflow-gateway
 `)
 	th.writeK("/manifests/jupyter/notebook-controller/overlays/istio", `
 apiVersion: kustomize.config.k8s.io/v1beta1
@@ -243,6 +246,8 @@ spec:
         env:
           - name: USE_ISTIO
             value: "false"
+          - name: ISTIO_GATEWAY
+            value: $(ISTIO_GATEWAY)
           - name: POD_LABELS
             value: $(POD_LABELS)
         imagePullPolicy: Always
@@ -266,6 +271,7 @@ spec:
 	th.writeF("/manifests/jupyter/notebook-controller/base/params.env", `
 POD_LABELS=gcp-cred-secret=user-gcp-sa,gcp-cred-secret-filename=user-gcp-sa.json
 USE_ISTIO=false
+ISTIO_GATEWAY=kubeflow/kubeflow-gateway
 `)
 	th.writeK("/manifests/jupyter/notebook-controller/base", `
 apiVersion: kustomize.config.k8s.io/v1beta1
@@ -306,6 +312,13 @@ vars:
     apiVersion: v1
   fieldref:
     fieldpath: data.USE_ISTIO
+- name: ISTIO_GATEWAY
+  objref:
+    kind: ConfigMap
+    name: parameters
+    apiVersion: v1
+  fieldref:
+    fieldpath: data.ISTIO_GATEWAY
 `)
 }
 


### PR DESCRIPTION
As part of `kubeflow/kubeflow` PR [[3945] Configurable Istio Gateway for Notebook Controller](https://github.com/kubeflow/kubeflow/pull/4216), I am adding the possibility to configure which Istio Gateway the Notebook Controller can use for setting up Virtual Services on Istio.

It defaults to `kubeflow/kubeflow-gateway`, which is what is used by default on Kubeflow.

Original issue: `kubeflow/kubeflow` [#3945](https://github.com/kubeflow/kubeflow/issues/3945)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/manifests/499)
<!-- Reviewable:end -->
