### PR TITLE
Use kustomize to make it easier to maintain the versioned KFDef specs.

### DIFF
--- a/hack/build_kfdef_specs.py
+++ b/hack/build_kfdef_specs.py
@@ -1,0 +1,75 @@
+"""Generate KFDef YAML from kustomize packages.
+
+This is a helper tool aimed at generating the RAW Yaml for KFDef specs into
+kubeflow/manifests.
+
+We use kustomize to make it easier to generate KFDef YAML files corresponding
+to different KF versions but we don't want users to be exposed to that.
+"""
+
+import fire
+import logging
+import os
+import subprocess
+import tempfile
+import yaml
+
+RESOURCE_PREFIX = "kfdef.apps.kubeflow.org_v1_kfdef_"
+
+class KFDefBuilder:
+  @staticmethod
+  def run():
+    root = os.path.abspath(os.path.join(os.path.dirname(__file__), ".."))
+
+    kfdef_dir = os.path.join(root, "kfdef")
+    source_dir = os.path.join(root, "kfdef", "source")
+
+    # Walk over all versions
+    for base, dirs, _ in os.walk(source_dir):
+      for version in dirs:
+        package_dir = os.path.join(base, version)
+
+        # Create a temporary directory to write all the kustomize output to
+        temp_dir = tempfile.mkdtemp()
+
+        subprocess.check_call(["kustomize", "build", package_dir, "-o",
+                               temp_dir])
+
+        for f in os.listdir(temp_dir):
+          new_name = f[len(RESOURCE_PREFIX):]
+
+          # To preserve the existing pattern for now master files are just
+          # named kfctl_?.Yaml
+          # whereas version files are named kfctl_?.version.yaml
+          # in subsequent PRs we might change that
+
+          if version == "master":
+            ext = ".yaml"
+          else:
+            ext = "." + version + ".yaml"
+
+          basename, _ = os.path.splitext(new_name)
+          new_name = basename + ext
+
+          new_file = os.path.join(kfdef_dir, new_name)
+          logging.info(f"Processing file: {f} -> {new_file}")
+
+          with open(os.path.join(temp_dir, f)) as hf:
+            spec = yaml.load(hf)
+
+          # Remove the name. Kustomize requires a name but we don't want
+          # a name so that kfctl will fill it in based on the app directory
+          del spec["metadata"]["name"]
+
+          with open(new_file, "w") as hf:
+            yaml.safe_dump(spec, hf)
+
+if __name__ == "__main__":
+
+  logging.basicConfig(level=logging.INFO,
+                      format=('%(levelname)s|%(asctime)s'
+                              '|%(message)s|%(pathname)s|%(lineno)d|'),
+                      datefmt='%Y-%m-%dT%H:%M:%S',
+                      )
+
+  fire.Fire(KFDefBuilder)

--- a/kfdef/kfctl_anthos.v1.0.0.yaml
+++ b/kfdef/kfctl_anthos.v1.0.0.yaml
@@ -1,6 +1,7 @@
 apiVersion: kfdef.apps.kubeflow.org/v1
 kind: KfDef
-metadata: {}
+metadata:
+  namespace: kubeflow
 spec:
   applications:
   - kustomizeConfig:

--- a/kfdef/kfctl_anthos.v1.0.0.yaml
+++ b/kfdef/kfctl_anthos.v1.0.0.yaml
@@ -5,24 +5,10 @@ spec:
   applications:
   - kustomizeConfig:
       parameters:
-      - name: namespace
-        value: istio-system
-      repoRef:
-        name: manifests
-        path: istio/istio-crds
-    name: istio-crds
-  - kustomizeConfig:
-      parameters:
-      - name: namespace
-        value: istio-system
-      repoRef:
-        name: manifests
-        path: istio/istio-install
-    name: istio-install
-  - kustomizeConfig:
-      parameters:
       - name: clusterRbacConfig
-        value: 'ON'
+        value: 'OFF'
+      - name: gatewaySelector
+        value: ingress-gke-system
       repoRef:
         name: manifests
         path: istio/istio
@@ -69,11 +55,6 @@ spec:
   - kustomizeConfig:
       repoRef:
         name: manifests
-        path: kubeflow-roles
-    name: kubeflow-roles
-  - kustomizeConfig:
-      repoRef:
-        name: manifests
         path: metacontroller
     name: metacontroller
   - kustomizeConfig:
@@ -85,14 +66,14 @@ spec:
         path: argo
     name: argo
   - kustomizeConfig:
+      repoRef:
+        name: manifests
+        path: kubeflow-roles
+    name: kubeflow-roles
+  - kustomizeConfig:
       overlays:
       - istio
       - application
-      parameters:
-      - name: userid-header
-        value: X-Goog-Authenticated-User-Email
-      - name: userid-prefix
-        value: 'accounts.google.com:'
       repoRef:
         name: manifests
         path: common/centraldashboard
@@ -102,27 +83,19 @@ spec:
       - application
       repoRef:
         name: manifests
-        path: admission-webhook/webhook
-    name: webhook
-  - kustomizeConfig:
-      overlays:
-      - application
-      parameters:
-      - name: webhookNamePrefix
-        value: admission-webhook-
-      repoRef:
-        name: manifests
         path: admission-webhook/bootstrap
     name: bootstrap
   - kustomizeConfig:
       overlays:
+      - application
+      repoRef:
+        name: manifests
+        path: admission-webhook/webhook
+    name: webhook
+  - kustomizeConfig:
+      overlays:
       - istio
       - application
-      parameters:
-      - name: userid-header
-        value: X-Goog-Authenticated-User-Email
-      - name: userid-prefix
-        value: 'accounts.google.com:'
       repoRef:
         name: manifests
         path: jupyter/jupyter-web-app
@@ -147,9 +120,6 @@ spec:
       overlays:
       - istio
       - application
-      parameters:
-      - name: injectGcpCredentials
-        value: 'true'
       repoRef:
         name: manifests
         path: jupyter/notebook-controller
@@ -207,7 +177,7 @@ spec:
       - application
       parameters:
       - name: usageId
-        value: '7439583937720421527'
+        value: <randomly-generated-id>
       - name: reportUsage
         value: 'true'
       repoRef:
@@ -259,13 +229,8 @@ spec:
     name: api-service
   - kustomizeConfig:
       overlays:
-      - minioPd
       - application
       parameters:
-      - name: minioPd
-        value: test1-storage-artifact-store
-      - name: minioPvName
-        value: minio-pv
       - name: minioPvcName
         value: minio-pv-claim
       repoRef:
@@ -274,13 +239,8 @@ spec:
     name: minio
   - kustomizeConfig:
       overlays:
-      - mysqlPd
       - application
       parameters:
-      - name: mysqlPd
-        value: test1-storage-metadata-store
-      - name: mysqlPvName
-        value: mysql-pv
       - name: mysqlPvcName
         value: mysql-pv-claim
       repoRef:
@@ -303,7 +263,6 @@ spec:
     name: pipelines-runner
   - kustomizeConfig:
       overlays:
-      - gcp
       - istio
       - application
       repoRef:
@@ -327,27 +286,10 @@ spec:
   - kustomizeConfig:
       overlays:
       - application
-      repoRef:
-        name: manifests
-        path: pipeline/pipeline-visualization-service
-    name: pipeline-visualization-service
-  - kustomizeConfig:
-      overlays:
-      - application
-      repoRef:
-        name: manifests
-        path: gcp/cloud-endpoints
-    name: cloud-endpoints
-  - kustomizeConfig:
-      overlays:
-      - application
       - istio
       parameters:
       - name: admin
-      - name: userid-header
-        value: X-Goog-Authenticated-User-Email
-      - name: userid-prefix
-        value: 'accounts.google.com:'
+        value: johnDoe@acme.com
       repoRef:
         name: manifests
         path: profiles
@@ -357,53 +299,9 @@ spec:
       - application
       repoRef:
         name: manifests
-        path: gcp/gpu-driver
-    name: gpu-driver
-  - kustomizeConfig:
-      overlays:
-      - managed-cert
-      - application
-      parameters:
-      - name: namespace
-        value: istio-system
-      - name: ipName
-        value: test1-ip
-      - name: hostname
-      repoRef:
-        name: manifests
-        path: gcp/iap-ingress
-    name: iap-ingress
-  - kustomizeConfig:
-      overlays:
-      - application
-      repoRef:
-        name: manifests
         path: seldon/seldon-core-operator
     name: seldon-core-operator
-  - kustomizeConfig:
-      parameters:
-      - name: user
-      - name: profile-name
-        value: anonymous
-      repoRef:
-        name: manifests
-        path: default-install
-    name: default-install
-  plugins:
-  - kind: KfGcpPlugin
-    metadata:
-      creationTimestamp: null
-      name: gcp
-    spec:
-      createPipelinePersistentStorage: true
-      deploymentManagerConfig:
-        repoRef:
-          name: manifests
-          path: gcp/deployment_manager_configs
-      enableWorkloadIdentity: true
-      skipInitProject: true
-      useBasicAuth: false
   repos:
   - name: manifests
-    uri: https://github.com/kubeflow/manifests/archive/master.tar.gz
-  version: master
+    uri: https://github.com/kubeflow/manifests/archive/v1.0-branch.tar.gz
+  version: v1.0.0

--- a/kfdef/kfctl_anthos.yaml
+++ b/kfdef/kfctl_anthos.yaml
@@ -1,6 +1,7 @@
 apiVersion: kfdef.apps.kubeflow.org/v1
 kind: KfDef
-metadata: {}
+metadata:
+  namespace: kubeflow
 spec:
   applications:
   - kustomizeConfig:

--- a/kfdef/kfctl_anthos.yaml
+++ b/kfdef/kfctl_anthos.yaml
@@ -1,19 +1,12 @@
-# This is the config to install Kubeflow on an Anthos.
-# The cluster comes with customized Istio installation.
-
 apiVersion: kfdef.apps.kubeflow.org/v1
 kind: KfDef
-metadata:
-  # User needs to set the app name, otherwise will try to infer from the directory.
-  # name: kubeflow_app
-  namespace: kubeflow
+metadata: {}
 spec:
   applications:
-  # This component is the istio resources for Kubeflow (e.g. gateway), not about installing istio.
   - kustomizeConfig:
       parameters:
       - name: clusterRbacConfig
-        value: "OFF"
+        value: 'OFF'
       - name: gatewaySelector
         value: ingress-gke-system
       repoRef:
@@ -58,7 +51,7 @@ spec:
       repoRef:
         name: manifests
         path: cert-manager/cert-manager
-    name: cert-manager        
+    name: cert-manager
   - kustomizeConfig:
       repoRef:
         name: manifests
@@ -186,7 +179,7 @@ spec:
       - name: usageId
         value: <randomly-generated-id>
       - name: reportUsage
-        value: "true"
+        value: 'true'
       repoRef:
         name: manifests
         path: common/spartakus
@@ -311,6 +304,4 @@ spec:
   repos:
   - name: manifests
     uri: https://github.com/kubeflow/manifests/archive/master.tar.gz
-    # An example uri that uses a PR version of the manifest repo.
-    # uri: https://github.com/kubeflow/manifests/archive/pull/PR_NUMBER/head.tar.gz
   version: master

--- a/kfdef/kfctl_gcp_basic_auth.v1.0.0.yaml
+++ b/kfdef/kfctl_gcp_basic_auth.v1.0.0.yaml
@@ -1,6 +1,7 @@
 apiVersion: kfdef.apps.kubeflow.org/v1
 kind: KfDef
-metadata: {}
+metadata:
+  namespace: kubeflow
 spec:
   applications:
   - kustomizeConfig:

--- a/kfdef/kfctl_gcp_basic_auth.v1.0.0.yaml
+++ b/kfdef/kfctl_gcp_basic_auth.v1.0.0.yaml
@@ -22,7 +22,7 @@ spec:
   - kustomizeConfig:
       parameters:
       - name: clusterRbacConfig
-        value: 'ON'
+        value: 'OFF'
       repoRef:
         name: manifests
         path: istio/istio
@@ -69,11 +69,6 @@ spec:
   - kustomizeConfig:
       repoRef:
         name: manifests
-        path: kubeflow-roles
-    name: kubeflow-roles
-  - kustomizeConfig:
-      repoRef:
-        name: manifests
         path: metacontroller
     name: metacontroller
   - kustomizeConfig:
@@ -85,14 +80,14 @@ spec:
         path: argo
     name: argo
   - kustomizeConfig:
+      repoRef:
+        name: manifests
+        path: kubeflow-roles
+    name: kubeflow-roles
+  - kustomizeConfig:
       overlays:
       - istio
       - application
-      parameters:
-      - name: userid-header
-        value: X-Goog-Authenticated-User-Email
-      - name: userid-prefix
-        value: 'accounts.google.com:'
       repoRef:
         name: manifests
         path: common/centraldashboard
@@ -118,11 +113,6 @@ spec:
       overlays:
       - istio
       - application
-      parameters:
-      - name: userid-header
-        value: X-Goog-Authenticated-User-Email
-      - name: userid-prefix
-        value: 'accounts.google.com:'
       repoRef:
         name: manifests
         path: jupyter/jupyter-web-app
@@ -207,7 +197,7 @@ spec:
       - application
       parameters:
       - name: usageId
-        value: '7439583937720421527'
+        value: '2700513155662330975'
       - name: reportUsage
         value: 'true'
       repoRef:
@@ -334,6 +324,10 @@ spec:
   - kustomizeConfig:
       overlays:
       - application
+      parameters:
+      - name: ipName
+        value: ipName
+      - name: hostname
       repoRef:
         name: manifests
         path: gcp/cloud-endpoints
@@ -344,10 +338,6 @@ spec:
       - istio
       parameters:
       - name: admin
-      - name: userid-header
-        value: X-Goog-Authenticated-User-Email
-      - name: userid-prefix
-        value: 'accounts.google.com:'
       repoRef:
         name: manifests
         path: profiles
@@ -361,20 +351,6 @@ spec:
     name: gpu-driver
   - kustomizeConfig:
       overlays:
-      - managed-cert
-      - application
-      parameters:
-      - name: namespace
-        value: istio-system
-      - name: ipName
-        value: test1-ip
-      - name: hostname
-      repoRef:
-        name: manifests
-        path: gcp/iap-ingress
-    name: iap-ingress
-  - kustomizeConfig:
-      overlays:
       - application
       repoRef:
         name: manifests
@@ -382,9 +358,38 @@ spec:
     name: seldon-core-operator
   - kustomizeConfig:
       parameters:
-      - name: user
-      - name: profile-name
-        value: anonymous
+      - name: ambassadorServiceType
+        value: NodePort
+      - name: namespace
+        value: istio-system
+      repoRef:
+        name: manifests
+        path: common/ambassador
+    name: ambassador
+  - kustomizeConfig:
+      repoRef:
+        name: manifests
+        path: common/basic-auth
+    name: basic-auth
+  - kustomizeConfig:
+      overlays:
+      - managed-cert
+      - application
+      parameters:
+      - name: namespace
+        value: istio-system
+      - name: ipName
+      - name: hostname
+      - name: project
+      - name: ingressName
+        value: envoy-ingress
+      - name: issuer
+        value: letsencrypt-prod
+      repoRef:
+        name: manifests
+        path: gcp/basic-auth-ingress
+    name: basic-auth-ingress
+  - kustomizeConfig:
       repoRef:
         name: manifests
         path: default-install
@@ -402,8 +407,8 @@ spec:
           path: gcp/deployment_manager_configs
       enableWorkloadIdentity: true
       skipInitProject: true
-      useBasicAuth: false
+      useBasicAuth: true
   repos:
   - name: manifests
-    uri: https://github.com/kubeflow/manifests/archive/master.tar.gz
-  version: master
+    uri: https://github.com/kubeflow/manifests/archive/v1.0-branch.tar.gz
+  version: v1.0.0

--- a/kfdef/kfctl_gcp_basic_auth.yaml
+++ b/kfdef/kfctl_gcp_basic_auth.yaml
@@ -1,6 +1,7 @@
 apiVersion: kfdef.apps.kubeflow.org/v1
 kind: KfDef
-metadata: {}
+metadata:
+  namespace: kubeflow
 spec:
   applications:
   - kustomizeConfig:

--- a/kfdef/kfctl_gcp_basic_auth.yaml
+++ b/kfdef/kfctl_gcp_basic_auth.yaml
@@ -1,10 +1,6 @@
-# Please set project and email!
 apiVersion: kfdef.apps.kubeflow.org/v1
 kind: KfDef
-metadata:
-  # If name is not set, kfctl will infer app name from the directory.
-  # name: myapp2
-  namespace: kubeflow
+metadata: {}
 spec:
   applications:
   - kustomizeConfig:
@@ -26,7 +22,7 @@ spec:
   - kustomizeConfig:
       parameters:
       - name: clusterRbacConfig
-        value: "OFF"
+        value: 'OFF'
       repoRef:
         name: manifests
         path: istio/istio
@@ -69,7 +65,7 @@ spec:
       repoRef:
         name: manifests
         path: cert-manager/cert-manager
-    name: cert-manager        
+    name: cert-manager
   - kustomizeConfig:
       repoRef:
         name: manifests
@@ -143,7 +139,7 @@ spec:
       - application
       parameters:
       - name: injectGcpCredentials
-        value: "true"
+        value: 'true'
       repoRef:
         name: manifests
         path: jupyter/notebook-controller
@@ -201,9 +197,9 @@ spec:
       - application
       parameters:
       - name: usageId
-        value: "2700513155662330975"
+        value: '2700513155662330975'
       - name: reportUsage
-        value: "true"
+        value: 'true'
       repoRef:
         name: manifests
         path: common/spartakus
@@ -342,8 +338,6 @@ spec:
       - istio
       parameters:
       - name: admin
-        # email will be auto-filled.
-        # value: SET_EMAIL
       repoRef:
         name: manifests
         path: profiles
@@ -385,14 +379,8 @@ spec:
       - name: namespace
         value: istio-system
       - name: ipName
-        # ipName will be auto-filled based on app name if not set.
-        # value: test1-ip
       - name: hostname
-        # hostname will be auto-filled if not set.
-        # value: <deployName>.endpoints.<project>.cloud.goog
       - name: project
-        # Project will be auto-filled.
-        # value: SET_PROJECT
       - name: ingressName
         value: envoy-ingress
       - name: issuer
@@ -420,19 +408,6 @@ spec:
       enableWorkloadIdentity: true
       skipInitProject: true
       useBasicAuth: true
-      # email should  be set the google account of the person setting up Kubeflow.
-      # If its not set kfctl generate will try to set it automatically based on the default
-      # gcloud config
-      # email: <your_email@gmail.com>
-      #
-      # Project should be set to the GCP project you want to use.
-      # If you run kfctl init --config=<path>/kfctl_gcp_iap.yaml
-      # kfctl will try to automatically set it.
-      # project: <your project>
-      #
-      # User can specify which zone to deploy to. If not set, will try to auto-fill
-      # this field based on default config in gcloud.
-      # zone: us-east1-d
   repos:
   - name: manifests
     uri: https://github.com/kubeflow/manifests/archive/master.tar.gz

--- a/kfdef/kfctl_gcp_iap.v1.0.0.yaml
+++ b/kfdef/kfctl_gcp_iap.v1.0.0.yaml
@@ -1,6 +1,7 @@
 apiVersion: kfdef.apps.kubeflow.org/v1
 kind: KfDef
-metadata: {}
+metadata:
+  namespace: kubeflow
 spec:
   applications:
   - kustomizeConfig:

--- a/kfdef/kfctl_gcp_iap.v1.0.0.yaml
+++ b/kfdef/kfctl_gcp_iap.v1.0.0.yaml
@@ -405,5 +405,5 @@ spec:
       useBasicAuth: false
   repos:
   - name: manifests
-    uri: https://github.com/kubeflow/manifests/archive/master.tar.gz
-  version: master
+    uri: https://github.com/kubeflow/manifests/archive/v1.0-branch.tar.gz
+  version: v1.0.0

--- a/kfdef/kfctl_gcp_iap.yaml
+++ b/kfdef/kfctl_gcp_iap.yaml
@@ -1,6 +1,7 @@
 apiVersion: kfdef.apps.kubeflow.org/v1
 kind: KfDef
-metadata: {}
+metadata:
+  namespace: kubeflow
 spec:
   applications:
   - kustomizeConfig:

--- a/kfdef/source/README.md
+++ b/kfdef/source/README.md
@@ -1,0 +1,3 @@
+This directory contains kustomization packages that are used to generate the YAML specs for the KFDef.
+
+The script `hack/build_kfdef_specs.py` is used to run kustomize and output the YAML files.

--- a/kfdef/source/README.md
+++ b/kfdef/source/README.md
@@ -1,3 +1,16 @@
 This directory contains kustomization packages that are used to generate the YAML specs for the KFDef.
 
 The script `hack/build_kfdef_specs.py` is used to run kustomize and output the YAML files.
+
+## Subdirectories
+
+Each sub-directory corresponds to a kustomize package corresponding to a different release
+of Kubeflow.
+
+* **master**: This is the base kustomization package
+  * In general when adding new applications or making other KFDef specs that should be carried throughout
+    future versions you would make here
+
+* **vX.Y.Z**: This is the kustomization package for Kubeflow release x.y.x. It will
+   typically reference another version as its base and define patches to apply the appropriate
+   modifications.

--- a/kfdef/source/master/kfctl_anthos.yaml
+++ b/kfdef/source/master/kfctl_anthos.yaml
@@ -1,28 +1,19 @@
+# This is the config to install Kubeflow on an Anthos.
+# The cluster comes with customized Istio installation.
+
 apiVersion: kfdef.apps.kubeflow.org/v1
 kind: KfDef
-metadata: {}
+metadata:
+  name: kfctl_anthos
 spec:
   applications:
-  - kustomizeConfig:
-      parameters:
-      - name: namespace
-        value: istio-system
-      repoRef:
-        name: manifests
-        path: istio/istio-crds
-    name: istio-crds
-  - kustomizeConfig:
-      parameters:
-      - name: namespace
-        value: istio-system
-      repoRef:
-        name: manifests
-        path: istio/istio-install
-    name: istio-install
+  # This component is the istio resources for Kubeflow (e.g. gateway), not about installing istio.
   - kustomizeConfig:
       parameters:
       - name: clusterRbacConfig
-        value: 'ON'
+        value: "OFF"
+      - name: gatewaySelector
+        value: ingress-gke-system
       repoRef:
         name: manifests
         path: istio/istio
@@ -65,12 +56,7 @@ spec:
       repoRef:
         name: manifests
         path: cert-manager/cert-manager
-    name: cert-manager
-  - kustomizeConfig:
-      repoRef:
-        name: manifests
-        path: kubeflow-roles
-    name: kubeflow-roles
+    name: cert-manager        
   - kustomizeConfig:
       repoRef:
         name: manifests
@@ -85,14 +71,14 @@ spec:
         path: argo
     name: argo
   - kustomizeConfig:
+      repoRef:
+        name: manifests
+        path: kubeflow-roles
+    name: kubeflow-roles
+  - kustomizeConfig:
       overlays:
       - istio
       - application
-      parameters:
-      - name: userid-header
-        value: X-Goog-Authenticated-User-Email
-      - name: userid-prefix
-        value: 'accounts.google.com:'
       repoRef:
         name: manifests
         path: common/centraldashboard
@@ -102,27 +88,19 @@ spec:
       - application
       repoRef:
         name: manifests
-        path: admission-webhook/webhook
-    name: webhook
-  - kustomizeConfig:
-      overlays:
-      - application
-      parameters:
-      - name: webhookNamePrefix
-        value: admission-webhook-
-      repoRef:
-        name: manifests
         path: admission-webhook/bootstrap
     name: bootstrap
   - kustomizeConfig:
       overlays:
+      - application
+      repoRef:
+        name: manifests
+        path: admission-webhook/webhook
+    name: webhook
+  - kustomizeConfig:
+      overlays:
       - istio
       - application
-      parameters:
-      - name: userid-header
-        value: X-Goog-Authenticated-User-Email
-      - name: userid-prefix
-        value: 'accounts.google.com:'
       repoRef:
         name: manifests
         path: jupyter/jupyter-web-app
@@ -147,9 +125,6 @@ spec:
       overlays:
       - istio
       - application
-      parameters:
-      - name: injectGcpCredentials
-        value: 'true'
       repoRef:
         name: manifests
         path: jupyter/notebook-controller
@@ -207,9 +182,9 @@ spec:
       - application
       parameters:
       - name: usageId
-        value: '7439583937720421527'
+        value: <randomly-generated-id>
       - name: reportUsage
-        value: 'true'
+        value: "true"
       repoRef:
         name: manifests
         path: common/spartakus
@@ -259,13 +234,8 @@ spec:
     name: api-service
   - kustomizeConfig:
       overlays:
-      - minioPd
       - application
       parameters:
-      - name: minioPd
-        value: test1-storage-artifact-store
-      - name: minioPvName
-        value: minio-pv
       - name: minioPvcName
         value: minio-pv-claim
       repoRef:
@@ -274,13 +244,8 @@ spec:
     name: minio
   - kustomizeConfig:
       overlays:
-      - mysqlPd
       - application
       parameters:
-      - name: mysqlPd
-        value: test1-storage-metadata-store
-      - name: mysqlPvName
-        value: mysql-pv
       - name: mysqlPvcName
         value: mysql-pv-claim
       repoRef:
@@ -303,7 +268,6 @@ spec:
     name: pipelines-runner
   - kustomizeConfig:
       overlays:
-      - gcp
       - istio
       - application
       repoRef:
@@ -327,27 +291,10 @@ spec:
   - kustomizeConfig:
       overlays:
       - application
-      repoRef:
-        name: manifests
-        path: pipeline/pipeline-visualization-service
-    name: pipeline-visualization-service
-  - kustomizeConfig:
-      overlays:
-      - application
-      repoRef:
-        name: manifests
-        path: gcp/cloud-endpoints
-    name: cloud-endpoints
-  - kustomizeConfig:
-      overlays:
-      - application
       - istio
       parameters:
       - name: admin
-      - name: userid-header
-        value: X-Goog-Authenticated-User-Email
-      - name: userid-prefix
-        value: 'accounts.google.com:'
+        value: johnDoe@acme.com
       repoRef:
         name: manifests
         path: profiles
@@ -357,53 +304,11 @@ spec:
       - application
       repoRef:
         name: manifests
-        path: gcp/gpu-driver
-    name: gpu-driver
-  - kustomizeConfig:
-      overlays:
-      - managed-cert
-      - application
-      parameters:
-      - name: namespace
-        value: istio-system
-      - name: ipName
-        value: test1-ip
-      - name: hostname
-      repoRef:
-        name: manifests
-        path: gcp/iap-ingress
-    name: iap-ingress
-  - kustomizeConfig:
-      overlays:
-      - application
-      repoRef:
-        name: manifests
         path: seldon/seldon-core-operator
     name: seldon-core-operator
-  - kustomizeConfig:
-      parameters:
-      - name: user
-      - name: profile-name
-        value: anonymous
-      repoRef:
-        name: manifests
-        path: default-install
-    name: default-install
-  plugins:
-  - kind: KfGcpPlugin
-    metadata:
-      creationTimestamp: null
-      name: gcp
-    spec:
-      createPipelinePersistentStorage: true
-      deploymentManagerConfig:
-        repoRef:
-          name: manifests
-          path: gcp/deployment_manager_configs
-      enableWorkloadIdentity: true
-      skipInitProject: true
-      useBasicAuth: false
   repos:
   - name: manifests
     uri: https://github.com/kubeflow/manifests/archive/master.tar.gz
+    # An example uri that uses a PR version of the manifest repo.
+    # uri: https://github.com/kubeflow/manifests/archive/pull/PR_NUMBER/head.tar.gz
   version: master

--- a/kfdef/source/master/kfctl_aws.yaml
+++ b/kfdef/source/master/kfctl_aws.yaml
@@ -1,6 +1,8 @@
 apiVersion: kfdef.apps.kubeflow.org/v1
 kind: KfDef
-metadata: {}
+metadata:
+  name: kubeflow-aws
+  namespace: kubeflow
 spec:
   applications:
   - kustomizeConfig:
@@ -22,7 +24,7 @@ spec:
   - kustomizeConfig:
       parameters:
       - name: clusterRbacConfig
-        value: 'ON'
+        value: "OFF"
       repoRef:
         name: manifests
         path: istio/istio
@@ -65,12 +67,7 @@ spec:
       repoRef:
         name: manifests
         path: cert-manager/cert-manager
-    name: cert-manager
-  - kustomizeConfig:
-      repoRef:
-        name: manifests
-        path: kubeflow-roles
-    name: kubeflow-roles
+    name: cert-manager        
   - kustomizeConfig:
       repoRef:
         name: manifests
@@ -85,14 +82,14 @@ spec:
         path: argo
     name: argo
   - kustomizeConfig:
+      repoRef:
+        name: manifests
+        path: kubeflow-roles
+    name: kubeflow-roles
+  - kustomizeConfig:
       overlays:
       - istio
       - application
-      parameters:
-      - name: userid-header
-        value: X-Goog-Authenticated-User-Email
-      - name: userid-prefix
-        value: 'accounts.google.com:'
       repoRef:
         name: manifests
         path: common/centraldashboard
@@ -118,11 +115,6 @@ spec:
       overlays:
       - istio
       - application
-      parameters:
-      - name: userid-header
-        value: X-Goog-Authenticated-User-Email
-      - name: userid-prefix
-        value: 'accounts.google.com:'
       repoRef:
         name: manifests
         path: jupyter/jupyter-web-app
@@ -147,9 +139,6 @@ spec:
       overlays:
       - istio
       - application
-      parameters:
-      - name: injectGcpCredentials
-        value: 'true'
       repoRef:
         name: manifests
         path: jupyter/notebook-controller
@@ -172,44 +161,10 @@ spec:
       overlays:
       - application
       parameters:
-      - name: namespace
-        value: knative-serving
-      repoRef:
-        name: manifests
-        path: knative/knative-serving-crds
-    name: knative-crds
-  - kustomizeConfig:
-      overlays:
-      - application
-      parameters:
-      - name: namespace
-        value: knative-serving
-      repoRef:
-        name: manifests
-        path: knative/knative-serving-install
-    name: knative-install
-  - kustomizeConfig:
-      overlays:
-      - application
-      repoRef:
-        name: manifests
-        path: kfserving/kfserving-crds
-    name: kfserving-crds
-  - kustomizeConfig:
-      overlays:
-      - application
-      repoRef:
-        name: manifests
-        path: kfserving/kfserving-install
-    name: kfserving-install
-  - kustomizeConfig:
-      overlays:
-      - application
-      parameters:
       - name: usageId
-        value: '7439583937720421527'
+        value: <randomly-generated-id>
       - name: reportUsage
-        value: 'true'
+        value: "true"
       repoRef:
         name: manifests
         path: common/spartakus
@@ -259,13 +214,8 @@ spec:
     name: api-service
   - kustomizeConfig:
       overlays:
-      - minioPd
       - application
       parameters:
-      - name: minioPd
-        value: test1-storage-artifact-store
-      - name: minioPvName
-        value: minio-pv
       - name: minioPvcName
         value: minio-pv-claim
       repoRef:
@@ -274,13 +224,8 @@ spec:
     name: minio
   - kustomizeConfig:
       overlays:
-      - mysqlPd
       - application
       parameters:
-      - name: mysqlPd
-        value: test1-storage-metadata-store
-      - name: mysqlPvName
-        value: mysql-pv
       - name: mysqlPvcName
         value: mysql-pv-claim
       repoRef:
@@ -303,7 +248,6 @@ spec:
     name: pipelines-runner
   - kustomizeConfig:
       overlays:
-      - gcp
       - istio
       - application
       repoRef:
@@ -334,20 +278,7 @@ spec:
   - kustomizeConfig:
       overlays:
       - application
-      repoRef:
-        name: manifests
-        path: gcp/cloud-endpoints
-    name: cloud-endpoints
-  - kustomizeConfig:
-      overlays:
-      - application
       - istio
-      parameters:
-      - name: admin
-      - name: userid-header
-        value: X-Goog-Authenticated-User-Email
-      - name: userid-prefix
-        value: 'accounts.google.com:'
       repoRef:
         name: manifests
         path: profiles
@@ -357,52 +288,53 @@ spec:
       - application
       repoRef:
         name: manifests
-        path: gcp/gpu-driver
-    name: gpu-driver
+        path: seldon/seldon-core-operator
+    name: seldon-core
   - kustomizeConfig:
       overlays:
-      - managed-cert
       - application
+      repoRef:
+        name: manifests
+        path: mpi-job/mpi-operator
+    name: mpi-operator
+  - kustomizeConfig:
       parameters:
       - name: namespace
         value: istio-system
-      - name: ipName
-        value: test1-ip
-      - name: hostname
       repoRef:
         name: manifests
-        path: gcp/iap-ingress
-    name: iap-ingress
+        path: aws/istio-ingress
+    name: istio-ingress
+  - kustomizeConfig:
+      overlays:
+      - application
+      parameters:
+      - name: clusterName
+        value: kubeflow-aws
+      repoRef:
+        name: manifests
+        path: aws/aws-alb-ingress-controller
+    name: aws-alb-ingress-controller
   - kustomizeConfig:
       overlays:
       - application
       repoRef:
         name: manifests
-        path: seldon/seldon-core-operator
-    name: seldon-core-operator
-  - kustomizeConfig:
-      parameters:
-      - name: user
-      - name: profile-name
-        value: anonymous
-      repoRef:
-        name: manifests
-        path: default-install
-    name: default-install
+        path: aws/nvidia-device-plugin
+    name: nvidia-device-plugin
   plugins:
-  - kind: KfGcpPlugin
+  - kind: KfAwsPlugin
     metadata:
-      creationTimestamp: null
-      name: gcp
+      name: aws
     spec:
-      createPipelinePersistentStorage: true
-      deploymentManagerConfig:
-        repoRef:
-          name: manifests
-          path: gcp/deployment_manager_configs
-      enableWorkloadIdentity: true
-      skipInitProject: true
-      useBasicAuth: false
+      auth:
+        basicAuth:
+          password:
+            name: password
+          username: admin
+      region: us-west-2
+      roles:
+      - eksctl-kubeflow-aws-nodegroup-ng-a2-NodeInstanceRole-xxxxxxx
   repos:
   - name: manifests
     uri: https://github.com/kubeflow/manifests/archive/master.tar.gz

--- a/kfdef/source/master/kfctl_aws_cognito.yaml
+++ b/kfdef/source/master/kfctl_aws_cognito.yaml
@@ -1,6 +1,7 @@
 apiVersion: kfdef.apps.kubeflow.org/v1
 kind: KfDef
-metadata: {}
+metadata:
+  name: kubeflow-aws-cognito
 spec:
   applications:
   - kustomizeConfig:
@@ -22,7 +23,7 @@ spec:
   - kustomizeConfig:
       parameters:
       - name: clusterRbacConfig
-        value: 'ON'
+        value: "OFF"
       repoRef:
         name: manifests
         path: istio/istio
@@ -65,12 +66,7 @@ spec:
       repoRef:
         name: manifests
         path: cert-manager/cert-manager
-    name: cert-manager
-  - kustomizeConfig:
-      repoRef:
-        name: manifests
-        path: kubeflow-roles
-    name: kubeflow-roles
+    name: cert-manager        
   - kustomizeConfig:
       repoRef:
         name: manifests
@@ -85,14 +81,14 @@ spec:
         path: argo
     name: argo
   - kustomizeConfig:
+      repoRef:
+        name: manifests
+        path: kubeflow-roles
+    name: kubeflow-roles
+  - kustomizeConfig:
       overlays:
       - istio
       - application
-      parameters:
-      - name: userid-header
-        value: X-Goog-Authenticated-User-Email
-      - name: userid-prefix
-        value: 'accounts.google.com:'
       repoRef:
         name: manifests
         path: common/centraldashboard
@@ -118,11 +114,6 @@ spec:
       overlays:
       - istio
       - application
-      parameters:
-      - name: userid-header
-        value: X-Goog-Authenticated-User-Email
-      - name: userid-prefix
-        value: 'accounts.google.com:'
       repoRef:
         name: manifests
         path: jupyter/jupyter-web-app
@@ -147,9 +138,6 @@ spec:
       overlays:
       - istio
       - application
-      parameters:
-      - name: injectGcpCredentials
-        value: 'true'
       repoRef:
         name: manifests
         path: jupyter/notebook-controller
@@ -172,44 +160,10 @@ spec:
       overlays:
       - application
       parameters:
-      - name: namespace
-        value: knative-serving
-      repoRef:
-        name: manifests
-        path: knative/knative-serving-crds
-    name: knative-crds
-  - kustomizeConfig:
-      overlays:
-      - application
-      parameters:
-      - name: namespace
-        value: knative-serving
-      repoRef:
-        name: manifests
-        path: knative/knative-serving-install
-    name: knative-install
-  - kustomizeConfig:
-      overlays:
-      - application
-      repoRef:
-        name: manifests
-        path: kfserving/kfserving-crds
-    name: kfserving-crds
-  - kustomizeConfig:
-      overlays:
-      - application
-      repoRef:
-        name: manifests
-        path: kfserving/kfserving-install
-    name: kfserving-install
-  - kustomizeConfig:
-      overlays:
-      - application
-      parameters:
       - name: usageId
-        value: '7439583937720421527'
+        value: <randomly-generated-id>
       - name: reportUsage
-        value: 'true'
+        value: "true"
       repoRef:
         name: manifests
         path: common/spartakus
@@ -259,11 +213,8 @@ spec:
     name: api-service
   - kustomizeConfig:
       overlays:
-      - minioPd
       - application
       parameters:
-      - name: minioPd
-        value: test1-storage-artifact-store
       - name: minioPvName
         value: minio-pv
       - name: minioPvcName
@@ -274,11 +225,8 @@ spec:
     name: minio
   - kustomizeConfig:
       overlays:
-      - mysqlPd
       - application
       parameters:
-      - name: mysqlPd
-        value: test1-storage-metadata-store
       - name: mysqlPvName
         value: mysql-pv
       - name: mysqlPvcName
@@ -303,7 +251,6 @@ spec:
     name: pipelines-runner
   - kustomizeConfig:
       overlays:
-      - gcp
       - istio
       - application
       repoRef:
@@ -334,20 +281,7 @@ spec:
   - kustomizeConfig:
       overlays:
       - application
-      repoRef:
-        name: manifests
-        path: gcp/cloud-endpoints
-    name: cloud-endpoints
-  - kustomizeConfig:
-      overlays:
-      - application
       - istio
-      parameters:
-      - name: admin
-      - name: userid-header
-        value: X-Goog-Authenticated-User-Email
-      - name: userid-prefix
-        value: 'accounts.google.com:'
       repoRef:
         name: manifests
         path: profiles
@@ -357,52 +291,56 @@ spec:
       - application
       repoRef:
         name: manifests
-        path: gcp/gpu-driver
-    name: gpu-driver
+        path: seldon/seldon-core-operator
+    name: seldon-core
   - kustomizeConfig:
       overlays:
-      - managed-cert
       - application
+      repoRef:
+        name: manifests
+        path: mpi-job/mpi-operator
+    name: mpi-operator
+  - kustomizeConfig:
+      overlays:
+      - cognito
       parameters:
       - name: namespace
         value: istio-system
-      - name: ipName
-        value: test1-ip
-      - name: hostname
       repoRef:
         name: manifests
-        path: gcp/iap-ingress
-    name: iap-ingress
+        path: aws/istio-ingress
+    name: istio-ingress
+  - kustomizeConfig:
+      overlays:
+      - application
+      parameters:
+      - name: clusterName
+        value: kubeflow-aws
+      repoRef:
+        name: manifests
+        path: aws/aws-alb-ingress-controller
+    name: aws-alb-ingress-controller
   - kustomizeConfig:
       overlays:
       - application
       repoRef:
         name: manifests
-        path: seldon/seldon-core-operator
-    name: seldon-core-operator
-  - kustomizeConfig:
-      parameters:
-      - name: user
-      - name: profile-name
-        value: anonymous
-      repoRef:
-        name: manifests
-        path: default-install
-    name: default-install
+        path: aws/nvidia-device-plugin
+    name: nvidia-device-plugin
   plugins:
-  - kind: KfGcpPlugin
+  - kind: KfAwsPlugin
     metadata:
-      creationTimestamp: null
-      name: gcp
+      name: aws
     spec:
-      createPipelinePersistentStorage: true
-      deploymentManagerConfig:
-        repoRef:
-          name: manifests
-          path: gcp/deployment_manager_configs
-      enableWorkloadIdentity: true
-      skipInitProject: true
-      useBasicAuth: false
+      auth:
+        cognito:
+          certArn: arn:aws:acm:us-west-2:xxxxx:certificate/xxxxxxxxxxxxx-xxxx
+          cognitoAppClientId: xxxxxbxxxxxx
+          cognitoUserPoolArn: arn:aws:cognito-idp:us-west-2:xxxxx:userpool/us-west-2_xxxxxx
+          cognitoUserPoolDomain: your-user-pool
+      region: us-west-2
+      roles:
+      - eksctl-kubeflow-aws-nodegroup-ng-a2-NodeInstanceRole-xxxxx
   repos:
   - name: manifests
     uri: https://github.com/kubeflow/manifests/archive/master.tar.gz

--- a/kfdef/source/master/kfctl_gcp_basic_auth.yaml
+++ b/kfdef/source/master/kfctl_gcp_basic_auth.yaml
@@ -1,6 +1,8 @@
+# Please set project and email!
 apiVersion: kfdef.apps.kubeflow.org/v1
 kind: KfDef
-metadata: {}
+metadata:
+  name: kfctl_gcp_basic_auth
 spec:
   applications:
   - kustomizeConfig:
@@ -22,7 +24,7 @@ spec:
   - kustomizeConfig:
       parameters:
       - name: clusterRbacConfig
-        value: 'ON'
+        value: "OFF"
       repoRef:
         name: manifests
         path: istio/istio
@@ -65,12 +67,7 @@ spec:
       repoRef:
         name: manifests
         path: cert-manager/cert-manager
-    name: cert-manager
-  - kustomizeConfig:
-      repoRef:
-        name: manifests
-        path: kubeflow-roles
-    name: kubeflow-roles
+    name: cert-manager        
   - kustomizeConfig:
       repoRef:
         name: manifests
@@ -85,14 +82,14 @@ spec:
         path: argo
     name: argo
   - kustomizeConfig:
+      repoRef:
+        name: manifests
+        path: kubeflow-roles
+    name: kubeflow-roles
+  - kustomizeConfig:
       overlays:
       - istio
       - application
-      parameters:
-      - name: userid-header
-        value: X-Goog-Authenticated-User-Email
-      - name: userid-prefix
-        value: 'accounts.google.com:'
       repoRef:
         name: manifests
         path: common/centraldashboard
@@ -118,11 +115,6 @@ spec:
       overlays:
       - istio
       - application
-      parameters:
-      - name: userid-header
-        value: X-Goog-Authenticated-User-Email
-      - name: userid-prefix
-        value: 'accounts.google.com:'
       repoRef:
         name: manifests
         path: jupyter/jupyter-web-app
@@ -149,7 +141,7 @@ spec:
       - application
       parameters:
       - name: injectGcpCredentials
-        value: 'true'
+        value: "true"
       repoRef:
         name: manifests
         path: jupyter/notebook-controller
@@ -207,9 +199,9 @@ spec:
       - application
       parameters:
       - name: usageId
-        value: '7439583937720421527'
+        value: "2700513155662330975"
       - name: reportUsage
-        value: 'true'
+        value: "true"
       repoRef:
         name: manifests
         path: common/spartakus
@@ -334,6 +326,10 @@ spec:
   - kustomizeConfig:
       overlays:
       - application
+      parameters:
+      - name: ipName
+        value: ipName
+      - name: hostname
       repoRef:
         name: manifests
         path: gcp/cloud-endpoints
@@ -344,10 +340,8 @@ spec:
       - istio
       parameters:
       - name: admin
-      - name: userid-header
-        value: X-Goog-Authenticated-User-Email
-      - name: userid-prefix
-        value: 'accounts.google.com:'
+        # email will be auto-filled.
+        # value: SET_EMAIL
       repoRef:
         name: manifests
         path: profiles
@@ -361,20 +355,6 @@ spec:
     name: gpu-driver
   - kustomizeConfig:
       overlays:
-      - managed-cert
-      - application
-      parameters:
-      - name: namespace
-        value: istio-system
-      - name: ipName
-        value: test1-ip
-      - name: hostname
-      repoRef:
-        name: manifests
-        path: gcp/iap-ingress
-    name: iap-ingress
-  - kustomizeConfig:
-      overlays:
       - application
       repoRef:
         name: manifests
@@ -382,9 +362,44 @@ spec:
     name: seldon-core-operator
   - kustomizeConfig:
       parameters:
-      - name: user
-      - name: profile-name
-        value: anonymous
+      - name: ambassadorServiceType
+        value: NodePort
+      - name: namespace
+        value: istio-system
+      repoRef:
+        name: manifests
+        path: common/ambassador
+    name: ambassador
+  - kustomizeConfig:
+      repoRef:
+        name: manifests
+        path: common/basic-auth
+    name: basic-auth
+  - kustomizeConfig:
+      overlays:
+      - managed-cert
+      - application
+      parameters:
+      - name: namespace
+        value: istio-system
+      - name: ipName
+        # ipName will be auto-filled based on app name if not set.
+        # value: test1-ip
+      - name: hostname
+        # hostname will be auto-filled if not set.
+        # value: <deployName>.endpoints.<project>.cloud.goog
+      - name: project
+        # Project will be auto-filled.
+        # value: SET_PROJECT
+      - name: ingressName
+        value: envoy-ingress
+      - name: issuer
+        value: letsencrypt-prod
+      repoRef:
+        name: manifests
+        path: gcp/basic-auth-ingress
+    name: basic-auth-ingress
+  - kustomizeConfig:
       repoRef:
         name: manifests
         path: default-install
@@ -402,7 +417,20 @@ spec:
           path: gcp/deployment_manager_configs
       enableWorkloadIdentity: true
       skipInitProject: true
-      useBasicAuth: false
+      useBasicAuth: true
+      # email should  be set the google account of the person setting up Kubeflow.
+      # If its not set kfctl generate will try to set it automatically based on the default
+      # gcloud config
+      # email: <your_email@gmail.com>
+      #
+      # Project should be set to the GCP project you want to use.
+      # If you run kfctl init --config=<path>/kfctl_gcp_iap.yaml
+      # kfctl will try to automatically set it.
+      # project: <your project>
+      #
+      # User can specify which zone to deploy to. If not set, will try to auto-fill
+      # this field based on default config in gcloud.
+      # zone: us-east1-d
   repos:
   - name: manifests
     uri: https://github.com/kubeflow/manifests/archive/master.tar.gz

--- a/kfdef/source/master/kfctl_gcp_iap.yaml
+++ b/kfdef/source/master/kfctl_gcp_iap.yaml
@@ -1,6 +1,9 @@
+# Please set project and email!
 apiVersion: kfdef.apps.kubeflow.org/v1
 kind: KfDef
-metadata: {}
+metadata:
+  # kustomize requires a name.
+  name: kfctl_gcp_iap
 spec:
   applications:
   - kustomizeConfig:
@@ -22,7 +25,7 @@ spec:
   - kustomizeConfig:
       parameters:
       - name: clusterRbacConfig
-        value: 'ON'
+        value: "ON"
       repoRef:
         name: manifests
         path: istio/istio
@@ -65,7 +68,7 @@ spec:
       repoRef:
         name: manifests
         path: cert-manager/cert-manager
-    name: cert-manager
+    name: cert-manager        
   - kustomizeConfig:
       repoRef:
         name: manifests
@@ -149,7 +152,7 @@ spec:
       - application
       parameters:
       - name: injectGcpCredentials
-        value: 'true'
+        value: "true"
       repoRef:
         name: manifests
         path: jupyter/notebook-controller
@@ -207,9 +210,9 @@ spec:
       - application
       parameters:
       - name: usageId
-        value: '7439583937720421527'
+        value: "7439583937720421527"
       - name: reportUsage
-        value: 'true'
+        value: "true"
       repoRef:
         name: manifests
         path: common/spartakus
@@ -343,7 +346,9 @@ spec:
       - application
       - istio
       parameters:
+        # kfctl will set admin to current user account that deploying kubeflow
       - name: admin
+        # value: SET_EMAIL
       - name: userid-header
         value: X-Goog-Authenticated-User-Email
       - name: userid-prefix
@@ -366,9 +371,13 @@ spec:
       parameters:
       - name: namespace
         value: istio-system
+        # email will be auto-filled.
       - name: ipName
         value: test1-ip
       - name: hostname
+        # The value of hostname should be the DNS address for ingress.
+        # This will be set automatically during kfctl generate.
+        # value: test1.endpoints.SET_PROJECT.cloud.goog
       repoRef:
         name: manifests
         path: gcp/iap-ingress
@@ -383,7 +392,10 @@ spec:
   - kustomizeConfig:
       parameters:
       - name: user
+        # kfctl will set user to current user account that deploying kubeflow
+        # value: SET_EMAIL
       - name: profile-name
+        # kfctl might overwrite profile name
         value: anonymous
       repoRef:
         name: manifests
@@ -403,7 +415,22 @@ spec:
       enableWorkloadIdentity: true
       skipInitProject: true
       useBasicAuth: false
+      # email should  be set the google account of the person setting up Kubeflow.
+      # If its not set kfctl generate will try to set it automatically based on the default
+      # gcloud config
+      # email: <your_email@gmail.com>
+      #
+      # Project should be set to the GCP project you want to use.
+      # If you run kfctl init --config=<path>/kfctl_gcp_iap.yaml
+      # kfctl will try to automatically set it.
+      # project: <your project>
+      #
+      # User can specify which zone to deploy to. If not set, will try to auto-fill
+      # this field based on default config in gcloud.
+      # zone: us-east1-d
   repos:
   - name: manifests
     uri: https://github.com/kubeflow/manifests/archive/master.tar.gz
+    # To get manifest at a PR:
+    #uri: https://github.com/kubeflow/manifests/archive/pull/235/head.tar.gz
   version: master

--- a/kfdef/source/master/kfctl_ibm.yaml
+++ b/kfdef/source/master/kfctl_ibm.yaml
@@ -1,8 +1,12 @@
+# This is the config to install Kubeflow on an existing IBM Cloud Kubernetes cluster.
+# If the cluster already has istio, comment out the istio install part below.
 apiVersion: kfdef.apps.kubeflow.org/v1
 kind: KfDef
-metadata: {}
+metadata:
+  name: kubeflow-ibm  
 spec:
   applications:
+  # Istio install. If not needed, comment out istio-crds and istio-install.
   - kustomizeConfig:
       parameters:
       - name: namespace
@@ -19,10 +23,11 @@ spec:
         name: manifests
         path: istio/istio-install
     name: istio-install
+  # This component is the istio resources for Kubeflow (e.g. gateway), not about installing istio.
   - kustomizeConfig:
       parameters:
       - name: clusterRbacConfig
-        value: 'ON'
+        value: "OFF"
       repoRef:
         name: manifests
         path: istio/istio
@@ -40,38 +45,6 @@ spec:
         path: application/application
     name: application
   - kustomizeConfig:
-      parameters:
-      - name: namespace
-        value: cert-manager
-      repoRef:
-        name: manifests
-        path: cert-manager/cert-manager-crds
-    name: cert-manager-crds
-  - kustomizeConfig:
-      parameters:
-      - name: namespace
-        value: kube-system
-      repoRef:
-        name: manifests
-        path: cert-manager/cert-manager-kube-system-resources
-    name: cert-manager-kube-system-resources
-  - kustomizeConfig:
-      overlays:
-      - self-signed
-      - application
-      parameters:
-      - name: namespace
-        value: cert-manager
-      repoRef:
-        name: manifests
-        path: cert-manager/cert-manager
-    name: cert-manager
-  - kustomizeConfig:
-      repoRef:
-        name: manifests
-        path: kubeflow-roles
-    name: kubeflow-roles
-  - kustomizeConfig:
       repoRef:
         name: manifests
         path: metacontroller
@@ -80,19 +53,22 @@ spec:
       overlays:
       - istio
       - application
+      parameters:
+      - name: containerRuntimeExecutor
+        value: pns
       repoRef:
         name: manifests
         path: argo
     name: argo
   - kustomizeConfig:
+      repoRef:
+        name: manifests
+        path: kubeflow-roles
+    name: kubeflow-roles
+  - kustomizeConfig:
       overlays:
       - istio
       - application
-      parameters:
-      - name: userid-header
-        value: X-Goog-Authenticated-User-Email
-      - name: userid-prefix
-        value: 'accounts.google.com:'
       repoRef:
         name: manifests
         path: common/centraldashboard
@@ -102,27 +78,19 @@ spec:
       - application
       repoRef:
         name: manifests
-        path: admission-webhook/webhook
-    name: webhook
-  - kustomizeConfig:
-      overlays:
-      - application
-      parameters:
-      - name: webhookNamePrefix
-        value: admission-webhook-
-      repoRef:
-        name: manifests
         path: admission-webhook/bootstrap
     name: bootstrap
   - kustomizeConfig:
       overlays:
+      - application
+      repoRef:
+        name: manifests
+        path: admission-webhook/webhook
+    name: webhook
+  - kustomizeConfig:
+      overlays:
       - istio
       - application
-      parameters:
-      - name: userid-header
-        value: X-Goog-Authenticated-User-Email
-      - name: userid-prefix
-        value: 'accounts.google.com:'
       repoRef:
         name: manifests
         path: jupyter/jupyter-web-app
@@ -138,6 +106,7 @@ spec:
       overlays:
       - istio
       - application
+      - ibm-storage-config
       - db
       repoRef:
         name: manifests
@@ -147,9 +116,6 @@ spec:
       overlays:
       - istio
       - application
-      parameters:
-      - name: injectGcpCredentials
-        value: 'true'
       repoRef:
         name: manifests
         path: jupyter/notebook-controller
@@ -207,9 +173,9 @@ spec:
       - application
       parameters:
       - name: usageId
-        value: '7439583937720421527'
+        value: <randomly-generated-id>
       - name: reportUsage
-        value: 'true'
+        value: "true"
       repoRef:
         name: manifests
         path: common/spartakus
@@ -246,6 +212,7 @@ spec:
       overlays:
       - application
       - istio
+      - ibm-storage-config
       repoRef:
         name: manifests
         path: katib/katib-controller
@@ -259,13 +226,8 @@ spec:
     name: api-service
   - kustomizeConfig:
       overlays:
-      - minioPd
       - application
       parameters:
-      - name: minioPd
-        value: test1-storage-artifact-store
-      - name: minioPvName
-        value: minio-pv
       - name: minioPvcName
         value: minio-pv-claim
       repoRef:
@@ -274,13 +236,8 @@ spec:
     name: minio
   - kustomizeConfig:
       overlays:
-      - mysqlPd
       - application
       parameters:
-      - name: mysqlPd
-        value: test1-storage-metadata-store
-      - name: mysqlPvName
-        value: mysql-pv
       - name: mysqlPvcName
         value: mysql-pv-claim
       repoRef:
@@ -303,7 +260,6 @@ spec:
     name: pipelines-runner
   - kustomizeConfig:
       overlays:
-      - gcp
       - istio
       - application
       repoRef:
@@ -334,20 +290,10 @@ spec:
   - kustomizeConfig:
       overlays:
       - application
-      repoRef:
-        name: manifests
-        path: gcp/cloud-endpoints
-    name: cloud-endpoints
-  - kustomizeConfig:
-      overlays:
-      - application
       - istio
       parameters:
       - name: admin
-      - name: userid-header
-        value: X-Goog-Authenticated-User-Email
-      - name: userid-prefix
-        value: 'accounts.google.com:'
+        value: example@kubeflow.org
       repoRef:
         name: manifests
         path: profiles
@@ -357,52 +303,8 @@ spec:
       - application
       repoRef:
         name: manifests
-        path: gcp/gpu-driver
-    name: gpu-driver
-  - kustomizeConfig:
-      overlays:
-      - managed-cert
-      - application
-      parameters:
-      - name: namespace
-        value: istio-system
-      - name: ipName
-        value: test1-ip
-      - name: hostname
-      repoRef:
-        name: manifests
-        path: gcp/iap-ingress
-    name: iap-ingress
-  - kustomizeConfig:
-      overlays:
-      - application
-      repoRef:
-        name: manifests
         path: seldon/seldon-core-operator
     name: seldon-core-operator
-  - kustomizeConfig:
-      parameters:
-      - name: user
-      - name: profile-name
-        value: anonymous
-      repoRef:
-        name: manifests
-        path: default-install
-    name: default-install
-  plugins:
-  - kind: KfGcpPlugin
-    metadata:
-      creationTimestamp: null
-      name: gcp
-    spec:
-      createPipelinePersistentStorage: true
-      deploymentManagerConfig:
-        repoRef:
-          name: manifests
-          path: gcp/deployment_manager_configs
-      enableWorkloadIdentity: true
-      skipInitProject: true
-      useBasicAuth: false
   repos:
   - name: manifests
     uri: https://github.com/kubeflow/manifests/archive/master.tar.gz

--- a/kfdef/source/master/kfctl_k8s_istio.yaml
+++ b/kfdef/source/master/kfctl_k8s_istio.yaml
@@ -1,8 +1,15 @@
+# This is the config to install Kubeflow on an existing k8s cluster.
+# If the cluster already has istio, comment out the istio install part below.
 apiVersion: kfdef.apps.kubeflow.org/v1
 kind: KfDef
-metadata: {}
+metadata:
+  # If name is not set, kfctl will infer app name from the directory.
+  # name: myapp2
+  namespace: kubeflow-k8s-istio
+  name: kubeflow-k8s-istio
 spec:
   applications:
+  # Istio install. If not needed, comment out istio-crds and istio-install.
   - kustomizeConfig:
       parameters:
       - name: namespace
@@ -19,10 +26,11 @@ spec:
         name: manifests
         path: istio/istio-install
     name: istio-install
+  # This component is the istio resources for Kubeflow (e.g. gateway), not about installing istio.
   - kustomizeConfig:
       parameters:
       - name: clusterRbacConfig
-        value: 'ON'
+        value: "OFF"
       repoRef:
         name: manifests
         path: istio/istio
@@ -65,12 +73,7 @@ spec:
       repoRef:
         name: manifests
         path: cert-manager/cert-manager
-    name: cert-manager
-  - kustomizeConfig:
-      repoRef:
-        name: manifests
-        path: kubeflow-roles
-    name: kubeflow-roles
+    name: cert-manager        
   - kustomizeConfig:
       repoRef:
         name: manifests
@@ -85,14 +88,14 @@ spec:
         path: argo
     name: argo
   - kustomizeConfig:
+      repoRef:
+        name: manifests
+        path: kubeflow-roles
+    name: kubeflow-roles
+  - kustomizeConfig:
       overlays:
       - istio
       - application
-      parameters:
-      - name: userid-header
-        value: X-Goog-Authenticated-User-Email
-      - name: userid-prefix
-        value: 'accounts.google.com:'
       repoRef:
         name: manifests
         path: common/centraldashboard
@@ -102,27 +105,19 @@ spec:
       - application
       repoRef:
         name: manifests
-        path: admission-webhook/webhook
-    name: webhook
-  - kustomizeConfig:
-      overlays:
-      - application
-      parameters:
-      - name: webhookNamePrefix
-        value: admission-webhook-
-      repoRef:
-        name: manifests
         path: admission-webhook/bootstrap
     name: bootstrap
   - kustomizeConfig:
       overlays:
+      - application
+      repoRef:
+        name: manifests
+        path: admission-webhook/webhook
+    name: webhook
+  - kustomizeConfig:
+      overlays:
       - istio
       - application
-      parameters:
-      - name: userid-header
-        value: X-Goog-Authenticated-User-Email
-      - name: userid-prefix
-        value: 'accounts.google.com:'
       repoRef:
         name: manifests
         path: jupyter/jupyter-web-app
@@ -147,9 +142,6 @@ spec:
       overlays:
       - istio
       - application
-      parameters:
-      - name: injectGcpCredentials
-        value: 'true'
       repoRef:
         name: manifests
         path: jupyter/notebook-controller
@@ -207,9 +199,9 @@ spec:
       - application
       parameters:
       - name: usageId
-        value: '7439583937720421527'
+        value: <randomly-generated-id>
       - name: reportUsage
-        value: 'true'
+        value: "true"
       repoRef:
         name: manifests
         path: common/spartakus
@@ -259,13 +251,8 @@ spec:
     name: api-service
   - kustomizeConfig:
       overlays:
-      - minioPd
       - application
       parameters:
-      - name: minioPd
-        value: test1-storage-artifact-store
-      - name: minioPvName
-        value: minio-pv
       - name: minioPvcName
         value: minio-pv-claim
       repoRef:
@@ -274,13 +261,8 @@ spec:
     name: minio
   - kustomizeConfig:
       overlays:
-      - mysqlPd
       - application
       parameters:
-      - name: mysqlPd
-        value: test1-storage-metadata-store
-      - name: mysqlPvName
-        value: mysql-pv
       - name: mysqlPvcName
         value: mysql-pv-claim
       repoRef:
@@ -303,7 +285,6 @@ spec:
     name: pipelines-runner
   - kustomizeConfig:
       overlays:
-      - gcp
       - istio
       - application
       repoRef:
@@ -334,20 +315,10 @@ spec:
   - kustomizeConfig:
       overlays:
       - application
-      repoRef:
-        name: manifests
-        path: gcp/cloud-endpoints
-    name: cloud-endpoints
-  - kustomizeConfig:
-      overlays:
-      - application
       - istio
       parameters:
       - name: admin
-      - name: userid-header
-        value: X-Goog-Authenticated-User-Email
-      - name: userid-prefix
-        value: 'accounts.google.com:'
+        value: johnDoe@acme.com
       repoRef:
         name: manifests
         path: profiles
@@ -357,52 +328,8 @@ spec:
       - application
       repoRef:
         name: manifests
-        path: gcp/gpu-driver
-    name: gpu-driver
-  - kustomizeConfig:
-      overlays:
-      - managed-cert
-      - application
-      parameters:
-      - name: namespace
-        value: istio-system
-      - name: ipName
-        value: test1-ip
-      - name: hostname
-      repoRef:
-        name: manifests
-        path: gcp/iap-ingress
-    name: iap-ingress
-  - kustomizeConfig:
-      overlays:
-      - application
-      repoRef:
-        name: manifests
         path: seldon/seldon-core-operator
     name: seldon-core-operator
-  - kustomizeConfig:
-      parameters:
-      - name: user
-      - name: profile-name
-        value: anonymous
-      repoRef:
-        name: manifests
-        path: default-install
-    name: default-install
-  plugins:
-  - kind: KfGcpPlugin
-    metadata:
-      creationTimestamp: null
-      name: gcp
-    spec:
-      createPipelinePersistentStorage: true
-      deploymentManagerConfig:
-        repoRef:
-          name: manifests
-          path: gcp/deployment_manager_configs
-      enableWorkloadIdentity: true
-      skipInitProject: true
-      useBasicAuth: false
   repos:
   - name: manifests
     uri: https://github.com/kubeflow/manifests/archive/master.tar.gz

--- a/kfdef/source/master/kustomization.yaml
+++ b/kfdef/source/master/kustomization.yaml
@@ -1,5 +1,6 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
+namespace: kubeflow
 resources:
 - kfctl_anthos.yaml
 - kfctl_gcp_iap.yaml

--- a/kfdef/source/master/kustomization.yaml
+++ b/kfdef/source/master/kustomization.yaml
@@ -1,0 +1,6 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+- kfctl_anthos.yaml
+- kfctl_gcp_iap.yaml
+- kfctl_gcp_basic_auth.yaml

--- a/kfdef/source/v1.0.0/kfctl_anthos.yaml
+++ b/kfdef/source/v1.0.0/kfctl_anthos.yaml
@@ -1,0 +1,13 @@
+# This is the config to install Kubeflow on an Anthos.
+# The cluster comes with customized Istio installation.
+apiVersion: kfdef.apps.kubeflow.org/v1
+kind: KfDef
+metadata:
+  name: kfctl_anthos
+spec:
+  repos:
+  - name: manifests
+    uri: https://github.com/kubeflow/manifests/archive/v1.0-branch.tar.gz
+    # To get manifest at a PR:
+    #uri: https://github.com/kubeflow/manifests/archive/pull/235/head.tar.gz
+  version: v1.0.0

--- a/kfdef/source/v1.0.0/kfctl_gcp_basic_auth.yaml
+++ b/kfdef/source/v1.0.0/kfctl_gcp_basic_auth.yaml
@@ -1,0 +1,13 @@
+# Please set project and email!
+apiVersion: kfdef.apps.kubeflow.org/v1
+kind: KfDef
+metadata:
+  name: kfctl_gcp_basic_auth
+spec:
+  repos:
+  - name: manifests
+    uri: https://github.com/kubeflow/manifests/archive/v1.0-branch.tar.gz
+    # To get manifest at a PR:
+    #uri: https://github.com/kubeflow/manifests/archive/pull/235/head.tar.gz
+  version: v1.0.0
+

--- a/kfdef/source/v1.0.0/kfctl_gcp_iap.yaml
+++ b/kfdef/source/v1.0.0/kfctl_gcp_iap.yaml
@@ -1,0 +1,12 @@
+# Please set project and email!
+apiVersion: kfdef.apps.kubeflow.org/v1
+kind: KfDef
+metadata:
+  name: kfctl_gcp_iap
+spec:
+  repos:
+  - name: manifests
+    uri: https://github.com/kubeflow/manifests/archive/v1.0-branch.tar.gz
+    # To get manifest at a PR:
+    #uri: https://github.com/kubeflow/manifests/archive/pull/235/head.tar.gz
+  version: v1.0.0

--- a/kfdef/source/v1.0.0/kustomization.yaml
+++ b/kfdef/source/v1.0.0/kustomization.yaml
@@ -1,0 +1,9 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+bases:
+  - ../master
+patchesStrategicMerge:
+- kfctl_anthos.yaml
+- kfctl_gcp_iap.yaml
+- kfctl_gcp_basic_auth.yaml
+

--- a/kfdef/source/v1.0.0/kustomization.yaml
+++ b/kfdef/source/v1.0.0/kustomization.yaml
@@ -1,5 +1,6 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
+namespace: kubeflow
 bases:
   - ../master
 patchesStrategicMerge:


### PR DESCRIPTION
* For each KF release we need to define a KFDef spec that overrides certain
  values (e.g. the repo of kubeflow/manifests it uses)

* Previously we just did this by modifying the KFDef specs on the release
  branch. But this was very costly to maintain; i.e. backporting changes
  on master to the release branch

* To make that easier we can generate the KFDef YAML files using kustomize;
  this allows us to use overlays to define the changes needed to customize
  the specs for a particular version

* We can keep these versioned overlays on master so that the divergence between
  master and the branches is very low

* To preserve existing behavior we still check in YAML files. a simple
  script build_kfdef_specs.py is provided to generate them.

Related to: kubeflow/kubeflow#4685

Some History:

@kkasravi originally had the idea of using kustomize to help maintain our KFDef specs. Originally the logic for generating KFDef via kustomize was baked into kfctl. We decided that was overly complicated and that following a shift left philosophy we would move the generation of the KFDef (via kustomize) to prior to invoking kfctl. That is consistent with what this PR is doing.

Furthermore, in the original use of Kustomize to generate KFDef; overlays were used to generate KFDef specs for different clouds e.g. IBM, vs. GCP, etc...

In this PR overlays are instead used to generate KFDefs for different KF versions.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/manifests/778)
<!-- Reviewable:end -->
