### PR TITLE
metadata: Stadardizing metadata db configs

### DIFF
--- a/metadata/base/kustomization.yaml
+++ b/metadata/base/kustomization.yaml
@@ -8,6 +8,7 @@ configMapGenerator:
   env: params.env
 resources:
 - metadata-db-pvc.yaml
+- metadata-db-configmap.yaml
 - metadata-db-secret.yaml
 - metadata-db-deployment.yaml
 - metadata-db-service.yaml

--- a/metadata/base/metadata-db-configmap.yaml
+++ b/metadata/base/metadata-db-configmap.yaml
@@ -1,0 +1,7 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: db-configmap
+data:
+  mysql_database: "metadb"
+  mysql_port: "3306"

--- a/metadata/base/metadata-db-deployment.yaml
+++ b/metadata/base/metadata-db-deployment.yaml
@@ -23,11 +23,14 @@ spec:
             valueFrom:
               secretKeyRef:
                 name: metadata-db-secrets
-                key: MYSQL_ROOT_PASSWORD
+                key: password
           - name: MYSQL_ALLOW_EMPTY_PASSWORD
             value: "true"
           - name: MYSQL_DATABASE
-            value: "metadb"
+            valueFrom:
+              configMapKeyRef:
+                name: metadata-db-configmap
+                key: mysql_database
         ports:
         - name: dbapi
           containerPort: 3306

--- a/metadata/base/metadata-db-secret.yaml
+++ b/metadata/base/metadata-db-secret.yaml
@@ -4,4 +4,5 @@ type: Opaque
 metadata:
   name: db-secrets
 data:
-  MYSQL_ROOT_PASSWORD: dGVzdA== # "test"
+  username: "cm9vdA==" # "root"
+  password: "dGVzdA==" # "test"

--- a/metadata/base/metadata-deployment.yaml
+++ b/metadata/base/metadata-deployment.yaml
@@ -18,18 +18,33 @@ spec:
       - name: container
         image: gcr.io/kubeflow-images-public/metadata:v0.1.10
         env:
-          - name: MYSQL_ROOT_PASSWORD
-            valueFrom:
-              secretKeyRef:
-                name: metadata-db-secrets
-                key: MYSQL_ROOT_PASSWORD
+        - name: MYSQL_ROOT_PASSWORD
+          valueFrom:
+            secretKeyRef:
+              name: metadata-db-secrets
+              key: password
+        - name: MYSQL_USER_NAME
+          valueFrom:
+            secretKeyRef:
+              name: metadata-db-secrets
+              key: username
+        - name: MYSQL_DATABASE
+          valueFrom:
+            configMapKeyRef:
+              name: metadata-db-configmap
+              key: mysql_database
+        - name: MYSQL_PORT
+          valueFrom:
+            configMapKeyRef:
+              name: metadata-db-configmap
+              key: mysql_port
         command: ["./server/server",
                   "--http_port=8080",
                   "--mysql_service_host=metadata-db.kubeflow",
-                  "--mysql_service_port=3306",
-                  "--mysql_service_user=root",
+                  "--mysql_service_port=$(MYSQL_PORT)",
+                  "--mysql_service_user=$(MYSQL_USER_NAME)",
                   "--mysql_service_password=$(MYSQL_ROOT_PASSWORD)",
-                  "--mlmd_db_name=metadb"]
+                  "--mlmd_db_name=$(MYSQL_DATABASE)"]
         ports:
         - name: backendapi
           containerPort: 8080
@@ -65,17 +80,32 @@ spec:
         - name: container
           image: gcr.io/tfx-oss-public/ml_metadata_store_server:0.14.0
           env:
-            - name: MYSQL_ROOT_PASSWORD
-              valueFrom:
-                secretKeyRef:
-                  name: metadata-db-secrets
-                  key: MYSQL_ROOT_PASSWORD
+          - name: MYSQL_ROOT_PASSWORD
+            valueFrom:
+              secretKeyRef:
+                name: metadata-db-secrets
+                key: password
+          - name: MYSQL_USER_NAME
+            valueFrom:
+              secretKeyRef:
+                name: metadata-db-secrets
+                key: username
+          - name: MYSQL_DATABASE
+            valueFrom:
+              configMapKeyRef:
+                name: metadata-db-configmap
+                key: mysql_database
+          - name: MYSQL_PORT
+            valueFrom:
+              configMapKeyRef:
+                name: metadata-db-configmap
+                key: mysql_port
           command: ["/bin/metadata_store_server"]
           args: ["--grpc_port=8080",
                  "--mysql_config_host=metadata-db.kubeflow",
-                 "--mysql_config_database=metadb",
-                 "--mysql_config_port=3306",
-                 "--mysql_config_user=root",
+                 "--mysql_config_database=$(MYSQL_DATABASE)",
+                 "--mysql_config_port=$(MYSQL_PORT)",
+                 "--mysql_config_user=$(MYSQL_USER_NAME)",
                  "--mysql_config_password=$(MYSQL_ROOT_PASSWORD)"
           ]
           ports:

--- a/tests/metadata-base_test.go
+++ b/tests/metadata-base_test.go
@@ -26,6 +26,15 @@ spec:
     requests:
       storage: 10Gi
 `)
+	th.writeF("/manifests/metadata/base/metadata-db-configmap.yaml", `
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: db-configmap
+data:
+  mysql_database: "metadb"
+  mysql_port: "3306"
+`)
 	th.writeF("/manifests/metadata/base/metadata-db-secret.yaml", `
 apiVersion: v1
 kind: Secret
@@ -33,7 +42,8 @@ type: Opaque
 metadata:
   name: db-secrets
 data:
-  MYSQL_ROOT_PASSWORD: dGVzdA== # "test"
+  username: cm9vdA== # "root"
+  password: dGVzdA== # "test"
 `)
 	th.writeF("/manifests/metadata/base/metadata-db-deployment.yaml", `
 apiVersion: apps/v1
@@ -57,15 +67,18 @@ spec:
         - --datadir
         - /var/lib/mysql/datadir
         env:
-          - name: MYSQL_ROOT_PASSWORD
-            valueFrom:
-              secretKeyRef:
-                name: metadata-db-secrets
-                key: MYSQL_ROOT_PASSWORD
-          - name: MYSQL_ALLOW_EMPTY_PASSWORD
-            value: "true"
-          - name: MYSQL_DATABASE
-            value: "metadb"
+        - name: MYSQL_ROOT_PASSWORD
+          valueFrom:
+            secretKeyRef:
+              name: metadata-db-secrets
+              key: password
+        - name: MYSQL_ALLOW_EMPTY_PASSWORD
+          value: "true"
+        - name: MYSQL_DATABASE
+          valueFrom:
+            configMapKeyRef:
+              name: metadata-db-configmap
+              key: mysql_database
         ports:
         - name: dbapi
           containerPort: 3306
@@ -123,18 +136,33 @@ spec:
       - name: container
         image: gcr.io/kubeflow-images-public/metadata:v0.1.9
         env:
-          - name: MYSQL_ROOT_PASSWORD
-            valueFrom:
-              secretKeyRef:
-                name: metadata-db-secrets
-                key: MYSQL_ROOT_PASSWORD
+        - name: MYSQL_ROOT_PASSWORD
+          valueFrom:
+            secretKeyRef:
+              name: metadata-db-secrets
+              key: password
+        - name: MYSQL_USER_NAME
+          valueFrom:
+            secretKeyRef:
+              name: metadata-db-secrets
+              key: username
+        - name: MYSQL_DATABASE
+          valueFrom:
+            configMapKeyRef:
+              name: metadata-db-configmap
+              key: mysql_database
+        - name: MYSQL_PORT
+          valueFrom:
+            configMapKeyRef:
+              name: metadata-db-configmap
+              key: mysql_port
         command: ["./server/server",
                   "--http_port=8080",
                   "--mysql_service_host=metadata-db.kubeflow",
-                  "--mysql_service_port=3306",
-                  "--mysql_service_user=root",
+                  "--mysql_service_port=$(MYSQL_PORT)",
+                  "--mysql_service_user=$(MYSQL_USER_NAME)",
                   "--mysql_service_password=$(MYSQL_ROOT_PASSWORD)",
-                  "--mlmd_db_name=metadb"]
+                  "--mlmd_db_name=$(MYSQL_DATABASE)"]
         ports:
         - name: backendapi
           containerPort: 8080
@@ -170,17 +198,32 @@ spec:
         - name: container
           image: gcr.io/tfx-oss-public/ml_metadata_store_server:0.14.0
           env:
-            - name: MYSQL_ROOT_PASSWORD
-              valueFrom:
-                secretKeyRef:
-                  name: metadata-db-secrets
-                  key: MYSQL_ROOT_PASSWORD
+          - name: MYSQL_ROOT_PASSWORD
+            valueFrom:
+              secretKeyRef:
+                name: metadata-db-secrets
+                key: password
+          - name: MYSQL_USER_NAME
+            valueFrom:
+              secretKeyRef:
+                name: metadata-db-secrets
+                key: username
+          - name: MYSQL_DATABASE
+            valueFrom:
+              configMapKeyRef:
+                name: metadata-db-configmap
+                key: mysql_database
+          - name: MYSQL_PORT
+            valueFrom:
+              configMapKeyRef:
+                name: metadata-db-configmap
+                key: mysql_port
           command: ["/bin/metadata_store_server"]
           args: ["--grpc_port=8080",
                  "--mysql_config_host=metadata-db.kubeflow",
-                 "--mysql_config_database=metadb",
-                 "--mysql_config_port=3306",
-                 "--mysql_config_user=root",
+                 "--mysql_config_database=$(MYSQL_DATABASE)",
+                 "--mysql_config_port=$(MYSQL_PORT)",
+                 "--mysql_config_user=$(MYSQL_USER_NAME)",
                  "--mysql_config_password=$(MYSQL_ROOT_PASSWORD)"
           ]
           ports:
@@ -364,6 +407,7 @@ configMapGenerator:
   env: params.env
 resources:
 - metadata-db-pvc.yaml
+- metadata-db-configmap.yaml
 - metadata-db-secret.yaml
 - metadata-db-deployment.yaml
 - metadata-db-service.yaml

--- a/tests/metadata-overlays-application_test.go
+++ b/tests/metadata-overlays-application_test.go
@@ -83,6 +83,15 @@ spec:
     requests:
       storage: 10Gi
 `)
+	th.writeF("/manifests/metadata/base/metadata-db-configmap.yaml", `
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: db-configmap
+data:
+  mysql_database: "metadb"
+  mysql_port: "3306"
+`)
 	th.writeF("/manifests/metadata/base/metadata-db-secret.yaml", `
 apiVersion: v1
 kind: Secret
@@ -90,7 +99,8 @@ type: Opaque
 metadata:
   name: db-secrets
 data:
-  MYSQL_ROOT_PASSWORD: dGVzdA== # "test"
+  username: cm9vdA== # "root"
+  password: dGVzdA== # "test"
 `)
 	th.writeF("/manifests/metadata/base/metadata-db-deployment.yaml", `
 apiVersion: apps/v1
@@ -114,15 +124,18 @@ spec:
         - --datadir
         - /var/lib/mysql/datadir
         env:
-          - name: MYSQL_ROOT_PASSWORD
-            valueFrom:
-              secretKeyRef:
-                name: metadata-db-secrets
-                key: MYSQL_ROOT_PASSWORD
-          - name: MYSQL_ALLOW_EMPTY_PASSWORD
-            value: "true"
-          - name: MYSQL_DATABASE
-            value: "metadb"
+        - name: MYSQL_ROOT_PASSWORD
+          valueFrom:
+            secretKeyRef:
+              name: metadata-db-secrets
+              key: password
+        - name: MYSQL_ALLOW_EMPTY_PASSWORD
+          value: "true"
+        - name: MYSQL_DATABASE
+          valueFrom:
+            configMapKeyRef:
+              name: metadata-db-configmap
+              key: mysql_database
         ports:
         - name: dbapi
           containerPort: 3306
@@ -180,18 +193,33 @@ spec:
       - name: container
         image: gcr.io/kubeflow-images-public/metadata:v0.1.9
         env:
-          - name: MYSQL_ROOT_PASSWORD
-            valueFrom:
-              secretKeyRef:
-                name: metadata-db-secrets
-                key: MYSQL_ROOT_PASSWORD
+        - name: MYSQL_ROOT_PASSWORD
+          valueFrom:
+            secretKeyRef:
+              name: metadata-db-secrets
+              key: password
+        - name: MYSQL_USER_NAME
+          valueFrom:
+            secretKeyRef:
+              name: metadata-db-secrets
+              key: username
+        - name: MYSQL_DATABASE
+          valueFrom:
+            configMapKeyRef:
+              name: metadata-db-configmap
+              key: mysql_database
+        - name: MYSQL_PORT
+          valueFrom:
+            configMapKeyRef:
+              name: metadata-db-configmap
+              key: mysql_port
         command: ["./server/server",
                   "--http_port=8080",
                   "--mysql_service_host=metadata-db.kubeflow",
-                  "--mysql_service_port=3306",
-                  "--mysql_service_user=root",
+                  "--mysql_service_port=$(MYSQL_PORT)",
+                  "--mysql_service_user=$(MYSQL_USER_NAME)",
                   "--mysql_service_password=$(MYSQL_ROOT_PASSWORD)",
-                  "--mlmd_db_name=metadb"]
+                  "--mlmd_db_name=$(MYSQL_DATABASE)"]
         ports:
         - name: backendapi
           containerPort: 8080
@@ -227,17 +255,32 @@ spec:
         - name: container
           image: gcr.io/tfx-oss-public/ml_metadata_store_server:0.14.0
           env:
-            - name: MYSQL_ROOT_PASSWORD
-              valueFrom:
-                secretKeyRef:
-                  name: metadata-db-secrets
-                  key: MYSQL_ROOT_PASSWORD
+          - name: MYSQL_ROOT_PASSWORD
+            valueFrom:
+              secretKeyRef:
+                name: metadata-db-secrets
+                key: password
+          - name: MYSQL_USER_NAME
+            valueFrom:
+              secretKeyRef:
+                name: metadata-db-secrets
+                key: username
+          - name: MYSQL_DATABASE
+            valueFrom:
+              configMapKeyRef:
+                name: metadata-db-configmap
+                key: mysql_database
+          - name: MYSQL_PORT
+            valueFrom:
+              configMapKeyRef:
+                name: metadata-db-configmap
+                key: mysql_port
           command: ["/bin/metadata_store_server"]
           args: ["--grpc_port=8080",
                  "--mysql_config_host=metadata-db.kubeflow",
-                 "--mysql_config_database=metadb",
-                 "--mysql_config_port=3306",
-                 "--mysql_config_user=root",
+                 "--mysql_config_database=$(MYSQL_DATABASE)",
+                 "--mysql_config_port=$(MYSQL_PORT)",
+                 "--mysql_config_user=$(MYSQL_USER_NAME)",
                  "--mysql_config_password=$(MYSQL_ROOT_PASSWORD)"
           ]
           ports:
@@ -421,6 +464,7 @@ configMapGenerator:
   env: params.env
 resources:
 - metadata-db-pvc.yaml
+- metadata-db-configmap.yaml
 - metadata-db-secret.yaml
 - metadata-db-deployment.yaml
 - metadata-db-service.yaml

--- a/tests/metadata-overlays-istio_test.go
+++ b/tests/metadata-overlays-istio_test.go
@@ -88,6 +88,15 @@ spec:
     requests:
       storage: 10Gi
 `)
+	th.writeF("/manifests/metadata/base/metadata-db-configmap.yaml", `
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: db-configmap
+data:
+  mysql_database: "metadb"
+  mysql_port: "3306"
+`)
 	th.writeF("/manifests/metadata/base/metadata-db-secret.yaml", `
 apiVersion: v1
 kind: Secret
@@ -95,7 +104,8 @@ type: Opaque
 metadata:
   name: db-secrets
 data:
-  MYSQL_ROOT_PASSWORD: dGVzdA== # "test"
+  username: cm9vdA== # "root"
+  password: dGVzdA== # "test"
 `)
 	th.writeF("/manifests/metadata/base/metadata-db-deployment.yaml", `
 apiVersion: apps/v1
@@ -119,15 +129,18 @@ spec:
         - --datadir
         - /var/lib/mysql/datadir
         env:
-          - name: MYSQL_ROOT_PASSWORD
-            valueFrom:
-              secretKeyRef:
-                name: metadata-db-secrets
-                key: MYSQL_ROOT_PASSWORD
-          - name: MYSQL_ALLOW_EMPTY_PASSWORD
-            value: "true"
-          - name: MYSQL_DATABASE
-            value: "metadb"
+        - name: MYSQL_ROOT_PASSWORD
+          valueFrom:
+            secretKeyRef:
+              name: metadata-db-secrets
+              key: password
+        - name: MYSQL_ALLOW_EMPTY_PASSWORD
+          value: "true"
+        - name: MYSQL_DATABASE
+          valueFrom:
+            configMapKeyRef:
+              name: metadata-db-configmap
+              key: mysql_database
         ports:
         - name: dbapi
           containerPort: 3306
@@ -185,18 +198,33 @@ spec:
       - name: container
         image: gcr.io/kubeflow-images-public/metadata:v0.1.9
         env:
-          - name: MYSQL_ROOT_PASSWORD
-            valueFrom:
-              secretKeyRef:
-                name: metadata-db-secrets
-                key: MYSQL_ROOT_PASSWORD
+        - name: MYSQL_ROOT_PASSWORD
+          valueFrom:
+            secretKeyRef:
+              name: metadata-db-secrets
+              key: password
+        - name: MYSQL_USER_NAME
+          valueFrom:
+            secretKeyRef:
+              name: metadata-db-secrets
+              key: username
+        - name: MYSQL_DATABASE
+          valueFrom:
+            configMapKeyRef:
+              name: metadata-db-configmap
+              key: mysql_database
+        - name: MYSQL_PORT
+          valueFrom:
+            configMapKeyRef:
+              name: metadata-db-configmap
+              key: mysql_port
         command: ["./server/server",
                   "--http_port=8080",
                   "--mysql_service_host=metadata-db.kubeflow",
-                  "--mysql_service_port=3306",
-                  "--mysql_service_user=root",
+                  "--mysql_service_port=$(MYSQL_PORT)",
+                  "--mysql_service_user=$(MYSQL_USER_NAME)",
                   "--mysql_service_password=$(MYSQL_ROOT_PASSWORD)",
-                  "--mlmd_db_name=metadb"]
+                  "--mlmd_db_name=$(MYSQL_DATABASE)"]
         ports:
         - name: backendapi
           containerPort: 8080
@@ -232,17 +260,32 @@ spec:
         - name: container
           image: gcr.io/tfx-oss-public/ml_metadata_store_server:0.14.0
           env:
-            - name: MYSQL_ROOT_PASSWORD
-              valueFrom:
-                secretKeyRef:
-                  name: metadata-db-secrets
-                  key: MYSQL_ROOT_PASSWORD
+          - name: MYSQL_ROOT_PASSWORD
+            valueFrom:
+              secretKeyRef:
+                name: metadata-db-secrets
+                key: password
+          - name: MYSQL_USER_NAME
+            valueFrom:
+              secretKeyRef:
+                name: metadata-db-secrets
+                key: username
+          - name: MYSQL_DATABASE
+            valueFrom:
+              configMapKeyRef:
+                name: metadata-db-configmap
+                key: mysql_database
+          - name: MYSQL_PORT
+            valueFrom:
+              configMapKeyRef:
+                name: metadata-db-configmap
+                key: mysql_port
           command: ["/bin/metadata_store_server"]
           args: ["--grpc_port=8080",
                  "--mysql_config_host=metadata-db.kubeflow",
-                 "--mysql_config_database=metadb",
-                 "--mysql_config_port=3306",
-                 "--mysql_config_user=root",
+                 "--mysql_config_database=$(MYSQL_DATABASE)",
+                 "--mysql_config_port=$(MYSQL_PORT)",
+                 "--mysql_config_user=$(MYSQL_USER_NAME)",
                  "--mysql_config_password=$(MYSQL_ROOT_PASSWORD)"
           ]
           ports:
@@ -426,6 +469,7 @@ configMapGenerator:
   env: params.env
 resources:
 - metadata-db-pvc.yaml
+- metadata-db-configmap.yaml
 - metadata-db-secret.yaml
 - metadata-db-deployment.yaml
 - metadata-db-service.yaml


### PR DESCRIPTION
This change standardizes the way we specify metadata db configuration through creating a K8 configmap. The change also moves the db user name to metadata-db-secrets.

Resolves https://github.com/kubeflow/manifests/issues/591

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/manifests/624)
<!-- Reviewable:end -->
