### PR TITLE
Remove istio-ingress component in kfctl_aws

### DIFF
--- a/kfdef/kfctl_aws.v1.0.0.yaml
+++ b/kfdef/kfctl_aws.v1.0.0.yaml
@@ -316,14 +316,6 @@ spec:
         path: mpi-job/mpi-operator
     name: mpi-operator
   - kustomizeConfig:
-      parameters:
-      - name: namespace
-        value: istio-system
-      repoRef:
-        name: manifests
-        path: aws/istio-ingress
-    name: istio-ingress
-  - kustomizeConfig:
       overlays:
       - application
       parameters:

--- a/kfdef/kfctl_aws.v1.0.1.yaml
+++ b/kfdef/kfctl_aws.v1.0.1.yaml
@@ -316,14 +316,6 @@ spec:
         path: mpi-job/mpi-operator
     name: mpi-operator
   - kustomizeConfig:
-      parameters:
-      - name: namespace
-        value: istio-system
-      repoRef:
-        name: manifests
-        path: aws/istio-ingress
-    name: istio-ingress
-  - kustomizeConfig:
       overlays:
       - application
       parameters:

--- a/kfdef/kfctl_aws.yaml
+++ b/kfdef/kfctl_aws.yaml
@@ -316,14 +316,6 @@ spec:
         path: mpi-job/mpi-operator
     name: mpi-operator
   - kustomizeConfig:
-      parameters:
-      - name: namespace
-        value: istio-system
-      repoRef:
-        name: manifests
-        path: aws/istio-ingress
-    name: istio-ingress
-  - kustomizeConfig:
       overlays:
       - application
       parameters:

--- a/kfdef/source/master/kfctl_aws.yaml
+++ b/kfdef/source/master/kfctl_aws.yaml
@@ -316,14 +316,6 @@ spec:
         path: mpi-job/mpi-operator
     name: mpi-operator
   - kustomizeConfig:
-      parameters:
-      - name: namespace
-        value: istio-system
-      repoRef:
-        name: manifests
-        path: aws/istio-ingress
-    name: istio-ingress
-  - kustomizeConfig:
       overlays:
       - application
       parameters:


### PR DESCRIPTION
**Which issue is resolved by this Pull Request:**
Resolves #

**Description of your changes:**
Remove istio-ingress component in kfctl_aws

**Checklist:**
- [x] Unit tests have been rebuilt: 
    1. `cd manifests/tests`
    2. `make generate-changed-only`
    3. `make test`
