### PR TITLE
Add application name for seldon and mpi-operator

### DIFF
--- a/kfdef/kfctl_aws.yaml
+++ b/kfdef/kfctl_aws.yaml
@@ -251,12 +251,14 @@ spec:
       repoRef:
         name: manifests
         path: seldon/seldon-core-operator
+    name: seldon-core
   - kustomizeConfig:
       overlays:
       - application
       repoRef:
         name: manifests
         path: mpi-job/mpi-operator
+    name: mpi-operator
   - kustomizeConfig:
       parameters:
       - name: namespace

--- a/kfdef/kfctl_aws_cognito.yaml
+++ b/kfdef/kfctl_aws_cognito.yaml
@@ -255,12 +255,14 @@ spec:
       repoRef:
         name: manifests
         path: seldon/seldon-core-operator
+    name: seldon-core
   - kustomizeConfig:
       overlays:
       - application
       repoRef:
         name: manifests
         path: mpi-job/mpi-operator
+    name: mpi-operator
   - kustomizeConfig:
       overlays:
       - cognito


### PR DESCRIPTION
**Which issue is resolved by this Pull Request:**
Resolves #517 

**Description of your changes:**
Add application name and make sure they're populated in `kfctl build`

**Checklist:**
- [x] Unit tests have been rebuilt: 
    1. `cd manifests/tests`
    2. `make generate`
    3. `make test`

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/manifests/518)
<!-- Reviewable:end -->
