### PR TITLE
Allow nb-controller get/list/watch/create events

### DIFF
--- a/jupyter/jupyter-web-app/base/cluster-role.yaml
+++ b/jupyter/jupyter-web-app/base/cluster-role.yaml
@@ -36,10 +36,7 @@ rules:
   resources:
   - events
   verbs:
-  - get
   - list
-  - watch
-  - create
 - apiGroups:
   - storage.k8s.io
   resources:

--- a/jupyter/jupyter-web-app/base/cluster-role.yaml
+++ b/jupyter/jupyter-web-app/base/cluster-role.yaml
@@ -32,6 +32,15 @@ rules:
   - get
   - list
 - apiGroups:
+  - ""
+  resources:
+  - events
+  verbs:
+  - get
+  - list
+  - watch
+  - create
+- apiGroups:
   - storage.k8s.io
   resources:
   - storageclasses

--- a/jupyter/notebook-controller/base/cluster-role.yaml
+++ b/jupyter/notebook-controller/base/cluster-role.yaml
@@ -25,6 +25,15 @@ rules:
   verbs:
   - '*'
 - apiGroups:
+  - ""
+  resources:
+  - events
+  verbs:
+  - get
+  - list
+  - watch
+  - create
+- apiGroups:
   - kubeflow.org
   resources:
   - notebooks

--- a/tests/jupyter-web-app-base_test.go
+++ b/tests/jupyter-web-app-base_test.go
@@ -66,10 +66,7 @@ rules:
   resources:
   - events
   verbs:
-  - get
   - list
-  - watch
-  - create
 - apiGroups:
   - storage.k8s.io
   resources:

--- a/tests/jupyter-web-app-base_test.go
+++ b/tests/jupyter-web-app-base_test.go
@@ -62,6 +62,15 @@ rules:
   - get
   - list
 - apiGroups:
+  - ""
+  resources:
+  - events
+  verbs:
+  - get
+  - list
+  - watch
+  - create
+- apiGroups:
   - storage.k8s.io
   resources:
   - storageclasses
@@ -328,7 +337,8 @@ varReference:
 - path: spec/template/spec/containers/0/env/2/value
   kind: Deployment
 - path: spec/template/spec/containers/0/env/3/value
-  kind: Deployment`)
+  kind: Deployment
+`)
 	th.writeF("/manifests/jupyter/jupyter-web-app/base/params.env", `
 UI=default
 ROK_SECRET_NAME=secret-rok-{username}
@@ -336,7 +346,8 @@ policy=Always
 prefix=jupyter
 clusterDomain=cluster.local
 userid-header=
-userid-prefix=`)
+userid-prefix=
+`)
 	th.writeK("/manifests/jupyter/jupyter-web-app/base", `
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization

--- a/tests/jupyter-web-app-overlays-application_test.go
+++ b/tests/jupyter-web-app-overlays-application_test.go
@@ -128,6 +128,15 @@ rules:
   - get
   - list
 - apiGroups:
+  - ""
+  resources:
+  - events
+  verbs:
+  - get
+  - list
+  - watch
+  - create
+- apiGroups:
   - storage.k8s.io
   resources:
   - storageclasses
@@ -394,7 +403,8 @@ varReference:
 - path: spec/template/spec/containers/0/env/2/value
   kind: Deployment
 - path: spec/template/spec/containers/0/env/3/value
-  kind: Deployment`)
+  kind: Deployment
+`)
 	th.writeF("/manifests/jupyter/jupyter-web-app/base/params.env", `
 UI=default
 ROK_SECRET_NAME=secret-rok-{username}
@@ -402,7 +412,8 @@ policy=Always
 prefix=jupyter
 clusterDomain=cluster.local
 userid-header=
-userid-prefix=`)
+userid-prefix=
+`)
 	th.writeK("/manifests/jupyter/jupyter-web-app/base", `
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization

--- a/tests/jupyter-web-app-overlays-application_test.go
+++ b/tests/jupyter-web-app-overlays-application_test.go
@@ -132,10 +132,7 @@ rules:
   resources:
   - events
   verbs:
-  - get
   - list
-  - watch
-  - create
 - apiGroups:
   - storage.k8s.io
   resources:

--- a/tests/jupyter-web-app-overlays-istio_test.go
+++ b/tests/jupyter-web-app-overlays-istio_test.go
@@ -101,6 +101,15 @@ rules:
   - get
   - list
 - apiGroups:
+  - ""
+  resources:
+  - events
+  verbs:
+  - get
+  - list
+  - watch
+  - create
+- apiGroups:
   - storage.k8s.io
   resources:
   - storageclasses
@@ -367,7 +376,8 @@ varReference:
 - path: spec/template/spec/containers/0/env/2/value
   kind: Deployment
 - path: spec/template/spec/containers/0/env/3/value
-  kind: Deployment`)
+  kind: Deployment
+`)
 	th.writeF("/manifests/jupyter/jupyter-web-app/base/params.env", `
 UI=default
 ROK_SECRET_NAME=secret-rok-{username}
@@ -375,7 +385,8 @@ policy=Always
 prefix=jupyter
 clusterDomain=cluster.local
 userid-header=
-userid-prefix=`)
+userid-prefix=
+`)
 	th.writeK("/manifests/jupyter/jupyter-web-app/base", `
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization

--- a/tests/jupyter-web-app-overlays-istio_test.go
+++ b/tests/jupyter-web-app-overlays-istio_test.go
@@ -105,10 +105,7 @@ rules:
   resources:
   - events
   verbs:
-  - get
   - list
-  - watch
-  - create
 - apiGroups:
   - storage.k8s.io
   resources:

--- a/tests/notebook-controller-base_test.go
+++ b/tests/notebook-controller-base_test.go
@@ -55,6 +55,15 @@ rules:
   verbs:
   - '*'
 - apiGroups:
+  - ""
+  resources:
+  - events
+  verbs:
+  - get
+  - list
+  - watch
+  - create
+- apiGroups:
   - kubeflow.org
   resources:
   - notebooks

--- a/tests/notebook-controller-overlays-application_test.go
+++ b/tests/notebook-controller-overlays-application_test.go
@@ -111,6 +111,15 @@ rules:
   verbs:
   - '*'
 - apiGroups:
+  - ""
+  resources:
+  - events
+  verbs:
+  - get
+  - list
+  - watch
+  - create
+- apiGroups:
   - kubeflow.org
   resources:
   - notebooks

--- a/tests/notebook-controller-overlays-istio_test.go
+++ b/tests/notebook-controller-overlays-istio_test.go
@@ -89,6 +89,15 @@ rules:
   verbs:
   - '*'
 - apiGroups:
+  - ""
+  resources:
+  - events
+  verbs:
+  - get
+  - list
+  - watch
+  - create
+- apiGroups:
   - kubeflow.org
   resources:
   - notebooks


### PR DESCRIPTION
**Which issue is resolved by this Pull Request:**

Partial fix of https://github.com/kubeflow/kubeflow/issues/3772, used by already merged PR https://github.com/kubeflow/kubeflow/pull/4139

**Description of your changes:**

The `notebook-controller` reissues pods and statefulsets events as notebook events, hence, it needs permission to get/list/watch/create events otherwise:

```
Failed to list *v1.Event: events is forbidden: User "system:serviceaccount:kubeflow:notebook-controller-service-account" cannot list resource "events" in API group "" at the cluster scope
```

**Checklist:**
- [x] Unit tests have been rebuilt: 
    1. `cd manifests/tests`
    2. `make generate`
    3. `make test`

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/manifests/641)
<!-- Reviewable:end -->
