### PR TITLE
Cleanup notebook UI kubeflow user roles (related to kubeflow/kubeflow#4699)

### DIFF
--- a/jupyter/jupyter-web-app/base/cluster-role.yaml
+++ b/jupyter/jupyter-web-app/base/cluster-role.yaml
@@ -61,10 +61,6 @@ metadata:
   name: kubeflow-notebook-ui-admin
   labels:
     rbac.authorization.kubeflow.org/aggregate-to-kubeflow-admin: "true"
-aggregationRule:
-  clusterRoleSelectors:
-  - matchLabels:
-      rbac.authorization.kubeflow.org/aggregate-to-kubeflow-tfjobs-admin: "true"
 rules: []
 
 ---
@@ -75,7 +71,6 @@ metadata:
   name: kubeflow-notebook-ui-edit
   labels:
     rbac.authorization.kubeflow.org/aggregate-to-kubeflow-edit: "true"
-    rbac.authorization.kubeflow.org/aggregate-to-kubeflow-tfjobs-admin: "true"
 rules:
 - apiGroups:
   - kubeflow.org
@@ -108,8 +103,10 @@ rules:
   - get
   - list
 - apiGroups:
-  - ""
+  - storage.k8s.io
   resources:
-  - events
+  - storageclasses
   verbs:
+  - get
   - list
+  - watch

--- a/tests/jupyter-jupyter-web-app-base_test.go
+++ b/tests/jupyter-jupyter-web-app-base_test.go
@@ -91,10 +91,6 @@ metadata:
   name: kubeflow-notebook-ui-admin
   labels:
     rbac.authorization.kubeflow.org/aggregate-to-kubeflow-admin: "true"
-aggregationRule:
-  clusterRoleSelectors:
-  - matchLabels:
-      rbac.authorization.kubeflow.org/aggregate-to-kubeflow-tfjobs-admin: "true"
 rules: []
 
 ---
@@ -105,7 +101,6 @@ metadata:
   name: kubeflow-notebook-ui-edit
   labels:
     rbac.authorization.kubeflow.org/aggregate-to-kubeflow-edit: "true"
-    rbac.authorization.kubeflow.org/aggregate-to-kubeflow-tfjobs-admin: "true"
 rules:
 - apiGroups:
   - kubeflow.org
@@ -138,11 +133,13 @@ rules:
   - get
   - list
 - apiGroups:
-  - ""
+  - storage.k8s.io
   resources:
-  - events
+  - storageclasses
   verbs:
-  - list`)
+  - get
+  - list
+  - watch`)
 	th.writeF("/manifests/jupyter/jupyter-web-app/base/config-map.yaml", `
 apiVersion: v1
 data:

--- a/tests/jupyter-jupyter-web-app-overlays-application_test.go
+++ b/tests/jupyter-jupyter-web-app-overlays-application_test.go
@@ -157,10 +157,6 @@ metadata:
   name: kubeflow-notebook-ui-admin
   labels:
     rbac.authorization.kubeflow.org/aggregate-to-kubeflow-admin: "true"
-aggregationRule:
-  clusterRoleSelectors:
-  - matchLabels:
-      rbac.authorization.kubeflow.org/aggregate-to-kubeflow-tfjobs-admin: "true"
 rules: []
 
 ---
@@ -171,7 +167,6 @@ metadata:
   name: kubeflow-notebook-ui-edit
   labels:
     rbac.authorization.kubeflow.org/aggregate-to-kubeflow-edit: "true"
-    rbac.authorization.kubeflow.org/aggregate-to-kubeflow-tfjobs-admin: "true"
 rules:
 - apiGroups:
   - kubeflow.org
@@ -204,11 +199,13 @@ rules:
   - get
   - list
 - apiGroups:
-  - ""
+  - storage.k8s.io
   resources:
-  - events
+  - storageclasses
   verbs:
-  - list`)
+  - get
+  - list
+  - watch`)
 	th.writeF("/manifests/jupyter/jupyter-web-app/base/config-map.yaml", `
 apiVersion: v1
 data:

--- a/tests/jupyter-jupyter-web-app-overlays-istio_test.go
+++ b/tests/jupyter-jupyter-web-app-overlays-istio_test.go
@@ -130,10 +130,6 @@ metadata:
   name: kubeflow-notebook-ui-admin
   labels:
     rbac.authorization.kubeflow.org/aggregate-to-kubeflow-admin: "true"
-aggregationRule:
-  clusterRoleSelectors:
-  - matchLabels:
-      rbac.authorization.kubeflow.org/aggregate-to-kubeflow-tfjobs-admin: "true"
 rules: []
 
 ---
@@ -144,7 +140,6 @@ metadata:
   name: kubeflow-notebook-ui-edit
   labels:
     rbac.authorization.kubeflow.org/aggregate-to-kubeflow-edit: "true"
-    rbac.authorization.kubeflow.org/aggregate-to-kubeflow-tfjobs-admin: "true"
 rules:
 - apiGroups:
   - kubeflow.org
@@ -177,11 +172,13 @@ rules:
   - get
   - list
 - apiGroups:
-  - ""
+  - storage.k8s.io
   resources:
-  - events
+  - storageclasses
   verbs:
-  - list`)
+  - get
+  - list
+  - watch`)
 	th.writeF("/manifests/jupyter/jupyter-web-app/base/config-map.yaml", `
 apiVersion: v1
 data:


### PR DESCRIPTION
* There were some labels that shouldn't have added; they were left over
  from bad copy and paste.

* Get rid of events permission; this doesn't actually fix kubeflow/kubeflow#4699
  events are cluster scoped resources. So creating a rolebinding has no effect.

* We primarily use Kubeflow roles as rolebindings not clusterrolebindings
  so including cluster scoped resources doesn't make much sense.

* Related to kubeflow/kubeflow#4699

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/manifests/821)
<!-- Reviewable:end -->
