### PR TITLE
oidc-authservice: parameterize auth scopes

### DIFF
--- a/istio/oidc-authservice/base/kustomization.yaml
+++ b/istio/oidc-authservice/base/kustomization.yaml
@@ -44,6 +44,13 @@ vars:
     apiVersion: v1
   fieldref:
     fieldpath: data.oidc_auth_url
+- name: oidc_scopes
+  objref:
+    kind: ConfigMap
+    name: oidc-authservice-parameters
+    apiVersion: v1
+  fieldref:
+    fieldpath: data.oidc_scopes
 - name: application_secret
   objref:
     kind: ConfigMap

--- a/istio/oidc-authservice/base/params.env
+++ b/istio/oidc-authservice/base/params.env
@@ -2,6 +2,7 @@ client_id=ldapdexapp
 oidc_provider=
 oidc_redirect_uri=
 oidc_auth_url=
+oidc_scopes=profile email groups
 application_secret=pUBnBOY80SnXgjibTYM9ZWNzY2xreNGQok
 skip_auth_uri=
 userid-header=

--- a/istio/oidc-authservice/base/statefulset.yaml
+++ b/istio/oidc-authservice/base/statefulset.yaml
@@ -34,7 +34,7 @@ spec:
           - name: OIDC_AUTH_URL
             value: $(oidc_auth_url)
           - name: OIDC_SCOPES
-            value: "profile email groups"
+            value: $(oidc_scopes)
           - name: REDIRECT_URL
             value: $(oidc_redirect_uri)
           - name: SKIP_AUTH_URI

--- a/tests/istio-oidc-authservice-base_test.go
+++ b/tests/istio-oidc-authservice-base_test.go
@@ -65,7 +65,7 @@ spec:
           - name: OIDC_AUTH_URL
             value: $(oidc_auth_url)
           - name: OIDC_SCOPES
-            value: "profile email groups"
+            value: $(oidc_scopes)
           - name: REDIRECT_URL
             value: $(oidc_redirect_uri)
           - name: SKIP_AUTH_URI
@@ -150,6 +150,7 @@ client_id=ldapdexapp
 oidc_provider=
 oidc_redirect_uri=
 oidc_auth_url=
+oidc_scopes=profile email groups
 application_secret=pUBnBOY80SnXgjibTYM9ZWNzY2xreNGQok
 skip_auth_uri=
 userid-header=
@@ -202,6 +203,13 @@ vars:
     apiVersion: v1
   fieldref:
     fieldpath: data.oidc_auth_url
+- name: oidc_scopes
+  objref:
+    kind: ConfigMap
+    name: oidc-authservice-parameters
+    apiVersion: v1
+  fieldref:
+    fieldpath: data.oidc_scopes
 - name: application_secret
   objref:
     kind: ConfigMap

--- a/tests/istio-oidc-authservice-overlays-application_test.go
+++ b/tests/istio-oidc-authservice-overlays-application_test.go
@@ -124,7 +124,7 @@ spec:
           - name: OIDC_AUTH_URL
             value: $(oidc_auth_url)
           - name: OIDC_SCOPES
-            value: "profile email groups"
+            value: $(oidc_scopes)
           - name: REDIRECT_URL
             value: $(oidc_redirect_uri)
           - name: SKIP_AUTH_URI
@@ -209,6 +209,7 @@ client_id=ldapdexapp
 oidc_provider=
 oidc_redirect_uri=
 oidc_auth_url=
+oidc_scopes=profile email groups
 application_secret=pUBnBOY80SnXgjibTYM9ZWNzY2xreNGQok
 skip_auth_uri=
 userid-header=
@@ -261,6 +262,13 @@ vars:
     apiVersion: v1
   fieldref:
     fieldpath: data.oidc_auth_url
+- name: oidc_scopes
+  objref:
+    kind: ConfigMap
+    name: oidc-authservice-parameters
+    apiVersion: v1
+  fieldref:
+    fieldpath: data.oidc_scopes
 - name: application_secret
   objref:
     kind: ConfigMap

--- a/tests/istio-oidc-authservice-overlays-ibm-storage-config_test.go
+++ b/tests/istio-oidc-authservice-overlays-ibm-storage-config_test.go
@@ -94,7 +94,7 @@ spec:
           - name: OIDC_AUTH_URL
             value: $(oidc_auth_url)
           - name: OIDC_SCOPES
-            value: "profile email groups"
+            value: $(oidc_scopes)
           - name: REDIRECT_URL
             value: $(oidc_redirect_uri)
           - name: SKIP_AUTH_URI
@@ -179,6 +179,7 @@ client_id=ldapdexapp
 oidc_provider=
 oidc_redirect_uri=
 oidc_auth_url=
+oidc_scopes=profile email groups
 application_secret=pUBnBOY80SnXgjibTYM9ZWNzY2xreNGQok
 skip_auth_uri=
 userid-header=
@@ -231,6 +232,13 @@ vars:
     apiVersion: v1
   fieldref:
     fieldpath: data.oidc_auth_url
+- name: oidc_scopes
+  objref:
+    kind: ConfigMap
+    name: oidc-authservice-parameters
+    apiVersion: v1
+  fieldref:
+    fieldpath: data.oidc_scopes
 - name: application_secret
   objref:
     kind: ConfigMap


### PR DESCRIPTION
**Which issue is resolved by this Pull Request:**
Resolves #861

**Description of your changes:**
Added a new parameter `oidc_scopes` with the current default.

**Checklist:**
- [x] Unit tests have been rebuilt: 
    1. `cd manifests/tests`
    2. `make generate-changed-only`
    3. `make test`

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/manifests/862)
<!-- Reviewable:end -->
