### PR TITLE
kfdef: existing_arrikto: add v0.7.0 config

### DIFF
--- a/kfdef/kfctl_existing_arrikto.0.7.0.yaml
+++ b/kfdef/kfctl_existing_arrikto.0.7.0.yaml
@@ -324,4 +324,4 @@ spec:
     name: seldon-core-operator
   repos:
   - name: manifests
-    uri: https://github.com/kubeflow/manifests/archive/v0.7-branch.tar.gz
+    uri: https://github.com/kubeflow/manifests/archive/2b34c263cf5165339f856b50cd759db30c6cae9d.tar.gz


### PR DESCRIPTION
**Description of your changes:**
Pins existing_arrikto to a known and tested version of manifests.
Includes https://github.com/kubeflow/manifests/pull/549 which is not in v0.7-branch.
Will revert to a v0.7-branch commit when all the cherry picks are done.

/cc @ryandawsonuk @jlewi 

**Checklist:**
- [X] Unit tests have been rebuilt: 
    1. `cd manifests/tests`
    2. `make generate`
    3. `make test`

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/manifests/571)
<!-- Reviewable:end -->
