### PR TITLE
Applications should not try to take ownership of cluster scoped resources

### DIFF
--- a/admission-webhook/webhook/overlays/application/application.yaml
+++ b/admission-webhook/webhook/overlays/application/application.yaml
@@ -6,11 +6,11 @@ spec:
   selector:
     matchLabels:
       app.kubernetes.io/name: webhook
-      app.kubernetes.io/instance: webhook-v0.7.0
+      app.kubernetes.io/instance: webhook-v1.0.0
       app.kubernetes.io/managed-by: kfctl
       app.kubernetes.io/component: bootstrap
       app.kubernetes.io/part-of: webhook
-      app.kubernetes.io/version: v0.7.0
+      app.kubernetes.io/version: v1.0.0
   componentKinds:
   # Do not select any cluster scoped resources
   # as that will cause problems.

--- a/admission-webhook/webhook/overlays/application/application.yaml
+++ b/admission-webhook/webhook/overlays/application/application.yaml
@@ -12,8 +12,8 @@ spec:
       app.kubernetes.io/part-of: webhook
       app.kubernetes.io/version: v0.7.0
   componentKinds:
-  - group: admissionregistration.k8s.io
-    kind: MutatingWebhookConfiguration
+  # Do not select any cluster scoped resources
+  # as that will cause problems.
   - group: core
     kind: ConfigMap
   - group: apps

--- a/profiles/overlays/application/application.yaml
+++ b/profiles/overlays/application/application.yaml
@@ -12,10 +12,8 @@ spec:
       app.kubernetes.io/part-of: kubeflow
       app.kubernetes.io/version: v1.0.0
   componentKinds:
-  - group: rbac.authorization.k8s.io
-    kind: ClusterRole
-  - group: rbac.authorization.k8s.io
-    kind: ClusterRoleBinding
+  # Do not select any cluster scoped resources
+  # as that will cause problems.
   - group: apps
     kind: Deployment
   - group: core

--- a/tests/admission-webhook-webhook-overlays-application_test.go
+++ b/tests/admission-webhook-webhook-overlays-application_test.go
@@ -29,8 +29,8 @@ spec:
       app.kubernetes.io/part-of: webhook
       app.kubernetes.io/version: v0.7.0
   componentKinds:
-  - group: admissionregistration.k8s.io
-    kind: MutatingWebhookConfiguration
+  # Do not select any cluster scoped resources
+  # as that will cause problems.
   - group: core
     kind: ConfigMap
   - group: apps

--- a/tests/admission-webhook-webhook-overlays-application_test.go
+++ b/tests/admission-webhook-webhook-overlays-application_test.go
@@ -23,11 +23,11 @@ spec:
   selector:
     matchLabels:
       app.kubernetes.io/name: webhook
-      app.kubernetes.io/instance: webhook-v0.7.0
+      app.kubernetes.io/instance: webhook-v1.0.0
       app.kubernetes.io/managed-by: kfctl
       app.kubernetes.io/component: bootstrap
       app.kubernetes.io/part-of: webhook
-      app.kubernetes.io/version: v0.7.0
+      app.kubernetes.io/version: v1.0.0
   componentKinds:
   # Do not select any cluster scoped resources
   # as that will cause problems.

--- a/tests/profiles-overlays-application_test.go
+++ b/tests/profiles-overlays-application_test.go
@@ -29,10 +29,8 @@ spec:
       app.kubernetes.io/part-of: kubeflow
       app.kubernetes.io/version: v1.0.0
   componentKinds:
-  - group: rbac.authorization.k8s.io
-    kind: ClusterRole
-  - group: rbac.authorization.k8s.io
-    kind: ClusterRoleBinding
+  # Do not select any cluster scoped resources
+  # as that will cause problems.
   - group: apps
     kind: Deployment
   - group: core


### PR DESCRIPTION
* See kubeflow/kubeflow#4767 - If applications try to take ownership
  of cluster scoped resources or resources in other namespaces
  this can violate requirements of the K8s GC and lead to unpredictable
  behavior.

* It looks like this might be causing the profile controller deployment
  to get GC'd after 24 hours.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/manifests/921)
<!-- Reviewable:end -->
