### PR TITLE
Automated cherry pick of #896: ISTIO rbac roles should include networking.istio.io; #891 Cherry pick of #896 on v1.0-branch. #896: ISTIO rbac roles should include networking.istio.io; #891

### DIFF
--- a/hack/generate_tests.py
+++ b/hack/generate_tests.py
@@ -27,8 +27,14 @@ def get_changed_dirs():
   """Return a list of directories of changed kustomization packages."""
   # Generate a list of the files which have changed with respect to the upstream
   # branch
+
+  # TODO(jlewi): Upstream doesn't seem to work in some cases. I think
+  # upstream might end up referring to the
+  origin = os.getenv("REMOTE_ORIGIN", "@{upstream}")
+  logging.info("Using %s as remote origin; you can override using environment "
+               "variable REMOTE_ORIGIN", origin)
   modified_files = subprocess.check_output(
-    ["git", "diff", "--name-only", "@{upstream}"])
+    ["git", "diff", "--name-only", origin])
 
   repo_root = subprocess.check_output(["git", "rev-parse", "--show-toplevel"])
   repo_root = repo_root.decode()

--- a/istio/istio/base/cluster-roles.yaml
+++ b/istio/istio/base/cluster-roles.yaml
@@ -22,7 +22,9 @@ metadata:
     rbac.authorization.kubeflow.org/aggregate-to-kubeflow-edit: "true"
     rbac.authorization.kubeflow.org/aggregate-to-kubeflow-istio-admin: "true"
 rules:
-- apiGroups: ["istio.io"]
+- apiGroups: 
+  - istio.io
+  - networking.istio.io
   resources: ["*"]
   verbs:
   - get
@@ -43,7 +45,9 @@ metadata:
   labels:
     rbac.authorization.kubeflow.org/aggregate-to-kubeflow-view: "true"
 rules:
-- apiGroups: ["istio.io"]
+- apiGroups:
+  - istio.io
+  - networking.istio.io
   resources: ["*"]
   verbs:
   - get

--- a/tests/istio-istio-base_test.go
+++ b/tests/istio-istio-base_test.go
@@ -151,7 +151,9 @@ metadata:
     rbac.authorization.kubeflow.org/aggregate-to-kubeflow-edit: "true"
     rbac.authorization.kubeflow.org/aggregate-to-kubeflow-istio-admin: "true"
 rules:
-- apiGroups: ["istio.io"]
+- apiGroups: 
+  - istio.io
+  - networking.istio.io
   resources: ["*"]
   verbs:
   - get
@@ -172,7 +174,9 @@ metadata:
   labels:
     rbac.authorization.kubeflow.org/aggregate-to-kubeflow-view: "true"
 rules:
-- apiGroups: ["istio.io"]
+- apiGroups:
+  - istio.io
+  - networking.istio.io
   resources: ["*"]
   verbs:
   - get

--- a/tests/istio-istio-overlays-https-gateway_test.go
+++ b/tests/istio-istio-overlays-https-gateway_test.go
@@ -194,7 +194,9 @@ metadata:
     rbac.authorization.kubeflow.org/aggregate-to-kubeflow-edit: "true"
     rbac.authorization.kubeflow.org/aggregate-to-kubeflow-istio-admin: "true"
 rules:
-- apiGroups: ["istio.io"]
+- apiGroups: 
+  - istio.io
+  - networking.istio.io
   resources: ["*"]
   verbs:
   - get
@@ -215,7 +217,9 @@ metadata:
   labels:
     rbac.authorization.kubeflow.org/aggregate-to-kubeflow-view: "true"
 rules:
-- apiGroups: ["istio.io"]
+- apiGroups:
+  - istio.io
+  - networking.istio.io
   resources: ["*"]
   verbs:
   - get


### PR DESCRIPTION


<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/manifests/899)
<!-- Reviewable:end -->
