### PR TITLE
Migrate Kfdef to v1beta1

### DIFF
--- a/kfdef/kfctl_anthos.yaml
+++ b/kfdef/kfctl_anthos.yaml
@@ -1,25 +1,21 @@
 # This is the config to install Kubeflow on an Anthos.
 # The cluster comes with customized Istio installation.
 
-apiVersion: kfdef.apps.kubeflow.org/v1alpha1
+apiVersion: kfdef.apps.kubeflow.org/v1beta1
 kind: KfDef
 metadata:
-  name: kubeflow_app
+  # User needs to set the app name, otherwise will try to infer from the directory.
+  # name: kubeflow_app
   namespace: kubeflow
 spec:
-  repos:
-  - name: manifests
-    uri: https://github.com/kubeflow/manifests/archive/master.tar.gz
-    # An example uri that uses a PR version of the manifest repo.
-    # uri: https://github.com/kubeflow/manifests/archive/pull/PR_NUMBER/head.tar.gz
   applications:
   # This component is the istio resources for Kubeflow (e.g. gateway), not about installing istio.
   - kustomizeConfig:
       parameters:
-        - name: clusterRbacConfig
-          value: "OFF"
-        - name: gatewaySelector
-          value: "ingress-gke-system"
+      - name: clusterRbacConfig
+        value: "OFF"
+      - name: gatewaySelector
+        value: ingress-gke-system
       repoRef:
         name: manifests
         path: istio/istio
@@ -151,11 +147,9 @@ spec:
       overlays:
       - application
       parameters:
-      - initRequired: true
-        name: usageId
+      - name: usageId
         value: <randomly-generated-id>
-      - initRequired: true
-        name: reportUsage
+      - name: reportUsage
         value: "true"
       repoRef:
         name: manifests
@@ -263,8 +257,7 @@ spec:
       - application
       - istio
       parameters:
-      - initRequired: true
-        name: admin
+      - name: admin
         value: johnDoe@acme.com
       repoRef:
         name: manifests
@@ -277,9 +270,9 @@ spec:
         name: manifests
         path: seldon/seldon-core-operator
     name: seldon-core-operator
-  enableApplications: true
-  packageManager: kustomize
-  skipInitProject: true
-  useBasicAuth: false
-  useIstio: true
+  repos:
+  - name: manifests
+    uri: https://github.com/kubeflow/manifests/archive/master.tar.gz
+    # An example uri that uses a PR version of the manifest repo.
+    # uri: https://github.com/kubeflow/manifests/archive/pull/PR_NUMBER/head.tar.gz
   version: master

--- a/kfdef/kfctl_aws.yaml
+++ b/kfdef/kfctl_aws.yaml
@@ -1,309 +1,301 @@
-apiVersion: kfdef.apps.kubeflow.org/v1alpha1
+apiVersion: kfdef.apps.kubeflow.org/v1beta1
 kind: KfDef
 metadata:
   name: kubeflow-aws
   namespace: kubeflow
 spec:
-  platform: aws
   applications:
-    - kustomizeConfig:
-        parameters:
-          - name: namespace
-            value: istio-system
-        repoRef:
-          name: manifests
-          path: istio/istio-crds
-      name: istio-crds
-    - kustomizeConfig:
-        parameters:
-          - name: namespace
-            value: istio-system
-        repoRef:
-          name: manifests
-          path: istio/istio-install
-      name: istio-install
-    - kustomizeConfig:
-        parameters:
-          - name: clusterRbacConfig
-            value: "OFF"
-        repoRef:
-          name: manifests
-          path: istio/istio
-      name: istio
-    - kustomizeConfig:
-        repoRef:
-          name: manifests
-          path: application/application-crds
-      name: application-crds
-    - kustomizeConfig:
-        overlays:
-          - application
-        repoRef:
-          name: manifests
-          path: application/application
-      name: application
-    - kustomizeConfig:
-        repoRef:
-          name: manifests
-          path: metacontroller
-      name: metacontroller
-    - kustomizeConfig:
-        overlays:
-          - istio
-          - application
-        repoRef:
-          name: manifests
-          path: argo
-      name: argo
-    - kustomizeConfig:
-        repoRef:
-          name: manifests
-          path: kubeflow-roles
-      name: kubeflow-roles
-    - kustomizeConfig:
-        overlays:
-          - istio
-          - application
-        repoRef:
-          name: manifests
-          path: common/centraldashboard
-      name: centraldashboard
-    - kustomizeConfig:
-        overlays:
-        - application
-        repoRef:
-          name: manifests
-          path: admission-webhook/webhook
-      name: webhook
-    - kustomizeConfig:
-        overlays:
-        - application
-        parameters:
-          - name: webhookNamePrefix
-            value: admission-webhook-
-        repoRef:
-          name: manifests
-          path: admission-webhook/bootstrap
-      name: bootstrap
-    - kustomizeConfig:
-        overlays:
-          - istio
-          - application
-        repoRef:
-          name: manifests
-          path: jupyter/jupyter-web-app
-      name: jupyter-web-app
-    - kustomizeConfig:
-        overlays:
-          - istio
-        repoRef:
-          name: manifests
-          path: metadata
-      name: metadata
-    - kustomizeConfig:
-        overlays:
-          - istio
-          - application
-        repoRef:
-          name: manifests
-          path: jupyter/notebook-controller
-      name: notebook-controller
-    - kustomizeConfig:
-        overlays:
-          - application
-        repoRef:
-          name: manifests
-          path: pytorch-job/pytorch-job-crds
-      name: pytorch-job-crds
-    - kustomizeConfig:
-        overlays:
-          - application
-        repoRef:
-          name: manifests
-          path: pytorch-job/pytorch-operator
-      name: pytorch-operator
-    - kustomizeConfig:
-        overlays:
-          - application
-        parameters:
-          - initRequired: true
-            name: usageId
-            value: <randomly-generated-id>
-          - initRequired: true
-            name: reportUsage
-            value: "true"
-        repoRef:
-          name: manifests
-          path: common/spartakus
-      name: spartakus
-    - kustomizeConfig:
-        overlays:
-          - istio
-        repoRef:
-          name: manifests
-          path: tensorboard
-      name: tensorboard
-    - kustomizeConfig:
-        overlays:
-          - application
-        repoRef:
-          name: manifests
-          path: tf-training/tf-job-crds
-      name: tf-job-crds
-    - kustomizeConfig:
-        overlays:
-          - application
-        repoRef:
-          name: manifests
-          path: tf-training/tf-job-operator
-      name: tf-job-operator
-    - kustomizeConfig:
-        repoRef:
-          name: manifests
-          path: katib/katib-crds
-      name: katib-crds
-    - kustomizeConfig:
-        overlays:
-          - application
-          - istio
-        repoRef:
-          name: manifests
-          path: katib/katib-controller
-      name: katib-controller
-    - kustomizeConfig:
-        overlays:
-          - application
-        repoRef:
-          name: manifests
-          path: pipeline/api-service
-      name: api-service
-    - kustomizeConfig:
-        overlays:
-          - application
-        parameters:
-          - name: minioPvcName
-            value: minio-pv-claim
-        repoRef:
-          name: manifests
-          path: pipeline/minio
-      name: minio
-    - kustomizeConfig:
-        overlays:
-          - application
-        parameters:
-          - name: mysqlPvcName
-            value: mysql-pv-claim
-        repoRef:
-          name: manifests
-          path: pipeline/mysql
-      name: mysql
-    - kustomizeConfig:
-        overlays:
-          - application
-        repoRef:
-          name: manifests
-          path: pipeline/persistent-agent
-      name: persistent-agent
-    - kustomizeConfig:
-        overlays:
-          - application
-        repoRef:
-          name: manifests
-          path: pipeline/pipelines-runner
-      name: pipelines-runner
-    - kustomizeConfig:
-        overlays:
-          - istio
-          - application
-        repoRef:
-          name: manifests
-          path: pipeline/pipelines-ui
-      name: pipelines-ui
-    - kustomizeConfig:
-        overlays:
-          - application
-        repoRef:
-          name: manifests
-          path: pipeline/pipelines-viewer
-      name: pipelines-viewer
-    - kustomizeConfig:
-        overlays:
-          - application
-        repoRef:
-          name: manifests
-          path: pipeline/scheduledworkflow
-      name: scheduledworkflow
-    - kustomizeConfig:
-        overlays:
-          - application
-        repoRef:
-          name: manifests
-          path: pipeline/pipeline-visualization-service
-      name: pipeline-visualization-service
-    - kustomizeConfig:
-        overlays:
-          - application
-          - istio
-        repoRef:
-          name: manifests
-          path: profiles
-      name: profiles
-    - kustomizeConfig:
-        overlays:
-          - application
-        repoRef:
-          name: manifests
-          path: seldon/seldon-core-operator
-    - kustomizeConfig:
-        overlays:
-          - application
-        repoRef:
-          name: manifests
-          path: mpi-job/mpi-operator
-    - kustomizeConfig:
-        parameters:
-          - initRequired: true
-            name: namespace
-            value: istio-system
-        repoRef:
-          name: manifests
-          path: aws/istio-ingress
-      name: istio-ingress
-    - kustomizeConfig:
-        overlays:
-          - application
-        parameters:
-          - initRequired: true
-            name: clusterName
-            value: kubeflow-aws
-        repoRef:
-          name: manifests
-          path: aws/aws-alb-ingress-controller
-      name: aws-alb-ingress-controller
-    - kustomizeConfig:
-        overlays:
-          - application
-        repoRef:
-          name: manifests
-          path: aws/nvidia-device-plugin
-      name: nvidia-device-plugin
-  enableApplications: true
-  packageManager: kustomize
-  repos:
-    - name: manifests
-      root: manifests-master
-      uri: https://github.com/kubeflow/manifests/archive/master.tar.gz
-  useBasicAuth: false
-  useIstio: true
-  version: master
+  - kustomizeConfig:
+      parameters:
+      - name: namespace
+        value: istio-system
+      repoRef:
+        name: manifests
+        path: istio/istio-crds
+    name: istio-crds
+  - kustomizeConfig:
+      parameters:
+      - name: namespace
+        value: istio-system
+      repoRef:
+        name: manifests
+        path: istio/istio-install
+    name: istio-install
+  - kustomizeConfig:
+      parameters:
+      - name: clusterRbacConfig
+        value: "OFF"
+      repoRef:
+        name: manifests
+        path: istio/istio
+    name: istio
+  - kustomizeConfig:
+      repoRef:
+        name: manifests
+        path: application/application-crds
+    name: application-crds
+  - kustomizeConfig:
+      overlays:
+      - application
+      repoRef:
+        name: manifests
+        path: application/application
+    name: application
+  - kustomizeConfig:
+      repoRef:
+        name: manifests
+        path: metacontroller
+    name: metacontroller
+  - kustomizeConfig:
+      overlays:
+      - istio
+      - application
+      repoRef:
+        name: manifests
+        path: argo
+    name: argo
+  - kustomizeConfig:
+      repoRef:
+        name: manifests
+        path: kubeflow-roles
+    name: kubeflow-roles
+  - kustomizeConfig:
+      overlays:
+      - istio
+      - application
+      repoRef:
+        name: manifests
+        path: common/centraldashboard
+    name: centraldashboard
+  - kustomizeConfig:
+      overlays:
+      - application
+      repoRef:
+        name: manifests
+        path: admission-webhook/webhook
+    name: webhook
+  - kustomizeConfig:
+      overlays:
+      - application
+      parameters:
+      - name: webhookNamePrefix
+        value: admission-webhook-
+      repoRef:
+        name: manifests
+        path: admission-webhook/bootstrap
+    name: bootstrap
+  - kustomizeConfig:
+      overlays:
+      - istio
+      - application
+      repoRef:
+        name: manifests
+        path: jupyter/jupyter-web-app
+    name: jupyter-web-app
+  - kustomizeConfig:
+      overlays:
+      - istio
+      repoRef:
+        name: manifests
+        path: metadata
+    name: metadata
+  - kustomizeConfig:
+      overlays:
+      - istio
+      - application
+      repoRef:
+        name: manifests
+        path: jupyter/notebook-controller
+    name: notebook-controller
+  - kustomizeConfig:
+      overlays:
+      - application
+      repoRef:
+        name: manifests
+        path: pytorch-job/pytorch-job-crds
+    name: pytorch-job-crds
+  - kustomizeConfig:
+      overlays:
+      - application
+      repoRef:
+        name: manifests
+        path: pytorch-job/pytorch-operator
+    name: pytorch-operator
+  - kustomizeConfig:
+      overlays:
+      - application
+      parameters:
+      - name: usageId
+        value: <randomly-generated-id>
+      - name: reportUsage
+        value: "true"
+      repoRef:
+        name: manifests
+        path: common/spartakus
+    name: spartakus
+  - kustomizeConfig:
+      overlays:
+      - istio
+      repoRef:
+        name: manifests
+        path: tensorboard
+    name: tensorboard
+  - kustomizeConfig:
+      overlays:
+      - application
+      repoRef:
+        name: manifests
+        path: tf-training/tf-job-crds
+    name: tf-job-crds
+  - kustomizeConfig:
+      overlays:
+      - application
+      repoRef:
+        name: manifests
+        path: tf-training/tf-job-operator
+    name: tf-job-operator
+  - kustomizeConfig:
+      repoRef:
+        name: manifests
+        path: katib/katib-crds
+    name: katib-crds
+  - kustomizeConfig:
+      overlays:
+      - application
+      - istio
+      repoRef:
+        name: manifests
+        path: katib/katib-controller
+    name: katib-controller
+  - kustomizeConfig:
+      overlays:
+      - application
+      repoRef:
+        name: manifests
+        path: pipeline/api-service
+    name: api-service
+  - kustomizeConfig:
+      overlays:
+      - application
+      parameters:
+      - name: minioPvcName
+        value: minio-pv-claim
+      repoRef:
+        name: manifests
+        path: pipeline/minio
+    name: minio
+  - kustomizeConfig:
+      overlays:
+      - application
+      parameters:
+      - name: mysqlPvcName
+        value: mysql-pv-claim
+      repoRef:
+        name: manifests
+        path: pipeline/mysql
+    name: mysql
+  - kustomizeConfig:
+      overlays:
+      - application
+      repoRef:
+        name: manifests
+        path: pipeline/persistent-agent
+    name: persistent-agent
+  - kustomizeConfig:
+      overlays:
+      - application
+      repoRef:
+        name: manifests
+        path: pipeline/pipelines-runner
+    name: pipelines-runner
+  - kustomizeConfig:
+      overlays:
+      - istio
+      - application
+      repoRef:
+        name: manifests
+        path: pipeline/pipelines-ui
+    name: pipelines-ui
+  - kustomizeConfig:
+      overlays:
+      - application
+      repoRef:
+        name: manifests
+        path: pipeline/pipelines-viewer
+    name: pipelines-viewer
+  - kustomizeConfig:
+      overlays:
+      - application
+      repoRef:
+        name: manifests
+        path: pipeline/scheduledworkflow
+    name: scheduledworkflow
+  - kustomizeConfig:
+      overlays:
+      - application
+      repoRef:
+        name: manifests
+        path: pipeline/pipeline-visualization-service
+    name: pipeline-visualization-service
+  - kustomizeConfig:
+      overlays:
+      - application
+      - istio
+      repoRef:
+        name: manifests
+        path: profiles
+    name: profiles
+  - kustomizeConfig:
+      overlays:
+      - application
+      repoRef:
+        name: manifests
+        path: seldon/seldon-core-operator
+  - kustomizeConfig:
+      overlays:
+      - application
+      repoRef:
+        name: manifests
+        path: mpi-job/mpi-operator
+  - kustomizeConfig:
+      parameters:
+      - name: namespace
+        value: istio-system
+      repoRef:
+        name: manifests
+        path: aws/istio-ingress
+    name: istio-ingress
+  - kustomizeConfig:
+      overlays:
+      - application
+      parameters:
+      - name: clusterName
+        value: kubeflow-aws
+      repoRef:
+        name: manifests
+        path: aws/aws-alb-ingress-controller
+    name: aws-alb-ingress-controller
+  - kustomizeConfig:
+      overlays:
+      - application
+      repoRef:
+        name: manifests
+        path: aws/nvidia-device-plugin
+    name: nvidia-device-plugin
   plugins:
-    - name: aws
-      spec:
-        roles:
-          - eksctl-kubeflow-aws-nodegroup-ng-a2-NodeInstanceRole-xxxxxxx
-        region: us-west-2
-        auth:
-          basicAuth:
-            password:
-              name: password
-            username: admin
+  - kind: KfAwsPlugin
+    metadata:
+      name: aws
+    spec:
+      auth:
+        basicAuth:
+          password:
+            name: password
+          username: admin
+      region: us-west-2
+      roles:
+      - eksctl-kubeflow-aws-nodegroup-ng-a2-NodeInstanceRole-xxxxxxx
+  repos:
+  - name: manifests
+    uri: https://github.com/kubeflow/manifests/archive/master.tar.gz
+  version: master

--- a/kfdef/kfctl_aws_cognito.yaml
+++ b/kfdef/kfctl_aws_cognito.yaml
@@ -1,316 +1,308 @@
-apiVersion: kfdef.apps.kubeflow.org/v1alpha1
+apiVersion: kfdef.apps.kubeflow.org/v1beta1
 kind: KfDef
 metadata:
   name: kubeflow-aws
   namespace: kubeflow
 spec:
-  platform: aws
   applications:
-    - kustomizeConfig:
-        parameters:
-          - name: namespace
-            value: istio-system
-        repoRef:
-          name: manifests
-          path: istio/istio-crds
-      name: istio-crds
-    - kustomizeConfig:
-        parameters:
-          - name: namespace
-            value: istio-system
-        repoRef:
-          name: manifests
-          path: istio/istio-install
-      name: istio-install
-    - kustomizeConfig:
-        parameters:
-          - name: clusterRbacConfig
-            value: "OFF"
-        repoRef:
-          name: manifests
-          path: istio/istio
-      name: istio
-    - kustomizeConfig:
-        repoRef:
-          name: manifests
-          path: application/application-crds
-      name: application-crds
-    - kustomizeConfig:
-        overlays:
-          - application
-        repoRef:
-          name: manifests
-          path: application/application
-      name: application
-    - kustomizeConfig:
-        repoRef:
-          name: manifests
-          path: metacontroller
-      name: metacontroller
-    - kustomizeConfig:
-        overlays:
-          - istio
-          - application
-        repoRef:
-          name: manifests
-          path: argo
-      name: argo
-    - kustomizeConfig:
-        repoRef:
-          name: manifests
-          path: kubeflow-roles
-      name: kubeflow-roles
-    - kustomizeConfig:
-        overlays:
-          - istio
-          - application
-        repoRef:
-          name: manifests
-          path: common/centraldashboard
-      name: centraldashboard
-    - kustomizeConfig:
-        overlays:
-          - application
-        repoRef:
-          name: manifests
-          path: admission-webhook/webhook
-      name: webhook
-    - kustomizeConfig:
-        overlays:
-          - application
-        parameters:
-          - name: webhookNamePrefix
-            value: admission-webhook-
-        repoRef:
-          name: manifests
-          path: admission-webhook/bootstrap
-      name: bootstrap
-    - kustomizeConfig:
-        overlays:
-          - istio
-          - application
-        repoRef:
-          name: manifests
-          path: jupyter/jupyter-web-app
-      name: jupyter-web-app
-    - kustomizeConfig:
-        overlays:
-          - istio
-        repoRef:
-          name: manifests
-          path: metadata
-      name: metadata
-    - kustomizeConfig:
-        overlays:
-          - istio
-          - application
-        repoRef:
-          name: manifests
-          path: jupyter/notebook-controller
-      name: notebook-controller
-    - kustomizeConfig:
-        overlays:
-          - application
-        repoRef:
-          name: manifests
-          path: pytorch-job/pytorch-job-crds
-      name: pytorch-job-crds
-    - kustomizeConfig:
-        overlays:
-          - application
-        repoRef:
-          name: manifests
-          path: pytorch-job/pytorch-operator
-      name: pytorch-operator
-    - kustomizeConfig:
-        overlays:
-          - application
-        parameters:
-          - initRequired: true
-            name: usageId
-            value: <randomly-generated-id>
-          - initRequired: true
-            name: reportUsage
-            value: "true"
-        repoRef:
-          name: manifests
-          path: common/spartakus
-      name: spartakus
-    - kustomizeConfig:
-        overlays:
-          - istio
-        repoRef:
-          name: manifests
-          path: tensorboard
-      name: tensorboard
-    - kustomizeConfig:
-        overlays:
-        - application
-        repoRef:
-          name: manifests
-          path: tf-training/tf-job-crds
-      name: tf-job-crds
-    - kustomizeConfig:
-        overlays:
-          - application
-        repoRef:
-          name: manifests
-          path: tf-training/tf-job-operator
-      name: tf-job-operator
-    - kustomizeConfig:
-        repoRef:
-          name: manifests
-          path: katib/katib-crds
-      name: katib-crds
-    - kustomizeConfig:
-        overlays:
-        - application
-        - istio
-        repoRef:
-          name: manifests
-          path: katib/katib-controller
-      name: katib-controller
-    - kustomizeConfig:
-        overlays:
-        - application
-        repoRef:
-          name: manifests
-          path: pipeline/api-service
-      name: api-service
-    - kustomizeConfig:
-        overlays:
-        - application
-        parameters:
-          - name: minioPvName
-            value: minio-pv
-          - name: minioPvcName
-            value: minio-pv-claim
-        repoRef:
-          name: manifests
-          path: pipeline/minio
-      name: minio
-    - kustomizeConfig:
-        overlays:
-        - application
-        parameters:
-          - name: mysqlPvName
-            value: mysql-pv
-          - name: mysqlPvcName
-            value: mysql-pv-claim
-        repoRef:
-          name: manifests
-          path: pipeline/mysql
-      name: mysql
-    - kustomizeConfig:
-        overlays:
-        - application
-        repoRef:
-          name: manifests
-          path: pipeline/persistent-agent
-      name: persistent-agent
-    - kustomizeConfig:
-        overlays:
-        - application
-        repoRef:
-          name: manifests
-          path: pipeline/pipelines-runner
-      name: pipelines-runner
-    - kustomizeConfig:
-        overlays:
-          - istio
-          - application
-        repoRef:
-          name: manifests
-          path: pipeline/pipelines-ui
-      name: pipelines-ui
-    - kustomizeConfig:
-        overlays:
-        - application
-        repoRef:
-          name: manifests
-          path: pipeline/pipelines-viewer
-      name: pipelines-viewer
-    - kustomizeConfig:
-        overlays:
-        - application
-        repoRef:
-          name: manifests
-          path: pipeline/scheduledworkflow
-      name: scheduledworkflow
-    - kustomizeConfig:
-        overlays:
-        - application
-        repoRef:
-          name: manifests
-          path: pipeline/pipeline-visualization-service
-      name: pipeline-visualization-service
-    - kustomizeConfig:
-        overlays:
-        - application
-        - istio
-        repoRef:
-          name: manifests
-          path: profiles
-      name: profiles
-    - kustomizeConfig:
-        overlays:
-          - application
-        repoRef:
-          name: manifests
-          path: seldon/seldon-core-operator
-    - kustomizeConfig:
-        overlays:
-          - application
-        repoRef:
-          name: manifests
-          path: mpi-job/mpi-operator
-    - kustomizeConfig:
-        overlays:
-          - cognito
-        parameters:
-          - initRequired: true
-            name: namespace
-            value: istio-system
-        repoRef:
-          name: manifests
-          path: aws/istio-ingress
-      name: istio-ingress
-    - kustomizeConfig:
-        overlays:
-          - application
-        parameters:
-          - initRequired: true
-            name: clusterName
-            value: kubeflow-aws
-        repoRef:
-          name: manifests
-          path: aws/aws-alb-ingress-controller
-      name: aws-alb-ingress-controller
-    - kustomizeConfig:
-        overlays:
-          - application
-        repoRef:
-          name: manifests
-          path: aws/nvidia-device-plugin
-      name: nvidia-device-plugin
-  enableApplications: true
-  packageManager: kustomize
-  repos:
-    - name: manifests
-      root: manifests-master
-      uri: https://github.com/kubeflow/manifests/archive/master.tar.gz
-  useBasicAuth: false
-  useIstio: true
-  version: master
+  - kustomizeConfig:
+      parameters:
+      - name: namespace
+        value: istio-system
+      repoRef:
+        name: manifests
+        path: istio/istio-crds
+    name: istio-crds
+  - kustomizeConfig:
+      parameters:
+      - name: namespace
+        value: istio-system
+      repoRef:
+        name: manifests
+        path: istio/istio-install
+    name: istio-install
+  - kustomizeConfig:
+      parameters:
+      - name: clusterRbacConfig
+        value: "OFF"
+      repoRef:
+        name: manifests
+        path: istio/istio
+    name: istio
+  - kustomizeConfig:
+      repoRef:
+        name: manifests
+        path: application/application-crds
+    name: application-crds
+  - kustomizeConfig:
+      overlays:
+      - application
+      repoRef:
+        name: manifests
+        path: application/application
+    name: application
+  - kustomizeConfig:
+      repoRef:
+        name: manifests
+        path: metacontroller
+    name: metacontroller
+  - kustomizeConfig:
+      overlays:
+      - istio
+      - application
+      repoRef:
+        name: manifests
+        path: argo
+    name: argo
+  - kustomizeConfig:
+      repoRef:
+        name: manifests
+        path: kubeflow-roles
+    name: kubeflow-roles
+  - kustomizeConfig:
+      overlays:
+      - istio
+      - application
+      repoRef:
+        name: manifests
+        path: common/centraldashboard
+    name: centraldashboard
+  - kustomizeConfig:
+      overlays:
+      - application
+      repoRef:
+        name: manifests
+        path: admission-webhook/webhook
+    name: webhook
+  - kustomizeConfig:
+      overlays:
+      - application
+      parameters:
+      - name: webhookNamePrefix
+        value: admission-webhook-
+      repoRef:
+        name: manifests
+        path: admission-webhook/bootstrap
+    name: bootstrap
+  - kustomizeConfig:
+      overlays:
+      - istio
+      - application
+      repoRef:
+        name: manifests
+        path: jupyter/jupyter-web-app
+    name: jupyter-web-app
+  - kustomizeConfig:
+      overlays:
+      - istio
+      repoRef:
+        name: manifests
+        path: metadata
+    name: metadata
+  - kustomizeConfig:
+      overlays:
+      - istio
+      - application
+      repoRef:
+        name: manifests
+        path: jupyter/notebook-controller
+    name: notebook-controller
+  - kustomizeConfig:
+      overlays:
+      - application
+      repoRef:
+        name: manifests
+        path: pytorch-job/pytorch-job-crds
+    name: pytorch-job-crds
+  - kustomizeConfig:
+      overlays:
+      - application
+      repoRef:
+        name: manifests
+        path: pytorch-job/pytorch-operator
+    name: pytorch-operator
+  - kustomizeConfig:
+      overlays:
+      - application
+      parameters:
+      - name: usageId
+        value: <randomly-generated-id>
+      - name: reportUsage
+        value: "true"
+      repoRef:
+        name: manifests
+        path: common/spartakus
+    name: spartakus
+  - kustomizeConfig:
+      overlays:
+      - istio
+      repoRef:
+        name: manifests
+        path: tensorboard
+    name: tensorboard
+  - kustomizeConfig:
+      overlays:
+      - application
+      repoRef:
+        name: manifests
+        path: tf-training/tf-job-crds
+    name: tf-job-crds
+  - kustomizeConfig:
+      overlays:
+      - application
+      repoRef:
+        name: manifests
+        path: tf-training/tf-job-operator
+    name: tf-job-operator
+  - kustomizeConfig:
+      repoRef:
+        name: manifests
+        path: katib/katib-crds
+    name: katib-crds
+  - kustomizeConfig:
+      overlays:
+      - application
+      - istio
+      repoRef:
+        name: manifests
+        path: katib/katib-controller
+    name: katib-controller
+  - kustomizeConfig:
+      overlays:
+      - application
+      repoRef:
+        name: manifests
+        path: pipeline/api-service
+    name: api-service
+  - kustomizeConfig:
+      overlays:
+      - application
+      parameters:
+      - name: minioPvName
+        value: minio-pv
+      - name: minioPvcName
+        value: minio-pv-claim
+      repoRef:
+        name: manifests
+        path: pipeline/minio
+    name: minio
+  - kustomizeConfig:
+      overlays:
+      - application
+      parameters:
+      - name: mysqlPvName
+        value: mysql-pv
+      - name: mysqlPvcName
+        value: mysql-pv-claim
+      repoRef:
+        name: manifests
+        path: pipeline/mysql
+    name: mysql
+  - kustomizeConfig:
+      overlays:
+      - application
+      repoRef:
+        name: manifests
+        path: pipeline/persistent-agent
+    name: persistent-agent
+  - kustomizeConfig:
+      overlays:
+      - application
+      repoRef:
+        name: manifests
+        path: pipeline/pipelines-runner
+    name: pipelines-runner
+  - kustomizeConfig:
+      overlays:
+      - istio
+      - application
+      repoRef:
+        name: manifests
+        path: pipeline/pipelines-ui
+    name: pipelines-ui
+  - kustomizeConfig:
+      overlays:
+      - application
+      repoRef:
+        name: manifests
+        path: pipeline/pipelines-viewer
+    name: pipelines-viewer
+  - kustomizeConfig:
+      overlays:
+      - application
+      repoRef:
+        name: manifests
+        path: pipeline/scheduledworkflow
+    name: scheduledworkflow
+  - kustomizeConfig:
+      overlays:
+      - application
+      repoRef:
+        name: manifests
+        path: pipeline/pipeline-visualization-service
+    name: pipeline-visualization-service
+  - kustomizeConfig:
+      overlays:
+      - application
+      - istio
+      repoRef:
+        name: manifests
+        path: profiles
+    name: profiles
+  - kustomizeConfig:
+      overlays:
+      - application
+      repoRef:
+        name: manifests
+        path: seldon/seldon-core-operator
+  - kustomizeConfig:
+      overlays:
+      - application
+      repoRef:
+        name: manifests
+        path: mpi-job/mpi-operator
+  - kustomizeConfig:
+      overlays:
+      - cognito
+      parameters:
+      - name: namespace
+        value: istio-system
+      repoRef:
+        name: manifests
+        path: aws/istio-ingress
+    name: istio-ingress
+  - kustomizeConfig:
+      overlays:
+      - application
+      parameters:
+      - name: clusterName
+        value: kubeflow-aws
+      repoRef:
+        name: manifests
+        path: aws/aws-alb-ingress-controller
+    name: aws-alb-ingress-controller
+  - kustomizeConfig:
+      overlays:
+      - application
+      repoRef:
+        name: manifests
+        path: aws/nvidia-device-plugin
+    name: nvidia-device-plugin
   plugins:
-    - name: aws
-      spec:
-        auth:
-          cognito:
-            cognitoUserPoolArn: arn:aws:cognito-idp:us-west-2:xxxxx:userpool/us-west-2_xxxxxx
-            cognitoAppClientId: xxxxxbxxxxxx
-            cognitoUserPoolDomain: your-user-pool
-            certArn: arn:aws:acm:us-west-2:xxxxx:certificate/xxxxxxxxxxxxx-xxxx
-        roles:
-          - eksctl-kubeflow-aws-nodegroup-ng-a2-NodeInstanceRole-xxxxx
-        region: us-west-2
+  - kind: KfAwsPlugin
+    metadata:
+      name: aws
+    spec:
+      auth:
+        cognito:
+          certArn: arn:aws:acm:us-west-2:xxxxx:certificate/xxxxxxxxxxxxx-xxxx
+          cognitoAppClientId: xxxxxbxxxxxx
+          cognitoUserPoolArn: arn:aws:cognito-idp:us-west-2:xxxxx:userpool/us-west-2_xxxxxx
+          cognitoUserPoolDomain: your-user-pool
+      region: us-west-2
+      roles:
+      - eksctl-kubeflow-aws-nodegroup-ng-a2-NodeInstanceRole-xxxxx
+  repos:
+  - name: manifests
+    uri: https://github.com/kubeflow/manifests/archive/master.tar.gz
+  version: master

--- a/kfdef/kfctl_existing_arrikto.yaml
+++ b/kfdef/kfctl_existing_arrikto.yaml
@@ -1,13 +1,12 @@
 # This is the config to install Kubeflow on an existing K8s cluster, with support
 # for multi-user and LDAP auth using Dex.
 
-apiVersion: kfdef.apps.kubeflow.org/v1alpha1
+apiVersion: kfdef.apps.kubeflow.org/v1beta1
 kind: KfDef
 metadata:
   name: demo
   namespace: kubeflow
 spec:
-  packageManager: kustomize
   applications:
   - kustomizeConfig:
       repoRef:
@@ -23,27 +22,27 @@ spec:
     name: application
   - kustomizeConfig:
       parameters:
-        - name: namespace
-          value: cert-manager
+      - name: namespace
+        value: cert-manager
       repoRef:
         name: manifests
         path: cert-manager/cert-manager-crds
     name: cert-manager-crds
   - kustomizeConfig:
       parameters:
-        - name: namespace
-          value: kube-system
+      - name: namespace
+        value: kube-system
       repoRef:
         name: manifests
         path: cert-manager/cert-manager-kube-system-resources
     name: cert-manager-kube-system-resources
   - kustomizeConfig:
       overlays:
-        - self-signed
-        - application
+      - self-signed
+      - application
       parameters:
-        - name: namespace
-          value: cert-manager
+      - name: namespace
+        value: cert-manager
       repoRef:
         name: manifests
         path: cert-manager/cert-manager
@@ -51,68 +50,68 @@ spec:
   # Istio install. If not needed, comment out istio-crds and istio-install.
   - kustomizeConfig:
       parameters:
-        - name: namespace
-          value: istio-system
+      - name: namespace
+        value: istio-system
       repoRef:
         name: manifests
         path: istio/istio-crds
     name: istio-crds
   - kustomizeConfig:
       parameters:
-        - name: namespace
-          value: istio-system
+      - name: namespace
+        value: istio-system
       repoRef:
         name: manifests
         path: istio/istio-install
     name: istio-install
-  # This component is the istio resources for Kubeflow (e.g. gateway), not about installing istio.
+  # This component is the istio resources for Kubeflow (e.g. gateway), not about installing istio
   - kustomizeConfig:
       parameters:
-        - name: clusterRbacConfig
-          value: "ON"
+      - name: clusterRbacConfig
+        value: "ON"
       repoRef:
         name: manifests
         path: istio/istio
     name: istio
   - kustomizeConfig:
       overlays:
-        - application
+      - application
       parameters:
-        - name: namespace
-          value: istio-system
-        - name: userid-header
-          value: kubeflow-userid
-        - name: oidc_provider
-          value: http://dex.auth.svc.cluster.local:5556/dex
-        - name: oidc_redirect_uri
-          value: /login/oidc
-        - name: oidc_auth_url
-          value: /dex/auth
-        - name: skip_auth_uri
-          value: /dex
-        - name: client_id
-          value: kubeflow-oidc-authservice        
+      - name: namespace
+        value: istio-system
+      - name: userid-header
+        value: kubeflow-userid
+      - name: oidc_provider
+        value: http://dex.auth.svc.cluster.local:5556/dex
+      - name: oidc_redirect_uri
+        value: /login/oidc
+      - name: oidc_auth_url
+        value: /dex/auth
+      - name: skip_auth_uri
+        value: /dex
+      - name: client_id
+        value: kubeflow-oidc-authservice
       repoRef:
         name: manifests
         path: istio/oidc-authservice
     name: oidc-authservice
   - kustomizeConfig:
       overlays:
-        - istio
+      - istio
       parameters:
-        - name: namespace
-          value: auth
-        - name: issuer
-          value: http://dex.auth.svc.cluster.local:5556/dex
-        - name: client_id
-          value: kubeflow-oidc-authservice
-        - name: oidc_redirect_uris
-          value: '["/login/oidc"]'
-        - name: static_email
-          value: admin@kubeflow.org
-        # Password is "12341234", 12-round bcrypt-hashed.
-        - name: static_password_hash
-          value: $2y$12$ruoM7FqXrpVgaol44eRZW.4HWS8SAvg6KYVVSCIwKQPBmTpCm.EeO
+      - name: namespace
+        value: auth
+      - name: issuer
+        value: http://dex.auth.svc.cluster.local:5556/dex
+      - name: client_id
+        value: kubeflow-oidc-authservice
+      - name: oidc_redirect_uris
+        value: '["/login/oidc"]'
+      - name: static_email
+        value: admin@kubeflow.org
+      # Password is "12341234", 12-round bcrypt-hashed.
+      - name: static_password_hash
+        value: $2y$12$ruoM7FqXrpVgaol44eRZW.4HWS8SAvg6KYVVSCIwKQPBmTpCm.EeO
       repoRef:
         name: manifests
         path: dex-auth/dex-crds
@@ -131,12 +130,12 @@ spec:
         path: kubeflow-roles
     name: kubeflow-roles
   - kustomizeConfig:
-      parameters:
-      - name: userid-header
-        value: kubeflow-userid
       overlays:
       - istio
       - application
+      parameters:
+      - name: userid-header
+        value: kubeflow-userid
       repoRef:
         name: manifests
         path: common/centraldashboard
@@ -150,12 +149,12 @@ spec:
         path: admission-webhook/webhook
     name: webhook
   - kustomizeConfig:
-      parameters:
-      - name: userid-header
-        value: kubeflow-userid
       overlays:
       - istio
       - application
+      parameters:
+      - name: userid-header
+        value: kubeflow-userid
       repoRef:
         name: manifests
         path: jupyter/jupyter-web-app
@@ -177,14 +176,14 @@ spec:
     name: notebook-controller
   - kustomizeConfig:
       overlays:
-        - application
+      - application
       repoRef:
         name: manifests
         path: pytorch-job/pytorch-job-crds
     name: pytorch-job-crds
   - kustomizeConfig:
       overlays:
-        - application
+      - application
       repoRef:
         name: manifests
         path: pytorch-job/pytorch-operator
@@ -193,11 +192,9 @@ spec:
       overlays:
       - application
       parameters:
-      - initRequired: true
-        name: usageId
+      - name: usageId
         value: <randomly-generated-id>
-      - initRequired: true
-        name: reportUsage
+      - name: reportUsage
         value: "true"
       repoRef:
         name: manifests
@@ -308,12 +305,12 @@ spec:
         path: pipeline/pipeline-visualization-service
     name: pipeline-visualization-service
   - kustomizeConfig:
-      parameters:
-      - name: userid-header
-        value: kubeflow-userid
       overlays:
       - application
       - istio
+      parameters:
+      - name: userid-header
+        value: kubeflow-userid
       repoRef:
         name: manifests
         path: profiles


### PR DESCRIPTION
Migrate all `KfDef` to v1beta1 format.

Ran with command:
`kfdef-converter tov1beta1 <filename>`

Related to: kubeflow/kubeflow#3703
<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/manifests/553)
<!-- Reviewable:end -->
