### PR TITLE
Adding finalizers for Openshift support

### DIFF
--- a/pytorch-job/pytorch-operator/base/cluster-role.yaml
+++ b/pytorch-job/pytorch-operator/base/cluster-role.yaml
@@ -10,6 +10,7 @@ rules:
   resources:
   - pytorchjobs
   - pytorchjobs/status
+  - pytorchjobs/finalizers
   verbs:
   - '*'
 - apiGroups:


### PR DESCRIPTION
**Which issue is resolved by this Pull Request:**
Resolves #
Installing kubeflow/pytorch on openshift
**Description of your changes:**
Added "finalizer" to the cluster-role

**Checklist:**
- [ ] Unit tests have been rebuilt: 
    1. `cd manifests/tests`
    2. `make generate-changed-only`
    3. `make test`

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/manifests/892)
<!-- Reviewable:end -->
