### PR TITLE
EnvoyFilter to add anonymous@kubeflow.org user to all gateway requests

### DIFF
--- a/istio/add-anonymous-user-filter/base/envoy-filter.yaml
+++ b/istio/add-anonymous-user-filter/base/envoy-filter.yaml
@@ -1,0 +1,19 @@
+apiVersion: networking.istio.io/v1alpha3
+kind: EnvoyFilter
+metadata:
+  name: add-user-filter
+spec:
+  workloadLabels:
+    app: istio-ingressgateway
+  filters:
+  - listenerMatch:
+      listenerType: GATEWAY
+    filterName: envoy.lua
+    filterType: HTTP
+    insertPosition:
+      index: FIRST
+    filterConfig:
+      inlineCode: |
+        function envoy_on_request(request_handle)
+            request_handle:headers():add("kubeflow-userid","anonymous@kubeflow.org")
+        end

--- a/istio/add-anonymous-user-filter/base/kustomization.yaml
+++ b/istio/add-anonymous-user-filter/base/kustomization.yaml
@@ -1,0 +1,5 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+namespace: istio-system
+resources:
+- envoy-filter.yaml

--- a/kfdef/kfctl_k8s_istio.yaml
+++ b/kfdef/kfctl_k8s_istio.yaml
@@ -29,6 +29,14 @@ spec:
         path: istio/istio
     name: istio
   - kustomizeConfig:
+      parameters:
+      - name: namespace
+        value: istio-system
+      repoRef:
+        name: manifests
+        path: istio/add-anonymous-user-filter
+    name: add-anonymous-user-filter
+  - kustomizeConfig:
       repoRef:
         name: manifests
         path: application/application-crds

--- a/kfdef/kfctl_k8s_istio.yaml
+++ b/kfdef/kfctl_k8s_istio.yaml
@@ -119,6 +119,9 @@ spec:
       overlays:
       - istio
       - application
+      parameters:
+      - name: userid-header
+        value: kubeflow-userid
       repoRef:
         name: manifests
         path: jupyter/jupyter-web-app

--- a/tests/istio-add-anonymous-user-filter-base_test.go
+++ b/tests/istio-add-anonymous-user-filter-base_test.go
@@ -1,0 +1,76 @@
+package tests_test
+
+import (
+	"sigs.k8s.io/kustomize/v3/k8sdeps/kunstruct"
+	"sigs.k8s.io/kustomize/v3/k8sdeps/transformer"
+	"sigs.k8s.io/kustomize/v3/pkg/fs"
+	"sigs.k8s.io/kustomize/v3/pkg/loader"
+	"sigs.k8s.io/kustomize/v3/pkg/plugins"
+	"sigs.k8s.io/kustomize/v3/pkg/resmap"
+	"sigs.k8s.io/kustomize/v3/pkg/resource"
+	"sigs.k8s.io/kustomize/v3/pkg/target"
+	"sigs.k8s.io/kustomize/v3/pkg/validators"
+	"testing"
+)
+
+func writeAddAnonymousUserFilterBase(th *KustTestHarness) {
+	th.writeF("/manifests/istio/add-anonymous-user-filter/base/envoy-filter.yaml", `
+apiVersion: networking.istio.io/v1alpha3
+kind: EnvoyFilter
+metadata:
+  name: add-user-filter
+spec:
+  workloadLabels:
+    app: istio-ingressgateway
+  filters:
+  - listenerMatch:
+      listenerType: GATEWAY
+    filterName: envoy.lua
+    filterType: HTTP
+    insertPosition:
+      index: FIRST
+    filterConfig:
+      inlineCode: |
+        function envoy_on_request(request_handle)
+            request_handle:headers():add("kubeflow-userid","anonymous@kubeflow.org")
+        end
+`)
+	th.writeK("/manifests/istio/add-anonymous-user-filter/base", `
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+namespace: istio-system
+resources:
+- envoy-filter.yaml
+`)
+}
+
+func TestAddAnonymousUserFilterBase(t *testing.T) {
+	th := NewKustTestHarness(t, "/manifests/istio/add-anonymous-user-filter/base")
+	writeAddAnonymousUserFilterBase(th)
+	m, err := th.makeKustTarget().MakeCustomizedResMap()
+	if err != nil {
+		t.Fatalf("Err: %v", err)
+	}
+	expected, err := m.AsYaml()
+	if err != nil {
+		t.Fatalf("Err: %v", err)
+	}
+	targetPath := "../istio/add-anonymous-user-filter/base"
+	fsys := fs.MakeRealFS()
+	lrc := loader.RestrictionRootOnly
+	_loader, loaderErr := loader.NewLoader(lrc, validators.MakeFakeValidator(), targetPath, fsys)
+	if loaderErr != nil {
+		t.Fatalf("could not load kustomize loader: %v", loaderErr)
+	}
+	rf := resmap.NewFactory(resource.NewFactory(kunstruct.NewKunstructuredFactoryImpl()), transformer.NewFactoryImpl())
+	pc := plugins.DefaultPluginConfig()
+	kt, err := target.NewKustTarget(_loader, rf, transformer.NewFactoryImpl(), plugins.NewLoader(pc, rf))
+	if err != nil {
+		th.t.Fatalf("Unexpected construction error %v", err)
+	}
+	actual, err := kt.MakeCustomizedResMap()
+	if err != nil {
+		t.Fatalf("Err: %v", err)
+	}
+	th.assertActualEqualsExpected(actual, string(expected))
+}


### PR DESCRIPTION
**Which issue is resolved by this Pull Request:**
Related to kubeflow/kubeflow#4731

**Description of your changes:**
Anonymous user anonymous@kubeflow.org added through this manifest to Istio gateway based requests.

Note that this implementation spoofs a user to enable non-auth setups with an anonymous user.
**Checklist:**
- [x] Unit tests have been rebuilt: 
    1. `cd manifests/tests`
    2. `make generate-changed-only`
    3. `make test`

/assign @jlewi @swiftdiaries

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/manifests/885)
<!-- Reviewable:end -->
