### PR TITLE
Remove certmanager annoations on GCP ingress; kubeflow/kubeflow#4716

### DIFF
--- a/gcp/basic-auth-ingress/base/ingress.yaml
+++ b/gcp/basic-auth-ingress/base/ingress.yaml
@@ -2,7 +2,6 @@ apiVersion: extensions/v1beta1 # networking.k8s.io/v1beta1
 kind: Ingress
 metadata:
   annotations:
-    certmanager.k8s.io/issuer: $(issuer)
     ingress.kubernetes.io/ssl-redirect: "true"
     kubernetes.io/ingress.global-static-ip-name: $(ipName)
     kubernetes.io/tls-acme: "true"

--- a/gcp/basic-auth-ingress/base/kustomization.yaml
+++ b/gcp/basic-auth-ingress/base/kustomization.yaml
@@ -77,13 +77,6 @@ vars:
     apiVersion: v1
   fieldref:
     fieldpath: data.ingressName
-- name: issuer
-  objref:
-    kind: ConfigMap
-    name: basic-auth-ingress-parameters
-    apiVersion: v1
-  fieldref:
-    fieldpath: data.issuer
 - name: istioNamespace
   objref:
     kind: ConfigMap

--- a/gcp/basic-auth-ingress/base/params.env
+++ b/gcp/basic-auth-ingress/base/params.env
@@ -6,5 +6,4 @@ ipName=
 secretName=envoy-ingress-tls
 privateGKECluster=false
 ingressName=envoy-ingress
-issuer=letsencrypt-prod
 istioNamespace=istio-system

--- a/gcp/iap-ingress/base/ingress.yaml
+++ b/gcp/iap-ingress/base/ingress.yaml
@@ -2,7 +2,6 @@ apiVersion: extensions/v1beta1 # networking.k8s.io/v1beta1
 kind: Ingress
 metadata:
   annotations:
-    certmanager.k8s.io/issuer: $(issuer)
     ingress.kubernetes.io/ssl-redirect: "true"
     kubernetes.io/ingress.global-static-ip-name: $(ipName)
     kubernetes.io/tls-acme: "true"

--- a/gcp/iap-ingress/base/kustomization.yaml
+++ b/gcp/iap-ingress/base/kustomization.yaml
@@ -66,13 +66,6 @@ vars:
     apiVersion: v1
   fieldref:
     fieldpath: data.ingressName
-- name: issuer
-  objref:
-    kind: ConfigMap
-    name: parameters
-    apiVersion: v1
-  fieldref:
-    fieldpath: data.issuer
 - name: oauthSecretName
   objref:
     kind: ConfigMap

--- a/gcp/iap-ingress/base/params.env
+++ b/gcp/iap-ingress/base/params.env
@@ -3,7 +3,6 @@ appName=kubeflow
 hostname=
 ingressName=envoy-ingress
 ipName=
-issuer=letsencrypt-prod
 oauthSecretName=kubeflow-oauth
 project=
 adminSaSecretName=admin-gcp-sa

--- a/tests/gcp-basic-auth-ingress-base_test.go
+++ b/tests/gcp-basic-auth-ingress-base_test.go
@@ -224,7 +224,6 @@ apiVersion: extensions/v1beta1 # networking.k8s.io/v1beta1
 kind: Ingress
 metadata:
   annotations:
-    certmanager.k8s.io/issuer: $(issuer)
     ingress.kubernetes.io/ssl-redirect: "true"
     kubernetes.io/ingress.global-static-ip-name: $(ipName)
     kubernetes.io/tls-acme: "true"
@@ -388,7 +387,6 @@ ipName=
 secretName=envoy-ingress-tls
 privateGKECluster=false
 ingressName=envoy-ingress
-issuer=letsencrypt-prod
 istioNamespace=istio-system
 `)
 	th.writeK("/manifests/gcp/basic-auth-ingress/base", `
@@ -471,13 +469,6 @@ vars:
     apiVersion: v1
   fieldref:
     fieldpath: data.ingressName
-- name: issuer
-  objref:
-    kind: ConfigMap
-    name: basic-auth-ingress-parameters
-    apiVersion: v1
-  fieldref:
-    fieldpath: data.issuer
 - name: istioNamespace
   objref:
     kind: ConfigMap

--- a/tests/gcp-basic-auth-ingress-overlays-application_test.go
+++ b/tests/gcp-basic-auth-ingress-overlays-application_test.go
@@ -272,7 +272,6 @@ apiVersion: extensions/v1beta1 # networking.k8s.io/v1beta1
 kind: Ingress
 metadata:
   annotations:
-    certmanager.k8s.io/issuer: $(issuer)
     ingress.kubernetes.io/ssl-redirect: "true"
     kubernetes.io/ingress.global-static-ip-name: $(ipName)
     kubernetes.io/tls-acme: "true"
@@ -436,7 +435,6 @@ ipName=
 secretName=envoy-ingress-tls
 privateGKECluster=false
 ingressName=envoy-ingress
-issuer=letsencrypt-prod
 istioNamespace=istio-system
 `)
 	th.writeK("/manifests/gcp/basic-auth-ingress/base", `
@@ -519,13 +517,6 @@ vars:
     apiVersion: v1
   fieldref:
     fieldpath: data.ingressName
-- name: issuer
-  objref:
-    kind: ConfigMap
-    name: basic-auth-ingress-parameters
-    apiVersion: v1
-  fieldref:
-    fieldpath: data.issuer
 - name: istioNamespace
   objref:
     kind: ConfigMap

--- a/tests/gcp-basic-auth-ingress-overlays-certmanager_test.go
+++ b/tests/gcp-basic-auth-ingress-overlays-certmanager_test.go
@@ -293,7 +293,6 @@ apiVersion: extensions/v1beta1 # networking.k8s.io/v1beta1
 kind: Ingress
 metadata:
   annotations:
-    certmanager.k8s.io/issuer: $(issuer)
     ingress.kubernetes.io/ssl-redirect: "true"
     kubernetes.io/ingress.global-static-ip-name: $(ipName)
     kubernetes.io/tls-acme: "true"
@@ -457,7 +456,6 @@ ipName=
 secretName=envoy-ingress-tls
 privateGKECluster=false
 ingressName=envoy-ingress
-issuer=letsencrypt-prod
 istioNamespace=istio-system
 `)
 	th.writeK("/manifests/gcp/basic-auth-ingress/base", `
@@ -540,13 +538,6 @@ vars:
     apiVersion: v1
   fieldref:
     fieldpath: data.ingressName
-- name: issuer
-  objref:
-    kind: ConfigMap
-    name: basic-auth-ingress-parameters
-    apiVersion: v1
-  fieldref:
-    fieldpath: data.issuer
 - name: istioNamespace
   objref:
     kind: ConfigMap

--- a/tests/gcp-basic-auth-ingress-overlays-gcp-credentials_test.go
+++ b/tests/gcp-basic-auth-ingress-overlays-gcp-credentials_test.go
@@ -255,7 +255,6 @@ apiVersion: extensions/v1beta1 # networking.k8s.io/v1beta1
 kind: Ingress
 metadata:
   annotations:
-    certmanager.k8s.io/issuer: $(issuer)
     ingress.kubernetes.io/ssl-redirect: "true"
     kubernetes.io/ingress.global-static-ip-name: $(ipName)
     kubernetes.io/tls-acme: "true"
@@ -419,7 +418,6 @@ ipName=
 secretName=envoy-ingress-tls
 privateGKECluster=false
 ingressName=envoy-ingress
-issuer=letsencrypt-prod
 istioNamespace=istio-system
 `)
 	th.writeK("/manifests/gcp/basic-auth-ingress/base", `
@@ -502,13 +500,6 @@ vars:
     apiVersion: v1
   fieldref:
     fieldpath: data.ingressName
-- name: issuer
-  objref:
-    kind: ConfigMap
-    name: basic-auth-ingress-parameters
-    apiVersion: v1
-  fieldref:
-    fieldpath: data.issuer
 - name: istioNamespace
   objref:
     kind: ConfigMap

--- a/tests/gcp-basic-auth-ingress-overlays-managed-cert_test.go
+++ b/tests/gcp-basic-auth-ingress-overlays-managed-cert_test.go
@@ -243,7 +243,6 @@ apiVersion: extensions/v1beta1 # networking.k8s.io/v1beta1
 kind: Ingress
 metadata:
   annotations:
-    certmanager.k8s.io/issuer: $(issuer)
     ingress.kubernetes.io/ssl-redirect: "true"
     kubernetes.io/ingress.global-static-ip-name: $(ipName)
     kubernetes.io/tls-acme: "true"
@@ -407,7 +406,6 @@ ipName=
 secretName=envoy-ingress-tls
 privateGKECluster=false
 ingressName=envoy-ingress
-issuer=letsencrypt-prod
 istioNamespace=istio-system
 `)
 	th.writeK("/manifests/gcp/basic-auth-ingress/base", `
@@ -490,13 +488,6 @@ vars:
     apiVersion: v1
   fieldref:
     fieldpath: data.ingressName
-- name: issuer
-  objref:
-    kind: ConfigMap
-    name: basic-auth-ingress-parameters
-    apiVersion: v1
-  fieldref:
-    fieldpath: data.issuer
 - name: istioNamespace
   objref:
     kind: ConfigMap

--- a/tests/gcp-iap-ingress-base_test.go
+++ b/tests/gcp-iap-ingress-base_test.go
@@ -392,7 +392,6 @@ apiVersion: extensions/v1beta1 # networking.k8s.io/v1beta1
 kind: Ingress
 metadata:
   annotations:
-    certmanager.k8s.io/issuer: $(issuer)
     ingress.kubernetes.io/ssl-redirect: "true"
     kubernetes.io/ingress.global-static-ip-name: $(ipName)
     kubernetes.io/tls-acme: "true"
@@ -547,7 +546,6 @@ appName=kubeflow
 hostname=
 ingressName=envoy-ingress
 ipName=
-issuer=letsencrypt-prod
 oauthSecretName=kubeflow-oauth
 project=
 adminSaSecretName=admin-gcp-sa
@@ -622,13 +620,6 @@ vars:
     apiVersion: v1
   fieldref:
     fieldpath: data.ingressName
-- name: issuer
-  objref:
-    kind: ConfigMap
-    name: parameters
-    apiVersion: v1
-  fieldref:
-    fieldpath: data.issuer
 - name: oauthSecretName
   objref:
     kind: ConfigMap

--- a/tests/gcp-iap-ingress-overlays-application_test.go
+++ b/tests/gcp-iap-ingress-overlays-application_test.go
@@ -440,7 +440,6 @@ apiVersion: extensions/v1beta1 # networking.k8s.io/v1beta1
 kind: Ingress
 metadata:
   annotations:
-    certmanager.k8s.io/issuer: $(issuer)
     ingress.kubernetes.io/ssl-redirect: "true"
     kubernetes.io/ingress.global-static-ip-name: $(ipName)
     kubernetes.io/tls-acme: "true"
@@ -595,7 +594,6 @@ appName=kubeflow
 hostname=
 ingressName=envoy-ingress
 ipName=
-issuer=letsencrypt-prod
 oauthSecretName=kubeflow-oauth
 project=
 adminSaSecretName=admin-gcp-sa
@@ -670,13 +668,6 @@ vars:
     apiVersion: v1
   fieldref:
     fieldpath: data.ingressName
-- name: issuer
-  objref:
-    kind: ConfigMap
-    name: parameters
-    apiVersion: v1
-  fieldref:
-    fieldpath: data.issuer
 - name: oauthSecretName
   objref:
     kind: ConfigMap

--- a/tests/gcp-iap-ingress-overlays-certmanager_test.go
+++ b/tests/gcp-iap-ingress-overlays-certmanager_test.go
@@ -473,7 +473,6 @@ apiVersion: extensions/v1beta1 # networking.k8s.io/v1beta1
 kind: Ingress
 metadata:
   annotations:
-    certmanager.k8s.io/issuer: $(issuer)
     ingress.kubernetes.io/ssl-redirect: "true"
     kubernetes.io/ingress.global-static-ip-name: $(ipName)
     kubernetes.io/tls-acme: "true"
@@ -628,7 +627,6 @@ appName=kubeflow
 hostname=
 ingressName=envoy-ingress
 ipName=
-issuer=letsencrypt-prod
 oauthSecretName=kubeflow-oauth
 project=
 adminSaSecretName=admin-gcp-sa
@@ -703,13 +701,6 @@ vars:
     apiVersion: v1
   fieldref:
     fieldpath: data.ingressName
-- name: issuer
-  objref:
-    kind: ConfigMap
-    name: parameters
-    apiVersion: v1
-  fieldref:
-    fieldpath: data.issuer
 - name: oauthSecretName
   objref:
     kind: ConfigMap

--- a/tests/gcp-iap-ingress-overlays-gcp-credentials_test.go
+++ b/tests/gcp-iap-ingress-overlays-gcp-credentials_test.go
@@ -447,7 +447,6 @@ apiVersion: extensions/v1beta1 # networking.k8s.io/v1beta1
 kind: Ingress
 metadata:
   annotations:
-    certmanager.k8s.io/issuer: $(issuer)
     ingress.kubernetes.io/ssl-redirect: "true"
     kubernetes.io/ingress.global-static-ip-name: $(ipName)
     kubernetes.io/tls-acme: "true"
@@ -602,7 +601,6 @@ appName=kubeflow
 hostname=
 ingressName=envoy-ingress
 ipName=
-issuer=letsencrypt-prod
 oauthSecretName=kubeflow-oauth
 project=
 adminSaSecretName=admin-gcp-sa
@@ -677,13 +675,6 @@ vars:
     apiVersion: v1
   fieldref:
     fieldpath: data.ingressName
-- name: issuer
-  objref:
-    kind: ConfigMap
-    name: parameters
-    apiVersion: v1
-  fieldref:
-    fieldpath: data.issuer
 - name: oauthSecretName
   objref:
     kind: ConfigMap

--- a/tests/gcp-iap-ingress-overlays-managed-cert_test.go
+++ b/tests/gcp-iap-ingress-overlays-managed-cert_test.go
@@ -412,7 +412,6 @@ apiVersion: extensions/v1beta1 # networking.k8s.io/v1beta1
 kind: Ingress
 metadata:
   annotations:
-    certmanager.k8s.io/issuer: $(issuer)
     ingress.kubernetes.io/ssl-redirect: "true"
     kubernetes.io/ingress.global-static-ip-name: $(ipName)
     kubernetes.io/tls-acme: "true"
@@ -567,7 +566,6 @@ appName=kubeflow
 hostname=
 ingressName=envoy-ingress
 ipName=
-issuer=letsencrypt-prod
 oauthSecretName=kubeflow-oauth
 project=
 adminSaSecretName=admin-gcp-sa
@@ -642,13 +640,6 @@ vars:
     apiVersion: v1
   fieldref:
     fieldpath: data.ingressName
-- name: issuer
-  objref:
-    kind: ConfigMap
-    name: parameters
-    apiVersion: v1
-  fieldref:
-    fieldpath: data.issuer
 - name: oauthSecretName
   objref:
     kind: ConfigMap


### PR DESCRIPTION
* On GCP we stopped using certmanager for certificates and switched
  to managed certificates

* Users are reporting warnings on the ingress like

   Could not determine issuer for ingress due to bad annotations: failed to determine issuer name to be used for ingress resource

* This is coming from cert manager. which was recently added back for Seldon:
  kubeflow/manifests#806. So if we remove the annotation that should
  prevent cert-manager from trying to provision certificates and hopefully
  generating this warning.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/manifests/828)
<!-- Reviewable:end -->
