### PR TITLE
Example of regenerating all tests

### DIFF
--- a/tests/metadata-base_test.go
+++ b/tests/metadata-base_test.go
@@ -77,7 +77,7 @@ spec:
           args: ["--grpc_port=$(METADATA_GRPC_SERVICE_PORT)"]
           ports:
             - name: grpc-backendapi
-              containerPort: 8080
+              containerPort: 8080 #The value of the port number needs to be in sync with value  specified in grpc-params.env
 `)
 	th.writeF("/manifests/metadata/base/metadata-service.yaml", `
 kind: Service
@@ -244,10 +244,6 @@ spec:
 `)
 	th.writeF("/manifests/metadata/base/params.env", `
 uiClusterDomain=cluster.local
-`)
-	th.writeF("/manifests/metadata/base/grpc-params.env", `
-METADATA_GRPC_SERVICE_HOST=metadata-grpc-service
-METADATA_GRPC_SERVICE_PORT=8080
 `)
 	th.writeK("/manifests/metadata/base", `
 namePrefix: metadata-

--- a/tests/metadata-overlays-application_test.go
+++ b/tests/metadata-overlays-application_test.go
@@ -134,7 +134,7 @@ spec:
           args: ["--grpc_port=$(METADATA_GRPC_SERVICE_PORT)"]
           ports:
             - name: grpc-backendapi
-              containerPort: 8080
+              containerPort: 8080 #The value of the port number needs to be in sync with value  specified in grpc-params.env
 `)
 	th.writeF("/manifests/metadata/base/metadata-service.yaml", `
 kind: Service
@@ -301,10 +301,6 @@ spec:
 `)
 	th.writeF("/manifests/metadata/base/params.env", `
 uiClusterDomain=cluster.local
-`)
-	th.writeF("/manifests/metadata/base/grpc-params.env", `
-METADATA_GRPC_SERVICE_HOST=metadata-grpc-service
-METADATA_GRPC_SERVICE_PORT=8080
 `)
 	th.writeK("/manifests/metadata/base", `
 namePrefix: metadata-

--- a/tests/metadata-overlays-db_test.go
+++ b/tests/metadata-overlays-db_test.go
@@ -260,7 +260,7 @@ spec:
           args: ["--grpc_port=$(METADATA_GRPC_SERVICE_PORT)"]
           ports:
             - name: grpc-backendapi
-              containerPort: 8080
+              containerPort: 8080 #The value of the port number needs to be in sync with value  specified in grpc-params.env
 `)
 	th.writeF("/manifests/metadata/base/metadata-service.yaml", `
 kind: Service
@@ -427,10 +427,6 @@ spec:
 `)
 	th.writeF("/manifests/metadata/base/params.env", `
 uiClusterDomain=cluster.local
-`)
-	th.writeF("/manifests/metadata/base/grpc-params.env", `
-METADATA_GRPC_SERVICE_HOST=metadata-grpc-service
-METADATA_GRPC_SERVICE_PORT=8080
 `)
 	th.writeK("/manifests/metadata/base", `
 namePrefix: metadata-

--- a/tests/metadata-overlays-ibm-storage-config_test.go
+++ b/tests/metadata-overlays-ibm-storage-config_test.go
@@ -87,7 +87,7 @@ spec:
           args: ["--grpc_port=$(METADATA_GRPC_SERVICE_PORT)"]
           ports:
             - name: grpc-backendapi
-              containerPort: 8080
+              containerPort: 8080 #The value of the port number needs to be in sync with value  specified in grpc-params.env
 `)
 	th.writeF("/manifests/metadata/base/metadata-service.yaml", `
 kind: Service
@@ -254,10 +254,6 @@ spec:
 `)
 	th.writeF("/manifests/metadata/base/params.env", `
 uiClusterDomain=cluster.local
-`)
-	th.writeF("/manifests/metadata/base/grpc-params.env", `
-METADATA_GRPC_SERVICE_HOST=metadata-grpc-service
-METADATA_GRPC_SERVICE_PORT=8080
 `)
 	th.writeK("/manifests/metadata/base", `
 namePrefix: metadata-

--- a/tests/metadata-overlays-istio_test.go
+++ b/tests/metadata-overlays-istio_test.go
@@ -139,7 +139,7 @@ spec:
           args: ["--grpc_port=$(METADATA_GRPC_SERVICE_PORT)"]
           ports:
             - name: grpc-backendapi
-              containerPort: 8080
+              containerPort: 8080 #The value of the port number needs to be in sync with value  specified in grpc-params.env
 `)
 	th.writeF("/manifests/metadata/base/metadata-service.yaml", `
 kind: Service
@@ -306,10 +306,6 @@ spec:
 `)
 	th.writeF("/manifests/metadata/base/params.env", `
 uiClusterDomain=cluster.local
-`)
-	th.writeF("/manifests/metadata/base/grpc-params.env", `
-METADATA_GRPC_SERVICE_HOST=metadata-grpc-service
-METADATA_GRPC_SERVICE_PORT=8080
 `)
 	th.writeK("/manifests/metadata/base", `
 namePrefix: metadata-


### PR DESCRIPTION
**Which issue is resolved by this Pull Request:**
Example of problem met in https://github.com/kubeflow/manifests/pull/712

**Description of your changes:**
I ran
* `cd manifests/tests`
* `make generate`
* `make test`

I regenerate test cases for https://github.com/kubeflow/manifests/blob/9aae81d93b78b3fe802527b084530672f39e2b1a/metadata/base/metadata-envoy-deployment.yaml, but some metadata tests are generated differently than in master and the tests fail.
```
--- FAIL: TestMetadataBase (0.01s)
    metadata-base_test.go:325: Err: env source files: [grpc-params.env]: cannot read file "/manifests/metadata/base/grpc-params.env"
=== RUN   TestMetadataOverlaysApplication
--- FAIL: TestMetadataOverlaysApplication (0.01s)
    metadata-overlays-application_test.go:382: Err: accumulating resources: recursed accumulation of path '../../base': env source files: [grpc-params.env]: cannot read file "/manifests/metadata/base/grpc-params.env"
=== RUN   TestMetadataOverlaysDb
--- FAIL: TestMetadataOverlaysDb (0.01s)
    metadata-overlays-db_test.go:508: Err: accumulating resources: recursed accumulation of path '../../base': env source files: [grpc-params.env]: cannot read file "/manifests/metadata/base/grpc-params.env"
=== RUN   TestMetadataOverlaysIbmStorageConfig
--- FAIL: TestMetadataOverlaysIbmStorageConfig (0.01s)
    metadata-overlays-ibm-storage-config_test.go:335: Err: accumulating resources: recursed accumulation of path '../../base': env source files: [grpc-params.env]: cannot read file "/manifests/metadata/base/grpc-params.env"
=== RUN   TestMetadataOverlaysIstio
--- FAIL: TestMetadataOverlaysIstio (0.01s)
    metadata-overlays-istio_test.go:387: Err: accumulating resources: recursed accumulation of path '../../base': env source files: [grpc-params.env]: cannot read file "/manifests/metadata/base/grpc-params.env"
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/manifests/716)
<!-- Reviewable:end -->
