### PR TITLE
Automated cherry pick of #586: Update deployments to use `apps/v1` api version on v0.7-branch.

### DIFF
--- a/metadata/base/metadata-envoy-deployment.yaml
+++ b/metadata/base/metadata-envoy-deployment.yaml
@@ -1,4 +1,4 @@
-apiVersion: apps/v1beta2
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: envoy-deployment

--- a/tests/metadata-base_test.go
+++ b/tests/metadata-base_test.go
@@ -309,7 +309,7 @@ spec:
     app: metadata-ui
 `)
 	th.writeF("/manifests/metadata/base/metadata-envoy-deployment.yaml", `
-apiVersion: apps/v1beta2
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: envoy-deployment

--- a/tests/metadata-overlays-application_test.go
+++ b/tests/metadata-overlays-application_test.go
@@ -366,7 +366,7 @@ spec:
     app: metadata-ui
 `)
 	th.writeF("/manifests/metadata/base/metadata-envoy-deployment.yaml", `
-apiVersion: apps/v1beta2
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: envoy-deployment

--- a/tests/metadata-overlays-istio_test.go
+++ b/tests/metadata-overlays-istio_test.go
@@ -371,7 +371,7 @@ spec:
     app: metadata-ui
 `)
 	th.writeF("/manifests/metadata/base/metadata-envoy-deployment.yaml", `
-apiVersion: apps/v1beta2
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: envoy-deployment


### PR DESCRIPTION


<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/manifests/588)
<!-- Reviewable:end -->
