### PR TITLE
existing_arrikto: add cert-manager

### DIFF
--- a/admission-webhook/webhook/overlays/cert-manager/certificate.yaml
+++ b/admission-webhook/webhook/overlays/cert-manager/certificate.yaml
@@ -1,0 +1,14 @@
+apiVersion: cert-manager.io/v1alpha2
+kind: Certificate
+metadata:
+  name: admission-webhook-cert
+spec:
+  isCA: true
+  commonName: $(serviceName).$(namespace).svc
+  dnsNames:
+  - $(serviceName).$(namespace).svc
+  - $(serviceName).$(namespace).svc.cluster.local
+  issuerRef:
+    kind: ClusterIssuer
+    name: $(issuer)
+  secretName: webhook-certs

--- a/admission-webhook/webhook/overlays/cert-manager/deployment.yaml
+++ b/admission-webhook/webhook/overlays/cert-manager/deployment.yaml
@@ -1,0 +1,12 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: deployment
+spec:
+  template:
+    spec:
+      containers:
+      - name: admission-webhook
+        args:
+        - --tlsCertFile=/etc/webhook/certs/tls.crt
+        - --tlsKeyFile=/etc/webhook/certs/tls.key

--- a/admission-webhook/webhook/overlays/cert-manager/kustomization.yaml
+++ b/admission-webhook/webhook/overlays/cert-manager/kustomization.yaml
@@ -1,0 +1,36 @@
+bases:
+- ../../base
+
+resources:
+- certificate.yaml
+
+patchesStrategicMerge:
+- mutating-webhook-configuration.yaml
+- deployment.yaml
+
+configMapGenerator:
+- name: admission-webhook-parameters
+  behavior: merge
+  env: params.env
+generatorOptions:
+  disableNameSuffixHash: true
+
+vars:
+- name: issuer
+  objref:
+    kind: ConfigMap
+    name: admission-webhook-parameters
+    apiVersion: v1
+  fieldref:
+    fieldpath: data.issuer
+- name: cert_name
+  objref:
+      kind: Certificate
+      group: cert-manager.io
+      version: v1alpha2
+      name: admission-webhook-cert
+  fieldref:
+    fieldpath: metadata.name
+
+configurations:
+- params.yaml

--- a/admission-webhook/webhook/overlays/cert-manager/mutating-webhook-configuration.yaml
+++ b/admission-webhook/webhook/overlays/cert-manager/mutating-webhook-configuration.yaml
@@ -1,0 +1,7 @@
+apiVersion: admissionregistration.k8s.io/v1beta1
+kind: MutatingWebhookConfiguration
+metadata:
+  name: mutating-webhook-configuration
+  annotations:
+    cert-manager.io/inject-ca-from: $(namespace)/$(cert_name)
+  

--- a/admission-webhook/webhook/overlays/cert-manager/params.env
+++ b/admission-webhook/webhook/overlays/cert-manager/params.env
@@ -1,0 +1,1 @@
+issuer=kubeflow-self-signing-issuer

--- a/admission-webhook/webhook/overlays/cert-manager/params.yaml
+++ b/admission-webhook/webhook/overlays/cert-manager/params.yaml
@@ -1,0 +1,9 @@
+varReference:
+- path: spec/commonName
+  kind: Certificate
+- path: spec/dnsNames
+  kind: Certificate
+- path: spec/issuerRef/name
+  kind: Certificate
+- path: metadata/annotations
+  kind: MutatingWebhookConfiguration

--- a/kfdef/kfctl_existing_arrikto.yaml
+++ b/kfdef/kfctl_existing_arrikto.yaml
@@ -143,21 +143,12 @@ spec:
     name: centraldashboard
   - kustomizeConfig:
       overlays:
+      - cert-manager
       - application
       repoRef:
         name: manifests
         path: admission-webhook/webhook
     name: webhook
-  - kustomizeConfig:
-      overlays:
-      - application
-      parameters:
-      - name: webhookNamePrefix
-        value: admission-webhook-
-      repoRef:
-        name: manifests
-        path: admission-webhook/bootstrap
-    name: bootstrap
   - kustomizeConfig:
       parameters:
       - name: userid-header

--- a/kfdef/kfctl_existing_arrikto.yaml
+++ b/kfdef/kfctl_existing_arrikto.yaml
@@ -21,6 +21,33 @@ spec:
         name: manifests
         path: application/application
     name: application
+  - kustomizeConfig:
+      parameters:
+        - name: namespace
+          value: cert-manager
+      repoRef:
+        name: manifests
+        path: cert-manager/cert-manager-crds
+    name: cert-manager-crds
+  - kustomizeConfig:
+      parameters:
+        - name: namespace
+          value: kube-system
+      repoRef:
+        name: manifests
+        path: cert-manager/cert-manager-kube-system-resources
+    name: cert-manager-kube-system-resources
+  - kustomizeConfig:
+      overlays:
+        - self-signed
+        - application
+      parameters:
+        - name: namespace
+          value: cert-manager
+      repoRef:
+        name: manifests
+        path: cert-manager/cert-manager
+    name: cert-manager
   # Istio install. If not needed, comment out istio-crds and istio-install.
   - kustomizeConfig:
       parameters:

--- a/tests/webhook-overlays-cert-manager_test.go
+++ b/tests/webhook-overlays-cert-manager_test.go
@@ -1,0 +1,390 @@
+package tests_test
+
+import (
+	"sigs.k8s.io/kustomize/v3/k8sdeps/kunstruct"
+	"sigs.k8s.io/kustomize/v3/k8sdeps/transformer"
+	"sigs.k8s.io/kustomize/v3/pkg/fs"
+	"sigs.k8s.io/kustomize/v3/pkg/loader"
+	"sigs.k8s.io/kustomize/v3/pkg/plugins"
+	"sigs.k8s.io/kustomize/v3/pkg/resmap"
+	"sigs.k8s.io/kustomize/v3/pkg/resource"
+	"sigs.k8s.io/kustomize/v3/pkg/target"
+	"sigs.k8s.io/kustomize/v3/pkg/validators"
+	"testing"
+)
+
+func writeWebhookOverlaysCertManager(th *KustTestHarness) {
+	th.writeF("/manifests/admission-webhook/webhook/overlays/cert-manager/certificate.yaml", `
+apiVersion: cert-manager.io/v1alpha2
+kind: Certificate
+metadata:
+  name: admission-webhook-cert
+spec:
+  isCA: true
+  commonName: $(serviceName).$(namespace).svc
+  dnsNames:
+  - $(serviceName).$(namespace).svc
+  - $(serviceName).$(namespace).svc.cluster.local
+  issuerRef:
+    kind: ClusterIssuer
+    name: $(issuer)
+  secretName: webhook-certs`)
+	th.writeF("/manifests/admission-webhook/webhook/overlays/cert-manager/mutating-webhook-configuration.yaml", `
+apiVersion: admissionregistration.k8s.io/v1beta1
+kind: MutatingWebhookConfiguration
+metadata:
+  name: mutating-webhook-configuration
+  annotations:
+    cert-manager.io/inject-ca-from: $(namespace)/$(cert_name)
+  `)
+	th.writeF("/manifests/admission-webhook/webhook/overlays/cert-manager/deployment.yaml", `
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: deployment
+spec:
+  template:
+    spec:
+      containers:
+      - name: admission-webhook
+        args:
+        - --tlsCertFile=/etc/webhook/certs/tls.crt
+        - --tlsKeyFile=/etc/webhook/certs/tls.key
+`)
+	th.writeF("/manifests/admission-webhook/webhook/overlays/cert-manager/params.yaml", `
+varReference:
+- path: spec/commonName
+  kind: Certificate
+- path: spec/dnsNames
+  kind: Certificate
+- path: spec/issuerRef/name
+  kind: Certificate
+- path: metadata/annotations
+  kind: MutatingWebhookConfiguration
+`)
+	th.writeF("/manifests/admission-webhook/webhook/overlays/cert-manager/params.env", `
+issuer=kubeflow-self-signing-issuer`)
+	th.writeK("/manifests/admission-webhook/webhook/overlays/cert-manager", `
+bases:
+- ../../base
+
+resources:
+- certificate.yaml
+
+patchesStrategicMerge:
+- mutating-webhook-configuration.yaml
+- deployment.yaml
+
+configMapGenerator:
+- name: admission-webhook-parameters
+  behavior: merge
+  env: params.env
+generatorOptions:
+  disableNameSuffixHash: true
+
+vars:
+- name: issuer
+  objref:
+    kind: ConfigMap
+    name: admission-webhook-parameters
+    apiVersion: v1
+  fieldref:
+    fieldpath: data.issuer
+- name: cert_name
+  objref:
+      kind: Certificate
+      group: cert-manager.io
+      version: v1alpha2
+      name: admission-webhook-cert
+  fieldref:
+    fieldpath: metadata.name
+
+configurations:
+- params.yaml`)
+	th.writeF("/manifests/admission-webhook/webhook/base/cluster-role-binding.yaml", `
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: cluster-role-binding
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: cluster-role
+subjects:
+- kind: ServiceAccount
+  name: service-account
+`)
+	th.writeF("/manifests/admission-webhook/webhook/base/cluster-role.yaml", `
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: cluster-role
+rules:
+- apiGroups:
+  - kubeflow.org
+  resources:
+  - poddefaults
+  verbs:
+  - get
+  - watch
+  - list
+  - update
+  - create
+  - patch
+  - delete
+
+---
+
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: kubeflow-poddefaults-admin
+  labels:
+    rbac.authorization.kubeflow.org/aggregate-to-kubeflow-admin: "true"
+aggregationRule:
+  clusterRoleSelectors:
+  - matchLabels:
+      rbac.authorization.kubeflow.org/aggregate-to-kubeflow-poddefaults-admin: "true"
+rules: []
+
+---
+
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: kubeflow-poddefaults-edit
+  labels:
+    rbac.authorization.kubeflow.org/aggregate-to-kubeflow-edit: "true"
+aggregationRule:
+  clusterRoleSelectors:
+  - matchLabels:
+      rbac.authorization.kubeflow.org/aggregate-to-kubeflow-poddefaults-edit: "true"
+rules: []
+
+---
+
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: kubeflow-poddefaults-view
+  labels:
+    rbac.authorization.kubeflow.org/aggregate-to-kubeflow-poddefaults-admin: "true"
+    rbac.authorization.kubeflow.org/aggregate-to-kubeflow-poddefaults-edit: "true"
+    rbac.authorization.kubeflow.org/aggregate-to-kubeflow-view: "true"
+rules:
+- apiGroups:
+  - kubeflow.org
+  resources:
+  - poddefaults
+  verbs:
+  - get
+  - list
+  - watch
+`)
+	th.writeF("/manifests/admission-webhook/webhook/base/deployment.yaml", `
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: deployment
+spec:
+  template:
+    spec:
+      containers:
+      - image: gcr.io/kubeflow-images-public/admission-webhook:v20190520-v0-139-gcee39dbc-dirty-0d8f4c
+        name: admission-webhook
+        volumeMounts:
+        - mountPath: /etc/webhook/certs
+          name: webhook-cert
+          readOnly: true
+      volumes:
+      - name: webhook-cert
+        secret:
+          secretName: webhook-certs
+      serviceAccountName: service-account    
+`)
+	th.writeF("/manifests/admission-webhook/webhook/base/mutating-webhook-configuration.yaml", `
+apiVersion: admissionregistration.k8s.io/v1beta1
+kind: MutatingWebhookConfiguration
+metadata:
+  name: mutating-webhook-configuration
+webhooks:
+- clientConfig:
+    caBundle: ""
+    service:
+      name: $(serviceName)
+      namespace: $(namespace)
+      path: /apply-poddefault
+  name: $(deploymentName).kubeflow.org
+  rules:
+  - apiGroups:
+    - ""
+    apiVersions:
+    - v1
+    operations:
+    - CREATE
+    resources:
+    - pods
+`)
+	th.writeF("/manifests/admission-webhook/webhook/base/service-account.yaml", `
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: service-account
+`)
+	th.writeF("/manifests/admission-webhook/webhook/base/service.yaml", `
+apiVersion: v1
+kind: Service
+metadata:
+  name: service
+spec:
+  ports:
+  - port: 443
+    targetPort: 443
+`)
+	th.writeF("/manifests/admission-webhook/webhook/base/crd.yaml", `
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  name: poddefaults.kubeflow.org
+spec:
+  group: kubeflow.org
+  names:
+    kind: PodDefault
+    plural: poddefaults
+    singular: poddefault
+  scope: Namespaced
+  version: v1alpha1
+  validation:
+    openAPIV3Schema:
+      properties:
+        apiVersion:
+          type: string
+        kind:
+          type: string
+        metadata:
+          type: object
+        spec:
+          properties:
+            desc:
+              type: string
+            serviceAccountName:
+              type: string
+            env:
+              items:
+                type: object
+              type: array
+            envFrom:
+              items:
+                type: object
+              type: array
+            selector:
+              type: object
+            volumeMounts:
+              items:
+                type: object
+              type: array
+            volumes:
+              items:
+                type: object
+              type: array
+          required:
+          - selector
+          type: object
+        status:
+          type: object
+      type: object
+`)
+	th.writeF("/manifests/admission-webhook/webhook/base/params.yaml", `
+varReference:
+- path: webhooks/clientConfig/service/namespace
+  kind: MutatingWebhookConfiguration
+- path: webhooks/clientConfig/service/name
+  kind: MutatingWebhookConfiguration
+- path: webhooks/name
+  kind: MutatingWebhookConfiguration
+`)
+	th.writeF("/manifests/admission-webhook/webhook/base/params.env", `
+namespace=kubeflow
+`)
+	th.writeK("/manifests/admission-webhook/webhook/base", `
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+- cluster-role-binding.yaml
+- cluster-role.yaml
+- deployment.yaml
+- mutating-webhook-configuration.yaml
+- service-account.yaml
+- service.yaml
+- crd.yaml
+commonLabels:
+  kustomize.component: admission-webhook
+  app: admission-webhook
+namePrefix: admission-webhook-
+images:
+- name: gcr.io/kubeflow-images-public/admission-webhook
+  newName: gcr.io/kubeflow-images-public/admission-webhook
+  newTag: v20190520-v0-139-gcee39dbc-dirty-0d8f4c
+namespace: kubeflow
+configMapGenerator:
+- name: admission-webhook-parameters
+  env: params.env
+generatorOptions:
+  disableNameSuffixHash: true
+vars:
+- name: namespace
+  objref:
+    kind: ConfigMap
+    name: admission-webhook-parameters
+    apiVersion: v1
+  fieldref:
+    fieldpath: data.namespace
+- name: serviceName
+  objref:
+    kind: Service
+    name: service
+    apiVersion: v1
+  fieldref:
+    fieldpath: metadata.name
+- name: deploymentName
+  objref:
+    kind: Deployment
+    name: deployment
+    apiVersion: apps/v1
+  fieldref:
+    fieldpath: metadata.name
+configurations:
+- params.yaml
+`)
+}
+
+func TestWebhookOverlaysCertManager(t *testing.T) {
+	th := NewKustTestHarness(t, "/manifests/admission-webhook/webhook/overlays/cert-manager")
+	writeWebhookOverlaysCertManager(th)
+	m, err := th.makeKustTarget().MakeCustomizedResMap()
+	if err != nil {
+		t.Fatalf("Err: %v", err)
+	}
+	expected, err := m.AsYaml()
+	if err != nil {
+		t.Fatalf("Err: %v", err)
+	}
+	targetPath := "../admission-webhook/webhook/overlays/cert-manager"
+	fsys := fs.MakeRealFS()
+	lrc := loader.RestrictionRootOnly
+	_loader, loaderErr := loader.NewLoader(lrc, validators.MakeFakeValidator(), targetPath, fsys)
+	if loaderErr != nil {
+		t.Fatalf("could not load kustomize loader: %v", loaderErr)
+	}
+	rf := resmap.NewFactory(resource.NewFactory(kunstruct.NewKunstructuredFactoryImpl()), transformer.NewFactoryImpl())
+	pc := plugins.DefaultPluginConfig()
+	kt, err := target.NewKustTarget(_loader, rf, transformer.NewFactoryImpl(), plugins.NewLoader(pc, rf))
+	if err != nil {
+		th.t.Fatalf("Unexpected construction error %v", err)
+	}
+	actual, err := kt.MakeCustomizedResMap()
+	if err != nil {
+		t.Fatalf("Err: %v", err)
+	}
+	th.assertActualEqualsExpected(actual, string(expected))
+}


### PR DESCRIPTION
**Description of your changes:**
Adds support for cert-manager certificate in admission webhook.
Adds support for cert-manager in existing_arrikto config.

/cc @ryandawsonuk @kkasravi 

**Checklist:**
- [X] Unit tests have been rebuilt: 
    1. `cd manifests/tests`
    2. `make generate`
    3. `make test`

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/manifests/549)
<!-- Reviewable:end -->
