### PR TITLE
Remove more cert-manager annotations kubeflow/kubeflow#4716

### DIFF
--- a/gcp/basic-auth-ingress/base/ingress.yaml
+++ b/gcp/basic-auth-ingress/base/ingress.yaml
@@ -4,7 +4,6 @@ metadata:
   annotations:
     ingress.kubernetes.io/ssl-redirect: "true"
     kubernetes.io/ingress.global-static-ip-name: $(ipName)
-    kubernetes.io/tls-acme: "true"
     networking.gke.io/managed-certificates: gke-certificate
   name: $(ingressName)
 spec:

--- a/gcp/iap-ingress/base/ingress.yaml
+++ b/gcp/iap-ingress/base/ingress.yaml
@@ -4,7 +4,6 @@ metadata:
   annotations:
     ingress.kubernetes.io/ssl-redirect: "true"
     kubernetes.io/ingress.global-static-ip-name: $(ipName)
-    kubernetes.io/tls-acme: "true"
     networking.gke.io/managed-certificates: gke-certificate
   name: envoy-ingress
 spec:

--- a/tests/gcp-basic-auth-ingress-base_test.go
+++ b/tests/gcp-basic-auth-ingress-base_test.go
@@ -226,7 +226,6 @@ metadata:
   annotations:
     ingress.kubernetes.io/ssl-redirect: "true"
     kubernetes.io/ingress.global-static-ip-name: $(ipName)
-    kubernetes.io/tls-acme: "true"
     networking.gke.io/managed-certificates: gke-certificate
   name: $(ingressName)
 spec:

--- a/tests/gcp-basic-auth-ingress-overlays-application_test.go
+++ b/tests/gcp-basic-auth-ingress-overlays-application_test.go
@@ -274,7 +274,6 @@ metadata:
   annotations:
     ingress.kubernetes.io/ssl-redirect: "true"
     kubernetes.io/ingress.global-static-ip-name: $(ipName)
-    kubernetes.io/tls-acme: "true"
     networking.gke.io/managed-certificates: gke-certificate
   name: $(ingressName)
 spec:

--- a/tests/gcp-basic-auth-ingress-overlays-certmanager_test.go
+++ b/tests/gcp-basic-auth-ingress-overlays-certmanager_test.go
@@ -295,7 +295,6 @@ metadata:
   annotations:
     ingress.kubernetes.io/ssl-redirect: "true"
     kubernetes.io/ingress.global-static-ip-name: $(ipName)
-    kubernetes.io/tls-acme: "true"
     networking.gke.io/managed-certificates: gke-certificate
   name: $(ingressName)
 spec:

--- a/tests/gcp-basic-auth-ingress-overlays-gcp-credentials_test.go
+++ b/tests/gcp-basic-auth-ingress-overlays-gcp-credentials_test.go
@@ -257,7 +257,6 @@ metadata:
   annotations:
     ingress.kubernetes.io/ssl-redirect: "true"
     kubernetes.io/ingress.global-static-ip-name: $(ipName)
-    kubernetes.io/tls-acme: "true"
     networking.gke.io/managed-certificates: gke-certificate
   name: $(ingressName)
 spec:

--- a/tests/gcp-basic-auth-ingress-overlays-managed-cert_test.go
+++ b/tests/gcp-basic-auth-ingress-overlays-managed-cert_test.go
@@ -245,7 +245,6 @@ metadata:
   annotations:
     ingress.kubernetes.io/ssl-redirect: "true"
     kubernetes.io/ingress.global-static-ip-name: $(ipName)
-    kubernetes.io/tls-acme: "true"
     networking.gke.io/managed-certificates: gke-certificate
   name: $(ingressName)
 spec:

--- a/tests/gcp-iap-ingress-base_test.go
+++ b/tests/gcp-iap-ingress-base_test.go
@@ -394,7 +394,6 @@ metadata:
   annotations:
     ingress.kubernetes.io/ssl-redirect: "true"
     kubernetes.io/ingress.global-static-ip-name: $(ipName)
-    kubernetes.io/tls-acme: "true"
     networking.gke.io/managed-certificates: gke-certificate
   name: envoy-ingress
 spec:

--- a/tests/gcp-iap-ingress-overlays-application_test.go
+++ b/tests/gcp-iap-ingress-overlays-application_test.go
@@ -442,7 +442,6 @@ metadata:
   annotations:
     ingress.kubernetes.io/ssl-redirect: "true"
     kubernetes.io/ingress.global-static-ip-name: $(ipName)
-    kubernetes.io/tls-acme: "true"
     networking.gke.io/managed-certificates: gke-certificate
   name: envoy-ingress
 spec:

--- a/tests/gcp-iap-ingress-overlays-certmanager_test.go
+++ b/tests/gcp-iap-ingress-overlays-certmanager_test.go
@@ -475,7 +475,6 @@ metadata:
   annotations:
     ingress.kubernetes.io/ssl-redirect: "true"
     kubernetes.io/ingress.global-static-ip-name: $(ipName)
-    kubernetes.io/tls-acme: "true"
     networking.gke.io/managed-certificates: gke-certificate
   name: envoy-ingress
 spec:

--- a/tests/gcp-iap-ingress-overlays-gcp-credentials_test.go
+++ b/tests/gcp-iap-ingress-overlays-gcp-credentials_test.go
@@ -449,7 +449,6 @@ metadata:
   annotations:
     ingress.kubernetes.io/ssl-redirect: "true"
     kubernetes.io/ingress.global-static-ip-name: $(ipName)
-    kubernetes.io/tls-acme: "true"
     networking.gke.io/managed-certificates: gke-certificate
   name: envoy-ingress
 spec:

--- a/tests/gcp-iap-ingress-overlays-managed-cert_test.go
+++ b/tests/gcp-iap-ingress-overlays-managed-cert_test.go
@@ -414,7 +414,6 @@ metadata:
   annotations:
     ingress.kubernetes.io/ssl-redirect: "true"
     kubernetes.io/ingress.global-static-ip-name: $(ipName)
-    kubernetes.io/tls-acme: "true"
     networking.gke.io/managed-certificates: gke-certificate
   name: envoy-ingress
 spec:


### PR DESCRIPTION
* It looks like the annotation `kubernetes.io/tls-acme` is also
  a cert-manager annotation.
  https://cert-manager.io/docs/usage/ingress/#supported-annotations

* We want to get rid of it since we use managed certificates;
  if we don't get rid of it; cert-manager will issue warnings about
  bad configuration.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/manifests/842)
<!-- Reviewable:end -->
