### PR TITLE
Adding Katib db liveness check

### DIFF
--- a/katib/katib-controller/base/katib-db-deployment.yaml
+++ b/katib/katib-controller/base/katib-db-deployment.yaml
@@ -20,7 +20,7 @@ spec:
     spec:
       containers:
       - name: katib-db
-        image: mysql:8.0.3
+        image: mysql:8
         args:
         - --datadir
         - /var/lib/mysql/datadir
@@ -42,10 +42,19 @@ spec:
             command:
             - "/bin/bash"
             - "-c"
-            - "mysql -D $$MYSQL_DATABASE -p$$MYSQL_ROOT_PASSWORD -e 'SELECT 1'"
+            - "mysql -D ${MYSQL_DATABASE} -p${MYSQL_ROOT_PASSWORD} -e 'SELECT 1'"
           initialDelaySeconds: 5
-          periodSeconds: 2
+          periodSeconds: 10
           timeoutSeconds: 1
+        livenessProbe:
+          exec:
+            command:
+            - "/bin/bash"
+            - "-c"
+            - "mysqladmin ping -u root -p${MYSQL_ROOT_PASSWORD}"
+          initialDelaySeconds: 30
+          periodSeconds: 10
+          timeoutSeconds: 5
         volumeMounts:
         - name: katib-mysql
           mountPath: /var/lib/mysql

--- a/katib/katib-controller/base/kustomization.yaml
+++ b/katib/katib-controller/base/kustomization.yaml
@@ -36,7 +36,7 @@ images:
   newTag: 7ade03b
   newName: gcr.io/kubeflow-images-public/katib/v1alpha3/katib-ui
 - name: mysql
-  newTag: 8.0.3
+  newTag: "8"
   newName: mysql
 vars:
 - name: clusterDomain

--- a/tests/katib-controller-base_test.go
+++ b/tests/katib-controller-base_test.go
@@ -226,7 +226,7 @@ spec:
     spec:
       containers:
       - name: katib-db
-        image: mysql:8.0.3
+        image: mysql:8
         args:
         - --datadir
         - /var/lib/mysql/datadir
@@ -248,10 +248,19 @@ spec:
             command:
             - "/bin/bash"
             - "-c"
-            - "mysql -D $$MYSQL_DATABASE -p$$MYSQL_ROOT_PASSWORD -e 'SELECT 1'"
+            - "mysql -D ${MYSQL_DATABASE} -p${MYSQL_ROOT_PASSWORD} -e 'SELECT 1'"
           initialDelaySeconds: 5
-          periodSeconds: 2
+          periodSeconds: 10
           timeoutSeconds: 1
+        livenessProbe:
+          exec:
+            command:
+            - "/bin/bash"
+            - "-c"
+            - "mysqladmin ping -u root -p${MYSQL_ROOT_PASSWORD}"
+          initialDelaySeconds: 30
+          periodSeconds: 10
+          timeoutSeconds: 5
         volumeMounts:
         - name: katib-mysql
           mountPath: /var/lib/mysql
@@ -585,7 +594,7 @@ images:
   newTag: 7ade03b
   newName: gcr.io/kubeflow-images-public/katib/v1alpha3/katib-ui
 - name: mysql
-  newTag: 8.0.3
+  newTag: "8"
   newName: mysql
 vars:
 - name: clusterDomain

--- a/tests/katib-controller-overlays-application_test.go
+++ b/tests/katib-controller-overlays-application_test.go
@@ -305,7 +305,7 @@ spec:
     spec:
       containers:
       - name: katib-db
-        image: mysql:8.0.3
+        image: mysql:8
         args:
         - --datadir
         - /var/lib/mysql/datadir
@@ -327,10 +327,19 @@ spec:
             command:
             - "/bin/bash"
             - "-c"
-            - "mysql -D $$MYSQL_DATABASE -p$$MYSQL_ROOT_PASSWORD -e 'SELECT 1'"
+            - "mysql -D ${MYSQL_DATABASE} -p${MYSQL_ROOT_PASSWORD} -e 'SELECT 1'"
           initialDelaySeconds: 5
-          periodSeconds: 2
+          periodSeconds: 10
           timeoutSeconds: 1
+        livenessProbe:
+          exec:
+            command:
+            - "/bin/bash"
+            - "-c"
+            - "mysqladmin ping -u root -p${MYSQL_ROOT_PASSWORD}"
+          initialDelaySeconds: 30
+          periodSeconds: 10
+          timeoutSeconds: 5
         volumeMounts:
         - name: katib-mysql
           mountPath: /var/lib/mysql
@@ -664,7 +673,7 @@ images:
   newTag: 7ade03b
   newName: gcr.io/kubeflow-images-public/katib/v1alpha3/katib-ui
 - name: mysql
-  newTag: 8.0.3
+  newTag: "8"
   newName: mysql
 vars:
 - name: clusterDomain

--- a/tests/katib-controller-overlays-istio_test.go
+++ b/tests/katib-controller-overlays-istio_test.go
@@ -263,7 +263,7 @@ spec:
     spec:
       containers:
       - name: katib-db
-        image: mysql:8.0.3
+        image: mysql:8
         args:
         - --datadir
         - /var/lib/mysql/datadir
@@ -285,10 +285,19 @@ spec:
             command:
             - "/bin/bash"
             - "-c"
-            - "mysql -D $$MYSQL_DATABASE -p$$MYSQL_ROOT_PASSWORD -e 'SELECT 1'"
+            - "mysql -D ${MYSQL_DATABASE} -p${MYSQL_ROOT_PASSWORD} -e 'SELECT 1'"
           initialDelaySeconds: 5
-          periodSeconds: 2
+          periodSeconds: 10
           timeoutSeconds: 1
+        livenessProbe:
+          exec:
+            command:
+            - "/bin/bash"
+            - "-c"
+            - "mysqladmin ping -u root -p${MYSQL_ROOT_PASSWORD}"
+          initialDelaySeconds: 30
+          periodSeconds: 10
+          timeoutSeconds: 5
         volumeMounts:
         - name: katib-mysql
           mountPath: /var/lib/mysql
@@ -622,7 +631,7 @@ images:
   newTag: 7ade03b
   newName: gcr.io/kubeflow-images-public/katib/v1alpha3/katib-ui
 - name: mysql
-  newTag: 8.0.3
+  newTag: "8"
   newName: mysql
 vars:
 - name: clusterDomain


### PR DESCRIPTION
Related: https://github.com/kubeflow/katib/pull/871

**Checklist:**
- [x] Unit tests have been rebuilt: 
    1. `cd manifests/tests`
    2. `make generate`
    3. `make test`

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/manifests/503)
<!-- Reviewable:end -->
