### PR TITLE
kfdef 0.7.0 pin commit

### DIFF
--- a/kfdef/kfctl_anthos.0.7.0.yaml
+++ b/kfdef/kfctl_anthos.0.7.0.yaml
@@ -275,7 +275,7 @@ spec:
     name: seldon-core-operator
   repos:
   - name: manifests
-    uri: https://github.com/kubeflow/manifests/archive/v0.7-branch.tar.gz
+    uri: https://github.com/kubeflow/manifests/archive/c0e81bedec9a4df8acf568cc5ccacc4bc05a3b38.tar.gz
     # An example uri that uses a PR version of the manifest repo.
     # uri: https://github.com/kubeflow/manifests/archive/pull/PR_NUMBER/head.tar.gz
   version: v0.7.0

--- a/kfdef/kfctl_aws.0.7.0.yaml
+++ b/kfdef/kfctl_aws.0.7.0.yaml
@@ -302,5 +302,5 @@ spec:
       - eksctl-kubeflow-aws-nodegroup-ng-a2-NodeInstanceRole-xxxxxxx
   repos:
   - name: manifests
-    uri: https://github.com/kubeflow/manifests/archive/v0.7-branch.tar.gz
+    uri: https://github.com/kubeflow/manifests/archive/c0e81bedec9a4df8acf568cc5ccacc4bc05a3b38.tar.gz
   version: v0.7.0

--- a/kfdef/kfctl_aws_cognito.0.7.0.yaml
+++ b/kfdef/kfctl_aws_cognito.0.7.0.yaml
@@ -309,5 +309,5 @@ spec:
       - eksctl-kubeflow-aws-nodegroup-ng-a2-NodeInstanceRole-xxxxx
   repos:
   - name: manifests
-    uri: https://github.com/kubeflow/manifests/archive/v0.7-branch.tar.gz
+    uri: https://github.com/kubeflow/manifests/archive/c0e81bedec9a4df8acf568cc5ccacc4bc05a3b38.tar.gz
   version: v0.7.0

--- a/kfdef/kfctl_existing_arrikto.0.7.0.yaml
+++ b/kfdef/kfctl_existing_arrikto.0.7.0.yaml
@@ -327,4 +327,4 @@ spec:
     name: seldon-core-operator
   repos:
   - name: manifests
-    uri: https://github.com/kubeflow/manifests/archive/2b34c263cf5165339f856b50cd759db30c6cae9d.tar.gz
+    uri: https://github.com/kubeflow/manifests/archive/c0e81bedec9a4df8acf568cc5ccacc4bc05a3b38.tar.gz

--- a/kfdef/kfctl_gcp_basic_auth.0.7.0.yaml
+++ b/kfdef/kfctl_gcp_basic_auth.0.7.0.yaml
@@ -400,5 +400,5 @@ spec:
       # zone: us-east1-d
   repos:
   - name: manifests
-    uri: https://github.com/kubeflow/manifests/archive/v0.7-branch.tar.gz
+    uri: https://github.com/kubeflow/manifests/archive/c0e81bedec9a4df8acf568cc5ccacc4bc05a3b38.tar.gz
   version: v0.7.0

--- a/kfdef/kfctl_gcp_iap.0.7.0.yaml
+++ b/kfdef/kfctl_gcp_iap.0.7.0.yaml
@@ -396,7 +396,7 @@ spec:
       # zone: us-east1-d
   repos:
   - name: manifests
-    uri: https://github.com/kubeflow/manifests/archive/v0.7-branch.tar.gz
+    uri: https://github.com/kubeflow/manifests/archive/c0e81bedec9a4df8acf568cc5ccacc4bc05a3b38.tar.gz
     # To get manifest at a PR:
     #uri: https://github.com/kubeflow/manifests/archive/pull/235/head.tar.gz
   version: v0.7.0

--- a/kfdef/kfctl_k8s_istio.0.7.0.yaml
+++ b/kfdef/kfctl_k8s_istio.0.7.0.yaml
@@ -296,5 +296,5 @@ spec:
     name: seldon-core-operator
   repos:
   - name: manifests
-    uri: https://github.com/kubeflow/manifests/archive/v0.7-branch.tar.gz
+    uri: https://github.com/kubeflow/manifests/archive/c0e81bedec9a4df8acf568cc5ccacc4bc05a3b38.tar.gz
   version: v0.7.0


### PR DESCRIPTION
**Which issue is resolved by this Pull Request:**
Resolves https://github.com/kubeflow/manifests/issues/643

also related: https://github.com/kubeflow/kfserving/issues/568#issuecomment-561974987

**Description of your changes:**
0.7.0 kfdef pin the commit of current 0.7 head.

/cc @jlewi @richardsliu 

existing arrikto is already pinning to an earlier commit.
Should we update it as well?
/cc @yanniszark 

**Checklist:**
- [ ] Unit tests have been rebuilt: 
    1. `cd manifests/tests`
    2. `make generate`
    3. `make test`

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/manifests/645)
<!-- Reviewable:end -->
