### PR TITLE
Unittests for manifests should run on postsubmit and periodic; not ju…

### DIFF
--- a/prow_config.yaml
+++ b/prow_config.yaml
@@ -8,9 +8,12 @@ python_paths:
 workflows:
   - app_dir: kubeflow/manifests/tests/workflows
     component: workflows
-    name: e2e
+    name: unit
     job_types:
       - presubmit
+      - postsubmit
+      - periodic    
+
   # Run the e2e tests to ensure that changes to manifests don't break deployments.
   - py_func: kubeflow.kfctl.testing.ci.kfctl_e2e_workflow.create_workflow
     name: kfctl-go-iap


### PR DESCRIPTION
…st presubmit

* Rename the test to unittests rather than e2e because we are running
  the unittest for each manifest.

**Which issue is resolved by this Pull Request:**
Resolves #

**Description of your changes:**


**Checklist:**
- [ ] Unit tests have been rebuilt: 
    1. `cd manifests/tests`
    2. `make generate-changed-only`
    3. `make test`

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/manifests/699)
<!-- Reviewable:end -->
