### PR TITLE
metadata: Adding metadata-grpc config map

### DIFF
--- a/metadata/base/kustomization.yaml
+++ b/metadata/base/kustomization.yaml
@@ -9,6 +9,7 @@ configMapGenerator:
 resources:
 - metadata-db-pvc.yaml
 - metadata-db-configmap.yaml
+- metadata-grpc-configmap.yaml
 - metadata-db-secret.yaml
 - metadata-db-deployment.yaml
 - metadata-db-service.yaml

--- a/metadata/base/metadata-db-configmap.yaml
+++ b/metadata/base/metadata-db-configmap.yaml
@@ -1,7 +1,8 @@
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: db-configmap
+  name: metadata-configmap
 data:
   mysql_database: "metadb"
+  mysql_host: "metadata-db.kubeflow"
   mysql_port: "3306"

--- a/metadata/base/metadata-db-deployment.yaml
+++ b/metadata/base/metadata-db-deployment.yaml
@@ -22,14 +22,14 @@ spec:
           - name: MYSQL_ROOT_PASSWORD
             valueFrom:
               secretKeyRef:
-                name: metadata-db-secrets
+                name: mysql-credential
                 key: password
           - name: MYSQL_ALLOW_EMPTY_PASSWORD
             value: "true"
           - name: MYSQL_DATABASE
             valueFrom:
               configMapKeyRef:
-                name: metadata-db-configmap
+                name: metadata-configmap
                 key: mysql_database
         ports:
         - name: dbapi

--- a/metadata/base/metadata-db-secret.yaml
+++ b/metadata/base/metadata-db-secret.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 kind: Secret
 type: Opaque
 metadata:
-  name: db-secrets
+  name: mysql-credential
 data:
   username: "cm9vdA==" # "root"
   password: "dGVzdA==" # "test"

--- a/metadata/base/metadata-deployment.yaml
+++ b/metadata/base/metadata-deployment.yaml
@@ -21,22 +21,22 @@ spec:
         - name: MYSQL_ROOT_PASSWORD
           valueFrom:
             secretKeyRef:
-              name: metadata-db-secrets
+              name: mysql-credential
               key: password
         - name: MYSQL_USER_NAME
           valueFrom:
             secretKeyRef:
-              name: metadata-db-secrets
+              name: mysql-credential
               key: username
         - name: MYSQL_DATABASE
           valueFrom:
             configMapKeyRef:
-              name: metadata-db-configmap
+              name: metadata-configmap
               key: mysql_database
         - name: MYSQL_PORT
           valueFrom:
             configMapKeyRef:
-              name: metadata-db-configmap
+              name: metadata-configmap
               key: mysql_port
         command: ["./server/server",
                   "--http_port=8080",
@@ -83,22 +83,22 @@ spec:
           - name: MYSQL_ROOT_PASSWORD
             valueFrom:
               secretKeyRef:
-                name: metadata-db-secrets
+                name: mysql-credential
                 key: password
           - name: MYSQL_USER_NAME
             valueFrom:
               secretKeyRef:
-                name: metadata-db-secrets
+                name: mysql-credential
                 key: username
           - name: MYSQL_DATABASE
             valueFrom:
               configMapKeyRef:
-                name: metadata-db-configmap
+                name: metadata-configmap
                 key: mysql_database
           - name: MYSQL_PORT
             valueFrom:
               configMapKeyRef:
-                name: metadata-db-configmap
+                name: metadata-configmap
                 key: mysql_port
           command: ["/bin/metadata_store_server"]
           args: ["--grpc_port=8080",

--- a/metadata/base/metadata-grpc-configmap.yaml
+++ b/metadata/base/metadata-grpc-configmap.yaml
@@ -1,0 +1,7 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: metadata-grpc-configmap
+data:
+  METADATA_GRPC_SERVICE_HOST: "grpc-service"
+  METADATA_GRPC_SERVICE_PORT: "8080"

--- a/tests/metadata-base_test.go
+++ b/tests/metadata-base_test.go
@@ -30,17 +30,27 @@ spec:
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: db-configmap
+  name: metadata-configmap
 data:
   mysql_database: "metadb"
+  mysql_host: "metadata-db.kubeflow"
   mysql_port: "3306"
+`)
+	th.writeF("/manifests/metadata/base/metadata-grpc-configmap.yaml", `
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: metadata-grpc-configmap
+data:
+  METADATA_GRPC_SERVICE_HOST: "grpc-service"
+  METADATA_GRPC_SERVICE_PORT: "8080"
 `)
 	th.writeF("/manifests/metadata/base/metadata-db-secret.yaml", `
 apiVersion: v1
 kind: Secret
 type: Opaque
 metadata:
-  name: db-secrets
+  name: mysql-credential
 data:
   username: "cm9vdA==" # "root"
   password: "dGVzdA==" # "test"
@@ -70,14 +80,14 @@ spec:
           - name: MYSQL_ROOT_PASSWORD
             valueFrom:
               secretKeyRef:
-                name: metadata-db-secrets
+                name: mysql-credential
                 key: password
           - name: MYSQL_ALLOW_EMPTY_PASSWORD
             value: "true"
           - name: MYSQL_DATABASE
             valueFrom:
               configMapKeyRef:
-                name: metadata-db-configmap
+                name: metadata-configmap
                 key: mysql_database
         ports:
         - name: dbapi
@@ -139,22 +149,22 @@ spec:
         - name: MYSQL_ROOT_PASSWORD
           valueFrom:
             secretKeyRef:
-              name: metadata-db-secrets
+              name: mysql-credential
               key: password
         - name: MYSQL_USER_NAME
           valueFrom:
             secretKeyRef:
-              name: metadata-db-secrets
+              name: mysql-credential
               key: username
         - name: MYSQL_DATABASE
           valueFrom:
             configMapKeyRef:
-              name: metadata-db-configmap
+              name: metadata-configmap
               key: mysql_database
         - name: MYSQL_PORT
           valueFrom:
             configMapKeyRef:
-              name: metadata-db-configmap
+              name: metadata-configmap
               key: mysql_port
         command: ["./server/server",
                   "--http_port=8080",
@@ -201,22 +211,22 @@ spec:
           - name: MYSQL_ROOT_PASSWORD
             valueFrom:
               secretKeyRef:
-                name: metadata-db-secrets
+                name: mysql-credential
                 key: password
           - name: MYSQL_USER_NAME
             valueFrom:
               secretKeyRef:
-                name: metadata-db-secrets
+                name: mysql-credential
                 key: username
           - name: MYSQL_DATABASE
             valueFrom:
               configMapKeyRef:
-                name: metadata-db-configmap
+                name: metadata-configmap
                 key: mysql_database
           - name: MYSQL_PORT
             valueFrom:
               configMapKeyRef:
-                name: metadata-db-configmap
+                name: metadata-configmap
                 key: mysql_port
           command: ["/bin/metadata_store_server"]
           args: ["--grpc_port=8080",
@@ -408,6 +418,7 @@ configMapGenerator:
 resources:
 - metadata-db-pvc.yaml
 - metadata-db-configmap.yaml
+- metadata-grpc-configmap.yaml
 - metadata-db-secret.yaml
 - metadata-db-deployment.yaml
 - metadata-db-service.yaml

--- a/tests/metadata-overlays-istio_test.go
+++ b/tests/metadata-overlays-istio_test.go
@@ -92,17 +92,27 @@ spec:
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: db-configmap
+  name: metadata-configmap
 data:
   mysql_database: "metadb"
+	mysql_host: "metadata-db.kubeflow"
   mysql_port: "3306"
+`)
+	th.writeF("/manifests/metadata/base/metadata-grpc-configmap.yaml", `
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: metadata-grpc-configmap
+data:
+  METADATA_GRPC_SERVICE_HOST: "grpc-service"
+  METADATA_GRPC_SERVICE_PORT: "8080"
 `)
 	th.writeF("/manifests/metadata/base/metadata-db-secret.yaml", `
 apiVersion: v1
 kind: Secret
 type: Opaque
 metadata:
-  name: db-secrets
+  name: mysql-credential
 data:
   username: "cm9vdA==" # "root"
   password: "dGVzdA==" # "test"
@@ -132,14 +142,14 @@ spec:
           - name: MYSQL_ROOT_PASSWORD
             valueFrom:
               secretKeyRef:
-                name: metadata-db-secrets
+                name: mysql-credential
                 key: password
           - name: MYSQL_ALLOW_EMPTY_PASSWORD
             value: "true"
           - name: MYSQL_DATABASE
             valueFrom:
               configMapKeyRef:
-                name: metadata-db-configmap
+                name: metadata-configmap
                 key: mysql_database
         ports:
         - name: dbapi
@@ -201,22 +211,22 @@ spec:
         - name: MYSQL_ROOT_PASSWORD
           valueFrom:
             secretKeyRef:
-              name: metadata-db-secrets
+              name: mysql-credential
               key: password
         - name: MYSQL_USER_NAME
           valueFrom:
             secretKeyRef:
-              name: metadata-db-secrets
+              name: mysql-credential
               key: username
         - name: MYSQL_DATABASE
           valueFrom:
             configMapKeyRef:
-              name: metadata-db-configmap
+              name: metadata-configmap
               key: mysql_database
         - name: MYSQL_PORT
           valueFrom:
             configMapKeyRef:
-              name: metadata-db-configmap
+              name: metadata-configmap
               key: mysql_port
         command: ["./server/server",
                   "--http_port=8080",
@@ -263,22 +273,22 @@ spec:
           - name: MYSQL_ROOT_PASSWORD
             valueFrom:
               secretKeyRef:
-                name: metadata-db-secrets
+                name: mysql-credential
                 key: password
           - name: MYSQL_USER_NAME
             valueFrom:
               secretKeyRef:
-                name: metadata-db-secrets
+                name: mysql-credential
                 key: username
           - name: MYSQL_DATABASE
             valueFrom:
               configMapKeyRef:
-                name: metadata-db-configmap
+                name: metadata-configmap
                 key: mysql_database
           - name: MYSQL_PORT
             valueFrom:
               configMapKeyRef:
-                name: metadata-db-configmap
+                name: metadata-configmap
                 key: mysql_port
           command: ["/bin/metadata_store_server"]
           args: ["--grpc_port=8080",
@@ -470,6 +480,7 @@ configMapGenerator:
 resources:
 - metadata-db-pvc.yaml
 - metadata-db-configmap.yaml
+- metadata-grpc-configmap.yaml
 - metadata-db-secret.yaml
 - metadata-db-deployment.yaml
 - metadata-db-service.yaml


### PR DESCRIPTION
This change adds the necessary config-map related to gRPC MLMD server.

This also standardizes the names of the configuration across KF-Metadata and KFP

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/manifests/662)
<!-- Reviewable:end -->
