### PR TITLE
Update KFServing ONNX version

### DIFF
--- a/kfserving/kfserving-install/base/config-map.yaml
+++ b/kfserving/kfserving-install/base/config-map.yaml
@@ -24,10 +24,10 @@ data:
         },
         "onnx": {
             "image": "mcr.microsoft.com/onnxruntime/server",
-            "defaultImageVersion": "v0.5.0",
+            "defaultImageVersion": "v0.5.1",
             "allowedImageVersions": [
                "latest",
-               "v0.5.0"
+               "v0.5.1"
             ]
         },
         "sklearn": {

--- a/tests/kfserving-install-base_test.go
+++ b/tests/kfserving-install-base_test.go
@@ -271,10 +271,10 @@ data:
         },
         "onnx": {
             "image": "mcr.microsoft.com/onnxruntime/server",
-            "defaultImageVersion": "v0.5.0",
+            "defaultImageVersion": "v0.5.1",
             "allowedImageVersions": [
                "latest",
-               "v0.5.0"
+               "v0.5.1"
             ]
         },
         "sklearn": {

--- a/tests/kfserving-install-overlays-application_test.go
+++ b/tests/kfserving-install-overlays-application_test.go
@@ -328,10 +328,10 @@ data:
         },
         "onnx": {
             "image": "mcr.microsoft.com/onnxruntime/server",
-            "defaultImageVersion": "v0.5.0",
+            "defaultImageVersion": "v0.5.1",
             "allowedImageVersions": [
                "latest",
-               "v0.5.0"
+               "v0.5.1"
             ]
         },
         "sklearn": {


### PR DESCRIPTION
Update to 0.5.1 version - this version is required to work with the kfserving v1 dataplane

**Which issue is resolved by this Pull Request:**
Resolves #

**Description of your changes:**


**Checklist:**
- [x] Unit tests have been rebuilt: 
    1. `cd manifests/tests`
    2. `make generate`
    3. `make test`

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/manifests/555)
<!-- Reviewable:end -->
