### PR TITLE
Unpin from GKE 1.14.6-gke.2; 1.14.6 is no longer a valid master.

### DIFF
--- a/gcp/deployment_manager_configs/cluster-kubeflow.yaml
+++ b/gcp/deployment_manager_configs/cluster-kubeflow.yaml
@@ -31,9 +31,7 @@ resources:
     zone: SET_THE_ZONE
     # "1.X": picks the highest valid patch+gke.N patch in the 1.X version
     # https://cloud.google.com/kubernetes-engine/docs/reference/rest/v1/projects.zones.clusters
-    # TODO(https://github.com/kubeflow/kfctl/issues/48): This is a short term
-    # work around. We should unpin once 1.14.6-gke.14 is available.
-    cluster-version: "1.14.6-gke.2"
+    cluster-version: "1.14"
     # Set this to v1beta1 to use beta features such as private clusterss
     # and the Kubernetes stackdriver agents.
     gkeApiVersion: SET_GKE_API_VERSION


### PR DESCRIPTION
Related to kubeflow/manifests#508

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/manifests/577)
<!-- Reviewable:end -->
