### PR TITLE
Migrate KfDef to v1beta1

### DIFF
--- a/kfdef/kfctl_gcp_basic_auth.yaml
+++ b/kfdef/kfctl_gcp_basic_auth.yaml
@@ -304,6 +304,8 @@ spec:
       - istio
       parameters:
       - name: admin
+        # email will be auto-filled.
+        # value: SET_EMAIL
       repoRef:
         name: manifests
         path: profiles
@@ -345,9 +347,14 @@ spec:
       - name: namespace
         value: istio-system
       - name: ipName
-        value: test1-ip
+        # ipName will be auto-filled based on app name if not set.
+        # value: test1-ip
       - name: hostname
+        # hostname will be auto-filled if not set.
+        # value: <deployName>.endpoints.<project>.cloud.goog
       - name: project
+        # Project will be auto-filled.
+        # value: SET_PROJECT
       - name: ingressName
         value: envoy-ingress
       - name: issuer
@@ -375,6 +382,15 @@ spec:
       enableWorkloadIdentity: true
       skipInitProject: true
       useBasicAuth: true
+      # email should  be set the google account of the person setting up Kubeflow.
+      # If its not set kfctl generate will try to set it automatically based on the default
+      # gcloud config
+      # email: <your_email@gmail.com>
+      #
+      # Project should be set to the GCP project you want to use.
+      # If you run kfctl init --config=<path>/kfctl_gcp_iap.yaml
+      # kfctl will try to automatically set it.
+      # project: <your project>
   repos:
   - name: manifests
     uri: https://github.com/kubeflow/manifests/archive/master.tar.gz

--- a/kfdef/kfctl_gcp_basic_auth.yaml
+++ b/kfdef/kfctl_gcp_basic_auth.yaml
@@ -2,7 +2,6 @@
 apiVersion: kfdef.apps.kubeflow.org/v1beta1
 kind: KfDef
 metadata:
-  creationTimestamp: null
   # If name is not set, kfctl will infer app name from the directory.
   # name: myapp2
   namespace: kubeflow

--- a/kfdef/kfctl_gcp_basic_auth.yaml
+++ b/kfdef/kfctl_gcp_basic_auth.yaml
@@ -390,6 +390,10 @@ spec:
       # If you run kfctl init --config=<path>/kfctl_gcp_iap.yaml
       # kfctl will try to automatically set it.
       # project: <your project>
+      #
+      # User can specify which zone to deploy to. If not set, will try to auto-fill
+      # this field based on default config in gcloud.
+      # zone: us-east1-d
   repos:
   - name: manifests
     uri: https://github.com/kubeflow/manifests/archive/master.tar.gz

--- a/kfdef/kfctl_gcp_basic_auth.yaml
+++ b/kfdef/kfctl_gcp_basic_auth.yaml
@@ -1,8 +1,10 @@
+# Please set project and email!
 apiVersion: kfdef.apps.kubeflow.org/v1beta1
 kind: KfDef
 metadata:
   creationTimestamp: null
-  name: myapp2
+  # If name is not set, kfctl will infer app name from the directory.
+  # name: myapp2
   namespace: kubeflow
 spec:
   applications:

--- a/kfdef/kfctl_gcp_basic_auth.yaml
+++ b/kfdef/kfctl_gcp_basic_auth.yaml
@@ -374,8 +374,6 @@ spec:
       skipInitProject: true
       useBasicAuth: true
   repos:
-  - name: kubeflow
-    uri: https://github.com/kubeflow/kubeflow/archive/master.tar.gz
   - name: manifests
     uri: https://github.com/kubeflow/manifests/archive/master.tar.gz
   version: master

--- a/kfdef/kfctl_gcp_basic_auth.yaml
+++ b/kfdef/kfctl_gcp_basic_auth.yaml
@@ -1,21 +1,10 @@
-# Please set project and email!
-apiVersion: kfdef.apps.kubeflow.org/v1alpha1
+apiVersion: kfdef.apps.kubeflow.org/v1beta1
 kind: KfDef
 metadata:
   creationTimestamp: null
   name: myapp2
   namespace: kubeflow
 spec:
-  repos:
-  - name: kubeflow
-    root: kubeflow-master
-    uri: https://github.com/kubeflow/kubeflow/archive/master.tar.gz
-  - name: manifests
-    root: master/
-    uri: https://github.com/kubeflow/manifests/archive/master.tar.gz
-    # To get manifest at a PR:
-    #uri: https://github.com/kubeflow/manifests/archive/pull/235/head.tar.gz
-  appdir: /tmp/myapp2
   applications:
   - kustomizeConfig:
       parameters:
@@ -174,11 +163,9 @@ spec:
       overlays:
       - application
       parameters:
-      - initRequired: true
-        name: usageId
+      - name: usageId
         value: "2700513155662330975"
-      - initRequired: true
-        name: reportUsage
+      - name: reportUsage
         value: "true"
       repoRef:
         name: manifests
@@ -302,13 +289,9 @@ spec:
       overlays:
       - application
       parameters:
-      - initRequired: true
-        name: ipName
+      - name: ipName
         value: ipName
-      - initRequired: true
-        name: hostname
-        # hostname will be set automatically by kfctl init & generate
-        # value: <deployName>.endpoints.<project>.cloud.goog
+      - name: hostname
       repoRef:
         name: manifests
         path: gcp/cloud-endpoints
@@ -318,10 +301,7 @@ spec:
       - application
       - istio
       parameters:
-      - initRequired: true
-        name: admin
-        # emaill will be set automatically by kfctl init and generate
-        # value: SET_EMAIL
+      - name: admin
       repoRef:
         name: manifests
         path: profiles
@@ -362,17 +342,10 @@ spec:
       parameters:
       - name: namespace
         value: istio-system
-      - initRequired: true
-        name: ipName
+      - name: ipName
         value: test1-ip
-      - initRequired: true
-        name: hostname
-        # project will be set automatically by kfctl init & generate
-        # value: test1.endpoints.SET_PROJECT.cloud.goog
-      - initRequired: true
-        name: project
-        # Project will be set automatically by kfctl init & generate
-        # value: SET_PROJECT
+      - name: hostname
+      - name: project
       - name: ingressName
         value: envoy-ingress
       - name: issuer
@@ -386,15 +359,11 @@ spec:
         name: manifests
         path: default-install
     name: default-install
-  # email should  be set the google account of the person setting up Kubeflow.
-  # If its not set kfctl generate will try to set it automatically based on the default
-  # gcloud config
-  # email: <your_email@gmail.com>
-  enableApplications: true
-  packageManager: kustomize
-  platform: gcp
   plugins:
-  - name: gcp
+  - kind: KfGcpPlugin
+    metadata:
+      creationTimestamp: null
+      name: gcp
     spec:
       createPipelinePersistentStorage: true
       deploymentManagerConfig:
@@ -402,11 +371,12 @@ spec:
           name: manifests
           path: gcp/deployment_manager_configs
       enableWorkloadIdentity: true
-  skipInitProject: true
-  useBasicAuth: true
-  useIstio: true
+      skipInitProject: true
+      useBasicAuth: true
+  repos:
+  - name: kubeflow
+    uri: https://github.com/kubeflow/kubeflow/archive/master.tar.gz
+  - name: manifests
+    uri: https://github.com/kubeflow/manifests/archive/master.tar.gz
   version: master
-  # Project should be set to the GCP project you want to use.
-  # If you run kfctl init --config=<path>/kfctl_gcp_iap.yaml
-  # kfctl will try to automatically set it.
-  # project: <your project>
+status: {}

--- a/kfdef/kfctl_gcp_basic_auth.yaml
+++ b/kfdef/kfctl_gcp_basic_auth.yaml
@@ -398,4 +398,3 @@ spec:
   - name: manifests
     uri: https://github.com/kubeflow/manifests/archive/master.tar.gz
   version: master
-status: {}

--- a/kfdef/kfctl_gcp_iap.yaml
+++ b/kfdef/kfctl_gcp_iap.yaml
@@ -1,17 +1,10 @@
-# Please set project and email!
-apiVersion: kfdef.apps.kubeflow.org/v1alpha1
+apiVersion: kfdef.apps.kubeflow.org/v1beta1
 kind: KfDef
 metadata:
   creationTimestamp: null
   name: myapp2
   namespace: kubeflow
 spec:
-  repos:
-  - name: manifests
-    uri: https://github.com/kubeflow/manifests/archive/master.tar.gz
-    # To get manifest at a PR:
-    #uri: https://github.com/kubeflow/manifests/archive/pull/235/head.tar.gz
-  appdir: /tmp/myapp2
   applications:
   - kustomizeConfig:
       parameters:
@@ -75,7 +68,7 @@ spec:
       - name: userid-header
         value: X-Goog-Authenticated-User-Email
       - name: userid-prefix
-        value: "accounts.google.com:"
+        value: 'accounts.google.com:'
       repoRef:
         name: manifests
         path: common/centraldashboard
@@ -105,7 +98,7 @@ spec:
       - name: userid-header
         value: X-Goog-Authenticated-User-Email
       - name: userid-prefix
-        value: "accounts.google.com:"
+        value: 'accounts.google.com:'
       repoRef:
         name: manifests
         path: jupyter/jupyter-web-app
@@ -180,11 +173,9 @@ spec:
       overlays:
       - application
       parameters:
-      - initRequired: true
-        name: usageId
+      - name: usageId
         value: "7439583937720421527"
-      - initRequired: true
-        name: reportUsage
+      - name: reportUsage
         value: "true"
       repoRef:
         name: manifests
@@ -316,14 +307,12 @@ spec:
       - application
       - istio
       parameters:
-      - initRequired: true
-        # kfctl will set admin to current user account that deploying kubeflow
-        name: admin
+      - name: admin
         value: SET_EMAIL
       - name: userid-header
         value: X-Goog-Authenticated-User-Email
       - name: userid-prefix
-        value: "accounts.google.com:"
+        value: 'accounts.google.com:'
       repoRef:
         name: manifests
         path: profiles
@@ -342,14 +331,9 @@ spec:
       parameters:
       - name: namespace
         value: istio-system
-      - initRequired: true
-        name: ipName
+      - name: ipName
         value: test1-ip
-      - initRequired: true
-        name: hostname
-        # The value of hostname should be the DNS address for ingress.
-        # This will be set automatically during kfctl generate.
-        # value: test1.endpoints.SET_PROJECT.cloud.goog
+      - name: hostname
       repoRef:
         name: manifests
         path: gcp/iap-ingress
@@ -363,25 +347,19 @@ spec:
     name: seldon-core-operator
   - kustomizeConfig:
       parameters:
-        - name: user
-          # kfctl will set user to current user account that deploying kubeflow
-          value: SET_EMAIL
-        - name: profile-name
-          # kfctl might overwrite profile name
-          value: anonymous
+      - name: user
+        value: SET_EMAIL
+      - name: profile-name
+        value: anonymous
       repoRef:
         name: manifests
         path: default-install
     name: default-install
-  # email should  be set the google account of the person setting up Kubeflow.
-  # If its not set kfctl generate will try to set it automatically based on the default
-  # gcloud config
-  # email: <your_email@gmail.com>
-  enableApplications: true
-  packageManager: kustomize
-  platform: gcp
   plugins:
-  - name: gcp
+  - kind: KfGcpPlugin
+    metadata:
+      creationTimestamp: null
+      name: gcp
     spec:
       createPipelinePersistentStorage: true
       deploymentManagerConfig:
@@ -389,11 +367,10 @@ spec:
           name: manifests
           path: gcp/deployment_manager_configs
       enableWorkloadIdentity: true
-  skipInitProject: true
-  useBasicAuth: false
-  useIstio: true
+      skipInitProject: true
+      useBasicAuth: false
+  repos:
+  - name: manifests
+    uri: https://github.com/kubeflow/manifests/archive/master.tar.gz
   version: master
-  # Project should be set to the GCP project you want to use.
-  # If you run kfctl init --config=<path>/kfctl_gcp_iap.yaml
-  # kfctl will try to automatically set it.
-  # project: <your project>
+status: {}

--- a/kfdef/kfctl_gcp_iap.yaml
+++ b/kfdef/kfctl_gcp_iap.yaml
@@ -2,7 +2,6 @@
 apiVersion: kfdef.apps.kubeflow.org/v1beta1
 kind: KfDef
 metadata:
-  creationTimestamp: null
   # If name is not set, kfctl will infer app name from the directory.
   # name: myapp2
   namespace: kubeflow

--- a/kfdef/kfctl_gcp_iap.yaml
+++ b/kfdef/kfctl_gcp_iap.yaml
@@ -386,6 +386,10 @@ spec:
       # If you run kfctl init --config=<path>/kfctl_gcp_iap.yaml
       # kfctl will try to automatically set it.
       # project: <your project>
+      #
+      # User can specify which zone to deploy to. If not set, will try to auto-fill
+      # this field based on default config in gcloud.
+      # zone: us-east1-d
   repos:
   - name: manifests
     uri: https://github.com/kubeflow/manifests/archive/master.tar.gz

--- a/kfdef/kfctl_gcp_iap.yaml
+++ b/kfdef/kfctl_gcp_iap.yaml
@@ -1,8 +1,10 @@
+# Please set project and email!
 apiVersion: kfdef.apps.kubeflow.org/v1beta1
 kind: KfDef
 metadata:
   creationTimestamp: null
-  name: myapp2
+  # If name is not set, kfctl will infer app name from the directory.
+  # name: myapp2
   namespace: kubeflow
 spec:
   applications:

--- a/kfdef/kfctl_gcp_iap.yaml
+++ b/kfdef/kfctl_gcp_iap.yaml
@@ -396,4 +396,3 @@ spec:
     # To get manifest at a PR:
     #uri: https://github.com/kubeflow/manifests/archive/pull/235/head.tar.gz
   version: master
-status: {}

--- a/kfdef/kfctl_gcp_iap.yaml
+++ b/kfdef/kfctl_gcp_iap.yaml
@@ -309,8 +309,9 @@ spec:
       - application
       - istio
       parameters:
+        # kfctl will set admin to current user account that deploying kubeflow
       - name: admin
-        value: SET_EMAIL
+        # value: SET_EMAIL
       - name: userid-header
         value: X-Goog-Authenticated-User-Email
       - name: userid-prefix
@@ -333,9 +334,13 @@ spec:
       parameters:
       - name: namespace
         value: istio-system
+        # email will be auto-filled.
       - name: ipName
         value: test1-ip
       - name: hostname
+        # The value of hostname should be the DNS address for ingress.
+        # This will be set automatically during kfctl generate.
+        # value: test1.endpoints.SET_PROJECT.cloud.goog
       repoRef:
         name: manifests
         path: gcp/iap-ingress
@@ -350,8 +355,10 @@ spec:
   - kustomizeConfig:
       parameters:
       - name: user
-        value: SET_EMAIL
+        # kfctl will set user to current user account that deploying kubeflow
+        # value: SET_EMAIL
       - name: profile-name
+        # kfctl might overwrite profile name
         value: anonymous
       repoRef:
         name: manifests
@@ -371,8 +378,19 @@ spec:
       enableWorkloadIdentity: true
       skipInitProject: true
       useBasicAuth: false
+      # email should  be set the google account of the person setting up Kubeflow.
+      # If its not set kfctl generate will try to set it automatically based on the default
+      # gcloud config
+      # email: <your_email@gmail.com>
+      #
+      # Project should be set to the GCP project you want to use.
+      # If you run kfctl init --config=<path>/kfctl_gcp_iap.yaml
+      # kfctl will try to automatically set it.
+      # project: <your project>
   repos:
   - name: manifests
     uri: https://github.com/kubeflow/manifests/archive/master.tar.gz
+    # To get manifest at a PR:
+    #uri: https://github.com/kubeflow/manifests/archive/pull/235/head.tar.gz
   version: master
 status: {}

--- a/kfdef/kfctl_k8s_istio.yaml
+++ b/kfdef/kfctl_k8s_istio.yaml
@@ -3,7 +3,6 @@
 apiVersion: kfdef.apps.kubeflow.org/v1beta1
 kind: KfDef
 metadata:
-  creationTimestamp: null
   # If name is not set, kfctl will infer app name from the directory.
   # name: myapp2
   namespace: kubeflow

--- a/kfdef/kfctl_k8s_istio.yaml
+++ b/kfdef/kfctl_k8s_istio.yaml
@@ -295,4 +295,3 @@ spec:
   - name: manifests
     uri: https://github.com/kubeflow/manifests/archive/master.tar.gz
   version: master
-status: {}

--- a/kfdef/kfctl_k8s_istio.yaml
+++ b/kfdef/kfctl_k8s_istio.yaml
@@ -1,4 +1,5 @@
-# Please set project and email!
+# This is the config to install Kubeflow on an existing k8s cluster.
+# If the cluster already has istio, comment out the istio install part below.
 apiVersion: kfdef.apps.kubeflow.org/v1beta1
 kind: KfDef
 metadata:
@@ -8,6 +9,7 @@ metadata:
   namespace: kubeflow
 spec:
   applications:
+  # Istio install. If not needed, comment out istio-crds and istio-install.
   - kustomizeConfig:
       parameters:
       - name: namespace
@@ -24,6 +26,7 @@ spec:
         name: manifests
         path: istio/istio-install
     name: istio-install
+  # This component is the istio resources for Kubeflow (e.g. gateway), not about installing istio.
   - kustomizeConfig:
       parameters:
       - name: clusterRbacConfig

--- a/kfdef/kfctl_k8s_istio.yaml
+++ b/kfdef/kfctl_k8s_istio.yaml
@@ -1,8 +1,10 @@
+# Please set project and email!
 apiVersion: kfdef.apps.kubeflow.org/v1beta1
 kind: KfDef
 metadata:
   creationTimestamp: null
-  name: kubeflow_app
+  # If name is not set, kfctl will infer app name from the directory.
+  # name: myapp2
   namespace: kubeflow
 spec:
   applications:

--- a/kfdef/kfctl_k8s_istio.yaml
+++ b/kfdef/kfctl_k8s_istio.yaml
@@ -1,18 +1,11 @@
-# This is the config to install Kubeflow on an existing k8s cluster.
-# If the cluster already has istio, comment out the istio install part below.
-
-apiVersion: kfdef.apps.kubeflow.org/v1alpha1
+apiVersion: kfdef.apps.kubeflow.org/v1beta1
 kind: KfDef
 metadata:
+  creationTimestamp: null
   name: kubeflow_app
   namespace: kubeflow
 spec:
-  repos:
-  - name: manifests
-    root: manifests-master
-    uri: https://github.com/kubeflow/manifests/archive/master.tar.gz
   applications:
-  # Istio install. If not needed, comment out istio-crds and istio-install.
   - kustomizeConfig:
       parameters:
       - name: namespace
@@ -29,11 +22,10 @@ spec:
         name: manifests
         path: istio/istio-install
     name: istio-install
-  # This component is the istio resources for Kubeflow (e.g. gateway), not about installing istio.
   - kustomizeConfig:
       parameters:
-        - name: clusterRbacConfig
-          value: "OFF"
+      - name: clusterRbacConfig
+        value: "OFF"
       repoRef:
         name: manifests
         path: istio/istio
@@ -165,11 +157,9 @@ spec:
       overlays:
       - application
       parameters:
-      - initRequired: true
-        name: usageId
+      - name: usageId
         value: <randomly-generated-id>
-      - initRequired: true
-        name: reportUsage
+      - name: reportUsage
         value: "true"
       repoRef:
         name: manifests
@@ -284,8 +274,7 @@ spec:
       - application
       - istio
       parameters:
-      - initRequired: true
-        name: admin
+      - name: admin
         value: johnDoe@acme.com
       repoRef:
         name: manifests
@@ -298,9 +287,8 @@ spec:
         name: manifests
         path: seldon/seldon-core-operator
     name: seldon-core-operator
-  enableApplications: true
-  packageManager: kustomize
-  skipInitProject: true
-  useBasicAuth: false
-  useIstio: true
+  repos:
+  - name: manifests
+    uri: https://github.com/kubeflow/manifests/archive/master.tar.gz
   version: master
+status: {}


### PR DESCRIPTION
Generated with command:
`kfdef-converter tov1beta1 <filename>`

Related to kubeflow/kubeflow#3703

Fixes #544 

TODOs:
- [x] Add comment back.
- [x] Check if `kfdef-converter` worked as expected.
- [x] Verify deployments using new KfDef works fine.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/manifests/542)
<!-- Reviewable:end -->
