### PR TITLE
Fix KFServing preventing notebook (and other pods) form starting.

### DIFF
--- a/gcp/deployment_manager_configs/cluster-kubeflow.yaml
+++ b/gcp/deployment_manager_configs/cluster-kubeflow.yaml
@@ -31,9 +31,7 @@ resources:
     zone: SET_THE_ZONE
     # "1.X": picks the highest valid patch+gke.N patch in the 1.X version
     # https://cloud.google.com/kubernetes-engine/docs/reference/rest/v1/projects.zones.clusters
-    # TODO(https://github.com/kubeflow/kfctl/issues/48): This is a short term
-    # work around. We should unpin once 1.14.6-gke.14 is available.
-    cluster-version: "1.14.6-gke.2"
+    cluster-version: "1.14"
     # Set this to v1beta1 to use beta features such as private clusterss
     # and the Kubernetes stackdriver agents.
     gkeApiVersion: SET_GKE_API_VERSION

--- a/kfserving/kfserving-install/base/kustomization.yaml
+++ b/kfserving/kfserving-install/base/kustomization.yaml
@@ -27,6 +27,6 @@ images:
 - name: gcr.io/kubebuilder/kube-rbac-proxy
   newName: gcr.io/kubebuilder/kube-rbac-proxy
   newTag: v0.4.0
-- name: $(registry)/kfserving-controller
-  newName: $(registry)/kfserving-controller
-  newTag: 0.2.0
+- name: gcr.io/kfserving/kfserving-controller
+  newName: gcr.io/kfserving/kfserving-controller
+  digest: sha256:180d06026c4dd6c2d3ce4748efc896751b9bb6108b67a9eaa0e50158d6e10f1e

--- a/kfserving/kfserving-install/base/statefulset.yaml
+++ b/kfserving/kfserving-install/base/statefulset.yaml
@@ -39,7 +39,7 @@ spec:
               fieldPath: metadata.namespace
         - name: SECRET_NAME
           value: kfserving-webhook-server-secret
-        image: $(registry)/kfserving-controller:0.2.0
+        image: gcr.io/kfserving/kfserving-controller
         imagePullPolicy: Always
         name: manager
         ports:

--- a/tests/kfserving-install-base_test.go
+++ b/tests/kfserving-install-base_test.go
@@ -388,7 +388,7 @@ spec:
               fieldPath: metadata.namespace
         - name: SECRET_NAME
           value: kfserving-webhook-server-secret
-        image: $(registry)/kfserving-controller:0.2.0
+        image: gcr.io/kfserving/kfserving-controller
         imagePullPolicy: Always
         name: manager
         ports:
@@ -490,9 +490,9 @@ images:
 - name: gcr.io/kubebuilder/kube-rbac-proxy
   newName: gcr.io/kubebuilder/kube-rbac-proxy
   newTag: v0.4.0
-- name: $(registry)/kfserving-controller
-  newName: $(registry)/kfserving-controller
-  newTag: 0.2.0
+- name: gcr.io/kfserving/kfserving-controller
+  newName: gcr.io/kfserving/kfserving-controller
+  digest: sha256:180d06026c4dd6c2d3ce4748efc896751b9bb6108b67a9eaa0e50158d6e10f1e
 `)
 }
 

--- a/tests/kfserving-install-overlays-application_test.go
+++ b/tests/kfserving-install-overlays-application_test.go
@@ -445,7 +445,7 @@ spec:
               fieldPath: metadata.namespace
         - name: SECRET_NAME
           value: kfserving-webhook-server-secret
-        image: $(registry)/kfserving-controller:0.2.0
+        image: gcr.io/kfserving/kfserving-controller
         imagePullPolicy: Always
         name: manager
         ports:
@@ -547,9 +547,9 @@ images:
 - name: gcr.io/kubebuilder/kube-rbac-proxy
   newName: gcr.io/kubebuilder/kube-rbac-proxy
   newTag: v0.4.0
-- name: $(registry)/kfserving-controller
-  newName: $(registry)/kfserving-controller
-  newTag: 0.2.0
+- name: gcr.io/kfserving/kfserving-controller
+  newName: gcr.io/kfserving/kfserving-controller
+  digest: sha256:180d06026c4dd6c2d3ce4748efc896751b9bb6108b67a9eaa0e50158d6e10f1e
 `)
 }
 


### PR DESCRIPTION
* Related to kubeflow/kfserving#486
* The tag for the kfserving image, 0.2.0, this caused a breakage.
  With the newest image there is a bug and the kfserving mutator starts
  applying itself to non kfserving pods and ends up rejecting them.

* This change rolls back to an earlier image that was used yesterday in my
  deployment.

* We remove the $(registry) parameter from kustomization.yaml
  We don't want to treat registry as a parameter; this breaks the ability
  to use kustomize's ability to override images.

**Which issue is resolved by this Pull Request:**
Resolves #

**Description of your changes:**


**Checklist:**
- [ ] Unit tests have been rebuilt: 
    1. `cd manifests/tests`
    2. `make generate`
    3. `make test`

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/manifests/576)
<!-- Reviewable:end -->
