### PR TITLE
Regenerate tests

### DIFF
--- a/hack/gen-test-target.sh
+++ b/hack/gen-test-target.sh
@@ -12,7 +12,7 @@ kebab-case-2-PascalCase() {
   local a=$1 b='' array
   IFS='-' read -r -a array <<< "$a"
   for element in "${array[@]}"; do
-    part="${element}"
+    part="${element//./_}"
     part="$(tr '[:lower:]' '[:upper:]' <<< ${part:0:1})${part:1}"
     b+=$part
   done

--- a/hack/generate_tests.py
+++ b/hack/generate_tests.py
@@ -6,7 +6,7 @@ import logging
 import os
 import subprocess
 
-TOP_LEVEL_EXCLUDES = ["docs", "hack", "tests"]
+TOP_LEVEL_EXCLUDES = ["docs", "hack", "tests", "kfdef"]
 
 def generate_test_name(repo_root, package_dir):
   """Generate the name of the go file to write the test to.

--- a/tests/kfserving-kfserving-crds-base_test.go
+++ b/tests/kfserving-kfserving-crds-base_test.go
@@ -627,7 +627,8 @@ status:
     kind: ""
     plural: ""
   conditions: []
-  storedVersions: []`)
+  storedVersions: []
+`)
 	th.writeK("/manifests/kfserving/kfserving-crds/base", `
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization

--- a/tests/kfserving-kfserving-crds-overlays-application_test.go
+++ b/tests/kfserving-kfserving-crds-overlays-application_test.go
@@ -675,7 +675,8 @@ status:
     kind: ""
     plural: ""
   conditions: []
-  storedVersions: []`)
+  storedVersions: []
+`)
 	th.writeK("/manifests/kfserving/kfserving-crds/base", `
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization

--- a/tests/kfserving-kfserving-install-base_test.go
+++ b/tests/kfserving-kfserving-install-base_test.go
@@ -354,7 +354,8 @@ data:
         "memoryLimit": "1Gi",
         "cpuRequest": "100m",
         "cpuLimit": "1"
-    }`)
+    }
+`)
 	th.writeF("/manifests/kfserving/kfserving-install/base/secret.yaml", `
 apiVersion: v1
 kind: Secret

--- a/tests/kfserving-kfserving-install-overlays-application_test.go
+++ b/tests/kfserving-kfserving-install-overlays-application_test.go
@@ -411,7 +411,8 @@ data:
         "memoryLimit": "1Gi",
         "cpuRequest": "100m",
         "cpuLimit": "1"
-    }`)
+    }
+`)
 	th.writeF("/manifests/kfserving/kfserving-install/base/secret.yaml", `
 apiVersion: v1
 kind: Secret

--- a/tests/metadata-base_test.go
+++ b/tests/metadata-base_test.go
@@ -255,8 +255,7 @@ uiClusterDomain=cluster.local
 `)
 	th.writeF("/manifests/metadata/base/grpc-params.env", `
 METADATA_GRPC_SERVICE_HOST=metadata-grpc-service
-METADATA_GRPC_SERVICE_PORT=8080
-`)
+METADATA_GRPC_SERVICE_PORT=8080`)
 	th.writeK("/manifests/metadata/base", `
 namePrefix: metadata-
 apiVersion: kustomize.config.k8s.io/v1beta1

--- a/tests/metadata-overlays-application_test.go
+++ b/tests/metadata-overlays-application_test.go
@@ -312,8 +312,7 @@ uiClusterDomain=cluster.local
 `)
 	th.writeF("/manifests/metadata/base/grpc-params.env", `
 METADATA_GRPC_SERVICE_HOST=metadata-grpc-service
-METADATA_GRPC_SERVICE_PORT=8080
-`)
+METADATA_GRPC_SERVICE_PORT=8080`)
 	th.writeK("/manifests/metadata/base", `
 namePrefix: metadata-
 apiVersion: kustomize.config.k8s.io/v1beta1

--- a/tests/metadata-overlays-db_test.go
+++ b/tests/metadata-overlays-db_test.go
@@ -156,17 +156,14 @@ spec:
                  "--mysql_config_port=$(MYSQL_PORT)",
                  "--mysql_config_user=$(MYSQL_USER_NAME)",
                  "--mysql_config_password=$(MYSQL_ROOT_PASSWORD)"
-          ]
-`)
+          ]`)
 	th.writeF("/manifests/metadata/overlays/db/params.env", `
 MYSQL_DATABASE=metadb
 MYSQL_PORT=3306
-MYSQL_ALLOW_EMPTY_PASSWORD=true
-`)
+MYSQL_ALLOW_EMPTY_PASSWORD=true`)
 	th.writeF("/manifests/metadata/overlays/db/secrets.env", `
 MYSQL_USER_NAME=root
-MYSQL_ROOT_PASSWORD=test
-`)
+MYSQL_ROOT_PASSWORD=test`)
 	th.writeK("/manifests/metadata/overlays/db", `
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
@@ -201,8 +198,7 @@ vars:
     name: metadata-db
     apiVersion: v1
   fieldref:
-    fieldpath: metadata.name
-`)
+    fieldpath: metadata.name`)
 	th.writeF("/manifests/metadata/base/metadata-deployment.yaml", `
 apiVersion: apps/v1
 kind: Deployment
@@ -444,8 +440,7 @@ uiClusterDomain=cluster.local
 `)
 	th.writeF("/manifests/metadata/base/grpc-params.env", `
 METADATA_GRPC_SERVICE_HOST=metadata-grpc-service
-METADATA_GRPC_SERVICE_PORT=8080
-`)
+METADATA_GRPC_SERVICE_PORT=8080`)
 	th.writeK("/manifests/metadata/base", `
 namePrefix: metadata-
 apiVersion: kustomize.config.k8s.io/v1beta1

--- a/tests/metadata-overlays-ibm-storage-config_test.go
+++ b/tests/metadata-overlays-ibm-storage-config_test.go
@@ -265,8 +265,7 @@ uiClusterDomain=cluster.local
 `)
 	th.writeF("/manifests/metadata/base/grpc-params.env", `
 METADATA_GRPC_SERVICE_HOST=metadata-grpc-service
-METADATA_GRPC_SERVICE_PORT=8080
-`)
+METADATA_GRPC_SERVICE_PORT=8080`)
 	th.writeK("/manifests/metadata/base", `
 namePrefix: metadata-
 apiVersion: kustomize.config.k8s.io/v1beta1

--- a/tests/metadata-overlays-istio_test.go
+++ b/tests/metadata-overlays-istio_test.go
@@ -317,8 +317,7 @@ uiClusterDomain=cluster.local
 `)
 	th.writeF("/manifests/metadata/base/grpc-params.env", `
 METADATA_GRPC_SERVICE_HOST=metadata-grpc-service
-METADATA_GRPC_SERVICE_PORT=8080
-`)
+METADATA_GRPC_SERVICE_PORT=8080`)
 	th.writeK("/manifests/metadata/base", `
 namePrefix: metadata-
 apiVersion: kustomize.config.k8s.io/v1beta1


### PR DESCRIPTION
- Exclude kfdef
- Account for directory name with dot
- Rerun generation

**Which issue is resolved by this Pull Request:**
Resolves #

**Description of your changes:**


**Checklist:**
- [ ] Unit tests have been rebuilt: 
    1. `cd manifests/tests`
    2. `make generate-changed-only`
    3. `make test`

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/manifests/831)
<!-- Reviewable:end -->
