### PR TITLE
Automated cherry pick of #801: Fix autoprovisioning settings. Cherry pick of #801 on v1.0-branch. #801: Fix autoprovisioning settings.

### DIFF
--- a/gcp/deployment_manager_configs/cluster-kubeflow.yaml
+++ b/gcp/deployment_manager_configs/cluster-kubeflow.yaml
@@ -70,11 +70,12 @@ resources:
     # This is configured by the gkeApiVersion setting.
     autoprovisioning-config:
       enabled: true
-      max-cpu: 20
-      max-memory: 200
+      # Max CPU and Max Memory are the total maximum allowed CPU and Memory in the cluster
+      max-cpu: 128
+      max-memory: 2000
       max-accelerator:
         - type: nvidia-tesla-k80
-          count: 8
+          count: 16
     # Whether to enable TPUs
     enable_tpu: false
     securityConfig:

--- a/gcp/deployment_manager_configs/cluster.jinja
+++ b/gcp/deployment_manager_configs/cluster.jinja
@@ -97,7 +97,7 @@ resources:
       autoscaling:
         enableNodeAutoprovisioning: true
         autoprovisioningNodePoolDefaults:
-          # oauthScopes can't be set with service account
+          oauthScopes: {{ VM_OAUTH_SCOPES }}
           serviceAccount: {{ KF_VM_SA_NAME }}@{{ env['project'] }}.iam.gserviceaccount.com
           
         resourceLimits:


### PR DESCRIPTION
* kubeflow/kubeflow#4259 GKE now allows setting oauthscopes and VM service
  account for NAP pools. We need to use this otherwise private images
  won't be accessible.

* kubeflow/kubeflow#3930 Bump NAP resource constraints because these
  are global constraints not per node constraints.

  * Bump max CPU to 128 CPUs
  * Bump memory

<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/manifests/809)
<!-- Reviewable:end -->
