### PR TITLE
Trigger kfctl e2e tests on kubeflow/manifests

### DIFF
--- a/prow_config.yaml
+++ b/prow_config.yaml
@@ -27,4 +27,4 @@ workflows:
       test_endpoint: true
       # The path for the config should depend on the commit we are testing manifests on.
       # so we use the local path which will be checked out to the correct commit
-      config_path: {srcrootdir}/kubeflow/manifests/kfdef/kfctl_gcp_iap.yaml
+      config_path: "{srcrootdir}/kubeflow/manifests/kfdef/kfctl_gcp_iap.yaml"

--- a/prow_config.yaml
+++ b/prow_config.yaml
@@ -27,4 +27,4 @@ workflows:
       test_endpoint: true
       # The path for the config should depend on the commit we are testing manifests on.
       # so we use the local path which will be checked out to the correct commit
-      config_path: /src/kubeflow/manifests/kfdef/kfctl_gcp_iap.yaml
+      config_path: {srcrootdir}/kubeflow/manifests/kfdef/kfctl_gcp_iap.yaml

--- a/prow_config.yaml
+++ b/prow_config.yaml
@@ -1,8 +1,30 @@
 # This file configures the workflows to trigger in our Prow jobs.
 # see kubeflow/testing/py/run_e2e_workflow.py
+python_paths:
+  # Need to place kubeflow/testing in front of kubeflow/testing so that the package can
+  # be correctly located.
+  - kubeflow/testing/py
+  - kubeflow/kfctl/py
 workflows:
   - app_dir: kubeflow/manifests/tests/workflows
     component: workflows
     name: e2e
     job_types:
       - presubmit
+  # Run the e2e tests to ensure that changes to manifests don't break deployments.
+  - py_func: kubeflow.kfctl.testing.ci.kfctl_e2e_workflow.create_workflow
+    name: kfctl-go-iap
+    job_types:
+      - presubmit
+      - postsubmit
+      - periodic    
+    kwargs:
+      use_basic_auth: false
+      # Run build and then apply rather than just apply
+      build_and_apply: true
+      # test_endpoint flag is actually deprecated; we use pytest annotations to skip on
+      # presubmit.
+      test_endpoint: true
+      # The path for the config should depend on the commit we are testing manifests on.
+      # so we use the local path which will be checked out to the correct commit
+      config_path: /src/kubeflow/manifests/kfdef/kfctl_gcp_iap.yaml


### PR DESCRIPTION
* We want to verify that changes to kubeflow/manifests don't break Kubeflow e2e

* We use to trigger the E2E tests on changes to kubeflow/manifests but we
  disabled it because the test broke during the move of kfctl to
  kubeflow/manifests

* This PR should fix that.

* Related to kubeflow/manifests#613

**Which issue is resolved by this Pull Request:**
Resolves #

**Description of your changes:**


**Checklist:**
- [ ] Unit tests have been rebuilt: 
    1. `cd manifests/tests`
    2. `make generate`
    3. `make test`

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/manifests/660)
<!-- Reviewable:end -->
