### PR TITLE
Automated cherry pick of #846: centraldashboard use /healthz for liveness probe Cherry pick of #846 on v1.0-branch. #846: centraldashboard use /healthz for liveness probe

### DIFF
--- a/common/centraldashboard/base/deployment.yaml
+++ b/common/centraldashboard/base/deployment.yaml
@@ -19,7 +19,7 @@ spec:
         imagePullPolicy: IfNotPresent
         livenessProbe:
           httpGet:
-            path: /api/workgroup/env-info
+            path: /healthz
             port: 8082
           initialDelaySeconds: 30
           periodSeconds: 30

--- a/tests/common-centraldashboard-base_test.go
+++ b/tests/common-centraldashboard-base_test.go
@@ -71,7 +71,7 @@ spec:
         imagePullPolicy: IfNotPresent
         livenessProbe:
           httpGet:
-            path: /api/workgroup/env-info
+            path: /healthz
             port: 8082
           initialDelaySeconds: 30
           periodSeconds: 30

--- a/tests/common-centraldashboard-overlays-application_test.go
+++ b/tests/common-centraldashboard-overlays-application_test.go
@@ -142,7 +142,7 @@ spec:
         imagePullPolicy: IfNotPresent
         livenessProbe:
           httpGet:
-            path: /api/workgroup/env-info
+            path: /healthz
             port: 8082
           initialDelaySeconds: 30
           periodSeconds: 30

--- a/tests/common-centraldashboard-overlays-istio_test.go
+++ b/tests/common-centraldashboard-overlays-istio_test.go
@@ -109,7 +109,7 @@ spec:
         imagePullPolicy: IfNotPresent
         livenessProbe:
           httpGet:
-            path: /api/workgroup/env-info
+            path: /healthz
             port: 8082
           initialDelaySeconds: 30
           periodSeconds: 30


### PR DESCRIPTION


<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/manifests/851)
<!-- Reviewable:end -->
