### PR TITLE
oidc-authservice: Various fixes

### DIFF
--- a/istio/oidc-authservice/base/kustomization.yaml
+++ b/istio/oidc-authservice/base/kustomization.yaml
@@ -3,7 +3,7 @@ kind: Kustomization
 
 resources:
 - service.yaml
-- deployment.yaml
+- statefulset.yaml
 - envoy-filter.yaml
 - pvc.yaml
 

--- a/istio/oidc-authservice/base/params.yaml
+++ b/istio/oidc-authservice/base/params.yaml
@@ -1,6 +1,6 @@
 varReference:
 - path: spec/template/spec/containers/env/value
-  kind: Deployment
+  kind: StatefulSet
 - path: spec/filters/filterConfig/httpService/serverUri/uri
   kind: EnvoyFilter
 - path: spec/filters/filterConfig/httpService/serverUri/cluster

--- a/istio/oidc-authservice/base/service.yaml
+++ b/istio/oidc-authservice/base/service.yaml
@@ -10,3 +10,4 @@ spec:
   - port: 8080
     name: http-authservice
     targetPort: http-api
+  publishNotReadyAddresses: true

--- a/istio/oidc-authservice/base/statefulset.yaml
+++ b/istio/oidc-authservice/base/statefulset.yaml
@@ -1,5 +1,5 @@
 apiVersion: apps/v1
-kind: Deployment
+kind: StatefulSet
 metadata:
   name: authservice
 spec:
@@ -7,8 +7,7 @@ spec:
   selector:
     matchLabels:
       app: authservice
-  strategy:
-    type: RollingUpdate
+  serviceName: authservice
   template:
     metadata:
       annotations:

--- a/istio/oidc-authservice/overlays/application/application.yaml
+++ b/istio/oidc-authservice/overlays/application/application.yaml
@@ -14,7 +14,7 @@ spec:
       app.kubernetes.io/version: v0.7.0
   componentKinds:
   - group: apps
-    kind: Deployment
+    kind: StatefulSet
   - group: core
     kind: Service
   - group: core

--- a/istio/oidc-authservice/overlays/ibm-storage-config/kustomization.yaml
+++ b/istio/oidc-authservice/overlays/ibm-storage-config/kustomization.yaml
@@ -3,7 +3,7 @@ kind: Kustomization
 bases:
 - ../../base
 patchesStrategicMerge:
-- deployment.yaml
+- statefulset.yaml
 images:
   - name: busybox
     newTag: "latest"

--- a/istio/oidc-authservice/overlays/ibm-storage-config/statefulset.yaml
+++ b/istio/oidc-authservice/overlays/ibm-storage-config/statefulset.yaml
@@ -1,5 +1,5 @@
 apiVersion: apps/v1
-kind: Deployment
+kind: StatefulSet
 metadata:
   name: authservice
 spec:

--- a/tests/istio-oidc-authservice-base_test.go
+++ b/tests/istio-oidc-authservice-base_test.go
@@ -26,10 +26,11 @@ spec:
   ports:
   - port: 8080
     name: http-authservice
-    targetPort: http-api`)
-	th.writeF("/manifests/istio/oidc-authservice/base/deployment.yaml", `
+    targetPort: http-api
+  publishNotReadyAddresses: true`)
+	th.writeF("/manifests/istio/oidc-authservice/base/statefulset.yaml", `
 apiVersion: apps/v1
-kind: Deployment
+kind: StatefulSet
 metadata:
   name: authservice
 spec:
@@ -37,8 +38,7 @@ spec:
   selector:
     matchLabels:
       app: authservice
-  strategy:
-    type: RollingUpdate
+  serviceName: authservice
   template:
     metadata:
       annotations:
@@ -140,7 +140,7 @@ spec:
 	th.writeF("/manifests/istio/oidc-authservice/base/params.yaml", `
 varReference:
 - path: spec/template/spec/containers/env/value
-  kind: Deployment
+  kind: StatefulSet
 - path: spec/filters/filterConfig/httpService/serverUri/uri
   kind: EnvoyFilter
 - path: spec/filters/filterConfig/httpService/serverUri/cluster
@@ -161,7 +161,7 @@ kind: Kustomization
 
 resources:
 - service.yaml
-- deployment.yaml
+- statefulset.yaml
 - envoy-filter.yaml
 - pvc.yaml
 

--- a/tests/istio-oidc-authservice-overlays-application_test.go
+++ b/tests/istio-oidc-authservice-overlays-application_test.go
@@ -31,7 +31,7 @@ spec:
       app.kubernetes.io/version: v0.7.0
   componentKinds:
   - group: apps
-    kind: Deployment
+    kind: StatefulSet
   - group: core
     kind: Service
   - group: core
@@ -85,10 +85,11 @@ spec:
   ports:
   - port: 8080
     name: http-authservice
-    targetPort: http-api`)
-	th.writeF("/manifests/istio/oidc-authservice/base/deployment.yaml", `
+    targetPort: http-api
+  publishNotReadyAddresses: true`)
+	th.writeF("/manifests/istio/oidc-authservice/base/statefulset.yaml", `
 apiVersion: apps/v1
-kind: Deployment
+kind: StatefulSet
 metadata:
   name: authservice
 spec:
@@ -96,8 +97,7 @@ spec:
   selector:
     matchLabels:
       app: authservice
-  strategy:
-    type: RollingUpdate
+  serviceName: authservice
   template:
     metadata:
       annotations:
@@ -199,7 +199,7 @@ spec:
 	th.writeF("/manifests/istio/oidc-authservice/base/params.yaml", `
 varReference:
 - path: spec/template/spec/containers/env/value
-  kind: Deployment
+  kind: StatefulSet
 - path: spec/filters/filterConfig/httpService/serverUri/uri
   kind: EnvoyFilter
 - path: spec/filters/filterConfig/httpService/serverUri/cluster
@@ -220,7 +220,7 @@ kind: Kustomization
 
 resources:
 - service.yaml
-- deployment.yaml
+- statefulset.yaml
 - envoy-filter.yaml
 - pvc.yaml
 

--- a/tests/istio-oidc-authservice-overlays-ibm-storage-config_test.go
+++ b/tests/istio-oidc-authservice-overlays-ibm-storage-config_test.go
@@ -14,9 +14,9 @@ import (
 )
 
 func writeOidcAuthserviceOverlaysIbmStorageConfig(th *KustTestHarness) {
-	th.writeF("/manifests/istio/oidc-authservice/overlays/ibm-storage-config/deployment.yaml", `
+	th.writeF("/manifests/istio/oidc-authservice/overlays/ibm-storage-config/statefulset.yaml", `
 apiVersion: apps/v1
-kind: Deployment
+kind: StatefulSet
 metadata:
   name: authservice
 spec:
@@ -37,7 +37,7 @@ kind: Kustomization
 bases:
 - ../../base
 patchesStrategicMerge:
-- deployment.yaml
+- statefulset.yaml
 images:
   - name: busybox
     newTag: "latest"
@@ -55,10 +55,11 @@ spec:
   ports:
   - port: 8080
     name: http-authservice
-    targetPort: http-api`)
-	th.writeF("/manifests/istio/oidc-authservice/base/deployment.yaml", `
+    targetPort: http-api
+  publishNotReadyAddresses: true`)
+	th.writeF("/manifests/istio/oidc-authservice/base/statefulset.yaml", `
 apiVersion: apps/v1
-kind: Deployment
+kind: StatefulSet
 metadata:
   name: authservice
 spec:
@@ -66,8 +67,7 @@ spec:
   selector:
     matchLabels:
       app: authservice
-  strategy:
-    type: RollingUpdate
+  serviceName: authservice
   template:
     metadata:
       annotations:
@@ -169,7 +169,7 @@ spec:
 	th.writeF("/manifests/istio/oidc-authservice/base/params.yaml", `
 varReference:
 - path: spec/template/spec/containers/env/value
-  kind: Deployment
+  kind: StatefulSet
 - path: spec/filters/filterConfig/httpService/serverUri/uri
   kind: EnvoyFilter
 - path: spec/filters/filterConfig/httpService/serverUri/cluster
@@ -190,7 +190,7 @@ kind: Kustomization
 
 resources:
 - service.yaml
-- deployment.yaml
+- statefulset.yaml
 - envoy-filter.yaml
 - pvc.yaml
 


### PR DESCRIPTION
**Which issue is resolved by this Pull Request:**
Resolves https://github.com/kubeflow/kubeflow/issues/4517
Resolves https://github.com/kubeflow/manifests/issues/636

**Description of your changes:**

- Change Deployment to StatefulSet as only 1 process can have the
  database file open.
- Add `publishNotReadyEndpoints` option to authservice Service, since we
  want the whitelisted paths to be served even if the OIDC setup hasn't
  completed.

/cc @krishnadurai @ryandawsonuk 

**Checklist:**
- [X] Unit tests have been rebuilt: 
    1. `cd manifests/tests`
    2. `make generate-changed-only`
    3. `make test`

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/manifests/702)
<!-- Reviewable:end -->
