### PR TITLE
dex + istio: make service type configurable

### DIFF
--- a/dex-auth/dex-crds/base/kustomization.yaml
+++ b/dex-auth/dex-crds/base/kustomization.yaml
@@ -76,6 +76,13 @@ vars:
     apiVersion: v1
   fieldref:
     fieldpath: data.application_secret
+- name: service_type
+  objref:
+    kind: ConfigMap
+    name: dex-parameters
+    apiVersion: v1
+  fieldref:
+    fieldpath: data.service_type
 configurations:
 - params.yaml
 images:

--- a/dex-auth/dex-crds/base/params.env
+++ b/dex-auth/dex-crds/base/params.env
@@ -9,3 +9,4 @@ static_user_id=08a8684b-db88-4b73-90a9-3cd1661f5466
 client_id=ldapdexapp
 oidc_redirect_uris=['http://login.example.org:5555/callback/onprem-cluster']
 application_secret=pUBnBOY80SnXgjibTYM9ZWNzY2xreNGQok
+service_type=NodePort

--- a/dex-auth/dex-crds/base/params.yaml
+++ b/dex-auth/dex-crds/base/params.yaml
@@ -3,3 +3,5 @@ varReference:
   kind: Deployment
 - path: data/config.yaml
   kind: ConfigMap
+- path: spec/type
+  kind: Service

--- a/dex-auth/dex-crds/base/service.yaml
+++ b/dex-auth/dex-crds/base/service.yaml
@@ -3,12 +3,11 @@ kind: Service
 metadata:
   name: dex
 spec:
-  type: NodePort
+  type: $(service_type)
   ports:
   - name: dex
     port: 5556
     protocol: TCP
     targetPort: 5556
-    nodePort: 32000
   selector:
     app: dex

--- a/istio/istio-install/base/istio-noauth.yaml
+++ b/istio/istio-install/base/istio-noauth.yaml
@@ -14044,7 +14044,7 @@ metadata:
     app: istio-ingressgateway
     istio: ingressgateway
 spec:
-  type: NodePort
+  type: $(service_type)
   selector:
     release: istio
     app: istio-ingressgateway
@@ -14056,16 +14056,13 @@ spec:
       targetPort: 15020
     -
       name: http2
-      nodePort: 31380
       port: 80
       targetPort: 80
     -
       name: https
-      nodePort: 31390
       port: 443
     -
       name: tcp
-      nodePort: 31400
       port: 31400
     -
       name: https-kiali

--- a/istio/istio-install/base/kustomization.yaml
+++ b/istio/istio-install/base/kustomization.yaml
@@ -37,3 +37,19 @@ images:
 - name: docker.io/jaegertracing/all-in-one
   newName: docker.io/jaegertracing/all-in-one
   newTag: '1.9'
+
+configMapGenerator:
+- name: istio-install-parameters
+  env: params.env
+generatorOptions:
+  disableNameSuffixHash: true
+vars:
+- name: service_type
+  objref:
+    kind: ConfigMap
+    name: istio-install-parameters
+    apiVersion: v1
+  fieldref:
+    fieldpath: data.service_type
+configurations:
+- params.yaml

--- a/istio/istio-install/base/params.env
+++ b/istio/istio-install/base/params.env
@@ -1,0 +1,1 @@
+service_type=NodePort

--- a/istio/istio-install/base/params.yaml
+++ b/istio/istio-install/base/params.yaml
@@ -1,0 +1,3 @@
+varReference:
+- path: spec/type
+  kind: Service

--- a/tests/aws-aws-alb-ingress-controller-base_test.go
+++ b/tests/aws-aws-alb-ingress-controller-base_test.go
@@ -49,8 +49,7 @@ rules:
     verbs:
       - get
       - list
-      - watch
-`)
+      - watch`)
 	th.writeF("/manifests/aws/aws-alb-ingress-controller/base/cluster-role-binding.yaml", `
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
@@ -62,8 +61,7 @@ roleRef:
   name: alb-ingress-controller
 subjects:
   - kind: ServiceAccount
-    name: alb-ingress-controller
-`)
+    name: alb-ingress-controller`)
 	th.writeF("/manifests/aws/aws-alb-ingress-controller/base/deployment.yaml", `
 # Application Load Balancer (ALB) Ingress Controller Deployment Manifest.
 # This manifest details sensible defaults for deploying an ALB Ingress Controller.
@@ -123,11 +121,9 @@ spec:
 apiVersion: v1
 kind: ServiceAccount
 metadata:
-  name: alb-ingress-controller
-`)
+  name: alb-ingress-controller`)
 	th.writeF("/manifests/aws/aws-alb-ingress-controller/base/params.env", `
-clusterName=
-`)
+clusterName=`)
 	th.writeK("/manifests/aws/aws-alb-ingress-controller/base", `
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization

--- a/tests/aws-aws-alb-ingress-controller-overlays-application_test.go
+++ b/tests/aws-aws-alb-ingress-controller-overlays-application_test.go
@@ -101,8 +101,7 @@ rules:
     verbs:
       - get
       - list
-      - watch
-`)
+      - watch`)
 	th.writeF("/manifests/aws/aws-alb-ingress-controller/base/cluster-role-binding.yaml", `
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
@@ -114,8 +113,7 @@ roleRef:
   name: alb-ingress-controller
 subjects:
   - kind: ServiceAccount
-    name: alb-ingress-controller
-`)
+    name: alb-ingress-controller`)
 	th.writeF("/manifests/aws/aws-alb-ingress-controller/base/deployment.yaml", `
 # Application Load Balancer (ALB) Ingress Controller Deployment Manifest.
 # This manifest details sensible defaults for deploying an ALB Ingress Controller.
@@ -175,11 +173,9 @@ spec:
 apiVersion: v1
 kind: ServiceAccount
 metadata:
-  name: alb-ingress-controller
-`)
+  name: alb-ingress-controller`)
 	th.writeF("/manifests/aws/aws-alb-ingress-controller/base/params.env", `
-clusterName=
-`)
+clusterName=`)
 	th.writeK("/manifests/aws/aws-alb-ingress-controller/base", `
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization

--- a/tests/aws-aws-alb-ingress-controller-overlays-vpc_test.go
+++ b/tests/aws-aws-alb-ingress-controller-overlays-vpc_test.go
@@ -44,8 +44,7 @@ spec:
 `)
 	th.writeF("/manifests/aws/aws-alb-ingress-controller/overlays/vpc/params.env", `
 vpcId=
-region=us-west-2
-`)
+region=us-west-2`)
 	th.writeK("/manifests/aws/aws-alb-ingress-controller/overlays/vpc", `
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
@@ -107,8 +106,7 @@ rules:
     verbs:
       - get
       - list
-      - watch
-`)
+      - watch`)
 	th.writeF("/manifests/aws/aws-alb-ingress-controller/base/cluster-role-binding.yaml", `
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
@@ -120,8 +118,7 @@ roleRef:
   name: alb-ingress-controller
 subjects:
   - kind: ServiceAccount
-    name: alb-ingress-controller
-`)
+    name: alb-ingress-controller`)
 	th.writeF("/manifests/aws/aws-alb-ingress-controller/base/deployment.yaml", `
 # Application Load Balancer (ALB) Ingress Controller Deployment Manifest.
 # This manifest details sensible defaults for deploying an ALB Ingress Controller.
@@ -181,11 +178,9 @@ spec:
 apiVersion: v1
 kind: ServiceAccount
 metadata:
-  name: alb-ingress-controller
-`)
+  name: alb-ingress-controller`)
 	th.writeF("/manifests/aws/aws-alb-ingress-controller/base/params.env", `
-clusterName=
-`)
+clusterName=`)
 	th.writeK("/manifests/aws/aws-alb-ingress-controller/base", `
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization

--- a/tests/aws-aws-efs-csi-driver-base_test.go
+++ b/tests/aws-aws-efs-csi-driver-base_test.go
@@ -81,8 +81,7 @@ rules:
     verbs: ["get", "list", "watch"]
   - apiGroups: ["storage.k8s.io"]
     resources: ["volumeattachments"]
-    verbs: ["get", "list", "watch", "update"]
-`)
+    verbs: ["get", "list", "watch", "update"]`)
 	th.writeF("/manifests/aws/aws-efs-csi-driver/base/csi-attacher-cluster-role-binding.yaml", `
 kind: ClusterRoleBinding
 apiVersion: rbac.authorization.k8s.io/v1
@@ -95,14 +94,12 @@ subjects:
 roleRef:
   kind: ClusterRole
   name: efs-csi-external-attacher-clusterrole
-  apiGroup: rbac.authorization.k8s.io
-`)
+  apiGroup: rbac.authorization.k8s.io`)
 	th.writeF("/manifests/aws/aws-efs-csi-driver/base/csi-controller-sa.yaml", `
 apiVersion: v1
 kind: ServiceAccount
 metadata:
-  name: efs-csi-controller-sa
-`)
+  name: efs-csi-controller-sa`)
 	th.writeF("/manifests/aws/aws-efs-csi-driver/base/csi-node-cluster-role.yaml", `
 kind: ClusterRole
 apiVersion: rbac.authorization.k8s.io/v1
@@ -126,8 +123,7 @@ rules:
     verbs: ["get", "list", "watch", "update"]
   - apiGroups: ["csi.storage.k8s.io"]
     resources: ["csinodeinfos"]
-    verbs: ["get", "list", "watch", "update"]
-`)
+    verbs: ["get", "list", "watch", "update"]`)
 	th.writeF("/manifests/aws/aws-efs-csi-driver/base/csi-node-cluster-role-binding.yaml", `
 kind: ClusterRoleBinding
 apiVersion: rbac.authorization.k8s.io/v1
@@ -140,8 +136,7 @@ subjects:
 roleRef:
   kind: ClusterRole
   name: efs-csi-node-clusterrole
-  apiGroup: rbac.authorization.k8s.io
-`)
+  apiGroup: rbac.authorization.k8s.io`)
 	th.writeF("/manifests/aws/aws-efs-csi-driver/base/csi-node-daemon-set.yaml", `
 kind: DaemonSet
 apiVersion: apps/v1
@@ -225,15 +220,13 @@ spec:
 apiVersion: v1
 kind: ServiceAccount
 metadata:
-  name: efs-csi-node-sa
-`)
+  name: efs-csi-node-sa`)
 	th.writeF("/manifests/aws/aws-efs-csi-driver/base/csi-default-storage.yaml", `
 apiVersion: storage.k8s.io/v1
 kind: StorageClass
 metadata:
   name: efs-default
-provisioner: efs.csi.aws.com
-`)
+provisioner: efs.csi.aws.com`)
 	th.writeK("/manifests/aws/aws-efs-csi-driver/base", `
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization

--- a/tests/aws-aws-fsx-csi-driver-base_test.go
+++ b/tests/aws-aws-fsx-csi-driver-base_test.go
@@ -92,8 +92,7 @@ rules:
     verbs: ["get", "list", "watch"]
   - apiGroups: ["storage.k8s.io"]
     resources: ["volumeattachments"]
-    verbs: ["get", "list", "watch", "update"]
-`)
+    verbs: ["get", "list", "watch", "update"]`)
 	th.writeF("/manifests/aws/aws-fsx-csi-driver/base/csi-attacher-cluster-role-binding.yaml", `
 kind: ClusterRoleBinding
 apiVersion: rbac.authorization.k8s.io/v1
@@ -106,8 +105,7 @@ subjects:
 roleRef:
   kind: ClusterRole
   name: fsx-csi-external-attacher-clusterrole
-  apiGroup: rbac.authorization.k8s.io
-`)
+  apiGroup: rbac.authorization.k8s.io`)
 	th.writeF("/manifests/aws/aws-fsx-csi-driver/base/csi-controller-cluster-role.yaml", `
 kind: ClusterRole
 apiVersion: rbac.authorization.k8s.io/v1
@@ -125,8 +123,7 @@ rules:
     verbs: ["get", "list", "watch"]
   - apiGroups: [""]
     resources: ["events"]
-    verbs: ["get", "list", "watch", "create", "update", "patch"]
-`)
+    verbs: ["get", "list", "watch", "create", "update", "patch"]`)
 	th.writeF("/manifests/aws/aws-fsx-csi-driver/base/csi-controller-cluster-role-binding.yaml", `
 kind: ClusterRoleBinding
 apiVersion: rbac.authorization.k8s.io/v1
@@ -139,8 +136,7 @@ subjects:
 roleRef:
   kind: ClusterRole
   name: external-provisioner-role
-  apiGroup: rbac.authorization.k8s.io
-`)
+  apiGroup: rbac.authorization.k8s.io`)
 	th.writeF("/manifests/aws/aws-fsx-csi-driver/base/csi-controller-sa.yaml", `
 apiVersion: v1
 kind: ServiceAccount
@@ -184,8 +180,7 @@ subjects:
 roleRef:
   kind: ClusterRole
   name: fsx-csi-node-clusterrole
-  apiGroup: rbac.authorization.k8s.io
-`)
+  apiGroup: rbac.authorization.k8s.io`)
 	th.writeF("/manifests/aws/aws-fsx-csi-driver/base/csi-node-daemonset.yaml", `
 kind: DaemonSet
 apiVersion: apps/v1
@@ -286,8 +281,7 @@ rules:
     verbs: ["get", "list", "watch"]
   - apiGroups: [""]
     resources: ["events"]
-    verbs: ["get", "list", "watch", "create", "update", "patch"]
-`)
+    verbs: ["get", "list", "watch", "create", "update", "patch"]`)
 	th.writeF("/manifests/aws/aws-fsx-csi-driver/base/csi-provisioner-cluster-role-binding.yaml", `
 kind: ClusterRoleBinding
 apiVersion: rbac.authorization.k8s.io/v1
@@ -300,15 +294,13 @@ subjects:
 roleRef:
   kind: ClusterRole
   name: fsx-external-provisioner-clusterrole
-  apiGroup: rbac.authorization.k8s.io
-`)
+  apiGroup: rbac.authorization.k8s.io`)
 	th.writeF("/manifests/aws/aws-fsx-csi-driver/base/csi-default-storage.yaml", `
 apiVersion: storage.k8s.io/v1
 kind: StorageClass
 metadata:
   name: fsx-default
-provisioner: fsx.csi.aws.com
-`)
+provisioner: fsx.csi.aws.com`)
 	th.writeK("/manifests/aws/aws-fsx-csi-driver/base", `
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization

--- a/tests/aws-aws-istio-authz-adaptor-base_test.go
+++ b/tests/aws-aws-istio-authz-adaptor-base_test.go
@@ -37,8 +37,7 @@ spec:
         name: authzadaptor
         ports:
         - containerPort: 9070
-          protocol: TCP
-`)
+          protocol: TCP`)
 	th.writeF("/manifests/aws/aws-istio-authz-adaptor/base/service.yaml", `
 apiVersion: v1
 kind: Service
@@ -51,8 +50,7 @@ spec:
     targetPort: 9070
   selector:
     run: authzadaptor
-  type: ClusterIP
-`)
+  type: ClusterIP`)
 	th.writeF("/manifests/aws/aws-istio-authz-adaptor/base/template.yaml", `
 # this config is created through command
 # mixgen template -d $REPO_ROOT/authzadaptor/template_handler_service.descriptor_set -o $REPO_ROOT/authzadaptor/template.yaml -n authzadaptor
@@ -89,8 +87,7 @@ spec:
   connection:
     address: authzadaptor:9070
   params:
-    valid_duration: 1s
-`)
+    valid_duration: 1s`)
 	th.writeF("/manifests/aws/aws-istio-authz-adaptor/base/instance.yaml", `
 apiVersion: config.istio.io/v1alpha2
 kind: instance
@@ -99,8 +96,7 @@ metadata:
 spec:
   template: authzadaptor
   params:
-    key: request.headers["$(origin-header)"] | "unknown"
-`)
+    key: request.headers["$(origin-header)"] | "unknown"`)
 	th.writeF("/manifests/aws/aws-istio-authz-adaptor/base/rule.yaml", `
 apiVersion: config.istio.io/v1alpha2
 kind: rule
@@ -118,8 +114,7 @@ spec:
   # set  header to the output value of action "action" in the request
   - name: $(custom-header)
     values:
-    - action.output.email
-`)
+    - action.output.email`)
 	th.writeF("/manifests/aws/aws-istio-authz-adaptor/base/params.yaml", `
 varReference:
 - path: spec/actions/handler
@@ -127,13 +122,11 @@ varReference:
 - path: spec/requestHeaderOperations/name
   kind: rule
 - path: spec/params/key
-  kind: instance
-`)
+  kind: instance`)
 	th.writeF("/manifests/aws/aws-istio-authz-adaptor/base/params.env", `
 origin-header=x-amzn-oidc-header
 custom-header=kubeflow-userid
-istio-namespace=istio-system
-`)
+istio-namespace=istio-system`)
 	th.writeK("/manifests/aws/aws-istio-authz-adaptor/base", `
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
@@ -180,8 +173,7 @@ vars:
   fieldref:
     fieldpath: data.custom-header
 configurations:
-- params.yaml
-`)
+- params.yaml`)
 }
 
 func TestAwsIstioAuthzAdaptorBase(t *testing.T) {

--- a/tests/aws-aws-istio-authz-adaptor-overlays-application_test.go
+++ b/tests/aws-aws-istio-authz-adaptor-overlays-application_test.go
@@ -88,8 +88,7 @@ spec:
         name: authzadaptor
         ports:
         - containerPort: 9070
-          protocol: TCP
-`)
+          protocol: TCP`)
 	th.writeF("/manifests/aws/aws-istio-authz-adaptor/base/service.yaml", `
 apiVersion: v1
 kind: Service
@@ -102,8 +101,7 @@ spec:
     targetPort: 9070
   selector:
     run: authzadaptor
-  type: ClusterIP
-`)
+  type: ClusterIP`)
 	th.writeF("/manifests/aws/aws-istio-authz-adaptor/base/template.yaml", `
 # this config is created through command
 # mixgen template -d $REPO_ROOT/authzadaptor/template_handler_service.descriptor_set -o $REPO_ROOT/authzadaptor/template.yaml -n authzadaptor
@@ -140,8 +138,7 @@ spec:
   connection:
     address: authzadaptor:9070
   params:
-    valid_duration: 1s
-`)
+    valid_duration: 1s`)
 	th.writeF("/manifests/aws/aws-istio-authz-adaptor/base/instance.yaml", `
 apiVersion: config.istio.io/v1alpha2
 kind: instance
@@ -150,8 +147,7 @@ metadata:
 spec:
   template: authzadaptor
   params:
-    key: request.headers["$(origin-header)"] | "unknown"
-`)
+    key: request.headers["$(origin-header)"] | "unknown"`)
 	th.writeF("/manifests/aws/aws-istio-authz-adaptor/base/rule.yaml", `
 apiVersion: config.istio.io/v1alpha2
 kind: rule
@@ -169,8 +165,7 @@ spec:
   # set  header to the output value of action "action" in the request
   - name: $(custom-header)
     values:
-    - action.output.email
-`)
+    - action.output.email`)
 	th.writeF("/manifests/aws/aws-istio-authz-adaptor/base/params.yaml", `
 varReference:
 - path: spec/actions/handler
@@ -178,13 +173,11 @@ varReference:
 - path: spec/requestHeaderOperations/name
   kind: rule
 - path: spec/params/key
-  kind: instance
-`)
+  kind: instance`)
 	th.writeF("/manifests/aws/aws-istio-authz-adaptor/base/params.env", `
 origin-header=x-amzn-oidc-header
 custom-header=kubeflow-userid
-istio-namespace=istio-system
-`)
+istio-namespace=istio-system`)
 	th.writeK("/manifests/aws/aws-istio-authz-adaptor/base", `
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
@@ -231,8 +224,7 @@ vars:
   fieldref:
     fieldpath: data.custom-header
 configurations:
-- params.yaml
-`)
+- params.yaml`)
 }
 
 func TestAwsIstioAuthzAdaptorOverlaysApplication(t *testing.T) {

--- a/tests/aws-fluentd-cloud-watch-base_test.go
+++ b/tests/aws-fluentd-cloud-watch-base_test.go
@@ -24,8 +24,7 @@ rules:
     resources:
       - namespaces
       - pods
-    verbs: ["get", "list", "watch"]
-`)
+    verbs: ["get", "list", "watch"]`)
 	th.writeF("/manifests/aws/fluentd-cloud-watch/base/cluster-role-binding.yaml", `
 apiVersion: rbac.authorization.k8s.io/v1beta1
 kind: ClusterRoleBinding
@@ -38,8 +37,7 @@ roleRef:
 subjects:
   - kind: ServiceAccount
     name: fluentd
-    namespace: kube-system
-`)
+    namespace: kube-system`)
 	th.writeF("/manifests/aws/fluentd-cloud-watch/base/configmap.yaml", `
 apiVersion: v1
 kind: ConfigMap
@@ -352,8 +350,7 @@ data:
           retry_forever true
         </buffer>
       </match>
-    </label>
-`)
+    </label>`)
 	th.writeF("/manifests/aws/fluentd-cloud-watch/base/daemonset.yaml", `
 apiVersion: apps/v1
 kind: DaemonSet
@@ -433,14 +430,12 @@ spec:
             path: /run/log/journal
         - name: dmesg
           hostPath:
-            path: /var/log/dmesg
-`)
+            path: /var/log/dmesg`)
 	th.writeF("/manifests/aws/fluentd-cloud-watch/base/service-account.yaml", `
 apiVersion: v1
 kind: ServiceAccount
 metadata:
-  name: fluentd
-`)
+  name: fluentd`)
 	th.writeF("/manifests/aws/fluentd-cloud-watch/base/params.env", `
 region=us-west-2
 clusterName=

--- a/tests/aws-istio-ingress-base_test.go
+++ b/tests/aws-istio-ingress-base_test.go
@@ -35,11 +35,9 @@ spec:
 	th.writeF("/manifests/aws/istio-ingress/base/params.yaml", `
 varReference:
 - path: metadata/annotations
-  kind: Ingress
-`)
+  kind: Ingress`)
 	th.writeF("/manifests/aws/istio-ingress/base/params.env", `
-loadBalancerScheme=internet-facing
-`)
+loadBalancerScheme=internet-facing`)
 	th.writeK("/manifests/aws/istio-ingress/base", `
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
@@ -61,8 +59,7 @@ vars:
   fieldref:
     fieldpath: data.loadBalancerScheme
 configurations:
-- params.yaml
-`)
+- params.yaml`)
 }
 
 func TestIstioIngressBase(t *testing.T) {

--- a/tests/aws-istio-ingress-overlays-cognito_test.go
+++ b/tests/aws-istio-ingress-overlays-cognito_test.go
@@ -28,14 +28,12 @@ metadata:
 	th.writeF("/manifests/aws/istio-ingress/overlays/cognito/params.yaml", `
 varReference:
 - path: metadata/annotations
-  kind: Ingress
-`)
+  kind: Ingress`)
 	th.writeF("/manifests/aws/istio-ingress/overlays/cognito/params.env", `
 CognitoUserPoolArn=
 CognitoAppClientId=
 CognitoUserPoolDomain=
-certArn=
-`)
+certArn=`)
 	th.writeK("/manifests/aws/istio-ingress/overlays/cognito", `
 bases:
 - ../../base
@@ -98,11 +96,9 @@ spec:
 	th.writeF("/manifests/aws/istio-ingress/base/params.yaml", `
 varReference:
 - path: metadata/annotations
-  kind: Ingress
-`)
+  kind: Ingress`)
 	th.writeF("/manifests/aws/istio-ingress/base/params.env", `
-loadBalancerScheme=internet-facing
-`)
+loadBalancerScheme=internet-facing`)
 	th.writeK("/manifests/aws/istio-ingress/base", `
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
@@ -124,8 +120,7 @@ vars:
   fieldref:
     fieldpath: data.loadBalancerScheme
 configurations:
-- params.yaml
-`)
+- params.yaml`)
 }
 
 func TestIstioIngressOverlaysCognito(t *testing.T) {

--- a/tests/aws-istio-ingress-overlays-oidc_test.go
+++ b/tests/aws-istio-ingress-overlays-oidc_test.go
@@ -29,16 +29,14 @@ metadata:
 	th.writeF("/manifests/aws/istio-ingress/overlays/oidc/params.yaml", `
 varReference:
 - path: metadata/annotations
-  kind: Ingress
-`)
+  kind: Ingress`)
 	th.writeF("/manifests/aws/istio-ingress/overlays/oidc/params.env", `
 oidcIssuer=
 oidcAuthorizationEndpoint=
 oidcTokenEndpoint=
 oidcUserInfoEndpoint=
 oidcSecretName=istio-oidc-secret
-certArn=
-`)
+certArn=`)
 	th.writeF("/manifests/aws/istio-ingress/overlays/oidc/secrets.env", `
 clientId=
 clientSecret=
@@ -123,11 +121,9 @@ spec:
 	th.writeF("/manifests/aws/istio-ingress/base/params.yaml", `
 varReference:
 - path: metadata/annotations
-  kind: Ingress
-`)
+  kind: Ingress`)
 	th.writeF("/manifests/aws/istio-ingress/base/params.env", `
-loadBalancerScheme=internet-facing
-`)
+loadBalancerScheme=internet-facing`)
 	th.writeK("/manifests/aws/istio-ingress/base", `
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
@@ -149,8 +145,7 @@ vars:
   fieldref:
     fieldpath: data.loadBalancerScheme
 configurations:
-- params.yaml
-`)
+- params.yaml`)
 }
 
 func TestIstioIngressOverlaysOidc(t *testing.T) {

--- a/tests/aws-istio-ingress-overlays-secure_test.go
+++ b/tests/aws-istio-ingress-overlays-secure_test.go
@@ -28,13 +28,11 @@ metadata:
 	th.writeF("/manifests/aws/istio-ingress/overlays/secure/params.yaml", `
 varReference:
 - path: metadata/annotations
-  kind: Ingress
-`)
+  kind: Ingress`)
 	th.writeF("/manifests/aws/istio-ingress/overlays/secure/params.env", `
 certArn=
 hostname=
-inboundCidrs=
-`)
+inboundCidrs=`)
 	th.writeK("/manifests/aws/istio-ingress/overlays/secure", `
 bases:
 - ../../base
@@ -93,11 +91,9 @@ spec:
 	th.writeF("/manifests/aws/istio-ingress/base/params.yaml", `
 varReference:
 - path: metadata/annotations
-  kind: Ingress
-`)
+  kind: Ingress`)
 	th.writeF("/manifests/aws/istio-ingress/base/params.env", `
-loadBalancerScheme=internet-facing
-`)
+loadBalancerScheme=internet-facing`)
 	th.writeK("/manifests/aws/istio-ingress/base", `
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
@@ -119,8 +115,7 @@ vars:
   fieldref:
     fieldpath: data.loadBalancerScheme
 configurations:
-- params.yaml
-`)
+- params.yaml`)
 }
 
 func TestIstioIngressOverlaysSecure(t *testing.T) {

--- a/tests/dex-auth-dex-crds-overlays-istio_test.go
+++ b/tests/dex-auth-dex-crds-overlays-istio_test.go
@@ -197,13 +197,12 @@ kind: Service
 metadata:
   name: dex
 spec:
-  type: NodePort
+  type: $(service_type)
   ports:
   - name: dex
     port: 5556
     protocol: TCP
     targetPort: 5556
-    nodePort: 32000
   selector:
     app: dex
 `)
@@ -213,6 +212,8 @@ varReference:
   kind: Deployment
 - path: data/config.yaml
   kind: ConfigMap
+- path: spec/type
+  kind: Service
 `)
 	th.writeF("/manifests/dex-auth/dex-crds/base/params.env", `
 # Dex Server Parameters (some params are shared with client)
@@ -226,7 +227,7 @@ static_user_id=08a8684b-db88-4b73-90a9-3cd1661f5466
 client_id=ldapdexapp
 oidc_redirect_uris=['http://login.example.org:5555/callback/onprem-cluster']
 application_secret=pUBnBOY80SnXgjibTYM9ZWNzY2xreNGQok
-`)
+service_type=NodePort`)
 	th.writeK("/manifests/dex-auth/dex-crds/base", `
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
@@ -306,8 +307,19 @@ vars:
     apiVersion: v1
   fieldref:
     fieldpath: data.application_secret
+- name: service_type
+  objref:
+    kind: ConfigMap
+    name: dex-parameters
+    apiVersion: v1
+  fieldref:
+    fieldpath: data.service_type
 configurations:
 - params.yaml
+images:
+- name: quay.io/dexidp/dex
+  newName: quay.io/dexidp/dex
+  newTag: v2.22.0
 `)
 }
 

--- a/tests/dex-auth-dex-crds-overlays-ldap_test.go
+++ b/tests/dex-auth-dex-crds-overlays-ldap_test.go
@@ -335,13 +335,12 @@ kind: Service
 metadata:
   name: dex
 spec:
-  type: NodePort
+  type: $(service_type)
   ports:
   - name: dex
     port: 5556
     protocol: TCP
     targetPort: 5556
-    nodePort: 32000
   selector:
     app: dex
 `)
@@ -351,6 +350,8 @@ varReference:
   kind: Deployment
 - path: data/config.yaml
   kind: ConfigMap
+- path: spec/type
+  kind: Service
 `)
 	th.writeF("/manifests/dex-auth/dex-crds/base/params.env", `
 # Dex Server Parameters (some params are shared with client)
@@ -364,7 +365,7 @@ static_user_id=08a8684b-db88-4b73-90a9-3cd1661f5466
 client_id=ldapdexapp
 oidc_redirect_uris=['http://login.example.org:5555/callback/onprem-cluster']
 application_secret=pUBnBOY80SnXgjibTYM9ZWNzY2xreNGQok
-`)
+service_type=NodePort`)
 	th.writeK("/manifests/dex-auth/dex-crds/base", `
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
@@ -444,8 +445,19 @@ vars:
     apiVersion: v1
   fieldref:
     fieldpath: data.application_secret
+- name: service_type
+  objref:
+    kind: ConfigMap
+    name: dex-parameters
+    apiVersion: v1
+  fieldref:
+    fieldpath: data.service_type
 configurations:
 - params.yaml
+images:
+- name: quay.io/dexidp/dex
+  newName: quay.io/dexidp/dex
+  newTag: v2.22.0
 `)
 }
 

--- a/tests/gcp-privateutil-base_test.go
+++ b/tests/gcp-privateutil-base_test.go
@@ -1,0 +1,152 @@
+package tests_test
+
+import (
+	"sigs.k8s.io/kustomize/v3/k8sdeps/kunstruct"
+	"sigs.k8s.io/kustomize/v3/k8sdeps/transformer"
+	"sigs.k8s.io/kustomize/v3/pkg/fs"
+	"sigs.k8s.io/kustomize/v3/pkg/loader"
+	"sigs.k8s.io/kustomize/v3/pkg/plugins"
+	"sigs.k8s.io/kustomize/v3/pkg/resmap"
+	"sigs.k8s.io/kustomize/v3/pkg/resource"
+	"sigs.k8s.io/kustomize/v3/pkg/target"
+	"sigs.k8s.io/kustomize/v3/pkg/validators"
+	"testing"
+)
+
+func writePrivateutilBase(th *KustTestHarness) {
+	th.writeF("/manifests/gcp/privateutil/base/iap-jwt-key.yaml", `
+apiVersion: v1
+data:
+  public_key-jwk: |
+    {
+       "keys" : [
+          {
+             "alg" : "ES256",
+             "crv" : "P-256",
+             "kid" : "6BEeoA",
+             "kty" : "EC",
+             "use" : "sig",
+             "x" : "lmi1hJdqtbvdX1INOf5B9dWvkydYoowHUXiw8ELWzk8",
+             "y" : "2BxEja_L10KMjrizhLS2XgkGxZHi1KsWKdbEwKyjbvw"
+          },
+          {
+             "alg" : "ES256",
+             "crv" : "P-256",
+             "kid" : "2nMJtw",
+             "kty" : "EC",
+             "use" : "sig",
+             "x" : "9e1x7YRZg53A5zIJ0p2ZQ9yTrgPLGIf4ntOk-4O2R28",
+             "y" : "q8iDm7nsnpz1xPdrWBtTZSowzciS3O7bMYtFFJ8saYo"
+          },
+          {
+             "alg" : "ES256",
+             "crv" : "P-256",
+             "kid" : "LYyP2g",
+             "kty" : "EC",
+             "use" : "sig",
+             "x" : "SlXFFkJ3JxMsXyXNrqzE3ozl_0913PmNbccLLWfeQFU",
+             "y" : "GLSahrZfBErmMUcHP0MGaeVnJdBwquhrhQ8eP05NfCI"
+          },
+          {
+             "alg" : "ES256",
+             "crv" : "P-256",
+             "kid" : "mpf0DA",
+             "kty" : "EC",
+             "use" : "sig",
+             "x" : "fHEdeT3a6KaC1kbwov73ZwB_SiUHEyKQwUUtMCEn0aI",
+             "y" : "QWOjwPhInNuPlqjxLQyhveXpWqOFcQPhZ3t-koMNbZI"
+          },
+          {
+             "alg" : "ES256",
+             "crv" : "P-256",
+             "kid" : "b9vTLA",
+             "kty" : "EC",
+             "use" : "sig",
+             "x" : "qCByTAvci-jRAD7uQSEhTdOs8iA714IbcY2L--YzynI",
+             "y" : "WQY0uCoQyPSozWKGQ0anmFeOH5JNXiZa9i6SNqOcm7w"
+          }
+       ]
+    }
+kind: ConfigMap
+metadata:
+  name: pubkey
+  namespace: istio-system
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: pubkey
+  namespace: istio-system
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      service: pubkey
+  template:
+    metadata:
+      labels:
+        service: pubkey
+    spec:
+      containers:
+        - command:
+          - /pub-key-server
+          image: gcr.io/kubeflow-images-public/jwtpubkey:v20200311-v0.7.0-rc.5-109-g641fb40b-dirty-eb1cdc
+          name: pubkey
+          volumeMounts:
+            - mountPath: /var/pubkey/
+              name: config-volume
+      restartPolicy: Always
+      serviceAccountName: kf-admin
+      volumes:
+        - configMap:
+            name: pubkey
+          name: config-volume
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: pubkey
+  namespace: istio-system
+spec:
+  ports:
+    - port: 8087
+  selector:
+    service: pubkey`)
+	th.writeK("/manifests/gcp/privateutil/base", `
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+- iap-jwt-key.yaml
+`)
+}
+
+func TestPrivateutilBase(t *testing.T) {
+	th := NewKustTestHarness(t, "/manifests/gcp/privateutil/base")
+	writePrivateutilBase(th)
+	m, err := th.makeKustTarget().MakeCustomizedResMap()
+	if err != nil {
+		t.Fatalf("Err: %v", err)
+	}
+	expected, err := m.AsYaml()
+	if err != nil {
+		t.Fatalf("Err: %v", err)
+	}
+	targetPath := "../gcp/privateutil/base"
+	fsys := fs.MakeRealFS()
+	lrc := loader.RestrictionRootOnly
+	_loader, loaderErr := loader.NewLoader(lrc, validators.MakeFakeValidator(), targetPath, fsys)
+	if loaderErr != nil {
+		t.Fatalf("could not load kustomize loader: %v", loaderErr)
+	}
+	rf := resmap.NewFactory(resource.NewFactory(kunstruct.NewKunstructuredFactoryImpl()), transformer.NewFactoryImpl())
+	pc := plugins.DefaultPluginConfig()
+	kt, err := target.NewKustTarget(_loader, rf, transformer.NewFactoryImpl(), plugins.NewLoader(pc, rf))
+	if err != nil {
+		th.t.Fatalf("Unexpected construction error %v", err)
+	}
+	actual, err := kt.MakeCustomizedResMap()
+	if err != nil {
+		t.Fatalf("Err: %v", err)
+	}
+	th.assertActualEqualsExpected(actual, string(expected))
+}

--- a/tests/istio-cluster-local-gateway-base_test.go
+++ b/tests/istio-cluster-local-gateway-base_test.go
@@ -28,8 +28,7 @@ roleRef:
 subjects:
 - kind: ServiceAccount
   name: cluster-local-gateway-service-account
-  namespace: $(namespace)
-`)
+  namespace: $(namespace)`)
 	th.writeF("/manifests/istio/cluster-local-gateway/base/cluster-role.yaml", `
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
@@ -52,8 +51,7 @@ rules:
     verbs: ['get', 'watch', 'list']
   - apiGroups: ["extensions", "apps"]
     resources: ["replicasets"]
-    verbs: ["get", "list", "watch"]
-`)
+    verbs: ["get", "list", "watch"]`)
 	th.writeF("/manifests/istio/cluster-local-gateway/base/deployment.yaml", `
 apiVersion: apps/v1
 kind: Deployment
@@ -212,8 +210,7 @@ spec:
               - key: beta.kubernetes.io/arch
                 operator: In
                 values:
-                - s390x
-`)
+                - s390x`)
 	th.writeF("/manifests/istio/cluster-local-gateway/base/horizontal-pod-autoscaler.yaml", `
 apiVersion: autoscaling/v2beta1
 kind: HorizontalPodAutoscaler
@@ -233,8 +230,7 @@ spec:
   scaleTargetRef:
     apiVersion: apps/v1
     kind: Deployment
-    name: cluster-local-gateway
-`)
+    name: cluster-local-gateway`)
 	th.writeF("/manifests/istio/cluster-local-gateway/base/namespace.yaml", `
 apiVersion: v1
 kind: Namespace
@@ -255,8 +251,7 @@ spec:
   selector:
     matchLabels:
       app: cluster-local-gateway
-      istio: cluster-local-gateway
-`)
+      istio: cluster-local-gateway`)
 	th.writeF("/manifests/istio/cluster-local-gateway/base/service-account.yaml", `
 apiVersion: v1
 kind: ServiceAccount
@@ -268,8 +263,7 @@ metadata:
 apiVersion: v1
 kind: ServiceAccount
 metadata:
-  name: istio-multi
-`)
+  name: istio-multi`)
 	th.writeF("/manifests/istio/cluster-local-gateway/base/service.yaml", `
 apiVersion: v1
 kind: Service
@@ -318,8 +312,7 @@ spec:
     -
       name: http2-tracing
       port: 15032
-      targetPort: 15032
-`)
+      targetPort: 15032`)
 	th.writeF("/manifests/istio/cluster-local-gateway/base/params.yaml", `
 varReference:
 - path: metadata/name

--- a/tests/istio-istio-base_test.go
+++ b/tests/istio-istio-base_test.go
@@ -191,12 +191,10 @@ varReference:
 - path: spec/mode
   kind: ClusterRbacConfig
 - path: spec/selector
-  kind: Gateway
-`)
+  kind: Gateway`)
 	th.writeF("/manifests/istio/istio/base/params.env", `
 clusterRbacConfig=ON_WITH_EXCLUSION
-gatewaySelector=ingressgateway
-`)
+gatewaySelector=ingressgateway`)
 	th.writeK("/manifests/istio/istio/base", `
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization

--- a/tests/istio-istio-overlays-https-gateway_test.go
+++ b/tests/istio-istio-overlays-https-gateway_test.go
@@ -234,12 +234,10 @@ varReference:
 - path: spec/mode
   kind: ClusterRbacConfig
 - path: spec/selector
-  kind: Gateway
-`)
+  kind: Gateway`)
 	th.writeF("/manifests/istio/istio/base/params.env", `
 clusterRbacConfig=ON_WITH_EXCLUSION
-gatewaySelector=ingressgateway
-`)
+gatewaySelector=ingressgateway`)
 	th.writeK("/manifests/istio/istio/base", `
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization

--- a/tests/istio-oidc-authservice-base_test.go
+++ b/tests/istio-oidc-authservice-base_test.go
@@ -27,8 +27,7 @@ spec:
   - port: 8080
     name: http-authservice
     targetPort: http-api
-  publishNotReadyAddresses: true
-`)
+  publishNotReadyAddresses: true`)
 	th.writeF("/manifests/istio/oidc-authservice/base/statefulset.yaml", `
 apiVersion: apps/v1
 kind: StatefulSet
@@ -137,8 +136,7 @@ spec:
     - ReadWriteOnce
   resources:
     requests:
-      storage: 10Gi
-`)
+      storage: 10Gi`)
 	th.writeF("/manifests/istio/oidc-authservice/base/params.yaml", `
 varReference:
 - path: spec/template/spec/containers/env/value
@@ -146,8 +144,7 @@ varReference:
 - path: spec/filters/filterConfig/httpService/serverUri/uri
   kind: EnvoyFilter
 - path: spec/filters/filterConfig/httpService/serverUri/cluster
-  kind: EnvoyFilter
-`)
+  kind: EnvoyFilter`)
 	th.writeF("/manifests/istio/oidc-authservice/base/params.env", `
 client_id=ldapdexapp
 oidc_provider=
@@ -157,8 +154,7 @@ application_secret=pUBnBOY80SnXgjibTYM9ZWNzY2xreNGQok
 skip_auth_uri=
 userid-header=
 userid-prefix=
-namespace=istio-system
-`)
+namespace=istio-system`)
 	th.writeK("/manifests/istio/oidc-authservice/base", `
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization

--- a/tests/istio-oidc-authservice-overlays-application_test.go
+++ b/tests/istio-oidc-authservice-overlays-application_test.go
@@ -72,8 +72,7 @@ commonLabels:
   app.kubernetes.io/managed-by: kfctl
   app.kubernetes.io/component: oidc-authservice
   app.kubernetes.io/part-of: kubeflow
-  app.kubernetes.io/version: v0.7.0
-`)
+  app.kubernetes.io/version: v0.7.0`)
 	th.writeF("/manifests/istio/oidc-authservice/base/service.yaml", `
 apiVersion: v1
 kind: Service
@@ -87,8 +86,7 @@ spec:
   - port: 8080
     name: http-authservice
     targetPort: http-api
-  publishNotReadyAddresses: true
-`)
+  publishNotReadyAddresses: true`)
 	th.writeF("/manifests/istio/oidc-authservice/base/statefulset.yaml", `
 apiVersion: apps/v1
 kind: StatefulSet
@@ -197,8 +195,7 @@ spec:
     - ReadWriteOnce
   resources:
     requests:
-      storage: 10Gi
-`)
+      storage: 10Gi`)
 	th.writeF("/manifests/istio/oidc-authservice/base/params.yaml", `
 varReference:
 - path: spec/template/spec/containers/env/value
@@ -206,8 +203,7 @@ varReference:
 - path: spec/filters/filterConfig/httpService/serverUri/uri
   kind: EnvoyFilter
 - path: spec/filters/filterConfig/httpService/serverUri/cluster
-  kind: EnvoyFilter
-`)
+  kind: EnvoyFilter`)
 	th.writeF("/manifests/istio/oidc-authservice/base/params.env", `
 client_id=ldapdexapp
 oidc_provider=
@@ -217,8 +213,7 @@ application_secret=pUBnBOY80SnXgjibTYM9ZWNzY2xreNGQok
 skip_auth_uri=
 userid-header=
 userid-prefix=
-namespace=istio-system
-`)
+namespace=istio-system`)
 	th.writeK("/manifests/istio/oidc-authservice/base", `
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization

--- a/tests/istio-oidc-authservice-overlays-ibm-storage-config_test.go
+++ b/tests/istio-oidc-authservice-overlays-ibm-storage-config_test.go
@@ -56,8 +56,7 @@ spec:
   - port: 8080
     name: http-authservice
     targetPort: http-api
-  publishNotReadyAddresses: true
-`)
+  publishNotReadyAddresses: true`)
 	th.writeF("/manifests/istio/oidc-authservice/base/statefulset.yaml", `
 apiVersion: apps/v1
 kind: StatefulSet
@@ -166,8 +165,7 @@ spec:
     - ReadWriteOnce
   resources:
     requests:
-      storage: 10Gi
-`)
+      storage: 10Gi`)
 	th.writeF("/manifests/istio/oidc-authservice/base/params.yaml", `
 varReference:
 - path: spec/template/spec/containers/env/value
@@ -175,8 +173,7 @@ varReference:
 - path: spec/filters/filterConfig/httpService/serverUri/uri
   kind: EnvoyFilter
 - path: spec/filters/filterConfig/httpService/serverUri/cluster
-  kind: EnvoyFilter
-`)
+  kind: EnvoyFilter`)
 	th.writeF("/manifests/istio/oidc-authservice/base/params.env", `
 client_id=ldapdexapp
 oidc_provider=
@@ -186,8 +183,7 @@ application_secret=pUBnBOY80SnXgjibTYM9ZWNzY2xreNGQok
 skip_auth_uri=
 userid-header=
 userid-prefix=
-namespace=istio-system
-`)
+namespace=istio-system`)
 	th.writeK("/manifests/istio/oidc-authservice/base", `
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization

--- a/tests/metadata-overlays-external-mysql_test.go
+++ b/tests/metadata-overlays-external-mysql_test.go
@@ -83,8 +83,7 @@ spec:
 MYSQL_HOST=external_host
 MYSQL_DATABASE=metadb
 MYSQL_PORT=3306
-MYSQL_ALLOW_EMPTY_PASSWORD=true
-`)
+MYSQL_ALLOW_EMPTY_PASSWORD=true`)
 	th.writeF("/manifests/metadata/overlays/external-mysql/secrets.env", `
 MYSQL_USERNAME=root
 MYSQ_PASSWORD=test
@@ -103,8 +102,7 @@ secretGenerator:
 bases:
 - ../../base
 patchesStrategicMerge:
-- metadata-deployment.yaml
-`)
+- metadata-deployment.yaml`)
 	th.writeF("/manifests/metadata/base/metadata-deployment.yaml", `
 apiVersion: apps/v1
 kind: Deployment
@@ -346,8 +344,7 @@ uiClusterDomain=cluster.local
 `)
 	th.writeF("/manifests/metadata/base/grpc-params.env", `
 METADATA_GRPC_SERVICE_HOST=metadata-grpc-service
-METADATA_GRPC_SERVICE_PORT=8080
-`)
+METADATA_GRPC_SERVICE_PORT=8080`)
 	th.writeK("/manifests/metadata/base", `
 namePrefix: metadata-
 apiVersion: kustomize.config.k8s.io/v1beta1

--- a/tests/pipeline-api-service-overlays-external-mysql_test.go
+++ b/tests/pipeline-api-service-overlays-external-mysql_test.go
@@ -47,13 +47,11 @@ metadata:
 	th.writeF("/manifests/pipeline/api-service/overlays/external-mysql/params.yaml", `
 varReference:
 - path: data
-  kind: ConfigMap
-`)
+  kind: ConfigMap`)
 	th.writeF("/manifests/pipeline/api-service/overlays/external-mysql/params.env", `
 mysqlHost=
 mysqlUser=
-mysqlPassword=
-`)
+mysqlPassword=`)
 	th.writeK("/manifests/pipeline/api-service/overlays/external-mysql", `
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
@@ -89,8 +87,7 @@ vars:
   fieldref:
     fieldpath: data.mysqlPassword
 configurations:
-- params.yaml
-`)
+- params.yaml`)
 	th.writeF("/manifests/pipeline/api-service/base/config-map.yaml", `
 # The configuration for the ML pipelines APIServer
 # Based on https://github.com/kubeflow/pipelines/blob/master/backend/src/apiserver/config/config.json


### PR DESCRIPTION
**Issue:**
Related https://github.com/kubeflow/manifests/issues/566

**Description of your changes:**
This PR exposes the service type of the Istio IngressGateway and Dex services to make them configurable.
It also removes hardcoded nodePort values, as it was necessary for ClusterIP to work.
In addition, Kubernetes can choose them at runtime and it makes the configs more portable.

/cc @elikatsis @lluunn @kkasravi @krishnadurai @jlewi @ryandawsonuk 

**Checklist:**
- [X] Unit tests have been rebuilt: 
    1. `cd manifests/tests`
    2. `make generate`
    3. `make test`

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/manifests/558)
<!-- Reviewable:end -->
