### PR TITLE
Add sidecar.istio.io/inject false annotations to all stateful sets in kubeflow ns

### DIFF
--- a/admission-webhook/bootstrap/base/stateful-set.yaml
+++ b/admission-webhook/bootstrap/base/stateful-set.yaml
@@ -6,6 +6,9 @@ spec:
   replicas: 1
   serviceName: service
   template:
+    metadata:
+      annotations:
+        sidecar.istio.io/inject: "false"
     spec:
       containers:
       - command:

--- a/application/application/base/stateful-set.yaml
+++ b/application/application/base/stateful-set.yaml
@@ -11,6 +11,8 @@ spec:
     metadata:
       labels:
         app: application-controller
+      annotations:
+        sidecar.istio.io/inject: "false"
     spec:
       containers:
       - name: manager

--- a/application/application/overlays/debug/stateful-set.yaml
+++ b/application/application/overlays/debug/stateful-set.yaml
@@ -4,13 +4,16 @@ metadata:
   name: stateful-set
 spec:
   template:
+    metadata:
+      annotations:
+        sidecar.istio.io/inject: "false"
     spec:
       containers:
       - name: manager
         image: gcr.io/$(project)/application-controller:latest
-        command: 
+        command:
         - /go/bin/dlv
-        args: 
+        args:
         - --listen=:2345
         - --headless=true
         - --api-version=2

--- a/aws/aws-efs-csi-driver/base/csi-controller-stateful-set.yaml
+++ b/aws/aws-efs-csi-driver/base/csi-controller-stateful-set.yaml
@@ -12,6 +12,8 @@ spec:
     metadata:
       labels:
         app: efs-csi-controller
+      annotations:
+        sidecar.istio.io/inject: "false"
     spec:
       serviceAccount: efs-csi-controller-sa
       #priorityClassName: system-cluster-critical

--- a/aws/aws-fsx-csi-driver/base/csi-controller-stateful-set.yaml
+++ b/aws/aws-fsx-csi-driver/base/csi-controller-stateful-set.yaml
@@ -12,6 +12,8 @@ spec:
     metadata:
       labels:
         app: fsx-csi-controller
+      annotations:
+        sidecar.istio.io/inject: "false"
     spec:
       serviceAccount: fsx-csi-controller-sa
 #      priorityClassName: system-cluster-critical

--- a/kfserving/kfserving-install/base/statefulset.yaml
+++ b/kfserving/kfserving-install/base/statefulset.yaml
@@ -16,6 +16,8 @@ spec:
       labels:
         control-plane: kfserving-controller-manager
         controller-tools.k8s.io: "1.0"
+      annotations:
+        sidecar.istio.io/inject: "false"
     spec:
       containers:
       - args:

--- a/metacontroller/base/stateful-set.yaml
+++ b/metacontroller/base/stateful-set.yaml
@@ -14,6 +14,8 @@ spec:
     metadata:
       labels:
         app: metacontroller
+      annotations:
+        sidecar.istio.io/inject: "false"
     spec:
       containers:
       - command:

--- a/seldon/seldon-core-operator/base/seldon-operator-controller-manager-statefulset.yaml
+++ b/seldon/seldon-core-operator/base/seldon-operator-controller-manager-statefulset.yaml
@@ -22,6 +22,7 @@ spec:
     metadata:
       annotations:
         prometheus.io/scrape: "true"
+        sidecar.istio.io/inject: "false"
       labels:
         app.kubernetes.io/instance: seldon-core-operator
         app.kubernetes.io/name: seldon-core-operator

--- a/tests/admission-webhook-bootstrap-base_test.go
+++ b/tests/admission-webhook-bootstrap-base_test.go
@@ -202,6 +202,9 @@ spec:
   replicas: 1
   serviceName: service
   template:
+    metadata:
+      annotations:
+        sidecar.istio.io/inject: "false"
     spec:
       containers:
       - command:

--- a/tests/admission-webhook-bootstrap-overlays-application_test.go
+++ b/tests/admission-webhook-bootstrap-overlays-application_test.go
@@ -253,6 +253,9 @@ spec:
   replicas: 1
   serviceName: service
   template:
+    metadata:
+      annotations:
+        sidecar.istio.io/inject: "false"
     spec:
       containers:
       - command:

--- a/tests/application-application-base_test.go
+++ b/tests/application-application-base_test.go
@@ -79,6 +79,8 @@ spec:
     metadata:
       labels:
         app: application-controller
+      annotations:
+        sidecar.istio.io/inject: "false"
     spec:
       containers:
       - name: manager

--- a/tests/application-application-overlays-application_test.go
+++ b/tests/application-application-overlays-application_test.go
@@ -130,6 +130,8 @@ spec:
     metadata:
       labels:
         app: application-controller
+      annotations:
+        sidecar.istio.io/inject: "false"
     spec:
       containers:
       - name: manager

--- a/tests/application-application-overlays-debug_test.go
+++ b/tests/application-application-overlays-debug_test.go
@@ -21,13 +21,16 @@ metadata:
   name: stateful-set
 spec:
   template:
+    metadata:
+      annotations:
+        sidecar.istio.io/inject: "false"
     spec:
       containers:
       - name: manager
         image: gcr.io/$(project)/application-controller:latest
-        command: 
+        command:
         - /go/bin/dlv
-        args: 
+        args:
         - --listen=:2345
         - --headless=true
         - --api-version=2
@@ -115,6 +118,8 @@ spec:
     metadata:
       labels:
         app: application-controller
+      annotations:
+        sidecar.istio.io/inject: "false"
     spec:
       containers:
       - name: manager

--- a/tests/aws-aws-efs-csi-driver-base_test.go
+++ b/tests/aws-aws-efs-csi-driver-base_test.go
@@ -29,6 +29,8 @@ spec:
     metadata:
       labels:
         app: efs-csi-controller
+      annotations:
+        sidecar.istio.io/inject: "false"
     spec:
       serviceAccount: efs-csi-controller-sa
       #priorityClassName: system-cluster-critical

--- a/tests/aws-aws-fsx-csi-driver-base_test.go
+++ b/tests/aws-aws-fsx-csi-driver-base_test.go
@@ -29,6 +29,8 @@ spec:
     metadata:
       labels:
         app: fsx-csi-controller
+      annotations:
+        sidecar.istio.io/inject: "false"
     spec:
       serviceAccount: fsx-csi-controller-sa
 #      priorityClassName: system-cluster-critical

--- a/tests/kfserving-kfserving-install-base_test.go
+++ b/tests/kfserving-kfserving-install-base_test.go
@@ -380,6 +380,8 @@ spec:
       labels:
         control-plane: kfserving-controller-manager
         controller-tools.k8s.io: "1.0"
+      annotations:
+        sidecar.istio.io/inject: "false"
     spec:
       containers:
       - args:

--- a/tests/kfserving-kfserving-install-overlays-application_test.go
+++ b/tests/kfserving-kfserving-install-overlays-application_test.go
@@ -437,6 +437,8 @@ spec:
       labels:
         control-plane: kfserving-controller-manager
         controller-tools.k8s.io: "1.0"
+      annotations:
+        sidecar.istio.io/inject: "false"
     spec:
       containers:
       - args:

--- a/tests/metacontroller-base_test.go
+++ b/tests/metacontroller-base_test.go
@@ -97,6 +97,8 @@ spec:
     metadata:
       labels:
         app: metacontroller
+      annotations:
+        sidecar.istio.io/inject: "false"
     spec:
       containers:
       - command:

--- a/tests/seldon-seldon-core-operator-base_test.go
+++ b/tests/seldon-seldon-core-operator-base_test.go
@@ -94,6 +94,7 @@ spec:
     metadata:
       annotations:
         prometheus.io/scrape: "true"
+        sidecar.istio.io/inject: "false"
       labels:
         app.kubernetes.io/instance: seldon-core-operator
         app.kubernetes.io/name: seldon-core-operator

--- a/tests/seldon-seldon-core-operator-overlays-application_test.go
+++ b/tests/seldon-seldon-core-operator-overlays-application_test.go
@@ -143,6 +143,7 @@ spec:
     metadata:
       annotations:
         prometheus.io/scrape: "true"
+        sidecar.istio.io/inject: "false"
       labels:
         app.kubernetes.io/instance: seldon-core-operator
         app.kubernetes.io/name: seldon-core-operator


### PR DESCRIPTION
**Which issue is resolved by this Pull Request:**
Part of https://github.com/kubeflow/pipelines/issues/1223
Unblocks https://github.com/kubeflow/kfctl/pull/131

**Description of your changes:**
Add the annotation to disable istio sidecar injection for these stateful sets.

**Checklist:**
- [x] Unit tests have been rebuilt: 
    1. `cd manifests/tests`
    2. `make generate-changed-only`
    3. `make test`

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/manifests/711)
<!-- Reviewable:end -->
