### PR TITLE
Pin the 1.0.0 manifests to a specific commit.

### DIFF
--- a/kfdef/kfctl_aws.v1.0.0.yaml
+++ b/kfdef/kfctl_aws.v1.0.0.yaml
@@ -355,5 +355,5 @@ spec:
       - eksctl-kubeflow-aws-nodegroup-ng-a2-NodeInstanceRole-xxxxxxx
   repos:
   - name: manifests
-    uri: https://github.com/kubeflow/manifests/archive/v1.0-branch.tar.gz
+    uri: https://github.com/kubeflow/manifests/archive/v1.0.0.tar.gz
   version: v1.0.0

--- a/kfdef/kfctl_aws_cognito.v1.0.0.yaml
+++ b/kfdef/kfctl_aws_cognito.v1.0.0.yaml
@@ -382,5 +382,5 @@ spec:
       - eksctl-kubeflow-aws-nodegroup-ng-a2-NodeInstanceRole-xxxxx
   repos:
   - name: manifests
-    uri: https://github.com/kubeflow/manifests/archive/v1.0-branch.tar.gz
+    uri: https://github.com/kubeflow/manifests/archive/v1.0.0.tar.gz
   version: v1.0.0

--- a/kfdef/kfctl_gcp_basic_auth.v1.0.0.yaml
+++ b/kfdef/kfctl_gcp_basic_auth.v1.0.0.yaml
@@ -419,5 +419,5 @@ spec:
       useBasicAuth: true
   repos:
   - name: manifests
-    uri: https://github.com/kubeflow/manifests/archive/v1.0-branch.tar.gz
+    uri: https://github.com/kubeflow/manifests/archive/v1.0.0.tar.gz
   version: v1.0.0

--- a/kfdef/kfctl_gcp_iap.v1.0.0.yaml
+++ b/kfdef/kfctl_gcp_iap.v1.0.0.yaml
@@ -414,5 +414,5 @@ spec:
       useBasicAuth: false
   repos:
   - name: manifests
-    uri: https://github.com/kubeflow/manifests/archive/v1.0-branch.tar.gz
+    uri: https://github.com/kubeflow/manifests/archive/v1.0.0.tar.gz
   version: v1.0.0

--- a/kfdef/kfctl_ibm.v1.0.0.yaml
+++ b/kfdef/kfctl_ibm.v1.0.0.yaml
@@ -338,5 +338,5 @@ spec:
     name: seldon-core-operator
   repos:
   - name: manifests
-    uri: https://github.com/kubeflow/manifests/archive/v1.0-branch.tar.gz
+    uri: https://github.com/kubeflow/manifests/archive/v1.0.0.tar.gz
   version: v1.0.0

--- a/kfdef/kfctl_istio_dex.v1.0.0.yaml
+++ b/kfdef/kfctl_istio_dex.v1.0.0.yaml
@@ -370,5 +370,5 @@ spec:
     name: seldon-core-operator
   repos:
   - name: manifests
-    uri: https://github.com/kubeflow/manifests/archive/v1.0-branch.tar.gz
+    uri: https://github.com/kubeflow/manifests/archive/v1.0.0.tar.gz
   version: v1.0.0

--- a/kfdef/kfctl_k8s_istio.v1.0.0.yaml
+++ b/kfdef/kfctl_k8s_istio.v1.0.0.yaml
@@ -344,5 +344,5 @@ spec:
     name: seldon-core-operator
   repos:
   - name: manifests
-    uri: https://github.com/kubeflow/manifests/archive/v1.0-branch.tar.gz
+    uri: https://github.com/kubeflow/manifests/archive/v1.0.0.tar.gz
   version: v1.0.0

--- a/kfdef/source/v1.0.0/kfctl_aws.yaml
+++ b/kfdef/source/v1.0.0/kfctl_aws.yaml
@@ -7,7 +7,7 @@ metadata:
 spec:
   repos:
   - name: manifests
-    uri: https://github.com/kubeflow/manifests/archive/v1.0-branch.tar.gz
+    uri: https://github.com/kubeflow/manifests/archive/v1.0.0.tar.gz
     # To get manifest at a PR:
     #uri: https://github.com/kubeflow/manifests/archive/pull/235/head.tar.gz
   version: v1.0.0

--- a/kfdef/source/v1.0.0/kfctl_aws_cognito.yaml
+++ b/kfdef/source/v1.0.0/kfctl_aws_cognito.yaml
@@ -7,7 +7,7 @@ metadata:
 spec:
   repos:
   - name: manifests
-    uri: https://github.com/kubeflow/manifests/archive/v1.0-branch.tar.gz
+    uri: https://github.com/kubeflow/manifests/archive/v1.0.0.tar.gz
     # To get manifest at a PR:
     #uri: https://github.com/kubeflow/manifests/archive/pull/235/head.tar.gz
   version: v1.0.0

--- a/kfdef/source/v1.0.0/kfctl_gcp_basic_auth.yaml
+++ b/kfdef/source/v1.0.0/kfctl_gcp_basic_auth.yaml
@@ -6,7 +6,7 @@ metadata:
 spec:
   repos:
   - name: manifests
-    uri: https://github.com/kubeflow/manifests/archive/v1.0-branch.tar.gz
+    uri: https://github.com/kubeflow/manifests/archive/v1.0.0.tar.gz
     # To get manifest at a PR:
     #uri: https://github.com/kubeflow/manifests/archive/pull/235/head.tar.gz
   version: v1.0.0

--- a/kfdef/source/v1.0.0/kfctl_gcp_iap.yaml
+++ b/kfdef/source/v1.0.0/kfctl_gcp_iap.yaml
@@ -6,7 +6,7 @@ metadata:
 spec:
   repos:
   - name: manifests
-    uri: https://github.com/kubeflow/manifests/archive/v1.0-branch.tar.gz
+    uri: https://github.com/kubeflow/manifests/archive/v1.0.0.tar.gz
     # To get manifest at a PR:
     #uri: https://github.com/kubeflow/manifests/archive/pull/235/head.tar.gz
   version: v1.0.0

--- a/kfdef/source/v1.0.0/kfctl_ibm.yaml
+++ b/kfdef/source/v1.0.0/kfctl_ibm.yaml
@@ -7,7 +7,7 @@ metadata:
 spec:
   repos:
   - name: manifests
-    uri: https://github.com/kubeflow/manifests/archive/v1.0-branch.tar.gz
+    uri: https://github.com/kubeflow/manifests/archive/v1.0.0.tar.gz
     # To get manifest at a PR:
     #uri: https://github.com/kubeflow/manifests/archive/pull/235/head.tar.gz
   version: v1.0.0

--- a/kfdef/source/v1.0.0/kfctl_istio_dex.yaml
+++ b/kfdef/source/v1.0.0/kfctl_istio_dex.yaml
@@ -8,7 +8,7 @@ metadata:
 spec:
   repos:
     - name: manifests
-      uri: https://github.com/kubeflow/manifests/archive/v1.0-branch.tar.gz
+      uri: https://github.com/kubeflow/manifests/archive/v1.0.0.tar.gz
       # To get manifest at a PR:
       #uri: https://github.com/kubeflow/manifests/archive/pull/235/head.tar.gz
   version: v1.0.0

--- a/kfdef/source/v1.0.0/kfctl_k8s_istio.yaml
+++ b/kfdef/source/v1.0.0/kfctl_k8s_istio.yaml
@@ -7,7 +7,7 @@ metadata:
 spec:
   repos:
     - name: manifests
-      uri: https://github.com/kubeflow/manifests/archive/v1.0-branch.tar.gz
+      uri: https://github.com/kubeflow/manifests/archive/v1.0.0.tar.gz
       # To get manifest at a PR:
       #uri: https://github.com/kubeflow/manifests/archive/pull/235/head.tar.gz
   version: v1.0.0


### PR DESCRIPTION
* We want to start pinning the v1.0.0 configs to a specific commit
  of kubeflow/manifests so that we get stability. This is discussed
  more in #4685.

* We will create patch releases 1.0.X as needed.

* I created a release tag which points at the appropriate stable release.

* Related to #4685 cut 1.0 RC

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/manifests/940)
<!-- Reviewable:end -->
