### PR TITLE
iap jwt public key service

### DIFF
--- a/gcp/privateutil/base/iap-jwt-key.yaml
+++ b/gcp/privateutil/base/iap-jwt-key.yaml
@@ -1,0 +1,97 @@
+apiVersion: v1
+data:
+  public_key-jwk: |
+    {
+       "keys" : [
+          {
+             "alg" : "ES256",
+             "crv" : "P-256",
+             "kid" : "6BEeoA",
+             "kty" : "EC",
+             "use" : "sig",
+             "x" : "lmi1hJdqtbvdX1INOf5B9dWvkydYoowHUXiw8ELWzk8",
+             "y" : "2BxEja_L10KMjrizhLS2XgkGxZHi1KsWKdbEwKyjbvw"
+          },
+          {
+             "alg" : "ES256",
+             "crv" : "P-256",
+             "kid" : "2nMJtw",
+             "kty" : "EC",
+             "use" : "sig",
+             "x" : "9e1x7YRZg53A5zIJ0p2ZQ9yTrgPLGIf4ntOk-4O2R28",
+             "y" : "q8iDm7nsnpz1xPdrWBtTZSowzciS3O7bMYtFFJ8saYo"
+          },
+          {
+             "alg" : "ES256",
+             "crv" : "P-256",
+             "kid" : "LYyP2g",
+             "kty" : "EC",
+             "use" : "sig",
+             "x" : "SlXFFkJ3JxMsXyXNrqzE3ozl_0913PmNbccLLWfeQFU",
+             "y" : "GLSahrZfBErmMUcHP0MGaeVnJdBwquhrhQ8eP05NfCI"
+          },
+          {
+             "alg" : "ES256",
+             "crv" : "P-256",
+             "kid" : "mpf0DA",
+             "kty" : "EC",
+             "use" : "sig",
+             "x" : "fHEdeT3a6KaC1kbwov73ZwB_SiUHEyKQwUUtMCEn0aI",
+             "y" : "QWOjwPhInNuPlqjxLQyhveXpWqOFcQPhZ3t-koMNbZI"
+          },
+          {
+             "alg" : "ES256",
+             "crv" : "P-256",
+             "kid" : "b9vTLA",
+             "kty" : "EC",
+             "use" : "sig",
+             "x" : "qCByTAvci-jRAD7uQSEhTdOs8iA714IbcY2L--YzynI",
+             "y" : "WQY0uCoQyPSozWKGQ0anmFeOH5JNXiZa9i6SNqOcm7w"
+          }
+       ]
+    }
+kind: ConfigMap
+metadata:
+  name: pubkey
+  namespace: istio-system
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: pubkey
+  namespace: istio-system
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      service: pubkey
+  template:
+    metadata:
+      labels:
+        service: pubkey
+    spec:
+      containers:
+        - command:
+          - /pub-key-server
+          image: gcr.io/kubeflow-images-public/jwtpubkey:v20200311-v0.7.0-rc.5-109-g641fb40b-dirty-eb1cdc
+          name: pubkey
+          volumeMounts:
+            - mountPath: /var/pubkey/
+              name: config-volume
+      restartPolicy: Always
+      serviceAccountName: kf-admin
+      volumes:
+        - configMap:
+            name: pubkey
+          name: config-volume
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: pubkey
+  namespace: istio-system
+spec:
+  ports:
+    - port: 8087
+  selector:
+    service: pubkey

--- a/gcp/privateutil/base/kustomization.yaml
+++ b/gcp/privateutil/base/kustomization.yaml
@@ -1,0 +1,4 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+- iap-jwt-key.yaml


### PR DESCRIPTION
When Istio is configured to use IAP jwt, istio need to access
`jwksUri: https://www.gstatic.com/iap/verify/public_key-jwk` for jwt verification.
However above uri is not accessible from a private network.

This PR contains a k8s service that host the same public key as `https://www.gstatic.com/iap/verify/public_key-jwk` to allow jwt verification within cluster.

Note: the config map need update if the IAP public key rotate.

To apply the new pkg, user can either add it to kfdef or directly 
`kustomize build ... | kubectl apply ...`

**Checklist:**
- [x] Unit tests have been rebuilt: 
    1. `cd manifests/tests`
    2. `make generate-changed-only`
    3. `make test`

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/manifests/999)
<!-- Reviewable:end -->
