### PR TITLE
Adds kfserving ingressgateway for Istio 1.1.6

### DIFF
--- a/istio/kfserving-gateway/base/deployment.yaml
+++ b/istio/kfserving-gateway/base/deployment.yaml
@@ -1,4 +1,4 @@
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: kfserving-ingressgateway
@@ -6,7 +6,6 @@ metadata:
     app: kfserving-ingressgateway
     kfserving: ingressgateway
 spec:
-  replicas: 1
   selector:
     matchLabels:
       app: kfserving-ingressgateway
@@ -18,123 +17,152 @@ spec:
         kfserving: ingressgateway
       annotations:
         sidecar.istio.io/inject: "false"
-        scheduler.alpha.kubernetes.io/critical-pod: ""
     spec:
       serviceAccountName: istio-ingressgateway-service-account
       containers:
         - name: istio-proxy
-          image: "docker.io/istio/proxyv2:1.0.2"
+          image: "docker.io/istio/proxyv2:1.1.6"
           imagePullPolicy: IfNotPresent
           ports:
+            - containerPort: 15020
             - containerPort: 80
             - containerPort: 443
             - containerPort: 31400
-            - containerPort: 15011
-            - containerPort: 8060
-            - containerPort: 853
+            - containerPort: 15029
             - containerPort: 15030
             - containerPort: 15031
+            - containerPort: 15032
+            - containerPort: 15443
+            - containerPort: 15090
+              protocol: TCP
+              name: http-envoy-prom
           args:
-            - proxy
-            - router
-            - -v
-            - "2"
-            - --discoveryRefreshDelay
-            - "1s" #discoveryRefreshDelay
-            - --drainDuration
-            - "45s" #drainDuration
-            - --parentShutdownDuration
-            - "1m0s" #parentShutdownDuration
-            - --connectTimeout
-            - "10s" #connectTimeout
-            - --serviceCluster
-            - kfserving-ingressgateway
-            - --zipkinAddress
-            - zipkin:9411
-            - --statsdUdpAddress
-            - istio-statsd-prom-bridge:9125
-            - --proxyAdminPort
-            - "15000"
-            - --controlPlaneAuthPolicy
-            - NONE
-            - --discoveryAddress
-            - istio-pilot:8080
+          - proxy
+          - router
+          - --domain
+          - $(POD_NAMESPACE).svc.cluster.local
+          - --log_output_level=default:info
+          - --drainDuration
+          - '45s' #drainDuration
+          - --parentShutdownDuration
+          - '1m0s' #parentShutdownDuration
+          - --connectTimeout
+          - '10s' #connectTimeout
+          - --serviceCluster
+          - kfserving-ingressgateway
+          - --zipkinAddress
+          - zipkin:9411
+          - --proxyAdminPort
+          - "15000"
+          - --statusPort
+          - "15020"
+          - --controlPlaneAuthPolicy
+          - NONE
+          - --discoveryAddress
+          - istio-pilot:15010
+          readinessProbe:
+            failureThreshold: 30
+            httpGet:
+              path: /healthz/ready
+              port: 15020
+              scheme: HTTP
+            initialDelaySeconds: 1
+            periodSeconds: 2
+            successThreshold: 1
+            timeoutSeconds: 1
           resources:
+            limits:
+              cpu: 100m
+              memory: 128Mi
             requests:
               cpu: 10m
+              memory: 40Mi
+
           env:
-            - name: POD_NAME
-              valueFrom:
-                fieldRef:
-                  apiVersion: v1
-                  fieldPath: metadata.name
-            - name: POD_NAMESPACE
-              valueFrom:
-                fieldRef:
-                  apiVersion: v1
-                  fieldPath: metadata.namespace
-            - name: INSTANCE_IP
-              valueFrom:
-                fieldRef:
-                  apiVersion: v1
-                  fieldPath: status.podIP
-            - name: ISTIO_META_POD_NAME
-              valueFrom:
-                fieldRef:
-                  fieldPath: metadata.name
+          - name: POD_NAME
+            valueFrom:
+              fieldRef:
+                apiVersion: v1
+                fieldPath: metadata.name
+          - name: POD_NAMESPACE
+            valueFrom:
+              fieldRef:
+                apiVersion: v1
+                fieldPath: metadata.namespace
+          - name: INSTANCE_IP
+            valueFrom:
+              fieldRef:
+                apiVersion: v1
+                fieldPath: status.podIP
+          - name: HOST_IP
+            valueFrom:
+              fieldRef:
+                apiVersion: v1
+                fieldPath: status.hostIP
+          - name: ISTIO_META_POD_NAME
+            valueFrom:
+              fieldRef:
+                apiVersion: v1
+                fieldPath: metadata.name
+          - name: ISTIO_META_CONFIG_NAMESPACE
+            valueFrom:
+              fieldRef:
+                fieldPath: metadata.namespace
+          - name: ISTIO_META_ROUTER_MODE
+            value: sni-dnat
           volumeMounts:
-            - name: istio-certs
-              mountPath: /etc/certs
-              readOnly: true
-            - name: ingressgateway-certs
-              mountPath: "/etc/istio/ingressgateway-certs"
-              readOnly: true
-            - name: ingressgateway-ca-certs
-              mountPath: "/etc/istio/ingressgateway-ca-certs"
-              readOnly: true
+          - name: istio-certs
+            mountPath: /etc/certs
+            readOnly: true
+          - name: ingressgateway-certs
+            mountPath: "/etc/istio/ingressgateway-certs"
+            readOnly: true
+          - name: ingressgateway-ca-certs
+            mountPath: "/etc/istio/ingressgateway-ca-certs"
+            readOnly: true
       volumes:
-        - name: istio-certs
-          secret:
-            secretName: istio.istio-ingressgateway-service-account
-            optional: true
-        - name: ingressgateway-certs
-          secret:
-            secretName: "istio-ingressgateway-certs"
-            optional: true
-        - name: ingressgateway-ca-certs
-          secret:
-            secretName: "istio-ingressgateway-ca-certs"
-            optional: true
-      affinity:
+      - name: istio-certs
+        secret:
+          secretName: istio.istio-ingressgateway-service-account
+          optional: true
+      - name: ingressgateway-certs
+        secret:
+          secretName: "istio-ingressgateway-certs"
+          optional: true
+      - name: ingressgateway-ca-certs
+        secret:
+          secretName: "istio-ingressgateway-ca-certs"
+          optional: true
+      affinity:      
         nodeAffinity:
           requiredDuringSchedulingIgnoredDuringExecution:
             nodeSelectorTerms:
-              - matchExpressions:
-                  - key: beta.kubernetes.io/arch
-                    operator: In
-                    values:
-                      - amd64
-                      - ppc64le
-                      - s390x
+            - matchExpressions:
+              - key: beta.kubernetes.io/arch
+                operator: In
+                values:
+                - amd64
+                - ppc64le
+                - s390x
           preferredDuringSchedulingIgnoredDuringExecution:
-            - weight: 2
-              preference:
-                matchExpressions:
-                  - key: beta.kubernetes.io/arch
-                    operator: In
-                    values:
-                      - amd64
-            - weight: 2
-              preference:
-                matchExpressions:
-                  - key: beta.kubernetes.io/arch
-                    operator: In
-                    values:
-                      - ppc64le
-            - weight: 2
-              preference:
-                matchExpressions:
-                  - key: beta.kubernetes.io/arch
-                    operator: In
-                    values:
-                      - s390x
+          - weight: 2
+            preference:
+              matchExpressions:
+              - key: beta.kubernetes.io/arch
+                operator: In
+                values:
+                - amd64
+          - weight: 2
+            preference:
+              matchExpressions:
+              - key: beta.kubernetes.io/arch
+                operator: In
+                values:
+                - ppc64le
+          - weight: 2
+            preference:
+              matchExpressions:
+              - key: beta.kubernetes.io/arch
+                operator: In
+                values:
+                - s390x

--- a/istio/kfserving-gateway/base/deployment.yaml
+++ b/istio/kfserving-gateway/base/deployment.yaml
@@ -1,0 +1,140 @@
+apiVersion: extensions/v1beta1
+kind: Deployment
+metadata:
+  name: kfserving-ingressgateway
+  labels:
+    app: kfserving-ingressgateway
+    kfserving: ingressgateway
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: kfserving-ingressgateway
+      kfserving: ingressgateway
+  template:
+    metadata:
+      labels:
+        app: kfserving-ingressgateway
+        kfserving: ingressgateway
+      annotations:
+        sidecar.istio.io/inject: "false"
+        scheduler.alpha.kubernetes.io/critical-pod: ""
+    spec:
+      serviceAccountName: istio-ingressgateway-service-account
+      containers:
+        - name: istio-proxy
+          image: "docker.io/istio/proxyv2:1.0.2"
+          imagePullPolicy: IfNotPresent
+          ports:
+            - containerPort: 80
+            - containerPort: 443
+            - containerPort: 31400
+            - containerPort: 15011
+            - containerPort: 8060
+            - containerPort: 853
+            - containerPort: 15030
+            - containerPort: 15031
+          args:
+            - proxy
+            - router
+            - -v
+            - "2"
+            - --discoveryRefreshDelay
+            - "1s" #discoveryRefreshDelay
+            - --drainDuration
+            - "45s" #drainDuration
+            - --parentShutdownDuration
+            - "1m0s" #parentShutdownDuration
+            - --connectTimeout
+            - "10s" #connectTimeout
+            - --serviceCluster
+            - kfserving-ingressgateway
+            - --zipkinAddress
+            - zipkin:9411
+            - --statsdUdpAddress
+            - istio-statsd-prom-bridge:9125
+            - --proxyAdminPort
+            - "15000"
+            - --controlPlaneAuthPolicy
+            - NONE
+            - --discoveryAddress
+            - istio-pilot:8080
+          resources:
+            requests:
+              cpu: 10m
+          env:
+            - name: POD_NAME
+              valueFrom:
+                fieldRef:
+                  apiVersion: v1
+                  fieldPath: metadata.name
+            - name: POD_NAMESPACE
+              valueFrom:
+                fieldRef:
+                  apiVersion: v1
+                  fieldPath: metadata.namespace
+            - name: INSTANCE_IP
+              valueFrom:
+                fieldRef:
+                  apiVersion: v1
+                  fieldPath: status.podIP
+            - name: ISTIO_META_POD_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.name
+          volumeMounts:
+            - name: istio-certs
+              mountPath: /etc/certs
+              readOnly: true
+            - name: ingressgateway-certs
+              mountPath: "/etc/istio/ingressgateway-certs"
+              readOnly: true
+            - name: ingressgateway-ca-certs
+              mountPath: "/etc/istio/ingressgateway-ca-certs"
+              readOnly: true
+      volumes:
+        - name: istio-certs
+          secret:
+            secretName: istio.istio-ingressgateway-service-account
+            optional: true
+        - name: ingressgateway-certs
+          secret:
+            secretName: "istio-ingressgateway-certs"
+            optional: true
+        - name: ingressgateway-ca-certs
+          secret:
+            secretName: "istio-ingressgateway-ca-certs"
+            optional: true
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+              - matchExpressions:
+                  - key: beta.kubernetes.io/arch
+                    operator: In
+                    values:
+                      - amd64
+                      - ppc64le
+                      - s390x
+          preferredDuringSchedulingIgnoredDuringExecution:
+            - weight: 2
+              preference:
+                matchExpressions:
+                  - key: beta.kubernetes.io/arch
+                    operator: In
+                    values:
+                      - amd64
+            - weight: 2
+              preference:
+                matchExpressions:
+                  - key: beta.kubernetes.io/arch
+                    operator: In
+                    values:
+                      - ppc64le
+            - weight: 2
+              preference:
+                matchExpressions:
+                  - key: beta.kubernetes.io/arch
+                    operator: In
+                    values:
+                      - s390x

--- a/istio/kfserving-gateway/base/horizontal-pod-autoscaler.yaml
+++ b/istio/kfserving-gateway/base/horizontal-pod-autoscaler.yaml
@@ -1,0 +1,19 @@
+apiVersion: autoscaling/v2beta1
+kind: HorizontalPodAutoscaler
+metadata:
+  labels:
+    app: kfserving-ingressgateway
+    kfserving: ingressgateway
+  name: kfserving-ingressgateway
+spec:
+  maxReplicas: 5
+  metrics:
+  - resource:
+      name: cpu
+      targetAverageUtilization: 80
+    type: Resource
+  minReplicas: 1
+  scaleTargetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: kfserving-ingressgateway

--- a/istio/kfserving-gateway/base/kustomization.yaml
+++ b/istio/kfserving-gateway/base/kustomization.yaml
@@ -1,0 +1,6 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+namespace: istio-system
+resources:
+- deployment.yaml
+- service.yaml

--- a/istio/kfserving-gateway/base/kustomization.yaml
+++ b/istio/kfserving-gateway/base/kustomization.yaml
@@ -3,4 +3,5 @@ kind: Kustomization
 namespace: istio-system
 resources:
 - deployment.yaml
+- horizontal-pod-autoscaler.yaml
 - service.yaml

--- a/istio/kfserving-gateway/base/service.yaml
+++ b/istio/kfserving-gateway/base/service.yaml
@@ -1,0 +1,38 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: kfserving-ingressgateway
+  labels:
+    app: kfserving-ingressgateway
+    kfserving: ingressgateway
+spec:
+  type: LoadBalancer
+  selector:
+    app: kfserving-ingressgateway
+    kfserving: ingressgateway
+  ports:
+    - name: http2
+      nodePort: 32380
+      port: 80
+      targetPort: 80
+    - name: https
+      nodePort: 32390
+      port: 443
+    - name: tcp
+      nodePort: 32400
+      port: 31400
+    - name: tcp-pilot-grpc-tls
+      port: 15011
+      targetPort: 15011
+    - name: tcp-citadel-grpc-tls
+      port: 8060
+      targetPort: 8060
+    - name: tcp-dns-tls
+      port: 853
+      targetPort: 853
+    - name: http2-prometheus
+      port: 15030
+      targetPort: 15030
+    - name: http2-grafana
+      port: 15031
+      targetPort: 15031

--- a/istio/kfserving-gateway/base/service.yaml
+++ b/istio/kfserving-gateway/base/service.yaml
@@ -11,6 +11,9 @@ spec:
     app: kfserving-ingressgateway
     kfserving: ingressgateway
   ports:
+    - name: status-port
+      port: 15020
+      targetPort: 15020
     - name: http2
       nodePort: 32380
       port: 80
@@ -30,9 +33,18 @@ spec:
     - name: tcp-dns-tls
       port: 853
       targetPort: 853
+    - name: https-kiali
+      port: 15029
+      targetPort: 15029
     - name: http2-prometheus
       port: 15030
       targetPort: 15030
     - name: http2-grafana
       port: 15031
       targetPort: 15031
+    - name: https-tracing
+      port: 15032
+      targetPort: 15032
+    - name: tls
+      port: 15443
+      targetPort: 15443

--- a/kfdef/kfctl_gcp_basic_auth.v1.0.0.yaml
+++ b/kfdef/kfctl_gcp_basic_auth.v1.0.0.yaml
@@ -30,6 +30,14 @@ spec:
     name: cluster-local-gateway
   - kustomizeConfig:
       parameters:
+      - name: namespace
+        value: istio-system
+      repoRef:
+        name: manifests
+        path: istio/kfserving-gateway
+    name: kfserving-gateway
+  - kustomizeConfig:
+      parameters:
       - name: clusterRbacConfig
         value: 'OFF'
       repoRef:

--- a/kfdef/kfctl_gcp_basic_auth.yaml
+++ b/kfdef/kfctl_gcp_basic_auth.yaml
@@ -30,6 +30,14 @@ spec:
     name: cluster-local-gateway
   - kustomizeConfig:
       parameters:
+      - name: namespace
+        value: istio-system
+      repoRef:
+        name: manifests
+        path: istio/kfserving-gateway
+    name: kfserving-gateway
+  - kustomizeConfig:
+      parameters:
       - name: clusterRbacConfig
         value: 'OFF'
       repoRef:

--- a/kfdef/kfctl_gcp_iap.v1.0.0.yaml
+++ b/kfdef/kfctl_gcp_iap.v1.0.0.yaml
@@ -30,6 +30,14 @@ spec:
     name: cluster-local-gateway
   - kustomizeConfig:
       parameters:
+      - name: namespace
+        value: istio-system
+      repoRef:
+        name: manifests
+        path: istio/kfserving-gateway
+    name: kfserving-gateway
+  - kustomizeConfig:
+      parameters:
       - name: clusterRbacConfig
         value: 'ON'
       repoRef:

--- a/kfdef/kfctl_gcp_iap.yaml
+++ b/kfdef/kfctl_gcp_iap.yaml
@@ -30,6 +30,14 @@ spec:
     name: cluster-local-gateway
   - kustomizeConfig:
       parameters:
+      - name: namespace
+        value: istio-system
+      repoRef:
+        name: manifests
+        path: istio/kfserving-gateway
+    name: kfserving-gateway
+  - kustomizeConfig:
+      parameters:
       - name: clusterRbacConfig
         value: 'ON'
       repoRef:

--- a/kfdef/kfctl_ibm.v1.0.0.yaml
+++ b/kfdef/kfctl_ibm.v1.0.0.yaml
@@ -30,6 +30,14 @@ spec:
     name: cluster-local-gateway
   - kustomizeConfig:
       parameters:
+      - name: namespace
+        value: istio-system
+      repoRef:
+        name: manifests
+        path: istio/kfserving-gateway
+    name: kfserving-gateway
+  - kustomizeConfig:
+      parameters:
       - name: clusterRbacConfig
         value: 'OFF'
       repoRef:

--- a/kfdef/kfctl_ibm.yaml
+++ b/kfdef/kfctl_ibm.yaml
@@ -30,6 +30,14 @@ spec:
     name: cluster-local-gateway
   - kustomizeConfig:
       parameters:
+      - name: namespace
+        value: istio-system
+      repoRef:
+        name: manifests
+        path: istio/kfserving-gateway
+    name: kfserving-gateway
+  - kustomizeConfig:
+      parameters:
       - name: clusterRbacConfig
         value: 'OFF'
       repoRef:

--- a/kfdef/kfctl_k8s_istio.v1.0.0.yaml
+++ b/kfdef/kfctl_k8s_istio.v1.0.0.yaml
@@ -30,6 +30,14 @@ spec:
     name: cluster-local-gateway
   - kustomizeConfig:
       parameters:
+      - name: namespace
+        value: istio-system
+      repoRef:
+        name: manifests
+        path: istio/kfserving-gateway
+    name: kfserving-gateway
+  - kustomizeConfig:
+      parameters:
       - name: clusterRbacConfig
         value: 'OFF'
       repoRef:

--- a/kfdef/kfctl_k8s_istio.yaml
+++ b/kfdef/kfctl_k8s_istio.yaml
@@ -30,6 +30,14 @@ spec:
     name: cluster-local-gateway
   - kustomizeConfig:
       parameters:
+      - name: namespace
+        value: istio-system
+      repoRef:
+        name: manifests
+        path: istio/kfserving-gateway
+    name: kfserving-gateway
+  - kustomizeConfig:
+      parameters:
       - name: clusterRbacConfig
         value: 'OFF'
       repoRef:

--- a/kfdef/source/master/kfctl_gcp_basic_auth.yaml
+++ b/kfdef/source/master/kfctl_gcp_basic_auth.yaml
@@ -31,6 +31,14 @@ spec:
     name: cluster-local-gateway
   - kustomizeConfig:
       parameters:
+      - name: namespace
+        value: istio-system
+      repoRef:
+        name: manifests
+        path: istio/kfserving-gateway
+    name: kfserving-gateway
+  - kustomizeConfig:
+      parameters:
       - name: clusterRbacConfig
         value: "OFF"
       repoRef:

--- a/kfdef/source/master/kfctl_gcp_iap.yaml
+++ b/kfdef/source/master/kfctl_gcp_iap.yaml
@@ -32,6 +32,14 @@ spec:
     name: cluster-local-gateway
   - kustomizeConfig:
       parameters:
+      - name: namespace
+        value: istio-system
+      repoRef:
+        name: manifests
+        path: istio/kfserving-gateway
+    name: kfserving-gateway
+  - kustomizeConfig:
+      parameters:
       - name: clusterRbacConfig
         value: "ON"
       repoRef:

--- a/kfdef/source/master/kfctl_ibm.yaml
+++ b/kfdef/source/master/kfctl_ibm.yaml
@@ -34,6 +34,14 @@ spec:
     name: cluster-local-gateway
   - kustomizeConfig:
       parameters:
+      - name: namespace
+        value: istio-system
+      repoRef:
+        name: manifests
+        path: istio/kfserving-gateway
+    name: kfserving-gateway
+  - kustomizeConfig:
+      parameters:
       - name: clusterRbacConfig
         value: "OFF"
       repoRef:

--- a/kfdef/source/master/kfctl_k8s_istio.yaml
+++ b/kfdef/source/master/kfctl_k8s_istio.yaml
@@ -35,6 +35,14 @@ spec:
     name: cluster-local-gateway
   - kustomizeConfig:
       parameters:
+      - name: namespace
+        value: istio-system
+      repoRef:
+        name: manifests
+        path: istio/kfserving-gateway
+    name: kfserving-gateway
+  - kustomizeConfig:
+      parameters:
       - name: clusterRbacConfig
         value: "OFF"
       repoRef:

--- a/kfserving/kfserving-install/base/config-map.yaml
+++ b/kfserving/kfserving-install/base/config-map.yaml
@@ -89,7 +89,7 @@ data:
     }
   ingress: |-
     {
-        "ingressGateway" : "knative-serving.knative-ingress-gateway",
+        "ingressGateway" : "knative-ingress-gateway.knative-serving",
         "ingressService" : "kfserving-ingressgateway.istio-system.svc.cluster.local"
     }
   logger: |-

--- a/kfserving/kfserving-install/base/config-map.yaml
+++ b/kfserving/kfserving-install/base/config-map.yaml
@@ -89,8 +89,8 @@ data:
     }
   ingress: |-
     {
-        "ingressGateway" : "kubeflow-gateway.kubeflow",
-        "ingressService" : "istio-ingressgateway.istio-system.svc.cluster.local"
+        "ingressGateway" : "knative-serving.knative-ingress-gateway",
+        "ingressService" : "kfserving-ingressgateway.istio-system.svc.cluster.local"
     }
   logger: |-
     {

--- a/knative/knative-serving-install/base/config-map.yaml
+++ b/knative/knative-serving-install/base/config-map.yaml
@@ -658,7 +658,7 @@ data:
     # {{ingress_namespace}}.svc.cluster.local"`. The {{gateway_namespace}}
     # is optional; when it is omitted, the system will search for
     # the gateway in the serving system namespace `knative-serving`
-    gateway.kubeflow.kubeflow-gateway: "istio-ingressgateway.istio-system.svc.cluster.local"
+    gateway.knative-serving.knative-ingress-gateway: "kfserving-ingressgateway.istio-system.svc.cluster.local"
 
     # A cluster local gateway to allow pods outside of the mesh to access
     # Services and Routes not exposing through an ingress.  If the users

--- a/knative/knative-serving-install/base/gateway.yaml
+++ b/knative/knative-serving-install/base/gateway.yaml
@@ -1,4 +1,3 @@
----
 apiVersion: networking.istio.io/v1alpha3
 kind: Gateway
 metadata:
@@ -17,3 +16,23 @@ spec:
         name: http
         number: 80
         protocol: HTTP
+
+---
+apiVersion: networking.istio.io/v1alpha3
+kind: Gateway
+metadata:
+  labels:
+    networking.knative.dev/ingress-provider: istio
+  name: knative-ingress-gateway
+  namespace: knative-serving
+spec:
+  selector:
+     app: kfserving-ingressgateway
+     kfserving: ingressgateway
+  servers:
+  - hosts:
+    - '*'
+    port:
+      name: http
+      number: 80
+      protocol: HTTP

--- a/tests/istio-kfserving-gateway-base_test.go
+++ b/tests/istio-kfserving-gateway-base_test.go
@@ -184,6 +184,27 @@ spec:
                 values:
                 - s390x
 `)
+	th.writeF("/manifests/istio/kfserving-gateway/base/horizontal-pod-autoscaler.yaml", `
+apiVersion: autoscaling/v2beta1
+kind: HorizontalPodAutoscaler
+metadata:
+  labels:
+    app: kfserving-ingressgateway
+    kfserving: ingressgateway
+  name: kfserving-ingressgateway
+spec:
+  maxReplicas: 5
+  metrics:
+  - resource:
+      name: cpu
+      targetAverageUtilization: 80
+    type: Resource
+  minReplicas: 1
+  scaleTargetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: kfserving-ingressgateway
+`)
 	th.writeF("/manifests/istio/kfserving-gateway/base/service.yaml", `
 apiVersion: v1
 kind: Service
@@ -242,6 +263,7 @@ kind: Kustomization
 namespace: istio-system
 resources:
 - deployment.yaml
+- horizontal-pod-autoscaler.yaml
 - service.yaml
 `)
 }

--- a/tests/istio-kfserving-gateway-base_test.go
+++ b/tests/istio-kfserving-gateway-base_test.go
@@ -15,7 +15,7 @@ import (
 
 func writeKfservingGatewayBase(th *KustTestHarness) {
 	th.writeF("/manifests/istio/kfserving-gateway/base/deployment.yaml", `
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: kfserving-ingressgateway
@@ -23,7 +23,6 @@ metadata:
     app: kfserving-ingressgateway
     kfserving: ingressgateway
 spec:
-  replicas: 1
   selector:
     matchLabels:
       app: kfserving-ingressgateway
@@ -35,126 +34,155 @@ spec:
         kfserving: ingressgateway
       annotations:
         sidecar.istio.io/inject: "false"
-        scheduler.alpha.kubernetes.io/critical-pod: ""
     spec:
       serviceAccountName: istio-ingressgateway-service-account
       containers:
         - name: istio-proxy
-          image: "docker.io/istio/proxyv2:1.0.2"
+          image: "docker.io/istio/proxyv2:1.1.6"
           imagePullPolicy: IfNotPresent
           ports:
+            - containerPort: 15020
             - containerPort: 80
             - containerPort: 443
             - containerPort: 31400
-            - containerPort: 15011
-            - containerPort: 8060
-            - containerPort: 853
+            - containerPort: 15029
             - containerPort: 15030
             - containerPort: 15031
+            - containerPort: 15032
+            - containerPort: 15443
+            - containerPort: 15090
+              protocol: TCP
+              name: http-envoy-prom
           args:
-            - proxy
-            - router
-            - -v
-            - "2"
-            - --discoveryRefreshDelay
-            - "1s" #discoveryRefreshDelay
-            - --drainDuration
-            - "45s" #drainDuration
-            - --parentShutdownDuration
-            - "1m0s" #parentShutdownDuration
-            - --connectTimeout
-            - "10s" #connectTimeout
-            - --serviceCluster
-            - kfserving-ingressgateway
-            - --zipkinAddress
-            - zipkin:9411
-            - --statsdUdpAddress
-            - istio-statsd-prom-bridge:9125
-            - --proxyAdminPort
-            - "15000"
-            - --controlPlaneAuthPolicy
-            - NONE
-            - --discoveryAddress
-            - istio-pilot:8080
+          - proxy
+          - router
+          - --domain
+          - $(POD_NAMESPACE).svc.cluster.local
+          - --log_output_level=default:info
+          - --drainDuration
+          - '45s' #drainDuration
+          - --parentShutdownDuration
+          - '1m0s' #parentShutdownDuration
+          - --connectTimeout
+          - '10s' #connectTimeout
+          - --serviceCluster
+          - kfserving-ingressgateway
+          - --zipkinAddress
+          - zipkin:9411
+          - --proxyAdminPort
+          - "15000"
+          - --statusPort
+          - "15020"
+          - --controlPlaneAuthPolicy
+          - NONE
+          - --discoveryAddress
+          - istio-pilot:15010
+          readinessProbe:
+            failureThreshold: 30
+            httpGet:
+              path: /healthz/ready
+              port: 15020
+              scheme: HTTP
+            initialDelaySeconds: 1
+            periodSeconds: 2
+            successThreshold: 1
+            timeoutSeconds: 1
           resources:
+            limits:
+              cpu: 100m
+              memory: 128Mi
             requests:
               cpu: 10m
+              memory: 40Mi
+
           env:
-            - name: POD_NAME
-              valueFrom:
-                fieldRef:
-                  apiVersion: v1
-                  fieldPath: metadata.name
-            - name: POD_NAMESPACE
-              valueFrom:
-                fieldRef:
-                  apiVersion: v1
-                  fieldPath: metadata.namespace
-            - name: INSTANCE_IP
-              valueFrom:
-                fieldRef:
-                  apiVersion: v1
-                  fieldPath: status.podIP
-            - name: ISTIO_META_POD_NAME
-              valueFrom:
-                fieldRef:
-                  fieldPath: metadata.name
+          - name: POD_NAME
+            valueFrom:
+              fieldRef:
+                apiVersion: v1
+                fieldPath: metadata.name
+          - name: POD_NAMESPACE
+            valueFrom:
+              fieldRef:
+                apiVersion: v1
+                fieldPath: metadata.namespace
+          - name: INSTANCE_IP
+            valueFrom:
+              fieldRef:
+                apiVersion: v1
+                fieldPath: status.podIP
+          - name: HOST_IP
+            valueFrom:
+              fieldRef:
+                apiVersion: v1
+                fieldPath: status.hostIP
+          - name: ISTIO_META_POD_NAME
+            valueFrom:
+              fieldRef:
+                apiVersion: v1
+                fieldPath: metadata.name
+          - name: ISTIO_META_CONFIG_NAMESPACE
+            valueFrom:
+              fieldRef:
+                fieldPath: metadata.namespace
+          - name: ISTIO_META_ROUTER_MODE
+            value: sni-dnat
           volumeMounts:
-            - name: istio-certs
-              mountPath: /etc/certs
-              readOnly: true
-            - name: ingressgateway-certs
-              mountPath: "/etc/istio/ingressgateway-certs"
-              readOnly: true
-            - name: ingressgateway-ca-certs
-              mountPath: "/etc/istio/ingressgateway-ca-certs"
-              readOnly: true
+          - name: istio-certs
+            mountPath: /etc/certs
+            readOnly: true
+          - name: ingressgateway-certs
+            mountPath: "/etc/istio/ingressgateway-certs"
+            readOnly: true
+          - name: ingressgateway-ca-certs
+            mountPath: "/etc/istio/ingressgateway-ca-certs"
+            readOnly: true
       volumes:
-        - name: istio-certs
-          secret:
-            secretName: istio.istio-ingressgateway-service-account
-            optional: true
-        - name: ingressgateway-certs
-          secret:
-            secretName: "istio-ingressgateway-certs"
-            optional: true
-        - name: ingressgateway-ca-certs
-          secret:
-            secretName: "istio-ingressgateway-ca-certs"
-            optional: true
-      affinity:
+      - name: istio-certs
+        secret:
+          secretName: istio.istio-ingressgateway-service-account
+          optional: true
+      - name: ingressgateway-certs
+        secret:
+          secretName: "istio-ingressgateway-certs"
+          optional: true
+      - name: ingressgateway-ca-certs
+        secret:
+          secretName: "istio-ingressgateway-ca-certs"
+          optional: true
+      affinity:      
         nodeAffinity:
           requiredDuringSchedulingIgnoredDuringExecution:
             nodeSelectorTerms:
-              - matchExpressions:
-                  - key: beta.kubernetes.io/arch
-                    operator: In
-                    values:
-                      - amd64
-                      - ppc64le
-                      - s390x
+            - matchExpressions:
+              - key: beta.kubernetes.io/arch
+                operator: In
+                values:
+                - amd64
+                - ppc64le
+                - s390x
           preferredDuringSchedulingIgnoredDuringExecution:
-            - weight: 2
-              preference:
-                matchExpressions:
-                  - key: beta.kubernetes.io/arch
-                    operator: In
-                    values:
-                      - amd64
-            - weight: 2
-              preference:
-                matchExpressions:
-                  - key: beta.kubernetes.io/arch
-                    operator: In
-                    values:
-                      - ppc64le
-            - weight: 2
-              preference:
-                matchExpressions:
-                  - key: beta.kubernetes.io/arch
-                    operator: In
-                    values:
-                      - s390x
+          - weight: 2
+            preference:
+              matchExpressions:
+              - key: beta.kubernetes.io/arch
+                operator: In
+                values:
+                - amd64
+          - weight: 2
+            preference:
+              matchExpressions:
+              - key: beta.kubernetes.io/arch
+                operator: In
+                values:
+                - ppc64le
+          - weight: 2
+            preference:
+              matchExpressions:
+              - key: beta.kubernetes.io/arch
+                operator: In
+                values:
+                - s390x
 `)
 	th.writeF("/manifests/istio/kfserving-gateway/base/service.yaml", `
 apiVersion: v1
@@ -170,6 +198,9 @@ spec:
     app: kfserving-ingressgateway
     kfserving: ingressgateway
   ports:
+    - name: status-port
+      port: 15020
+      targetPort: 15020
     - name: http2
       nodePort: 32380
       port: 80
@@ -189,12 +220,21 @@ spec:
     - name: tcp-dns-tls
       port: 853
       targetPort: 853
+    - name: https-kiali
+      port: 15029
+      targetPort: 15029
     - name: http2-prometheus
       port: 15030
       targetPort: 15030
     - name: http2-grafana
       port: 15031
       targetPort: 15031
+    - name: https-tracing
+      port: 15032
+      targetPort: 15032
+    - name: tls
+      port: 15443
+      targetPort: 15443
 `)
 	th.writeK("/manifests/istio/kfserving-gateway/base", `
 apiVersion: kustomize.config.k8s.io/v1beta1

--- a/tests/istio-kfserving-gateway-base_test.go
+++ b/tests/istio-kfserving-gateway-base_test.go
@@ -1,0 +1,238 @@
+package tests_test
+
+import (
+	"sigs.k8s.io/kustomize/v3/k8sdeps/kunstruct"
+	"sigs.k8s.io/kustomize/v3/k8sdeps/transformer"
+	"sigs.k8s.io/kustomize/v3/pkg/fs"
+	"sigs.k8s.io/kustomize/v3/pkg/loader"
+	"sigs.k8s.io/kustomize/v3/pkg/plugins"
+	"sigs.k8s.io/kustomize/v3/pkg/resmap"
+	"sigs.k8s.io/kustomize/v3/pkg/resource"
+	"sigs.k8s.io/kustomize/v3/pkg/target"
+	"sigs.k8s.io/kustomize/v3/pkg/validators"
+	"testing"
+)
+
+func writeKfservingGatewayBase(th *KustTestHarness) {
+	th.writeF("/manifests/istio/kfserving-gateway/base/deployment.yaml", `
+apiVersion: extensions/v1beta1
+kind: Deployment
+metadata:
+  name: kfserving-ingressgateway
+  labels:
+    app: kfserving-ingressgateway
+    kfserving: ingressgateway
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: kfserving-ingressgateway
+      kfserving: ingressgateway
+  template:
+    metadata:
+      labels:
+        app: kfserving-ingressgateway
+        kfserving: ingressgateway
+      annotations:
+        sidecar.istio.io/inject: "false"
+        scheduler.alpha.kubernetes.io/critical-pod: ""
+    spec:
+      serviceAccountName: istio-ingressgateway-service-account
+      containers:
+        - name: istio-proxy
+          image: "docker.io/istio/proxyv2:1.0.2"
+          imagePullPolicy: IfNotPresent
+          ports:
+            - containerPort: 80
+            - containerPort: 443
+            - containerPort: 31400
+            - containerPort: 15011
+            - containerPort: 8060
+            - containerPort: 853
+            - containerPort: 15030
+            - containerPort: 15031
+          args:
+            - proxy
+            - router
+            - -v
+            - "2"
+            - --discoveryRefreshDelay
+            - "1s" #discoveryRefreshDelay
+            - --drainDuration
+            - "45s" #drainDuration
+            - --parentShutdownDuration
+            - "1m0s" #parentShutdownDuration
+            - --connectTimeout
+            - "10s" #connectTimeout
+            - --serviceCluster
+            - kfserving-ingressgateway
+            - --zipkinAddress
+            - zipkin:9411
+            - --statsdUdpAddress
+            - istio-statsd-prom-bridge:9125
+            - --proxyAdminPort
+            - "15000"
+            - --controlPlaneAuthPolicy
+            - NONE
+            - --discoveryAddress
+            - istio-pilot:8080
+          resources:
+            requests:
+              cpu: 10m
+          env:
+            - name: POD_NAME
+              valueFrom:
+                fieldRef:
+                  apiVersion: v1
+                  fieldPath: metadata.name
+            - name: POD_NAMESPACE
+              valueFrom:
+                fieldRef:
+                  apiVersion: v1
+                  fieldPath: metadata.namespace
+            - name: INSTANCE_IP
+              valueFrom:
+                fieldRef:
+                  apiVersion: v1
+                  fieldPath: status.podIP
+            - name: ISTIO_META_POD_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.name
+          volumeMounts:
+            - name: istio-certs
+              mountPath: /etc/certs
+              readOnly: true
+            - name: ingressgateway-certs
+              mountPath: "/etc/istio/ingressgateway-certs"
+              readOnly: true
+            - name: ingressgateway-ca-certs
+              mountPath: "/etc/istio/ingressgateway-ca-certs"
+              readOnly: true
+      volumes:
+        - name: istio-certs
+          secret:
+            secretName: istio.istio-ingressgateway-service-account
+            optional: true
+        - name: ingressgateway-certs
+          secret:
+            secretName: "istio-ingressgateway-certs"
+            optional: true
+        - name: ingressgateway-ca-certs
+          secret:
+            secretName: "istio-ingressgateway-ca-certs"
+            optional: true
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+              - matchExpressions:
+                  - key: beta.kubernetes.io/arch
+                    operator: In
+                    values:
+                      - amd64
+                      - ppc64le
+                      - s390x
+          preferredDuringSchedulingIgnoredDuringExecution:
+            - weight: 2
+              preference:
+                matchExpressions:
+                  - key: beta.kubernetes.io/arch
+                    operator: In
+                    values:
+                      - amd64
+            - weight: 2
+              preference:
+                matchExpressions:
+                  - key: beta.kubernetes.io/arch
+                    operator: In
+                    values:
+                      - ppc64le
+            - weight: 2
+              preference:
+                matchExpressions:
+                  - key: beta.kubernetes.io/arch
+                    operator: In
+                    values:
+                      - s390x
+`)
+	th.writeF("/manifests/istio/kfserving-gateway/base/service.yaml", `
+apiVersion: v1
+kind: Service
+metadata:
+  name: kfserving-ingressgateway
+  labels:
+    app: kfserving-ingressgateway
+    kfserving: ingressgateway
+spec:
+  type: LoadBalancer
+  selector:
+    app: kfserving-ingressgateway
+    kfserving: ingressgateway
+  ports:
+    - name: http2
+      nodePort: 32380
+      port: 80
+      targetPort: 80
+    - name: https
+      nodePort: 32390
+      port: 443
+    - name: tcp
+      nodePort: 32400
+      port: 31400
+    - name: tcp-pilot-grpc-tls
+      port: 15011
+      targetPort: 15011
+    - name: tcp-citadel-grpc-tls
+      port: 8060
+      targetPort: 8060
+    - name: tcp-dns-tls
+      port: 853
+      targetPort: 853
+    - name: http2-prometheus
+      port: 15030
+      targetPort: 15030
+    - name: http2-grafana
+      port: 15031
+      targetPort: 15031
+`)
+	th.writeK("/manifests/istio/kfserving-gateway/base", `
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+namespace: istio-system
+resources:
+- deployment.yaml
+- service.yaml
+`)
+}
+
+func TestKfservingGatewayBase(t *testing.T) {
+	th := NewKustTestHarness(t, "/manifests/istio/kfserving-gateway/base")
+	writeKfservingGatewayBase(th)
+	m, err := th.makeKustTarget().MakeCustomizedResMap()
+	if err != nil {
+		t.Fatalf("Err: %v", err)
+	}
+	expected, err := m.AsYaml()
+	if err != nil {
+		t.Fatalf("Err: %v", err)
+	}
+	targetPath := "../istio/kfserving-gateway/base"
+	fsys := fs.MakeRealFS()
+	lrc := loader.RestrictionRootOnly
+	_loader, loaderErr := loader.NewLoader(lrc, validators.MakeFakeValidator(), targetPath, fsys)
+	if loaderErr != nil {
+		t.Fatalf("could not load kustomize loader: %v", loaderErr)
+	}
+	rf := resmap.NewFactory(resource.NewFactory(kunstruct.NewKunstructuredFactoryImpl()), transformer.NewFactoryImpl())
+	pc := plugins.DefaultPluginConfig()
+	kt, err := target.NewKustTarget(_loader, rf, transformer.NewFactoryImpl(), plugins.NewLoader(pc, rf))
+	if err != nil {
+		th.t.Fatalf("Unexpected construction error %v", err)
+	}
+	actual, err := kt.MakeCustomizedResMap()
+	if err != nil {
+		t.Fatalf("Err: %v", err)
+	}
+	th.assertActualEqualsExpected(actual, string(expected))
+}

--- a/tests/kfserving-kfserving-install-base_test.go
+++ b/tests/kfserving-kfserving-install-base_test.go
@@ -344,7 +344,7 @@ data:
     }
   ingress: |-
     {
-        "ingressGateway" : "knative-serving.knative-ingress-gateway",
+        "ingressGateway" : "knative-ingress-gateway.knative-serving",
         "ingressService" : "kfserving-ingressgateway.istio-system.svc.cluster.local"
     }
   logger: |-

--- a/tests/kfserving-kfserving-install-base_test.go
+++ b/tests/kfserving-kfserving-install-base_test.go
@@ -344,8 +344,8 @@ data:
     }
   ingress: |-
     {
-        "ingressGateway" : "kubeflow-gateway.kubeflow",
-        "ingressService" : "istio-ingressgateway.istio-system.svc.cluster.local"
+        "ingressGateway" : "knative-serving.knative-ingress-gateway",
+        "ingressService" : "kfserving-ingressgateway.istio-system.svc.cluster.local"
     }
   logger: |-
     {

--- a/tests/kfserving-kfserving-install-overlays-application_test.go
+++ b/tests/kfserving-kfserving-install-overlays-application_test.go
@@ -401,7 +401,7 @@ data:
     }
   ingress: |-
     {
-        "ingressGateway" : "knative-serving.knative-ingress-gateway",
+        "ingressGateway" : "knative-ingress-gateway.knative-serving",
         "ingressService" : "kfserving-ingressgateway.istio-system.svc.cluster.local"
     }
   logger: |-

--- a/tests/kfserving-kfserving-install-overlays-application_test.go
+++ b/tests/kfserving-kfserving-install-overlays-application_test.go
@@ -401,8 +401,8 @@ data:
     }
   ingress: |-
     {
-        "ingressGateway" : "kubeflow-gateway.kubeflow",
-        "ingressService" : "istio-ingressgateway.istio-system.svc.cluster.local"
+        "ingressGateway" : "knative-serving.knative-ingress-gateway",
+        "ingressService" : "kfserving-ingressgateway.istio-system.svc.cluster.local"
     }
   logger: |-
     {

--- a/tests/knative-knative-serving-install-base_test.go
+++ b/tests/knative-knative-serving-install-base_test.go
@@ -15,7 +15,6 @@ import (
 
 func writeKnativeServingInstallBase(th *KustTestHarness) {
 	th.writeF("/manifests/knative/knative-serving-install/base/gateway.yaml", `
----
 apiVersion: networking.istio.io/v1alpha3
 kind: Gateway
 metadata:
@@ -34,6 +33,26 @@ spec:
         name: http
         number: 80
         protocol: HTTP
+
+---
+apiVersion: networking.istio.io/v1alpha3
+kind: Gateway
+metadata:
+  labels:
+    networking.knative.dev/ingress-provider: istio
+  name: knative-ingress-gateway
+  namespace: knative-serving
+spec:
+  selector:
+     app: kfserving-ingressgateway
+     kfserving: ingressgateway
+  servers:
+  - hosts:
+    - '*'
+    port:
+      name: http
+      number: 80
+      protocol: HTTP
 `)
 	th.writeF("/manifests/knative/knative-serving-install/base/cluster-role.yaml", `
 ---
@@ -1062,7 +1081,7 @@ data:
     # {{ingress_namespace}}.svc.cluster.local"`+"`"+`. The {{gateway_namespace}}
     # is optional; when it is omitted, the system will search for
     # the gateway in the serving system namespace `+"`"+`knative-serving`+"`"+`
-    gateway.kubeflow.kubeflow-gateway: "istio-ingressgateway.istio-system.svc.cluster.local"
+    gateway.knative-serving.knative-ingress-gateway: "kfserving-ingressgateway.istio-system.svc.cluster.local"
 
     # A cluster local gateway to allow pods outside of the mesh to access
     # Services and Routes not exposing through an ingress.  If the users

--- a/tests/knative-knative-serving-install-overlays-application_test.go
+++ b/tests/knative-knative-serving-install-overlays-application_test.go
@@ -63,7 +63,6 @@ commonLabels:
   app.kubernetes.io/version: v0.11.1
 `)
 	th.writeF("/manifests/knative/knative-serving-install/base/gateway.yaml", `
----
 apiVersion: networking.istio.io/v1alpha3
 kind: Gateway
 metadata:
@@ -82,6 +81,26 @@ spec:
         name: http
         number: 80
         protocol: HTTP
+
+---
+apiVersion: networking.istio.io/v1alpha3
+kind: Gateway
+metadata:
+  labels:
+    networking.knative.dev/ingress-provider: istio
+  name: knative-ingress-gateway
+  namespace: knative-serving
+spec:
+  selector:
+     app: kfserving-ingressgateway
+     kfserving: ingressgateway
+  servers:
+  - hosts:
+    - '*'
+    port:
+      name: http
+      number: 80
+      protocol: HTTP
 `)
 	th.writeF("/manifests/knative/knative-serving-install/base/cluster-role.yaml", `
 ---
@@ -1110,7 +1129,7 @@ data:
     # {{ingress_namespace}}.svc.cluster.local"`+"`"+`. The {{gateway_namespace}}
     # is optional; when it is omitted, the system will search for
     # the gateway in the serving system namespace `+"`"+`knative-serving`+"`"+`
-    gateway.kubeflow.kubeflow-gateway: "istio-ingressgateway.istio-system.svc.cluster.local"
+    gateway.knative-serving.knative-ingress-gateway: "kfserving-ingressgateway.istio-system.svc.cluster.local"
 
     # A cluster local gateway to allow pods outside of the mesh to access
     # Services and Routes not exposing through an ingress.  If the users


### PR DESCRIPTION
Modifies KFServing and KNative Serving config-maps to use this gateway

**Which issue is resolved by this Pull Request:**
Addresses: kubeflow/manifests#924

**Description of your changes:**
This implementation introduces an alternative Kubeflow ingress-gateway for KFServing. This route was chosen because the existing Kubeflow gateway is protected by Auth in several configurations. The Knative service readiness prober requests fail when they try to probe a KFServing InferenceService since those prober requests are not backed with Authentication credentials.

This implementation is a temporary solution until KNative introduces a solution for probing services behind an authenticated gateway as mentioned in this issue: knative/serving#6829

Related issues:
kubeflow/kfserving#668

/cc @yuzisun @animeshsingh 

/hold for testing

**Checklist:**
- [x] Unit tests have been rebuilt: 
    1. `cd manifests/tests`
    2. `make generate-changed-only`
    3. `make test`

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/manifests/949)
<!-- Reviewable:end -->
