### PR TITLE
Automated cherry pick of #594: Fix ml-pipeline-ui doesn't have gcp permission bug Cherry pick of #594 on v0.7-branch. #594: Fix ml-pipeline-ui doesn't have gcp permission bug

### DIFF
--- a/kfdef/kfctl_gcp_basic_auth.0.7.0.yaml
+++ b/kfdef/kfctl_gcp_basic_auth.0.7.0.yaml
@@ -259,6 +259,7 @@ spec:
     name: pipelines-runner
   - kustomizeConfig:
       overlays:
+      - gcp
       - istio
       - application
       repoRef:

--- a/kfdef/kfctl_gcp_iap.0.7.0.yaml
+++ b/kfdef/kfctl_gcp_iap.0.7.0.yaml
@@ -269,6 +269,7 @@ spec:
     name: pipelines-runner
   - kustomizeConfig:
       overlays:
+      - gcp
       - istio
       - application
       repoRef:

--- a/pipeline/pipelines-ui/base/deployment.yaml
+++ b/pipeline/pipelines-ui/base/deployment.yaml
@@ -13,21 +13,10 @@ spec:
       labels:
         app: ml-pipeline-ui
     spec:
-      volumes:
-      - name: gcp-sa-token
-        secret:
-          secretName: user-gcp-sa
       containers:
       - name: ml-pipeline-ui
-        env:
-        - name: GOOGLE_APPLICATION_CREDENTIALS
-          value: /etc/credentials/user-gcp-sa.json
         image: gcr.io/ml-pipeline/frontend
         imagePullPolicy: IfNotPresent
         ports:
         - containerPort: 3000
-        volumeMounts:
-        - name: gcp-sa-token
-          mountPath: "/etc/credentials"
-          readOnly: true
       serviceAccountName: ml-pipeline-ui

--- a/pipeline/pipelines-ui/base/deployment.yaml
+++ b/pipeline/pipelines-ui/base/deployment.yaml
@@ -13,10 +13,21 @@ spec:
       labels:
         app: ml-pipeline-ui
     spec:
+      volumes:
+      - name: gcp-sa-token
+        secret:
+          secretName: user-gcp-sa
       containers:
       - name: ml-pipeline-ui
+        env:
+        - name: GOOGLE_APPLICATION_CREDENTIALS
+          value: /etc/credentials/user-gcp-sa.json
         image: gcr.io/ml-pipeline/frontend
         imagePullPolicy: IfNotPresent
         ports:
         - containerPort: 3000
+        volumeMounts:
+        - name: gcp-sa-token
+          mountPath: "/etc/credentials"
+          readOnly: true
       serviceAccountName: ml-pipeline-ui

--- a/pipeline/pipelines-ui/overlays/gcp/deployment.yaml
+++ b/pipeline/pipelines-ui/overlays/gcp/deployment.yaml
@@ -1,0 +1,20 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: ml-pipeline-ui
+spec:
+  template:
+    spec:
+      volumes:
+      - name: gcp-sa-token
+        secret:
+          secretName: user-gcp-sa
+      containers:
+      - name: ml-pipeline-ui
+        env:
+        - name: GOOGLE_APPLICATION_CREDENTIALS
+          value: /etc/credentials/user-gcp-sa.json
+        volumeMounts:
+        - name: gcp-sa-token
+          mountPath: "/etc/credentials"
+          readOnly: true

--- a/pipeline/pipelines-ui/overlays/gcp/kustomization.yaml
+++ b/pipeline/pipelines-ui/overlays/gcp/kustomization.yaml
@@ -1,0 +1,6 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+bases:
+- ../../base
+patchesStrategicMerge:
+- deployment.yaml

--- a/tests/istio-ingress-overlays-cognito_test.go
+++ b/tests/istio-ingress-overlays-cognito_test.go
@@ -31,14 +31,12 @@ metadata:
 	th.writeF("/manifests/aws/istio-ingress/overlays/cognito/params.yaml", `
 varReference:
 - path: metadata/annotations
-  kind: Ingress
-`)
+  kind: Ingress`)
 	th.writeF("/manifests/aws/istio-ingress/overlays/cognito/params.env", `
 CognitoUserPoolArn=
 CognitoAppClientId=
 CognitoUserPoolDomain=
-certArn=
-`)
+certArn=`)
 	th.writeK("/manifests/aws/istio-ingress/overlays/cognito", `
 bases:
 - ../../base

--- a/tests/istio-ingress-overlays-oidc_test.go
+++ b/tests/istio-ingress-overlays-oidc_test.go
@@ -40,8 +40,7 @@ oidcAuthorizationEndpoint=
 oidcTokenEndpoint=
 oidcUserInfoEndpoint=
 oidcSecretName=istio-oidc-secret
-certArn=
-`)
+certArn=`)
 	th.writeF("/manifests/aws/istio-ingress/overlays/oidc/secrets.env", `
 clientId=
 clientSecret=

--- a/tests/pipelines-ui-overlays-gcp_test.go
+++ b/tests/pipelines-ui-overlays-gcp_test.go
@@ -1,0 +1,258 @@
+package tests_test
+
+import (
+	"sigs.k8s.io/kustomize/v3/k8sdeps/kunstruct"
+	"sigs.k8s.io/kustomize/v3/k8sdeps/transformer"
+	"sigs.k8s.io/kustomize/v3/pkg/fs"
+	"sigs.k8s.io/kustomize/v3/pkg/loader"
+	"sigs.k8s.io/kustomize/v3/pkg/plugins"
+	"sigs.k8s.io/kustomize/v3/pkg/resmap"
+	"sigs.k8s.io/kustomize/v3/pkg/resource"
+	"sigs.k8s.io/kustomize/v3/pkg/target"
+	"sigs.k8s.io/kustomize/v3/pkg/validators"
+	"testing"
+)
+
+func writePipelinesUiOverlaysGcp(th *KustTestHarness) {
+	th.writeF("/manifests/pipeline/pipelines-ui/overlays/gcp/deployment.yaml", `
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: ml-pipeline-ui
+spec:
+  template:
+    spec:
+      volumes:
+      - name: gcp-sa-token
+        secret:
+          secretName: user-gcp-sa
+      containers:
+      - name: ml-pipeline-ui
+        env:
+        - name: GOOGLE_APPLICATION_CREDENTIALS
+          value: /etc/credentials/user-gcp-sa.json
+        volumeMounts:
+        - name: gcp-sa-token
+          mountPath: "/etc/credentials"
+          readOnly: true
+`)
+	th.writeK("/manifests/pipeline/pipelines-ui/overlays/gcp", `
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+bases:
+- ../../base
+patchesStrategicMerge:
+- deployment.yaml
+`)
+	th.writeF("/manifests/pipeline/pipelines-ui/base/deployment.yaml", `
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  labels:
+    app: ml-pipeline-ui
+  name: ml-pipeline-ui
+spec:
+  selector:
+    matchLabels:
+      app: ml-pipeline-ui
+  template:
+    metadata:
+      labels:
+        app: ml-pipeline-ui
+    spec:
+      containers:
+      - name: ml-pipeline-ui
+        image: gcr.io/ml-pipeline/frontend
+        imagePullPolicy: IfNotPresent
+        ports:
+        - containerPort: 3000
+      serviceAccountName: ml-pipeline-ui
+`)
+	th.writeF("/manifests/pipeline/pipelines-ui/base/role-binding.yaml", `
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: RoleBinding
+metadata:
+  labels:
+    app: ml-pipeline-ui
+  name: ml-pipeline-ui
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: ml-pipeline-ui
+subjects:
+- kind: ServiceAccount
+  name: ml-pipeline-ui
+`)
+	th.writeF("/manifests/pipeline/pipelines-ui/base/role.yaml", `
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: Role
+metadata:
+  labels:
+    app: ml-pipeline-ui
+  name: ml-pipeline-ui
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - pods
+  - pods/log
+  verbs:
+  - create
+  - get
+  - list
+- apiGroups:
+  - "kubeflow.org"
+  resources:
+  - viewers
+  verbs:
+  - create
+  - get
+  - list
+  - watch
+  - delete
+`)
+	th.writeF("/manifests/pipeline/pipelines-ui/base/service-account.yaml", `
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: ml-pipeline-ui
+`)
+	th.writeF("/manifests/pipeline/pipelines-ui/base/service.yaml", `
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: ml-pipeline-ui
+  annotations:
+    getambassador.io/config: |-
+      ---
+      apiVersion: ambassador/v0
+      kind:  Mapping
+      name: pipelineui-mapping
+      prefix: /pipeline
+      rewrite: /pipeline
+      timeout_ms: 300000
+      service: $(service).$(ui-namespace)
+      use_websocket: true
+  labels:
+    app: ml-pipeline-ui
+spec:
+  ports:
+  - port: 80
+    targetPort: 3000
+  selector:
+    app: ml-pipeline-ui
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: ml-pipeline-tensorboard-ui
+  annotations:
+    getambassador.io/config: |-
+      ---
+      apiVersion: ambassador/v0
+      kind:  Mapping
+      name: pipeline-tensorboard-ui-mapping
+      prefix: /data
+      rewrite: /data
+      timeout_ms: 300000
+      service: $(service).$(ui-namespace)
+      use_websocket: true
+  labels:
+    app: ml-pipeline-tensorboard-ui
+spec:
+  ports:
+  - port: 80
+    targetPort: 3000
+  selector:
+    app: ml-pipeline-tensorboard-ui
+`)
+	th.writeF("/manifests/pipeline/pipelines-ui/base/params.yaml", `
+varReference:
+- path: metadata/annotations/getambassador.io\/config
+  kind: Service
+`)
+	th.writeF("/manifests/pipeline/pipelines-ui/base/params.env", `
+uiClusterDomain=cluster.local
+`)
+	th.writeK("/manifests/pipeline/pipelines-ui/base", `
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+namespace: kubeflow
+resources:
+- deployment.yaml
+- role-binding.yaml
+- role.yaml
+- service-account.yaml
+- service.yaml
+configMapGenerator:
+- name: ui-parameters
+  env: params.env
+images:
+- name: gcr.io/ml-pipeline/frontend
+  newTag: 0.1.31
+  newName: gcr.io/ml-pipeline/frontend
+vars:
+- name: ui-namespace
+  objref:
+    kind: Service
+    name: ml-pipeline-ui
+    apiVersion: v1
+  fieldref:
+    fieldpath: metadata.namespace
+- name: ui-clusterDomain
+  objref:
+    kind: ConfigMap
+    name: ui-parameters
+    version: v1
+  fieldref:
+    fieldpath: data.uiClusterDomain
+- name: service
+  objref:
+    kind: Service
+    name: ml-pipeline-ui
+    apiVersion: v1
+  fieldref:
+    fieldpath: metadata.name
+- name: tensorboard-service
+  objref:
+    kind: Service
+    name: ml-pipeline-tensorboard-ui
+    apiVersion: v1
+  fieldref:
+    fieldpath: metadata.name
+configurations:
+- params.yaml
+`)
+}
+
+func TestPipelinesUiOverlaysGcp(t *testing.T) {
+	th := NewKustTestHarness(t, "/manifests/pipeline/pipelines-ui/overlays/gcp")
+	writePipelinesUiOverlaysGcp(th)
+	m, err := th.makeKustTarget().MakeCustomizedResMap()
+	if err != nil {
+		t.Fatalf("Err: %v", err)
+	}
+	expected, err := m.AsYaml()
+	if err != nil {
+		t.Fatalf("Err: %v", err)
+	}
+	targetPath := "../pipeline/pipelines-ui/overlays/gcp"
+	fsys := fs.MakeRealFS()
+	lrc := loader.RestrictionRootOnly
+	_loader, loaderErr := loader.NewLoader(lrc, validators.MakeFakeValidator(), targetPath, fsys)
+	if loaderErr != nil {
+		t.Fatalf("could not load kustomize loader: %v", loaderErr)
+	}
+	rf := resmap.NewFactory(resource.NewFactory(kunstruct.NewKunstructuredFactoryImpl()), transformer.NewFactoryImpl())
+	pc := plugins.DefaultPluginConfig()
+	kt, err := target.NewKustTarget(_loader, rf, transformer.NewFactoryImpl(), plugins.NewLoader(pc, rf))
+	if err != nil {
+		th.t.Fatalf("Unexpected construction error %v", err)
+	}
+	actual, err := kt.MakeCustomizedResMap()
+	if err != nil {
+		t.Fatalf("Err: %v", err)
+	}
+	th.assertActualEqualsExpected(actual, string(expected))
+}

--- a/tests/profiles-base_test.go
+++ b/tests/profiles-base_test.go
@@ -184,8 +184,7 @@ status:
     kind: ""
     plural: ""
   conditions: []
-  storedVersions: []
-`)
+  storedVersions: []`)
 	th.writeF("/manifests/profiles/base/deployment.yaml", `
 apiVersion: apps/v1
 kind: Deployment
@@ -229,8 +228,7 @@ metadata:
   name: kfam
 spec:
   ports:
-    - port: 8081
-`)
+    - port: 8081`)
 	th.writeF("/manifests/profiles/base/service-account.yaml", `
 apiVersion: v1
 kind: ServiceAccount

--- a/tests/profiles-overlays-application_test.go
+++ b/tests/profiles-overlays-application_test.go
@@ -240,8 +240,7 @@ status:
     kind: ""
     plural: ""
   conditions: []
-  storedVersions: []
-`)
+  storedVersions: []`)
 	th.writeF("/manifests/profiles/base/deployment.yaml", `
 apiVersion: apps/v1
 kind: Deployment
@@ -285,8 +284,7 @@ metadata:
   name: kfam
 spec:
   ports:
-    - port: 8081
-`)
+    - port: 8081`)
 	th.writeF("/manifests/profiles/base/service-account.yaml", `
 apiVersion: v1
 kind: ServiceAccount

--- a/tests/profiles-overlays-debug_test.go
+++ b/tests/profiles-overlays-debug_test.go
@@ -243,8 +243,7 @@ status:
     kind: ""
     plural: ""
   conditions: []
-  storedVersions: []
-`)
+  storedVersions: []`)
 	th.writeF("/manifests/profiles/base/deployment.yaml", `
 apiVersion: apps/v1
 kind: Deployment
@@ -288,8 +287,7 @@ metadata:
   name: kfam
 spec:
   ports:
-    - port: 8081
-`)
+    - port: 8081`)
 	th.writeF("/manifests/profiles/base/service-account.yaml", `
 apiVersion: v1
 kind: ServiceAccount

--- a/tests/profiles-overlays-devices_test.go
+++ b/tests/profiles-overlays-devices_test.go
@@ -210,8 +210,7 @@ status:
     kind: ""
     plural: ""
   conditions: []
-  storedVersions: []
-`)
+  storedVersions: []`)
 	th.writeF("/manifests/profiles/base/deployment.yaml", `
 apiVersion: apps/v1
 kind: Deployment
@@ -255,8 +254,7 @@ metadata:
   name: kfam
 spec:
   ports:
-    - port: 8081
-`)
+    - port: 8081`)
 	th.writeF("/manifests/profiles/base/service-account.yaml", `
 apiVersion: v1
 kind: ServiceAccount

--- a/tests/profiles-overlays-istio_test.go
+++ b/tests/profiles-overlays-istio_test.go
@@ -225,8 +225,7 @@ status:
     kind: ""
     plural: ""
   conditions: []
-  storedVersions: []
-`)
+  storedVersions: []`)
 	th.writeF("/manifests/profiles/base/deployment.yaml", `
 apiVersion: apps/v1
 kind: Deployment
@@ -270,8 +269,7 @@ metadata:
   name: kfam
 spec:
   ports:
-    - port: 8081
-`)
+    - port: 8081`)
 	th.writeF("/manifests/profiles/base/service-account.yaml", `
 apiVersion: v1
 kind: ServiceAccount

--- a/tests/profiles-overlays-test_test.go
+++ b/tests/profiles-overlays-test_test.go
@@ -192,8 +192,7 @@ status:
     kind: ""
     plural: ""
   conditions: []
-  storedVersions: []
-`)
+  storedVersions: []`)
 	th.writeF("/manifests/profiles/base/deployment.yaml", `
 apiVersion: apps/v1
 kind: Deployment
@@ -237,8 +236,7 @@ metadata:
   name: kfam
 spec:
   ports:
-    - port: 8081
-`)
+    - port: 8081`)
 	th.writeF("/manifests/profiles/base/service-account.yaml", `
 apiVersion: v1
 kind: ServiceAccount


### PR DESCRIPTION
Related to kubeflow/pipelines#2501

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/manifests/604)
<!-- Reviewable:end -->
