### PR TITLE
change configMapGenerator env to envs

### DIFF
--- a/admission-webhook/bootstrap/base/kustomization.yaml
+++ b/admission-webhook/bootstrap/base/kustomization.yaml
@@ -21,7 +21,8 @@ namespace: kubeflow
 configMapGenerator:
 - name: config-map
   behavior: merge
-  env: params.env
+  envs:
+  - params.env
 vars:
 - name: webhookNamePrefix
   objref:

--- a/admission-webhook/webhook/overlays/cert-manager/kustomization.yaml
+++ b/admission-webhook/webhook/overlays/cert-manager/kustomization.yaml
@@ -11,7 +11,8 @@ patchesStrategicMerge:
 configMapGenerator:
 - name: admission-webhook-parameters
   behavior: merge
-  env: params.env
+  envs:
+  - params.env
 generatorOptions:
   disableNameSuffixHash: true
 

--- a/application/application/base/kustomization.yaml
+++ b/application/application/base/kustomization.yaml
@@ -10,7 +10,8 @@ namespace: kubeflow
 nameprefix: application-controller-
 configMapGenerator:
 - name: parameters
-  env: params.env
+  envs:
+  - params.env
 generatorOptions:
   disableNameSuffixHash: true
 images:

--- a/argo/base/kustomization.yaml
+++ b/argo/base/kustomization.yaml
@@ -19,7 +19,8 @@ images:
   newTag: v2.3.0
 configMapGenerator:
 - name: workflow-controller-parameters
-  env: params.env
+  envs:
+  - params.env
 generatorOptions:
   disableNameSuffixHash: true
 vars:

--- a/aws/aws-alb-ingress-controller/base/kustomization.yaml
+++ b/aws/aws-alb-ingress-controller/base/kustomization.yaml
@@ -16,7 +16,8 @@ images:
   newTag: v1.1.2
 configMapGenerator:
 - name: alb-ingress-controller-parameters
-  env: params.env
+  envs:
+  - params.env
 vars:
 - name: CLUSTER_NAME
   objref:

--- a/aws/aws-alb-ingress-controller/overlays/vpc/kustomization.yaml
+++ b/aws/aws-alb-ingress-controller/overlays/vpc/kustomization.yaml
@@ -6,7 +6,8 @@ resources:
 - vpc.yaml
 configMapGenerator:
 - name: alb-ingress-controller-vpc-parameters
-  env: params.env
+  envs:
+  - params.env
 vars:
 - name: VPC_ID
   objref:

--- a/aws/fluentd-cloud-watch/base/kustomization.yaml
+++ b/aws/fluentd-cloud-watch/base/kustomization.yaml
@@ -17,7 +17,8 @@ images:
   newTag: v1.1-debian-cloudwatch
 configMapGenerator:
 - name: fluentd-cloud-watch-parameters
-  env: params.env
+  envs:
+  - params.env
 vars:
 - name: CLUSTER_NAME
   objref:

--- a/aws/istio-ingress/overlays/cognito/kustomization.yaml
+++ b/aws/istio-ingress/overlays/cognito/kustomization.yaml
@@ -4,7 +4,8 @@ patchesStrategicMerge:
 - ingress.yaml
 configMapGenerator:
 - name: istio-ingress-cognito-parameters
-  env: params.env
+  envs:
+  - params.env
 vars:
 - name: CognitoUserPoolArn
   objref:

--- a/aws/istio-ingress/overlays/oidc/kustomization.yaml
+++ b/aws/istio-ingress/overlays/oidc/kustomization.yaml
@@ -9,7 +9,8 @@ secretGenerator:
   namespace: istio-system
 configMapGenerator:
 - name: istio-ingress-oidc-parameters
-  env: params.env
+  envs:
+  - params.env
 vars:
 - name: oidcIssuer
   objref:

--- a/cert-manager/cert-manager-kube-system-resources/base/kustomization.yaml
+++ b/cert-manager/cert-manager-kube-system-resources/base/kustomization.yaml
@@ -8,7 +8,8 @@ commonLabels:
   kustomize.component: cert-manager
 configMapGenerator:
 - name: cert-manager-kube-params-parameters
-  env: params.env
+  envs:
+  - params.env
 generatorOptions:
   disableNameSuffixHash: true
 vars:

--- a/cert-manager/cert-manager/base/kustomization.yaml
+++ b/cert-manager/cert-manager/base/kustomization.yaml
@@ -25,7 +25,8 @@ images:
   newTag: v0.11.0
 configMapGenerator:
 - name: cert-manager-parameters
-  env: params.env
+  envs:
+  - params.env
 generatorOptions:
   disableNameSuffixHash: true
 vars:

--- a/cert-manager/cert-manager/overlays/letsencrypt/kustomization.yaml
+++ b/cert-manager/cert-manager/overlays/letsencrypt/kustomization.yaml
@@ -10,7 +10,8 @@ commonLabels:
 configMapGenerator:
 - name: cert-manager-parameters
   behavior: merge
-  env: params.env
+  envs:
+  - params.env
 generatorOptions:
   disableNameSuffixHash: true
 vars:

--- a/common/ambassador/base/kustomization.yaml
+++ b/common/ambassador/base/kustomization.yaml
@@ -15,7 +15,8 @@ images:
   newTag: 0.37.0
 configMapGenerator:
 - name: ambassador-parameters
-  env: params.env
+  envs:
+  - params.env
 generatorOptions:
   disableNameSuffixHash: true
 patchesJson6902:

--- a/common/basic-auth/base/kustomization.yaml
+++ b/common/basic-auth/base/kustomization.yaml
@@ -19,7 +19,8 @@ generatorOptions:
   disableNameSuffixHash: true
 configMapGenerator:
 - name: basic-auth-parameters
-  env: params.env
+  envs:
+  - params.env
 vars:
 - name: service-namespace
   objref:

--- a/common/spartakus/base/kustomization.yaml
+++ b/common/spartakus/base/kustomization.yaml
@@ -13,7 +13,8 @@ images:
   newTag: v1.1.0
 configMapGenerator:
 - name: spartakus-parameters
-  env: params.env
+  envs:
+  - params.env
 generatorOptions:
   disableNameSuffixHash: true
 vars:

--- a/default-install/base/kustomization.yaml
+++ b/default-install/base/kustomization.yaml
@@ -4,7 +4,8 @@ resources:
 - profile-instance.yaml
 configMapGenerator:
 - name: default-install-parameters
-  env: params.env
+  envs:
+  - params.env
 vars:
 - name: user
   objref:

--- a/dex-auth/dex-authenticator/base/kustomization.yaml
+++ b/dex-auth/dex-authenticator/base/kustomization.yaml
@@ -8,7 +8,8 @@ resources:
 - service.yaml
 configMapGenerator:
 - name: dex-authn-parameters
-  env: params.env
+  envs:
+  - params.env
 vars:
 - name: issuer
   objref:

--- a/dex-auth/dex-crds/base/kustomization.yaml
+++ b/dex-auth/dex-crds/base/kustomization.yaml
@@ -9,7 +9,8 @@ resources:
 - service.yaml
 configMapGenerator:
 - name: dex-parameters
-  env: params.env
+  envs:
+  - params.env
 generatorOptions:
   disableNameSuffixHash: true
 vars:

--- a/dex-auth/dex-crds/overlays/istio/kustomization.yaml
+++ b/dex-auth/dex-crds/overlays/istio/kustomization.yaml
@@ -8,7 +8,8 @@ resources:
 configMapGenerator:
 - name: dex-parameters
   behavior: merge
-  env: params.env
+  envs:
+  - params.env
 generatorOptions:
   disableNameSuffixHash: true
 vars:

--- a/dex-auth/dex-crds/overlays/ldap/kustomization.yaml
+++ b/dex-auth/dex-crds/overlays/ldap/kustomization.yaml
@@ -11,7 +11,8 @@ patchesStrategicMerge:
 configMapGenerator:
 - name: dex-parameters
   behavior: merge
-  env: params.env
+  envs:
+  - params.env
 generatorOptions:
   disableNameSuffixHash: true
 vars:

--- a/dex-auth/keycloak-gatekeeper/base/kustomization.yaml
+++ b/dex-auth/keycloak-gatekeeper/base/kustomization.yaml
@@ -11,7 +11,8 @@ resources:
 
 configMapGenerator:
 - name: keycloak-gatekeeper-parameters
-  env: params.env
+  envs:
+  - params.env
 generatorOptions:
   disableNameSuffixHash: true
 

--- a/docs/dex-auth/examples/authentication/Istio/base/kustomization.yaml
+++ b/docs/dex-auth/examples/authentication/Istio/base/kustomization.yaml
@@ -7,7 +7,8 @@ resources:
 
 configMapGenerator:
 - name: auth-parameters
-  env: params.env
+  envs:
+  - params.env
 
 vars:
 - name: issuer

--- a/gcp/basic-auth-ingress/base/kustomization.yaml
+++ b/gcp/basic-auth-ingress/base/kustomization.yaml
@@ -24,7 +24,8 @@ images:
   newTag: 1.0.0
 configMapGenerator:
 - name: basic-auth-ingress-parameters
-  env: params.env
+  envs:
+  - params.env
 generatorOptions:
   disableNameSuffixHash: true
 vars:

--- a/gcp/cloud-endpoints/base/kustomization.yaml
+++ b/gcp/cloud-endpoints/base/kustomization.yaml
@@ -17,7 +17,8 @@ images:
   newTag: 0.2.1
 configMapGenerator:
 - name: cloud-endpoints-parameters
-  env: params.env
+  envs:
+  - params.env
 generatorOptions:
   disableNameSuffixHash: true
 vars:

--- a/gcp/iap-ingress/base/kustomization.yaml
+++ b/gcp/iap-ingress/base/kustomization.yaml
@@ -27,7 +27,8 @@ images:
   newTag: 1.0.0
 configMapGenerator:
 - name: parameters
-  env: params.env
+  envs:
+  - params.env
 generatorOptions:
   disableNameSuffixHash: true
 vars:

--- a/gcp/prometheus/base/kustomization.yaml
+++ b/gcp/prometheus/base/kustomization.yaml
@@ -6,7 +6,8 @@ commonLabels:
   kustomize.component: prometheus
 configMapGenerator:
 - name: prometheus-parameters
-  env: params.env
+  envs:
+  - params.env
 images:
 - name: gcr.io/stackdriver-prometheus/stackdriver-prometheus
   newName: gcr.io/stackdriver-prometheus/stackdriver-prometheus

--- a/istio-1-3-1/istio-install-1-3-1/base/kustomization.yaml
+++ b/istio-1-3-1/istio-install-1-3-1/base/kustomization.yaml
@@ -2,7 +2,8 @@
 # one ConfigMap resource (it's a generator of n maps).
 configMapGenerator:
 - name: istio-install-parameters
-  env: params.env
+  envs:
+  - params.env
 
 # Images modify the tags for images without
 # creating patches.

--- a/istio/ingressgateway-self-signed-cert/base/kustomization.yaml
+++ b/istio/ingressgateway-self-signed-cert/base/kustomization.yaml
@@ -6,7 +6,8 @@ resources:
 
 configMapGenerator:
 - name: ingressgateway-self-signed-cert-parameters
-  env: params.env
+  envs:
+  - params.env
 generatorOptions:
   disableNameSuffixHash: true
 

--- a/istio/istio/base/kustomization.yaml
+++ b/istio/istio/base/kustomization.yaml
@@ -6,7 +6,8 @@ resources:
 namespace: kubeflow
 configMapGenerator:
 - name: istio-parameters
-  env: params.env
+  envs:
+  - params.env
 vars:
 - name: clusterRbacConfig
   objref:

--- a/istio/istio/overlays/https-gateway/kustomization.yaml
+++ b/istio/istio/overlays/https-gateway/kustomization.yaml
@@ -8,6 +8,7 @@ patchesStrategicMerge:
 configMapGenerator:
 - name: istio-parameters
   behavior: merge
-  env: params.env
+  envs:
+  - params.env
 configurations:
 - params.yaml

--- a/istio/oidc-authservice/base/kustomization.yaml
+++ b/istio/oidc-authservice/base/kustomization.yaml
@@ -11,7 +11,8 @@ namespace: istio-system
 
 configMapGenerator:
 - name: oidc-authservice-parameters
-  env: params.env
+  envs:
+  - params.env
 generatorOptions:
   disableNameSuffixHash: true
 

--- a/jupyter/notebook-controller/overlays/istio/kustomization.yaml
+++ b/jupyter/notebook-controller/overlays/istio/kustomization.yaml
@@ -7,6 +7,7 @@ patchesStrategicMerge:
 configMapGenerator:
 - name: parameters
   behavior: merge
-  env: params.env
+  envs:
+  - params.env
 generatorOptions:
   disableNameSuffixHash: true

--- a/katib/katib-controller/base/kustomization.yaml
+++ b/katib/katib-controller/base/kustomization.yaml
@@ -17,7 +17,8 @@ resources:
 - trial-template-configmap.yaml
 configMapGenerator:
 - name: katib-parameters
-  env: params.env
+  envs:
+  - params.env
 generatorOptions:
   disableNameSuffixHash: true
 images:

--- a/kfserving/kfserving-install/base/kustomization.yaml
+++ b/kfserving/kfserving-install/base/kustomization.yaml
@@ -12,7 +12,8 @@ commonLabels:
   kustomize.component: kfserving
 configMapGenerator:
 - name: kfserving-parameters
-  env: params.env
+  envs:
+  - params.env
 vars:
 - name: registry
   objref:

--- a/kubebench/base/kustomization.yaml
+++ b/kubebench/base/kustomization.yaml
@@ -12,7 +12,8 @@ commonLabels:
   kustomize.component: kubebench
 configMapGenerator:
 - name: parameters
-  env: params.env
+  envs:
+  - params.env
 images:
   # NOTE: the image for workflow agent should be configured in config-map.yaml
   - name:  gcr.io/kubeflow-images-public/kubebench/kubebench-operator-v1alpha2

--- a/metadata/base/kustomization.yaml
+++ b/metadata/base/kustomization.yaml
@@ -5,7 +5,8 @@ commonLabels:
   kustomize.component: metadata
 configMapGenerator:
 - name: ui-parameters
-  env: params.env
+  envs:
+  - params.env
 - name: metadata-grpc-configmap
   env: grpc-params.env
 resources:

--- a/metadata/overlays/db/kustomization.yaml
+++ b/metadata/overlays/db/kustomization.yaml
@@ -8,7 +8,8 @@ generatorOptions:
   disableNameSuffixHash: true
 configMapGenerator:
 - name: metadata-db-parameters
-  env: params.env
+  envs:
+  - params.env
 secretGenerator:
 - name: metadata-db-secrets
   env: secrets.env

--- a/mpi-job/mpi-operator/base/kustomization.yaml
+++ b/mpi-job/mpi-operator/base/kustomization.yaml
@@ -15,7 +15,8 @@ images:
   newTag: 0.1.0
 configMapGenerator:
 - name: mpi-operator-config
-  env: params.env
+  envs:
+  - params.env
 generatorOptions:
   disableNameSuffixHash: true
 vars:

--- a/pipeline/minio/base/kustomization.yaml
+++ b/pipeline/minio/base/kustomization.yaml
@@ -9,7 +9,8 @@ resources:
 - persistent-volume-claim.yaml
 configMapGenerator:
 - name: pipeline-minio-parameters
-  env: params.env
+  envs:
+  - params.env
 generatorOptions:
   disableNameSuffixHash: true
 vars:

--- a/pipeline/minio/overlays/minioPd/kustomization.yaml
+++ b/pipeline/minio/overlays/minioPd/kustomization.yaml
@@ -9,7 +9,8 @@ patchesStrategicMerge:
 configMapGenerator:
 - name: pipeline-minio-parameters
   behavior: merge
-  env: params.env
+  envs:
+  - params.env
 generatorOptions:
   disableNameSuffixHash: true
 vars:

--- a/pipeline/mysql/base/kustomization.yaml
+++ b/pipeline/mysql/base/kustomization.yaml
@@ -8,7 +8,8 @@ resources:
 - persistent-volume-claim.yaml
 configMapGenerator:
 - name: pipeline-mysql-parameters
-  env: params.env
+  envs:
+  - params.env
 generatorOptions:
   disableNameSuffixHash: true
 vars:

--- a/pipeline/mysql/overlays/mysqlPd/kustomization.yaml
+++ b/pipeline/mysql/overlays/mysqlPd/kustomization.yaml
@@ -9,7 +9,8 @@ patchesStrategicMerge:
 configMapGenerator:
 - name: pipeline-mysql-parameters
   behavior: merge
-  env: params.env
+  envs:
+  - params.env
 generatorOptions:
   disableNameSuffixHash: true
 vars:

--- a/pipeline/pipelines-ui/base/kustomization.yaml
+++ b/pipeline/pipelines-ui/base/kustomization.yaml
@@ -9,7 +9,8 @@ resources:
 - service.yaml
 configMapGenerator:
 - name: ui-parameters
-  env: params.env
+  envs:
+  - params.env
 images:
 - name: gcr.io/ml-pipeline/frontend
   newTag: 0.2.0

--- a/profiles/overlays/debug/kustomization.yaml
+++ b/profiles/overlays/debug/kustomization.yaml
@@ -6,7 +6,8 @@ patchesStrategicMerge:
 - deployment.yaml
 configMapGenerator:
 - name: parameters
-  env: params.env
+  envs:
+  - params.env
 generatorOptions:
   disableNameSuffixHash: true
 vars:

--- a/tektoncd/tektoncd-dashboard/overlays/application/kustomization.yaml
+++ b/tektoncd/tektoncd-dashboard/overlays/application/kustomization.yaml
@@ -6,7 +6,8 @@ resources:
 - application.yaml
 configMapGenerator:
 - name: tektoncd-dashboard-app-parameters
-  env: params.env
+  envs:
+  - params.env
 vars:
 - name: generateName
   objref:

--- a/tektoncd/tektoncd-dashboard/overlays/istio/kustomization.yaml
+++ b/tektoncd/tektoncd-dashboard/overlays/istio/kustomization.yaml
@@ -6,7 +6,8 @@ resources:
 - virtual-service.yaml
 configMapGenerator:
 - name: tektoncd-dashboard-parameters
-  env: params.env
+  envs:
+  - params.env
 vars:
 - name: namespace
   objref:

--- a/tektoncd/tektoncd-install/base/kustomization.yaml
+++ b/tektoncd/tektoncd-install/base/kustomization.yaml
@@ -13,7 +13,8 @@ resources:
 namespace: tekton-pipelines
 configMapGenerator:
 - name: tektoncd-parameters
-  env: params.env
+  envs:
+  - params.env
 generatorOptions:
   disableNameSuffixHash: true
 vars:

--- a/tektoncd/tektoncd-install/overlays/application/kustomization.yaml
+++ b/tektoncd/tektoncd-install/overlays/application/kustomization.yaml
@@ -6,7 +6,8 @@ resources:
 - application.yaml
 configMapGenerator:
 - name: tektoncd-install-parameters
-  env: params.env
+  envs:
+  - params.env
 vars:
 - name: generateName
   objref:

--- a/tektoncd/tektoncd-install/overlays/istio/kustomization.yaml
+++ b/tektoncd/tektoncd-install/overlays/istio/kustomization.yaml
@@ -6,7 +6,8 @@ resources:
 - virtual-service.yaml
 configMapGenerator:
 - name: tektoncd-install-istio-parameters
-  env: params.env
+  envs:
+  - params.env
 generatorOptions:
   disableNameSuffixHash: true
 vars:

--- a/tensorboard/base/kustomization.yaml
+++ b/tensorboard/base/kustomization.yaml
@@ -8,7 +8,8 @@ commonLabels:
   kustomize.component: tensorboard
 configMapGenerator:
 - name: parameters
-  env: params.env
+  envs:
+  - params.env
 vars:
 - name: namespace
   objref:

--- a/tests/admission-webhook-bootstrap-base_test.go
+++ b/tests/admission-webhook-bootstrap-base_test.go
@@ -257,7 +257,8 @@ namespace: kubeflow
 configMapGenerator:
 - name: config-map
   behavior: merge
-  env: params.env
+  envs:
+  - params.env
 vars:
 - name: webhookNamePrefix
   objref:

--- a/tests/admission-webhook-bootstrap-overlays-application_test.go
+++ b/tests/admission-webhook-bootstrap-overlays-application_test.go
@@ -308,7 +308,8 @@ namespace: kubeflow
 configMapGenerator:
 - name: config-map
   behavior: merge
-  env: params.env
+  envs:
+  - params.env
 vars:
 - name: webhookNamePrefix
   objref:

--- a/tests/admission-webhook-webhook-overlays-cert-manager_test.go
+++ b/tests/admission-webhook-webhook-overlays-cert-manager_test.go
@@ -78,7 +78,8 @@ patchesStrategicMerge:
 configMapGenerator:
 - name: admission-webhook-parameters
   behavior: merge
-  env: params.env
+  envs:
+  - params.env
 generatorOptions:
   disableNameSuffixHash: true
 

--- a/tests/application-application-base_test.go
+++ b/tests/application-application-base_test.go
@@ -115,7 +115,8 @@ namespace: kubeflow
 nameprefix: application-controller-
 configMapGenerator:
 - name: parameters
-  env: params.env
+  envs:
+  - params.env
 generatorOptions:
   disableNameSuffixHash: true
 images:

--- a/tests/application-application-overlays-application_test.go
+++ b/tests/application-application-overlays-application_test.go
@@ -166,7 +166,8 @@ namespace: kubeflow
 nameprefix: application-controller-
 configMapGenerator:
 - name: parameters
-  env: params.env
+  envs:
+  - params.env
 generatorOptions:
   disableNameSuffixHash: true
 images:

--- a/tests/application-application-overlays-debug_test.go
+++ b/tests/application-application-overlays-debug_test.go
@@ -154,7 +154,8 @@ namespace: kubeflow
 nameprefix: application-controller-
 configMapGenerator:
 - name: parameters
-  env: params.env
+  envs:
+  - params.env
 generatorOptions:
   disableNameSuffixHash: true
 images:

--- a/tests/argo-base_test.go
+++ b/tests/argo-base_test.go
@@ -370,7 +370,8 @@ images:
   newTag: v2.3.0
 configMapGenerator:
 - name: workflow-controller-parameters
-  env: params.env
+  envs:
+  - params.env
 generatorOptions:
   disableNameSuffixHash: true
 vars:

--- a/tests/argo-overlays-application_test.go
+++ b/tests/argo-overlays-application_test.go
@@ -425,7 +425,8 @@ images:
   newTag: v2.3.0
 configMapGenerator:
 - name: workflow-controller-parameters
-  env: params.env
+  envs:
+  - params.env
 generatorOptions:
   disableNameSuffixHash: true
 vars:

--- a/tests/argo-overlays-istio_test.go
+++ b/tests/argo-overlays-istio_test.go
@@ -407,7 +407,8 @@ images:
   newTag: v2.3.0
 configMapGenerator:
 - name: workflow-controller-parameters
-  env: params.env
+  envs:
+  - params.env
 generatorOptions:
   disableNameSuffixHash: true
 vars:

--- a/tests/aws-aws-alb-ingress-controller-base_test.go
+++ b/tests/aws-aws-alb-ingress-controller-base_test.go
@@ -145,7 +145,8 @@ images:
   newTag: v1.1.2
 configMapGenerator:
 - name: alb-ingress-controller-parameters
-  env: params.env
+  envs:
+  - params.env
 vars:
 - name: CLUSTER_NAME
   objref:

--- a/tests/aws-aws-alb-ingress-controller-overlays-application_test.go
+++ b/tests/aws-aws-alb-ingress-controller-overlays-application_test.go
@@ -197,7 +197,8 @@ images:
   newTag: v1.1.2
 configMapGenerator:
 - name: alb-ingress-controller-parameters
-  env: params.env
+  envs:
+  - params.env
 vars:
 - name: CLUSTER_NAME
   objref:

--- a/tests/aws-aws-alb-ingress-controller-overlays-vpc_test.go
+++ b/tests/aws-aws-alb-ingress-controller-overlays-vpc_test.go
@@ -54,7 +54,8 @@ resources:
 - vpc.yaml
 configMapGenerator:
 - name: alb-ingress-controller-vpc-parameters
-  env: params.env
+  envs:
+  - params.env
 vars:
 - name: VPC_ID
   objref:
@@ -202,7 +203,8 @@ images:
   newTag: v1.1.2
 configMapGenerator:
 - name: alb-ingress-controller-parameters
-  env: params.env
+  envs:
+  - params.env
 vars:
 - name: CLUSTER_NAME
   objref:

--- a/tests/aws-fluentd-cloud-watch-base_test.go
+++ b/tests/aws-fluentd-cloud-watch-base_test.go
@@ -260,7 +260,8 @@ images:
   newTag: v1.1-debian-cloudwatch
 configMapGenerator:
 - name: fluentd-cloud-watch-parameters
-  env: params.env
+  envs:
+  - params.env
 vars:
 - name: CLUSTER_NAME
   objref:

--- a/tests/aws-istio-ingress-overlays-cognito_test.go
+++ b/tests/aws-istio-ingress-overlays-cognito_test.go
@@ -44,7 +44,8 @@ patchesStrategicMerge:
 - ingress.yaml
 configMapGenerator:
 - name: istio-ingress-cognito-parameters
-  env: params.env
+  envs:
+  - params.env
 vars:
 - name: CognitoUserPoolArn
   objref:

--- a/tests/aws-istio-ingress-overlays-oidc_test.go
+++ b/tests/aws-istio-ingress-overlays-oidc_test.go
@@ -57,7 +57,8 @@ secretGenerator:
   namespace: istio-system
 configMapGenerator:
 - name: istio-ingress-oidc-parameters
-  env: params.env
+  envs:
+  - params.env
 vars:
 - name: oidcIssuer
   objref:

--- a/tests/cert-manager-cert-manager-base_test.go
+++ b/tests/cert-manager-cert-manager-base_test.go
@@ -736,7 +736,8 @@ images:
   newTag: v0.11.0
 configMapGenerator:
 - name: cert-manager-parameters
-  env: params.env
+  envs:
+  - params.env
 generatorOptions:
   disableNameSuffixHash: true
 vars:

--- a/tests/cert-manager-cert-manager-kube-system-resources-base_test.go
+++ b/tests/cert-manager-cert-manager-kube-system-resources-base_test.go
@@ -123,7 +123,8 @@ commonLabels:
   kustomize.component: cert-manager
 configMapGenerator:
 - name: cert-manager-kube-params-parameters
-  env: params.env
+  envs:
+  - params.env
 generatorOptions:
   disableNameSuffixHash: true
 vars:

--- a/tests/cert-manager-cert-manager-overlays-application_test.go
+++ b/tests/cert-manager-cert-manager-overlays-application_test.go
@@ -803,7 +803,8 @@ images:
   newTag: v0.11.0
 configMapGenerator:
 - name: cert-manager-parameters
-  env: params.env
+  envs:
+  - params.env
 generatorOptions:
   disableNameSuffixHash: true
 vars:

--- a/tests/cert-manager-cert-manager-overlays-letsencrypt_test.go
+++ b/tests/cert-manager-cert-manager-overlays-letsencrypt_test.go
@@ -51,7 +51,8 @@ commonLabels:
 configMapGenerator:
 - name: cert-manager-parameters
   behavior: merge
-  env: params.env
+  envs:
+  - params.env
 generatorOptions:
   disableNameSuffixHash: true
 vars:
@@ -794,7 +795,8 @@ images:
   newTag: v0.11.0
 configMapGenerator:
 - name: cert-manager-parameters
-  env: params.env
+  envs:
+  - params.env
 generatorOptions:
   disableNameSuffixHash: true
 vars:

--- a/tests/cert-manager-cert-manager-overlays-self-signed_test.go
+++ b/tests/cert-manager-cert-manager-overlays-self-signed_test.go
@@ -754,7 +754,8 @@ images:
   newTag: v0.11.0
 configMapGenerator:
 - name: cert-manager-parameters
-  env: params.env
+  envs:
+  - params.env
 generatorOptions:
   disableNameSuffixHash: true
 vars:

--- a/tests/common-ambassador-base_test.go
+++ b/tests/common-ambassador-base_test.go
@@ -175,7 +175,8 @@ images:
   newTag: 0.37.0
 configMapGenerator:
 - name: ambassador-parameters
-  env: params.env
+  envs:
+  - params.env
 generatorOptions:
   disableNameSuffixHash: true
 patchesJson6902:

--- a/tests/common-basic-auth-base_test.go
+++ b/tests/common-basic-auth-base_test.go
@@ -164,7 +164,8 @@ generatorOptions:
   disableNameSuffixHash: true
 configMapGenerator:
 - name: basic-auth-parameters
-  env: params.env
+  envs:
+  - params.env
 vars:
 - name: service-namespace
   objref:

--- a/tests/common-basic-auth-overlays-istio_test.go
+++ b/tests/common-basic-auth-overlays-istio_test.go
@@ -201,7 +201,8 @@ generatorOptions:
   disableNameSuffixHash: true
 configMapGenerator:
 - name: basic-auth-parameters
-  env: params.env
+  envs:
+  - params.env
 vars:
 - name: service-namespace
   objref:

--- a/tests/common-spartakus-base_test.go
+++ b/tests/common-spartakus-base_test.go
@@ -102,7 +102,8 @@ images:
   newTag: v1.1.0
 configMapGenerator:
 - name: spartakus-parameters
-  env: params.env
+  envs:
+  - params.env
 generatorOptions:
   disableNameSuffixHash: true
 vars:

--- a/tests/common-spartakus-overlays-application_test.go
+++ b/tests/common-spartakus-overlays-application_test.go
@@ -152,7 +152,8 @@ images:
   newTag: v1.1.0
 configMapGenerator:
 - name: spartakus-parameters
-  env: params.env
+  envs:
+  - params.env
 generatorOptions:
   disableNameSuffixHash: true
 vars:

--- a/tests/default-install-base_test.go
+++ b/tests/default-install-base_test.go
@@ -42,7 +42,8 @@ resources:
 - profile-instance.yaml
 configMapGenerator:
 - name: default-install-parameters
-  env: params.env
+  envs:
+  - params.env
 vars:
 - name: user
   objref:

--- a/tests/dex-auth-dex-authenticator-base_test.go
+++ b/tests/dex-auth-dex-authenticator-base_test.go
@@ -219,7 +219,8 @@ resources:
 - service.yaml
 configMapGenerator:
 - name: dex-authn-parameters
-  env: params.env
+  envs:
+  - params.env
 vars:
 - name: issuer
   objref:

--- a/tests/dex-auth-dex-crds-base_test.go
+++ b/tests/dex-auth-dex-crds-base_test.go
@@ -183,7 +183,8 @@ resources:
 - service.yaml
 configMapGenerator:
 - name: dex-parameters
-  env: params.env
+  envs:
+  - params.env
 generatorOptions:
   disableNameSuffixHash: true
 vars:

--- a/tests/dex-auth-dex-crds-overlays-istio_test.go
+++ b/tests/dex-auth-dex-crds-overlays-istio_test.go
@@ -56,7 +56,8 @@ resources:
 configMapGenerator:
 - name: dex-parameters
   behavior: merge
-  env: params.env
+  envs:
+  - params.env
 generatorOptions:
   disableNameSuffixHash: true
 vars:
@@ -239,7 +240,8 @@ resources:
 - service.yaml
 configMapGenerator:
 - name: dex-parameters
-  env: params.env
+  envs:
+  - params.env
 generatorOptions:
   disableNameSuffixHash: true
 vars:

--- a/tests/dex-auth-dex-crds-overlays-ldap_test.go
+++ b/tests/dex-auth-dex-crds-overlays-ldap_test.go
@@ -166,7 +166,8 @@ patchesStrategicMerge:
 configMapGenerator:
 - name: dex-parameters
   behavior: merge
-  env: params.env
+  envs:
+  - params.env
 generatorOptions:
   disableNameSuffixHash: true
 vars:
@@ -377,7 +378,8 @@ resources:
 - service.yaml
 configMapGenerator:
 - name: dex-parameters
-  env: params.env
+  envs:
+  - params.env
 generatorOptions:
   disableNameSuffixHash: true
 vars:

--- a/tests/dex-auth-keycloak-gatekeeper-base_test.go
+++ b/tests/dex-auth-keycloak-gatekeeper-base_test.go
@@ -223,7 +223,8 @@ resources:
 
 configMapGenerator:
 - name: keycloak-gatekeeper-parameters
-  env: params.env
+  envs:
+  - params.env
 generatorOptions:
   disableNameSuffixHash: true
 

--- a/tests/gcp-basic-auth-ingress-base_test.go
+++ b/tests/gcp-basic-auth-ingress-base_test.go
@@ -415,7 +415,8 @@ images:
   newTag: 1.0.0
 configMapGenerator:
 - name: basic-auth-ingress-parameters
-  env: params.env
+  envs:
+  - params.env
 generatorOptions:
   disableNameSuffixHash: true
 vars:

--- a/tests/gcp-basic-auth-ingress-overlays-application_test.go
+++ b/tests/gcp-basic-auth-ingress-overlays-application_test.go
@@ -463,7 +463,8 @@ images:
   newTag: 1.0.0
 configMapGenerator:
 - name: basic-auth-ingress-parameters
-  env: params.env
+  envs:
+  - params.env
 generatorOptions:
   disableNameSuffixHash: true
 vars:

--- a/tests/gcp-basic-auth-ingress-overlays-certmanager_test.go
+++ b/tests/gcp-basic-auth-ingress-overlays-certmanager_test.go
@@ -484,7 +484,8 @@ images:
   newTag: 1.0.0
 configMapGenerator:
 - name: basic-auth-ingress-parameters
-  env: params.env
+  envs:
+  - params.env
 generatorOptions:
   disableNameSuffixHash: true
 vars:

--- a/tests/gcp-basic-auth-ingress-overlays-gcp-credentials_test.go
+++ b/tests/gcp-basic-auth-ingress-overlays-gcp-credentials_test.go
@@ -446,7 +446,8 @@ images:
   newTag: 1.0.0
 configMapGenerator:
 - name: basic-auth-ingress-parameters
-  env: params.env
+  envs:
+  - params.env
 generatorOptions:
   disableNameSuffixHash: true
 vars:

--- a/tests/gcp-basic-auth-ingress-overlays-managed-cert_test.go
+++ b/tests/gcp-basic-auth-ingress-overlays-managed-cert_test.go
@@ -434,7 +434,8 @@ images:
   newTag: 1.0.0
 configMapGenerator:
 - name: basic-auth-ingress-parameters
-  env: params.env
+  envs:
+  - params.env
 generatorOptions:
   disableNameSuffixHash: true
 vars:

--- a/tests/gcp-cloud-endpoints-base_test.go
+++ b/tests/gcp-cloud-endpoints-base_test.go
@@ -171,7 +171,8 @@ images:
   newTag: 0.2.1
 configMapGenerator:
 - name: cloud-endpoints-parameters
-  env: params.env
+  envs: 
+  - params.env
 generatorOptions:
   disableNameSuffixHash: true
 vars:

--- a/tests/gcp-cloud-endpoints-overlays-application_test.go
+++ b/tests/gcp-cloud-endpoints-overlays-application_test.go
@@ -219,7 +219,8 @@ images:
   newTag: 0.2.1
 configMapGenerator:
 - name: cloud-endpoints-parameters
-  env: params.env
+  envs:
+  - params.env
 generatorOptions:
   disableNameSuffixHash: true
 vars:

--- a/tests/gcp-cloud-endpoints-overlays-gcp-credentials_test.go
+++ b/tests/gcp-cloud-endpoints-overlays-gcp-credentials_test.go
@@ -202,7 +202,8 @@ images:
   newTag: 0.2.1
 configMapGenerator:
 - name: cloud-endpoints-parameters
-  env: params.env
+  envs:
+  - params.env
 generatorOptions:
   disableNameSuffixHash: true
 vars:

--- a/tests/gcp-iap-ingress-base_test.go
+++ b/tests/gcp-iap-ingress-base_test.go
@@ -580,7 +580,8 @@ images:
   newTag: 1.0.0
 configMapGenerator:
 - name: parameters
-  env: params.env
+  envs:
+  - params.env
 generatorOptions:
   disableNameSuffixHash: true
 vars:

--- a/tests/gcp-iap-ingress-overlays-application_test.go
+++ b/tests/gcp-iap-ingress-overlays-application_test.go
@@ -628,7 +628,8 @@ images:
   newTag: 1.0.0
 configMapGenerator:
 - name: parameters
-  env: params.env
+  envs:
+  - params.env
 generatorOptions:
   disableNameSuffixHash: true
 vars:

--- a/tests/gcp-iap-ingress-overlays-certmanager_test.go
+++ b/tests/gcp-iap-ingress-overlays-certmanager_test.go
@@ -661,7 +661,8 @@ images:
   newTag: 1.0.0
 configMapGenerator:
 - name: parameters
-  env: params.env
+  envs:
+  - params.env
 generatorOptions:
   disableNameSuffixHash: true
 vars:

--- a/tests/gcp-iap-ingress-overlays-gcp-credentials_test.go
+++ b/tests/gcp-iap-ingress-overlays-gcp-credentials_test.go
@@ -635,7 +635,8 @@ images:
   newTag: 1.0.0
 configMapGenerator:
 - name: parameters
-  env: params.env
+  envs:
+  - params.env
 generatorOptions:
   disableNameSuffixHash: true
 vars:

--- a/tests/gcp-iap-ingress-overlays-managed-cert_test.go
+++ b/tests/gcp-iap-ingress-overlays-managed-cert_test.go
@@ -600,7 +600,8 @@ images:
   newTag: 1.0.0
 configMapGenerator:
 - name: parameters
-  env: params.env
+  envs:
+  - params.env
 generatorOptions:
   disableNameSuffixHash: true
 vars:

--- a/tests/gcp-prometheus-base_test.go
+++ b/tests/gcp-prometheus-base_test.go
@@ -308,7 +308,8 @@ commonLabels:
   kustomize.component: prometheus
 configMapGenerator:
 - name: prometheus-parameters
-  env: params.env
+  envs:
+  - params.env
 images:
 - name: gcr.io/stackdriver-prometheus/stackdriver-prometheus
   newName: gcr.io/stackdriver-prometheus/stackdriver-prometheus

--- a/tests/gcp-prometheus-overlays-application_test.go
+++ b/tests/gcp-prometheus-overlays-application_test.go
@@ -356,7 +356,8 @@ commonLabels:
   kustomize.component: prometheus
 configMapGenerator:
 - name: prometheus-parameters
-  env: params.env
+  envs:
+  - params.env
 images:
 - name: gcr.io/stackdriver-prometheus/stackdriver-prometheus
   newName: gcr.io/stackdriver-prometheus/stackdriver-prometheus

--- a/tests/istio-1-3-1-istio-install-1-3-1-base_test.go
+++ b/tests/istio-1-3-1-istio-install-1-3-1-base_test.go
@@ -4370,7 +4370,8 @@ namespace=istio-system
 # one ConfigMap resource (it's a generator of n maps).
 configMapGenerator:
 - name: istio-install-parameters
-  env: params.env
+  envs:
+  - params.env
 
 # Images modify the tags for images without
 # creating patches.

--- a/tests/istio-ingressgateway-self-signed-cert-base_test.go
+++ b/tests/istio-ingressgateway-self-signed-cert-base_test.go
@@ -46,7 +46,8 @@ resources:
 
 configMapGenerator:
 - name: ingressgateway-self-signed-cert-parameters
-  env: params.env
+  envs:
+  - params.env
 generatorOptions:
   disableNameSuffixHash: true
 

--- a/tests/istio-istio-base_test.go
+++ b/tests/istio-istio-base_test.go
@@ -197,7 +197,8 @@ resources:
 namespace: kubeflow
 configMapGenerator:
 - name: istio-parameters
-  env: params.env
+  envs:
+  - params.env
 vars:
 - name: clusterRbacConfig
   objref:

--- a/tests/istio-istio-overlays-https-gateway_test.go
+++ b/tests/istio-istio-overlays-https-gateway_test.go
@@ -53,7 +53,8 @@ patchesStrategicMerge:
 configMapGenerator:
 - name: istio-parameters
   behavior: merge
-  env: params.env
+  envs:
+  - params.env
 configurations:
 - params.yaml
 `)
@@ -240,7 +241,8 @@ resources:
 namespace: kubeflow
 configMapGenerator:
 - name: istio-parameters
-  env: params.env
+  envs:
+  - params.env
 vars:
 - name: clusterRbacConfig
   objref:

--- a/tests/istio-oidc-authservice-base_test.go
+++ b/tests/istio-oidc-authservice-base_test.go
@@ -169,7 +169,8 @@ namespace: istio-system
 
 configMapGenerator:
 - name: oidc-authservice-parameters
-  env: params.env
+  envs:
+  - params.env
 generatorOptions:
   disableNameSuffixHash: true
 

--- a/tests/istio-oidc-authservice-overlays-application_test.go
+++ b/tests/istio-oidc-authservice-overlays-application_test.go
@@ -228,7 +228,8 @@ namespace: istio-system
 
 configMapGenerator:
 - name: oidc-authservice-parameters
-  env: params.env
+  envs:
+  - params.env
 generatorOptions:
   disableNameSuffixHash: true
 

--- a/tests/istio-oidc-authservice-overlays-ibm-storage-config_test.go
+++ b/tests/istio-oidc-authservice-overlays-ibm-storage-config_test.go
@@ -198,7 +198,8 @@ namespace: istio-system
 
 configMapGenerator:
 - name: oidc-authservice-parameters
-  env: params.env
+  envs:
+  - params.env
 generatorOptions:
   disableNameSuffixHash: true
 

--- a/tests/jupyter-notebook-controller-overlays-istio_test.go
+++ b/tests/jupyter-notebook-controller-overlays-istio_test.go
@@ -44,7 +44,8 @@ patchesStrategicMerge:
 configMapGenerator:
 - name: parameters
   behavior: merge
-  env: params.env
+  envs:
+  - params.env
 generatorOptions:
   disableNameSuffixHash: true
 `)

--- a/tests/katib-katib-controller-base_test.go
+++ b/tests/katib-katib-controller-base_test.go
@@ -625,7 +625,8 @@ resources:
 - trial-template-configmap.yaml
 configMapGenerator:
 - name: katib-parameters
-  env: params.env
+  envs:
+  - params.env
 generatorOptions:
   disableNameSuffixHash: true
 images:

--- a/tests/katib-katib-controller-overlays-application_test.go
+++ b/tests/katib-katib-controller-overlays-application_test.go
@@ -705,7 +705,8 @@ resources:
 - trial-template-configmap.yaml
 configMapGenerator:
 - name: katib-parameters
-  env: params.env
+  envs:
+  - params.env
 generatorOptions:
   disableNameSuffixHash: true
 images:

--- a/tests/katib-katib-controller-overlays-ibm-storage-config_test.go
+++ b/tests/katib-katib-controller-overlays-ibm-storage-config_test.go
@@ -650,7 +650,8 @@ resources:
 - trial-template-configmap.yaml
 configMapGenerator:
 - name: katib-parameters
-  env: params.env
+  envs:
+  - params.env
 generatorOptions:
   disableNameSuffixHash: true
 images:

--- a/tests/katib-katib-controller-overlays-istio_test.go
+++ b/tests/katib-katib-controller-overlays-istio_test.go
@@ -662,7 +662,8 @@ resources:
 - trial-template-configmap.yaml
 configMapGenerator:
 - name: katib-parameters
-  env: params.env
+  envs:
+  - params.env
 generatorOptions:
   disableNameSuffixHash: true
 images:

--- a/tests/kfserving-kfserving-install-base_test.go
+++ b/tests/kfserving-kfserving-install-base_test.go
@@ -495,7 +495,8 @@ commonLabels:
   kustomize.component: kfserving
 configMapGenerator:
 - name: kfserving-parameters
-  env: params.env
+  envs:
+  - params.env
 vars:
 - name: registry
   objref:

--- a/tests/kfserving-kfserving-install-overlays-application_test.go
+++ b/tests/kfserving-kfserving-install-overlays-application_test.go
@@ -552,7 +552,8 @@ commonLabels:
   kustomize.component: kfserving
 configMapGenerator:
 - name: kfserving-parameters
-  env: params.env
+  envs:
+  - params.env
 vars:
 - name: registry
   objref:

--- a/tests/kubebench-base_test.go
+++ b/tests/kubebench-base_test.go
@@ -163,7 +163,8 @@ commonLabels:
   kustomize.component: kubebench
 configMapGenerator:
 - name: parameters
-  env: params.env
+  envs:
+  - params.env
 images:
   # NOTE: the image for workflow agent should be configured in config-map.yaml
   - name:  gcr.io/kubeflow-images-public/kubebench/kubebench-operator-v1alpha2

--- a/tests/kubebench-overlays-application_test.go
+++ b/tests/kubebench-overlays-application_test.go
@@ -211,7 +211,8 @@ commonLabels:
   kustomize.component: kubebench
 configMapGenerator:
 - name: parameters
-  env: params.env
+  envs:
+  - params.env
 images:
   # NOTE: the image for workflow agent should be configured in config-map.yaml
   - name:  gcr.io/kubeflow-images-public/kubebench/kubebench-operator-v1alpha2

--- a/tests/kubebench-overlays-istio_test.go
+++ b/tests/kubebench-overlays-istio_test.go
@@ -200,7 +200,8 @@ commonLabels:
   kustomize.component: kubebench
 configMapGenerator:
 - name: parameters
-  env: params.env
+  envs:
+  - params.env
 images:
   # NOTE: the image for workflow agent should be configured in config-map.yaml
   - name:  gcr.io/kubeflow-images-public/kubebench/kubebench-operator-v1alpha2

--- a/tests/metadata-base_test.go
+++ b/tests/metadata-base_test.go
@@ -264,7 +264,8 @@ commonLabels:
   kustomize.component: metadata
 configMapGenerator:
 - name: ui-parameters
-  env: params.env
+  envs:
+  - params.env
 - name: metadata-grpc-configmap
   env: grpc-params.env
 resources:

--- a/tests/metadata-overlays-application_test.go
+++ b/tests/metadata-overlays-application_test.go
@@ -321,7 +321,8 @@ commonLabels:
   kustomize.component: metadata
 configMapGenerator:
 - name: ui-parameters
-  env: params.env
+  envs:
+  - params.env
 - name: metadata-grpc-configmap
   env: grpc-params.env
 resources:

--- a/tests/metadata-overlays-db_test.go
+++ b/tests/metadata-overlays-db_test.go
@@ -175,7 +175,8 @@ generatorOptions:
   disableNameSuffixHash: true
 configMapGenerator:
 - name: metadata-db-parameters
-  env: params.env
+  envs:
+  - params.env
 secretGenerator:
 - name: metadata-db-secrets
   env: secrets.env
@@ -449,7 +450,8 @@ commonLabels:
   kustomize.component: metadata
 configMapGenerator:
 - name: ui-parameters
-  env: params.env
+  envs:
+  - params.env
 - name: metadata-grpc-configmap
   env: grpc-params.env
 resources:

--- a/tests/metadata-overlays-ibm-storage-config_test.go
+++ b/tests/metadata-overlays-ibm-storage-config_test.go
@@ -274,7 +274,8 @@ commonLabels:
   kustomize.component: metadata
 configMapGenerator:
 - name: ui-parameters
-  env: params.env
+  envs:
+  - params.env
 - name: metadata-grpc-configmap
   env: grpc-params.env
 resources:

--- a/tests/metadata-overlays-istio_test.go
+++ b/tests/metadata-overlays-istio_test.go
@@ -326,7 +326,8 @@ commonLabels:
   kustomize.component: metadata
 configMapGenerator:
 - name: ui-parameters
-  env: params.env
+  envs:
+  - params.env
 - name: metadata-grpc-configmap
   env: grpc-params.env
 resources:

--- a/tests/mpi-job-mpi-operator-base_test.go
+++ b/tests/mpi-job-mpi-operator-base_test.go
@@ -272,7 +272,8 @@ images:
   newTag: 0.1.0
 configMapGenerator:
 - name: mpi-operator-config
-  env: params.env
+  envs:
+  - params.env
 generatorOptions:
   disableNameSuffixHash: true
 vars:

--- a/tests/mpi-job-mpi-operator-overlays-application_test.go
+++ b/tests/mpi-job-mpi-operator-overlays-application_test.go
@@ -319,7 +319,8 @@ images:
   newTag: 0.1.0
 configMapGenerator:
 - name: mpi-operator-config
-  env: params.env
+  envs:
+  - params.env
 generatorOptions:
   disableNameSuffixHash: true
 vars:

--- a/tests/pipeline-minio-base_test.go
+++ b/tests/pipeline-minio-base_test.go
@@ -104,7 +104,8 @@ resources:
 - persistent-volume-claim.yaml
 configMapGenerator:
 - name: pipeline-minio-parameters
-  env: params.env
+  envs:
+  - params.env
 generatorOptions:
   disableNameSuffixHash: true
 vars:

--- a/tests/pipeline-minio-overlays-application_test.go
+++ b/tests/pipeline-minio-overlays-application_test.go
@@ -152,7 +152,8 @@ resources:
 - persistent-volume-claim.yaml
 configMapGenerator:
 - name: pipeline-minio-parameters
-  env: params.env
+  envs:
+  - params.env
 generatorOptions:
   disableNameSuffixHash: true
 vars:

--- a/tests/pipeline-minio-overlays-minioPd_test.go
+++ b/tests/pipeline-minio-overlays-minioPd_test.go
@@ -63,7 +63,8 @@ patchesStrategicMerge:
 configMapGenerator:
 - name: pipeline-minio-parameters
   behavior: merge
-  env: params.env
+  envs:
+  - params.env
 generatorOptions:
   disableNameSuffixHash: true
 vars:
@@ -174,7 +175,8 @@ resources:
 - persistent-volume-claim.yaml
 configMapGenerator:
 - name: pipeline-minio-parameters
-  env: params.env
+  envs:
+  - params.env
 generatorOptions:
   disableNameSuffixHash: true
 vars:

--- a/tests/pipeline-mysql-base_test.go
+++ b/tests/pipeline-mysql-base_test.go
@@ -84,7 +84,8 @@ resources:
 - persistent-volume-claim.yaml
 configMapGenerator:
 - name: pipeline-mysql-parameters
-  env: params.env
+  envs:
+  - params.env
 generatorOptions:
   disableNameSuffixHash: true
 vars:

--- a/tests/pipeline-mysql-overlays-application_test.go
+++ b/tests/pipeline-mysql-overlays-application_test.go
@@ -132,7 +132,8 @@ resources:
 - persistent-volume-claim.yaml
 configMapGenerator:
 - name: pipeline-mysql-parameters
-  env: params.env
+  envs:
+  - params.env
 generatorOptions:
   disableNameSuffixHash: true
 vars:

--- a/tests/pipeline-mysql-overlays-mysqlPd_test.go
+++ b/tests/pipeline-mysql-overlays-mysqlPd_test.go
@@ -64,7 +64,8 @@ patchesStrategicMerge:
 configMapGenerator:
 - name: pipeline-mysql-parameters
   behavior: merge
-  env: params.env
+  envs:
+  - params.env
 generatorOptions:
   disableNameSuffixHash: true
 vars:
@@ -155,7 +156,8 @@ resources:
 - persistent-volume-claim.yaml
 configMapGenerator:
 - name: pipeline-mysql-parameters
-  env: params.env
+  envs:
+  - params.env
 generatorOptions:
   disableNameSuffixHash: true
 vars:

--- a/tests/pipeline-pipelines-ui-base_test.go
+++ b/tests/pipeline-pipelines-ui-base_test.go
@@ -159,7 +159,8 @@ resources:
 - service.yaml
 configMapGenerator:
 - name: ui-parameters
-  env: params.env
+  envs:
+  - params.env
 images:
 - name: gcr.io/ml-pipeline/frontend
   newTag: 0.2.0

--- a/tests/pipeline-pipelines-ui-overlays-application_test.go
+++ b/tests/pipeline-pipelines-ui-overlays-application_test.go
@@ -207,7 +207,8 @@ resources:
 - service.yaml
 configMapGenerator:
 - name: ui-parameters
-  env: params.env
+  envs:
+  - params.env
 images:
 - name: gcr.io/ml-pipeline/frontend
   newTag: 0.2.0

--- a/tests/pipeline-pipelines-ui-overlays-gcp_test.go
+++ b/tests/pipeline-pipelines-ui-overlays-gcp_test.go
@@ -192,7 +192,8 @@ resources:
 - service.yaml
 configMapGenerator:
 - name: ui-parameters
-  env: params.env
+  envs:
+  - params.env
 images:
 - name: gcr.io/ml-pipeline/frontend
   newTag: 0.2.0

--- a/tests/pipeline-pipelines-ui-overlays-istio_test.go
+++ b/tests/pipeline-pipelines-ui-overlays-istio_test.go
@@ -219,7 +219,8 @@ resources:
 - service.yaml
 configMapGenerator:
 - name: ui-parameters
-  env: params.env
+  envs:
+  - params.env
 images:
 - name: gcr.io/ml-pipeline/frontend
   newTag: 0.2.0

--- a/tests/profiles-overlays-debug_test.go
+++ b/tests/profiles-overlays-debug_test.go
@@ -55,7 +55,8 @@ patchesStrategicMerge:
 - deployment.yaml
 configMapGenerator:
 - name: parameters
-  env: params.env
+  envs:
+  - params.env
 generatorOptions:
   disableNameSuffixHash: true
 vars:

--- a/tests/tektoncd-tektoncd-dashboard-overlays-application_test.go
+++ b/tests/tektoncd-tektoncd-dashboard-overlays-application_test.go
@@ -72,7 +72,8 @@ resources:
 - application.yaml
 configMapGenerator:
 - name: tektoncd-dashboard-app-parameters
-  env: params.env
+  envs:
+  - params.env
 vars:
 - name: generateName
   objref:

--- a/tests/tektoncd-tektoncd-dashboard-overlays-istio_test.go
+++ b/tests/tektoncd-tektoncd-dashboard-overlays-istio_test.go
@@ -55,7 +55,8 @@ resources:
 - virtual-service.yaml
 configMapGenerator:
 - name: tektoncd-dashboard-parameters
-  env: params.env
+  envs:
+  - params.env
 vars:
 - name: namespace
   objref:

--- a/tests/tektoncd-tektoncd-install-base_test.go
+++ b/tests/tektoncd-tektoncd-install-base_test.go
@@ -703,7 +703,8 @@ resources:
 namespace: tekton-pipelines
 configMapGenerator:
 - name: tektoncd-parameters
-  env: params.env
+  envs:
+  - params.env
 generatorOptions:
   disableNameSuffixHash: true
 vars:

--- a/tests/tektoncd-tektoncd-install-overlays-application_test.go
+++ b/tests/tektoncd-tektoncd-install-overlays-application_test.go
@@ -63,7 +63,8 @@ resources:
 - application.yaml
 configMapGenerator:
 - name: tektoncd-install-parameters
-  env: params.env
+  envs:
+  - params.env
 vars:
 - name: generateName
   objref:
@@ -771,7 +772,8 @@ resources:
 namespace: tekton-pipelines
 configMapGenerator:
 - name: tektoncd-parameters
-  env: params.env
+  envs:
+  - params.env
 generatorOptions:
   disableNameSuffixHash: true
 vars:

--- a/tests/tektoncd-tektoncd-install-overlays-istio_test.go
+++ b/tests/tektoncd-tektoncd-install-overlays-istio_test.go
@@ -54,7 +54,8 @@ resources:
 - virtual-service.yaml
 configMapGenerator:
 - name: tektoncd-install-istio-parameters
-  env: params.env
+  envs:
+  - params.env
 generatorOptions:
   disableNameSuffixHash: true
 vars:
@@ -764,7 +765,8 @@ resources:
 namespace: tekton-pipelines
 configMapGenerator:
 - name: tektoncd-parameters
-  env: params.env
+  envs:
+  - params.env
 generatorOptions:
   disableNameSuffixHash: true
 vars:

--- a/tests/tensorboard-base_test.go
+++ b/tests/tensorboard-base_test.go
@@ -120,7 +120,8 @@ commonLabels:
   kustomize.component: tensorboard
 configMapGenerator:
 - name: parameters
-  env: params.env
+  envs:
+  - params.env
 vars:
 - name: namespace
   objref:

--- a/tests/tensorboard-overlays-istio_test.go
+++ b/tests/tensorboard-overlays-istio_test.go
@@ -157,7 +157,8 @@ commonLabels:
   kustomize.component: tensorboard
 configMapGenerator:
 - name: parameters
-  env: params.env
+  envs:
+  - params.env
 vars:
 - name: namespace
   objref:


### PR DESCRIPTION
**Which issue is resolved by this Pull Request:**
Resolves #538 

**Description of your changes:**
apply repo wide string replacement of `env` to `envs` to support latest versions of `kustomize`

**Checklist:**
- [ x ] Unit tests have been rebuilt: 
    1. `cd manifests/tests`
    2. `make generate-changed-only`
    3. `make test`

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/manifests/887)
<!-- Reviewable:end -->
