### PR TITLE
Fix pipeline default service account

### DIFF
--- a/pipeline/api-service/base/config-map.yaml
+++ b/pipeline/api-service/base/config-map.yaml
@@ -3,6 +3,7 @@
 apiVersion: v1
 data:
   # apiserver assumes the config is named config.json
+  # temporarily switched to kf-user, because pipeline-runner isn't bound to workload identity by default
   config.json: |
     {
       "DBConfig": {
@@ -16,7 +17,7 @@ data:
         "BucketName": "mlpipeline"
       },
       "InitConnectionTimeout": "6m",
-      "DefaultPipelineRunnerServiceAccount": "pipeline-runner",
+      "DefaultPipelineRunnerServiceAccount": "kf-user",
       "ML_PIPELINE_VISUALIZATIONSERVER_SERVICE_HOST": "ml-pipeline-ml-pipeline-visualizationserver",
       "ML_PIPELINE_VISUALIZATIONSERVER_SERVICE_PORT": 8888
     }

--- a/pipeline/api-service/overlays/external-mysql/config-map.yaml
+++ b/pipeline/api-service/overlays/external-mysql/config-map.yaml
@@ -19,7 +19,7 @@ data:
         "BucketName": "mlpipeline"
       },
       "InitConnectionTimeout": "6m",
-      "DefaultPipelineRunnerServiceAccount": "pipeline-runner",
+      "DefaultPipelineRunnerServiceAccount": "kf-user",
       "ML_PIPELINE_VISUALIZATIONSERVER_SERVICE_HOST": "ml-pipeline-ml-pipeline-visualizationserver",
       "ML_PIPELINE_VISUALIZATIONSERVER_SERVICE_PORT": 8888
     }

--- a/pipeline/pipelines-runner/base/cluster-role-binding.yaml
+++ b/pipeline/pipelines-runner/base/cluster-role-binding.yaml
@@ -12,3 +12,4 @@ subjects:
 # temporarily switched to kf-user, because pipeline-runner isn't bound to workload identity by default
 - kind: ServiceAccount
   name: kf-user
+  namespace: kubeflow

--- a/pipeline/pipelines-runner/base/cluster-role-binding.yaml
+++ b/pipeline/pipelines-runner/base/cluster-role-binding.yaml
@@ -9,3 +9,6 @@ roleRef:
 subjects:
 - kind: ServiceAccount
   name: pipeline-runner
+# temporarily switched to kf-user, because pipeline-runner isn't bound to workload identity by default
+- kind: ServiceAccount
+  name: kf-user

--- a/tests/pipeline-api-service-base_test.go
+++ b/tests/pipeline-api-service-base_test.go
@@ -20,6 +20,7 @@ func writeApiServiceBase(th *KustTestHarness) {
 apiVersion: v1
 data:
   # apiserver assumes the config is named config.json
+  # temporarily switched to kf-user, because pipeline-runner isn't bound to workload identity by default
   config.json: |
     {
       "DBConfig": {
@@ -33,7 +34,7 @@ data:
         "BucketName": "mlpipeline"
       },
       "InitConnectionTimeout": "6m",
-      "DefaultPipelineRunnerServiceAccount": "pipeline-runner",
+      "DefaultPipelineRunnerServiceAccount": "kf-user",
       "ML_PIPELINE_VISUALIZATIONSERVER_SERVICE_HOST": "ml-pipeline-ml-pipeline-visualizationserver",
       "ML_PIPELINE_VISUALIZATIONSERVER_SERVICE_PORT": 8888
     }

--- a/tests/pipeline-api-service-overlays-application_test.go
+++ b/tests/pipeline-api-service-overlays-application_test.go
@@ -68,6 +68,7 @@ resources:
 apiVersion: v1
 data:
   # apiserver assumes the config is named config.json
+  # temporarily switched to kf-user, because pipeline-runner isn't bound to workload identity by default
   config.json: |
     {
       "DBConfig": {
@@ -81,7 +82,7 @@ data:
         "BucketName": "mlpipeline"
       },
       "InitConnectionTimeout": "6m",
-      "DefaultPipelineRunnerServiceAccount": "pipeline-runner",
+      "DefaultPipelineRunnerServiceAccount": "kf-user",
       "ML_PIPELINE_VISUALIZATIONSERVER_SERVICE_HOST": "ml-pipeline-ml-pipeline-visualizationserver",
       "ML_PIPELINE_VISUALIZATIONSERVER_SERVICE_PORT": 8888
     }

--- a/tests/pipeline-api-service-overlays-external-mysql_test.go
+++ b/tests/pipeline-api-service-overlays-external-mysql_test.go
@@ -36,7 +36,7 @@ data:
         "BucketName": "mlpipeline"
       },
       "InitConnectionTimeout": "6m",
-      "DefaultPipelineRunnerServiceAccount": "pipeline-runner",
+      "DefaultPipelineRunnerServiceAccount": "kf-user",
       "ML_PIPELINE_VISUALIZATIONSERVER_SERVICE_HOST": "ml-pipeline-ml-pipeline-visualizationserver",
       "ML_PIPELINE_VISUALIZATIONSERVER_SERVICE_PORT": 8888
     }
@@ -97,6 +97,7 @@ configurations:
 apiVersion: v1
 data:
   # apiserver assumes the config is named config.json
+  # temporarily switched to kf-user, because pipeline-runner isn't bound to workload identity by default
   config.json: |
     {
       "DBConfig": {
@@ -110,7 +111,7 @@ data:
         "BucketName": "mlpipeline"
       },
       "InitConnectionTimeout": "6m",
-      "DefaultPipelineRunnerServiceAccount": "pipeline-runner",
+      "DefaultPipelineRunnerServiceAccount": "kf-user",
       "ML_PIPELINE_VISUALIZATIONSERVER_SERVICE_HOST": "ml-pipeline-ml-pipeline-visualizationserver",
       "ML_PIPELINE_VISUALIZATIONSERVER_SERVICE_PORT": 8888
     }

--- a/tests/pipeline-pipelines-runner-base_test.go
+++ b/tests/pipeline-pipelines-runner-base_test.go
@@ -29,6 +29,7 @@ subjects:
 # temporarily switched to kf-user, because pipeline-runner isn't bound to workload identity by default
 - kind: ServiceAccount
   name: kf-user
+  namespace: kubeflow
 `)
 	th.writeF("/manifests/pipeline/pipelines-runner/base/cluster-role.yaml", `
 apiVersion: rbac.authorization.k8s.io/v1beta1

--- a/tests/pipeline-pipelines-runner-base_test.go
+++ b/tests/pipeline-pipelines-runner-base_test.go
@@ -26,6 +26,9 @@ roleRef:
 subjects:
 - kind: ServiceAccount
   name: pipeline-runner
+# temporarily switched to kf-user, because pipeline-runner isn't bound to workload identity by default
+- kind: ServiceAccount
+  name: kf-user
 `)
 	th.writeF("/manifests/pipeline/pipelines-runner/base/cluster-role.yaml", `
 apiVersion: rbac.authorization.k8s.io/v1beta1

--- a/tests/pipeline-pipelines-runner-overlays-application_test.go
+++ b/tests/pipeline-pipelines-runner-overlays-application_test.go
@@ -74,6 +74,9 @@ roleRef:
 subjects:
 - kind: ServiceAccount
   name: pipeline-runner
+# temporarily switched to kf-user, because pipeline-runner isn't bound to workload identity by default
+- kind: ServiceAccount
+  name: kf-user
 `)
 	th.writeF("/manifests/pipeline/pipelines-runner/base/cluster-role.yaml", `
 apiVersion: rbac.authorization.k8s.io/v1beta1

--- a/tests/pipeline-pipelines-runner-overlays-application_test.go
+++ b/tests/pipeline-pipelines-runner-overlays-application_test.go
@@ -77,6 +77,7 @@ subjects:
 # temporarily switched to kf-user, because pipeline-runner isn't bound to workload identity by default
 - kind: ServiceAccount
   name: kf-user
+  namespace: kubeflow
 `)
 	th.writeF("/manifests/pipeline/pipelines-runner/base/cluster-role.yaml", `
 apiVersion: rbac.authorization.k8s.io/v1beta1


### PR DESCRIPTION
**Which issue is resolved by this Pull Request:**
Resolves https://github.com/kubeflow/kubeflow/issues/4803

**Description of your changes:**
1. Use `kf-user` as pipeline default sa.
2. Bind `pipeline-runner` clusterrole to `kf-user` to avoid breaking existing usages.

**Checklist:**
- [x] Unit tests have been rebuilt: 
    1. `cd manifests/tests`
    2. `make generate-changed-only`
    3. `make test`

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/manifests/969)
<!-- Reviewable:end -->
