### PR TITLE
Metadata add readiness probe & reduce replicas#

### DIFF
--- a/metadata/base/metadata-deployment.yaml
+++ b/metadata/base/metadata-deployment.yaml
@@ -5,7 +5,7 @@ metadata:
   labels:
     component: server
 spec:
-  replicas: 3
+  replicas: 2
   selector:
     matchLabels:
       component: server
@@ -33,6 +33,17 @@ spec:
         ports:
         - name: backendapi
           containerPort: 8080
+
+        readinessProbe:
+          httpGet:
+            path: /api/v1alpha1/artifact_types
+            port: backendapi
+            httpHeaders:
+            - name: ContentType
+              value: application/json
+          initialDelaySeconds: 3
+          periodSeconds: 5
+          timeoutSeconds: 2
 ---
 apiVersion: apps/v1
 kind: Deployment
@@ -41,7 +52,7 @@ metadata:
   labels:
     component: grpc-server
 spec:
-  replicas: 3
+  replicas: 2
   selector:
     matchLabels:
       component: grpc-server

--- a/tests/metadata-base_test.go
+++ b/tests/metadata-base_test.go
@@ -110,7 +110,7 @@ metadata:
   labels:
     component: server
 spec:
-  replicas: 3
+  replicas: 2
   selector:
     matchLabels:
       component: server
@@ -138,6 +138,17 @@ spec:
         ports:
         - name: backendapi
           containerPort: 8080
+
+        readinessProbe:
+          httpGet:
+            path: /api/v1alpha1/artifact_types
+            port: backendapi
+            httpHeaders:
+            - name: ContentType
+              value: application/json
+          initialDelaySeconds: 3
+          periodSeconds: 5
+          timeoutSeconds: 2
 ---
 apiVersion: apps/v1
 kind: Deployment
@@ -146,7 +157,7 @@ metadata:
   labels:
     component: grpc-server
 spec:
-  replicas: 3
+  replicas: 2
   selector:
     matchLabels:
       component: grpc-server

--- a/tests/metadata-overlays-application_test.go
+++ b/tests/metadata-overlays-application_test.go
@@ -167,7 +167,7 @@ metadata:
   labels:
     component: server
 spec:
-  replicas: 3
+  replicas: 2
   selector:
     matchLabels:
       component: server
@@ -195,6 +195,17 @@ spec:
         ports:
         - name: backendapi
           containerPort: 8080
+
+        readinessProbe:
+          httpGet:
+            path: /api/v1alpha1/artifact_types
+            port: backendapi
+            httpHeaders:
+            - name: ContentType
+              value: application/json
+          initialDelaySeconds: 3
+          periodSeconds: 5
+          timeoutSeconds: 2
 ---
 apiVersion: apps/v1
 kind: Deployment
@@ -203,7 +214,7 @@ metadata:
   labels:
     component: grpc-server
 spec:
-  replicas: 3
+  replicas: 2
   selector:
     matchLabels:
       component: grpc-server

--- a/tests/metadata-overlays-istio_test.go
+++ b/tests/metadata-overlays-istio_test.go
@@ -172,7 +172,7 @@ metadata:
   labels:
     component: server
 spec:
-  replicas: 3
+  replicas: 2
   selector:
     matchLabels:
       component: server
@@ -200,6 +200,17 @@ spec:
         ports:
         - name: backendapi
           containerPort: 8080
+
+        readinessProbe:
+          httpGet:
+            path: /api/v1alpha1/artifact_types
+            port: backendapi
+            httpHeaders:
+            - name: ContentType
+              value: application/json
+          initialDelaySeconds: 3
+          periodSeconds: 5
+          timeoutSeconds: 2
 ---
 apiVersion: apps/v1
 kind: Deployment
@@ -208,7 +219,7 @@ metadata:
   labels:
     component: grpc-server
 spec:
-  replicas: 3
+  replicas: 2
   selector:
     matchLabels:
       component: grpc-server


### PR DESCRIPTION
**Description of your changes:**
- Add the readiness probe so that the pods won't serve traffic until they are connected to the DB.
- Reduce the #replicas from 3 to 2.

**Checklist:**
- [x] Unit tests have been rebuilt: 
    1. `cd manifests/tests`
    2. `make generate`
    3. `make test`

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/manifests/531)
<!-- Reviewable:end -->
