### PR TITLE
Add allowheader X-Auth-Token in authn-filter

### DIFF
--- a/istio/oidc-authservice/base/envoy-filter.yaml
+++ b/istio/oidc-authservice/base/envoy-filter.yaml
@@ -16,12 +16,12 @@ spec:
         authorizationRequest:
           allowedHeaders:
             patterns:
-              - exact: "cookie"
-              - exact: "X-Auth-Token"
+            - exact: "cookie"
+            - exact: "X-Auth-Token"
         authorizationResponse:
           allowedUpstreamHeaders:
             patterns:
-              - exact: "kubeflow-userid"
+            - exact: "kubeflow-userid"
       statusOnError:
         code: GatewayTimeout
     filterName: envoy.ext_authz

--- a/istio/oidc-authservice/base/envoy-filter.yaml
+++ b/istio/oidc-authservice/base/envoy-filter.yaml
@@ -13,14 +13,15 @@ spec:
           cluster: outbound|8080||authservice.$(namespace).svc.cluster.local
           failureModeAllow: false
           timeout: 10s
-        authorizationRequest: 
+        authorizationRequest:
           allowedHeaders:
             patterns:
-            - exact: "cookie"
+              - exact: "cookie"
+              - exact: "X-Auth-Token"
         authorizationResponse:
           allowedUpstreamHeaders:
             patterns:
-            - exact: "kubeflow-userid"
+              - exact: "kubeflow-userid"
       statusOnError:
         code: GatewayTimeout
     filterName: envoy.ext_authz

--- a/tests/istio-oidc-authservice-base_test.go
+++ b/tests/istio-oidc-authservice-base_test.go
@@ -108,10 +108,11 @@ spec:
           cluster: outbound|8080||authservice.$(namespace).svc.cluster.local
           failureModeAllow: false
           timeout: 10s
-        authorizationRequest: 
+        authorizationRequest:
           allowedHeaders:
             patterns:
             - exact: "cookie"
+            - exact: "X-Auth-Token"
         authorizationResponse:
           allowedUpstreamHeaders:
             patterns:

--- a/tests/istio-oidc-authservice-overlays-application_test.go
+++ b/tests/istio-oidc-authservice-overlays-application_test.go
@@ -167,10 +167,11 @@ spec:
           cluster: outbound|8080||authservice.$(namespace).svc.cluster.local
           failureModeAllow: false
           timeout: 10s
-        authorizationRequest: 
+        authorizationRequest:
           allowedHeaders:
             patterns:
             - exact: "cookie"
+            - exact: "X-Auth-Token"
         authorizationResponse:
           allowedUpstreamHeaders:
             patterns:

--- a/tests/istio-oidc-authservice-overlays-ibm-storage-config_test.go
+++ b/tests/istio-oidc-authservice-overlays-ibm-storage-config_test.go
@@ -137,10 +137,11 @@ spec:
           cluster: outbound|8080||authservice.$(namespace).svc.cluster.local
           failureModeAllow: false
           timeout: 10s
-        authorizationRequest: 
+        authorizationRequest:
           allowedHeaders:
             patterns:
             - exact: "cookie"
+            - exact: "X-Auth-Token"
         authorizationResponse:
           allowedUpstreamHeaders:
             patterns:


### PR DESCRIPTION
**Which issue is resolved by this Pull Request:**
In the authservice we allow user to set the token in the header **"X-Auth-Token"** to pass the authentication
according to: https://github.com/arrikto/ambassador-auth-oidc/blob/feature-kubeflow/auth.go#L111

This is useful when using command line to interact with Kubeflow service
For example you have to access kubeflow endpoint to do the inference using kfserving, [example](https://github.com/kubeflow/kfserving/tree/master/docs/samples/tensorflow) 
which you can't do the authn against dex within curl command.

In order to allow the  "X-Auth-Token" value to be passed to authservice we have to add  **"X-Auth-Token"** in the `AllowHeaders` field in the envoy-filter

**Description of your changes:**


**Checklist:**
- [x] Unit tests have been rebuilt: 
    1. `cd manifests/tests`
    2. `make generate`
    3. `make test`

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/manifests/672)
<!-- Reviewable:end -->
