### PR TITLE
Automated cherry pick of #921: Applications should not try to take ownership of cluster Cherry pick of #921 on v1.0-branch. #921: Applications should not try to take ownership of cluster

### DIFF
--- a/admission-webhook/webhook/overlays/application/application.yaml
+++ b/admission-webhook/webhook/overlays/application/application.yaml
@@ -12,8 +12,8 @@ spec:
       app.kubernetes.io/part-of: webhook
       app.kubernetes.io/version: v1.0.0
   componentKinds:
-  - group: admissionregistration.k8s.io
-    kind: MutatingWebhookConfiguration
+  # Do not select any cluster scoped resources
+  # as that will cause problems.
   - group: core
     kind: ConfigMap
   - group: apps

--- a/profiles/overlays/application/application.yaml
+++ b/profiles/overlays/application/application.yaml
@@ -12,10 +12,8 @@ spec:
       app.kubernetes.io/part-of: kubeflow
       app.kubernetes.io/version: v1.0.0
   componentKinds:
-  - group: rbac.authorization.k8s.io
-    kind: ClusterRole
-  - group: rbac.authorization.k8s.io
-    kind: ClusterRoleBinding
+  # Do not select any cluster scoped resources
+  # as that will cause problems.
   - group: apps
     kind: Deployment
   - group: core

--- a/tests/admission-webhook-webhook-overlays-application_test.go
+++ b/tests/admission-webhook-webhook-overlays-application_test.go
@@ -29,8 +29,8 @@ spec:
       app.kubernetes.io/part-of: webhook
       app.kubernetes.io/version: v1.0.0
   componentKinds:
-  - group: admissionregistration.k8s.io
-    kind: MutatingWebhookConfiguration
+  # Do not select any cluster scoped resources
+  # as that will cause problems.
   - group: core
     kind: ConfigMap
   - group: apps

--- a/tests/profiles-overlays-application_test.go
+++ b/tests/profiles-overlays-application_test.go
@@ -29,10 +29,8 @@ spec:
       app.kubernetes.io/part-of: kubeflow
       app.kubernetes.io/version: v1.0.0
   componentKinds:
-  - group: rbac.authorization.k8s.io
-    kind: ClusterRole
-  - group: rbac.authorization.k8s.io
-    kind: ClusterRoleBinding
+  # Do not select any cluster scoped resources
+  # as that will cause problems.
   - group: apps
     kind: Deployment
   - group: core


### PR DESCRIPTION


<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/manifests/922)
<!-- Reviewable:end -->
