### PR TITLE
Update metadata images to use MLMD 0.15.1

### DIFF
--- a/metadata/base/kustomization.yaml
+++ b/metadata/base/kustomization.yaml
@@ -54,10 +54,10 @@ vars:
 images:
 - name: gcr.io/kubeflow-images-public/metadata
   newName: gcr.io/kubeflow-images-public/metadata
-  newTag: v0.1.10
+  newTag: v0.1.11
 - name: gcr.io/tfx-oss-public/ml_metadata_store_server
   newName: gcr.io/tfx-oss-public/ml_metadata_store_server
-  newTag: 0.14.0
+  newTag: 0.15.1
 - name: gcr.io/ml-pipeline/envoy
   newName: gcr.io/ml-pipeline/envoy
   newTag: metadata-grpc

--- a/metadata/base/metadata-deployment.yaml
+++ b/metadata/base/metadata-deployment.yaml
@@ -16,7 +16,7 @@ spec:
     spec:
       containers:
       - name: container
-        image: gcr.io/kubeflow-images-public/metadata:v0.1.10
+        image: gcr.io/kubeflow-images-public/metadata:v0.1.11
         env:
         - name: MYSQL_ROOT_PASSWORD
           valueFrom:
@@ -78,7 +78,7 @@ spec:
     spec:
       containers:
         - name: container
-          image: gcr.io/tfx-oss-public/ml_metadata_store_server:0.14.0
+          image: gcr.io/tfx-oss-public/ml_metadata_store_server:0.15.1
           env:
           - name: MYSQL_ROOT_PASSWORD
             valueFrom:

--- a/tests/metadata-base_test.go
+++ b/tests/metadata-base_test.go
@@ -1,6 +1,8 @@
 package tests_test
 
 import (
+	"testing"
+
 	"sigs.k8s.io/kustomize/v3/k8sdeps/kunstruct"
 	"sigs.k8s.io/kustomize/v3/k8sdeps/transformer"
 	"sigs.k8s.io/kustomize/v3/pkg/fs"
@@ -10,7 +12,6 @@ import (
 	"sigs.k8s.io/kustomize/v3/pkg/resource"
 	"sigs.k8s.io/kustomize/v3/pkg/target"
 	"sigs.k8s.io/kustomize/v3/pkg/validators"
-	"testing"
 )
 
 func writeMetadataBase(th *KustTestHarness) {
@@ -134,7 +135,7 @@ spec:
     spec:
       containers:
       - name: container
-        image: gcr.io/kubeflow-images-public/metadata:v0.1.9
+        image: gcr.io/kubeflow-images-public/metadata:v0.1.11
         env:
         - name: MYSQL_ROOT_PASSWORD
           valueFrom:
@@ -196,7 +197,7 @@ spec:
     spec:
       containers:
         - name: container
-          image: gcr.io/tfx-oss-public/ml_metadata_store_server:0.14.0
+          image: gcr.io/tfx-oss-public/ml_metadata_store_server:0.15.1
           env:
           - name: MYSQL_ROOT_PASSWORD
             valueFrom:
@@ -453,10 +454,10 @@ vars:
 images:
 - name: gcr.io/kubeflow-images-public/metadata
   newName: gcr.io/kubeflow-images-public/metadata
-  newTag: v0.1.10
+  newTag: v0.1.11
 - name: gcr.io/tfx-oss-public/ml_metadata_store_server
   newName: gcr.io/tfx-oss-public/ml_metadata_store_server
-  newTag: 0.14.0
+  newTag: 0.15.1
 - name: gcr.io/ml-pipeline/envoy
   newName: gcr.io/ml-pipeline/envoy
   newTag: metadata-grpc

--- a/tests/metadata-overlays-application_test.go
+++ b/tests/metadata-overlays-application_test.go
@@ -1,6 +1,8 @@
 package tests_test
 
 import (
+	"testing"
+
 	"sigs.k8s.io/kustomize/v3/k8sdeps/kunstruct"
 	"sigs.k8s.io/kustomize/v3/k8sdeps/transformer"
 	"sigs.k8s.io/kustomize/v3/pkg/fs"
@@ -10,7 +12,6 @@ import (
 	"sigs.k8s.io/kustomize/v3/pkg/resource"
 	"sigs.k8s.io/kustomize/v3/pkg/target"
 	"sigs.k8s.io/kustomize/v3/pkg/validators"
-	"testing"
 )
 
 func writeMetadataOverlaysApplication(th *KustTestHarness) {
@@ -191,7 +192,7 @@ spec:
     spec:
       containers:
       - name: container
-        image: gcr.io/kubeflow-images-public/metadata:v0.1.9
+        image: gcr.io/kubeflow-images-public/metadata:v0.1.11
         env:
         - name: MYSQL_ROOT_PASSWORD
           valueFrom:
@@ -253,7 +254,7 @@ spec:
     spec:
       containers:
         - name: container
-          image: gcr.io/tfx-oss-public/ml_metadata_store_server:0.14.0
+          image: gcr.io/tfx-oss-public/ml_metadata_store_server:0.15.1
           env:
           - name: MYSQL_ROOT_PASSWORD
             valueFrom:
@@ -510,10 +511,10 @@ vars:
 images:
 - name: gcr.io/kubeflow-images-public/metadata
   newName: gcr.io/kubeflow-images-public/metadata
-  newTag: v0.1.10
+  newTag: v0.1.11
 - name: gcr.io/tfx-oss-public/ml_metadata_store_server
   newName: gcr.io/tfx-oss-public/ml_metadata_store_server
-  newTag: 0.14.0
+  newTag: 0.15.1
 - name: gcr.io/ml-pipeline/envoy
   newName: gcr.io/ml-pipeline/envoy
   newTag: metadata-grpc

--- a/tests/metadata-overlays-istio_test.go
+++ b/tests/metadata-overlays-istio_test.go
@@ -1,6 +1,8 @@
 package tests_test
 
 import (
+	"testing"
+
 	"sigs.k8s.io/kustomize/v3/k8sdeps/kunstruct"
 	"sigs.k8s.io/kustomize/v3/k8sdeps/transformer"
 	"sigs.k8s.io/kustomize/v3/pkg/fs"
@@ -10,7 +12,6 @@ import (
 	"sigs.k8s.io/kustomize/v3/pkg/resource"
 	"sigs.k8s.io/kustomize/v3/pkg/target"
 	"sigs.k8s.io/kustomize/v3/pkg/validators"
-	"testing"
 )
 
 func writeMetadataOverlaysIstio(th *KustTestHarness) {
@@ -196,7 +197,7 @@ spec:
     spec:
       containers:
       - name: container
-        image: gcr.io/kubeflow-images-public/metadata:v0.1.9
+        image: gcr.io/kubeflow-images-public/metadata:v0.1.11
         env:
         - name: MYSQL_ROOT_PASSWORD
           valueFrom:
@@ -258,7 +259,7 @@ spec:
     spec:
       containers:
         - name: container
-          image: gcr.io/tfx-oss-public/ml_metadata_store_server:0.14.0
+          image: gcr.io/tfx-oss-public/ml_metadata_store_server:0.15.1
           env:
           - name: MYSQL_ROOT_PASSWORD
             valueFrom:
@@ -515,10 +516,10 @@ vars:
 images:
 - name: gcr.io/kubeflow-images-public/metadata
   newName: gcr.io/kubeflow-images-public/metadata
-  newTag: v0.1.10
+  newTag: v0.1.11
 - name: gcr.io/tfx-oss-public/ml_metadata_store_server
   newName: gcr.io/tfx-oss-public/ml_metadata_store_server
-  newTag: 0.14.0
+  newTag: 0.15.1
 - name: gcr.io/ml-pipeline/envoy
   newName: gcr.io/ml-pipeline/envoy
   newTag: metadata-grpc


### PR DESCRIPTION
**Which issue is resolved by this Pull Request:**
Related to https://github.com/kubeflow/metadata/issues/138, which should be resolved after this PR is cherry-picked to v0.7-branch.

The new MLMD 0.15.1 disables DB table migration by default.


**Checklist:**
- [x] Unit tests have been rebuilt: 
    1. `cd manifests/tests`
    2. `make generate`
    3. `make test`

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/manifests/626)
<!-- Reviewable:end -->
