### PR TITLE
add dockerSockPath to argo config map

### DIFF
--- a/argo/base/config-map.yaml
+++ b/argo/base/config-map.yaml
@@ -8,6 +8,7 @@ data:
     {
     executorImage: $(executorImage),
     containerRuntimeExecutor: $(containerRuntimeExecutor),
+    dockerSockPath: $(dockerSockPath),
     artifactRepository:
     {
         s3: {

--- a/argo/base/kustomization.yaml
+++ b/argo/base/kustomization.yaml
@@ -37,6 +37,13 @@ vars:
     apiVersion: v1
   fieldref:
     fieldpath: data.containerRuntimeExecutor
+- name: dockerSockPath
+  objref:
+    kind: ConfigMap
+    name: workflow-controller-parameters
+    apiVersion: v1
+  fieldref:
+    fieldpath: data.dockerSockPath
 - name: artifactRepositoryBucket
   objref:
     kind: ConfigMap

--- a/argo/base/params.env
+++ b/argo/base/params.env
@@ -1,6 +1,7 @@
 namespace=
 executorImage=argoproj/argoexec:v2.3.0
 containerRuntimeExecutor=docker
+dockerSockPath=/var/run/docker.sock
 artifactRepositoryBucket=mlpipeline
 artifactRepositoryKeyPrefix=artifacts
 artifactRepositoryEndpoint=minio-service.kubeflow:9000

--- a/tests/argo-base_test.go
+++ b/tests/argo-base_test.go
@@ -135,6 +135,7 @@ data:
     {
     executorImage: $(executorImage),
     containerRuntimeExecutor: $(containerRuntimeExecutor),
+    dockerSockPath: $(dockerSockPath),
     artifactRepository:
     {
         s3: {
@@ -329,6 +330,7 @@ varReference:
 namespace=
 executorImage=argoproj/argoexec:v2.3.0
 containerRuntimeExecutor=docker
+dockerSockPath=/var/run/docker.sock
 artifactRepositoryBucket=mlpipeline
 artifactRepositoryKeyPrefix=artifacts
 artifactRepositoryEndpoint=minio-service.kubeflow:9000
@@ -379,6 +381,13 @@ vars:
     apiVersion: v1
   fieldref:
     fieldpath: data.containerRuntimeExecutor
+- name: dockerSockPath
+  objref:
+    kind: ConfigMap
+    name: workflow-controller-parameters
+    apiVersion: v1
+  fieldref:
+    fieldpath: data.dockerSockPath
 - name: artifactRepositoryBucket
   objref:
     kind: ConfigMap

--- a/tests/argo-overlays-application_test.go
+++ b/tests/argo-overlays-application_test.go
@@ -190,6 +190,7 @@ data:
     {
     executorImage: $(executorImage),
     containerRuntimeExecutor: $(containerRuntimeExecutor),
+    dockerSockPath: $(dockerSockPath),
     artifactRepository:
     {
         s3: {
@@ -384,6 +385,7 @@ varReference:
 namespace=
 executorImage=argoproj/argoexec:v2.3.0
 containerRuntimeExecutor=docker
+dockerSockPath=/var/run/docker.sock
 artifactRepositoryBucket=mlpipeline
 artifactRepositoryKeyPrefix=artifacts
 artifactRepositoryEndpoint=minio-service.kubeflow:9000
@@ -434,6 +436,13 @@ vars:
     apiVersion: v1
   fieldref:
     fieldpath: data.containerRuntimeExecutor
+- name: dockerSockPath
+  objref:
+    kind: ConfigMap
+    name: workflow-controller-parameters
+    apiVersion: v1
+  fieldref:
+    fieldpath: data.dockerSockPath
 - name: artifactRepositoryBucket
   objref:
     kind: ConfigMap

--- a/tests/argo-overlays-istio_test.go
+++ b/tests/argo-overlays-istio_test.go
@@ -172,6 +172,7 @@ data:
     {
     executorImage: $(executorImage),
     containerRuntimeExecutor: $(containerRuntimeExecutor),
+    dockerSockPath: $(dockerSockPath),
     artifactRepository:
     {
         s3: {
@@ -366,6 +367,7 @@ varReference:
 namespace=
 executorImage=argoproj/argoexec:v2.3.0
 containerRuntimeExecutor=docker
+dockerSockPath=/var/run/docker.sock
 artifactRepositoryBucket=mlpipeline
 artifactRepositoryKeyPrefix=artifacts
 artifactRepositoryEndpoint=minio-service.kubeflow:9000
@@ -416,6 +418,13 @@ vars:
     apiVersion: v1
   fieldref:
     fieldpath: data.containerRuntimeExecutor
+- name: dockerSockPath
+  objref:
+    kind: ConfigMap
+    name: workflow-controller-parameters
+    apiVersion: v1
+  fieldref:
+    fieldpath: data.dockerSockPath
 - name: artifactRepositoryBucket
   objref:
     kind: ConfigMap


### PR DESCRIPTION
**Which issue is resolved by this Pull Request:**

Since Argo v2.4.0, new config `dockerSockPath` is added to allow different location of docker.sock. Ref. https://github.com/argoproj/argo/pull/1419.
To reflect the change in Argo and to better support different docker installation, add the `dockerSockPath` to the Argo config map.

**Description of your changes:**

Add `dockerSockPath` to argo base config map and related kustomization yaml as well as the tests.

**Checklist:**
- [x] Unit tests have been rebuilt: 
    1. `cd manifests/tests`
    2. `make generate`
    3. `make test`

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/manifests/550)
<!-- Reviewable:end -->
