### PR TITLE
Fixing loadBalancerScheme issue in ingress annotation

### DIFF
--- a/aws/istio-ingress/base/ingress.yaml
+++ b/aws/istio-ingress/base/ingress.yaml
@@ -8,9 +8,9 @@ metadata:
   name: istio-ingress
 spec:
   rules:
-    - http:
-        paths:
-          - backend:
-              serviceName: istio-ingressgateway
-              servicePort: 80
-            path: /*
+  - http:
+      paths:
+      - backend:
+          serviceName: istio-ingressgateway
+          servicePort: 80
+        path: /*

--- a/aws/istio-ingress/base/kustomization.yaml
+++ b/aws/istio-ingress/base/kustomization.yaml
@@ -17,3 +17,5 @@ vars:
     apiVersion: v1
   fieldref:
     fieldpath: data.loadBalancerScheme
+configurations:
+- params.yaml

--- a/aws/istio-ingress/base/params.yaml
+++ b/aws/istio-ingress/base/params.yaml
@@ -1,0 +1,3 @@
+varReference:
+- path: metadata/annotations
+  kind: Ingress

--- a/tests/aws-istio-ingress-base_test.go
+++ b/tests/aws-istio-ingress-base_test.go
@@ -25,15 +25,21 @@ metadata:
   name: istio-ingress
 spec:
   rules:
-    - http:
-        paths:
-          - backend:
-              serviceName: istio-ingressgateway
-              servicePort: 80
-            path: /*
+  - http:
+      paths:
+      - backend:
+          serviceName: istio-ingressgateway
+          servicePort: 80
+        path: /*
+`)
+	th.writeF("/manifests/aws/istio-ingress/base/params.yaml", `
+varReference:
+- path: metadata/annotations
+  kind: Ingress
 `)
 	th.writeF("/manifests/aws/istio-ingress/base/params.env", `
-loadBalancerScheme=internet-facing`)
+loadBalancerScheme=internet-facing
+`)
 	th.writeK("/manifests/aws/istio-ingress/base", `
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
@@ -53,7 +59,10 @@ vars:
     name: istio-ingress-parameters
     apiVersion: v1
   fieldref:
-    fieldpath: data.loadBalancerScheme`)
+    fieldpath: data.loadBalancerScheme
+configurations:
+- params.yaml
+`)
 }
 
 func TestIstioIngressBase(t *testing.T) {

--- a/tests/aws-istio-ingress-overlays-cognito_test.go
+++ b/tests/aws-istio-ingress-overlays-cognito_test.go
@@ -88,15 +88,21 @@ metadata:
   name: istio-ingress
 spec:
   rules:
-    - http:
-        paths:
-          - backend:
-              serviceName: istio-ingressgateway
-              servicePort: 80
-            path: /*
+  - http:
+      paths:
+      - backend:
+          serviceName: istio-ingressgateway
+          servicePort: 80
+        path: /*
+`)
+	th.writeF("/manifests/aws/istio-ingress/base/params.yaml", `
+varReference:
+- path: metadata/annotations
+  kind: Ingress
 `)
 	th.writeF("/manifests/aws/istio-ingress/base/params.env", `
-loadBalancerScheme=internet-facing`)
+loadBalancerScheme=internet-facing
+`)
 	th.writeK("/manifests/aws/istio-ingress/base", `
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
@@ -116,7 +122,10 @@ vars:
     name: istio-ingress-parameters
     apiVersion: v1
   fieldref:
-    fieldpath: data.loadBalancerScheme`)
+    fieldpath: data.loadBalancerScheme
+configurations:
+- params.yaml
+`)
 }
 
 func TestIstioIngressOverlaysCognito(t *testing.T) {

--- a/tests/aws-istio-ingress-overlays-oidc_test.go
+++ b/tests/aws-istio-ingress-overlays-oidc_test.go
@@ -28,7 +28,8 @@ metadata:
 	th.writeF("/manifests/aws/istio-ingress/overlays/oidc/params.yaml", `
 varReference:
 - path: metadata/annotations
-  kind: Ingress`)
+  kind: Ingress
+`)
 	th.writeF("/manifests/aws/istio-ingress/overlays/oidc/params.env", `
 oidcIssuer=
 oidcAuthorizationEndpoint=
@@ -111,15 +112,21 @@ metadata:
   name: istio-ingress
 spec:
   rules:
-    - http:
-        paths:
-          - backend:
-              serviceName: istio-ingressgateway
-              servicePort: 80
-            path: /*
+  - http:
+      paths:
+      - backend:
+          serviceName: istio-ingressgateway
+          servicePort: 80
+        path: /*
+`)
+	th.writeF("/manifests/aws/istio-ingress/base/params.yaml", `
+varReference:
+- path: metadata/annotations
+  kind: Ingress
 `)
 	th.writeF("/manifests/aws/istio-ingress/base/params.env", `
-loadBalancerScheme=internet-facing`)
+loadBalancerScheme=internet-facing
+`)
 	th.writeK("/manifests/aws/istio-ingress/base", `
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
@@ -139,7 +146,10 @@ vars:
     name: istio-ingress-parameters
     apiVersion: v1
   fieldref:
-    fieldpath: data.loadBalancerScheme`)
+    fieldpath: data.loadBalancerScheme
+configurations:
+- params.yaml
+`)
 }
 
 func TestIstioIngressOverlaysOidc(t *testing.T) {

--- a/tests/aws-istio-ingress-overlays-secure_test.go
+++ b/tests/aws-istio-ingress-overlays-secure_test.go
@@ -83,12 +83,17 @@ metadata:
   name: istio-ingress
 spec:
   rules:
-    - http:
-        paths:
-          - backend:
-              serviceName: istio-ingressgateway
-              servicePort: 80
-            path: /*
+  - http:
+      paths:
+      - backend:
+          serviceName: istio-ingressgateway
+          servicePort: 80
+        path: /*
+`)
+	th.writeF("/manifests/aws/istio-ingress/base/params.yaml", `
+varReference:
+- path: metadata/annotations
+  kind: Ingress
 `)
 	th.writeF("/manifests/aws/istio-ingress/base/params.env", `
 loadBalancerScheme=internet-facing
@@ -113,6 +118,8 @@ vars:
     apiVersion: v1
   fieldref:
     fieldpath: data.loadBalancerScheme
+configurations:
+- params.yaml
 `)
 }
 


### PR DESCRIPTION
**Which issue is resolved by this Pull Request:**
Resolves #946

**Description of your changes:**
Fixing loadBalancerScheme issue in ingress annotation.
`loadBalancerScheme` was introduced in the base manifest but there's no `params.yaml` for base and annotation doesn't get updated. no-auth `kfctl_aws.yaml` is affected. Thus, I added one `params.yaml` and modified `kustomization.yaml` file.

**Checklist:**
- [Done] Unit tests have been rebuilt: 
    1. `cd manifests/tests`
    2. `make generate-changed-only`
    3. `make test`

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/manifests/952)
<!-- Reviewable:end -->
