### PR TITLE
Automated cherry pick of #860: Set the correct version for Katib,Seldon,metadata Cherry pick of #860 on v1.0-branch. #860: Set the correct version for Katib,Seldon,metadata

### DIFF
--- a/hack/gen-test-target.sh
+++ b/hack/gen-test-target.sh
@@ -12,7 +12,7 @@ kebab-case-2-PascalCase() {
   local a=$1 b='' array
   IFS='-' read -r -a array <<< "$a"
   for element in "${array[@]}"; do
-    part="${element}"
+    part="${element//./_}"
     part="$(tr '[:lower:]' '[:upper:]' <<< ${part:0:1})${part:1}"
     b+=$part
   done
@@ -45,7 +45,7 @@ gen-target-start() {
 
 gen-target-middle() {
   local directory=$1
-  for i in $(echo $(cat $directory/kustomization.yaml | grep '^- .*yaml$' | sed 's/^- //') $(cat $directory/kustomization.yaml | grep '  path: ' | sed 's/^.*: \(.*\)$/\1/') $(cat $directory/kustomization.yaml | sed '1,/^[ \t]*files:/d;/^[^ \t]/,$d' | sed 's/^[ \t]*- //') params.env secrets.env kustomization.yaml | sed 's/ /\\n/g' | sort | uniq | awk '{gsub(/\\n/,"\n")}1'); do
+  for i in $(echo $(cat $directory/kustomization.yaml | grep '^- .*yaml$' | sed 's/^- //') $(cat $directory/kustomization.yaml | grep '  path: ' | sed 's/^.*: \(.*\)$/\1/') $(cat $directory/kustomization.yaml | sed '1,/^[ \t]*files:/d;/^[^ \t]/,$d' | sed 's/^[ \t]*- //') params.env secrets.env grpc-params.env kustomization.yaml | sed 's/ /\\n/g' | sort | uniq | awk '{gsub(/\\n/,"\n")}1'); do
     file=$i
     if [[ -f $directory/$file ]]; then
       case $file in
@@ -56,6 +56,9 @@ gen-target-middle() {
           gen-target-resource $file $directory
           ;;
         params.env)
+          gen-target-resource $file $directory
+          ;;
+        grpc-params.env)
           gen-target-resource $file $directory
           ;;
         secrets.env)

--- a/hack/generate_tests.py
+++ b/hack/generate_tests.py
@@ -6,7 +6,7 @@ import logging
 import os
 import subprocess
 
-TOP_LEVEL_EXCLUDES = ["docs", "hack", "tests"]
+TOP_LEVEL_EXCLUDES = ["docs", "hack", "tests", "kfdef"]
 
 def generate_test_name(repo_root, package_dir):
   """Generate the name of the go file to write the test to.

--- a/hack/update-instance-labels.sh
+++ b/hack/update-instance-labels.sh
@@ -4,10 +4,10 @@
 # kubeflow/testing/py/kubeflow/testing/tools/applications.py
 # see https://github.com/kubeflow/testing/pull/596
 
-# Replace 'app.kubernetes.io/version: v0.7.x' with 'app.kubernetes.io/version: v1.0.0'
-grep -rl --exclude-dir={kfdef,gatekeeper,gcp/deployment_manager_configs,aws/infra_configs,docs,hack,plugins} 'app.kubernetes.io/version: v0.7' ./ \
-  | xargs sed -i -E 's/app.kubernetes.io\/version: v0.7(.*)/app.kubernetes.io\/version: v1.0.0/g'
+# Replace 'app.kubernetes.io/version: v0.6.x' with 'app.kubernetes.io/version: v0.7.0'
+grep -rl --exclude-dir={kfdef,gatekeeper,gcp/deployment_manager_configs,aws/infra_configs,docs,hack,plugins} 'app.kubernetes.io/version: v0.6' ./ \
+  | xargs sed -i -E 's/app.kubernetes.io\/version: v0.6(.*)/app.kubernetes.io\/version: v0.7.0/g'
 
-# Replace 'app.kubernetes.io/instance: <application>-v0.7.x' with 'app.kubernetes.io/instance: <application>-v1.0.0'
-grep -rl --exclude-dir={kfdef,gatekeeper,gcp/deployment_manager_configs,aws/infra_configs,docs,hack,plugins} 'app.kubernetes.io/instance: [a-z\-]*-v0.7' ./ \
-  | xargs sed -i -E 's/app.kubernetes.io\/instance: (.+)-v0.7(.*)/app.kubernetes.io\/instance: \1-v1.0.0/g'
+# Replace 'app.kubernetes.io/instance: <application>-v0.6.x' with 'app.kubernetes.io/instance: <application>-v0.7.0'
+grep -rl --exclude-dir={kfdef,gatekeeper,gcp/deployment_manager_configs,aws/infra_configs,docs,hack,plugins} 'app.kubernetes.io/instance: [a-z\-]*-v0.6' ./ \
+  | xargs sed -i -E 's/app.kubernetes.io\/instance: (.+)-v0.6(.*)/app.kubernetes.io\/instance: \1-v0.7.0/g'

--- a/katib/katib-controller/overlays/application/application.yaml
+++ b/katib/katib-controller/overlays/application/application.yaml
@@ -3,14 +3,7 @@ kind: Application
 metadata:
   name: katib-controller
 spec:
-  selector:
-    matchLabels:
-      app.kubernetes.io/name: katib-controller
-      app.kubernetes.io/instance: katib-controller-v1.0.0
-      app.kubernetes.io/managed-by: kfctl
-      app.kubernetes.io/component: katib
-      app.kubernetes.io/part-of: kubeflow
-      app.kubernetes.io/version: v1.0.0
+  addOwnerRef: true
   componentKinds:
   - group: core
     kind: Service
@@ -27,36 +20,44 @@ spec:
   - group: kubeflow.org
     kind: Trial
   descriptor:
-    type: "katib"
-    version: "v1alpha3"
-    description: "Katib is a service for hyperparameter tuning and neural architecture search."
-    maintainers:
-    - name: Ce Gao
-      email: gaoce@caicloud.io
-    - name: Johnu George
-      email: johnugeo@cisco.com
-    - name: Hougang Liu
-      email: liuhougang6@126.com
-    - name: Richard Liu
-      email: ricliu@google.com
-    - name: YujiOshima
-      email: yuji.oshima0x3fd@gmail.com
-    owners:
-    - name: Ce Gao
-      email: gaoce@caicloud.io
-    - name: Johnu George
-      email: johnugeo@cisco.com
-    - name: Hougang Liu
-      email: liuhougang6@126.com
-    - name: Richard Liu
-      email: ricliu@google.com
-    - name: YujiOshima
-      email: yuji.oshima0x3fd@gmail.com
+    description: Katib is a service for hyperparameter tuning and neural architecture
+      search.
     keywords:
     - katib
     - katib-controller
     - hyperparameter tuning
     links:
     - description: About
-      url: "https://github.com/kubeflow/katib"
-  addOwnerRef: true
+      url: https://github.com/kubeflow/katib
+    maintainers:
+    - email: gaoce@caicloud.io
+      name: Ce Gao
+    - email: johnugeo@cisco.com
+      name: Johnu George
+    - email: liuhougang6@126.com
+      name: Hougang Liu
+    - email: ricliu@google.com
+      name: Richard Liu
+    - email: yuji.oshima0x3fd@gmail.com
+      name: YujiOshima
+    owners:
+    - email: gaoce@caicloud.io
+      name: Ce Gao
+    - email: johnugeo@cisco.com
+      name: Johnu George
+    - email: liuhougang6@126.com
+      name: Hougang Liu
+    - email: ricliu@google.com
+      name: Richard Liu
+    - email: yuji.oshima0x3fd@gmail.com
+      name: YujiOshima
+    type: katib
+    version: v1alpha3
+  selector:
+    matchLabels:
+      app.kubernetes.io/component: katib
+      app.kubernetes.io/instance: katib-controller-0.8.0
+      app.kubernetes.io/managed-by: kfctl
+      app.kubernetes.io/name: katib-controller
+      app.kubernetes.io/part-of: kubeflow
+      app.kubernetes.io/version: 0.8.0

--- a/katib/katib-controller/overlays/application/kustomization.yaml
+++ b/katib/katib-controller/overlays/application/kustomization.yaml
@@ -1,13 +1,13 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
-kind: Kustomization
 bases:
 - ../../base
+commonLabels:
+  app.kubernetes.io/component: katib
+  app.kubernetes.io/instance: katib-controller-0.8.0
+  app.kubernetes.io/managed-by: kfctl
+  app.kubernetes.io/name: katib-controller
+  app.kubernetes.io/part-of: kubeflow
+  app.kubernetes.io/version: 0.8.0
+kind: Kustomization
 resources:
 - application.yaml
-commonLabels:
-  app.kubernetes.io/name: katib-controller
-  app.kubernetes.io/instance: katib-controller-v1.0.0
-  app.kubernetes.io/managed-by: kfctl
-  app.kubernetes.io/component: katib
-  app.kubernetes.io/part-of: kubeflow
-  app.kubernetes.io/version: v1.0.0

--- a/katib/katib-crds/overlays/application/application.yaml
+++ b/katib/katib-crds/overlays/application/application.yaml
@@ -3,14 +3,7 @@ kind: Application
 metadata:
   name: katib-crds
 spec:
-  selector:
-    matchLabels:
-      app.kubernetes.io/name: katib-crds
-      app.kubernetes.io/instance: katib-crds-v1.0.0
-      app.kubernetes.io/managed-by: kfctl
-      app.kubernetes.io/component: katib
-      app.kubernetes.io/part-of: kubeflow
-      app.kubernetes.io/version: v1.0.0
+  addOwnerRef: true
   componentKinds:
   - group: core
     kind: Service
@@ -25,36 +18,44 @@ spec:
   - group: kubeflow.org
     kind: Trial
   descriptor:
-    type: "katib"
-    version: "v1alpha3"
-    description: "Katib is a service for hyperparameter tuning and neural architecture search."
-    maintainers:
-    - name: Ce Gao
-      email: gaoce@caicloud.io
-    - name: Johnu George
-      email: johnugeo@cisco.com
-    - name: Hougang Liu
-      email: liuhougang6@126.com
-    - name: Richard Liu
-      email: ricliu@google.com
-    - name: YujiOshima
-      email: yuji.oshima0x3fd@gmail.com
-    owners:
-    - name: Ce Gao
-      email: gaoce@caicloud.io
-    - name: Johnu George
-      email: johnugeo@cisco.com
-    - name: Hougang Liu
-      email: liuhougang6@126.com
-    - name: Richard Liu
-      email: ricliu@google.com
-    - name: YujiOshima
-      email: yuji.oshima0x3fd@gmail.com
+    description: Katib is a service for hyperparameter tuning and neural architecture
+      search.
     keywords:
     - katib
     - katib-controller
     - hyperparameter tuning
     links:
     - description: About
-      url: "https://github.com/kubeflow/katib"
-  addOwnerRef: true
+      url: https://github.com/kubeflow/katib
+    maintainers:
+    - email: gaoce@caicloud.io
+      name: Ce Gao
+    - email: johnugeo@cisco.com
+      name: Johnu George
+    - email: liuhougang6@126.com
+      name: Hougang Liu
+    - email: ricliu@google.com
+      name: Richard Liu
+    - email: yuji.oshima0x3fd@gmail.com
+      name: YujiOshima
+    owners:
+    - email: gaoce@caicloud.io
+      name: Ce Gao
+    - email: johnugeo@cisco.com
+      name: Johnu George
+    - email: liuhougang6@126.com
+      name: Hougang Liu
+    - email: ricliu@google.com
+      name: Richard Liu
+    - email: yuji.oshima0x3fd@gmail.com
+      name: YujiOshima
+    type: katib
+    version: v1alpha3
+  selector:
+    matchLabels:
+      app.kubernetes.io/component: katib
+      app.kubernetes.io/instance: katib-crds-0.8.0
+      app.kubernetes.io/managed-by: kfctl
+      app.kubernetes.io/name: katib-crds
+      app.kubernetes.io/part-of: kubeflow
+      app.kubernetes.io/version: 0.8.0

--- a/katib/katib-crds/overlays/application/kustomization.yaml
+++ b/katib/katib-crds/overlays/application/kustomization.yaml
@@ -1,13 +1,13 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
-kind: Kustomization
 bases:
 - ../../base
+commonLabels:
+  app.kubernetes.io/component: katib
+  app.kubernetes.io/instance: katib-crds-0.8.0
+  app.kubernetes.io/managed-by: kfctl
+  app.kubernetes.io/name: katib-crds
+  app.kubernetes.io/part-of: kubeflow
+  app.kubernetes.io/version: 0.8.0
+kind: Kustomization
 resources:
 - application.yaml
-commonLabels:
-  app.kubernetes.io/name: katib-crds
-  app.kubernetes.io/instance: katib-crds-v1.0.0
-  app.kubernetes.io/managed-by: kfctl
-  app.kubernetes.io/component: katib
-  app.kubernetes.io/part-of: kubeflow
-  app.kubernetes.io/version: v1.0.0

--- a/metadata/overlays/application/application.yaml
+++ b/metadata/overlays/application/application.yaml
@@ -3,14 +3,7 @@ kind: Application
 metadata:
   name: metadata
 spec:
-  selector:
-    matchLabels:
-      app.kubernetes.io/name: metadata
-      app.kubernetes.io/instance: metadata-v1.0.0
-      app.kubernetes.io/managed-by: kfctl
-      app.kubernetes.io/component: metadata
-      app.kubernetes.io/part-of: kubeflow
-      app.kubernetes.io/version: v1.0.0
+  addOwnerRef: true
   componentKinds:
   - group: core
     kind: Service
@@ -21,20 +14,27 @@ spec:
   - group: core
     kind: ServiceAccount
   descriptor:
-    type: "metadata"
-    version: "alpha"
-    description: "Tracking and managing metadata of machine learning workflows in Kubeflow."
-    maintainers:
-    - name: Zhenghui Wang
-      email: zhenghui@google.com
-    owners:
-    - name: Ajay Gopinathan
-      email: ajaygopinathan@google.com
-    - name: Zhenghui Wang
-      email: zhenghui@google.com
+    description: Tracking and managing metadata of machine learning workflows in Kubeflow.
     keywords:
-    - "metadata"
+    - metadata
     links:
     - description: Docs
-      url: "https://www.kubeflow.org/docs/components/misc/metadata/"
-  addOwnerRef: true
+      url: https://www.kubeflow.org/docs/components/misc/metadata/
+    maintainers:
+    - email: zhenghui@google.com
+      name: Zhenghui Wang
+    owners:
+    - email: ajaygopinathan@google.com
+      name: Ajay Gopinathan
+    - email: zhenghui@google.com
+      name: Zhenghui Wang
+    type: metadata
+    version: alpha
+  selector:
+    matchLabels:
+      app.kubernetes.io/component: metadata
+      app.kubernetes.io/instance: metadata-0.2.1
+      app.kubernetes.io/managed-by: kfctl
+      app.kubernetes.io/name: metadata
+      app.kubernetes.io/part-of: kubeflow
+      app.kubernetes.io/version: 0.2.1

--- a/metadata/overlays/application/kustomization.yaml
+++ b/metadata/overlays/application/kustomization.yaml
@@ -1,13 +1,13 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
-kind: Kustomization
 bases:
 - ../../base
+commonLabels:
+  app.kubernetes.io/component: metadata
+  app.kubernetes.io/instance: metadata-0.2.1
+  app.kubernetes.io/managed-by: kfctl
+  app.kubernetes.io/name: metadata
+  app.kubernetes.io/part-of: kubeflow
+  app.kubernetes.io/version: 0.2.1
+kind: Kustomization
 resources:
 - application.yaml
-commonLabels:
-  app.kubernetes.io/name: metadata
-  app.kubernetes.io/instance: metadata-v1.0.0
-  app.kubernetes.io/managed-by: kfctl
-  app.kubernetes.io/component: metadata
-  app.kubernetes.io/part-of: kubeflow
-  app.kubernetes.io/version: v1.0.0

--- a/seldon/seldon-core-operator/overlays/application/application.yaml
+++ b/seldon/seldon-core-operator/overlays/application/application.yaml
@@ -1,32 +1,41 @@
 apiVersion: app.k8s.io/v1beta1
 kind: Application
 metadata:
-  name: "seldon-core-operator"
+  name: seldon-core-operator
 spec:
-  type: "seldon-core-operator"
   componentKinds:
-    - group: apps/v1
-      kind: StatefulSet
-    - group: v1
-      kind: Service
-    - group: apps/v1
-      kind: Deployment
-    - group: v1
-      kind: Secret
-    - group: v1
-      kind: ConfigMap
-  version: "v1"
-  description: "Seldon allows users to create ML Inference Graphs to deploy their models and serve predictions"
-  icons:
-  maintainers:
-    - name: Seldon
-      email: dev@seldon.io
-  owners:
-    - name: Seldon
-      email: dev@seldon.io
+  - group: apps/v1
+    kind: StatefulSet
+  - group: v1
+    kind: Service
+  - group: apps/v1
+    kind: Deployment
+  - group: v1
+    kind: Secret
+  - group: v1
+    kind: ConfigMap
+  description: Seldon allows users to create ML Inference Graphs to deploy their models
+    and serve predictions
+  icons: null
   keywords:
-   - "seldon"
-   - "inference"
+  - seldon
+  - inference
   links:
-    - description: Docs
-      url: "https://docs.seldon.io/projects/seldon-core/en/v1.0.1/"
+  - description: Docs
+    url: https://docs.seldon.io/projects/seldon-core/en/v1.0.1/
+  maintainers:
+  - email: dev@seldon.io
+    name: Seldon
+  owners:
+  - email: dev@seldon.io
+    name: Seldon
+  selector:
+    matchLabels:
+      app.kubernetes.io/component: seldon
+      app.kubernetes.io/instance: seldon-1.15
+      app.kubernetes.io/managed-by: kfctl
+      app.kubernetes.io/name: seldon
+      app.kubernetes.io/part-of: kubeflow
+      app.kubernetes.io/version: '1.15'
+  type: seldon-core-operator
+  version: v1

--- a/seldon/seldon-core-operator/overlays/application/kustomization.yaml
+++ b/seldon/seldon-core-operator/overlays/application/kustomization.yaml
@@ -1,13 +1,13 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
-kind: Kustomization
 bases:
 - ../../base
+commonLabels:
+  app.kubernetes.io/component: seldon
+  app.kubernetes.io/instance: seldon-1.15
+  app.kubernetes.io/managed-by: kfctl
+  app.kubernetes.io/name: seldon-core-operator
+  app.kubernetes.io/part-of: kubeflow
+  app.kubernetes.io/version: '1.15'
+kind: Kustomization
 resources:
 - application.yaml
-commonLabels:
-  app.kubernetes.io/name: seldon-core-operator
-  app.kubernetes.io/instance: seldon-core-operator-v1.0.1
-  app.kubernetes.io/managed-by: kfctl
-  app.kubernetes.io/component: seldon
-  app.kubernetes.io/part-of: kubeflow
-  app.kubernetes.io/version: v1.0.1

--- a/tests/katib-katib-controller-overlays-application_test.go
+++ b/tests/katib-katib-controller-overlays-application_test.go
@@ -20,14 +20,7 @@ kind: Application
 metadata:
   name: katib-controller
 spec:
-  selector:
-    matchLabels:
-      app.kubernetes.io/name: katib-controller
-      app.kubernetes.io/instance: katib-controller-v1.0.0
-      app.kubernetes.io/managed-by: kfctl
-      app.kubernetes.io/component: katib
-      app.kubernetes.io/part-of: kubeflow
-      app.kubernetes.io/version: v1.0.0
+  addOwnerRef: true
   componentKinds:
   - group: core
     kind: Service
@@ -44,54 +37,62 @@ spec:
   - group: kubeflow.org
     kind: Trial
   descriptor:
-    type: "katib"
-    version: "v1alpha3"
-    description: "Katib is a service for hyperparameter tuning and neural architecture search."
-    maintainers:
-    - name: Ce Gao
-      email: gaoce@caicloud.io
-    - name: Johnu George
-      email: johnugeo@cisco.com
-    - name: Hougang Liu
-      email: liuhougang6@126.com
-    - name: Richard Liu
-      email: ricliu@google.com
-    - name: YujiOshima
-      email: yuji.oshima0x3fd@gmail.com
-    owners:
-    - name: Ce Gao
-      email: gaoce@caicloud.io
-    - name: Johnu George
-      email: johnugeo@cisco.com
-    - name: Hougang Liu
-      email: liuhougang6@126.com
-    - name: Richard Liu
-      email: ricliu@google.com
-    - name: YujiOshima
-      email: yuji.oshima0x3fd@gmail.com
+    description: Katib is a service for hyperparameter tuning and neural architecture
+      search.
     keywords:
     - katib
     - katib-controller
     - hyperparameter tuning
     links:
     - description: About
-      url: "https://github.com/kubeflow/katib"
-  addOwnerRef: true
+      url: https://github.com/kubeflow/katib
+    maintainers:
+    - email: gaoce@caicloud.io
+      name: Ce Gao
+    - email: johnugeo@cisco.com
+      name: Johnu George
+    - email: liuhougang6@126.com
+      name: Hougang Liu
+    - email: ricliu@google.com
+      name: Richard Liu
+    - email: yuji.oshima0x3fd@gmail.com
+      name: YujiOshima
+    owners:
+    - email: gaoce@caicloud.io
+      name: Ce Gao
+    - email: johnugeo@cisco.com
+      name: Johnu George
+    - email: liuhougang6@126.com
+      name: Hougang Liu
+    - email: ricliu@google.com
+      name: Richard Liu
+    - email: yuji.oshima0x3fd@gmail.com
+      name: YujiOshima
+    type: katib
+    version: v1alpha3
+  selector:
+    matchLabels:
+      app.kubernetes.io/component: katib
+      app.kubernetes.io/instance: katib-controller-0.8.0
+      app.kubernetes.io/managed-by: kfctl
+      app.kubernetes.io/name: katib-controller
+      app.kubernetes.io/part-of: kubeflow
+      app.kubernetes.io/version: 0.8.0
 `)
 	th.writeK("/manifests/katib/katib-controller/overlays/application", `
 apiVersion: kustomize.config.k8s.io/v1beta1
-kind: Kustomization
 bases:
 - ../../base
+commonLabels:
+  app.kubernetes.io/component: katib
+  app.kubernetes.io/instance: katib-controller-0.8.0
+  app.kubernetes.io/managed-by: kfctl
+  app.kubernetes.io/name: katib-controller
+  app.kubernetes.io/part-of: kubeflow
+  app.kubernetes.io/version: 0.8.0
+kind: Kustomization
 resources:
 - application.yaml
-commonLabels:
-  app.kubernetes.io/name: katib-controller
-  app.kubernetes.io/instance: katib-controller-v1.0.0
-  app.kubernetes.io/managed-by: kfctl
-  app.kubernetes.io/component: katib
-  app.kubernetes.io/part-of: kubeflow
-  app.kubernetes.io/version: v1.0.0
 `)
 	th.writeF("/manifests/katib/katib-controller/base/katib-configmap.yaml", `
 apiVersion: v1

--- a/tests/katib-katib-crds-overlays-application_test.go
+++ b/tests/katib-katib-crds-overlays-application_test.go
@@ -20,14 +20,7 @@ kind: Application
 metadata:
   name: katib-crds
 spec:
-  selector:
-    matchLabels:
-      app.kubernetes.io/name: katib-crds
-      app.kubernetes.io/instance: katib-crds-v1.0.0
-      app.kubernetes.io/managed-by: kfctl
-      app.kubernetes.io/component: katib
-      app.kubernetes.io/part-of: kubeflow
-      app.kubernetes.io/version: v1.0.0
+  addOwnerRef: true
   componentKinds:
   - group: core
     kind: Service
@@ -42,54 +35,62 @@ spec:
   - group: kubeflow.org
     kind: Trial
   descriptor:
-    type: "katib"
-    version: "v1alpha3"
-    description: "Katib is a service for hyperparameter tuning and neural architecture search."
-    maintainers:
-    - name: Ce Gao
-      email: gaoce@caicloud.io
-    - name: Johnu George
-      email: johnugeo@cisco.com
-    - name: Hougang Liu
-      email: liuhougang6@126.com
-    - name: Richard Liu
-      email: ricliu@google.com
-    - name: YujiOshima
-      email: yuji.oshima0x3fd@gmail.com
-    owners:
-    - name: Ce Gao
-      email: gaoce@caicloud.io
-    - name: Johnu George
-      email: johnugeo@cisco.com
-    - name: Hougang Liu
-      email: liuhougang6@126.com
-    - name: Richard Liu
-      email: ricliu@google.com
-    - name: YujiOshima
-      email: yuji.oshima0x3fd@gmail.com
+    description: Katib is a service for hyperparameter tuning and neural architecture
+      search.
     keywords:
     - katib
     - katib-controller
     - hyperparameter tuning
     links:
     - description: About
-      url: "https://github.com/kubeflow/katib"
-  addOwnerRef: true
+      url: https://github.com/kubeflow/katib
+    maintainers:
+    - email: gaoce@caicloud.io
+      name: Ce Gao
+    - email: johnugeo@cisco.com
+      name: Johnu George
+    - email: liuhougang6@126.com
+      name: Hougang Liu
+    - email: ricliu@google.com
+      name: Richard Liu
+    - email: yuji.oshima0x3fd@gmail.com
+      name: YujiOshima
+    owners:
+    - email: gaoce@caicloud.io
+      name: Ce Gao
+    - email: johnugeo@cisco.com
+      name: Johnu George
+    - email: liuhougang6@126.com
+      name: Hougang Liu
+    - email: ricliu@google.com
+      name: Richard Liu
+    - email: yuji.oshima0x3fd@gmail.com
+      name: YujiOshima
+    type: katib
+    version: v1alpha3
+  selector:
+    matchLabels:
+      app.kubernetes.io/component: katib
+      app.kubernetes.io/instance: katib-crds-0.8.0
+      app.kubernetes.io/managed-by: kfctl
+      app.kubernetes.io/name: katib-crds
+      app.kubernetes.io/part-of: kubeflow
+      app.kubernetes.io/version: 0.8.0
 `)
 	th.writeK("/manifests/katib/katib-crds/overlays/application", `
 apiVersion: kustomize.config.k8s.io/v1beta1
-kind: Kustomization
 bases:
 - ../../base
+commonLabels:
+  app.kubernetes.io/component: katib
+  app.kubernetes.io/instance: katib-crds-0.8.0
+  app.kubernetes.io/managed-by: kfctl
+  app.kubernetes.io/name: katib-crds
+  app.kubernetes.io/part-of: kubeflow
+  app.kubernetes.io/version: 0.8.0
+kind: Kustomization
 resources:
 - application.yaml
-commonLabels:
-  app.kubernetes.io/name: katib-crds
-  app.kubernetes.io/instance: katib-crds-v1.0.0
-  app.kubernetes.io/managed-by: kfctl
-  app.kubernetes.io/component: katib
-  app.kubernetes.io/part-of: kubeflow
-  app.kubernetes.io/version: v1.0.0
 `)
 	th.writeF("/manifests/katib/katib-crds/base/experiment-crd.yaml", `
 apiVersion: apiextensions.k8s.io/v1beta1

--- a/tests/metadata-overlays-application_test.go
+++ b/tests/metadata-overlays-application_test.go
@@ -20,14 +20,7 @@ kind: Application
 metadata:
   name: metadata
 spec:
-  selector:
-    matchLabels:
-      app.kubernetes.io/name: metadata
-      app.kubernetes.io/instance: metadata-v1.0.0
-      app.kubernetes.io/managed-by: kfctl
-      app.kubernetes.io/component: metadata
-      app.kubernetes.io/part-of: kubeflow
-      app.kubernetes.io/version: v1.0.0
+  addOwnerRef: true
   componentKinds:
   - group: core
     kind: Service
@@ -38,38 +31,45 @@ spec:
   - group: core
     kind: ServiceAccount
   descriptor:
-    type: "metadata"
-    version: "alpha"
-    description: "Tracking and managing metadata of machine learning workflows in Kubeflow."
-    maintainers:
-    - name: Zhenghui Wang
-      email: zhenghui@google.com
-    owners:
-    - name: Ajay Gopinathan
-      email: ajaygopinathan@google.com
-    - name: Zhenghui Wang
-      email: zhenghui@google.com
+    description: Tracking and managing metadata of machine learning workflows in Kubeflow.
     keywords:
-    - "metadata"
+    - metadata
     links:
     - description: Docs
-      url: "https://www.kubeflow.org/docs/components/misc/metadata/"
-  addOwnerRef: true
+      url: https://www.kubeflow.org/docs/components/misc/metadata/
+    maintainers:
+    - email: zhenghui@google.com
+      name: Zhenghui Wang
+    owners:
+    - email: ajaygopinathan@google.com
+      name: Ajay Gopinathan
+    - email: zhenghui@google.com
+      name: Zhenghui Wang
+    type: metadata
+    version: alpha
+  selector:
+    matchLabels:
+      app.kubernetes.io/component: metadata
+      app.kubernetes.io/instance: metadata-0.2.1
+      app.kubernetes.io/managed-by: kfctl
+      app.kubernetes.io/name: metadata
+      app.kubernetes.io/part-of: kubeflow
+      app.kubernetes.io/version: 0.2.1
 `)
 	th.writeK("/manifests/metadata/overlays/application", `
 apiVersion: kustomize.config.k8s.io/v1beta1
-kind: Kustomization
 bases:
 - ../../base
+commonLabels:
+  app.kubernetes.io/component: metadata
+  app.kubernetes.io/instance: metadata-0.2.1
+  app.kubernetes.io/managed-by: kfctl
+  app.kubernetes.io/name: metadata
+  app.kubernetes.io/part-of: kubeflow
+  app.kubernetes.io/version: 0.2.1
+kind: Kustomization
 resources:
 - application.yaml
-commonLabels:
-  app.kubernetes.io/name: metadata
-  app.kubernetes.io/instance: metadata-v1.0.0
-  app.kubernetes.io/managed-by: kfctl
-  app.kubernetes.io/component: metadata
-  app.kubernetes.io/part-of: kubeflow
-  app.kubernetes.io/version: v1.0.0
 `)
 	th.writeF("/manifests/metadata/base/metadata-deployment.yaml", `
 apiVersion: apps/v1
@@ -134,7 +134,7 @@ spec:
           args: ["--grpc_port=$(METADATA_GRPC_SERVICE_PORT)"]
           ports:
             - name: grpc-backendapi
-              containerPort: 8080
+              containerPort: 8080 #The value of the port number needs to be in sync with value  specified in grpc-params.env
 `)
 	th.writeF("/manifests/metadata/base/metadata-service.yaml", `
 kind: Service
@@ -304,8 +304,7 @@ uiClusterDomain=cluster.local
 `)
 	th.writeF("/manifests/metadata/base/grpc-params.env", `
 METADATA_GRPC_SERVICE_HOST=metadata-grpc-service
-METADATA_GRPC_SERVICE_PORT=8080
-`)
+METADATA_GRPC_SERVICE_PORT=8080`)
 	th.writeK("/manifests/metadata/base", `
 namePrefix: metadata-
 apiVersion: kustomize.config.k8s.io/v1beta1

--- a/tests/seldon-seldon-core-operator-overlays-application_test.go
+++ b/tests/seldon-seldon-core-operator-overlays-application_test.go
@@ -18,50 +18,59 @@ func writeSeldonCoreOperatorOverlaysApplication(th *KustTestHarness) {
 apiVersion: app.k8s.io/v1beta1
 kind: Application
 metadata:
-  name: "seldon-core-operator"
+  name: seldon-core-operator
 spec:
-  type: "seldon-core-operator"
   componentKinds:
-    - group: apps/v1
-      kind: StatefulSet
-    - group: v1
-      kind: Service
-    - group: apps/v1
-      kind: Deployment
-    - group: v1
-      kind: Secret
-    - group: v1
-      kind: ConfigMap
-  version: "v1"
-  description: "Seldon allows users to create ML Inference Graphs to deploy their models and serve predictions"
-  icons:
-  maintainers:
-    - name: Seldon
-      email: dev@seldon.io
-  owners:
-    - name: Seldon
-      email: dev@seldon.io
+  - group: apps/v1
+    kind: StatefulSet
+  - group: v1
+    kind: Service
+  - group: apps/v1
+    kind: Deployment
+  - group: v1
+    kind: Secret
+  - group: v1
+    kind: ConfigMap
+  description: Seldon allows users to create ML Inference Graphs to deploy their models
+    and serve predictions
+  icons: null
   keywords:
-   - "seldon"
-   - "inference"
+  - seldon
+  - inference
   links:
-    - description: Docs
-      url: "https://docs.seldon.io/projects/seldon-core/en/v1.0.1/"
+  - description: Docs
+    url: https://docs.seldon.io/projects/seldon-core/en/v1.0.1/
+  maintainers:
+  - email: dev@seldon.io
+    name: Seldon
+  owners:
+  - email: dev@seldon.io
+    name: Seldon
+  selector:
+    matchLabels:
+      app.kubernetes.io/component: seldon
+      app.kubernetes.io/instance: seldon-1.15
+      app.kubernetes.io/managed-by: kfctl
+      app.kubernetes.io/name: seldon
+      app.kubernetes.io/part-of: kubeflow
+      app.kubernetes.io/version: '1.15'
+  type: seldon-core-operator
+  version: v1
 `)
 	th.writeK("/manifests/seldon/seldon-core-operator/overlays/application", `
 apiVersion: kustomize.config.k8s.io/v1beta1
-kind: Kustomization
 bases:
 - ../../base
+commonLabels:
+  app.kubernetes.io/component: seldon
+  app.kubernetes.io/instance: seldon-1.15
+  app.kubernetes.io/managed-by: kfctl
+  app.kubernetes.io/name: seldon-core-operator
+  app.kubernetes.io/part-of: kubeflow
+  app.kubernetes.io/version: '1.15'
+kind: Kustomization
 resources:
 - application.yaml
-commonLabels:
-  app.kubernetes.io/name: seldon-core-operator
-  app.kubernetes.io/instance: seldon-core-operator-v1.0.1
-  app.kubernetes.io/managed-by: kfctl
-  app.kubernetes.io/component: seldon
-  app.kubernetes.io/part-of: kubeflow
-  app.kubernetes.io/version: v1.0.1
 `)
 	th.writeF("/manifests/seldon/seldon-core-operator/base/resources.yaml", `
 ---


### PR DESCRIPTION
This isn't a clean cherry-pick.

* The manifests for katib on master had changed so I reran the update app script

* I had to pull in #831 as well to make test regeneration work.

<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/manifests/870)
<!-- Reviewable:end -->
