### PR TITLE
Use GPU_POOL variable for nodePool name

### DIFF
--- a/gcp/deployment_manager_configs/cluster.jinja
+++ b/gcp/deployment_manager_configs/cluster.jinja
@@ -150,7 +150,7 @@ resources:
     zone: {{ properties['zone'] }}
     clusterId: {{ CLUSTER_NAME }}
     nodePool:
-      name: gpu-pool
+      name: {{ GPU_POOL }}
       initialNodeCount: {{ properties['gpu-pool-initialNodeCount'] }}
       autoscaling:
         enabled: {{ properties['gpu-pool-enable-autoscaling'] }}


### PR DESCRIPTION
**Which issue is resolved by this Pull Request:**
Resolves #

**Description of your changes:**
Right now, how the jinja template is setup, you can't reapply changes if you have a GPU pool because it can't find the name. This seems to fix the issue (and make sure the node pools are versioned)

**Checklist:**
- [x] Unit tests have been rebuilt: 
    1. `cd manifests/tests`
    2. `make generate-changed-only`
    3. `make test`

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/manifests/690)
<!-- Reviewable:end -->
