### PR TITLE
Configures Istio Gateway to serve through port 443 for HTTPS

### DIFF
--- a/istio/istio/overlays/https-gateway/kf-istio-resources.yaml
+++ b/istio/istio/overlays/https-gateway/kf-istio-resources.yaml
@@ -1,0 +1,18 @@
+apiVersion: networking.istio.io/v1alpha3
+kind: Gateway
+metadata:
+  name: kubeflow-gateway
+spec:
+  selector:
+    istio: $(gatewaySelector)
+  servers:
+  - hosts:
+    - '*'
+    port:
+      name: https
+      number: 443
+      protocol: HTTPS
+    tls:
+      mode: SIMPLE
+      privateKey: /etc/istio/ingressgateway-certs/tls.key
+      serverCertificate: /etc/istio/ingressgateway-certs/tls.crt

--- a/istio/istio/overlays/https-gateway/kustomization.yaml
+++ b/istio/istio/overlays/https-gateway/kustomization.yaml
@@ -1,0 +1,13 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+bases:
+- ../../base
+patchesStrategicMerge:
+- kf-istio-resources.yaml
+
+configMapGenerator:
+- name: istio-parameters
+  behavior: merge
+  env: params.env
+configurations:
+- params.yaml

--- a/istio/istio/overlays/https-gateway/params.env
+++ b/istio/istio/overlays/https-gateway/params.env
@@ -1,0 +1,1 @@
+gatewaySelector=ingressgateway

--- a/istio/istio/overlays/https-gateway/params.yaml
+++ b/istio/istio/overlays/https-gateway/params.yaml
@@ -1,0 +1,3 @@
+varReference:
+- path: spec/selector
+  kind: Gateway

--- a/tests/istio-overlays-https-gateway_test.go
+++ b/tests/istio-overlays-https-gateway_test.go
@@ -1,0 +1,295 @@
+package tests_test
+
+import (
+	"sigs.k8s.io/kustomize/v3/k8sdeps/kunstruct"
+	"sigs.k8s.io/kustomize/v3/k8sdeps/transformer"
+	"sigs.k8s.io/kustomize/v3/pkg/fs"
+	"sigs.k8s.io/kustomize/v3/pkg/loader"
+	"sigs.k8s.io/kustomize/v3/pkg/plugins"
+	"sigs.k8s.io/kustomize/v3/pkg/resmap"
+	"sigs.k8s.io/kustomize/v3/pkg/resource"
+	"sigs.k8s.io/kustomize/v3/pkg/target"
+	"sigs.k8s.io/kustomize/v3/pkg/validators"
+	"testing"
+)
+
+func writeIstioOverlaysHttpsGateway(th *KustTestHarness) {
+	th.writeF("/manifests/istio/istio/overlays/https-gateway/kf-istio-resources.yaml", `
+apiVersion: networking.istio.io/v1alpha3
+kind: Gateway
+metadata:
+  name: kubeflow-gateway
+spec:
+  selector:
+    istio: $(gatewaySelector)
+  servers:
+  - hosts:
+    - '*'
+    port:
+      name: https
+      number: 443
+      protocol: HTTPS
+    tls:
+      mode: SIMPLE
+      privateKey: /etc/istio/ingressgateway-certs/tls.key
+      serverCertificate: /etc/istio/ingressgateway-certs/tls.crt
+`)
+	th.writeF("/manifests/istio/istio/overlays/https-gateway/params.yaml", `
+varReference:
+- path: spec/selector
+  kind: Gateway
+`)
+	th.writeF("/manifests/istio/istio/overlays/https-gateway/params.env", `
+gatewaySelector=ingressgateway
+`)
+	th.writeK("/manifests/istio/istio/overlays/https-gateway", `
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+bases:
+- ../../base
+patchesStrategicMerge:
+- kf-istio-resources.yaml
+
+configMapGenerator:
+- name: istio-parameters
+  behavior: merge
+  env: params.env
+configurations:
+- params.yaml
+`)
+	th.writeF("/manifests/istio/istio/base/kf-istio-resources.yaml", `
+apiVersion: networking.istio.io/v1alpha3
+kind: Gateway
+metadata:
+  name: kubeflow-gateway
+spec:
+  selector:
+    istio: $(gatewaySelector)
+  servers:
+  - port:
+      number: 80
+      name: http
+      protocol: HTTP
+    hosts:
+    - "*"
+---
+apiVersion: networking.istio.io/v1alpha3
+kind: VirtualService
+metadata:
+  name: grafana-vs
+spec:
+  hosts:
+  - "*"
+  gateways:
+  - "kubeflow-gateway"
+  http:
+  - match:
+    - uri:
+        prefix: "/istio/grafana/"
+      method:
+        exact: "GET"
+    rewrite:
+      uri: "/"
+    route:
+    - destination:
+        host: "grafana.istio-system.svc.cluster.local"
+        port:
+          number: 3000
+---
+apiVersion: networking.istio.io/v1alpha3
+kind: ServiceEntry
+metadata:
+  name: google-api-entry
+spec:
+  hosts:
+  - www.googleapis.com
+  ports:
+  - number: 443
+    name: https
+    protocol: HTTPS
+  resolution: DNS
+  location: MESH_EXTERNAL
+---
+apiVersion: networking.istio.io/v1alpha3
+kind: VirtualService
+metadata:
+  name: google-api-vs
+spec:
+  hosts:
+  - www.googleapis.com
+  tls:
+  - match:
+    - port: 443
+      sni_hosts:
+      - www.googleapis.com
+    route:
+    - destination:
+        host: www.googleapis.com
+        port:
+          number: 443
+      weight: 100
+---
+apiVersion: networking.istio.io/v1alpha3
+kind: ServiceEntry
+metadata:
+  name: google-storage-api-entry
+spec:
+  hosts:
+  - storage.googleapis.com
+  ports:
+  - number: 443
+    name: https
+    protocol: HTTPS
+  resolution: DNS
+  location: MESH_EXTERNAL
+---
+apiVersion: networking.istio.io/v1alpha3
+kind: VirtualService
+metadata:
+  name: google-storage-api-vs
+spec:
+  hosts:
+  - storage.googleapis.com
+  tls:
+  - match:
+    - port: 443
+      sni_hosts:
+      - storage.googleapis.com
+    route:
+    - destination:
+        host: storage.googleapis.com
+        port:
+          number: 443
+      weight: 100
+---
+apiVersion: rbac.istio.io/v1alpha1
+kind: ClusterRbacConfig
+metadata:
+  name: default
+spec:
+  mode: $(clusterRbacConfig)
+`)
+	th.writeF("/manifests/istio/istio/base/cluster-roles.yaml", `
+---
+
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: kubeflow-istio-admin
+  labels:
+    rbac.authorization.kubeflow.org/aggregate-to-kubeflow-admin: "true"
+aggregationRule:
+  clusterRoleSelectors:
+  - matchLabels:
+      rbac.authorization.kubeflow.org/aggregate-to-kubeflow-istio-admin: "true"
+rules: []
+
+---
+
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: kubeflow-istio-edit
+  labels:
+    rbac.authorization.kubeflow.org/aggregate-to-kubeflow-edit: "true"
+    rbac.authorization.kubeflow.org/aggregate-to-kubeflow-istio-admin: "true"
+rules:
+- apiGroups: ["istio.io"]
+  resources: ["*"]
+  verbs:
+  - get
+  - list
+  - watch
+  - create
+  - delete
+  - deletecollection
+  - patch
+  - update
+
+---
+
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: kubeflow-istio-view
+  labels:
+    rbac.authorization.kubeflow.org/aggregate-to-kubeflow-view: "true"
+rules:
+- apiGroups: ["istio.io"]
+  resources: ["*"]
+  verbs:
+  - get
+  - list
+  - watch
+`)
+	th.writeF("/manifests/istio/istio/base/params.yaml", `
+varReference:
+- path: spec/mode
+  kind: ClusterRbacConfig
+- path: spec/selector
+  kind: Gateway
+`)
+	th.writeF("/manifests/istio/istio/base/params.env", `
+clusterRbacConfig=ON
+gatewaySelector=ingressgateway
+`)
+	th.writeK("/manifests/istio/istio/base", `
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+- kf-istio-resources.yaml
+- cluster-roles.yaml
+namespace: kubeflow
+configMapGenerator:
+- name: istio-parameters
+  env: params.env
+vars:
+- name: clusterRbacConfig
+  objref:
+    kind: ConfigMap
+    name: istio-parameters
+    apiVersion: v1
+  fieldref:
+    fieldpath: data.clusterRbacConfig
+- name: gatewaySelector
+  objref:
+    kind: ConfigMap
+    name: istio-parameters
+    apiVersion: v1
+  fieldref:
+    fieldpath: data.gatewaySelector
+configurations:
+- params.yaml
+`)
+}
+
+func TestIstioOverlaysHttpsGateway(t *testing.T) {
+	th := NewKustTestHarness(t, "/manifests/istio/istio/overlays/https-gateway")
+	writeIstioOverlaysHttpsGateway(th)
+	m, err := th.makeKustTarget().MakeCustomizedResMap()
+	if err != nil {
+		t.Fatalf("Err: %v", err)
+	}
+	expected, err := m.AsYaml()
+	if err != nil {
+		t.Fatalf("Err: %v", err)
+	}
+	targetPath := "../istio/istio/overlays/https-gateway"
+	fsys := fs.MakeRealFS()
+	lrc := loader.RestrictionRootOnly
+	_loader, loaderErr := loader.NewLoader(lrc, validators.MakeFakeValidator(), targetPath, fsys)
+	if loaderErr != nil {
+		t.Fatalf("could not load kustomize loader: %v", loaderErr)
+	}
+	rf := resmap.NewFactory(resource.NewFactory(kunstruct.NewKunstructuredFactoryImpl()), transformer.NewFactoryImpl())
+	pc := plugins.DefaultPluginConfig()
+	kt, err := target.NewKustTarget(_loader, rf, transformer.NewFactoryImpl(), plugins.NewLoader(pc, rf))
+	if err != nil {
+		th.t.Fatalf("Unexpected construction error %v", err)
+	}
+	actual, err := kt.MakeCustomizedResMap()
+	if err != nil {
+		t.Fatalf("Err: %v", err)
+	}
+	th.assertActualEqualsExpected(actual, string(expected))
+}


### PR DESCRIPTION
**Description of your changes:**
Istio Gateway: kubeflow-gateway currently serves requests through HTTP port 80. This change adds an overlay to kubeflow's istio resources to have kubeflow-gateway serve through HTTPS port 443.

**Checklist:**
- [x] Unit tests have been rebuilt: 
    1. `cd manifests/tests`
    2. `make generate`
    3. `make test`

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/manifests/562)
<!-- Reviewable:end -->
