### PR TITLE
Fix the aws vpc over manifest.

### DIFF
--- a/aws/aws-alb-ingress-controller/overlays/application/kustomization.yaml
+++ b/aws/aws-alb-ingress-controller/overlays/application/kustomization.yaml
@@ -1,8 +1,7 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
-bases:
-- ../../base
 resources:
+- ../../base
 - application.yaml
 commonLabels:
   app.kubernetes.io/name: aws-alb-ingress-controller

--- a/aws/aws-alb-ingress-controller/overlays/vpc/kustomization.yaml
+++ b/aws/aws-alb-ingress-controller/overlays/vpc/kustomization.yaml
@@ -1,8 +1,8 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
-bases:
-- ../../base
 resources:
+- ../../base
+patchesStrategicMerge:
 - vpc.yaml
 configMapGenerator:
 - name: alb-ingress-controller-vpc-parameters

--- a/prow_config.yaml
+++ b/prow_config.yaml
@@ -16,7 +16,7 @@ workflows:
 
   # Run the e2e tests to ensure that changes to manifests don't break deployments.
   - py_func: kubeflow.kfctl.testing.ci.kfctl_e2e_workflow.create_workflow
-    name: kfctl-go-iap
+    name: e2e
     job_types:
       - presubmit
       - postsubmit

--- a/tests/aws-aws-alb-ingress-controller-overlays-application_test.go
+++ b/tests/aws-aws-alb-ingress-controller-overlays-application_test.go
@@ -53,9 +53,8 @@ spec:
 	th.writeK("/manifests/aws/aws-alb-ingress-controller/overlays/application", `
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
-bases:
-- ../../base
 resources:
+- ../../base
 - application.yaml
 commonLabels:
   app.kubernetes.io/name: aws-alb-ingress-controller
@@ -101,8 +100,7 @@ rules:
     verbs:
       - get
       - list
-      - watch
-`)
+      - watch`)
 	th.writeF("/manifests/aws/aws-alb-ingress-controller/base/cluster-role-binding.yaml", `
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
@@ -114,8 +112,7 @@ roleRef:
   name: alb-ingress-controller
 subjects:
   - kind: ServiceAccount
-    name: alb-ingress-controller
-`)
+    name: alb-ingress-controller`)
 	th.writeF("/manifests/aws/aws-alb-ingress-controller/base/deployment.yaml", `
 # Application Load Balancer (ALB) Ingress Controller Deployment Manifest.
 # This manifest details sensible defaults for deploying an ALB Ingress Controller.
@@ -175,11 +172,9 @@ spec:
 apiVersion: v1
 kind: ServiceAccount
 metadata:
-  name: alb-ingress-controller
-`)
+  name: alb-ingress-controller`)
 	th.writeF("/manifests/aws/aws-alb-ingress-controller/base/params.env", `
-clusterName=
-`)
+clusterName=`)
 	th.writeK("/manifests/aws/aws-alb-ingress-controller/base", `
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization

--- a/tests/aws-aws-alb-ingress-controller-overlays-vpc_test.go
+++ b/tests/aws-aws-alb-ingress-controller-overlays-vpc_test.go
@@ -44,14 +44,13 @@ spec:
 `)
 	th.writeF("/manifests/aws/aws-alb-ingress-controller/overlays/vpc/params.env", `
 vpcId=
-region=us-west-2
-`)
+region=us-west-2`)
 	th.writeK("/manifests/aws/aws-alb-ingress-controller/overlays/vpc", `
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
-bases:
-- ../../base
 resources:
+- ../../base
+patchesStrategicMerge:
 - vpc.yaml
 configMapGenerator:
 - name: alb-ingress-controller-vpc-parameters
@@ -107,8 +106,7 @@ rules:
     verbs:
       - get
       - list
-      - watch
-`)
+      - watch`)
 	th.writeF("/manifests/aws/aws-alb-ingress-controller/base/cluster-role-binding.yaml", `
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
@@ -120,8 +118,7 @@ roleRef:
   name: alb-ingress-controller
 subjects:
   - kind: ServiceAccount
-    name: alb-ingress-controller
-`)
+    name: alb-ingress-controller`)
 	th.writeF("/manifests/aws/aws-alb-ingress-controller/base/deployment.yaml", `
 # Application Load Balancer (ALB) Ingress Controller Deployment Manifest.
 # This manifest details sensible defaults for deploying an ALB Ingress Controller.
@@ -181,11 +178,9 @@ spec:
 apiVersion: v1
 kind: ServiceAccount
 metadata:
-  name: alb-ingress-controller
-`)
+  name: alb-ingress-controller`)
 	th.writeF("/manifests/aws/aws-alb-ingress-controller/base/params.env", `
-clusterName=
-`)
+clusterName=`)
 	th.writeK("/manifests/aws/aws-alb-ingress-controller/base", `
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization


### PR DESCRIPTION
* It looks like there is a bug in the VPC overlay for AWS. It looks like
  VPC is a patch but it is listed as a resource.

* This PR changes the kustomization.yaml file to list VPC.yaml as a patch
  and not a resource.

* In kustomize "bases" is deprecated. The newer syntax is to just list bases as resources.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/manifests/1011)
<!-- Reviewable:end -->
