### PR TITLE
Added istio sidecar false annotation to metadata deployments

### DIFF
--- a/hack/gen-test-target.sh
+++ b/hack/gen-test-target.sh
@@ -45,7 +45,7 @@ gen-target-start() {
 
 gen-target-middle() {
   local directory=$1
-  for i in $(echo $(cat $directory/kustomization.yaml | grep '^- .*yaml$' | sed 's/^- //') $(cat $directory/kustomization.yaml | grep '  path: ' | sed 's/^.*: \(.*\)$/\1/') $(cat $directory/kustomization.yaml | sed '1,/^[ \t]*files:/d;/^[^ \t]/,$d' | sed 's/^[ \t]*- //') params.env secrets.env kustomization.yaml | sed 's/ /\\n/g' | sort | uniq | awk '{gsub(/\\n/,"\n")}1'); do
+  for i in $(echo $(cat $directory/kustomization.yaml | grep '^- .*yaml$' | sed 's/^- //') $(cat $directory/kustomization.yaml | grep '  path: ' | sed 's/^.*: \(.*\)$/\1/') $(cat $directory/kustomization.yaml | sed '1,/^[ \t]*files:/d;/^[^ \t]/,$d' | sed 's/^[ \t]*- //') params.env secrets.env grpc-params.env kustomization.yaml | sed 's/ /\\n/g' | sort | uniq | awk '{gsub(/\\n/,"\n")}1'); do
     file=$i
     if [[ -f $directory/$file ]]; then
       case $file in
@@ -56,6 +56,9 @@ gen-target-middle() {
           gen-target-resource $file $directory
           ;;
         params.env)
+          gen-target-resource $file $directory
+          ;;
+        grpc-params.env)
           gen-target-resource $file $directory
           ;;
         secrets.env)

--- a/metadata/base/metadata-deployment.yaml
+++ b/metadata/base/metadata-deployment.yaml
@@ -13,6 +13,8 @@ spec:
     metadata:
       labels:
         component: server
+      annotations:
+        sidecar.istio.io/inject: "false"
     spec:
       containers:
       - name: container
@@ -49,6 +51,8 @@ spec:
     metadata:
       labels:
         component: grpc-server
+      annotations:
+        sidecar.istio.io/inject: "false"
     spec:
       containers:
         - name: container

--- a/metadata/base/metadata-envoy-deployment.yaml
+++ b/metadata/base/metadata-envoy-deployment.yaml
@@ -13,6 +13,8 @@ spec:
     metadata:
       labels:
         component: envoy
+      annotations:
+        sidecar.istio.io/inject: "false"
     spec:
       containers:
       - name: container

--- a/metadata/base/metadata-ui-deployment.yaml
+++ b/metadata/base/metadata-ui-deployment.yaml
@@ -13,6 +13,8 @@ spec:
       name: ui
       labels:
         app: metadata-ui
+      annotations:
+        sidecar.istio.io/inject: "false"
     spec:
       containers:
       - image: gcr.io/kubeflow-images-public/metadata-frontend:v0.1.8

--- a/metadata/overlays/db/metadata-db-deployment.yaml
+++ b/metadata/overlays/db/metadata-db-deployment.yaml
@@ -14,6 +14,8 @@ spec:
       name: db
       labels:
         component: db
+      annotations:
+        sidecar.istio.io/inject: "false"
     spec:
       containers:
       - name: db-container

--- a/tests/metadata-base_test.go
+++ b/tests/metadata-base_test.go
@@ -30,6 +30,8 @@ spec:
     metadata:
       labels:
         component: server
+      annotations:
+        sidecar.istio.io/inject: "false"
     spec:
       containers:
       - name: container
@@ -66,6 +68,8 @@ spec:
     metadata:
       labels:
         component: grpc-server
+      annotations:
+        sidecar.istio.io/inject: "false"
     spec:
       containers:
         - name: container
@@ -77,7 +81,7 @@ spec:
           args: ["--grpc_port=$(METADATA_GRPC_SERVICE_PORT)"]
           ports:
             - name: grpc-backendapi
-              containerPort: 8080
+              containerPort: 8080 #The value of the port number needs to be in sync with value  specified in grpc-params.env
 `)
 	th.writeF("/manifests/metadata/base/metadata-service.yaml", `
 kind: Service
@@ -126,6 +130,8 @@ spec:
       name: ui
       labels:
         app: metadata-ui
+      annotations:
+        sidecar.istio.io/inject: "false"
     spec:
       containers:
       - image: gcr.io/kubeflow-images-public/metadata-frontend:v0.1.8
@@ -216,6 +222,8 @@ spec:
     metadata:
       labels:
         component: envoy
+      annotations:
+        sidecar.istio.io/inject: "false"
     spec:
       containers:
       - name: container

--- a/tests/metadata-overlays-application_test.go
+++ b/tests/metadata-overlays-application_test.go
@@ -87,6 +87,8 @@ spec:
     metadata:
       labels:
         component: server
+      annotations:
+        sidecar.istio.io/inject: "false"
     spec:
       containers:
       - name: container
@@ -123,6 +125,8 @@ spec:
     metadata:
       labels:
         component: grpc-server
+      annotations:
+        sidecar.istio.io/inject: "false"
     spec:
       containers:
         - name: container
@@ -134,7 +138,7 @@ spec:
           args: ["--grpc_port=$(METADATA_GRPC_SERVICE_PORT)"]
           ports:
             - name: grpc-backendapi
-              containerPort: 8080
+              containerPort: 8080 #The value of the port number needs to be in sync with value  specified in grpc-params.env
 `)
 	th.writeF("/manifests/metadata/base/metadata-service.yaml", `
 kind: Service
@@ -183,6 +187,8 @@ spec:
       name: ui
       labels:
         app: metadata-ui
+      annotations:
+        sidecar.istio.io/inject: "false"
     spec:
       containers:
       - image: gcr.io/kubeflow-images-public/metadata-frontend:v0.1.8
@@ -273,6 +279,8 @@ spec:
     metadata:
       labels:
         component: envoy
+      annotations:
+        sidecar.istio.io/inject: "false"
     spec:
       containers:
       - name: container

--- a/tests/metadata-overlays-db_test.go
+++ b/tests/metadata-overlays-db_test.go
@@ -43,6 +43,8 @@ spec:
       name: db
       labels:
         component: db
+      annotations:
+        sidecar.istio.io/inject: "false"
     spec:
       containers:
       - name: db-container
@@ -154,14 +156,17 @@ spec:
                  "--mysql_config_port=$(MYSQL_PORT)",
                  "--mysql_config_user=$(MYSQL_USER_NAME)",
                  "--mysql_config_password=$(MYSQL_ROOT_PASSWORD)"
-          ]`)
+          ]
+`)
 	th.writeF("/manifests/metadata/overlays/db/params.env", `
 MYSQL_DATABASE=metadb
 MYSQL_PORT=3306
-MYSQL_ALLOW_EMPTY_PASSWORD=true`)
+MYSQL_ALLOW_EMPTY_PASSWORD=true
+`)
 	th.writeF("/manifests/metadata/overlays/db/secrets.env", `
 MYSQL_USER_NAME=root
-MYSQL_ROOT_PASSWORD=test`)
+MYSQL_ROOT_PASSWORD=test
+`)
 	th.writeK("/manifests/metadata/overlays/db", `
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
@@ -196,7 +201,8 @@ vars:
     name: metadata-db
     apiVersion: v1
   fieldref:
-    fieldpath: metadata.name`)
+    fieldpath: metadata.name
+`)
 	th.writeF("/manifests/metadata/base/metadata-deployment.yaml", `
 apiVersion: apps/v1
 kind: Deployment
@@ -213,6 +219,8 @@ spec:
     metadata:
       labels:
         component: server
+      annotations:
+        sidecar.istio.io/inject: "false"
     spec:
       containers:
       - name: container
@@ -249,6 +257,8 @@ spec:
     metadata:
       labels:
         component: grpc-server
+      annotations:
+        sidecar.istio.io/inject: "false"
     spec:
       containers:
         - name: container
@@ -260,7 +270,7 @@ spec:
           args: ["--grpc_port=$(METADATA_GRPC_SERVICE_PORT)"]
           ports:
             - name: grpc-backendapi
-              containerPort: 8080
+              containerPort: 8080 #The value of the port number needs to be in sync with value  specified in grpc-params.env
 `)
 	th.writeF("/manifests/metadata/base/metadata-service.yaml", `
 kind: Service
@@ -309,6 +319,8 @@ spec:
       name: ui
       labels:
         app: metadata-ui
+      annotations:
+        sidecar.istio.io/inject: "false"
     spec:
       containers:
       - image: gcr.io/kubeflow-images-public/metadata-frontend:v0.1.8
@@ -399,6 +411,8 @@ spec:
     metadata:
       labels:
         component: envoy
+      annotations:
+        sidecar.istio.io/inject: "false"
     spec:
       containers:
       - name: container

--- a/tests/metadata-overlays-ibm-storage-config_test.go
+++ b/tests/metadata-overlays-ibm-storage-config_test.go
@@ -40,6 +40,8 @@ spec:
     metadata:
       labels:
         component: server
+      annotations:
+        sidecar.istio.io/inject: "false"
     spec:
       containers:
       - name: container
@@ -76,6 +78,8 @@ spec:
     metadata:
       labels:
         component: grpc-server
+      annotations:
+        sidecar.istio.io/inject: "false"
     spec:
       containers:
         - name: container
@@ -87,7 +91,7 @@ spec:
           args: ["--grpc_port=$(METADATA_GRPC_SERVICE_PORT)"]
           ports:
             - name: grpc-backendapi
-              containerPort: 8080
+              containerPort: 8080 #The value of the port number needs to be in sync with value  specified in grpc-params.env
 `)
 	th.writeF("/manifests/metadata/base/metadata-service.yaml", `
 kind: Service
@@ -136,6 +140,8 @@ spec:
       name: ui
       labels:
         app: metadata-ui
+      annotations:
+        sidecar.istio.io/inject: "false"
     spec:
       containers:
       - image: gcr.io/kubeflow-images-public/metadata-frontend:v0.1.8
@@ -226,6 +232,8 @@ spec:
     metadata:
       labels:
         component: envoy
+      annotations:
+        sidecar.istio.io/inject: "false"
     spec:
       containers:
       - name: container

--- a/tests/metadata-overlays-istio_test.go
+++ b/tests/metadata-overlays-istio_test.go
@@ -92,6 +92,8 @@ spec:
     metadata:
       labels:
         component: server
+      annotations:
+        sidecar.istio.io/inject: "false"
     spec:
       containers:
       - name: container
@@ -128,6 +130,8 @@ spec:
     metadata:
       labels:
         component: grpc-server
+      annotations:
+        sidecar.istio.io/inject: "false"
     spec:
       containers:
         - name: container
@@ -139,7 +143,7 @@ spec:
           args: ["--grpc_port=$(METADATA_GRPC_SERVICE_PORT)"]
           ports:
             - name: grpc-backendapi
-              containerPort: 8080
+              containerPort: 8080 #The value of the port number needs to be in sync with value  specified in grpc-params.env
 `)
 	th.writeF("/manifests/metadata/base/metadata-service.yaml", `
 kind: Service
@@ -188,6 +192,8 @@ spec:
       name: ui
       labels:
         app: metadata-ui
+      annotations:
+        sidecar.istio.io/inject: "false"
     spec:
       containers:
       - image: gcr.io/kubeflow-images-public/metadata-frontend:v0.1.8
@@ -278,6 +284,8 @@ spec:
     metadata:
       labels:
         component: envoy
+      annotations:
+        sidecar.istio.io/inject: "false"
     spec:
       containers:
       - name: container


### PR DESCRIPTION
**Which issue is resolved by this Pull Request:**
Unblocks https://github.com/kubeflow/kfctl/pull/131
Part of kubeflow/pipelines#1223
Supercedes https://github.com/kubeflow/manifests/pull/716

**Description of your changes:**
1. Added istio sidecar injection false annotation to metadata deployments
2. Fixed test generation script to also take care of `grpc-params.env`. I'm not sure when was that introduced.

**Checklist:**
- [x] Unit tests have been rebuilt: 
    1. `cd manifests/tests`
    2. `make generate-changed-only`
    3. `make test`

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/manifests/804)
<!-- Reviewable:end -->
