### PR TITLE
centraldashboard use /healthz for liveness probe kubeflow/kubeflow#4022

### DIFF
--- a/common/centraldashboard/base/deployment.yaml
+++ b/common/centraldashboard/base/deployment.yaml
@@ -21,7 +21,7 @@ spec:
         imagePullPolicy: IfNotPresent
         livenessProbe:
           httpGet:
-            path: /api/workgroup/env-info
+            path: /healthz
             port: 8082
           initialDelaySeconds: 30
           periodSeconds: 30

--- a/tests/common-centraldashboard-base_test.go
+++ b/tests/common-centraldashboard-base_test.go
@@ -73,7 +73,7 @@ spec:
         imagePullPolicy: IfNotPresent
         livenessProbe:
           httpGet:
-            path: /api/workgroup/env-info
+            path: /healthz
             port: 8082
           initialDelaySeconds: 30
           periodSeconds: 30

--- a/tests/common-centraldashboard-overlays-application_test.go
+++ b/tests/common-centraldashboard-overlays-application_test.go
@@ -144,7 +144,7 @@ spec:
         imagePullPolicy: IfNotPresent
         livenessProbe:
           httpGet:
-            path: /api/workgroup/env-info
+            path: /healthz
             port: 8082
           initialDelaySeconds: 30
           periodSeconds: 30

--- a/tests/common-centraldashboard-overlays-istio_test.go
+++ b/tests/common-centraldashboard-overlays-istio_test.go
@@ -111,7 +111,7 @@ spec:
         imagePullPolicy: IfNotPresent
         livenessProbe:
           httpGet:
-            path: /api/workgroup/env-info
+            path: /healthz
             port: 8082
           initialDelaySeconds: 30
           periodSeconds: 30


### PR DESCRIPTION
* centraldashboard should use the new /healthz endpoint for liveness.
* The current endpoint depends on other services like the profile controller
  so the liveness probe ends up being a liveness check for those other
  services.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/manifests/846)
<!-- Reviewable:end -->
