### PR TITLE
Fix AWS OIDC settings

### DIFF
--- a/aws/istio-ingress/overlays/oidc/ingress.yaml
+++ b/aws/istio-ingress/overlays/oidc/ingress.yaml
@@ -7,3 +7,4 @@ metadata:
     alb.ingress.kubernetes.io/auth-idp-cognito: '{"Issuer":"$(oidcIssuer)","AuthorizationEndpoint":"$(oidcAuthorizationEndpoint)","TokenEndpoint":"$(oidcTokenEndpoint)","UserInfoEndpoint":"$(oidcUserInfoEndpoint)","SecretName":"$(oidcSecretName)"}'
     alb.ingress.kubernetes.io/certificate-arn: $(certArn)
     alb.ingress.kubernetes.io/listen-ports: '[{"HTTPS":443}]'
+    alb.ingress.kubernetes.io/auth-scope: 'email openid profile'

--- a/tests/aws-istio-ingress-overlays-oidc_test.go
+++ b/tests/aws-istio-ingress-overlays-oidc_test.go
@@ -24,6 +24,7 @@ metadata:
     alb.ingress.kubernetes.io/auth-idp-cognito: '{"Issuer":"$(oidcIssuer)","AuthorizationEndpoint":"$(oidcAuthorizationEndpoint)","TokenEndpoint":"$(oidcTokenEndpoint)","UserInfoEndpoint":"$(oidcUserInfoEndpoint)","SecretName":"$(oidcSecretName)"}'
     alb.ingress.kubernetes.io/certificate-arn: $(certArn)
     alb.ingress.kubernetes.io/listen-ports: '[{"HTTPS":443}]'
+    alb.ingress.kubernetes.io/auth-scope: 'email openid profile'
 `)
 	th.writeF("/manifests/aws/istio-ingress/overlays/oidc/params.yaml", `
 varReference:


### PR DESCRIPTION
**Which issue is resolved by this Pull Request:**
Resolves #945

**Description of your changes:**
Since we have the issues like:
```
time="2020-02-23T06:33:18Z" level=error msg="Email doesn't exist in user's claim map[exp:1.582439718e+09 iss:https://kubeflow.auth0.com/ sub:github|4739316]. This is not supported"
time="2020-02-23T06:33:18Z" level=error msg="Email doesn't exist in user's claim map[exp:1.582439718e+09 iss:https://kubeflow.auth0.com/ sub:github|4739316]. This is not supported"
```
We need to add auth scope to override default setting, which is:
```
 alb.ingress.kubernetes.io/auth-scope: 'openid email profile'
```
Modified `ingress.yaml`, `kustomize.yaml`, and `params.env` files to fulfill the functionality.

**Checklist:**
- [x] Unit tests have been rebuilt: 
    1. `cd manifests/tests`
    2. `make generate-changed-only`
    3. `make test`

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/manifests/953)
<!-- Reviewable:end -->
