### PR TITLE
Automated cherry pick of #795: Update TFJob manifest to work with new distroless image. Cherry pick of #795 on v1.0-branch. #795: Update TFJob manifest to work with new distroless image.

### DIFF
--- a/tests/tf-training-tf-job-operator-base_test.go
+++ b/tests/tf-training-tf-job-operator-base_test.go
@@ -144,8 +144,7 @@ spec:
         sidecar.istio.io/inject: "false"
     spec:
       containers:
-      - command:
-        - /opt/kubeflow/tf-operator.v1
+      - args:
         - --alsologtostderr
         - -v=1
         - --monitoring-port=8443
@@ -217,7 +216,7 @@ commonLabels:
 images:
 - name: gcr.io/kubeflow-images-public/tf_operator
   newName: gcr.io/kubeflow-images-public/tf_operator
-  newTag: v0.7.0
+  newTag: vmaster-g92389064
 `)
 }
 

--- a/tests/tf-training-tf-job-operator-overlays-application_test.go
+++ b/tests/tf-training-tf-job-operator-overlays-application_test.go
@@ -203,8 +203,7 @@ spec:
         sidecar.istio.io/inject: "false"
     spec:
       containers:
-      - command:
-        - /opt/kubeflow/tf-operator.v1
+      - args:
         - --alsologtostderr
         - -v=1
         - --monitoring-port=8443
@@ -276,7 +275,7 @@ commonLabels:
 images:
 - name: gcr.io/kubeflow-images-public/tf_operator
   newName: gcr.io/kubeflow-images-public/tf_operator
-  newTag: v0.7.0
+  newTag: vmaster-g92389064
 `)
 }
 

--- a/tf-training/tf-job-operator/base/deployment.yaml
+++ b/tf-training/tf-job-operator/base/deployment.yaml
@@ -13,8 +13,7 @@ spec:
         sidecar.istio.io/inject: "false"
     spec:
       containers:
-      - command:
-        - /opt/kubeflow/tf-operator.v1
+      - args:
         - --alsologtostderr
         - -v=1
         - --monitoring-port=8443

--- a/tf-training/tf-job-operator/base/kustomization.yaml
+++ b/tf-training/tf-job-operator/base/kustomization.yaml
@@ -12,4 +12,4 @@ commonLabels:
 images:
 - name: gcr.io/kubeflow-images-public/tf_operator
   newName: gcr.io/kubeflow-images-public/tf_operator
-  newTag: v0.7.0
+  newTag: vmaster-g92389064


### PR DESCRIPTION

Related to: #794 
<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/manifests/803)
<!-- Reviewable:end -->
