### PR TITLE
remove ambassador annotations from pipelines-ui manifest

### DIFF
--- a/pipeline/pipelines-ui/base/kustomization.yaml
+++ b/pipeline/pipelines-ui/base/kustomization.yaml
@@ -43,5 +43,3 @@ vars:
     apiVersion: v1
   fieldref:
     fieldpath: metadata.name
-configurations:
-- params.yaml

--- a/pipeline/pipelines-ui/base/params.yaml
+++ b/pipeline/pipelines-ui/base/params.yaml
@@ -1,3 +1,0 @@
-varReference:
-- path: metadata/annotations/getambassador.io\/config
-  kind: Service

--- a/pipeline/pipelines-ui/base/service.yaml
+++ b/pipeline/pipelines-ui/base/service.yaml
@@ -3,17 +3,6 @@ apiVersion: v1
 kind: Service
 metadata:
   name: ml-pipeline-ui
-  annotations:
-    getambassador.io/config: |-
-      ---
-      apiVersion: ambassador/v0
-      kind:  Mapping
-      name: pipelineui-mapping
-      prefix: /pipeline
-      rewrite: /pipeline
-      timeout_ms: 300000
-      service: $(service).$(ui-namespace)
-      use_websocket: true
   labels:
     app: ml-pipeline-ui
 spec:
@@ -27,17 +16,6 @@ apiVersion: v1
 kind: Service
 metadata:
   name: ml-pipeline-tensorboard-ui
-  annotations:
-    getambassador.io/config: |-
-      ---
-      apiVersion: ambassador/v0
-      kind:  Mapping
-      name: pipeline-tensorboard-ui-mapping
-      prefix: /data
-      rewrite: /data
-      timeout_ms: 300000
-      service: $(service).$(ui-namespace)
-      use_websocket: true
   labels:
     app: ml-pipeline-tensorboard-ui
 spec:

--- a/tests/pipeline-pipelines-ui-base_test.go
+++ b/tests/pipeline-pipelines-ui-base_test.go
@@ -95,17 +95,6 @@ apiVersion: v1
 kind: Service
 metadata:
   name: ml-pipeline-ui
-  annotations:
-    getambassador.io/config: |-
-      ---
-      apiVersion: ambassador/v0
-      kind:  Mapping
-      name: pipelineui-mapping
-      prefix: /pipeline
-      rewrite: /pipeline
-      timeout_ms: 300000
-      service: $(service).$(ui-namespace)
-      use_websocket: true
   labels:
     app: ml-pipeline-ui
 spec:
@@ -119,17 +108,6 @@ apiVersion: v1
 kind: Service
 metadata:
   name: ml-pipeline-tensorboard-ui
-  annotations:
-    getambassador.io/config: |-
-      ---
-      apiVersion: ambassador/v0
-      kind:  Mapping
-      name: pipeline-tensorboard-ui-mapping
-      prefix: /data
-      rewrite: /data
-      timeout_ms: 300000
-      service: $(service).$(ui-namespace)
-      use_websocket: true
   labels:
     app: ml-pipeline-tensorboard-ui
 spec:
@@ -138,11 +116,6 @@ spec:
     targetPort: 3000
   selector:
     app: ml-pipeline-tensorboard-ui
-`)
-	th.writeF("/manifests/pipeline/pipelines-ui/base/params.yaml", `
-varReference:
-- path: metadata/annotations/getambassador.io\/config
-  kind: Service
 `)
 	th.writeF("/manifests/pipeline/pipelines-ui/base/params.env", `
 uiClusterDomain=cluster.local
@@ -193,8 +166,6 @@ vars:
     apiVersion: v1
   fieldref:
     fieldpath: metadata.name
-configurations:
-- params.yaml
 `)
 }
 

--- a/tests/pipeline-pipelines-ui-overlays-application_test.go
+++ b/tests/pipeline-pipelines-ui-overlays-application_test.go
@@ -143,17 +143,6 @@ apiVersion: v1
 kind: Service
 metadata:
   name: ml-pipeline-ui
-  annotations:
-    getambassador.io/config: |-
-      ---
-      apiVersion: ambassador/v0
-      kind:  Mapping
-      name: pipelineui-mapping
-      prefix: /pipeline
-      rewrite: /pipeline
-      timeout_ms: 300000
-      service: $(service).$(ui-namespace)
-      use_websocket: true
   labels:
     app: ml-pipeline-ui
 spec:
@@ -167,17 +156,6 @@ apiVersion: v1
 kind: Service
 metadata:
   name: ml-pipeline-tensorboard-ui
-  annotations:
-    getambassador.io/config: |-
-      ---
-      apiVersion: ambassador/v0
-      kind:  Mapping
-      name: pipeline-tensorboard-ui-mapping
-      prefix: /data
-      rewrite: /data
-      timeout_ms: 300000
-      service: $(service).$(ui-namespace)
-      use_websocket: true
   labels:
     app: ml-pipeline-tensorboard-ui
 spec:
@@ -186,11 +164,6 @@ spec:
     targetPort: 3000
   selector:
     app: ml-pipeline-tensorboard-ui
-`)
-	th.writeF("/manifests/pipeline/pipelines-ui/base/params.yaml", `
-varReference:
-- path: metadata/annotations/getambassador.io\/config
-  kind: Service
 `)
 	th.writeF("/manifests/pipeline/pipelines-ui/base/params.env", `
 uiClusterDomain=cluster.local
@@ -241,8 +214,6 @@ vars:
     apiVersion: v1
   fieldref:
     fieldpath: metadata.name
-configurations:
-- params.yaml
 `)
 }
 

--- a/tests/pipeline-pipelines-ui-overlays-gcp_test.go
+++ b/tests/pipeline-pipelines-ui-overlays-gcp_test.go
@@ -128,17 +128,6 @@ apiVersion: v1
 kind: Service
 metadata:
   name: ml-pipeline-ui
-  annotations:
-    getambassador.io/config: |-
-      ---
-      apiVersion: ambassador/v0
-      kind:  Mapping
-      name: pipelineui-mapping
-      prefix: /pipeline
-      rewrite: /pipeline
-      timeout_ms: 300000
-      service: $(service).$(ui-namespace)
-      use_websocket: true
   labels:
     app: ml-pipeline-ui
 spec:
@@ -152,17 +141,6 @@ apiVersion: v1
 kind: Service
 metadata:
   name: ml-pipeline-tensorboard-ui
-  annotations:
-    getambassador.io/config: |-
-      ---
-      apiVersion: ambassador/v0
-      kind:  Mapping
-      name: pipeline-tensorboard-ui-mapping
-      prefix: /data
-      rewrite: /data
-      timeout_ms: 300000
-      service: $(service).$(ui-namespace)
-      use_websocket: true
   labels:
     app: ml-pipeline-tensorboard-ui
 spec:
@@ -171,11 +149,6 @@ spec:
     targetPort: 3000
   selector:
     app: ml-pipeline-tensorboard-ui
-`)
-	th.writeF("/manifests/pipeline/pipelines-ui/base/params.yaml", `
-varReference:
-- path: metadata/annotations/getambassador.io\/config
-  kind: Service
 `)
 	th.writeF("/manifests/pipeline/pipelines-ui/base/params.env", `
 uiClusterDomain=cluster.local
@@ -226,8 +199,6 @@ vars:
     apiVersion: v1
   fieldref:
     fieldpath: metadata.name
-configurations:
-- params.yaml
 `)
 }
 

--- a/tests/pipeline-pipelines-ui-overlays-istio_test.go
+++ b/tests/pipeline-pipelines-ui-overlays-istio_test.go
@@ -155,17 +155,6 @@ apiVersion: v1
 kind: Service
 metadata:
   name: ml-pipeline-ui
-  annotations:
-    getambassador.io/config: |-
-      ---
-      apiVersion: ambassador/v0
-      kind:  Mapping
-      name: pipelineui-mapping
-      prefix: /pipeline
-      rewrite: /pipeline
-      timeout_ms: 300000
-      service: $(service).$(ui-namespace)
-      use_websocket: true
   labels:
     app: ml-pipeline-ui
 spec:
@@ -179,17 +168,6 @@ apiVersion: v1
 kind: Service
 metadata:
   name: ml-pipeline-tensorboard-ui
-  annotations:
-    getambassador.io/config: |-
-      ---
-      apiVersion: ambassador/v0
-      kind:  Mapping
-      name: pipeline-tensorboard-ui-mapping
-      prefix: /data
-      rewrite: /data
-      timeout_ms: 300000
-      service: $(service).$(ui-namespace)
-      use_websocket: true
   labels:
     app: ml-pipeline-tensorboard-ui
 spec:
@@ -198,11 +176,6 @@ spec:
     targetPort: 3000
   selector:
     app: ml-pipeline-tensorboard-ui
-`)
-	th.writeF("/manifests/pipeline/pipelines-ui/base/params.yaml", `
-varReference:
-- path: metadata/annotations/getambassador.io\/config
-  kind: Service
 `)
 	th.writeF("/manifests/pipeline/pipelines-ui/base/params.env", `
 uiClusterDomain=cluster.local
@@ -253,8 +226,6 @@ vars:
     apiVersion: v1
   fieldref:
     fieldpath: metadata.name
-configurations:
-- params.yaml
 `)
 }
 


### PR DESCRIPTION
**Which issue is resolved by this Pull Request:**
Resolves #671 

**Description of your changes:**
Remove the ambassador annotations from the manifest of the pipelines-ui service

**Checklist:**
- [x] Unit tests have been rebuilt: 
    1. `cd manifests/tests`
    2. `make generate-changed-only`
    3. `make test`

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/manifests/951)
<!-- Reviewable:end -->
