### PR TITLE
Set Pipelines Application versiont to 0.2.0; kubeflow/manifests#796

### DIFF
--- a/hack/update-instance-labels.sh
+++ b/hack/update-instance-labels.sh
@@ -1,4 +1,8 @@
 #!/bin/bash
+#
+# TODO(jlewi): This script is outdated. You probably want to use
+# kubeflow/testing/py/kubeflow/testing/tools/applications.py
+# see https://github.com/kubeflow/testing/pull/596
 
 # Replace 'app.kubernetes.io/version: v0.6.x' with 'app.kubernetes.io/version: v0.7.0'
 grep -rl --exclude-dir={kfdef,gatekeeper,gcp/deployment_manager_configs,aws/infra_configs,docs,hack,plugins} 'app.kubernetes.io/version: v0.6' ./ \

--- a/pipeline/api-service/overlays/application/application.yaml
+++ b/pipeline/api-service/overlays/application/application.yaml
@@ -3,29 +3,29 @@ kind: Application
 metadata:
   name: api-service
 spec:
-  selector:
-    matchLabels:
-      app.kubernetes.io/name: api-service
-      app.kubernetes.io/instance: api-service-0.1.31
-      app.kubernetes.io/managed-by: kfctl
-      app.kubernetes.io/component: api-service
-      app.kubernetes.io/part-of: kubeflow
-      app.kubernetes.io/version: 0.1.31
+  addOwnerRef: true
   componentKinds:
   - group: core
     kind: ConfigMap
   - group: apps
     kind: Deployment
   descriptor:
-    type: api-service
-    version: v1beta1
-    description: ""
-    maintainers: []
-    owners: []
+    description: ''
     keywords:
-     - api-service
-     - kubeflow
+    - api-service
+    - kubeflow
     links:
     - description: About
-      url: ""
-  addOwnerRef: true
+      url: ''
+    maintainers: []
+    owners: []
+    type: api-service
+    version: v1beta1
+  selector:
+    matchLabels:
+      app.kubernetes.io/component: api-service
+      app.kubernetes.io/instance: api-service-0.2.0
+      app.kubernetes.io/managed-by: kfctl
+      app.kubernetes.io/name: api-service
+      app.kubernetes.io/part-of: kubeflow
+      app.kubernetes.io/version: 0.2.0

--- a/pipeline/api-service/overlays/application/kustomization.yaml
+++ b/pipeline/api-service/overlays/application/kustomization.yaml
@@ -1,13 +1,13 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
-kind: Kustomization
 bases:
 - ../../base
+commonLabels:
+  app.kubernetes.io/component: api-service
+  app.kubernetes.io/instance: api-service-0.2.0
+  app.kubernetes.io/managed-by: kfctl
+  app.kubernetes.io/name: api-service
+  app.kubernetes.io/part-of: kubeflow
+  app.kubernetes.io/version: 0.2.0
+kind: Kustomization
 resources:
 - application.yaml
-commonLabels:
-  app.kubernetes.io/name: api-service
-  app.kubernetes.io/instance: api-service-0.1.31
-  app.kubernetes.io/managed-by: kfctl
-  app.kubernetes.io/component: api-service
-  app.kubernetes.io/part-of: kubeflow
-  app.kubernetes.io/version: 0.1.31

--- a/pipeline/minio/overlays/application/application.yaml
+++ b/pipeline/minio/overlays/application/application.yaml
@@ -3,29 +3,29 @@ kind: Application
 metadata:
   name: minio
 spec:
-  selector:
-    matchLabels:
-      app.kubernetes.io/name: minio
-      app.kubernetes.io/instance: minio-0.1.31
-      app.kubernetes.io/managed-by: kfctl
-      app.kubernetes.io/component: minio
-      app.kubernetes.io/part-of: kubeflow
-      app.kubernetes.io/version: 0.1.31
+  addOwnerRef: true
   componentKinds:
   - group: core
     kind: ConfigMap
   - group: apps
     kind: Deployment
   descriptor:
-    type: minio
-    version: v1beta1
-    description: ""
-    maintainers: []
-    owners: []
+    description: ''
     keywords:
-     - minio
-     - kubeflow
+    - minio
+    - kubeflow
     links:
     - description: About
-      url: ""
-  addOwnerRef: true
+      url: ''
+    maintainers: []
+    owners: []
+    type: minio
+    version: v1beta1
+  selector:
+    matchLabels:
+      app.kubernetes.io/component: minio
+      app.kubernetes.io/instance: minio-0.2.0
+      app.kubernetes.io/managed-by: kfctl
+      app.kubernetes.io/name: minio
+      app.kubernetes.io/part-of: kubeflow
+      app.kubernetes.io/version: 0.2.0

--- a/pipeline/minio/overlays/application/kustomization.yaml
+++ b/pipeline/minio/overlays/application/kustomization.yaml
@@ -1,13 +1,13 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
-kind: Kustomization
 bases:
 - ../../base
+commonLabels:
+  app.kubernetes.io/component: minio
+  app.kubernetes.io/instance: minio-0.2.0
+  app.kubernetes.io/managed-by: kfctl
+  app.kubernetes.io/name: minio
+  app.kubernetes.io/part-of: kubeflow
+  app.kubernetes.io/version: 0.2.0
+kind: Kustomization
 resources:
 - application.yaml
-commonLabels:
-  app.kubernetes.io/name: minio
-  app.kubernetes.io/instance: minio-0.1.31
-  app.kubernetes.io/managed-by: kfctl
-  app.kubernetes.io/component: minio
-  app.kubernetes.io/part-of: kubeflow
-  app.kubernetes.io/version: 0.1.31

--- a/pipeline/mysql/overlays/application/application.yaml
+++ b/pipeline/mysql/overlays/application/application.yaml
@@ -3,29 +3,29 @@ kind: Application
 metadata:
   name: mysql
 spec:
-  selector:
-    matchLabels:
-      app.kubernetes.io/name: mysql
-      app.kubernetes.io/instance: mysql-0.1.31
-      app.kubernetes.io/managed-by: kfctl
-      app.kubernetes.io/component: mysql
-      app.kubernetes.io/part-of: kubeflow
-      app.kubernetes.io/version: 0.1.31
+  addOwnerRef: true
   componentKinds:
   - group: core
     kind: ConfigMap
   - group: apps
     kind: Deployment
   descriptor:
-    type: mysql
-    version: v1beta1
-    description: ""
-    maintainers: []
-    owners: []
+    description: ''
     keywords:
-     - mysql
-     - kubeflow
+    - mysql
+    - kubeflow
     links:
     - description: About
-      url: ""
-  addOwnerRef: true
+      url: ''
+    maintainers: []
+    owners: []
+    type: mysql
+    version: v1beta1
+  selector:
+    matchLabels:
+      app.kubernetes.io/component: mysql
+      app.kubernetes.io/instance: mysql-0.2.0
+      app.kubernetes.io/managed-by: kfctl
+      app.kubernetes.io/name: mysql
+      app.kubernetes.io/part-of: kubeflow
+      app.kubernetes.io/version: 0.2.0

--- a/pipeline/mysql/overlays/application/kustomization.yaml
+++ b/pipeline/mysql/overlays/application/kustomization.yaml
@@ -1,13 +1,13 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
-kind: Kustomization
 bases:
 - ../../base
+commonLabels:
+  app.kubernetes.io/component: mysql
+  app.kubernetes.io/instance: mysql-0.2.0
+  app.kubernetes.io/managed-by: kfctl
+  app.kubernetes.io/name: mysql
+  app.kubernetes.io/part-of: kubeflow
+  app.kubernetes.io/version: 0.2.0
+kind: Kustomization
 resources:
 - application.yaml
-commonLabels:
-  app.kubernetes.io/name: mysql
-  app.kubernetes.io/instance: mysql-0.1.31
-  app.kubernetes.io/managed-by: kfctl
-  app.kubernetes.io/component: mysql
-  app.kubernetes.io/part-of: kubeflow
-  app.kubernetes.io/version: 0.1.31

--- a/pipeline/persistent-agent/overlays/application/application.yaml
+++ b/pipeline/persistent-agent/overlays/application/application.yaml
@@ -3,29 +3,29 @@ kind: Application
 metadata:
   name: persistent-agent
 spec:
-  selector:
-    matchLabels:
-      app.kubernetes.io/name: persistent-agent
-      app.kubernetes.io/instance: persistent-agent-0.1.31
-      app.kubernetes.io/managed-by: kfctl
-      app.kubernetes.io/component: persistent-agent
-      app.kubernetes.io/part-of: kubeflow
-      app.kubernetes.io/version: 0.1.31
+  addOwnerRef: true
   componentKinds:
   - group: core
     kind: ConfigMap
   - group: apps
     kind: Deployment
   descriptor:
-    type: persistent-agent
-    version: v1beta1
-    description: ""
-    maintainers: []
-    owners: []
+    description: ''
     keywords:
-     - persistent-agent
-     - kubeflow
+    - persistent-agent
+    - kubeflow
     links:
     - description: About
-      url: ""
-  addOwnerRef: true
+      url: ''
+    maintainers: []
+    owners: []
+    type: persistent-agent
+    version: v1beta1
+  selector:
+    matchLabels:
+      app.kubernetes.io/component: persistent-agent
+      app.kubernetes.io/instance: persistent-agent-0.2.0
+      app.kubernetes.io/managed-by: kfctl
+      app.kubernetes.io/name: persistent-agent
+      app.kubernetes.io/part-of: kubeflow
+      app.kubernetes.io/version: 0.2.0

--- a/pipeline/persistent-agent/overlays/application/kustomization.yaml
+++ b/pipeline/persistent-agent/overlays/application/kustomization.yaml
@@ -1,13 +1,13 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
-kind: Kustomization
 bases:
 - ../../base
+commonLabels:
+  app.kubernetes.io/component: persistent-agent
+  app.kubernetes.io/instance: persistent-agent-0.2.0
+  app.kubernetes.io/managed-by: kfctl
+  app.kubernetes.io/name: persistent-agent
+  app.kubernetes.io/part-of: kubeflow
+  app.kubernetes.io/version: 0.2.0
+kind: Kustomization
 resources:
 - application.yaml
-commonLabels:
-  app.kubernetes.io/name: persistent-agent
-  app.kubernetes.io/instance: persistent-agent-0.1.31
-  app.kubernetes.io/managed-by: kfctl
-  app.kubernetes.io/component: persistent-agent
-  app.kubernetes.io/part-of: kubeflow
-  app.kubernetes.io/version: 0.1.31

--- a/pipeline/pipeline-visualization-service/overlays/application/application.yaml
+++ b/pipeline/pipeline-visualization-service/overlays/application/application.yaml
@@ -3,29 +3,29 @@ kind: Application
 metadata:
   name: pipeline-visualization-service
 spec:
-  selector:
-    matchLabels:
-      app.kubernetes.io/name: pipeline-visualization-service
-      app.kubernetes.io/instance: pipeline-visualization-service-0.1.31
-      app.kubernetes.io/managed-by: kfctl
-      app.kubernetes.io/component: pipeline-visualization-service
-      app.kubernetes.io/part-of: kubeflow
-      app.kubernetes.io/version: 0.1.31
+  addOwnerRef: true
   componentKinds:
   - group: core
     kind: ConfigMap
   - group: apps
     kind: Deployment
   descriptor:
-    type: pipeline-visualization-service
-    version: v1beta1
-    description: ""
-    maintainers: []
-    owners: []
+    description: ''
     keywords:
-     - pipeline-visualization-service
-     - kubeflow
+    - pipeline-visualization-service
+    - kubeflow
     links:
     - description: About
-      url: ""
-  addOwnerRef: true
+      url: ''
+    maintainers: []
+    owners: []
+    type: pipeline-visualization-service
+    version: v1beta1
+  selector:
+    matchLabels:
+      app.kubernetes.io/component: pipeline-visualization-service
+      app.kubernetes.io/instance: pipeline-visualization-service-0.2.0
+      app.kubernetes.io/managed-by: kfctl
+      app.kubernetes.io/name: pipeline-visualization-service
+      app.kubernetes.io/part-of: kubeflow
+      app.kubernetes.io/version: 0.2.0

--- a/pipeline/pipeline-visualization-service/overlays/application/kustomization.yaml
+++ b/pipeline/pipeline-visualization-service/overlays/application/kustomization.yaml
@@ -1,13 +1,13 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
-kind: Kustomization
 bases:
 - ../../base
+commonLabels:
+  app.kubernetes.io/component: pipeline-visualization-service
+  app.kubernetes.io/instance: pipeline-visualization-service-0.2.0
+  app.kubernetes.io/managed-by: kfctl
+  app.kubernetes.io/name: pipeline-visualization-service
+  app.kubernetes.io/part-of: kubeflow
+  app.kubernetes.io/version: 0.2.0
+kind: Kustomization
 resources:
 - application.yaml
-commonLabels:
-  app.kubernetes.io/name: pipeline-visualization-service
-  app.kubernetes.io/instance: pipeline-visualization-service-0.1.31
-  app.kubernetes.io/managed-by: kfctl
-  app.kubernetes.io/component: pipeline-visualization-service
-  app.kubernetes.io/part-of: kubeflow
-  app.kubernetes.io/version: 0.1.31

--- a/pipeline/pipelines-runner/overlays/application/application.yaml
+++ b/pipeline/pipelines-runner/overlays/application/application.yaml
@@ -3,29 +3,29 @@ kind: Application
 metadata:
   name: pipelines-runner
 spec:
-  selector:
-    matchLabels:
-      app.kubernetes.io/name: pipelines-runner
-      app.kubernetes.io/instance: pipelines-runner-0.1.31
-      app.kubernetes.io/managed-by: kfctl
-      app.kubernetes.io/component: pipelines-runner
-      app.kubernetes.io/part-of: kubeflow
-      app.kubernetes.io/version: 0.1.31
+  addOwnerRef: true
   componentKinds:
   - group: core
     kind: ConfigMap
   - group: apps
     kind: Deployment
   descriptor:
-    type: pipelines-runner
-    version: v1beta1
-    description: ""
-    maintainers: []
-    owners: []
+    description: ''
     keywords:
-     - pipelines-runner
-     - kubeflow
+    - pipelines-runner
+    - kubeflow
     links:
     - description: About
-      url: ""
-  addOwnerRef: true
+      url: ''
+    maintainers: []
+    owners: []
+    type: pipelines-runner
+    version: v1beta1
+  selector:
+    matchLabels:
+      app.kubernetes.io/component: pipelines-runner
+      app.kubernetes.io/instance: pipelines-runner-0.2.0
+      app.kubernetes.io/managed-by: kfctl
+      app.kubernetes.io/name: pipelines-runner
+      app.kubernetes.io/part-of: kubeflow
+      app.kubernetes.io/version: 0.2.0

--- a/pipeline/pipelines-runner/overlays/application/kustomization.yaml
+++ b/pipeline/pipelines-runner/overlays/application/kustomization.yaml
@@ -1,13 +1,13 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
-kind: Kustomization
 bases:
 - ../../base
+commonLabels:
+  app.kubernetes.io/component: pipelines-runner
+  app.kubernetes.io/instance: pipelines-runner-0.2.0
+  app.kubernetes.io/managed-by: kfctl
+  app.kubernetes.io/name: pipelines-runner
+  app.kubernetes.io/part-of: kubeflow
+  app.kubernetes.io/version: 0.2.0
+kind: Kustomization
 resources:
 - application.yaml
-commonLabels:
-  app.kubernetes.io/name: pipelines-runner
-  app.kubernetes.io/instance: pipelines-runner-0.1.31
-  app.kubernetes.io/managed-by: kfctl
-  app.kubernetes.io/component: pipelines-runner
-  app.kubernetes.io/part-of: kubeflow
-  app.kubernetes.io/version: 0.1.31

--- a/pipeline/pipelines-ui/overlays/application/application.yaml
+++ b/pipeline/pipelines-ui/overlays/application/application.yaml
@@ -3,29 +3,29 @@ kind: Application
 metadata:
   name: pipelines-ui
 spec:
-  selector:
-    matchLabels:
-      app.kubernetes.io/name: pipelines-ui
-      app.kubernetes.io/instance: pipelines-ui-0.1.31
-      app.kubernetes.io/managed-by: kfctl
-      app.kubernetes.io/component: pipelines-ui
-      app.kubernetes.io/part-of: kubeflow
-      app.kubernetes.io/version: 0.1.31
+  addOwnerRef: true
   componentKinds:
   - group: core
     kind: ConfigMap
   - group: apps
     kind: Deployment
   descriptor:
-    type: pipelines-ui
-    version: v1beta1
-    description: ""
-    maintainers: []
-    owners: []
+    description: ''
     keywords:
-     - pipelines-ui
-     - kubeflow
+    - pipelines-ui
+    - kubeflow
     links:
     - description: About
-      url: ""
-  addOwnerRef: true
+      url: ''
+    maintainers: []
+    owners: []
+    type: pipelines-ui
+    version: v1beta1
+  selector:
+    matchLabels:
+      app.kubernetes.io/component: pipelines-ui
+      app.kubernetes.io/instance: pipelines-ui-0.2.0
+      app.kubernetes.io/managed-by: kfctl
+      app.kubernetes.io/name: pipelines-ui
+      app.kubernetes.io/part-of: kubeflow
+      app.kubernetes.io/version: 0.2.0

--- a/pipeline/pipelines-ui/overlays/application/kustomization.yaml
+++ b/pipeline/pipelines-ui/overlays/application/kustomization.yaml
@@ -1,13 +1,13 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
-kind: Kustomization
 bases:
 - ../../base
+commonLabels:
+  app.kubernetes.io/component: pipelines-ui
+  app.kubernetes.io/instance: pipelines-ui-0.2.0
+  app.kubernetes.io/managed-by: kfctl
+  app.kubernetes.io/name: pipelines-ui
+  app.kubernetes.io/part-of: kubeflow
+  app.kubernetes.io/version: 0.2.0
+kind: Kustomization
 resources:
 - application.yaml
-commonLabels:
-  app.kubernetes.io/name: pipelines-ui
-  app.kubernetes.io/instance: pipelines-ui-0.1.31
-  app.kubernetes.io/managed-by: kfctl
-  app.kubernetes.io/component: pipelines-ui
-  app.kubernetes.io/part-of: kubeflow
-  app.kubernetes.io/version: 0.1.31

--- a/pipeline/pipelines-viewer/overlays/application/application.yaml
+++ b/pipeline/pipelines-viewer/overlays/application/application.yaml
@@ -3,29 +3,29 @@ kind: Application
 metadata:
   name: pipelines-viewer
 spec:
-  selector:
-    matchLabels:
-      app.kubernetes.io/name: pipelines-viewer
-      app.kubernetes.io/instance: pipelines-viewer-0.1.31
-      app.kubernetes.io/managed-by: kfctl
-      app.kubernetes.io/component: pipelines-viewer
-      app.kubernetes.io/part-of: kubeflow
-      app.kubernetes.io/version: 0.1.31
+  addOwnerRef: true
   componentKinds:
   - group: core
     kind: ConfigMap
   - group: apps
     kind: Deployment
   descriptor:
-    type: pipelines-viewer
-    version: v1beta1
-    description: ""
-    maintainers: []
-    owners: []
+    description: ''
     keywords:
-     - pipelines-viewer
-     - kubeflow
+    - pipelines-viewer
+    - kubeflow
     links:
     - description: About
-      url: ""
-  addOwnerRef: true
+      url: ''
+    maintainers: []
+    owners: []
+    type: pipelines-viewer
+    version: v1beta1
+  selector:
+    matchLabels:
+      app.kubernetes.io/component: pipelines-viewer
+      app.kubernetes.io/instance: pipelines-viewer-0.2.0
+      app.kubernetes.io/managed-by: kfctl
+      app.kubernetes.io/name: pipelines-viewer
+      app.kubernetes.io/part-of: kubeflow
+      app.kubernetes.io/version: 0.2.0

--- a/pipeline/pipelines-viewer/overlays/application/kustomization.yaml
+++ b/pipeline/pipelines-viewer/overlays/application/kustomization.yaml
@@ -1,13 +1,13 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
-kind: Kustomization
 bases:
 - ../../base
+commonLabels:
+  app.kubernetes.io/component: pipelines-viewer
+  app.kubernetes.io/instance: pipelines-viewer-0.2.0
+  app.kubernetes.io/managed-by: kfctl
+  app.kubernetes.io/name: pipelines-viewer
+  app.kubernetes.io/part-of: kubeflow
+  app.kubernetes.io/version: 0.2.0
+kind: Kustomization
 resources:
 - application.yaml
-commonLabels:
-  app.kubernetes.io/name: pipelines-viewer
-  app.kubernetes.io/instance: pipelines-viewer-0.1.31
-  app.kubernetes.io/managed-by: kfctl
-  app.kubernetes.io/component: pipelines-viewer
-  app.kubernetes.io/part-of: kubeflow
-  app.kubernetes.io/version: 0.1.31

--- a/pipeline/scheduledworkflow/overlays/application/application.yaml
+++ b/pipeline/scheduledworkflow/overlays/application/application.yaml
@@ -3,29 +3,29 @@ kind: Application
 metadata:
   name: scheduledworkflow
 spec:
-  selector:
-    matchLabels:
-      app.kubernetes.io/name: scheduledworkflow
-      app.kubernetes.io/instance: scheduledworkflow-0.1.31
-      app.kubernetes.io/managed-by: kfctl
-      app.kubernetes.io/component: scheduledworkflow
-      app.kubernetes.io/part-of: kubeflow
-      app.kubernetes.io/version: 0.1.31
+  addOwnerRef: true
   componentKinds:
   - group: core
     kind: ConfigMap
   - group: apps
     kind: Deployment
   descriptor:
-    type: scheduledworkflow
-    version: v1beta1
-    description: ""
-    maintainers: []
-    owners: []
+    description: ''
     keywords:
-     - scheduledworkflow
-     - kubeflow
+    - scheduledworkflow
+    - kubeflow
     links:
     - description: About
-      url: ""
-  addOwnerRef: true
+      url: ''
+    maintainers: []
+    owners: []
+    type: scheduledworkflow
+    version: v1beta1
+  selector:
+    matchLabels:
+      app.kubernetes.io/component: scheduledworkflow
+      app.kubernetes.io/instance: scheduledworkflow-0.2.0
+      app.kubernetes.io/managed-by: kfctl
+      app.kubernetes.io/name: scheduledworkflow
+      app.kubernetes.io/part-of: kubeflow
+      app.kubernetes.io/version: 0.2.0

--- a/pipeline/scheduledworkflow/overlays/application/kustomization.yaml
+++ b/pipeline/scheduledworkflow/overlays/application/kustomization.yaml
@@ -1,13 +1,13 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
-kind: Kustomization
 bases:
 - ../../base
+commonLabels:
+  app.kubernetes.io/component: scheduledworkflow
+  app.kubernetes.io/instance: scheduledworkflow-0.2.0
+  app.kubernetes.io/managed-by: kfctl
+  app.kubernetes.io/name: scheduledworkflow
+  app.kubernetes.io/part-of: kubeflow
+  app.kubernetes.io/version: 0.2.0
+kind: Kustomization
 resources:
 - application.yaml
-commonLabels:
-  app.kubernetes.io/name: scheduledworkflow
-  app.kubernetes.io/instance: scheduledworkflow-0.1.31
-  app.kubernetes.io/managed-by: kfctl
-  app.kubernetes.io/component: scheduledworkflow
-  app.kubernetes.io/part-of: kubeflow
-  app.kubernetes.io/version: 0.1.31

--- a/tests/pipeline-api-service-overlays-application_test.go
+++ b/tests/pipeline-api-service-overlays-application_test.go
@@ -20,47 +20,47 @@ kind: Application
 metadata:
   name: api-service
 spec:
-  selector:
-    matchLabels:
-      app.kubernetes.io/name: api-service
-      app.kubernetes.io/instance: api-service-0.1.31
-      app.kubernetes.io/managed-by: kfctl
-      app.kubernetes.io/component: api-service
-      app.kubernetes.io/part-of: kubeflow
-      app.kubernetes.io/version: 0.1.31
+  addOwnerRef: true
   componentKinds:
   - group: core
     kind: ConfigMap
   - group: apps
     kind: Deployment
   descriptor:
-    type: api-service
-    version: v1beta1
-    description: ""
-    maintainers: []
-    owners: []
+    description: ''
     keywords:
-     - api-service
-     - kubeflow
+    - api-service
+    - kubeflow
     links:
     - description: About
-      url: ""
-  addOwnerRef: true
+      url: ''
+    maintainers: []
+    owners: []
+    type: api-service
+    version: v1beta1
+  selector:
+    matchLabels:
+      app.kubernetes.io/component: api-service
+      app.kubernetes.io/instance: api-service-0.2.0
+      app.kubernetes.io/managed-by: kfctl
+      app.kubernetes.io/name: api-service
+      app.kubernetes.io/part-of: kubeflow
+      app.kubernetes.io/version: 0.2.0
 `)
 	th.writeK("/manifests/pipeline/api-service/overlays/application", `
 apiVersion: kustomize.config.k8s.io/v1beta1
-kind: Kustomization
 bases:
 - ../../base
+commonLabels:
+  app.kubernetes.io/component: api-service
+  app.kubernetes.io/instance: api-service-0.2.0
+  app.kubernetes.io/managed-by: kfctl
+  app.kubernetes.io/name: api-service
+  app.kubernetes.io/part-of: kubeflow
+  app.kubernetes.io/version: 0.2.0
+kind: Kustomization
 resources:
 - application.yaml
-commonLabels:
-  app.kubernetes.io/name: api-service
-  app.kubernetes.io/instance: api-service-0.1.31
-  app.kubernetes.io/managed-by: kfctl
-  app.kubernetes.io/component: api-service
-  app.kubernetes.io/part-of: kubeflow
-  app.kubernetes.io/version: 0.1.31
 `)
 	th.writeF("/manifests/pipeline/api-service/base/config-map.yaml", `
 # The configuration for the ML pipelines APIServer

--- a/tests/pipeline-minio-overlays-application_test.go
+++ b/tests/pipeline-minio-overlays-application_test.go
@@ -20,47 +20,47 @@ kind: Application
 metadata:
   name: minio
 spec:
-  selector:
-    matchLabels:
-      app.kubernetes.io/name: minio
-      app.kubernetes.io/instance: minio-0.1.31
-      app.kubernetes.io/managed-by: kfctl
-      app.kubernetes.io/component: minio
-      app.kubernetes.io/part-of: kubeflow
-      app.kubernetes.io/version: 0.1.31
+  addOwnerRef: true
   componentKinds:
   - group: core
     kind: ConfigMap
   - group: apps
     kind: Deployment
   descriptor:
-    type: minio
-    version: v1beta1
-    description: ""
-    maintainers: []
-    owners: []
+    description: ''
     keywords:
-     - minio
-     - kubeflow
+    - minio
+    - kubeflow
     links:
     - description: About
-      url: ""
-  addOwnerRef: true
+      url: ''
+    maintainers: []
+    owners: []
+    type: minio
+    version: v1beta1
+  selector:
+    matchLabels:
+      app.kubernetes.io/component: minio
+      app.kubernetes.io/instance: minio-0.2.0
+      app.kubernetes.io/managed-by: kfctl
+      app.kubernetes.io/name: minio
+      app.kubernetes.io/part-of: kubeflow
+      app.kubernetes.io/version: 0.2.0
 `)
 	th.writeK("/manifests/pipeline/minio/overlays/application", `
 apiVersion: kustomize.config.k8s.io/v1beta1
-kind: Kustomization
 bases:
 - ../../base
+commonLabels:
+  app.kubernetes.io/component: minio
+  app.kubernetes.io/instance: minio-0.2.0
+  app.kubernetes.io/managed-by: kfctl
+  app.kubernetes.io/name: minio
+  app.kubernetes.io/part-of: kubeflow
+  app.kubernetes.io/version: 0.2.0
+kind: Kustomization
 resources:
 - application.yaml
-commonLabels:
-  app.kubernetes.io/name: minio
-  app.kubernetes.io/instance: minio-0.1.31
-  app.kubernetes.io/managed-by: kfctl
-  app.kubernetes.io/component: minio
-  app.kubernetes.io/part-of: kubeflow
-  app.kubernetes.io/version: 0.1.31
 `)
 	th.writeF("/manifests/pipeline/minio/base/deployment.yaml", `
 apiVersion: apps/v1

--- a/tests/pipeline-mysql-overlays-application_test.go
+++ b/tests/pipeline-mysql-overlays-application_test.go
@@ -20,47 +20,47 @@ kind: Application
 metadata:
   name: mysql
 spec:
-  selector:
-    matchLabels:
-      app.kubernetes.io/name: mysql
-      app.kubernetes.io/instance: mysql-0.1.31
-      app.kubernetes.io/managed-by: kfctl
-      app.kubernetes.io/component: mysql
-      app.kubernetes.io/part-of: kubeflow
-      app.kubernetes.io/version: 0.1.31
+  addOwnerRef: true
   componentKinds:
   - group: core
     kind: ConfigMap
   - group: apps
     kind: Deployment
   descriptor:
-    type: mysql
-    version: v1beta1
-    description: ""
-    maintainers: []
-    owners: []
+    description: ''
     keywords:
-     - mysql
-     - kubeflow
+    - mysql
+    - kubeflow
     links:
     - description: About
-      url: ""
-  addOwnerRef: true
+      url: ''
+    maintainers: []
+    owners: []
+    type: mysql
+    version: v1beta1
+  selector:
+    matchLabels:
+      app.kubernetes.io/component: mysql
+      app.kubernetes.io/instance: mysql-0.2.0
+      app.kubernetes.io/managed-by: kfctl
+      app.kubernetes.io/name: mysql
+      app.kubernetes.io/part-of: kubeflow
+      app.kubernetes.io/version: 0.2.0
 `)
 	th.writeK("/manifests/pipeline/mysql/overlays/application", `
 apiVersion: kustomize.config.k8s.io/v1beta1
-kind: Kustomization
 bases:
 - ../../base
+commonLabels:
+  app.kubernetes.io/component: mysql
+  app.kubernetes.io/instance: mysql-0.2.0
+  app.kubernetes.io/managed-by: kfctl
+  app.kubernetes.io/name: mysql
+  app.kubernetes.io/part-of: kubeflow
+  app.kubernetes.io/version: 0.2.0
+kind: Kustomization
 resources:
 - application.yaml
-commonLabels:
-  app.kubernetes.io/name: mysql
-  app.kubernetes.io/instance: mysql-0.1.31
-  app.kubernetes.io/managed-by: kfctl
-  app.kubernetes.io/component: mysql
-  app.kubernetes.io/part-of: kubeflow
-  app.kubernetes.io/version: 0.1.31
 `)
 	th.writeF("/manifests/pipeline/mysql/base/deployment.yaml", `
 apiVersion: apps/v1

--- a/tests/pipeline-persistent-agent-overlays-application_test.go
+++ b/tests/pipeline-persistent-agent-overlays-application_test.go
@@ -20,47 +20,47 @@ kind: Application
 metadata:
   name: persistent-agent
 spec:
-  selector:
-    matchLabels:
-      app.kubernetes.io/name: persistent-agent
-      app.kubernetes.io/instance: persistent-agent-0.1.31
-      app.kubernetes.io/managed-by: kfctl
-      app.kubernetes.io/component: persistent-agent
-      app.kubernetes.io/part-of: kubeflow
-      app.kubernetes.io/version: 0.1.31
+  addOwnerRef: true
   componentKinds:
   - group: core
     kind: ConfigMap
   - group: apps
     kind: Deployment
   descriptor:
-    type: persistent-agent
-    version: v1beta1
-    description: ""
-    maintainers: []
-    owners: []
+    description: ''
     keywords:
-     - persistent-agent
-     - kubeflow
+    - persistent-agent
+    - kubeflow
     links:
     - description: About
-      url: ""
-  addOwnerRef: true
+      url: ''
+    maintainers: []
+    owners: []
+    type: persistent-agent
+    version: v1beta1
+  selector:
+    matchLabels:
+      app.kubernetes.io/component: persistent-agent
+      app.kubernetes.io/instance: persistent-agent-0.2.0
+      app.kubernetes.io/managed-by: kfctl
+      app.kubernetes.io/name: persistent-agent
+      app.kubernetes.io/part-of: kubeflow
+      app.kubernetes.io/version: 0.2.0
 `)
 	th.writeK("/manifests/pipeline/persistent-agent/overlays/application", `
 apiVersion: kustomize.config.k8s.io/v1beta1
-kind: Kustomization
 bases:
 - ../../base
+commonLabels:
+  app.kubernetes.io/component: persistent-agent
+  app.kubernetes.io/instance: persistent-agent-0.2.0
+  app.kubernetes.io/managed-by: kfctl
+  app.kubernetes.io/name: persistent-agent
+  app.kubernetes.io/part-of: kubeflow
+  app.kubernetes.io/version: 0.2.0
+kind: Kustomization
 resources:
 - application.yaml
-commonLabels:
-  app.kubernetes.io/name: persistent-agent
-  app.kubernetes.io/instance: persistent-agent-0.1.31
-  app.kubernetes.io/managed-by: kfctl
-  app.kubernetes.io/component: persistent-agent
-  app.kubernetes.io/part-of: kubeflow
-  app.kubernetes.io/version: 0.1.31
 `)
 	th.writeF("/manifests/pipeline/persistent-agent/base/clusterrole-binding.yaml", `
 apiVersion: rbac.authorization.k8s.io/v1beta1

--- a/tests/pipeline-pipeline-visualization-service-overlays-application_test.go
+++ b/tests/pipeline-pipeline-visualization-service-overlays-application_test.go
@@ -20,47 +20,47 @@ kind: Application
 metadata:
   name: pipeline-visualization-service
 spec:
-  selector:
-    matchLabels:
-      app.kubernetes.io/name: pipeline-visualization-service
-      app.kubernetes.io/instance: pipeline-visualization-service-0.1.31
-      app.kubernetes.io/managed-by: kfctl
-      app.kubernetes.io/component: pipeline-visualization-service
-      app.kubernetes.io/part-of: kubeflow
-      app.kubernetes.io/version: 0.1.31
+  addOwnerRef: true
   componentKinds:
   - group: core
     kind: ConfigMap
   - group: apps
     kind: Deployment
   descriptor:
-    type: pipeline-visualization-service
-    version: v1beta1
-    description: ""
-    maintainers: []
-    owners: []
+    description: ''
     keywords:
-     - pipeline-visualization-service
-     - kubeflow
+    - pipeline-visualization-service
+    - kubeflow
     links:
     - description: About
-      url: ""
-  addOwnerRef: true
+      url: ''
+    maintainers: []
+    owners: []
+    type: pipeline-visualization-service
+    version: v1beta1
+  selector:
+    matchLabels:
+      app.kubernetes.io/component: pipeline-visualization-service
+      app.kubernetes.io/instance: pipeline-visualization-service-0.2.0
+      app.kubernetes.io/managed-by: kfctl
+      app.kubernetes.io/name: pipeline-visualization-service
+      app.kubernetes.io/part-of: kubeflow
+      app.kubernetes.io/version: 0.2.0
 `)
 	th.writeK("/manifests/pipeline/pipeline-visualization-service/overlays/application", `
 apiVersion: kustomize.config.k8s.io/v1beta1
-kind: Kustomization
 bases:
 - ../../base
+commonLabels:
+  app.kubernetes.io/component: pipeline-visualization-service
+  app.kubernetes.io/instance: pipeline-visualization-service-0.2.0
+  app.kubernetes.io/managed-by: kfctl
+  app.kubernetes.io/name: pipeline-visualization-service
+  app.kubernetes.io/part-of: kubeflow
+  app.kubernetes.io/version: 0.2.0
+kind: Kustomization
 resources:
 - application.yaml
-commonLabels:
-  app.kubernetes.io/name: pipeline-visualization-service
-  app.kubernetes.io/instance: pipeline-visualization-service-0.1.31
-  app.kubernetes.io/managed-by: kfctl
-  app.kubernetes.io/component: pipeline-visualization-service
-  app.kubernetes.io/part-of: kubeflow
-  app.kubernetes.io/version: 0.1.31
 `)
 	th.writeF("/manifests/pipeline/pipeline-visualization-service/base/deployment.yaml", `
 apiVersion: apps/v1

--- a/tests/pipeline-pipelines-runner-overlays-application_test.go
+++ b/tests/pipeline-pipelines-runner-overlays-application_test.go
@@ -20,47 +20,47 @@ kind: Application
 metadata:
   name: pipelines-runner
 spec:
-  selector:
-    matchLabels:
-      app.kubernetes.io/name: pipelines-runner
-      app.kubernetes.io/instance: pipelines-runner-0.1.31
-      app.kubernetes.io/managed-by: kfctl
-      app.kubernetes.io/component: pipelines-runner
-      app.kubernetes.io/part-of: kubeflow
-      app.kubernetes.io/version: 0.1.31
+  addOwnerRef: true
   componentKinds:
   - group: core
     kind: ConfigMap
   - group: apps
     kind: Deployment
   descriptor:
-    type: pipelines-runner
-    version: v1beta1
-    description: ""
-    maintainers: []
-    owners: []
+    description: ''
     keywords:
-     - pipelines-runner
-     - kubeflow
+    - pipelines-runner
+    - kubeflow
     links:
     - description: About
-      url: ""
-  addOwnerRef: true
+      url: ''
+    maintainers: []
+    owners: []
+    type: pipelines-runner
+    version: v1beta1
+  selector:
+    matchLabels:
+      app.kubernetes.io/component: pipelines-runner
+      app.kubernetes.io/instance: pipelines-runner-0.2.0
+      app.kubernetes.io/managed-by: kfctl
+      app.kubernetes.io/name: pipelines-runner
+      app.kubernetes.io/part-of: kubeflow
+      app.kubernetes.io/version: 0.2.0
 `)
 	th.writeK("/manifests/pipeline/pipelines-runner/overlays/application", `
 apiVersion: kustomize.config.k8s.io/v1beta1
-kind: Kustomization
 bases:
 - ../../base
+commonLabels:
+  app.kubernetes.io/component: pipelines-runner
+  app.kubernetes.io/instance: pipelines-runner-0.2.0
+  app.kubernetes.io/managed-by: kfctl
+  app.kubernetes.io/name: pipelines-runner
+  app.kubernetes.io/part-of: kubeflow
+  app.kubernetes.io/version: 0.2.0
+kind: Kustomization
 resources:
 - application.yaml
-commonLabels:
-  app.kubernetes.io/name: pipelines-runner
-  app.kubernetes.io/instance: pipelines-runner-0.1.31
-  app.kubernetes.io/managed-by: kfctl
-  app.kubernetes.io/component: pipelines-runner
-  app.kubernetes.io/part-of: kubeflow
-  app.kubernetes.io/version: 0.1.31
 `)
 	th.writeF("/manifests/pipeline/pipelines-runner/base/cluster-role-binding.yaml", `
 apiVersion: rbac.authorization.k8s.io/v1beta1

--- a/tests/pipeline-pipelines-ui-overlays-application_test.go
+++ b/tests/pipeline-pipelines-ui-overlays-application_test.go
@@ -20,47 +20,47 @@ kind: Application
 metadata:
   name: pipelines-ui
 spec:
-  selector:
-    matchLabels:
-      app.kubernetes.io/name: pipelines-ui
-      app.kubernetes.io/instance: pipelines-ui-0.1.31
-      app.kubernetes.io/managed-by: kfctl
-      app.kubernetes.io/component: pipelines-ui
-      app.kubernetes.io/part-of: kubeflow
-      app.kubernetes.io/version: 0.1.31
+  addOwnerRef: true
   componentKinds:
   - group: core
     kind: ConfigMap
   - group: apps
     kind: Deployment
   descriptor:
-    type: pipelines-ui
-    version: v1beta1
-    description: ""
-    maintainers: []
-    owners: []
+    description: ''
     keywords:
-     - pipelines-ui
-     - kubeflow
+    - pipelines-ui
+    - kubeflow
     links:
     - description: About
-      url: ""
-  addOwnerRef: true
+      url: ''
+    maintainers: []
+    owners: []
+    type: pipelines-ui
+    version: v1beta1
+  selector:
+    matchLabels:
+      app.kubernetes.io/component: pipelines-ui
+      app.kubernetes.io/instance: pipelines-ui-0.2.0
+      app.kubernetes.io/managed-by: kfctl
+      app.kubernetes.io/name: pipelines-ui
+      app.kubernetes.io/part-of: kubeflow
+      app.kubernetes.io/version: 0.2.0
 `)
 	th.writeK("/manifests/pipeline/pipelines-ui/overlays/application", `
 apiVersion: kustomize.config.k8s.io/v1beta1
-kind: Kustomization
 bases:
 - ../../base
+commonLabels:
+  app.kubernetes.io/component: pipelines-ui
+  app.kubernetes.io/instance: pipelines-ui-0.2.0
+  app.kubernetes.io/managed-by: kfctl
+  app.kubernetes.io/name: pipelines-ui
+  app.kubernetes.io/part-of: kubeflow
+  app.kubernetes.io/version: 0.2.0
+kind: Kustomization
 resources:
 - application.yaml
-commonLabels:
-  app.kubernetes.io/name: pipelines-ui
-  app.kubernetes.io/instance: pipelines-ui-0.1.31
-  app.kubernetes.io/managed-by: kfctl
-  app.kubernetes.io/component: pipelines-ui
-  app.kubernetes.io/part-of: kubeflow
-  app.kubernetes.io/version: 0.1.31
 `)
 	th.writeF("/manifests/pipeline/pipelines-ui/base/deployment.yaml", `
 apiVersion: apps/v1

--- a/tests/pipeline-pipelines-viewer-overlays-application_test.go
+++ b/tests/pipeline-pipelines-viewer-overlays-application_test.go
@@ -20,47 +20,47 @@ kind: Application
 metadata:
   name: pipelines-viewer
 spec:
-  selector:
-    matchLabels:
-      app.kubernetes.io/name: pipelines-viewer
-      app.kubernetes.io/instance: pipelines-viewer-0.1.31
-      app.kubernetes.io/managed-by: kfctl
-      app.kubernetes.io/component: pipelines-viewer
-      app.kubernetes.io/part-of: kubeflow
-      app.kubernetes.io/version: 0.1.31
+  addOwnerRef: true
   componentKinds:
   - group: core
     kind: ConfigMap
   - group: apps
     kind: Deployment
   descriptor:
-    type: pipelines-viewer
-    version: v1beta1
-    description: ""
-    maintainers: []
-    owners: []
+    description: ''
     keywords:
-     - pipelines-viewer
-     - kubeflow
+    - pipelines-viewer
+    - kubeflow
     links:
     - description: About
-      url: ""
-  addOwnerRef: true
+      url: ''
+    maintainers: []
+    owners: []
+    type: pipelines-viewer
+    version: v1beta1
+  selector:
+    matchLabels:
+      app.kubernetes.io/component: pipelines-viewer
+      app.kubernetes.io/instance: pipelines-viewer-0.2.0
+      app.kubernetes.io/managed-by: kfctl
+      app.kubernetes.io/name: pipelines-viewer
+      app.kubernetes.io/part-of: kubeflow
+      app.kubernetes.io/version: 0.2.0
 `)
 	th.writeK("/manifests/pipeline/pipelines-viewer/overlays/application", `
 apiVersion: kustomize.config.k8s.io/v1beta1
-kind: Kustomization
 bases:
 - ../../base
+commonLabels:
+  app.kubernetes.io/component: pipelines-viewer
+  app.kubernetes.io/instance: pipelines-viewer-0.2.0
+  app.kubernetes.io/managed-by: kfctl
+  app.kubernetes.io/name: pipelines-viewer
+  app.kubernetes.io/part-of: kubeflow
+  app.kubernetes.io/version: 0.2.0
+kind: Kustomization
 resources:
 - application.yaml
-commonLabels:
-  app.kubernetes.io/name: pipelines-viewer
-  app.kubernetes.io/instance: pipelines-viewer-0.1.31
-  app.kubernetes.io/managed-by: kfctl
-  app.kubernetes.io/component: pipelines-viewer
-  app.kubernetes.io/part-of: kubeflow
-  app.kubernetes.io/version: 0.1.31
 `)
 	th.writeF("/manifests/pipeline/pipelines-viewer/base/crd.yaml", `
 apiVersion: apiextensions.k8s.io/v1beta1

--- a/tests/pipeline-scheduledworkflow-overlays-application_test.go
+++ b/tests/pipeline-scheduledworkflow-overlays-application_test.go
@@ -20,47 +20,47 @@ kind: Application
 metadata:
   name: scheduledworkflow
 spec:
-  selector:
-    matchLabels:
-      app.kubernetes.io/name: scheduledworkflow
-      app.kubernetes.io/instance: scheduledworkflow-0.1.31
-      app.kubernetes.io/managed-by: kfctl
-      app.kubernetes.io/component: scheduledworkflow
-      app.kubernetes.io/part-of: kubeflow
-      app.kubernetes.io/version: 0.1.31
+  addOwnerRef: true
   componentKinds:
   - group: core
     kind: ConfigMap
   - group: apps
     kind: Deployment
   descriptor:
-    type: scheduledworkflow
-    version: v1beta1
-    description: ""
-    maintainers: []
-    owners: []
+    description: ''
     keywords:
-     - scheduledworkflow
-     - kubeflow
+    - scheduledworkflow
+    - kubeflow
     links:
     - description: About
-      url: ""
-  addOwnerRef: true
+      url: ''
+    maintainers: []
+    owners: []
+    type: scheduledworkflow
+    version: v1beta1
+  selector:
+    matchLabels:
+      app.kubernetes.io/component: scheduledworkflow
+      app.kubernetes.io/instance: scheduledworkflow-0.2.0
+      app.kubernetes.io/managed-by: kfctl
+      app.kubernetes.io/name: scheduledworkflow
+      app.kubernetes.io/part-of: kubeflow
+      app.kubernetes.io/version: 0.2.0
 `)
 	th.writeK("/manifests/pipeline/scheduledworkflow/overlays/application", `
 apiVersion: kustomize.config.k8s.io/v1beta1
-kind: Kustomization
 bases:
 - ../../base
+commonLabels:
+  app.kubernetes.io/component: scheduledworkflow
+  app.kubernetes.io/instance: scheduledworkflow-0.2.0
+  app.kubernetes.io/managed-by: kfctl
+  app.kubernetes.io/name: scheduledworkflow
+  app.kubernetes.io/part-of: kubeflow
+  app.kubernetes.io/version: 0.2.0
+kind: Kustomization
 resources:
 - application.yaml
-commonLabels:
-  app.kubernetes.io/name: scheduledworkflow
-  app.kubernetes.io/instance: scheduledworkflow-0.1.31
-  app.kubernetes.io/managed-by: kfctl
-  app.kubernetes.io/component: scheduledworkflow
-  app.kubernetes.io/part-of: kubeflow
-  app.kubernetes.io/version: 0.1.31
 `)
 	th.writeF("/manifests/pipeline/scheduledworkflow/base/cluster-role.yaml", `
 ---


### PR DESCRIPTION
* We had previously updated the docker images to 0.2.0 but we
  hadn't updated the version specified in the Application resources
  because of a lack of tooling.

* Uses the script in kubeflow/testing#596

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/manifests/848)
<!-- Reviewable:end -->
