### PR TITLE
pipeline/api-service: Set minio secure=false

### DIFF
--- a/pipeline/api-service/base/config-map.yaml
+++ b/pipeline/api-service/base/config-map.yaml
@@ -13,7 +13,8 @@ data:
       "ObjectStoreConfig":{
         "AccessKey": "minio",
         "SecretAccessKey": "minio123",
-        "BucketName": "mlpipeline"
+        "BucketName": "mlpipeline",
+        "Secure": false
       },
       "InitConnectionTimeout": "6m",
       "DefaultPipelineRunnerServiceAccount": "pipeline-runner",

--- a/tests/pipeline/api-service/base/test_data/expected/~g_v1_configmap_ml-pipeline-config.yaml
+++ b/tests/pipeline/api-service/base/test_data/expected/~g_v1_configmap_ml-pipeline-config.yaml
@@ -10,7 +10,8 @@ data:
       "ObjectStoreConfig":{
         "AccessKey": "minio",
         "SecretAccessKey": "minio123",
-        "BucketName": "mlpipeline"
+        "BucketName": "mlpipeline",
+        "Secure": false
       },
       "InitConnectionTimeout": "6m",
       "DefaultPipelineRunnerServiceAccount": "pipeline-runner",

--- a/tests/pipeline/api-service/overlays/application/test_data/expected/~g_v1_configmap_ml-pipeline-config.yaml
+++ b/tests/pipeline/api-service/overlays/application/test_data/expected/~g_v1_configmap_ml-pipeline-config.yaml
@@ -10,7 +10,8 @@ data:
       "ObjectStoreConfig":{
         "AccessKey": "minio",
         "SecretAccessKey": "minio123",
-        "BucketName": "mlpipeline"
+        "BucketName": "mlpipeline",
+        "Secure": false
       },
       "InitConnectionTimeout": "6m",
       "DefaultPipelineRunnerServiceAccount": "pipeline-runner",

--- a/tests/pipeline/api-service/overlays/use-kf-user/test_data/expected/~g_v1_configmap_ml-pipeline-config.yaml
+++ b/tests/pipeline/api-service/overlays/use-kf-user/test_data/expected/~g_v1_configmap_ml-pipeline-config.yaml
@@ -10,7 +10,8 @@ data:
       "ObjectStoreConfig":{
         "AccessKey": "minio",
         "SecretAccessKey": "minio123",
-        "BucketName": "mlpipeline"
+        "BucketName": "mlpipeline",
+        "Secure": false
       },
       "InitConnectionTimeout": "6m",
       "DefaultPipelineRunnerServiceAccount": "pipeline-runner",


### PR DESCRIPTION
**Description of your changes:**

Currently the apiserver uses secure=false by default. That means people
using S3 for instance will default to not using TLS which is a security
issue.

Since the bundled minio doesn't support TLS, we should explicitly set
secure=false here and change the apiserver's defaults to secure=true.



**Checklist:**
- [z] Unit tests have been rebuilt: 
    1. `cd manifests/tests`
    2. `make generate-changed-only`
    3. `make test`

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/manifests/950)
<!-- Reviewable:end -->
