### PR TITLE
kubeflow on GCP: create empty GPU pool by default

### DIFF
--- a/gcp/deployment_manager_configs/cluster-kubeflow.yaml
+++ b/gcp/deployment_manager_configs/cluster-kubeflow.yaml
@@ -62,7 +62,7 @@ resources:
     # set gpu-pool-max-nodes to a none-zero value.
     gpu-pool-enable-autoscaling: true
     gpu-pool-min-nodes: 0
-    gpu-pool-max-nodes: 0
+    gpu-pool-max-nodes: 10
     # Controls gpu number per node, valid input: [1, num_cpu_per_node], for n1-standard-8, num_cpu_per_node = 8
     gpu-number-per-node: 1
     # Check https://cloud.google.com/compute/docs/gpus/ for available GPU models and their regions

--- a/tests/profiles-overlays-test_test.go
+++ b/tests/profiles-overlays-test_test.go
@@ -22,13 +22,24 @@ bases:
 #generators:
 #- app_test.yaml
 `)
+	th.writeF("/manifests/profiles/base/cluster-role-binding.yaml", `
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: cluster-role-binding
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: cluster-admin
+subjects:
+- kind: ServiceAccount
+  name: controller-service-account
+`)
 	th.writeF("/manifests/profiles/base/crd.yaml", `
 apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
 metadata:
   creationTimestamp: null
-  labels:
-    controller-tools.k8s.io: "1.0"
   name: profiles.kubeflow.org
 spec:
   group: kubeflow.org
@@ -36,8 +47,11 @@ spec:
     kind: Profile
     plural: profiles
   scope: Cluster
+  subresources:
+    status: {}
   validation:
     openAPIV3Schema:
+      description: Profile is the Schema for the profiles API
       properties:
         apiVersion:
           description: 'APIVersion defines the versioned schema of this representation
@@ -52,22 +66,127 @@ spec:
         metadata:
           type: object
         spec:
+          description: ProfileSpec defines the desired state of Profile
           properties:
             owner:
               description: The profile owner
+              properties:
+                apiGroup:
+                  description: APIGroup holds the API group of the referenced subject.
+                    Defaults to "" for ServiceAccount subjects. Defaults to "rbac.authorization.k8s.io"
+                    for User and Group subjects.
+                  type: string
+                kind:
+                  description: Kind of object being referenced. Values defined by
+                    this API group are "User", "Group", and "ServiceAccount". If the
+                    Authorizer does not recognized the kind value, the Authorizer
+                    should report an error.
+                  type: string
+                name:
+                  description: Name of the object being referenced.
+                  type: string
+              required:
+                - kind
+                - name
+              type: object
+            plugins:
+              items:
+                description: Plugin is for customize actions on different platform.
+                properties:
+                  apiVersion:
+                    description: 'APIVersion defines the versioned schema of this
+                      representation of an object. Servers should convert recognized
+                      schemas to the latest internal value, and may reject unrecognized
+                      values. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#resources'
+                    type: string
+                  kind:
+                    description: 'Kind is a string value representing the REST resource
+                      this object represents. Servers may infer this from the endpoint
+                      the client submits requests to. Cannot be updated. In CamelCase.
+                      More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds'
+                    type: string
+                  spec:
+                    type: object
+                type: object
+              type: array
+            resourcequotaspec:
+              description: Resourcequota that will be applied to target namespace
+              properties:
+                hard:
+                  additionalProperties:
+                    type: string
+                  description: 'hard is the set of desired hard limits for each named
+                    resource. More info: https://kubernetes.io/docs/concepts/policy/resource-quotas/'
+                  type: object
+                scopeSelector:
+                  description: scopeSelector is also a collection of filters like
+                    scopes that must match each object tracked by a quota but expressed
+                    using ScopeSelectorOperator in combination with possible values.
+                    For a resource to match, both scopes AND scopeSelector (if specified
+                    in spec), must be matched.
+                  properties:
+                    matchExpressions:
+                      description: A list of scope selector requirements by scope
+                        of the resources.
+                      items:
+                        description: A scoped-resource selector requirement is a selector
+                          that contains values, a scope name, and an operator that
+                          relates the scope name and values.
+                        properties:
+                          operator:
+                            description: Represents a scope's relationship to a set
+                              of values. Valid operators are In, NotIn, Exists, DoesNotExist.
+                            type: string
+                          scopeName:
+                            description: The name of the scope that the selector applies
+                              to.
+                            type: string
+                          values:
+                            description: An array of string values. If the operator
+                              is In or NotIn, the values array must be non-empty.
+                              If the operator is Exists or DoesNotExist, the values
+                              array must be empty. This array is replaced during a
+                              strategic merge patch.
+                            items:
+                              type: string
+                            type: array
+                        required:
+                          - operator
+                          - scopeName
+                        type: object
+                      type: array
+                  type: object
+                scopes:
+                  description: A collection of filters that must match each object
+                    tracked by a quota. If not specified, the quota matches all objects.
+                  items:
+                    description: A ResourceQuotaScope defines a filter that must match
+                      each object tracked by a quota
+                    type: string
+                  type: array
               type: object
           type: object
         status:
+          description: ProfileStatus defines the observed state of Profile
           properties:
-            message:
-              type: string
-            status:
-              description: 'INSERT ADDITIONAL STATUS FIELD - define observed state
-                of cluster Important: Run "make" to regenerate code after modifying
-                this file'
-              type: string
+            conditions:
+              items:
+                properties:
+                  message:
+                    type: string
+                  status:
+                    type: string
+                  type:
+                    type: string
+                type: object
+              type: array
           type: object
-  version: v1alpha1
+      type: object
+  version: v1beta1
+  versions:
+    - name: v1beta1
+      served: true
+      storage: true
 status:
   acceptedNames:
     kind: ""
@@ -75,74 +194,13 @@ status:
   conditions: []
   storedVersions: []
 `)
-	th.writeF("/manifests/profiles/base/service-account.yaml", `
----
-apiVersion: v1
-kind: ServiceAccount
-metadata:
-  name: controller-service-account
----
-apiVersion: v1
-kind: ServiceAccount
-metadata:
-  name: default-service-account
-`)
-	th.writeF("/manifests/profiles/base/cluster-role-binding.yaml", `
-apiVersion: rbac.authorization.k8s.io/v1
-kind: ClusterRoleBinding
-metadata:
-  name: cluster-role-binding
-roleRef:
-  apiGroup: rbac.authorization.k8s.io
-  kind: ClusterRole
-  name: cluster-admin
-subjects:
-- kind: ServiceAccount
-  name: controller-service-account
-`)
-	th.writeF("/manifests/profiles/base/role.yaml", `
-apiVersion: rbac.authorization.k8s.io/v1
-kind: Role
-metadata:
-  name: default-role
-rules:
-- apiGroups:
-  - kubeflow.org
-  resources:
-  - profiles
-  verbs:
-  - create
-  - watch
-  - list
-`)
-	th.writeF("/manifests/profiles/base/role-binding.yaml", `
-apiVersion: rbac.authorization.k8s.io/v1
-kind: RoleBinding
-metadata:
-  name: default-role-binding
-roleRef:
-  apiGroup: rbac.authorization.k8s.io
-  kind: Role
-  name: default-role
-subjects:
-- kind: ServiceAccount
-  name: default-service-account
-`)
-	th.writeF("/manifests/profiles/base/service.yaml", `
-apiVersion: v1
-kind: Service
-metadata:
-  name: kfam
-spec:
-  ports:
-    - port: 8081
-`)
 	th.writeF("/manifests/profiles/base/deployment.yaml", `
 apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: deployment
 spec:
+  replicas: 1
   template:
     spec:
       containers:
@@ -153,6 +211,8 @@ spec:
         - $(userid-header)
         - "-userid-prefix"
         - $(userid-prefix)
+        - "-workload-identity"
+        - $(gcp-sa)
         image: gcr.io/kubeflow-images-public/profile-controller:v20190619-v0-219-gbd3daa8c-dirty-1ced0e
         imagePullPolicy: Always
         name: manager
@@ -170,11 +230,28 @@ spec:
         name: kfam
       serviceAccountName: controller-service-account
 `)
+	th.writeF("/manifests/profiles/base/service.yaml", `
+apiVersion: v1
+kind: Service
+metadata:
+  name: kfam
+spec:
+  ports:
+    - port: 8081
+`)
+	th.writeF("/manifests/profiles/base/service-account.yaml", `
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: controller-service-account
+`)
 	th.writeF("/manifests/profiles/base/params.yaml", `
 varReference:
 - path: spec/template/spec/containers/0/args/1
   kind: Deployment
 - path: spec/template/spec/containers/0/args/3
+  kind: Deployment
+- path: spec/template/spec/containers/0/args/5
   kind: Deployment
 - path: spec/template/spec/containers/1/args/1
   kind: Deployment
@@ -184,7 +261,8 @@ varReference:
   kind: Deployment
 `)
 	th.writeF("/manifests/profiles/base/params.env", `
-admin=
+admin=anonymous
+gcp-sa=
 userid-header=
 userid-prefix=
 `)
@@ -192,13 +270,11 @@ userid-prefix=
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
-- crd.yaml
-- service-account.yaml
 - cluster-role-binding.yaml
-- role.yaml
-- role-binding.yaml
-- service.yaml
+- crd.yaml
 - deployment.yaml
+- service.yaml
+- service-account.yaml
 namePrefix: profiles-
 namespace: kubeflow
 commonLabels:
@@ -208,11 +284,9 @@ configMapGenerator:
   env: params.env
 images:
 - name: gcr.io/kubeflow-images-public/profile-controller
-  newName: gcr.io/kubeflow-images-public/profile-controller
-  newTag: v20190619-v0-219-gbd3daa8c-dirty-1ced0e
+  digest: sha256:f0011f9c8b73e8a26e2ea203394031104d09753f684177caf1017c15aac658f9
 - name: gcr.io/kubeflow-images-public/kfam
-  newName: gcr.io/kubeflow-images-public/kfam
-  newTag: v20190612-v0-170-ga06cdb79-dirty-a33ee4
+  digest: sha256:3b0d4be7e59a3fa5ed1d80dccc832312caa94f3b2d36682524d3afc4e45164f0
 vars:
 - name: admin
   objref:
@@ -221,6 +295,13 @@ vars:
     apiVersion: v1
   fieldref:
     fieldpath: data.admin
+- name: gcp-sa
+  objref:
+    kind: ConfigMap
+    name: profiles-parameters
+    apiVersion: v1
+  fieldref:
+    fieldpath: data.gcp-sa
 - name: userid-header
   objref:
     kind: ConfigMap


### PR DESCRIPTION

**Description of your changes:**
DM will create empty GPU pool by default when user deploy on GKE.


**Checklist:**
- [x] Unit tests have been rebuilt: 
    1. `cd manifests/tests`
    2. `make generate`
    3. `make test`

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/manifests/541)
<!-- Reviewable:end -->
