### PR TITLE
Pin GKE to 1.14.8 because the latest 1.14 release breaks workload identity

### DIFF
--- a/gcp/deployment_manager_configs/cluster-kubeflow.yaml
+++ b/gcp/deployment_manager_configs/cluster-kubeflow.yaml
@@ -31,7 +31,8 @@ resources:
     zone: SET_THE_ZONE
     # "1.X": picks the highest valid patch+gke.N patch in the 1.X version
     # https://cloud.google.com/kubernetes-engine/docs/reference/rest/v1/projects.zones.clusters
-    cluster-version: "1.14"
+    # TODO(https://github.com/kubeflow/manifests/issues/757): Unpin from 1.14.8
+    cluster-version: "1.14.8"
     # Set this to v1beta1 to use beta features such as private clusterss
     # and the Kubernetes stackdriver agents.
     gkeApiVersion: SET_GKE_API_VERSION


### PR DESCRIPTION
Related to kubeflow/kubeflow#4693

**Which issue is resolved by this Pull Request:**
Resolves #

**Description of your changes:**


**Checklist:**
- [ ] Unit tests have been rebuilt: 
    1. `cd manifests/tests`
    2. `make generate-changed-only`
    3. `make test`

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/manifests/760)
<!-- Reviewable:end -->
