### PR TITLE
Remove hardcoded namespace in argo clusterrolebinding

### DIFF
--- a/argo/base/cluster-role-binding.yaml
+++ b/argo/base/cluster-role-binding.yaml
@@ -12,7 +12,6 @@ roleRef:
 subjects:
 - kind: ServiceAccount
   name: argo
-  namespace: kubeflow
 ---
 apiVersion: rbac.authorization.k8s.io/v1beta1
 kind: ClusterRoleBinding

--- a/tests/argo-base_test.go
+++ b/tests/argo-base_test.go
@@ -29,7 +29,6 @@ roleRef:
 subjects:
 - kind: ServiceAccount
   name: argo
-  namespace: kubeflow
 ---
 apiVersion: rbac.authorization.k8s.io/v1beta1
 kind: ClusterRoleBinding

--- a/tests/argo-overlays-application_test.go
+++ b/tests/argo-overlays-application_test.go
@@ -84,7 +84,6 @@ roleRef:
 subjects:
 - kind: ServiceAccount
   name: argo
-  namespace: kubeflow
 ---
 apiVersion: rbac.authorization.k8s.io/v1beta1
 kind: ClusterRoleBinding

--- a/tests/argo-overlays-istio_test.go
+++ b/tests/argo-overlays-istio_test.go
@@ -66,7 +66,6 @@ roleRef:
 subjects:
 - kind: ServiceAccount
   name: argo
-  namespace: kubeflow
 ---
 apiVersion: rbac.authorization.k8s.io/v1beta1
 kind: ClusterRoleBinding


### PR DESCRIPTION
**Which issue is resolved by this Pull Request:**

Argo clusterrolebinding namespace should not be hardcoded just like argo-ui below
or if you install kubeflow in other namespace the RBAC will fail.

**Description of your changes:**
Remove hardcode namespace in argo clusterrolebinding

**Checklist:**
- [x] Unit tests have been rebuilt: 
    1. `cd manifests/tests`
    2. `make generate-changed-only`
    3. `make test`

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/manifests/1032)
<!-- Reviewable:end -->
