### PR TITLE
Adds necessary roles and roleBinding to Spark service account

### DIFF
--- a/spark/spark-operator/base/kustomization.yaml
+++ b/spark/spark-operator/base/kustomization.yaml
@@ -27,5 +27,7 @@ resources:
 - crd-cleanup-job.yaml
 - deploy.yaml
 - operator-sa.yaml
+- role.yaml
+- rolebinding.yaml
 - sparkapplications.sparkoperator.k8s.io-crd.yaml
 - scheduledsparkapplications.sparkoperator.k8s.io-crd.yaml

--- a/spark/spark-operator/base/role.yaml
+++ b/spark/spark-operator/base/role.yaml
@@ -1,0 +1,18 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: spark-role
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - pods
+  verbs:
+  - get
+  - list
+  - watch
+  - create
+  - delete
+  - deletecollection
+  - patch
+  - update

--- a/spark/spark-operator/base/rolebinding.yaml
+++ b/spark/spark-operator/base/rolebinding.yaml
@@ -8,5 +8,5 @@ roleRef:
   name: spark-role
 subjects:
 - kind: ServiceAccount
-  name: spark-sa
+  name: spark
 

--- a/spark/spark-operator/base/rolebinding.yaml
+++ b/spark/spark-operator/base/rolebinding.yaml
@@ -1,0 +1,12 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: spark-role-binding
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: spark-role
+subjects:
+- kind: ServiceAccount
+  name: spark-sa
+

--- a/spark/spark-operator/base/spark-sa.yaml
+++ b/spark/spark-operator/base/spark-sa.yaml
@@ -1,4 +1,4 @@
 apiVersion: v1
 kind: ServiceAccount
 metadata:
-  name: spark-sa
+  name: spark

--- a/tests/spark-spark-operator-base_test.go
+++ b/tests/spark-spark-operator-base_test.go
@@ -186,6 +186,40 @@ kind: ServiceAccount
 metadata:
   name: operator-sa
 `)
+	th.writeF("/manifests/spark/spark-operator/base/role.yaml", `
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: spark-role
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - pods
+  verbs:
+  - get
+  - list
+  - watch
+  - create
+  - delete
+  - deletecollection
+  - patch
+  - update
+`)
+	th.writeF("/manifests/spark/spark-operator/base/rolebinding.yaml", `
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: spark-role-binding
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: spark-role
+subjects:
+- kind: ServiceAccount
+  name: spark-sa
+
+`)
 	th.writeF("/manifests/spark/spark-operator/base/sparkapplications.sparkoperator.k8s.io-crd.yaml", `
 apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
@@ -5302,6 +5336,8 @@ resources:
 - crd-cleanup-job.yaml
 - deploy.yaml
 - operator-sa.yaml
+- role.yaml
+- rolebinding.yaml
 - sparkapplications.sparkoperator.k8s.io-crd.yaml
 - scheduledsparkapplications.sparkoperator.k8s.io-crd.yaml
 `)

--- a/tests/spark-spark-operator-base_test.go
+++ b/tests/spark-spark-operator-base_test.go
@@ -18,7 +18,7 @@ func writeSparkOperatorBase(th *KustTestHarness) {
 apiVersion: v1
 kind: ServiceAccount
 metadata:
-  name: spark-sa
+  name: spark
 `)
 	th.writeF("/manifests/spark/spark-operator/base/cr-clusterrole.yaml", `
 apiVersion: rbac.authorization.k8s.io/v1
@@ -217,7 +217,7 @@ roleRef:
   name: spark-role
 subjects:
 - kind: ServiceAccount
-  name: spark-sa
+  name: spark
 
 `)
 	th.writeF("/manifests/spark/spark-operator/base/sparkapplications.sparkoperator.k8s.io-crd.yaml", `

--- a/tests/spark-spark-operator-overlays-application_test.go
+++ b/tests/spark-spark-operator-overlays-application_test.go
@@ -72,7 +72,7 @@ commonLabels:
 apiVersion: v1
 kind: ServiceAccount
 metadata:
-  name: spark-sa
+  name: spark
 `)
 	th.writeF("/manifests/spark/spark-operator/base/cr-clusterrole.yaml", `
 apiVersion: rbac.authorization.k8s.io/v1
@@ -271,7 +271,7 @@ roleRef:
   name: spark-role
 subjects:
 - kind: ServiceAccount
-  name: spark-sa
+  name: spark
 
 `)
 	th.writeF("/manifests/spark/spark-operator/base/sparkapplications.sparkoperator.k8s.io-crd.yaml", `

--- a/tests/spark-spark-operator-overlays-application_test.go
+++ b/tests/spark-spark-operator-overlays-application_test.go
@@ -240,6 +240,40 @@ kind: ServiceAccount
 metadata:
   name: operator-sa
 `)
+	th.writeF("/manifests/spark/spark-operator/base/role.yaml", `
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: spark-role
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - pods
+  verbs:
+  - get
+  - list
+  - watch
+  - create
+  - delete
+  - deletecollection
+  - patch
+  - update
+`)
+	th.writeF("/manifests/spark/spark-operator/base/rolebinding.yaml", `
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: spark-role-binding
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: spark-role
+subjects:
+- kind: ServiceAccount
+  name: spark-sa
+
+`)
 	th.writeF("/manifests/spark/spark-operator/base/sparkapplications.sparkoperator.k8s.io-crd.yaml", `
 apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
@@ -5356,6 +5390,8 @@ resources:
 - crd-cleanup-job.yaml
 - deploy.yaml
 - operator-sa.yaml
+- role.yaml
+- rolebinding.yaml
 - sparkapplications.sparkoperator.k8s.io-crd.yaml
 - scheduledsparkapplications.sparkoperator.k8s.io-crd.yaml
 `)


### PR DESCRIPTION
**Which issue is resolved by this Pull Request:**
Spark Operator's example SparkApplication CR fails with an error failing to list or create pods with the service account ~~`spark-sa`.~~

Updates:
- Renames the service account to `spark` as mentioned in spark-operator examples.


**Description of your changes:**
This PR adds the necessary role and roleBinding to `spark-sa`

**Checklist:**
- [x] Unit tests have been rebuilt: 
    1. `cd manifests/tests`
    2. `make generate`
    3. `make test`

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/manifests/661)
<!-- Reviewable:end -->
