### PR TITLE
Update deployments to use `apps/v1` api version

### DIFF
--- a/metadata/base/metadata-envoy-deployment.yaml
+++ b/metadata/base/metadata-envoy-deployment.yaml
@@ -1,4 +1,4 @@
-apiVersion: apps/v1beta2
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: envoy-deployment

--- a/tests/metadata-base_test.go
+++ b/tests/metadata-base_test.go
@@ -309,7 +309,7 @@ spec:
     app: metadata-ui
 `)
 	th.writeF("/manifests/metadata/base/metadata-envoy-deployment.yaml", `
-apiVersion: apps/v1beta2
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: envoy-deployment

--- a/tests/metadata-overlays-application_test.go
+++ b/tests/metadata-overlays-application_test.go
@@ -366,7 +366,7 @@ spec:
     app: metadata-ui
 `)
 	th.writeF("/manifests/metadata/base/metadata-envoy-deployment.yaml", `
-apiVersion: apps/v1beta2
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: envoy-deployment

--- a/tests/metadata-overlays-istio_test.go
+++ b/tests/metadata-overlays-istio_test.go
@@ -371,7 +371,7 @@ spec:
     app: metadata-ui
 `)
 	th.writeF("/manifests/metadata/base/metadata-envoy-deployment.yaml", `
-apiVersion: apps/v1beta2
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: envoy-deployment


### PR DESCRIPTION
**Which issue is resolved by this Pull Request:**

Fixes https://github.com/kubeflow/manifests/issues/585

**Description of your changes:**

The `apps/v1beta2` has been removed from Kubernetes 1.16, so we should stick to `apps/v1` from now on.

**Checklist:**
- [x] Unit tests have been rebuilt: 
    1. `cd manifests/tests`
    2. `make generate`
    3. `make test`

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/manifests/586)
<!-- Reviewable:end -->
