### PR TITLE
Set the correct version for Katib,Seldon,metadata kubeflow/manifests#834

### DIFF
--- a/katib/katib-controller/overlays/application/application.yaml
+++ b/katib/katib-controller/overlays/application/application.yaml
@@ -3,14 +3,7 @@ kind: Application
 metadata:
   name: katib-controller
 spec:
-  selector:
-    matchLabels:
-      app.kubernetes.io/name: katib-controller
-      app.kubernetes.io/instance: katib-controller-v0.7.0
-      app.kubernetes.io/managed-by: kfctl
-      app.kubernetes.io/component: katib
-      app.kubernetes.io/part-of: kubeflow
-      app.kubernetes.io/version: v0.7.0
+  addOwnerRef: true
   componentKinds:
   - group: core
     kind: Service
@@ -27,36 +20,44 @@ spec:
   - group: kubeflow.org
     kind: Trial
   descriptor:
-    type: "katib"
-    version: "v1alpha3"
-    description: "Katib is a service for hyperparameter tuning and neural architecture search."
-    maintainers:
-    - name: Ce Gao
-      email: gaoce@caicloud.io
-    - name: Johnu George
-      email: johnugeo@cisco.com
-    - name: Hougang Liu
-      email: liuhougang6@126.com
-    - name: Richard Liu
-      email: ricliu@google.com
-    - name: YujiOshima
-      email: yuji.oshima0x3fd@gmail.com
-    owners:
-    - name: Ce Gao
-      email: gaoce@caicloud.io
-    - name: Johnu George
-      email: johnugeo@cisco.com
-    - name: Hougang Liu
-      email: liuhougang6@126.com
-    - name: Richard Liu
-      email: ricliu@google.com
-    - name: YujiOshima
-      email: yuji.oshima0x3fd@gmail.com
+    description: Katib is a service for hyperparameter tuning and neural architecture
+      search.
     keywords:
     - katib
     - katib-controller
     - hyperparameter tuning
     links:
     - description: About
-      url: "https://github.com/kubeflow/katib"
-  addOwnerRef: true
+      url: https://github.com/kubeflow/katib
+    maintainers:
+    - email: gaoce@caicloud.io
+      name: Ce Gao
+    - email: johnugeo@cisco.com
+      name: Johnu George
+    - email: liuhougang6@126.com
+      name: Hougang Liu
+    - email: ricliu@google.com
+      name: Richard Liu
+    - email: yuji.oshima0x3fd@gmail.com
+      name: YujiOshima
+    owners:
+    - email: gaoce@caicloud.io
+      name: Ce Gao
+    - email: johnugeo@cisco.com
+      name: Johnu George
+    - email: liuhougang6@126.com
+      name: Hougang Liu
+    - email: ricliu@google.com
+      name: Richard Liu
+    - email: yuji.oshima0x3fd@gmail.com
+      name: YujiOshima
+    type: katib
+    version: v1alpha3
+  selector:
+    matchLabels:
+      app.kubernetes.io/component: katib
+      app.kubernetes.io/instance: katib-controller-0.8.0
+      app.kubernetes.io/managed-by: kfctl
+      app.kubernetes.io/name: katib-controller
+      app.kubernetes.io/part-of: kubeflow
+      app.kubernetes.io/version: 0.8.0

--- a/katib/katib-controller/overlays/application/kustomization.yaml
+++ b/katib/katib-controller/overlays/application/kustomization.yaml
@@ -1,13 +1,13 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
-kind: Kustomization
 bases:
 - ../../base
+commonLabels:
+  app.kubernetes.io/component: katib
+  app.kubernetes.io/instance: katib-controller-0.8.0
+  app.kubernetes.io/managed-by: kfctl
+  app.kubernetes.io/name: katib-controller
+  app.kubernetes.io/part-of: kubeflow
+  app.kubernetes.io/version: 0.8.0
+kind: Kustomization
 resources:
 - application.yaml
-commonLabels:
-  app.kubernetes.io/name: katib-controller
-  app.kubernetes.io/instance: katib-controller-v0.7.0
-  app.kubernetes.io/managed-by: kfctl
-  app.kubernetes.io/component: katib
-  app.kubernetes.io/part-of: kubeflow
-  app.kubernetes.io/version: v0.7.0

--- a/katib/katib-crds/overlays/application/application.yaml
+++ b/katib/katib-crds/overlays/application/application.yaml
@@ -3,14 +3,7 @@ kind: Application
 metadata:
   name: katib-crds
 spec:
-  selector:
-    matchLabels:
-      app.kubernetes.io/name: katib-crds
-      app.kubernetes.io/instance: katib-crds-v0.7.0
-      app.kubernetes.io/managed-by: kfctl
-      app.kubernetes.io/component: katib
-      app.kubernetes.io/part-of: kubeflow
-      app.kubernetes.io/version: v0.7.0
+  addOwnerRef: true
   componentKinds:
   - group: core
     kind: Service
@@ -25,36 +18,44 @@ spec:
   - group: kubeflow.org
     kind: Trial
   descriptor:
-    type: "katib"
-    version: "v1alpha3"
-    description: "Katib is a service for hyperparameter tuning and neural architecture search."
-    maintainers:
-    - name: Ce Gao
-      email: gaoce@caicloud.io
-    - name: Johnu George
-      email: johnugeo@cisco.com
-    - name: Hougang Liu
-      email: liuhougang6@126.com
-    - name: Richard Liu
-      email: ricliu@google.com
-    - name: YujiOshima
-      email: yuji.oshima0x3fd@gmail.com
-    owners:
-    - name: Ce Gao
-      email: gaoce@caicloud.io
-    - name: Johnu George
-      email: johnugeo@cisco.com
-    - name: Hougang Liu
-      email: liuhougang6@126.com
-    - name: Richard Liu
-      email: ricliu@google.com
-    - name: YujiOshima
-      email: yuji.oshima0x3fd@gmail.com
+    description: Katib is a service for hyperparameter tuning and neural architecture
+      search.
     keywords:
     - katib
     - katib-controller
     - hyperparameter tuning
     links:
     - description: About
-      url: "https://github.com/kubeflow/katib"
-  addOwnerRef: true
+      url: https://github.com/kubeflow/katib
+    maintainers:
+    - email: gaoce@caicloud.io
+      name: Ce Gao
+    - email: johnugeo@cisco.com
+      name: Johnu George
+    - email: liuhougang6@126.com
+      name: Hougang Liu
+    - email: ricliu@google.com
+      name: Richard Liu
+    - email: yuji.oshima0x3fd@gmail.com
+      name: YujiOshima
+    owners:
+    - email: gaoce@caicloud.io
+      name: Ce Gao
+    - email: johnugeo@cisco.com
+      name: Johnu George
+    - email: liuhougang6@126.com
+      name: Hougang Liu
+    - email: ricliu@google.com
+      name: Richard Liu
+    - email: yuji.oshima0x3fd@gmail.com
+      name: YujiOshima
+    type: katib
+    version: v1alpha3
+  selector:
+    matchLabels:
+      app.kubernetes.io/component: katib
+      app.kubernetes.io/instance: katib-crds-0.8.0
+      app.kubernetes.io/managed-by: kfctl
+      app.kubernetes.io/name: katib-crds
+      app.kubernetes.io/part-of: kubeflow
+      app.kubernetes.io/version: 0.8.0

--- a/katib/katib-crds/overlays/application/kustomization.yaml
+++ b/katib/katib-crds/overlays/application/kustomization.yaml
@@ -1,13 +1,13 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
-kind: Kustomization
 bases:
 - ../../base
+commonLabels:
+  app.kubernetes.io/component: katib
+  app.kubernetes.io/instance: katib-crds-0.8.0
+  app.kubernetes.io/managed-by: kfctl
+  app.kubernetes.io/name: katib-crds
+  app.kubernetes.io/part-of: kubeflow
+  app.kubernetes.io/version: 0.8.0
+kind: Kustomization
 resources:
 - application.yaml
-commonLabels:
-  app.kubernetes.io/name: katib-crds
-  app.kubernetes.io/instance: katib-crds-v0.7.0
-  app.kubernetes.io/managed-by: kfctl
-  app.kubernetes.io/component: katib
-  app.kubernetes.io/part-of: kubeflow
-  app.kubernetes.io/version: v0.7.0

--- a/metadata/overlays/application/application.yaml
+++ b/metadata/overlays/application/application.yaml
@@ -3,14 +3,7 @@ kind: Application
 metadata:
   name: metadata
 spec:
-  selector:
-    matchLabels:
-      app.kubernetes.io/name: metadata
-      app.kubernetes.io/instance: metadata-v0.7.0
-      app.kubernetes.io/managed-by: kfctl
-      app.kubernetes.io/component: metadata
-      app.kubernetes.io/part-of: kubeflow
-      app.kubernetes.io/version: v0.7.0
+  addOwnerRef: true
   componentKinds:
   - group: core
     kind: Service
@@ -21,20 +14,27 @@ spec:
   - group: core
     kind: ServiceAccount
   descriptor:
-    type: "metadata"
-    version: "alpha"
-    description: "Tracking and managing metadata of machine learning workflows in Kubeflow."
-    maintainers:
-    - name: Zhenghui Wang
-      email: zhenghui@google.com
-    owners:
-    - name: Ajay Gopinathan
-      email: ajaygopinathan@google.com
-    - name: Zhenghui Wang
-      email: zhenghui@google.com
+    description: Tracking and managing metadata of machine learning workflows in Kubeflow.
     keywords:
-    - "metadata"
+    - metadata
     links:
     - description: Docs
-      url: "https://www.kubeflow.org/docs/components/misc/metadata/"
-  addOwnerRef: true
+      url: https://www.kubeflow.org/docs/components/misc/metadata/
+    maintainers:
+    - email: zhenghui@google.com
+      name: Zhenghui Wang
+    owners:
+    - email: ajaygopinathan@google.com
+      name: Ajay Gopinathan
+    - email: zhenghui@google.com
+      name: Zhenghui Wang
+    type: metadata
+    version: alpha
+  selector:
+    matchLabels:
+      app.kubernetes.io/component: metadata
+      app.kubernetes.io/instance: metadata-0.8.0
+      app.kubernetes.io/managed-by: kfctl
+      app.kubernetes.io/name: metadata
+      app.kubernetes.io/part-of: kubeflow
+      app.kubernetes.io/version: 0.8.0

--- a/metadata/overlays/application/application.yaml
+++ b/metadata/overlays/application/application.yaml
@@ -33,8 +33,8 @@ spec:
   selector:
     matchLabels:
       app.kubernetes.io/component: metadata
-      app.kubernetes.io/instance: metadata-0.8.0
+      app.kubernetes.io/instance: metadata-0.2.1
       app.kubernetes.io/managed-by: kfctl
       app.kubernetes.io/name: metadata
       app.kubernetes.io/part-of: kubeflow
-      app.kubernetes.io/version: 0.8.0
+      app.kubernetes.io/version: 0.2.1

--- a/metadata/overlays/application/kustomization.yaml
+++ b/metadata/overlays/application/kustomization.yaml
@@ -3,11 +3,11 @@ bases:
 - ../../base
 commonLabels:
   app.kubernetes.io/component: metadata
-  app.kubernetes.io/instance: metadata-0.8.0
+  app.kubernetes.io/instance: metadata-0.2.1
   app.kubernetes.io/managed-by: kfctl
   app.kubernetes.io/name: metadata
   app.kubernetes.io/part-of: kubeflow
-  app.kubernetes.io/version: 0.8.0
+  app.kubernetes.io/version: 0.2.1
 kind: Kustomization
 resources:
 - application.yaml

--- a/metadata/overlays/application/kustomization.yaml
+++ b/metadata/overlays/application/kustomization.yaml
@@ -1,13 +1,13 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
-kind: Kustomization
 bases:
 - ../../base
+commonLabels:
+  app.kubernetes.io/component: metadata
+  app.kubernetes.io/instance: metadata-0.8.0
+  app.kubernetes.io/managed-by: kfctl
+  app.kubernetes.io/name: metadata
+  app.kubernetes.io/part-of: kubeflow
+  app.kubernetes.io/version: 0.8.0
+kind: Kustomization
 resources:
 - application.yaml
-commonLabels:
-  app.kubernetes.io/name: metadata
-  app.kubernetes.io/instance: metadata-v0.7.0
-  app.kubernetes.io/managed-by: kfctl
-  app.kubernetes.io/component: metadata
-  app.kubernetes.io/part-of: kubeflow
-  app.kubernetes.io/version: v0.7.0

--- a/seldon/seldon-core-operator/overlays/application/application.yaml
+++ b/seldon/seldon-core-operator/overlays/application/application.yaml
@@ -1,32 +1,41 @@
 apiVersion: app.k8s.io/v1beta1
 kind: Application
 metadata:
-  name: "seldon-core-operator"
+  name: seldon-core-operator
 spec:
-  type: "seldon-core-operator"
   componentKinds:
-    - group: apps/v1
-      kind: StatefulSet
-    - group: v1
-      kind: Service
-    - group: apps/v1
-      kind: Deployment
-    - group: v1
-      kind: Secret
-    - group: v1
-      kind: ConfigMap
-  version: "v1"
-  description: "Seldon allows users to create ML Inference Graphs to deploy their models and serve predictions"
-  icons:
-  maintainers:
-    - name: Seldon
-      email: dev@seldon.io
-  owners:
-    - name: Seldon
-      email: dev@seldon.io
+  - group: apps/v1
+    kind: StatefulSet
+  - group: v1
+    kind: Service
+  - group: apps/v1
+    kind: Deployment
+  - group: v1
+    kind: Secret
+  - group: v1
+    kind: ConfigMap
+  description: Seldon allows users to create ML Inference Graphs to deploy their models
+    and serve predictions
+  icons: null
   keywords:
-   - "seldon"
-   - "inference"
+  - seldon
+  - inference
   links:
-    - description: Docs
-      url: "https://docs.seldon.io/projects/seldon-core/en/v1.0.1/"
+  - description: Docs
+    url: https://docs.seldon.io/projects/seldon-core/en/v1.0.1/
+  maintainers:
+  - email: dev@seldon.io
+    name: Seldon
+  owners:
+  - email: dev@seldon.io
+    name: Seldon
+  selector:
+    matchLabels:
+      app.kubernetes.io/component: seldon
+      app.kubernetes.io/instance: seldon-1.15
+      app.kubernetes.io/managed-by: kfctl
+      app.kubernetes.io/name: seldon
+      app.kubernetes.io/part-of: kubeflow
+      app.kubernetes.io/version: '1.15'
+  type: seldon-core-operator
+  version: v1

--- a/seldon/seldon-core-operator/overlays/application/kustomization.yaml
+++ b/seldon/seldon-core-operator/overlays/application/kustomization.yaml
@@ -1,13 +1,13 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
-kind: Kustomization
 bases:
 - ../../base
+commonLabels:
+  app.kubernetes.io/component: seldon
+  app.kubernetes.io/instance: seldon-1.15
+  app.kubernetes.io/managed-by: kfctl
+  app.kubernetes.io/name: seldon-core-operator
+  app.kubernetes.io/part-of: kubeflow
+  app.kubernetes.io/version: '1.15'
+kind: Kustomization
 resources:
 - application.yaml
-commonLabels:
-  app.kubernetes.io/name: seldon-core-operator
-  app.kubernetes.io/instance: seldon-core-operator-v1.0.1
-  app.kubernetes.io/managed-by: kfctl
-  app.kubernetes.io/component: seldon
-  app.kubernetes.io/part-of: kubeflow
-  app.kubernetes.io/version: v1.0.1

--- a/tests/katib-katib-controller-overlays-application_test.go
+++ b/tests/katib-katib-controller-overlays-application_test.go
@@ -20,14 +20,7 @@ kind: Application
 metadata:
   name: katib-controller
 spec:
-  selector:
-    matchLabels:
-      app.kubernetes.io/name: katib-controller
-      app.kubernetes.io/instance: katib-controller-v0.7.0
-      app.kubernetes.io/managed-by: kfctl
-      app.kubernetes.io/component: katib
-      app.kubernetes.io/part-of: kubeflow
-      app.kubernetes.io/version: v0.7.0
+  addOwnerRef: true
   componentKinds:
   - group: core
     kind: Service
@@ -44,54 +37,62 @@ spec:
   - group: kubeflow.org
     kind: Trial
   descriptor:
-    type: "katib"
-    version: "v1alpha3"
-    description: "Katib is a service for hyperparameter tuning and neural architecture search."
-    maintainers:
-    - name: Ce Gao
-      email: gaoce@caicloud.io
-    - name: Johnu George
-      email: johnugeo@cisco.com
-    - name: Hougang Liu
-      email: liuhougang6@126.com
-    - name: Richard Liu
-      email: ricliu@google.com
-    - name: YujiOshima
-      email: yuji.oshima0x3fd@gmail.com
-    owners:
-    - name: Ce Gao
-      email: gaoce@caicloud.io
-    - name: Johnu George
-      email: johnugeo@cisco.com
-    - name: Hougang Liu
-      email: liuhougang6@126.com
-    - name: Richard Liu
-      email: ricliu@google.com
-    - name: YujiOshima
-      email: yuji.oshima0x3fd@gmail.com
+    description: Katib is a service for hyperparameter tuning and neural architecture
+      search.
     keywords:
     - katib
     - katib-controller
     - hyperparameter tuning
     links:
     - description: About
-      url: "https://github.com/kubeflow/katib"
-  addOwnerRef: true
+      url: https://github.com/kubeflow/katib
+    maintainers:
+    - email: gaoce@caicloud.io
+      name: Ce Gao
+    - email: johnugeo@cisco.com
+      name: Johnu George
+    - email: liuhougang6@126.com
+      name: Hougang Liu
+    - email: ricliu@google.com
+      name: Richard Liu
+    - email: yuji.oshima0x3fd@gmail.com
+      name: YujiOshima
+    owners:
+    - email: gaoce@caicloud.io
+      name: Ce Gao
+    - email: johnugeo@cisco.com
+      name: Johnu George
+    - email: liuhougang6@126.com
+      name: Hougang Liu
+    - email: ricliu@google.com
+      name: Richard Liu
+    - email: yuji.oshima0x3fd@gmail.com
+      name: YujiOshima
+    type: katib
+    version: v1alpha3
+  selector:
+    matchLabels:
+      app.kubernetes.io/component: katib
+      app.kubernetes.io/instance: katib-controller-0.8.0
+      app.kubernetes.io/managed-by: kfctl
+      app.kubernetes.io/name: katib-controller
+      app.kubernetes.io/part-of: kubeflow
+      app.kubernetes.io/version: 0.8.0
 `)
 	th.writeK("/manifests/katib/katib-controller/overlays/application", `
 apiVersion: kustomize.config.k8s.io/v1beta1
-kind: Kustomization
 bases:
 - ../../base
+commonLabels:
+  app.kubernetes.io/component: katib
+  app.kubernetes.io/instance: katib-controller-0.8.0
+  app.kubernetes.io/managed-by: kfctl
+  app.kubernetes.io/name: katib-controller
+  app.kubernetes.io/part-of: kubeflow
+  app.kubernetes.io/version: 0.8.0
+kind: Kustomization
 resources:
 - application.yaml
-commonLabels:
-  app.kubernetes.io/name: katib-controller
-  app.kubernetes.io/instance: katib-controller-v0.7.0
-  app.kubernetes.io/managed-by: kfctl
-  app.kubernetes.io/component: katib
-  app.kubernetes.io/part-of: kubeflow
-  app.kubernetes.io/version: v0.7.0
 `)
 	th.writeF("/manifests/katib/katib-controller/base/katib-configmap.yaml", `
 apiVersion: v1

--- a/tests/katib-katib-crds-overlays-application_test.go
+++ b/tests/katib-katib-crds-overlays-application_test.go
@@ -20,14 +20,7 @@ kind: Application
 metadata:
   name: katib-crds
 spec:
-  selector:
-    matchLabels:
-      app.kubernetes.io/name: katib-crds
-      app.kubernetes.io/instance: katib-crds-v0.7.0
-      app.kubernetes.io/managed-by: kfctl
-      app.kubernetes.io/component: katib
-      app.kubernetes.io/part-of: kubeflow
-      app.kubernetes.io/version: v0.7.0
+  addOwnerRef: true
   componentKinds:
   - group: core
     kind: Service
@@ -42,54 +35,62 @@ spec:
   - group: kubeflow.org
     kind: Trial
   descriptor:
-    type: "katib"
-    version: "v1alpha3"
-    description: "Katib is a service for hyperparameter tuning and neural architecture search."
-    maintainers:
-    - name: Ce Gao
-      email: gaoce@caicloud.io
-    - name: Johnu George
-      email: johnugeo@cisco.com
-    - name: Hougang Liu
-      email: liuhougang6@126.com
-    - name: Richard Liu
-      email: ricliu@google.com
-    - name: YujiOshima
-      email: yuji.oshima0x3fd@gmail.com
-    owners:
-    - name: Ce Gao
-      email: gaoce@caicloud.io
-    - name: Johnu George
-      email: johnugeo@cisco.com
-    - name: Hougang Liu
-      email: liuhougang6@126.com
-    - name: Richard Liu
-      email: ricliu@google.com
-    - name: YujiOshima
-      email: yuji.oshima0x3fd@gmail.com
+    description: Katib is a service for hyperparameter tuning and neural architecture
+      search.
     keywords:
     - katib
     - katib-controller
     - hyperparameter tuning
     links:
     - description: About
-      url: "https://github.com/kubeflow/katib"
-  addOwnerRef: true
+      url: https://github.com/kubeflow/katib
+    maintainers:
+    - email: gaoce@caicloud.io
+      name: Ce Gao
+    - email: johnugeo@cisco.com
+      name: Johnu George
+    - email: liuhougang6@126.com
+      name: Hougang Liu
+    - email: ricliu@google.com
+      name: Richard Liu
+    - email: yuji.oshima0x3fd@gmail.com
+      name: YujiOshima
+    owners:
+    - email: gaoce@caicloud.io
+      name: Ce Gao
+    - email: johnugeo@cisco.com
+      name: Johnu George
+    - email: liuhougang6@126.com
+      name: Hougang Liu
+    - email: ricliu@google.com
+      name: Richard Liu
+    - email: yuji.oshima0x3fd@gmail.com
+      name: YujiOshima
+    type: katib
+    version: v1alpha3
+  selector:
+    matchLabels:
+      app.kubernetes.io/component: katib
+      app.kubernetes.io/instance: katib-crds-0.8.0
+      app.kubernetes.io/managed-by: kfctl
+      app.kubernetes.io/name: katib-crds
+      app.kubernetes.io/part-of: kubeflow
+      app.kubernetes.io/version: 0.8.0
 `)
 	th.writeK("/manifests/katib/katib-crds/overlays/application", `
 apiVersion: kustomize.config.k8s.io/v1beta1
-kind: Kustomization
 bases:
 - ../../base
+commonLabels:
+  app.kubernetes.io/component: katib
+  app.kubernetes.io/instance: katib-crds-0.8.0
+  app.kubernetes.io/managed-by: kfctl
+  app.kubernetes.io/name: katib-crds
+  app.kubernetes.io/part-of: kubeflow
+  app.kubernetes.io/version: 0.8.0
+kind: Kustomization
 resources:
 - application.yaml
-commonLabels:
-  app.kubernetes.io/name: katib-crds
-  app.kubernetes.io/instance: katib-crds-v0.7.0
-  app.kubernetes.io/managed-by: kfctl
-  app.kubernetes.io/component: katib
-  app.kubernetes.io/part-of: kubeflow
-  app.kubernetes.io/version: v0.7.0
 `)
 	th.writeF("/manifests/katib/katib-crds/base/experiment-crd.yaml", `
 apiVersion: apiextensions.k8s.io/v1beta1

--- a/tests/metadata-overlays-application_test.go
+++ b/tests/metadata-overlays-application_test.go
@@ -20,14 +20,7 @@ kind: Application
 metadata:
   name: metadata
 spec:
-  selector:
-    matchLabels:
-      app.kubernetes.io/name: metadata
-      app.kubernetes.io/instance: metadata-v0.7.0
-      app.kubernetes.io/managed-by: kfctl
-      app.kubernetes.io/component: metadata
-      app.kubernetes.io/part-of: kubeflow
-      app.kubernetes.io/version: v0.7.0
+  addOwnerRef: true
   componentKinds:
   - group: core
     kind: Service
@@ -38,38 +31,45 @@ spec:
   - group: core
     kind: ServiceAccount
   descriptor:
-    type: "metadata"
-    version: "alpha"
-    description: "Tracking and managing metadata of machine learning workflows in Kubeflow."
-    maintainers:
-    - name: Zhenghui Wang
-      email: zhenghui@google.com
-    owners:
-    - name: Ajay Gopinathan
-      email: ajaygopinathan@google.com
-    - name: Zhenghui Wang
-      email: zhenghui@google.com
+    description: Tracking and managing metadata of machine learning workflows in Kubeflow.
     keywords:
-    - "metadata"
+    - metadata
     links:
     - description: Docs
-      url: "https://www.kubeflow.org/docs/components/misc/metadata/"
-  addOwnerRef: true
+      url: https://www.kubeflow.org/docs/components/misc/metadata/
+    maintainers:
+    - email: zhenghui@google.com
+      name: Zhenghui Wang
+    owners:
+    - email: ajaygopinathan@google.com
+      name: Ajay Gopinathan
+    - email: zhenghui@google.com
+      name: Zhenghui Wang
+    type: metadata
+    version: alpha
+  selector:
+    matchLabels:
+      app.kubernetes.io/component: metadata
+      app.kubernetes.io/instance: metadata-0.8.0
+      app.kubernetes.io/managed-by: kfctl
+      app.kubernetes.io/name: metadata
+      app.kubernetes.io/part-of: kubeflow
+      app.kubernetes.io/version: 0.8.0
 `)
 	th.writeK("/manifests/metadata/overlays/application", `
 apiVersion: kustomize.config.k8s.io/v1beta1
-kind: Kustomization
 bases:
 - ../../base
+commonLabels:
+  app.kubernetes.io/component: metadata
+  app.kubernetes.io/instance: metadata-0.8.0
+  app.kubernetes.io/managed-by: kfctl
+  app.kubernetes.io/name: metadata
+  app.kubernetes.io/part-of: kubeflow
+  app.kubernetes.io/version: 0.8.0
+kind: Kustomization
 resources:
 - application.yaml
-commonLabels:
-  app.kubernetes.io/name: metadata
-  app.kubernetes.io/instance: metadata-v0.7.0
-  app.kubernetes.io/managed-by: kfctl
-  app.kubernetes.io/component: metadata
-  app.kubernetes.io/part-of: kubeflow
-  app.kubernetes.io/version: v0.7.0
 `)
 	th.writeF("/manifests/metadata/base/metadata-deployment.yaml", `
 apiVersion: apps/v1
@@ -312,8 +312,7 @@ uiClusterDomain=cluster.local
 `)
 	th.writeF("/manifests/metadata/base/grpc-params.env", `
 METADATA_GRPC_SERVICE_HOST=metadata-grpc-service
-METADATA_GRPC_SERVICE_PORT=8080
-`)
+METADATA_GRPC_SERVICE_PORT=8080`)
 	th.writeK("/manifests/metadata/base", `
 namePrefix: metadata-
 apiVersion: kustomize.config.k8s.io/v1beta1

--- a/tests/metadata-overlays-application_test.go
+++ b/tests/metadata-overlays-application_test.go
@@ -50,11 +50,11 @@ spec:
   selector:
     matchLabels:
       app.kubernetes.io/component: metadata
-      app.kubernetes.io/instance: metadata-0.8.0
+      app.kubernetes.io/instance: metadata-0.2.1
       app.kubernetes.io/managed-by: kfctl
       app.kubernetes.io/name: metadata
       app.kubernetes.io/part-of: kubeflow
-      app.kubernetes.io/version: 0.8.0
+      app.kubernetes.io/version: 0.2.1
 `)
 	th.writeK("/manifests/metadata/overlays/application", `
 apiVersion: kustomize.config.k8s.io/v1beta1
@@ -62,11 +62,11 @@ bases:
 - ../../base
 commonLabels:
   app.kubernetes.io/component: metadata
-  app.kubernetes.io/instance: metadata-0.8.0
+  app.kubernetes.io/instance: metadata-0.2.1
   app.kubernetes.io/managed-by: kfctl
   app.kubernetes.io/name: metadata
   app.kubernetes.io/part-of: kubeflow
-  app.kubernetes.io/version: 0.8.0
+  app.kubernetes.io/version: 0.2.1
 kind: Kustomization
 resources:
 - application.yaml

--- a/tests/seldon-seldon-core-operator-overlays-application_test.go
+++ b/tests/seldon-seldon-core-operator-overlays-application_test.go
@@ -18,50 +18,59 @@ func writeSeldonCoreOperatorOverlaysApplication(th *KustTestHarness) {
 apiVersion: app.k8s.io/v1beta1
 kind: Application
 metadata:
-  name: "seldon-core-operator"
+  name: seldon-core-operator
 spec:
-  type: "seldon-core-operator"
   componentKinds:
-    - group: apps/v1
-      kind: StatefulSet
-    - group: v1
-      kind: Service
-    - group: apps/v1
-      kind: Deployment
-    - group: v1
-      kind: Secret
-    - group: v1
-      kind: ConfigMap
-  version: "v1"
-  description: "Seldon allows users to create ML Inference Graphs to deploy their models and serve predictions"
-  icons:
-  maintainers:
-    - name: Seldon
-      email: dev@seldon.io
-  owners:
-    - name: Seldon
-      email: dev@seldon.io
+  - group: apps/v1
+    kind: StatefulSet
+  - group: v1
+    kind: Service
+  - group: apps/v1
+    kind: Deployment
+  - group: v1
+    kind: Secret
+  - group: v1
+    kind: ConfigMap
+  description: Seldon allows users to create ML Inference Graphs to deploy their models
+    and serve predictions
+  icons: null
   keywords:
-   - "seldon"
-   - "inference"
+  - seldon
+  - inference
   links:
-    - description: Docs
-      url: "https://docs.seldon.io/projects/seldon-core/en/v1.0.1/"
+  - description: Docs
+    url: https://docs.seldon.io/projects/seldon-core/en/v1.0.1/
+  maintainers:
+  - email: dev@seldon.io
+    name: Seldon
+  owners:
+  - email: dev@seldon.io
+    name: Seldon
+  selector:
+    matchLabels:
+      app.kubernetes.io/component: seldon
+      app.kubernetes.io/instance: seldon-1.15
+      app.kubernetes.io/managed-by: kfctl
+      app.kubernetes.io/name: seldon
+      app.kubernetes.io/part-of: kubeflow
+      app.kubernetes.io/version: '1.15'
+  type: seldon-core-operator
+  version: v1
 `)
 	th.writeK("/manifests/seldon/seldon-core-operator/overlays/application", `
 apiVersion: kustomize.config.k8s.io/v1beta1
-kind: Kustomization
 bases:
 - ../../base
+commonLabels:
+  app.kubernetes.io/component: seldon
+  app.kubernetes.io/instance: seldon-1.15
+  app.kubernetes.io/managed-by: kfctl
+  app.kubernetes.io/name: seldon-core-operator
+  app.kubernetes.io/part-of: kubeflow
+  app.kubernetes.io/version: '1.15'
+kind: Kustomization
 resources:
 - application.yaml
-commonLabels:
-  app.kubernetes.io/name: seldon-core-operator
-  app.kubernetes.io/instance: seldon-core-operator-v1.0.1
-  app.kubernetes.io/managed-by: kfctl
-  app.kubernetes.io/component: seldon
-  app.kubernetes.io/part-of: kubeflow
-  app.kubernetes.io/version: v1.0.1
 `)
 	th.writeF("/manifests/seldon/seldon-core-operator/base/resources.yaml", `
 ---


### PR DESCRIPTION
* The version in the application CR should be the version of the application
  not Kubeflow

* Since Katib and metadata aren't going 1.0 we should bump the version to
  "0.8.0"

* Seldon's version is 1.15

* Note: I'm not including the "v" prefix in the version number. I'm not sure
  where that started or why we did it but it looks like a bug. We are
  following semantic versioning. So the version is X.Y.Z.
  Most likely the v was included as some sort of prefix as part of some larger
  tag e.g. to ensure it was interpreted as a string and not an integer.

* Related to kubeflow/manifests#834

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/manifests/860)
<!-- Reviewable:end -->
