### PR TITLE
Add EnvoyFilter to add anonymous to all gateway requests in aws no-auth manifest

### DIFF
--- a/kfdef/kfctl_aws.v1.0.0.yaml
+++ b/kfdef/kfctl_aws.v1.0.0.yaml
@@ -29,6 +29,14 @@ spec:
         path: istio/istio
     name: istio
   - kustomizeConfig:
+      parameters:
+      - name: namespace
+        value: istio-system
+      repoRef:
+        name: manifests
+        path: istio/add-anonymous-user-filter
+    name: add-anonymous-user-filter
+  - kustomizeConfig:
       repoRef:
         name: manifests
         path: application/application-crds
@@ -114,6 +122,9 @@ spec:
       overlays:
       - istio
       - application
+      parameters:
+      - name: userid-header
+        value: kubeflow-userid
       repoRef:
         name: manifests
         path: jupyter/jupyter-web-app

--- a/kfdef/kfctl_aws.yaml
+++ b/kfdef/kfctl_aws.yaml
@@ -37,6 +37,14 @@ spec:
         path: istio/istio
     name: istio
   - kustomizeConfig:
+      parameters:
+      - name: namespace
+        value: istio-system
+      repoRef:
+        name: manifests
+        path: istio/add-anonymous-user-filter
+    name: add-anonymous-user-filter
+  - kustomizeConfig:
       repoRef:
         name: manifests
         path: application/application-crds
@@ -122,6 +130,9 @@ spec:
       overlays:
       - istio
       - application
+      parameters:
+      - name: userid-header
+        value: kubeflow-userid
       repoRef:
         name: manifests
         path: jupyter/jupyter-web-app

--- a/kfdef/kfctl_aws_cognito.v1.0.0.yaml
+++ b/kfdef/kfctl_aws_cognito.v1.0.0.yaml
@@ -29,6 +29,14 @@ spec:
         path: istio/istio
     name: istio
   - kustomizeConfig:
+      parameters:
+      - name: namespace
+        value: istio-system
+      repoRef:
+        name: manifests
+        path: istio/add-anonymous-user-filter
+    name: add-anonymous-user-filter
+  - kustomizeConfig:
       repoRef:
         name: manifests
         path: application/application-crds
@@ -114,6 +122,9 @@ spec:
       overlays:
       - istio
       - application
+      parameters:
+      - name: userid-header
+        value: kubeflow-userid
       repoRef:
         name: manifests
         path: jupyter/jupyter-web-app

--- a/kfdef/kfctl_aws_cognito.yaml
+++ b/kfdef/kfctl_aws_cognito.yaml
@@ -37,6 +37,14 @@ spec:
         path: istio/istio
     name: istio
   - kustomizeConfig:
+      parameters:
+      - name: namespace
+        value: istio-system
+      repoRef:
+        name: manifests
+        path: istio/add-anonymous-user-filter
+    name: add-anonymous-user-filter
+  - kustomizeConfig:
       repoRef:
         name: manifests
         path: application/application-crds
@@ -122,6 +130,9 @@ spec:
       overlays:
       - istio
       - application
+      parameters:
+      - name: userid-header
+        value: kubeflow-userid
       repoRef:
         name: manifests
         path: jupyter/jupyter-web-app

--- a/kfdef/source/master/kfctl_aws.yaml
+++ b/kfdef/source/master/kfctl_aws.yaml
@@ -29,6 +29,14 @@ spec:
         path: istio/istio
     name: istio
   - kustomizeConfig:
+      parameters:
+      - name: namespace
+        value: istio-system
+      repoRef:
+        name: manifests
+        path: istio/add-anonymous-user-filter
+    name: add-anonymous-user-filter
+  - kustomizeConfig:
       repoRef:
         name: manifests
         path: application/application-crds
@@ -66,7 +74,7 @@ spec:
       repoRef:
         name: manifests
         path: cert-manager/cert-manager
-    name: cert-manager        
+    name: cert-manager
   - kustomizeConfig:
       repoRef:
         name: manifests
@@ -114,6 +122,9 @@ spec:
       overlays:
       - istio
       - application
+      parameters:
+      - name: userid-header
+        value: kubeflow-userid
       repoRef:
         name: manifests
         path: jupyter/jupyter-web-app

--- a/kfdef/source/master/kfctl_aws_cognito.yaml
+++ b/kfdef/source/master/kfctl_aws_cognito.yaml
@@ -29,6 +29,14 @@ spec:
         path: istio/istio
     name: istio
   - kustomizeConfig:
+      parameters:
+      - name: namespace
+        value: istio-system
+      repoRef:
+        name: manifests
+        path: istio/add-anonymous-user-filter
+    name: add-anonymous-user-filter
+  - kustomizeConfig:
       repoRef:
         name: manifests
         path: application/application-crds
@@ -66,7 +74,7 @@ spec:
       repoRef:
         name: manifests
         path: cert-manager/cert-manager
-    name: cert-manager        
+    name: cert-manager
   - kustomizeConfig:
       repoRef:
         name: manifests
@@ -114,6 +122,9 @@ spec:
       overlays:
       - istio
       - application
+      parameters:
+      - name: userid-header
+        value: kubeflow-userid
       repoRef:
         name: manifests
         path: jupyter/jupyter-web-app


### PR DESCRIPTION
**Which issue is resolved by this Pull Request:**
Resolves https://github.com/kubeflow/kubeflow/issues/4731

**Description of your changes:**
Apply the fix https://github.com/kubeflow/manifests/pull/885 on aws manifest without auth. 

This change needs to be cherry-pick back to v1.0-branch

**Checklist:**
- [x] Unit tests have been rebuilt: 
    1. `cd manifests/tests`
    2. `make generate-changed-only`
    3. `make test`

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/manifests/909)
<!-- Reviewable:end -->
