### PR TITLE
publish cloud endpoint API spec template

### DIFF
--- a/experimental/gcp/template/openapi.yaml
+++ b/experimental/gcp/template/openapi.yaml
@@ -1,0 +1,54 @@
+swagger: "2.0"
+info:
+  description: "wildcard config for any HTTP service."
+  title: "General HTTP Service."
+  version: "1.0.0"
+host: "CHANGE.TO.YOUR.HOST.NAME"
+x-google-endpoints:
+- name: "CHANGE.TO.YOUR.HOST.NAME"
+  target: "CHANGE.TO.YOUR.IP"
+basePath: "/"
+consumes:
+- "application/json"
+produces:
+- "application/json"
+schemes:
+- "http"
+- "https"
+paths:
+  "/**":
+    get:
+      operationId: Get
+      responses:
+        '200':
+          description: Get
+        default:
+          description: Error
+    delete:
+      operationId: Delete
+      responses:
+        '204':
+          description: Delete
+        default:
+          description: Error
+    patch:
+      operationId: Patch
+      responses:
+        '200':
+          description: Patch
+        default:
+          description: Error
+    post:
+      operationId: Post
+      responses:
+        '200':
+          description: Post
+        default:
+          description: Error
+    put:
+      operationId: Put
+      responses:
+        '200':
+          description: Put
+        default:
+          description: Error


### PR DESCRIPTION
**Which issue is resolved by this Pull Request:**
This template is for users who need to create GCP cloud endpoint manually.

Replace Host & Ip before submit

**Description of your changes:**


**Checklist:**
- [x] Unit tests have been rebuilt: 
    1. `cd manifests/tests`
    2. `make generate-changed-only`
    3. `make test`

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/manifests/996)
<!-- Reviewable:end -->
