### PR TITLE
Add option to generate kfdef for KubeFlow Operator

### DIFF
--- a/hack/build_kfdef_specs.py
+++ b/hack/build_kfdef_specs.py
@@ -59,10 +59,11 @@ class KFDefBuilder:
 
           # Remove the name. Kustomize requires a name but we don't want
           # a name so that kfctl will fill it in based on the app directory
-          del spec["metadata"]["name"]
+          if os.environ.get("OPERATOR_KFDEF", "").lower() != "true":
+            del spec["metadata"]["name"]
 
           with open(new_file, "w") as hf:
-            yaml.safe_dump(spec, hf)
+            yaml.safe_dump(spec, hf, default_flow_style = False)
 
 if __name__ == "__main__":
 

--- a/kfdef/source/README.md
+++ b/kfdef/source/README.md
@@ -1,6 +1,8 @@
 This directory contains kustomization packages that are used to generate the YAML specs for the KFDef.
 
 The script `hack/build_kfdef_specs.py` is used to run kustomize and output the YAML files.
+By default *metadata.name* is not generated. However, `OPERATOR_KFDEF` environment variable can be
+set to `true` for building the KubeFlow operator version of kfdefs that contain *metadata.name*.
 
 ## Subdirectories
 


### PR DESCRIPTION
Right now the generated kfdef is not a valid Kubernetes resource since it's missing the metadata.name field. We want to add an option to the build_kfdef_specs.py to generate kfdef with metadata.name that can be used on KubeFlow Operator.

Also fixing a yaml formatting bug when generating kfdef. 

**Which issue is resolved by this Pull Request:**
Resolves #

**Description of your changes:**


**Checklist:**
- [x] Unit tests have been rebuilt: 
    1. `cd manifests/tests`
    2. `make generate-changed-only`
    3. `make test`

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/manifests/929)
<!-- Reviewable:end -->
