### PR TITLE
adds grpc server as part of Dex config for programmatic access

### DIFF
--- a/dex-auth/dex-crds/base/config-map.yaml
+++ b/dex-auth/dex-crds/base/config-map.yaml
@@ -18,6 +18,10 @@ data:
     oauth2:
       skipApprovalScreen: true
     enablePasswordDB: true
+    grpc:
+    # Cannot be the same address as an HTTP(S) service.
+    addr: 127.0.0.1:5557
+    reflection: true
     staticPasswords:
     - email: $(static_email)
       hash: $(static_password_hash)

--- a/dex-auth/dex-crds/base/config-map.yaml
+++ b/dex-auth/dex-crds/base/config-map.yaml
@@ -19,9 +19,9 @@ data:
       skipApprovalScreen: true
     enablePasswordDB: true
     grpc:
-    # Cannot be the same address as an HTTP(S) service.
-    addr: 127.0.0.1:5557
-    reflection: true
+      # Cannot be the same address as an HTTP(S) service.
+      addr: 127.0.0.1:5557
+      reflection: true
     staticPasswords:
     - email: $(static_email)
       hash: $(static_password_hash)

--- a/dex-auth/dex-crds/base/config-map.yaml
+++ b/dex-auth/dex-crds/base/config-map.yaml
@@ -20,7 +20,7 @@ data:
     enablePasswordDB: true
     grpc:
       # Cannot be the same address as an HTTP(S) service.
-      addr: 127.0.0.1:5557
+      addr: 0.0.0.0:5557
       reflection: true
     staticPasswords:
     - email: $(static_email)

--- a/tests/dex-auth-dex-crds-base_test.go
+++ b/tests/dex-auth-dex-crds-base_test.go
@@ -44,7 +44,7 @@ data:
     enablePasswordDB: true
     grpc:
       # Cannot be the same address as an HTTP(S) service.
-      addr: 127.0.0.1:5557
+      addr: 0.0.0.0:5557
       reflection: true
     staticPasswords:
     - email: $(static_email)

--- a/tests/dex-auth-dex-crds-base_test.go
+++ b/tests/dex-auth-dex-crds-base_test.go
@@ -1,6 +1,8 @@
 package tests_test
 
 import (
+	"testing"
+
 	"sigs.k8s.io/kustomize/v3/k8sdeps/kunstruct"
 	"sigs.k8s.io/kustomize/v3/k8sdeps/transformer"
 	"sigs.k8s.io/kustomize/v3/pkg/fs"
@@ -10,7 +12,6 @@ import (
 	"sigs.k8s.io/kustomize/v3/pkg/resource"
 	"sigs.k8s.io/kustomize/v3/pkg/target"
 	"sigs.k8s.io/kustomize/v3/pkg/validators"
-	"testing"
 )
 
 func writeDexCrdsBase(th *KustTestHarness) {
@@ -41,6 +42,10 @@ data:
     oauth2:
       skipApprovalScreen: true
     enablePasswordDB: true
+    grpc:
+      # Cannot be the same address as an HTTP(S) service.
+      addr: 127.0.0.1:5557
+      reflection: true
     staticPasswords:
     - email: $(static_email)
       hash: $(static_password_hash)

--- a/tests/dex-auth-dex-crds-overlays-istio_test.go
+++ b/tests/dex-auth-dex-crds-overlays-istio_test.go
@@ -1,6 +1,8 @@
 package tests_test
 
 import (
+	"testing"
+
 	"sigs.k8s.io/kustomize/v3/k8sdeps/kunstruct"
 	"sigs.k8s.io/kustomize/v3/k8sdeps/transformer"
 	"sigs.k8s.io/kustomize/v3/pkg/fs"
@@ -10,7 +12,6 @@ import (
 	"sigs.k8s.io/kustomize/v3/pkg/resource"
 	"sigs.k8s.io/kustomize/v3/pkg/target"
 	"sigs.k8s.io/kustomize/v3/pkg/validators"
-	"testing"
 )
 
 func writeDexCrdsOverlaysIstio(th *KustTestHarness) {
@@ -97,6 +98,10 @@ data:
     oauth2:
       skipApprovalScreen: true
     enablePasswordDB: true
+    grpc:
+      # Cannot be the same address as an HTTP(S) service.
+      addr: 127.0.0.1:5557
+      reflection: true
     staticPasswords:
     - email: $(static_email)
       hash: $(static_password_hash)

--- a/tests/dex-auth-dex-crds-overlays-istio_test.go
+++ b/tests/dex-auth-dex-crds-overlays-istio_test.go
@@ -100,7 +100,7 @@ data:
     enablePasswordDB: true
     grpc:
       # Cannot be the same address as an HTTP(S) service.
-      addr: 127.0.0.1:5557
+      addr: 0.0.0.0:5557
       reflection: true
     staticPasswords:
     - email: $(static_email)


### PR DESCRIPTION
**Which issue is resolved by this Pull Request:**
Related to https://github.com/kubeflow/kfctl/issues/140

**Description of your changes:**
Enables gRPC Server on Dex for programmatic access. This will go into a potential Kubeflow Auth library.

Dex documentation for using the Server and downstream clients:
https://github.com/dexidp/dex/blob/master/Documentation/api.md

**Checklist:**
- [x] Unit tests have been rebuilt: 
    1. `cd manifests/tests`
    2. `make generate-changed-only`
    3. `make test`

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/manifests/980)
<!-- Reviewable:end -->
