### PR TITLE
Update operator images to 0.7tag

### DIFF
--- a/pytorch-job/pytorch-operator/base/kustomization.yaml
+++ b/pytorch-job/pytorch-operator/base/kustomization.yaml
@@ -12,4 +12,4 @@ commonLabels:
 images:
 - name: gcr.io/kubeflow-images-public/pytorch-operator
   newName: gcr.io/kubeflow-images-public/pytorch-operator
-  newTag: v0.6.0-18-g5e36a57
+  newTag: v0.7.0

--- a/tests/pytorch-operator-base_test.go
+++ b/tests/pytorch-operator-base_test.go
@@ -200,7 +200,7 @@ commonLabels:
 images:
 - name: gcr.io/kubeflow-images-public/pytorch-operator
   newName: gcr.io/kubeflow-images-public/pytorch-operator
-  newTag: v0.6.0-18-g5e36a57
+  newTag: v0.7.0
 `)
 }
 

--- a/tests/pytorch-operator-overlays-application_test.go
+++ b/tests/pytorch-operator-overlays-application_test.go
@@ -261,7 +261,7 @@ commonLabels:
 images:
 - name: gcr.io/kubeflow-images-public/pytorch-operator
   newName: gcr.io/kubeflow-images-public/pytorch-operator
-  newTag: v0.6.0-18-g5e36a57
+  newTag: v0.7.0
 `)
 }
 

--- a/tests/tf-job-operator-base_test.go
+++ b/tests/tf-job-operator-base_test.go
@@ -214,7 +214,7 @@ commonLabels:
 images:
 - name: gcr.io/kubeflow-images-public/tf_operator
   newName: gcr.io/kubeflow-images-public/tf_operator
-  newTag: kubeflow-tf-operator-postsubmit-v1-5adee6f-6109-a25c
+  newTag: v0.7.0
 `)
 }
 

--- a/tests/tf-job-operator-overlays-application_test.go
+++ b/tests/tf-job-operator-overlays-application_test.go
@@ -273,7 +273,7 @@ commonLabels:
 images:
 - name: gcr.io/kubeflow-images-public/tf_operator
   newName: gcr.io/kubeflow-images-public/tf_operator
-  newTag: kubeflow-tf-operator-postsubmit-v1-5adee6f-6109-a25c
+  newTag: v0.7.0
 `)
 }
 

--- a/tf-training/tf-job-operator/base/kustomization.yaml
+++ b/tf-training/tf-job-operator/base/kustomization.yaml
@@ -12,4 +12,4 @@ commonLabels:
 images:
 - name: gcr.io/kubeflow-images-public/tf_operator
   newName: gcr.io/kubeflow-images-public/tf_operator
-  newTag: kubeflow-tf-operator-postsubmit-v1-5adee6f-6109-a25c
+  newTag: v0.7.0


### PR DESCRIPTION
Pin operator images to 0.7 tagged one. 

**Checklist:**
- [x] Unit tests have been rebuilt: 
    1. `cd manifests/tests`
    2. `make generate`
    3. `make test`

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/manifests/535)
<!-- Reviewable:end -->
