### PR TITLE
Two examples for disabling istio injection in kubeflow namespace

### DIFF
--- a/argo/base/deployment.yaml
+++ b/argo/base/deployment.yaml
@@ -23,6 +23,8 @@ spec:
       creationTimestamp: null
       labels:
         app: argo-ui
+      annotations:
+        sidecar.istio.io/inject: "false"
     spec:
       containers:
       - env:
@@ -79,6 +81,8 @@ spec:
       creationTimestamp: null
       labels:
         app: workflow-controller
+      annotations:
+        sidecar.istio.io/inject: "false"
     spec:
       containers:
       - args:

--- a/tests/argo-base_test.go
+++ b/tests/argo-base_test.go
@@ -200,6 +200,8 @@ spec:
       creationTimestamp: null
       labels:
         app: argo-ui
+      annotations:
+        sidecar.istio.io/inject: "false"
     spec:
       containers:
       - env:
@@ -256,6 +258,8 @@ spec:
       creationTimestamp: null
       labels:
         app: workflow-controller
+      annotations:
+        sidecar.istio.io/inject: "false"
     spec:
       containers:
       - args:

--- a/tests/argo-overlays-application_test.go
+++ b/tests/argo-overlays-application_test.go
@@ -255,6 +255,8 @@ spec:
       creationTimestamp: null
       labels:
         app: argo-ui
+      annotations:
+        sidecar.istio.io/inject: "false"
     spec:
       containers:
       - env:
@@ -311,6 +313,8 @@ spec:
       creationTimestamp: null
       labels:
         app: workflow-controller
+      annotations:
+        sidecar.istio.io/inject: "false"
     spec:
       containers:
       - args:

--- a/tests/argo-overlays-istio_test.go
+++ b/tests/argo-overlays-istio_test.go
@@ -237,6 +237,8 @@ spec:
       creationTimestamp: null
       labels:
         app: argo-ui
+      annotations:
+        sidecar.istio.io/inject: "false"
     spec:
       containers:
       - env:
@@ -293,6 +295,8 @@ spec:
       creationTimestamp: null
       labels:
         app: workflow-controller
+      annotations:
+        sidecar.istio.io/inject: "false"
     spec:
       containers:
       - args:

--- a/tests/tf-training-tf-job-operator-base_test.go
+++ b/tests/tf-training-tf-job-operator-base_test.go
@@ -140,6 +140,8 @@ spec:
     metadata:
       labels:
         name: tf-job-operator
+      annotations:
+        sidecar.istio.io/inject: "false"
     spec:
       containers:
       - command:

--- a/tests/tf-training-tf-job-operator-overlays-application_test.go
+++ b/tests/tf-training-tf-job-operator-overlays-application_test.go
@@ -199,6 +199,8 @@ spec:
     metadata:
       labels:
         name: tf-job-operator
+      annotations:
+        sidecar.istio.io/inject: "false"
     spec:
       containers:
       - command:

--- a/tf-training/tf-job-operator/base/deployment.yaml
+++ b/tf-training/tf-job-operator/base/deployment.yaml
@@ -9,6 +9,8 @@ spec:
     metadata:
       labels:
         name: tf-job-operator
+      annotations:
+        sidecar.istio.io/inject: "false"
     spec:
       containers:
       - command:


### PR DESCRIPTION
**Which issue is resolved by this Pull Request:**
Example of https://github.com/kubeflow/manifests/pull/700

**Description of your changes:**
Add istio disable injection annotations for two deployments.

**Checklist:**
- [x] Unit tests have been rebuilt: 
    1. `cd manifests/tests`
    2. `make generate-changed-only`
    3. `make test`

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/manifests/703)
<!-- Reviewable:end -->
