### PR TITLE
Fix KFP tensorboard no GCP permission

### DIFF
--- a/pipeline/pipelines-ui/overlays/gcp/configmap.yaml
+++ b/pipeline/pipelines-ui/overlays/gcp/configmap.yaml
@@ -1,0 +1,11 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: ml-pipeline-ui-configmap
+data:   
+   viewer-pod-template.json:  |-
+    {
+    "spec": {
+        "serviceAccountName": "kf-user"
+    }
+    }

--- a/pipeline/pipelines-ui/overlays/gcp/deployment.yaml
+++ b/pipeline/pipelines-ui/overlays/gcp/deployment.yaml
@@ -12,12 +12,20 @@ spec:
       - name: gcp-sa-token
         secret:
           secretName: user-gcp-sa
+      - name: config-volume
+        configMap:
+          name: ml-pipeline-ui-configmap
       containers:
       - name: ml-pipeline-ui
         env:
         - name: GOOGLE_APPLICATION_CREDENTIALS
           value: /etc/credentials/user-gcp-sa.json
+        - name: VIEWER_TENSORBOARD_POD_TEMPLATE_SPEC_PATH
+          value: /etc/config/viewer-pod-template.json
         volumeMounts:
         - name: gcp-sa-token
           mountPath: "/etc/credentials"
+          readOnly: true
+        - name: config-volume
+          mountPath: /etc/config
           readOnly: true

--- a/pipeline/pipelines-ui/overlays/gcp/kustomization.yaml
+++ b/pipeline/pipelines-ui/overlays/gcp/kustomization.yaml
@@ -4,3 +4,5 @@ bases:
 - ../../base
 patchesStrategicMerge:
 - deployment.yaml
+resources:
+- configmap.yaml

--- a/tests/pipeline-pipelines-ui-overlays-gcp_test.go
+++ b/tests/pipeline-pipelines-ui-overlays-gcp_test.go
@@ -29,15 +29,36 @@ spec:
       - name: gcp-sa-token
         secret:
           secretName: user-gcp-sa
+      - name: config-volume
+        configMap:
+          name: ml-pipeline-ui-configmap
       containers:
       - name: ml-pipeline-ui
         env:
         - name: GOOGLE_APPLICATION_CREDENTIALS
           value: /etc/credentials/user-gcp-sa.json
+        - name: VIEWER_TENSORBOARD_POD_TEMPLATE_SPEC_PATH
+          value: /etc/config/viewer-pod-template.json
         volumeMounts:
         - name: gcp-sa-token
           mountPath: "/etc/credentials"
           readOnly: true
+        - name: config-volume
+          mountPath: /etc/config
+          readOnly: true
+`)
+	th.writeF("/manifests/pipeline/pipelines-ui/overlays/gcp/configmap.yaml", `
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: ml-pipeline-ui-configmap
+data:   
+   viewer-pod-template.json:  |-
+    {
+    "spec": {
+        "serviceAccountName": "kf-user"
+    }
+    }
 `)
 	th.writeK("/manifests/pipeline/pipelines-ui/overlays/gcp", `
 apiVersion: kustomize.config.k8s.io/v1beta1
@@ -46,6 +67,8 @@ bases:
 - ../../base
 patchesStrategicMerge:
 - deployment.yaml
+resources:
+- configmap.yaml
 `)
 	th.writeF("/manifests/pipeline/pipelines-ui/base/deployment.yaml", `
 apiVersion: apps/v1


### PR DESCRIPTION
/area pipelines

**Which issue is resolved by this Pull Request:**
Resolves https://github.com/kubeflow/kubeflow/issues/4795

**Description of your changes:**
* Override KFP tensorboard pod template to use `kf-user` sa so it has GCP permissions.

**Checklist:**
- [x] Unit tests have been rebuilt: 
    1. `cd manifests/tests`
    2. `make generate-changed-only`
    3. `make test`

/assign @jlewi 
/cc @amygdala

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/manifests/970)
<!-- Reviewable:end -->
