### PR TITLE
Removing the 8888 seldon engine container uid specification

### DIFF
--- a/seldon/seldon-core-operator/base/seldon-operator-controller-manager-statefulset.yaml
+++ b/seldon/seldon-core-operator/base/seldon-operator-controller-manager-statefulset.yaml
@@ -48,8 +48,6 @@ spec:
           value: IfNotPresent
         - name: ENGINE_CONTAINER_SERVICE_ACCOUNT_NAME
           value: default
-        - name: ENGINE_CONTAINER_USER
-          value: "8888"
         - name: ENGINE_LOG_MESSAGES_EXTERNALLY
           value: "false"
         - name: PREDICTIVE_UNIT_SERVICE_PORT


### PR DESCRIPTION
**Which issue is resolved by this Pull Request:**
Resolves #
When a model is served using Seldon, an engine container is created with uid set to "8888". This is not allowed on openshift, since it has to be within a specific range. When we remove the specific setting of "8888" for the uid, openshift assigns a valid uid within range for the container
**Description of your changes:**
Deleted the specification of Engine Container UID of "8888"

**Checklist:**
- [ ] Unit tests have been rebuilt: 
    1. `cd manifests/tests`
    2. `make generate-changed-only`
    3. `make test`

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/manifests/893)
<!-- Reviewable:end -->
