### PR TITLE
Configure tolerations for istio-nodeagent so that it gets installed in GKE GPU node pools

### DIFF
--- a/istio-1-3-1/istio-install-1-3-1/base/daemon-set.yaml
+++ b/istio-1-3-1/istio-install-1-3-1/base/daemon-set.yaml
@@ -17,6 +17,11 @@ spec:
         app: nodeagent
         istio: nodeagent
     spec:
+      tolerations:
+      - effect: NoExecute
+        operator: Exists
+      - effect: NoSchedule
+        operator: Exists
       affinity:
         nodeAffinity:
           preferredDuringSchedulingIgnoredDuringExecution:

--- a/tests/istio-1-3-1-istio-install-1-3-1-base_test.go
+++ b/tests/istio-1-3-1-istio-install-1-3-1-base_test.go
@@ -1797,6 +1797,11 @@ spec:
         app: nodeagent
         istio: nodeagent
     spec:
+      tolerations:
+      - effect: NoExecute
+        operator: Exists
+      - effect: NoSchedule
+        operator: Exists
       affinity:
         nodeAffinity:
           preferredDuringSchedulingIgnoredDuringExecution:


### PR DESCRIPTION
**Which issue is resolved by this Pull Request:**

Resolves #923.

**Description of your changes:**

This adds the following toleration configuration to the `istio-nodeagent` daemonset so that it gets installed in GKE node pools with GPUs:

```
 tolerations:
- effect: NoExecute
  operator: Exists
- effect: NoSchedule
  operator: Exists
```

Issue #923 details the problem in detail.

**Checklist:**

- [x] Unit tests have been rebuilt: 
    1. `cd manifests/tests`
    2. `make generate-changed-only`
    3. `make test`

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/manifests/941)
<!-- Reviewable:end -->
