### PR TITLE
remove users

### DIFF
--- a/gcp/deployment_manager_configs/cluster-kubeflow.yaml
+++ b/gcp/deployment_manager_configs/cluster-kubeflow.yaml
@@ -92,12 +92,6 @@ resources:
       masterAuthorizedNetworksConfigEnabled: false
       masterAuthorizedNetworksConfigCidr:
       - cidrBlock: 1.2.3.4/32
-    users:
-      # List users to grant appropriate GCP permissions to use Kubeflow.
-      # These can either be individual users (Google accounts) or Google
-      # Groups.
-      # - user:john@acme.com
-      # - group:data-scientists@acme.com
     # This is the name of the GCP static ip address reserved for your domain.
     # Each Kubeflow deployment in your project should use one unique ipName among all configs.
     ipName: kubeflow-ip


### PR DESCRIPTION
**Which issue is resolved by this Pull Request:**
Resolves #

**Description of your changes:**
Thank you for always maintenance and thanks for the review!! 🎉 

Field of `users` exists in `deployment_manager_configs/cluster-kubeflow.yaml`.
But it isn't used in `cluster.jinja` template! (Unless my understanding is wrong)
Unnecessary settings cause misleading, so I want to delete them.

**Checklist:**
- [x] Unit tests have been rebuilt: 
    1. `cd manifests/tests`
    2. `make generate-changed-only`
    3. `make test`

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/manifests/708)
<!-- Reviewable:end -->
