### PR TITLE
Update the command for the kfam deployment in the manifest

### DIFF
--- a/profiles/base/deployment.yaml
+++ b/profiles/base/deployment.yaml
@@ -20,7 +20,7 @@ spec:
         imagePullPolicy: Always
         name: manager
       - command:
-        - /opt/kubeflow/access-management
+        - /access-management
         args:
         - "-cluster-admin"
         - $(admin)
@@ -28,7 +28,7 @@ spec:
         - $(userid-header)
         - "-userid-prefix"
         - $(userid-prefix)
-        image: gcr.io/kubeflow-images-public/kfam:v20190612-v0-170-ga06cdb79-dirty-a33ee4
+        image: gcr.io/kubeflow-images-public/kfam
         imagePullPolicy: Always
         name: kfam
       serviceAccountName: controller-service-account

--- a/tests/profiles-base_test.go
+++ b/tests/profiles-base_test.go
@@ -208,7 +208,7 @@ spec:
         imagePullPolicy: Always
         name: manager
       - command:
-        - /opt/kubeflow/access-management
+        - /access-management
         args:
         - "-cluster-admin"
         - $(admin)
@@ -216,7 +216,7 @@ spec:
         - $(userid-header)
         - "-userid-prefix"
         - $(userid-prefix)
-        image: gcr.io/kubeflow-images-public/kfam:v20190612-v0-170-ga06cdb79-dirty-a33ee4
+        image: gcr.io/kubeflow-images-public/kfam
         imagePullPolicy: Always
         name: kfam
       serviceAccountName: controller-service-account

--- a/tests/profiles-overlays-application_test.go
+++ b/tests/profiles-overlays-application_test.go
@@ -264,7 +264,7 @@ spec:
         imagePullPolicy: Always
         name: manager
       - command:
-        - /opt/kubeflow/access-management
+        - /access-management
         args:
         - "-cluster-admin"
         - $(admin)
@@ -272,7 +272,7 @@ spec:
         - $(userid-header)
         - "-userid-prefix"
         - $(userid-prefix)
-        image: gcr.io/kubeflow-images-public/kfam:v20190612-v0-170-ga06cdb79-dirty-a33ee4
+        image: gcr.io/kubeflow-images-public/kfam
         imagePullPolicy: Always
         name: kfam
       serviceAccountName: controller-service-account

--- a/tests/profiles-overlays-debug_test.go
+++ b/tests/profiles-overlays-debug_test.go
@@ -267,7 +267,7 @@ spec:
         imagePullPolicy: Always
         name: manager
       - command:
-        - /opt/kubeflow/access-management
+        - /access-management
         args:
         - "-cluster-admin"
         - $(admin)
@@ -275,7 +275,7 @@ spec:
         - $(userid-header)
         - "-userid-prefix"
         - $(userid-prefix)
-        image: gcr.io/kubeflow-images-public/kfam:v20190612-v0-170-ga06cdb79-dirty-a33ee4
+        image: gcr.io/kubeflow-images-public/kfam
         imagePullPolicy: Always
         name: kfam
       serviceAccountName: controller-service-account

--- a/tests/profiles-overlays-devices_test.go
+++ b/tests/profiles-overlays-devices_test.go
@@ -234,7 +234,7 @@ spec:
         imagePullPolicy: Always
         name: manager
       - command:
-        - /opt/kubeflow/access-management
+        - /access-management
         args:
         - "-cluster-admin"
         - $(admin)
@@ -242,7 +242,7 @@ spec:
         - $(userid-header)
         - "-userid-prefix"
         - $(userid-prefix)
-        image: gcr.io/kubeflow-images-public/kfam:v20190612-v0-170-ga06cdb79-dirty-a33ee4
+        image: gcr.io/kubeflow-images-public/kfam
         imagePullPolicy: Always
         name: kfam
       serviceAccountName: controller-service-account

--- a/tests/profiles-overlays-istio_test.go
+++ b/tests/profiles-overlays-istio_test.go
@@ -249,7 +249,7 @@ spec:
         imagePullPolicy: Always
         name: manager
       - command:
-        - /opt/kubeflow/access-management
+        - /access-management
         args:
         - "-cluster-admin"
         - $(admin)
@@ -257,7 +257,7 @@ spec:
         - $(userid-header)
         - "-userid-prefix"
         - $(userid-prefix)
-        image: gcr.io/kubeflow-images-public/kfam:v20190612-v0-170-ga06cdb79-dirty-a33ee4
+        image: gcr.io/kubeflow-images-public/kfam
         imagePullPolicy: Always
         name: kfam
       serviceAccountName: controller-service-account

--- a/tests/profiles-overlays-test_test.go
+++ b/tests/profiles-overlays-test_test.go
@@ -216,7 +216,7 @@ spec:
         imagePullPolicy: Always
         name: manager
       - command:
-        - /opt/kubeflow/access-management
+        - /access-management
         args:
         - "-cluster-admin"
         - $(admin)
@@ -224,7 +224,7 @@ spec:
         - $(userid-header)
         - "-userid-prefix"
         - $(userid-prefix)
-        image: gcr.io/kubeflow-images-public/kfam:v20190612-v0-170-ga06cdb79-dirty-a33ee4
+        image: gcr.io/kubeflow-images-public/kfam
         imagePullPolicy: Always
         name: kfam
       serviceAccountName: controller-service-account


### PR DESCRIPTION
* In kubeflow/kubeflow#707 the path of the binary in the docker image
  was changed so we need to update the command in the manifest.

Fix #724

**Which issue is resolved by this Pull Request:**
Resolves #

**Description of your changes:**


**Checklist:**
- [ ] Unit tests have been rebuilt: 
    1. `cd manifests/tests`
    2. `make generate-changed-only`
    3. `make test`

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/manifests/725)
<!-- Reviewable:end -->
