### PR TITLE
oidc-authservice: add authservice to manifests

### DIFF
--- a/dex-auth/dex-crds/base/kustomization.yaml
+++ b/dex-auth/dex-crds/base/kustomization.yaml
@@ -80,5 +80,5 @@ configurations:
 - params.yaml
 images:
 - name: quay.io/coreos/dex
-  newName: quay.io/coreos/dex
-  newTag: v2.9.0
+  newName: gcr.io/arrikto/dexidp/dex
+  newTag: 4bede5eb80822fc3a7fc9edca0ed2605cd339d17

--- a/dex-auth/dex-crds/overlays/istio/kustomization.yaml
+++ b/dex-auth/dex-crds/overlays/istio/kustomization.yaml
@@ -1,0 +1,6 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+bases:
+- ../../base
+resources:
+- virtual-service.yaml

--- a/dex-auth/dex-crds/overlays/istio/kustomization.yaml
+++ b/dex-auth/dex-crds/overlays/istio/kustomization.yaml
@@ -4,3 +4,20 @@ bases:
 - ../../base
 resources:
 - virtual-service.yaml
+
+configMapGenerator:
+- name: dex-parameters
+  behavior: merge
+  env: params.env
+generatorOptions:
+  disableNameSuffixHash: true
+vars:
+- name: namespace
+  objref:
+    kind: ConfigMap
+    name: dex-parameters
+    apiVersion: v1
+  fieldref:
+    fieldpath: data.namespace
+configurations:
+- params.yaml

--- a/dex-auth/dex-crds/overlays/istio/params.env
+++ b/dex-auth/dex-crds/overlays/istio/params.env
@@ -1,0 +1,1 @@
+namespace=auth

--- a/dex-auth/dex-crds/overlays/istio/params.yaml
+++ b/dex-auth/dex-crds/overlays/istio/params.yaml
@@ -1,0 +1,3 @@
+varReference:
+- path: spec/http/route/destination/host
+  kind: VirtualService

--- a/dex-auth/dex-crds/overlays/istio/virtual-service.yaml
+++ b/dex-auth/dex-crds/overlays/istio/virtual-service.yaml
@@ -17,6 +17,6 @@ spec:
         prefix: /dex/
     route:
     - destination:
-        host: dex.auth.svc.cluster.local
+        host: dex.$(namespace).svc.cluster.local
         port:
           number: 5556

--- a/dex-auth/dex-crds/overlays/istio/virtual-service.yaml
+++ b/dex-auth/dex-crds/overlays/istio/virtual-service.yaml
@@ -1,0 +1,22 @@
+# This config is gated on kiali upgrade to 0.21 from 0.16 in istio 1.1.6:
+# https://github.com/kiali/kiali/issues/1154
+# https://github.com/istio/istio/issues/11131
+
+apiVersion: networking.istio.io/v1alpha3
+kind: VirtualService
+metadata:
+  name: dex
+spec:
+  gateways:
+  - kubeflow/kubeflow-gateway
+  hosts:
+  - '*'
+  http:
+  - match:
+    - uri:
+        prefix: /dex/
+    route:
+    - destination:
+        host: dex.auth.svc.cluster.local
+        port:
+          number: 5556

--- a/istio/oidc-authservice/base/deployment.yaml
+++ b/istio/oidc-authservice/base/deployment.yaml
@@ -1,0 +1,59 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: authservice
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: authservice
+  strategy:
+    type: RollingUpdate
+  template:
+    metadata:
+      annotations:
+        sidecar.istio.io/inject: "false"
+      labels:
+        app: authservice
+    spec:
+      containers:
+      - name: authservice
+        image: gcr.io/arrikto/kubeflow/oidc-authservice:6ac9400
+        imagePullPolicy: Always
+        ports:
+        - name: http-api
+          containerPort: 8080
+        env:
+          - name: USERID_HEADER
+            value: $(userid-header)
+          - name: USERID_PREFIX
+            value: $(userid-prefix)
+          - name: USERID_CLAIM
+            value: email
+          - name: OIDC_PROVIDER
+            value: $(oidc_provider)
+          - name: OIDC_AUTH_URL
+            value: $(oidc_auth_url)
+          - name: OIDC_SCOPES
+            value: "profile email groups"
+          - name: REDIRECT_URL
+            value: $(oidc_redirect_uri)
+          - name: SKIP_AUTH_URI
+            value: $(skip_auth_uri)
+          - name: PORT
+            value: "8080"
+          - name: CLIENT_ID
+            value: $(client_id)
+          - name: CLIENT_SECRET
+            value: $(application_secret)
+          - name: STORE_PATH
+            value: /var/lib/authservice/data.db
+        volumeMounts:
+          - name: data
+            mountPath: /var/lib/authservice
+      securityContext:
+        fsGroup: 111
+      volumes:
+        - name: data
+          persistentVolumeClaim:
+              claimName: authservice-pvc          

--- a/istio/oidc-authservice/base/envoy-filter.yaml
+++ b/istio/oidc-authservice/base/envoy-filter.yaml
@@ -1,0 +1,32 @@
+apiVersion: networking.istio.io/v1alpha3
+kind: EnvoyFilter
+metadata:
+  name: authn-filter
+  namespace: istio-system
+spec:
+  workloadLabels:
+    istio: ingressgateway
+  filters:
+  - filterConfig:
+      httpService:
+        serverUri:
+          uri: http://authservice.istio-system.svc.cluster.local
+          cluster: outbound|8080||authservice.istio-system.svc.cluster.local
+          failureModeAllow: false
+          timeout: 10s
+        authorizationRequest: 
+          allowedHeaders:
+            patterns:
+            - exact: "cookie"
+        authorizationResponse:
+          allowedUpstreamHeaders:
+            patterns:
+            - exact: "kubeflow-userid"
+      statusOnError:
+        code: GatewayTimeout
+    filterName: envoy.ext_authz
+    filterType: HTTP
+    insertPosition:
+      index: FIRST
+    listenerMatch:
+      listenerType: GATEWAY

--- a/istio/oidc-authservice/base/envoy-filter.yaml
+++ b/istio/oidc-authservice/base/envoy-filter.yaml
@@ -2,7 +2,6 @@ apiVersion: networking.istio.io/v1alpha3
 kind: EnvoyFilter
 metadata:
   name: authn-filter
-  namespace: istio-system
 spec:
   workloadLabels:
     istio: ingressgateway
@@ -10,8 +9,8 @@ spec:
   - filterConfig:
       httpService:
         serverUri:
-          uri: http://authservice.istio-system.svc.cluster.local
-          cluster: outbound|8080||authservice.istio-system.svc.cluster.local
+          uri: http://authservice.$(namespace).svc.cluster.local
+          cluster: outbound|8080||authservice.$(namespace).svc.cluster.local
           failureModeAllow: false
           timeout: 10s
         authorizationRequest: 

--- a/istio/oidc-authservice/base/kustomization.yaml
+++ b/istio/oidc-authservice/base/kustomization.yaml
@@ -1,0 +1,80 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+- service.yaml
+- deployment.yaml
+- envoy-filter.yaml
+- pvc.yaml
+
+namespace: istio-system
+
+configMapGenerator:
+- name: oidc-authservice-parameters
+  env: params.env
+generatorOptions:
+  disableNameSuffixHash: true
+
+vars:
+- name: client_id
+  objref:
+    kind: ConfigMap
+    name: oidc-authservice-parameters
+    apiVersion: v1
+  fieldref:
+    fieldpath: data.client_id
+- name: oidc_provider
+  objref:
+    kind: ConfigMap
+    name: oidc-authservice-parameters
+    apiVersion: v1
+  fieldref:
+    fieldpath: data.oidc_provider
+- name: oidc_redirect_uri
+  objref:
+    kind: ConfigMap
+    name: oidc-authservice-parameters
+    apiVersion: v1
+  fieldref:
+    fieldpath: data.oidc_redirect_uri
+- name: oidc_auth_url
+  objref:
+    kind: ConfigMap
+    name: oidc-authservice-parameters
+    apiVersion: v1
+  fieldref:
+    fieldpath: data.oidc_auth_url
+- name: application_secret
+  objref:
+    kind: ConfigMap
+    name: oidc-authservice-parameters
+    apiVersion: v1
+  fieldref:
+    fieldpath: data.application_secret
+- name: skip_auth_uri
+  objref:
+    kind: ConfigMap
+    name: oidc-authservice-parameters
+    apiVersion: v1
+  fieldref:
+    fieldpath: data.skip_auth_uri
+- name: userid-header
+  objref:
+    kind: ConfigMap
+    name: oidc-authservice-parameters
+    apiVersion: v1
+  fieldref:
+    fieldpath: data.userid-header
+- name: userid-prefix
+  objref:
+    kind: ConfigMap
+    name: oidc-authservice-parameters
+    apiVersion: v1
+  fieldref:
+    fieldpath: data.userid-prefix
+configurations:
+- params.yaml
+images:
+- name: gcr.io/arrikto/kubeflow/oidc-authservice
+  newName: gcr.io/arrikto/kubeflow/oidc-authservice
+  newTag: 6ac9400

--- a/istio/oidc-authservice/base/kustomization.yaml
+++ b/istio/oidc-authservice/base/kustomization.yaml
@@ -72,6 +72,13 @@ vars:
     apiVersion: v1
   fieldref:
     fieldpath: data.userid-prefix
+- name: namespace
+  objref:
+    kind: ConfigMap
+    name: oidc-authservice-parameters
+    apiVersion: v1
+  fieldref:
+    fieldpath: data.namespace
 configurations:
 - params.yaml
 images:

--- a/istio/oidc-authservice/base/params.env
+++ b/istio/oidc-authservice/base/params.env
@@ -1,0 +1,8 @@
+client_id=ldapdexapp
+oidc_provider=
+oidc_redirect_uri=
+oidc_auth_url=
+application_secret=pUBnBOY80SnXgjibTYM9ZWNzY2xreNGQok
+skip_auth_uri=
+userid-header=
+userid-prefix=

--- a/istio/oidc-authservice/base/params.env
+++ b/istio/oidc-authservice/base/params.env
@@ -6,3 +6,4 @@ application_secret=pUBnBOY80SnXgjibTYM9ZWNzY2xreNGQok
 skip_auth_uri=
 userid-header=
 userid-prefix=
+namespace=istio-system

--- a/istio/oidc-authservice/base/params.yaml
+++ b/istio/oidc-authservice/base/params.yaml
@@ -1,0 +1,3 @@
+varReference:
+- path: spec/template/spec/containers/env/value
+  kind: Deployment

--- a/istio/oidc-authservice/base/params.yaml
+++ b/istio/oidc-authservice/base/params.yaml
@@ -1,3 +1,7 @@
 varReference:
 - path: spec/template/spec/containers/env/value
   kind: Deployment
+- path: spec/filters/filterConfig/httpService/serverUri/uri
+  kind: EnvoyFilter
+- path: spec/filters/filterConfig/httpService/serverUri/cluster
+  kind: EnvoyFilter

--- a/istio/oidc-authservice/base/pvc.yaml
+++ b/istio/oidc-authservice/base/pvc.yaml
@@ -1,0 +1,10 @@
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: authservice-pvc
+spec:
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: 10Gi

--- a/istio/oidc-authservice/base/service.yaml
+++ b/istio/oidc-authservice/base/service.yaml
@@ -1,0 +1,12 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: authservice
+spec:
+  type: ClusterIP
+  selector:
+    app: authservice
+  ports:
+  - port: 8080
+    name: http-authservice
+    targetPort: http-api

--- a/istio/oidc-authservice/overlays/application/application.yaml
+++ b/istio/oidc-authservice/overlays/application/application.yaml
@@ -1,0 +1,43 @@
+ 
+apiVersion: app.k8s.io/v1beta1
+kind: Application
+metadata:
+  name: oidc-authservice
+spec:
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: oidc-authservice
+      app.kubernetes.io/instance: oidc-authservice-v0.7.0
+      app.kubernetes.io/managed-by: kfctl
+      app.kubernetes.io/component: oidc-authservice
+      app.kubernetes.io/part-of: kubeflow
+      app.kubernetes.io/version: v0.7.0
+  componentKinds:
+  - group: apps
+    kind: Deployment
+  - group: core
+    kind: Service
+  - group: core
+    kind: PersistentVolumeClaim
+  - group: networking.istio.io
+    kind: EnvoyFilter
+  descriptor:
+    type: oidc-authservice
+    version: v1beta1
+    description: Provides OIDC-based authentication for Kubeflow Applications, at the Istio Gateway.
+    maintainers:
+    - name: Yannis Zarkadas
+      email: yanniszark@arrikto.com
+    owners:
+    - name: Yannis Zarkadas
+      email: yanniszark@arrikto.com
+    keywords:
+     - oidc
+     - authservice
+     - authentication  
+    links:
+    - description: About
+      url: https://github.com/kubeflow/kubeflow/tree/master/components/oidc-authservice
+    - description: Docs
+      url: https://www.kubeflow.org/docs/started/k8s/kfctl-existing-arrikto
+  addOwnerRef: true

--- a/istio/oidc-authservice/overlays/application/kustomization.yaml
+++ b/istio/oidc-authservice/overlays/application/kustomization.yaml
@@ -1,0 +1,13 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+bases:
+- ../../base
+resources:
+- application.yaml
+commonLabels:
+  app.kubernetes.io/name: oidc-authservice
+  app.kubernetes.io/instance: oidc-authservice-v0.7.0
+  app.kubernetes.io/managed-by: kfctl
+  app.kubernetes.io/component: oidc-authservice
+  app.kubernetes.io/part-of: kubeflow
+  app.kubernetes.io/version: v0.7.0

--- a/kfdef/kfctl_existing_arrikto.yaml
+++ b/kfdef/kfctl_existing_arrikto.yaml
@@ -9,6 +9,75 @@ metadata:
 spec:
   packageManager: kustomize
   applications:
+  # Istio install. If not needed, comment out istio-crds and istio-install.
+  - kustomizeConfig:
+      parameters:
+        - name: namespace
+          value: istio-system
+      repoRef:
+        name: manifests
+        path: istio/istio-crds
+    name: istio-crds
+  - kustomizeConfig:
+      parameters:
+        - name: namespace
+          value: istio-system
+      repoRef:
+        name: manifests
+        path: istio/istio-install
+    name: istio-install
+  # This component is the istio resources for Kubeflow (e.g. gateway), not about installing istio.
+  - kustomizeConfig:
+      parameters:
+        - name: clusterRbacConfig
+          value: "ON"
+      repoRef:
+        name: manifests
+        path: istio/istio
+    name: istio
+  - kustomizeConfig:
+      overlays:
+        - application
+      parameters:
+        - name: namespace
+          value: istio-system
+        - name: userid-header
+          value: kubeflow-userid
+        - name: oidc_provider
+          value: http://dex.auth.svc.cluster.local:5556/dex
+        - name: oidc_redirect_uri
+          value: /login/oidc
+        - name: oidc_auth_url
+          value: /dex/auth
+        - name: skip_auth_uri
+          value: /dex
+        - name: client_id
+          value: kubeflow-oidc-authservice        
+      repoRef:
+        name: manifests
+        path: istio/oidc-authservice
+    name: oidc-authservice
+  - kustomizeConfig:
+      overlays:
+        - istio
+      parameters:
+        - name: namespace
+          value: auth
+        - name: issuer
+          value: http://dex.auth.svc.cluster.local:5556/dex
+        - name: client_id
+          value: kubeflow-oidc-authservice
+        - name: oidc_redirect_uris
+          value: '["/login/oidc"]'
+        - name: static_email
+          value: admin@kubeflow.org
+        # Password is "12341234", 12-round bcrypt-hashed.
+        - name: static_password_hash
+          value: $2y$12$ruoM7FqXrpVgaol44eRZW.4HWS8SAvg6KYVVSCIwKQPBmTpCm.EeO
+      repoRef:
+        name: manifests
+        path: dex-auth/dex-crds
+    name: dex
   - kustomizeConfig:
       repoRef:
         name: manifests
@@ -238,8 +307,6 @@ spec:
         name: manifests
         path: seldon/seldon-core-operator
     name: seldon-core-operator
-  platform: existing_arrikto
   repos:
   - name: manifests
-    root: manifests-master
     uri: https://github.com/kubeflow/manifests/archive/master.tar.gz

--- a/kfdef/kfctl_existing_arrikto.yaml
+++ b/kfdef/kfctl_existing_arrikto.yaml
@@ -9,6 +9,18 @@ metadata:
 spec:
   packageManager: kustomize
   applications:
+  - kustomizeConfig:
+      repoRef:
+        name: manifests
+        path: application/application-crds
+    name: application-crds
+  - kustomizeConfig:
+      overlays:
+      - application
+      repoRef:
+        name: manifests
+        path: application/application
+    name: application
   # Istio install. If not needed, comment out istio-crds and istio-install.
   - kustomizeConfig:
       parameters:
@@ -78,18 +90,6 @@ spec:
         name: manifests
         path: dex-auth/dex-crds
     name: dex
-  - kustomizeConfig:
-      repoRef:
-        name: manifests
-        path: application/application-crds
-    name: application-crds
-  - kustomizeConfig:
-      overlays:
-      - application
-      repoRef:
-        name: manifests
-        path: application/application
-    name: application
   - kustomizeConfig:
       overlays:
       - istio

--- a/tests/basic-auth-ingress-overlays-application_test.go
+++ b/tests/basic-auth-ingress-overlays-application_test.go
@@ -69,8 +69,7 @@ metadata:
   name: basicauth-backendconfig
 spec:
   # Jupyter uses websockets so we want to increase the timeout.
-  timeoutSec: 3600
-`)
+  timeoutSec: 3600`)
 	th.writeF("/manifests/gcp/basic-auth-ingress/base/cloud-endpoint.yaml", `
 apiVersion: ctl.isla.solutions/v1
 kind: CloudEndpoint

--- a/tests/dex-crds-overlays-ldap_test.go
+++ b/tests/dex-crds-overlays-ldap_test.go
@@ -448,8 +448,8 @@ configurations:
 - params.yaml
 images:
 - name: quay.io/coreos/dex
-  newName: quay.io/coreos/dex
-  newTag: v2.9.0
+  newName: gcr.io/arrikto/dexidp/dex
+  newTag: 4bede5eb80822fc3a7fc9edca0ed2605cd339d17
 `)
 }
 

--- a/tests/mxnet-operator-overlays-application_test.go
+++ b/tests/mxnet-operator-overlays-application_test.go
@@ -82,8 +82,7 @@ roleRef:
   name: mxnet-operator
 subjects:
 - kind: ServiceAccount
-  name: mxnet-operator
-`)
+  name: mxnet-operator`)
 	th.writeF("/manifests/mxnet-job/mxnet-operator/base/cluster-role.yaml", `
 apiVersion: rbac.authorization.k8s.io/v1beta1
 kind: ClusterRole
@@ -133,8 +132,7 @@ rules:
   resources:
   - deployments
   verbs:
-  - '*'
-`)
+  - '*'`)
 	th.writeF("/manifests/mxnet-job/mxnet-operator/base/crd.yaml", `
 apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
@@ -186,8 +184,7 @@ kind: ServiceAccount
 metadata:
   labels:
     app: mxnet-operator
-  name: mxnet-operator
-`)
+  name: mxnet-operator`)
 	th.writeK("/manifests/mxnet-job/mxnet-operator/base", `
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization

--- a/tests/notebook-controller-overlays-istio_test.go
+++ b/tests/notebook-controller-overlays-istio_test.go
@@ -246,8 +246,6 @@ spec:
         env:
           - name: USE_ISTIO
             value: "false"
-          - name: ISTIO_GATEWAY
-            value: $(ISTIO_GATEWAY)
           - name: POD_LABELS
             value: $(POD_LABELS)
         imagePullPolicy: Always

--- a/tests/oidc-authservice-base_test.go
+++ b/tests/oidc-authservice-base_test.go
@@ -1,0 +1,273 @@
+package tests_test
+
+import (
+	"sigs.k8s.io/kustomize/v3/k8sdeps/kunstruct"
+	"sigs.k8s.io/kustomize/v3/k8sdeps/transformer"
+	"sigs.k8s.io/kustomize/v3/pkg/fs"
+	"sigs.k8s.io/kustomize/v3/pkg/loader"
+	"sigs.k8s.io/kustomize/v3/pkg/plugins"
+	"sigs.k8s.io/kustomize/v3/pkg/resmap"
+	"sigs.k8s.io/kustomize/v3/pkg/resource"
+	"sigs.k8s.io/kustomize/v3/pkg/target"
+	"sigs.k8s.io/kustomize/v3/pkg/validators"
+	"testing"
+)
+
+func writeOidcAuthserviceBase(th *KustTestHarness) {
+	th.writeF("/manifests/istio/oidc-authservice/base/service.yaml", `
+apiVersion: v1
+kind: Service
+metadata:
+  name: authservice
+spec:
+  type: ClusterIP
+  selector:
+    app: authservice
+  ports:
+  - port: 8080
+    name: http-authservice
+    targetPort: http-api`)
+	th.writeF("/manifests/istio/oidc-authservice/base/deployment.yaml", `
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: authservice
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: authservice
+  strategy:
+    type: RollingUpdate
+  template:
+    metadata:
+      annotations:
+        sidecar.istio.io/inject: "false"
+      labels:
+        app: authservice
+    spec:
+      containers:
+      - name: authservice
+        image: gcr.io/arrikto/kubeflow/oidc-authservice:6ac9400
+        imagePullPolicy: Always
+        ports:
+        - name: http-api
+          containerPort: 8080
+        env:
+          - name: USERID_HEADER
+            value: $(userid-header)
+          - name: USERID_PREFIX
+            value: $(userid-prefix)
+          - name: USERID_CLAIM
+            value: email
+          - name: OIDC_PROVIDER
+            value: $(oidc_provider)
+          - name: OIDC_AUTH_URL
+            value: $(oidc_auth_url)
+          - name: OIDC_SCOPES
+            value: "profile email groups"
+          - name: REDIRECT_URL
+            value: $(oidc_redirect_uri)
+          - name: SKIP_AUTH_URI
+            value: $(skip_auth_uri)
+          - name: PORT
+            value: "8080"
+          - name: CLIENT_ID
+            value: $(client_id)
+          - name: CLIENT_SECRET
+            value: $(application_secret)
+          - name: STORE_PATH
+            value: /var/lib/authservice/data.db
+        volumeMounts:
+          - name: data
+            mountPath: /var/lib/authservice
+      securityContext:
+        fsGroup: 111
+      volumes:
+        - name: data
+          persistentVolumeClaim:
+              claimName: authservice-pvc          
+`)
+	th.writeF("/manifests/istio/oidc-authservice/base/envoy-filter.yaml", `
+apiVersion: networking.istio.io/v1alpha3
+kind: EnvoyFilter
+metadata:
+  name: authn-filter
+spec:
+  workloadLabels:
+    istio: ingressgateway
+  filters:
+  - filterConfig:
+      httpService:
+        serverUri:
+          uri: http://authservice.$(namespace).svc.cluster.local
+          cluster: outbound|8080||authservice.$(namespace).svc.cluster.local
+          failureModeAllow: false
+          timeout: 10s
+        authorizationRequest: 
+          allowedHeaders:
+            patterns:
+            - exact: "cookie"
+        authorizationResponse:
+          allowedUpstreamHeaders:
+            patterns:
+            - exact: "kubeflow-userid"
+      statusOnError:
+        code: GatewayTimeout
+    filterName: envoy.ext_authz
+    filterType: HTTP
+    insertPosition:
+      index: FIRST
+    listenerMatch:
+      listenerType: GATEWAY
+`)
+	th.writeF("/manifests/istio/oidc-authservice/base/pvc.yaml", `
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: authservice-pvc
+spec:
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: 10Gi`)
+	th.writeF("/manifests/istio/oidc-authservice/base/params.yaml", `
+varReference:
+- path: spec/template/spec/containers/env/value
+  kind: Deployment
+- path: spec/filters/filterConfig/httpService/serverUri/uri
+  kind: EnvoyFilter
+- path: spec/filters/filterConfig/httpService/serverUri/cluster
+  kind: EnvoyFilter`)
+	th.writeF("/manifests/istio/oidc-authservice/base/params.env", `
+client_id=ldapdexapp
+oidc_provider=
+oidc_redirect_uri=
+oidc_auth_url=
+application_secret=pUBnBOY80SnXgjibTYM9ZWNzY2xreNGQok
+skip_auth_uri=
+userid-header=
+userid-prefix=
+namespace=istio-system`)
+	th.writeK("/manifests/istio/oidc-authservice/base", `
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+- service.yaml
+- deployment.yaml
+- envoy-filter.yaml
+- pvc.yaml
+
+namespace: istio-system
+
+configMapGenerator:
+- name: oidc-authservice-parameters
+  env: params.env
+generatorOptions:
+  disableNameSuffixHash: true
+
+vars:
+- name: client_id
+  objref:
+    kind: ConfigMap
+    name: oidc-authservice-parameters
+    apiVersion: v1
+  fieldref:
+    fieldpath: data.client_id
+- name: oidc_provider
+  objref:
+    kind: ConfigMap
+    name: oidc-authservice-parameters
+    apiVersion: v1
+  fieldref:
+    fieldpath: data.oidc_provider
+- name: oidc_redirect_uri
+  objref:
+    kind: ConfigMap
+    name: oidc-authservice-parameters
+    apiVersion: v1
+  fieldref:
+    fieldpath: data.oidc_redirect_uri
+- name: oidc_auth_url
+  objref:
+    kind: ConfigMap
+    name: oidc-authservice-parameters
+    apiVersion: v1
+  fieldref:
+    fieldpath: data.oidc_auth_url
+- name: application_secret
+  objref:
+    kind: ConfigMap
+    name: oidc-authservice-parameters
+    apiVersion: v1
+  fieldref:
+    fieldpath: data.application_secret
+- name: skip_auth_uri
+  objref:
+    kind: ConfigMap
+    name: oidc-authservice-parameters
+    apiVersion: v1
+  fieldref:
+    fieldpath: data.skip_auth_uri
+- name: userid-header
+  objref:
+    kind: ConfigMap
+    name: oidc-authservice-parameters
+    apiVersion: v1
+  fieldref:
+    fieldpath: data.userid-header
+- name: userid-prefix
+  objref:
+    kind: ConfigMap
+    name: oidc-authservice-parameters
+    apiVersion: v1
+  fieldref:
+    fieldpath: data.userid-prefix
+- name: namespace
+  objref:
+    kind: ConfigMap
+    name: oidc-authservice-parameters
+    apiVersion: v1
+  fieldref:
+    fieldpath: data.namespace
+configurations:
+- params.yaml
+images:
+- name: gcr.io/arrikto/kubeflow/oidc-authservice
+  newName: gcr.io/arrikto/kubeflow/oidc-authservice
+  newTag: 6ac9400
+`)
+}
+
+func TestOidcAuthserviceBase(t *testing.T) {
+	th := NewKustTestHarness(t, "/manifests/istio/oidc-authservice/base")
+	writeOidcAuthserviceBase(th)
+	m, err := th.makeKustTarget().MakeCustomizedResMap()
+	if err != nil {
+		t.Fatalf("Err: %v", err)
+	}
+	expected, err := m.AsYaml()
+	if err != nil {
+		t.Fatalf("Err: %v", err)
+	}
+	targetPath := "../istio/oidc-authservice/base"
+	fsys := fs.MakeRealFS()
+	lrc := loader.RestrictionRootOnly
+	_loader, loaderErr := loader.NewLoader(lrc, validators.MakeFakeValidator(), targetPath, fsys)
+	if loaderErr != nil {
+		t.Fatalf("could not load kustomize loader: %v", loaderErr)
+	}
+	rf := resmap.NewFactory(resource.NewFactory(kunstruct.NewKunstructuredFactoryImpl()), transformer.NewFactoryImpl())
+	pc := plugins.DefaultPluginConfig()
+	kt, err := target.NewKustTarget(_loader, rf, transformer.NewFactoryImpl(), plugins.NewLoader(pc, rf))
+	if err != nil {
+		th.t.Fatalf("Unexpected construction error %v", err)
+	}
+	actual, err := kt.MakeCustomizedResMap()
+	if err != nil {
+		t.Fatalf("Err: %v", err)
+	}
+	th.assertActualEqualsExpected(actual, string(expected))
+}

--- a/tests/oidc-authservice-overlays-application_test.go
+++ b/tests/oidc-authservice-overlays-application_test.go
@@ -1,0 +1,332 @@
+package tests_test
+
+import (
+	"sigs.k8s.io/kustomize/v3/k8sdeps/kunstruct"
+	"sigs.k8s.io/kustomize/v3/k8sdeps/transformer"
+	"sigs.k8s.io/kustomize/v3/pkg/fs"
+	"sigs.k8s.io/kustomize/v3/pkg/loader"
+	"sigs.k8s.io/kustomize/v3/pkg/plugins"
+	"sigs.k8s.io/kustomize/v3/pkg/resmap"
+	"sigs.k8s.io/kustomize/v3/pkg/resource"
+	"sigs.k8s.io/kustomize/v3/pkg/target"
+	"sigs.k8s.io/kustomize/v3/pkg/validators"
+	"testing"
+)
+
+func writeOidcAuthserviceOverlaysApplication(th *KustTestHarness) {
+	th.writeF("/manifests/istio/oidc-authservice/overlays/application/application.yaml", `
+ 
+apiVersion: app.k8s.io/v1beta1
+kind: Application
+metadata:
+  name: oidc-authservice
+spec:
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: oidc-authservice
+      app.kubernetes.io/instance: oidc-authservice-v0.7.0
+      app.kubernetes.io/managed-by: kfctl
+      app.kubernetes.io/component: oidc-authservice
+      app.kubernetes.io/part-of: kubeflow
+      app.kubernetes.io/version: v0.7.0
+  componentKinds:
+  - group: apps
+    kind: Deployment
+  - group: core
+    kind: Service
+  - group: core
+    kind: PersistentVolumeClaim
+  - group: networking.istio.io
+    kind: EnvoyFilter
+  descriptor:
+    type: oidc-authservice
+    version: v1beta1
+    description: Provides OIDC-based authentication for Kubeflow Applications, at the Istio Gateway.
+    maintainers:
+    - name: Yannis Zarkadas
+      email: yanniszark@arrikto.com
+    owners:
+    - name: Yannis Zarkadas
+      email: yanniszark@arrikto.com
+    keywords:
+     - oidc
+     - authservice
+     - authentication  
+    links:
+    - description: About
+      url: https://github.com/kubeflow/kubeflow/tree/master/components/oidc-authservice
+    - description: Docs
+      url: https://www.kubeflow.org/docs/started/k8s/kfctl-existing-arrikto
+  addOwnerRef: true
+`)
+	th.writeK("/manifests/istio/oidc-authservice/overlays/application", `
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+bases:
+- ../../base
+resources:
+- application.yaml
+commonLabels:
+  app.kubernetes.io/name: oidc-authservice
+  app.kubernetes.io/instance: oidc-authservice-v0.7.0
+  app.kubernetes.io/managed-by: kfctl
+  app.kubernetes.io/component: oidc-authservice
+  app.kubernetes.io/part-of: kubeflow
+  app.kubernetes.io/version: v0.7.0`)
+	th.writeF("/manifests/istio/oidc-authservice/base/service.yaml", `
+apiVersion: v1
+kind: Service
+metadata:
+  name: authservice
+spec:
+  type: ClusterIP
+  selector:
+    app: authservice
+  ports:
+  - port: 8080
+    name: http-authservice
+    targetPort: http-api`)
+	th.writeF("/manifests/istio/oidc-authservice/base/deployment.yaml", `
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: authservice
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: authservice
+  strategy:
+    type: RollingUpdate
+  template:
+    metadata:
+      annotations:
+        sidecar.istio.io/inject: "false"
+      labels:
+        app: authservice
+    spec:
+      containers:
+      - name: authservice
+        image: gcr.io/arrikto/kubeflow/oidc-authservice:6ac9400
+        imagePullPolicy: Always
+        ports:
+        - name: http-api
+          containerPort: 8080
+        env:
+          - name: USERID_HEADER
+            value: $(userid-header)
+          - name: USERID_PREFIX
+            value: $(userid-prefix)
+          - name: USERID_CLAIM
+            value: email
+          - name: OIDC_PROVIDER
+            value: $(oidc_provider)
+          - name: OIDC_AUTH_URL
+            value: $(oidc_auth_url)
+          - name: OIDC_SCOPES
+            value: "profile email groups"
+          - name: REDIRECT_URL
+            value: $(oidc_redirect_uri)
+          - name: SKIP_AUTH_URI
+            value: $(skip_auth_uri)
+          - name: PORT
+            value: "8080"
+          - name: CLIENT_ID
+            value: $(client_id)
+          - name: CLIENT_SECRET
+            value: $(application_secret)
+          - name: STORE_PATH
+            value: /var/lib/authservice/data.db
+        volumeMounts:
+          - name: data
+            mountPath: /var/lib/authservice
+      securityContext:
+        fsGroup: 111
+      volumes:
+        - name: data
+          persistentVolumeClaim:
+              claimName: authservice-pvc          
+`)
+	th.writeF("/manifests/istio/oidc-authservice/base/envoy-filter.yaml", `
+apiVersion: networking.istio.io/v1alpha3
+kind: EnvoyFilter
+metadata:
+  name: authn-filter
+spec:
+  workloadLabels:
+    istio: ingressgateway
+  filters:
+  - filterConfig:
+      httpService:
+        serverUri:
+          uri: http://authservice.$(namespace).svc.cluster.local
+          cluster: outbound|8080||authservice.$(namespace).svc.cluster.local
+          failureModeAllow: false
+          timeout: 10s
+        authorizationRequest: 
+          allowedHeaders:
+            patterns:
+            - exact: "cookie"
+        authorizationResponse:
+          allowedUpstreamHeaders:
+            patterns:
+            - exact: "kubeflow-userid"
+      statusOnError:
+        code: GatewayTimeout
+    filterName: envoy.ext_authz
+    filterType: HTTP
+    insertPosition:
+      index: FIRST
+    listenerMatch:
+      listenerType: GATEWAY
+`)
+	th.writeF("/manifests/istio/oidc-authservice/base/pvc.yaml", `
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: authservice-pvc
+spec:
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: 10Gi`)
+	th.writeF("/manifests/istio/oidc-authservice/base/params.yaml", `
+varReference:
+- path: spec/template/spec/containers/env/value
+  kind: Deployment
+- path: spec/filters/filterConfig/httpService/serverUri/uri
+  kind: EnvoyFilter
+- path: spec/filters/filterConfig/httpService/serverUri/cluster
+  kind: EnvoyFilter`)
+	th.writeF("/manifests/istio/oidc-authservice/base/params.env", `
+client_id=ldapdexapp
+oidc_provider=
+oidc_redirect_uri=
+oidc_auth_url=
+application_secret=pUBnBOY80SnXgjibTYM9ZWNzY2xreNGQok
+skip_auth_uri=
+userid-header=
+userid-prefix=
+namespace=istio-system`)
+	th.writeK("/manifests/istio/oidc-authservice/base", `
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+- service.yaml
+- deployment.yaml
+- envoy-filter.yaml
+- pvc.yaml
+
+namespace: istio-system
+
+configMapGenerator:
+- name: oidc-authservice-parameters
+  env: params.env
+generatorOptions:
+  disableNameSuffixHash: true
+
+vars:
+- name: client_id
+  objref:
+    kind: ConfigMap
+    name: oidc-authservice-parameters
+    apiVersion: v1
+  fieldref:
+    fieldpath: data.client_id
+- name: oidc_provider
+  objref:
+    kind: ConfigMap
+    name: oidc-authservice-parameters
+    apiVersion: v1
+  fieldref:
+    fieldpath: data.oidc_provider
+- name: oidc_redirect_uri
+  objref:
+    kind: ConfigMap
+    name: oidc-authservice-parameters
+    apiVersion: v1
+  fieldref:
+    fieldpath: data.oidc_redirect_uri
+- name: oidc_auth_url
+  objref:
+    kind: ConfigMap
+    name: oidc-authservice-parameters
+    apiVersion: v1
+  fieldref:
+    fieldpath: data.oidc_auth_url
+- name: application_secret
+  objref:
+    kind: ConfigMap
+    name: oidc-authservice-parameters
+    apiVersion: v1
+  fieldref:
+    fieldpath: data.application_secret
+- name: skip_auth_uri
+  objref:
+    kind: ConfigMap
+    name: oidc-authservice-parameters
+    apiVersion: v1
+  fieldref:
+    fieldpath: data.skip_auth_uri
+- name: userid-header
+  objref:
+    kind: ConfigMap
+    name: oidc-authservice-parameters
+    apiVersion: v1
+  fieldref:
+    fieldpath: data.userid-header
+- name: userid-prefix
+  objref:
+    kind: ConfigMap
+    name: oidc-authservice-parameters
+    apiVersion: v1
+  fieldref:
+    fieldpath: data.userid-prefix
+- name: namespace
+  objref:
+    kind: ConfigMap
+    name: oidc-authservice-parameters
+    apiVersion: v1
+  fieldref:
+    fieldpath: data.namespace
+configurations:
+- params.yaml
+images:
+- name: gcr.io/arrikto/kubeflow/oidc-authservice
+  newName: gcr.io/arrikto/kubeflow/oidc-authservice
+  newTag: 6ac9400
+`)
+}
+
+func TestOidcAuthserviceOverlaysApplication(t *testing.T) {
+	th := NewKustTestHarness(t, "/manifests/istio/oidc-authservice/overlays/application")
+	writeOidcAuthserviceOverlaysApplication(th)
+	m, err := th.makeKustTarget().MakeCustomizedResMap()
+	if err != nil {
+		t.Fatalf("Err: %v", err)
+	}
+	expected, err := m.AsYaml()
+	if err != nil {
+		t.Fatalf("Err: %v", err)
+	}
+	targetPath := "../istio/oidc-authservice/overlays/application"
+	fsys := fs.MakeRealFS()
+	lrc := loader.RestrictionRootOnly
+	_loader, loaderErr := loader.NewLoader(lrc, validators.MakeFakeValidator(), targetPath, fsys)
+	if loaderErr != nil {
+		t.Fatalf("could not load kustomize loader: %v", loaderErr)
+	}
+	rf := resmap.NewFactory(resource.NewFactory(kunstruct.NewKunstructuredFactoryImpl()), transformer.NewFactoryImpl())
+	pc := plugins.DefaultPluginConfig()
+	kt, err := target.NewKustTarget(_loader, rf, transformer.NewFactoryImpl(), plugins.NewLoader(pc, rf))
+	if err != nil {
+		th.t.Fatalf("Unexpected construction error %v", err)
+	}
+	actual, err := kt.MakeCustomizedResMap()
+	if err != nil {
+		t.Fatalf("Err: %v", err)
+	}
+	th.assertActualEqualsExpected(actual, string(expected))
+}

--- a/tests/profiles-base_test.go
+++ b/tests/profiles-base_test.go
@@ -184,8 +184,7 @@ status:
     kind: ""
     plural: ""
   conditions: []
-  storedVersions: []
-`)
+  storedVersions: []`)
 	th.writeF("/manifests/profiles/base/deployment.yaml", `
 apiVersion: apps/v1
 kind: Deployment
@@ -229,8 +228,7 @@ metadata:
   name: kfam
 spec:
   ports:
-    - port: 8081
-`)
+    - port: 8081`)
 	th.writeF("/manifests/profiles/base/service-account.yaml", `
 apiVersion: v1
 kind: ServiceAccount

--- a/tests/profiles-overlays-application_test.go
+++ b/tests/profiles-overlays-application_test.go
@@ -240,8 +240,7 @@ status:
     kind: ""
     plural: ""
   conditions: []
-  storedVersions: []
-`)
+  storedVersions: []`)
 	th.writeF("/manifests/profiles/base/deployment.yaml", `
 apiVersion: apps/v1
 kind: Deployment
@@ -285,8 +284,7 @@ metadata:
   name: kfam
 spec:
   ports:
-    - port: 8081
-`)
+    - port: 8081`)
 	th.writeF("/manifests/profiles/base/service-account.yaml", `
 apiVersion: v1
 kind: ServiceAccount

--- a/tests/profiles-overlays-debug_test.go
+++ b/tests/profiles-overlays-debug_test.go
@@ -243,8 +243,7 @@ status:
     kind: ""
     plural: ""
   conditions: []
-  storedVersions: []
-`)
+  storedVersions: []`)
 	th.writeF("/manifests/profiles/base/deployment.yaml", `
 apiVersion: apps/v1
 kind: Deployment
@@ -288,8 +287,7 @@ metadata:
   name: kfam
 spec:
   ports:
-    - port: 8081
-`)
+    - port: 8081`)
 	th.writeF("/manifests/profiles/base/service-account.yaml", `
 apiVersion: v1
 kind: ServiceAccount

--- a/tests/profiles-overlays-devices_test.go
+++ b/tests/profiles-overlays-devices_test.go
@@ -210,8 +210,7 @@ status:
     kind: ""
     plural: ""
   conditions: []
-  storedVersions: []
-`)
+  storedVersions: []`)
 	th.writeF("/manifests/profiles/base/deployment.yaml", `
 apiVersion: apps/v1
 kind: Deployment
@@ -255,8 +254,7 @@ metadata:
   name: kfam
 spec:
   ports:
-    - port: 8081
-`)
+    - port: 8081`)
 	th.writeF("/manifests/profiles/base/service-account.yaml", `
 apiVersion: v1
 kind: ServiceAccount

--- a/tests/profiles-overlays-istio_test.go
+++ b/tests/profiles-overlays-istio_test.go
@@ -225,8 +225,7 @@ status:
     kind: ""
     plural: ""
   conditions: []
-  storedVersions: []
-`)
+  storedVersions: []`)
 	th.writeF("/manifests/profiles/base/deployment.yaml", `
 apiVersion: apps/v1
 kind: Deployment
@@ -270,8 +269,7 @@ metadata:
   name: kfam
 spec:
   ports:
-    - port: 8081
-`)
+    - port: 8081`)
 	th.writeF("/manifests/profiles/base/service-account.yaml", `
 apiVersion: v1
 kind: ServiceAccount

--- a/tests/profiles-overlays-test_test.go
+++ b/tests/profiles-overlays-test_test.go
@@ -192,8 +192,7 @@ status:
     kind: ""
     plural: ""
   conditions: []
-  storedVersions: []
-`)
+  storedVersions: []`)
 	th.writeF("/manifests/profiles/base/deployment.yaml", `
 apiVersion: apps/v1
 kind: Deployment
@@ -237,8 +236,7 @@ metadata:
   name: kfam
 spec:
   ports:
-    - port: 8081
-`)
+    - port: 8081`)
 	th.writeF("/manifests/profiles/base/service-account.yaml", `
 apiVersion: v1
 kind: ServiceAccount


### PR DESCRIPTION
**Which issue is resolved by this Pull Request:**
Resolves #267
Resolves https://github.com/kubeflow/kubeflow/issues/3839

**Description of your changes:**
This PR adds the AuthService to manifests.

It also adds those new capabilities to the existing_arrikto config.

Some small changes that were made to the Dex application:
* Add VirtualService in istio overlay.
* Use the latest image built from master, so as to include https://github.com/dexidp/dex/pull/1554

**Checklist:**
- [X] Unit tests have been rebuilt: 
    1. `cd manifests/tests`
    2. `make generate`
    3. `make test`

/cc @krishnadurai @elikatsis

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/manifests/529)
<!-- Reviewable:end -->
