### PR TITLE
Shorten the name of the workflows to fix the tests #1012.

### DIFF
--- a/prow_config.yaml
+++ b/prow_config.yaml
@@ -16,7 +16,7 @@ workflows:
 
   # Run the e2e tests to ensure that changes to manifests don't break deployments.
   - py_func: kubeflow.kfctl.testing.ci.kfctl_e2e_workflow.create_workflow
-    name: kfctl-go-iap
+    name: e2e
     job_types:
       - presubmit
       - postsubmit


### PR DESCRIPTION
* The PR numbers are now 4 digits (XXXX) as a result the worklfow names
  exceeded the Kubernetes limits and the tests aren't running.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/manifests/1020)
<!-- Reviewable:end -->
