### PR TITLE
Fix alibi explainer configmap

### DIFF
--- a/kfserving/kfserving-install/base/config-map.yaml
+++ b/kfserving/kfserving-install/base/config-map.yaml
@@ -67,11 +67,13 @@ data:
     }
   explainers: |-
     {
-        "image" : "docker.io/seldonio/alibiexplainer",
-        "defaultImageVersion": "0.2.3",
-        "allowedImageVersions": [
-           "0.2.3"
-        ]
+        "alibi": {
+            "image": "docker.io/seldonio/alibiexplainer",
+            "defaultImageVersion": "0.2.3",
+            "allowedImageVersions": [
+               "0.2.3"
+            ]
+        }
     }
   storageInitializer: |-
     {

--- a/kfserving/kfserving-install/base/config-map.yaml
+++ b/kfserving/kfserving-install/base/config-map.yaml
@@ -68,7 +68,7 @@ data:
   explainers: |-
     {
         "alibi": {
-            "image": "docker.io/seldonio/alibiexplainer",
+            "image": "gcr.io/kfserving/alibi-explainer",
             "defaultImageVersion": "0.2.3",
             "allowedImageVersions": [
                "0.2.3"

--- a/tests/kfserving-install-base_test.go
+++ b/tests/kfserving-install-base_test.go
@@ -315,7 +315,7 @@ data:
   explainers: |-
     {
         "alibi": {
-            "image": "docker.io/seldonio/alibiexplainer",
+            "image": "gcr.io/kfserving/alibi-explainer",
             "defaultImageVersion": "0.2.3",
             "allowedImageVersions": [
                "0.2.3"

--- a/tests/kfserving-install-base_test.go
+++ b/tests/kfserving-install-base_test.go
@@ -314,11 +314,13 @@ data:
     }
   explainers: |-
     {
-        "image" : "docker.io/seldonio/alibiexplainer",
-        "defaultImageVersion": "0.2.3",
-        "allowedImageVersions": [
-           "0.2.3"
-        ]
+        "alibi": {
+            "image": "docker.io/seldonio/alibiexplainer",
+            "defaultImageVersion": "0.2.3",
+            "allowedImageVersions": [
+               "0.2.3"
+            ]
+        }
     }
   storageInitializer: |-
     {

--- a/tests/kfserving-install-overlays-application_test.go
+++ b/tests/kfserving-install-overlays-application_test.go
@@ -372,7 +372,7 @@ data:
   explainers: |-
     {
         "alibi": {
-            "image": "docker.io/seldonio/alibiexplainer",
+            "image": "gcr.io/kfserving/alibi-explainer",
             "defaultImageVersion": "0.2.3",
             "allowedImageVersions": [
                "0.2.3"

--- a/tests/kfserving-install-overlays-application_test.go
+++ b/tests/kfserving-install-overlays-application_test.go
@@ -371,11 +371,13 @@ data:
     }
   explainers: |-
     {
-        "image" : "docker.io/seldonio/alibiexplainer",
-        "defaultImageVersion": "0.2.3",
-        "allowedImageVersions": [
-           "0.2.3"
-        ]
+        "alibi": {
+            "image": "docker.io/seldonio/alibiexplainer",
+            "defaultImageVersion": "0.2.3",
+            "allowedImageVersions": [
+               "0.2.3"
+            ]
+        }
     }
   storageInitializer: |-
     {


### PR DESCRIPTION
**Which issue is resolved by this Pull Request:**
Resolves https://github.com/kubeflow/kfserving/issues/441

**Description of your changes:**
The explainer config map is missing the key with `alibi`

**Checklist:**
- [ ] Unit tests have been rebuilt: 
    1. `cd manifests/tests`
    2. `make generate`
    3. `make test`

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/manifests/514)
<!-- Reviewable:end -->
