### PR TITLE
OWNERS for tests/pipeline folder

### DIFF
--- a/tests/pipeline/OWNERS
+++ b/tests/pipeline/OWNERS
@@ -1,0 +1,4 @@
+  approvers:
+  - Bobgy
+  - IronPan
+  - rmgogogo


### PR DESCRIPTION
**Description of your changes:**
This replicates OWNER permissions for pipeline folder. In order to truly let us approve our own changes. See https://github.com/kubeflow/manifests/pull/950#issuecomment-603688741

/assign @jlewi 
/cc @rmgogogo @IronPan 

**Checklist:**
- [x] Unit tests have been rebuilt: 
    1. `cd manifests/tests`
    2. `make generate-changed-only`
    3. `make test`
