### PR TITLE
Add policy profile controller plugin needs

### DIFF
--- a/aws/infra_configs/iam_profile_controller_policy.json
+++ b/aws/infra_configs/iam_profile_controller_policy.json
@@ -1,0 +1,14 @@
+{
+    "Version": "2012-10-17",
+    "Statement": [
+        {
+            "Sid": "VisualEditor0",
+            "Effect": "Allow",
+            "Action": [
+                "iam:GetRole",
+                "iam:UpdateAssumeRolePolicy"
+            ],
+            "Resource": "*"
+        }
+    ]
+}


### PR DESCRIPTION
**Which issue is resolved by this Pull Request:**
Resolves https://github.com/kubeflow/kubeflow/issues/4403

**Description of your changes:**
Policy will be added to IAM role and profile controller service account can talk to AWS to get Role and update policy doc. 

Kfctl has corresponding change as well. 

**Checklist:**
- [x] Unit tests have been rebuilt: 
    1. `cd manifests/tests`
    2. `make generate-changed-only`
    3. `make test`

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/manifests/917)
<!-- Reviewable:end -->
