### PR TITLE
Upgrade pipeline-visualization-service to 0.1.31

### DIFF
--- a/pipeline/pipeline-visualization-service/base/kustomization.yaml
+++ b/pipeline/pipeline-visualization-service/base/kustomization.yaml
@@ -8,5 +8,5 @@ resources:
 - service.yaml
 images:
 - name: gcr.io/ml-pipeline/visualization-server
-  newTag: 0.1.27
+  newTag: 0.1.31
   newName: gcr.io/ml-pipeline/visualization-server


### PR DESCRIPTION
**Which issue is resolved by this Pull Request:**
Resolves https://github.com/kubeflow/pipelines/issues/2806

**Description of your changes:**
Upgrades `pipeline-visualization-service` from `0.1.27` to `0.1.31` to match `api-server` which is at `0.1.31` and is not longer compatible with the older visualization service due to the change in the parameters format introduced by https://github.com/kubeflow/pipelines/pull/1951

**Checklist:**
- [x] Unit tests have been rebuilt: 
    1. `cd manifests/tests`
    2. `make generate-changed-only`
    3. `make test`

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/manifests/709)
<!-- Reviewable:end -->
