### PR TITLE
Add OWNERS file under test folder

### DIFF
--- a/tests/OWNERS
+++ b/tests/OWNERS
@@ -1,0 +1,2 @@
+approvers:
+  - jeffwan


### PR DESCRIPTION
**Which issue is resolved by this Pull Request:**
Current problem is if user change aws manifest, I can not approve PRs.
This allows me to approve changes under `aws` folder. 

**Description of your changes:**
Add OWNERS file under `test` folder

**Checklist:**
- [x] Unit tests have been rebuilt: 
    1. `cd manifests/tests`
    2. `make generate-changed-only`
    3. `make test`

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/manifests/947)
<!-- Reviewable:end -->
