### PR TITLE
Cherry pick of #969 and #997: fix pipeline default sa

### DIFF
--- a/kfdef/source/master/kfctl_gcp_iap.yaml
+++ b/kfdef/source/master/kfctl_gcp_iap.yaml
@@ -264,6 +264,7 @@ spec:
   - kustomizeConfig:
       overlays:
       - application
+      - use-kf-user
       repoRef:
         name: manifests
         path: pipeline/api-service
@@ -308,6 +309,7 @@ spec:
   - kustomizeConfig:
       overlays:
       - application
+      - use-kf-user
       repoRef:
         name: manifests
         path: pipeline/pipelines-runner

--- a/pipeline/api-service/overlays/use-kf-user/deployment.yaml
+++ b/pipeline/api-service/overlays/use-kf-user/deployment.yaml
@@ -1,0 +1,12 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: ml-pipeline
+spec:
+  template:
+    spec:
+      containers:
+      - name: ml-pipeline-api-server
+        env:
+        - name: DEFAULTPIPELINERUNNERSERVICEACCOUNT
+          value: kf-user

--- a/pipeline/api-service/overlays/use-kf-user/kustomization.yaml
+++ b/pipeline/api-service/overlays/use-kf-user/kustomization.yaml
@@ -1,0 +1,6 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+bases:
+- ../../base
+patchesStrategicMerge:
+- deployment.yaml

--- a/pipeline/pipelines-runner/overlays/use-kf-user/cluster-role-binding.yaml
+++ b/pipeline/pipelines-runner/overlays/use-kf-user/cluster-role-binding.yaml
@@ -1,0 +1,9 @@
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: ClusterRoleBinding
+metadata:
+  name: pipeline-runner
+subjects:
+# temporarily switched to kf-user, because pipeline-runner isn't bound to workload identity by default
+- kind: ServiceAccount
+  name: kf-user
+  namespace: kubeflow

--- a/pipeline/pipelines-runner/overlays/use-kf-user/kustomization.yaml
+++ b/pipeline/pipelines-runner/overlays/use-kf-user/kustomization.yaml
@@ -1,0 +1,6 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+bases:
+- ../../base
+patchesStrategicMerge:
+- cluster-role-binding.yaml

--- a/tests/pipeline-api-service-overlays-use-kf-user_test.go
+++ b/tests/pipeline-api-service-overlays-use-kf-user_test.go
@@ -1,0 +1,222 @@
+package tests_test
+
+import (
+	"sigs.k8s.io/kustomize/v3/k8sdeps/kunstruct"
+	"sigs.k8s.io/kustomize/v3/k8sdeps/transformer"
+	"sigs.k8s.io/kustomize/v3/pkg/fs"
+	"sigs.k8s.io/kustomize/v3/pkg/loader"
+	"sigs.k8s.io/kustomize/v3/pkg/plugins"
+	"sigs.k8s.io/kustomize/v3/pkg/resmap"
+	"sigs.k8s.io/kustomize/v3/pkg/resource"
+	"sigs.k8s.io/kustomize/v3/pkg/target"
+	"sigs.k8s.io/kustomize/v3/pkg/validators"
+	"testing"
+)
+
+func writeApiServiceOverlaysUseKfUser(th *KustTestHarness) {
+	th.writeF("/manifests/pipeline/api-service/overlays/use-kf-user/deployment.yaml", `
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: ml-pipeline
+spec:
+  template:
+    spec:
+      containers:
+      - name: ml-pipeline-api-server
+        env:
+        - name: DEFAULTPIPELINERUNNERSERVICEACCOUNT
+          value: kf-user
+`)
+	th.writeK("/manifests/pipeline/api-service/overlays/use-kf-user", `
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+bases:
+- ../../base
+patchesStrategicMerge:
+- deployment.yaml
+`)
+	th.writeF("/manifests/pipeline/api-service/base/config-map.yaml", `
+# The configuration for the ML pipelines APIServer
+# Based on https://github.com/kubeflow/pipelines/blob/master/backend/src/apiserver/config/config.json
+apiVersion: v1
+data:
+  # apiserver assumes the config is named config.json
+  config.json: |
+    {
+      "DBConfig": {
+        "DriverName": "mysql",
+        "DataSourceName": "",
+        "DBName": "mlpipeline"
+      },
+      "ObjectStoreConfig":{
+        "AccessKey": "minio",
+        "SecretAccessKey": "minio123",
+        "BucketName": "mlpipeline"
+      },
+      "InitConnectionTimeout": "6m",
+      "DefaultPipelineRunnerServiceAccount": "pipeline-runner",
+      "ML_PIPELINE_VISUALIZATIONSERVER_SERVICE_HOST": "ml-pipeline-ml-pipeline-visualizationserver",
+      "ML_PIPELINE_VISUALIZATIONSERVER_SERVICE_PORT": 8888
+    }
+kind: ConfigMap
+metadata:
+  name: ml-pipeline-config
+`)
+	th.writeF("/manifests/pipeline/api-service/base/deployment.yaml", `
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: ml-pipeline
+spec:
+  template:
+    spec:
+      containers:
+      - name: ml-pipeline-api-server
+        env:
+        - name: POD_NAMESPACE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace
+        image: gcr.io/ml-pipeline/api-server
+        imagePullPolicy: IfNotPresent
+        command:
+          - apiserver 
+          - --config=/etc/ml-pipeline-config
+          - --sampleconfig=/config/sample_config.json 
+          - -logtostderr=true
+        ports:
+        - containerPort: 8888
+        - containerPort: 8887
+        volumeMounts:
+        - name: config-volume
+          mountPath: /etc/ml-pipeline-config
+      serviceAccountName: ml-pipeline      
+      volumes:
+        - name: config-volume
+          configMap:
+            name: ml-pipeline-config
+`)
+	th.writeF("/manifests/pipeline/api-service/base/role-binding.yaml", `
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: RoleBinding
+metadata:
+  name: ml-pipeline
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: ml-pipeline
+subjects:
+- kind: ServiceAccount
+  name: ml-pipeline
+`)
+	th.writeF("/manifests/pipeline/api-service/base/role.yaml", `
+apiVersion: rbac.authorization.k8s.io/v1beta1
+# TODO: Does this need to be changed to a clusterrole?
+# see  manifests in kubeflow/pipelines
+kind: Role
+metadata:
+  name: ml-pipeline
+rules:
+- apiGroups:
+  - argoproj.io
+  resources:
+  - workflows
+  verbs:
+  - create
+  - get
+  - list
+  - watch
+  - update
+  - patch
+  - delete
+- apiGroups:
+  - kubeflow.org
+  resources:
+  - scheduledworkflows
+  verbs:
+  - create
+  - get
+  - list
+  - update
+  - patch
+  - delete
+- apiGroups:
+  - ""
+  resources:
+  - pods
+  verbs:
+  - delete
+
+`)
+	th.writeF("/manifests/pipeline/api-service/base/service-account.yaml", `
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: ml-pipeline
+`)
+	th.writeF("/manifests/pipeline/api-service/base/service.yaml", `
+apiVersion: v1
+kind: Service
+metadata:
+  name: ml-pipeline
+spec:
+  ports:
+  - name: http
+    port: 8888
+    protocol: TCP
+    targetPort: 8888
+  - name: grpc
+    port: 8887
+    protocol: TCP
+    targetPort: 8887
+`)
+	th.writeK("/manifests/pipeline/api-service/base", `
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+commonLabels:
+  app: ml-pipeline
+resources:
+- config-map.yaml
+- deployment.yaml
+- role-binding.yaml
+- role.yaml
+- service-account.yaml
+- service.yaml
+images:
+- name: gcr.io/ml-pipeline/api-server
+  newTag: 0.2.0
+  newName: gcr.io/ml-pipeline/api-server
+`)
+}
+
+func TestApiServiceOverlaysUseKfUser(t *testing.T) {
+	th := NewKustTestHarness(t, "/manifests/pipeline/api-service/overlays/use-kf-user")
+	writeApiServiceOverlaysUseKfUser(th)
+	m, err := th.makeKustTarget().MakeCustomizedResMap()
+	if err != nil {
+		t.Fatalf("Err: %v", err)
+	}
+	expected, err := m.AsYaml()
+	if err != nil {
+		t.Fatalf("Err: %v", err)
+	}
+	targetPath := "../pipeline/api-service/overlays/use-kf-user"
+	fsys := fs.MakeRealFS()
+	lrc := loader.RestrictionRootOnly
+	_loader, loaderErr := loader.NewLoader(lrc, validators.MakeFakeValidator(), targetPath, fsys)
+	if loaderErr != nil {
+		t.Fatalf("could not load kustomize loader: %v", loaderErr)
+	}
+	rf := resmap.NewFactory(resource.NewFactory(kunstruct.NewKunstructuredFactoryImpl()), transformer.NewFactoryImpl())
+	pc := plugins.DefaultPluginConfig()
+	kt, err := target.NewKustTarget(_loader, rf, transformer.NewFactoryImpl(), plugins.NewLoader(pc, rf))
+	if err != nil {
+		th.t.Fatalf("Unexpected construction error %v", err)
+	}
+	actual, err := kt.MakeCustomizedResMap()
+	if err != nil {
+		t.Fatalf("Err: %v", err)
+	}
+	th.assertActualEqualsExpected(actual, string(expected))
+}

--- a/tests/pipeline-pipelines-runner-overlays-use-kf-user_test.go
+++ b/tests/pipeline-pipelines-runner-overlays-use-kf-user_test.go
@@ -1,0 +1,175 @@
+package tests_test
+
+import (
+	"sigs.k8s.io/kustomize/v3/k8sdeps/kunstruct"
+	"sigs.k8s.io/kustomize/v3/k8sdeps/transformer"
+	"sigs.k8s.io/kustomize/v3/pkg/fs"
+	"sigs.k8s.io/kustomize/v3/pkg/loader"
+	"sigs.k8s.io/kustomize/v3/pkg/plugins"
+	"sigs.k8s.io/kustomize/v3/pkg/resmap"
+	"sigs.k8s.io/kustomize/v3/pkg/resource"
+	"sigs.k8s.io/kustomize/v3/pkg/target"
+	"sigs.k8s.io/kustomize/v3/pkg/validators"
+	"testing"
+)
+
+func writePipelinesRunnerOverlaysUseKfUser(th *KustTestHarness) {
+	th.writeF("/manifests/pipeline/pipelines-runner/overlays/use-kf-user/cluster-role-binding.yaml", `
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: ClusterRoleBinding
+metadata:
+  name: pipeline-runner
+subjects:
+# temporarily switched to kf-user, because pipeline-runner isn't bound to workload identity by default
+- kind: ServiceAccount
+  name: kf-user
+  namespace: kubeflow
+`)
+	th.writeK("/manifests/pipeline/pipelines-runner/overlays/use-kf-user", `
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+bases:
+- ../../base
+patchesStrategicMerge:
+- cluster-role-binding.yaml
+`)
+	th.writeF("/manifests/pipeline/pipelines-runner/base/cluster-role-binding.yaml", `
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: ClusterRoleBinding
+metadata:
+  name: pipeline-runner
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: pipeline-runner
+subjects:
+- kind: ServiceAccount
+  name: pipeline-runner
+`)
+	th.writeF("/manifests/pipeline/pipelines-runner/base/cluster-role.yaml", `
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: ClusterRole
+metadata:
+  name: pipeline-runner
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - secrets
+  verbs:
+  - get
+- apiGroups:
+  - ""
+  resources:
+  - configmaps
+  verbs:
+  - get
+  - watch
+  - list
+- apiGroups:
+  - ""
+  resources:
+  - persistentvolumeclaims
+  verbs:
+  - create
+  - delete
+  - get
+- apiGroups:
+  - snapshot.storage.k8s.io
+  resources:
+  - volumesnapshots
+  verbs:
+  - create
+  - delete
+  - get
+- apiGroups:
+  - argoproj.io
+  resources:
+  - workflows
+  verbs:
+  - get
+  - list
+  - watch
+  - update
+  - patch
+- apiGroups:
+  - ""
+  resources:
+  - pods
+  - pods/exec
+  - pods/log
+  - services
+  verbs:
+  - '*'
+- apiGroups:
+  - ""
+  - apps
+  - extensions
+  resources:
+  - deployments
+  - replicasets
+  verbs:
+  - '*'
+- apiGroups:
+  - kubeflow.org
+  - serving.kubeflow.org
+  resources:
+  - '*'
+  verbs:
+  - '*'
+- apiGroups:
+  - batch
+  resources:
+  - jobs
+  verbs:
+  - '*'
+`)
+	th.writeF("/manifests/pipeline/pipelines-runner/base/service-account.yaml", `
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: pipeline-runner
+`)
+	th.writeK("/manifests/pipeline/pipelines-runner/base", `
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+namespace: kubeflow
+commonLabels:
+  app: pipeline-runner
+resources:
+- cluster-role-binding.yaml
+- cluster-role.yaml
+- service-account.yaml
+`)
+}
+
+func TestPipelinesRunnerOverlaysUseKfUser(t *testing.T) {
+	th := NewKustTestHarness(t, "/manifests/pipeline/pipelines-runner/overlays/use-kf-user")
+	writePipelinesRunnerOverlaysUseKfUser(th)
+	m, err := th.makeKustTarget().MakeCustomizedResMap()
+	if err != nil {
+		t.Fatalf("Err: %v", err)
+	}
+	expected, err := m.AsYaml()
+	if err != nil {
+		t.Fatalf("Err: %v", err)
+	}
+	targetPath := "../pipeline/pipelines-runner/overlays/use-kf-user"
+	fsys := fs.MakeRealFS()
+	lrc := loader.RestrictionRootOnly
+	_loader, loaderErr := loader.NewLoader(lrc, validators.MakeFakeValidator(), targetPath, fsys)
+	if loaderErr != nil {
+		t.Fatalf("could not load kustomize loader: %v", loaderErr)
+	}
+	rf := resmap.NewFactory(resource.NewFactory(kunstruct.NewKunstructuredFactoryImpl()), transformer.NewFactoryImpl())
+	pc := plugins.DefaultPluginConfig()
+	kt, err := target.NewKustTarget(_loader, rf, transformer.NewFactoryImpl(), plugins.NewLoader(pc, rf))
+	if err != nil {
+		th.t.Fatalf("Unexpected construction error %v", err)
+	}
+	actual, err := kt.MakeCustomizedResMap()
+	if err != nil {
+		t.Fatalf("Err: %v", err)
+	}
+	th.assertActualEqualsExpected(actual, string(expected))
+}


### PR DESCRIPTION
**Which issue is resolved by this Pull Request:**
Part of https://github.com/kubeflow/kubeflow/issues/4803

**Description of your changes:**
Cherry pick of https://github.com/kubeflow/manifests/commit/ad38b41ae5dce1fd5c77a6c5f69d499c9c157718 and 
https://github.com/kubeflow/manifests/commit/9e6ef8681003c195560fb7b3b75211830c19b7a0

**Checklist:**
- [x] Unit tests have been rebuilt: 
    1. `cd manifests/tests`
    2. `make generate-changed-only`
    3. `make test`

/assign @richardsliu @jlewi 