### PR TITLE
metadata deployment: Add liveness probe

### DIFF
--- a/metadata/base/metadata-deployment.yaml
+++ b/metadata/base/metadata-deployment.yaml
@@ -35,6 +35,17 @@ spec:
           initialDelaySeconds: 3
           periodSeconds: 5
           timeoutSeconds: 2
+
+        livenessProbe:
+          httpGet:
+            path: /api/v1alpha1/artifact_types
+            port: backendapi
+            httpHeaders:
+            - name: ContentType
+              value: application/json
+          initialDelaySeconds: 3
+          periodSeconds: 5
+          timeoutSeconds: 2
 ---
 apiVersion: apps/v1
 kind: Deployment

--- a/tests/tests/legacy_kustomizations/metadata/test_data/expected/apps_v1_deployment_metadata-deployment.yaml
+++ b/tests/tests/legacy_kustomizations/metadata/test_data/expected/apps_v1_deployment_metadata-deployment.yaml
@@ -53,6 +53,16 @@ spec:
         - secretRef:
             name: metadata-db-secrets
         image: gcr.io/kubeflow-images-public/metadata:v0.1.11
+        livenessProbe:
+          httpGet:
+            httpHeaders:
+            - name: ContentType
+              value: application/json
+            path: /api/v1alpha1/artifact_types
+            port: backendapi
+          initialDelaySeconds: 3
+          periodSeconds: 5
+          timeoutSeconds: 2
         name: container
         ports:
         - containerPort: 8080


### PR DESCRIPTION
**Which issue is resolved by this Pull Request:**
This fixes https://github.com/kubeflow/metadata/issues/198 partially. It only addresses the metadata server deployment, not the grpc one.

The grpc deployment doesn't seem to have a health endpoint. I've tried running https://github.com/grpc-ecosystem/grpc-health-probe to see if that's an option but getting an error that `grpc.health.v1.Health` isn't supported. So this is more involved and IMO should be addressed in another PR.

**Description of your changes:**
Copy readiness probe as liveness probe.

**Checklist:**
- [x] Unit tests have been rebuilt: 
    1. `cd manifests/tests`
    2. `make generate-changed-only`
    3. `make test`

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/manifests/928)
<!-- Reviewable:end -->
