### PR TITLE
Automated cherry pick of #633: istio: oidc-authservice: add readiness probe and update Cherry pick of #633 on v0.7-branch. #633: istio: oidc-authservice: add readiness probe and update

### DIFF
--- a/istio/oidc-authservice/base/deployment.yaml
+++ b/istio/oidc-authservice/base/deployment.yaml
@@ -51,6 +51,10 @@ spec:
         volumeMounts:
           - name: data
             mountPath: /var/lib/authservice
+        readinessProbe:
+            httpGet:
+              path: /
+              port: 8081
       securityContext:
         fsGroup: 111
       volumes:

--- a/istio/oidc-authservice/base/kustomization.yaml
+++ b/istio/oidc-authservice/base/kustomization.yaml
@@ -84,4 +84,4 @@ configurations:
 images:
 - name: gcr.io/arrikto/kubeflow/oidc-authservice
   newName: gcr.io/arrikto/kubeflow/oidc-authservice
-  newTag: 6ac9400
+  newTag: 28c59ef

--- a/tests/metadata-base_test.go
+++ b/tests/metadata-base_test.go
@@ -1,8 +1,6 @@
 package tests_test
 
 import (
-	"testing"
-
 	"sigs.k8s.io/kustomize/v3/k8sdeps/kunstruct"
 	"sigs.k8s.io/kustomize/v3/k8sdeps/transformer"
 	"sigs.k8s.io/kustomize/v3/pkg/fs"
@@ -12,6 +10,7 @@ import (
 	"sigs.k8s.io/kustomize/v3/pkg/resource"
 	"sigs.k8s.io/kustomize/v3/pkg/target"
 	"sigs.k8s.io/kustomize/v3/pkg/validators"
+	"testing"
 )
 
 func writeMetadataBase(th *KustTestHarness) {
@@ -43,8 +42,8 @@ type: Opaque
 metadata:
   name: db-secrets
 data:
-  username: cm9vdA== # "root"
-  password: dGVzdA== # "test"
+  username: "cm9vdA==" # "root"
+  password: "dGVzdA==" # "test"
 `)
 	th.writeF("/manifests/metadata/base/metadata-db-deployment.yaml", `
 apiVersion: apps/v1
@@ -68,18 +67,18 @@ spec:
         - --datadir
         - /var/lib/mysql/datadir
         env:
-        - name: MYSQL_ROOT_PASSWORD
-          valueFrom:
-            secretKeyRef:
-              name: metadata-db-secrets
-              key: password
-        - name: MYSQL_ALLOW_EMPTY_PASSWORD
-          value: "true"
-        - name: MYSQL_DATABASE
-          valueFrom:
-            configMapKeyRef:
-              name: metadata-db-configmap
-              key: mysql_database
+          - name: MYSQL_ROOT_PASSWORD
+            valueFrom:
+              secretKeyRef:
+                name: metadata-db-secrets
+                key: password
+          - name: MYSQL_ALLOW_EMPTY_PASSWORD
+            value: "true"
+          - name: MYSQL_DATABASE
+            valueFrom:
+              configMapKeyRef:
+                name: metadata-db-configmap
+                key: mysql_database
         ports:
         - name: dbapi
           containerPort: 3306

--- a/tests/metadata-overlays-application_test.go
+++ b/tests/metadata-overlays-application_test.go
@@ -1,8 +1,6 @@
 package tests_test
 
 import (
-	"testing"
-
 	"sigs.k8s.io/kustomize/v3/k8sdeps/kunstruct"
 	"sigs.k8s.io/kustomize/v3/k8sdeps/transformer"
 	"sigs.k8s.io/kustomize/v3/pkg/fs"
@@ -12,6 +10,7 @@ import (
 	"sigs.k8s.io/kustomize/v3/pkg/resource"
 	"sigs.k8s.io/kustomize/v3/pkg/target"
 	"sigs.k8s.io/kustomize/v3/pkg/validators"
+	"testing"
 )
 
 func writeMetadataOverlaysApplication(th *KustTestHarness) {
@@ -100,8 +99,8 @@ type: Opaque
 metadata:
   name: db-secrets
 data:
-  username: cm9vdA== # "root"
-  password: dGVzdA== # "test"
+  username: "cm9vdA==" # "root"
+  password: "dGVzdA==" # "test"
 `)
 	th.writeF("/manifests/metadata/base/metadata-db-deployment.yaml", `
 apiVersion: apps/v1
@@ -125,18 +124,18 @@ spec:
         - --datadir
         - /var/lib/mysql/datadir
         env:
-        - name: MYSQL_ROOT_PASSWORD
-          valueFrom:
-            secretKeyRef:
-              name: metadata-db-secrets
-              key: password
-        - name: MYSQL_ALLOW_EMPTY_PASSWORD
-          value: "true"
-        - name: MYSQL_DATABASE
-          valueFrom:
-            configMapKeyRef:
-              name: metadata-db-configmap
-              key: mysql_database
+          - name: MYSQL_ROOT_PASSWORD
+            valueFrom:
+              secretKeyRef:
+                name: metadata-db-secrets
+                key: password
+          - name: MYSQL_ALLOW_EMPTY_PASSWORD
+            value: "true"
+          - name: MYSQL_DATABASE
+            valueFrom:
+              configMapKeyRef:
+                name: metadata-db-configmap
+                key: mysql_database
         ports:
         - name: dbapi
           containerPort: 3306

--- a/tests/metadata-overlays-istio_test.go
+++ b/tests/metadata-overlays-istio_test.go
@@ -1,8 +1,6 @@
 package tests_test
 
 import (
-	"testing"
-
 	"sigs.k8s.io/kustomize/v3/k8sdeps/kunstruct"
 	"sigs.k8s.io/kustomize/v3/k8sdeps/transformer"
 	"sigs.k8s.io/kustomize/v3/pkg/fs"
@@ -12,6 +10,7 @@ import (
 	"sigs.k8s.io/kustomize/v3/pkg/resource"
 	"sigs.k8s.io/kustomize/v3/pkg/target"
 	"sigs.k8s.io/kustomize/v3/pkg/validators"
+	"testing"
 )
 
 func writeMetadataOverlaysIstio(th *KustTestHarness) {
@@ -105,8 +104,8 @@ type: Opaque
 metadata:
   name: db-secrets
 data:
-  username: cm9vdA== # "root"
-  password: dGVzdA== # "test"
+  username: "cm9vdA==" # "root"
+  password: "dGVzdA==" # "test"
 `)
 	th.writeF("/manifests/metadata/base/metadata-db-deployment.yaml", `
 apiVersion: apps/v1
@@ -130,18 +129,18 @@ spec:
         - --datadir
         - /var/lib/mysql/datadir
         env:
-        - name: MYSQL_ROOT_PASSWORD
-          valueFrom:
-            secretKeyRef:
-              name: metadata-db-secrets
-              key: password
-        - name: MYSQL_ALLOW_EMPTY_PASSWORD
-          value: "true"
-        - name: MYSQL_DATABASE
-          valueFrom:
-            configMapKeyRef:
-              name: metadata-db-configmap
-              key: mysql_database
+          - name: MYSQL_ROOT_PASSWORD
+            valueFrom:
+              secretKeyRef:
+                name: metadata-db-secrets
+                key: password
+          - name: MYSQL_ALLOW_EMPTY_PASSWORD
+            value: "true"
+          - name: MYSQL_DATABASE
+            valueFrom:
+              configMapKeyRef:
+                name: metadata-db-configmap
+                key: mysql_database
         ports:
         - name: dbapi
           containerPort: 3306

--- a/tests/oidc-authservice-base_test.go
+++ b/tests/oidc-authservice-base_test.go
@@ -81,6 +81,10 @@ spec:
         volumeMounts:
           - name: data
             mountPath: /var/lib/authservice
+        readinessProbe:
+            httpGet:
+              path: /
+              port: 8081
       securityContext:
         fsGroup: 111
       volumes:
@@ -237,7 +241,7 @@ configurations:
 images:
 - name: gcr.io/arrikto/kubeflow/oidc-authservice
   newName: gcr.io/arrikto/kubeflow/oidc-authservice
-  newTag: 6ac9400
+  newTag: 28c59ef
 `)
 }
 

--- a/tests/oidc-authservice-overlays-application_test.go
+++ b/tests/oidc-authservice-overlays-application_test.go
@@ -140,6 +140,10 @@ spec:
         volumeMounts:
           - name: data
             mountPath: /var/lib/authservice
+        readinessProbe:
+            httpGet:
+              path: /
+              port: 8081
       securityContext:
         fsGroup: 111
       volumes:
@@ -296,7 +300,7 @@ configurations:
 images:
 - name: gcr.io/arrikto/kubeflow/oidc-authservice
   newName: gcr.io/arrikto/kubeflow/oidc-authservice
-  newTag: 6ac9400
+  newTag: 28c59ef
 `)
 }
 


### PR DESCRIPTION
**Which issue is resolved by this Pull Request:**
Relevant Issues:  https://github.com/arrikto/oidc-authservice/issues/2 https://github.com/kubeflow/kubeflow/issues/4517 https://github.com/kubeflow/manifests/issues/632

**Description of your changes:**
This PR backports a new image of oidc-authservice which contains fixes for several issues.
It also adds a readiness check.
This should only affect the kfctl_istio_dex config.

/assign @krishnadurai @ryandawsonuk 

**Checklist:**
- [X] Unit tests have been rebuilt: 
    1. `cd manifests/tests`
    2. `make generate`
    3. `make test`

<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/manifests/639)
<!-- Reviewable:end -->
