### PR TITLE
Sync metadata folder from master to v1-branch

### DIFF
--- a/metadata/OWNERS
+++ b/metadata/OWNERS
@@ -1,5 +1,4 @@
 approvers:
   - neuromage
   - prodonjs
-  - rileyjbauer
   - zhenghuiwang

--- a/metadata/base/metadata-deployment.yaml
+++ b/metadata/base/metadata-deployment.yaml
@@ -13,6 +13,8 @@ spec:
     metadata:
       labels:
         component: server
+      annotations:
+        sidecar.istio.io/inject: "false"
     spec:
       containers:
       - name: container
@@ -49,6 +51,8 @@ spec:
     metadata:
       labels:
         component: grpc-server
+      annotations:
+        sidecar.istio.io/inject: "false"
     spec:
       containers:
         - name: container

--- a/metadata/base/metadata-envoy-deployment.yaml
+++ b/metadata/base/metadata-envoy-deployment.yaml
@@ -13,6 +13,8 @@ spec:
     metadata:
       labels:
         component: envoy
+      annotations:
+        sidecar.istio.io/inject: "false"
     spec:
       containers:
       - name: container

--- a/metadata/base/metadata-ui-deployment.yaml
+++ b/metadata/base/metadata-ui-deployment.yaml
@@ -13,6 +13,8 @@ spec:
       name: ui
       labels:
         app: metadata-ui
+      annotations:
+        sidecar.istio.io/inject: "false"
     spec:
       containers:
       - image: gcr.io/kubeflow-images-public/metadata-frontend:v0.1.8

--- a/metadata/overlays/db/metadata-db-deployment.yaml
+++ b/metadata/overlays/db/metadata-db-deployment.yaml
@@ -14,6 +14,8 @@ spec:
       name: db
       labels:
         component: db
+      annotations:
+        sidecar.istio.io/inject: "false"
     spec:
       containers:
       - name: db-container


### PR DESCRIPTION
This PR fixes the issue of v1-branch that metadata-db deployments can't be connected from other pods.

The cause is that v1-branch misses some `istio-sidecar` annotations. This PR adds them back to v1-branch.