### PR TITLE
livenessProbe for notebook-controller

### DIFF
--- a/jupyter/notebook-controller/base/deployment.yaml
+++ b/jupyter/notebook-controller/base/deployment.yaml
@@ -19,4 +19,10 @@ spec:
           - name: POD_LABELS
             value: $(POD_LABELS)
         imagePullPolicy: Always
+        livenessProbe:
+          httpGet:
+            path: /metrics
+            port: 8080
+          initialDelaySeconds: 30
+          periodSeconds: 30
       serviceAccountName: service-account

--- a/tests/jupyter-notebook-controller-base_test.go
+++ b/tests/jupyter-notebook-controller-base_test.go
@@ -231,6 +231,12 @@ spec:
           - name: POD_LABELS
             value: $(POD_LABELS)
         imagePullPolicy: Always
+        livenessProbe:
+          httpGet:
+            path: /metrics
+            port: 8080
+          initialDelaySeconds: 30
+          periodSeconds: 30
       serviceAccountName: service-account
 `)
 	th.writeF("/manifests/jupyter/notebook-controller/base/service-account.yaml", `

--- a/tests/jupyter-notebook-controller-overlays-application_test.go
+++ b/tests/jupyter-notebook-controller-overlays-application_test.go
@@ -287,6 +287,12 @@ spec:
           - name: POD_LABELS
             value: $(POD_LABELS)
         imagePullPolicy: Always
+        livenessProbe:
+          httpGet:
+            path: /metrics
+            port: 8080
+          initialDelaySeconds: 30
+          periodSeconds: 30
       serviceAccountName: service-account
 `)
 	th.writeF("/manifests/jupyter/notebook-controller/base/service-account.yaml", `

--- a/tests/jupyter-notebook-controller-overlays-istio_test.go
+++ b/tests/jupyter-notebook-controller-overlays-istio_test.go
@@ -265,6 +265,12 @@ spec:
           - name: POD_LABELS
             value: $(POD_LABELS)
         imagePullPolicy: Always
+        livenessProbe:
+          httpGet:
+            path: /metrics
+            port: 8080
+          initialDelaySeconds: 30
+          periodSeconds: 30
       serviceAccountName: service-account
 `)
 	th.writeF("/manifests/jupyter/notebook-controller/base/service-account.yaml", `


### PR DESCRIPTION
**Which issue is resolved by this Pull Request:**
Related to https://github.com/kubeflow/kubeflow/issues/4060

**Description of your changes:**
Use default run time metrics path as livenessProbe target.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/manifests/837)
<!-- Reviewable:end -->
