### PR TITLE
Bump KFP to 0.2.5

### DIFF
--- a/kfdef/kfctl_gcp_iap.yaml
+++ b/kfdef/kfctl_gcp_iap.yaml
@@ -270,6 +270,7 @@ spec:
   - kustomizeConfig:
       overlays:
       - application
+      - use-kf-user
       repoRef:
         name: manifests
         path: pipeline/api-service
@@ -314,6 +315,7 @@ spec:
   - kustomizeConfig:
       overlays:
       - application
+      - use-kf-user
       repoRef:
         name: manifests
         path: pipeline/pipelines-runner
@@ -344,6 +346,7 @@ spec:
   - kustomizeConfig:
       overlays:
       - application
+      - use-kf-user
       repoRef:
         name: manifests
         path: pipeline/pipeline-visualization-service

--- a/kfdef/source/master/kfctl_gcp_iap.yaml
+++ b/kfdef/source/master/kfctl_gcp_iap.yaml
@@ -348,6 +348,7 @@ spec:
   - kustomizeConfig:
       overlays:
       - application
+      - use-kf-user
       repoRef:
         name: manifests
         path: pipeline/pipeline-visualization-service

--- a/metadata/base/kustomization.yaml
+++ b/metadata/base/kustomization.yaml
@@ -6,8 +6,12 @@ commonLabels:
 configMapGenerator:
 - name: ui-parameters
   env: params.env
-- name: metadata-grpc-configmap
+- name: grpc-configmap
   env: grpc-params.env
+generatorOptions:
+  # TFX pipelines use metadata-grpc-configmap for finding grpc server host and
+  # port at runtime. Because they don't know the suffix, we have to disable it.
+  disableNameSuffixHash: true
 resources:
 - metadata-deployment.yaml
 - metadata-service.yaml

--- a/metadata/base/metadata-deployment.yaml
+++ b/metadata/base/metadata-deployment.yaml
@@ -58,7 +58,7 @@ spec:
         - name: container
           envFrom:
           - configMapRef:
-              name: metadata-grpc-configmap
+              name: grpc-configmap
           image: gcr.io/tfx-oss-public/ml_metadata_store_server:v0.21.1
           command: ["/bin/metadata_store_server"]
           args: ["--grpc_port=$(METADATA_GRPC_SERVICE_PORT)"]

--- a/metadata/overlays/db/metadata-deployment.yaml
+++ b/metadata/overlays/db/metadata-deployment.yaml
@@ -53,7 +53,7 @@ spec:
           - secretRef:
               name: metadata-db-secrets
           - configMapRef:
-              name: metadata-grpc-configmap
+              name: grpc-configmap
           args: ["--grpc_port=$(METADATA_GRPC_SERVICE_PORT)",
                  "--mysql_config_host=$(metadata-db-service)",
                  "--mysql_config_database=$(MYSQL_DATABASE)",

--- a/metadata/overlays/external-mysql/metadata-deployment.yaml
+++ b/metadata/overlays/external-mysql/metadata-deployment.yaml
@@ -53,7 +53,7 @@ spec:
           - secretRef:
               name: metadata-db-secrets
           - configMapRef:
-              name: metadata-grpc-configmap
+              name: grpc-configmap
           args: ["--grpc_port=$(METADATA_GRPC_SERVICE_PORT)",
                  "--mysql_config_host=$(MYSQL_HOST)",
                  "--mysql_config_database=$(MYSQL_DATABASE)",

--- a/pipeline/api-service/base/kustomization.yaml
+++ b/pipeline/api-service/base/kustomization.yaml
@@ -11,5 +11,5 @@ resources:
 - service.yaml
 images:
 - name: gcr.io/ml-pipeline/api-server
-  newTag: 0.2.0
+  newTag: 0.2.5
   newName: gcr.io/ml-pipeline/api-server

--- a/pipeline/api-service/overlays/application/application.yaml
+++ b/pipeline/api-service/overlays/application/application.yaml
@@ -24,8 +24,8 @@ spec:
   selector:
     matchLabels:
       app.kubernetes.io/component: api-service
-      app.kubernetes.io/instance: api-service-0.2.0
+      app.kubernetes.io/instance: api-service-0.2.5
       app.kubernetes.io/managed-by: kfctl
       app.kubernetes.io/name: api-service
       app.kubernetes.io/part-of: kubeflow
-      app.kubernetes.io/version: 0.2.0
+      app.kubernetes.io/version: 0.2.5

--- a/pipeline/api-service/overlays/application/kustomization.yaml
+++ b/pipeline/api-service/overlays/application/kustomization.yaml
@@ -3,11 +3,11 @@ bases:
 - ../../base
 commonLabels:
   app.kubernetes.io/component: api-service
-  app.kubernetes.io/instance: api-service-0.2.0
+  app.kubernetes.io/instance: api-service-0.2.5
   app.kubernetes.io/managed-by: kfctl
   app.kubernetes.io/name: api-service
   app.kubernetes.io/part-of: kubeflow
-  app.kubernetes.io/version: 0.2.0
+  app.kubernetes.io/version: 0.2.5
 kind: Kustomization
 resources:
 - application.yaml

--- a/pipeline/minio/overlays/application/application.yaml
+++ b/pipeline/minio/overlays/application/application.yaml
@@ -24,8 +24,8 @@ spec:
   selector:
     matchLabels:
       app.kubernetes.io/component: minio
-      app.kubernetes.io/instance: minio-0.2.0
+      app.kubernetes.io/instance: minio-0.2.5
       app.kubernetes.io/managed-by: kfctl
       app.kubernetes.io/name: minio
       app.kubernetes.io/part-of: kubeflow
-      app.kubernetes.io/version: 0.2.0
+      app.kubernetes.io/version: 0.2.5

--- a/pipeline/minio/overlays/application/kustomization.yaml
+++ b/pipeline/minio/overlays/application/kustomization.yaml
@@ -3,11 +3,11 @@ bases:
 - ../../base
 commonLabels:
   app.kubernetes.io/component: minio
-  app.kubernetes.io/instance: minio-0.2.0
+  app.kubernetes.io/instance: minio-0.2.5
   app.kubernetes.io/managed-by: kfctl
   app.kubernetes.io/name: minio
   app.kubernetes.io/part-of: kubeflow
-  app.kubernetes.io/version: 0.2.0
+  app.kubernetes.io/version: 0.2.5
 kind: Kustomization
 resources:
 - application.yaml

--- a/pipeline/mysql/overlays/application/application.yaml
+++ b/pipeline/mysql/overlays/application/application.yaml
@@ -24,8 +24,8 @@ spec:
   selector:
     matchLabels:
       app.kubernetes.io/component: mysql
-      app.kubernetes.io/instance: mysql-0.2.0
+      app.kubernetes.io/instance: mysql-0.2.5
       app.kubernetes.io/managed-by: kfctl
       app.kubernetes.io/name: mysql
       app.kubernetes.io/part-of: kubeflow
-      app.kubernetes.io/version: 0.2.0
+      app.kubernetes.io/version: 0.2.5

--- a/pipeline/mysql/overlays/application/kustomization.yaml
+++ b/pipeline/mysql/overlays/application/kustomization.yaml
@@ -3,11 +3,11 @@ bases:
 - ../../base
 commonLabels:
   app.kubernetes.io/component: mysql
-  app.kubernetes.io/instance: mysql-0.2.0
+  app.kubernetes.io/instance: mysql-0.2.5
   app.kubernetes.io/managed-by: kfctl
   app.kubernetes.io/name: mysql
   app.kubernetes.io/part-of: kubeflow
-  app.kubernetes.io/version: 0.2.0
+  app.kubernetes.io/version: 0.2.5
 kind: Kustomization
 resources:
 - application.yaml

--- a/pipeline/persistent-agent/base/kustomization.yaml
+++ b/pipeline/persistent-agent/base/kustomization.yaml
@@ -10,5 +10,5 @@ resources:
 - service-account.yaml
 images:
 - name: gcr.io/ml-pipeline/persistenceagent
-  newTag: 0.2.0
+  newTag: 0.2.5
   newName: gcr.io/ml-pipeline/persistenceagent

--- a/pipeline/persistent-agent/overlays/application/application.yaml
+++ b/pipeline/persistent-agent/overlays/application/application.yaml
@@ -24,8 +24,8 @@ spec:
   selector:
     matchLabels:
       app.kubernetes.io/component: persistent-agent
-      app.kubernetes.io/instance: persistent-agent-0.2.0
+      app.kubernetes.io/instance: persistent-agent-0.2.5
       app.kubernetes.io/managed-by: kfctl
       app.kubernetes.io/name: persistent-agent
       app.kubernetes.io/part-of: kubeflow
-      app.kubernetes.io/version: 0.2.0
+      app.kubernetes.io/version: 0.2.5

--- a/pipeline/persistent-agent/overlays/application/kustomization.yaml
+++ b/pipeline/persistent-agent/overlays/application/kustomization.yaml
@@ -3,11 +3,11 @@ bases:
 - ../../base
 commonLabels:
   app.kubernetes.io/component: persistent-agent
-  app.kubernetes.io/instance: persistent-agent-0.2.0
+  app.kubernetes.io/instance: persistent-agent-0.2.5
   app.kubernetes.io/managed-by: kfctl
   app.kubernetes.io/name: persistent-agent
   app.kubernetes.io/part-of: kubeflow
-  app.kubernetes.io/version: 0.2.0
+  app.kubernetes.io/version: 0.2.5
 kind: Kustomization
 resources:
 - application.yaml

--- a/pipeline/pipeline-visualization-service/base/kustomization.yaml
+++ b/pipeline/pipeline-visualization-service/base/kustomization.yaml
@@ -8,5 +8,5 @@ resources:
 - service.yaml
 images:
 - name: gcr.io/ml-pipeline/visualization-server
-  newTag: 0.2.0
+  newTag: 0.2.5
   newName: gcr.io/ml-pipeline/visualization-server

--- a/pipeline/pipeline-visualization-service/overlays/application/application.yaml
+++ b/pipeline/pipeline-visualization-service/overlays/application/application.yaml
@@ -24,8 +24,8 @@ spec:
   selector:
     matchLabels:
       app.kubernetes.io/component: pipeline-visualization-service
-      app.kubernetes.io/instance: pipeline-visualization-service-0.2.0
+      app.kubernetes.io/instance: pipeline-visualization-service-0.2.5
       app.kubernetes.io/managed-by: kfctl
       app.kubernetes.io/name: pipeline-visualization-service
       app.kubernetes.io/part-of: kubeflow
-      app.kubernetes.io/version: 0.2.0
+      app.kubernetes.io/version: 0.2.5

--- a/pipeline/pipeline-visualization-service/overlays/application/kustomization.yaml
+++ b/pipeline/pipeline-visualization-service/overlays/application/kustomization.yaml
@@ -3,11 +3,11 @@ bases:
 - ../../base
 commonLabels:
   app.kubernetes.io/component: pipeline-visualization-service
-  app.kubernetes.io/instance: pipeline-visualization-service-0.2.0
+  app.kubernetes.io/instance: pipeline-visualization-service-0.2.5
   app.kubernetes.io/managed-by: kfctl
   app.kubernetes.io/name: pipeline-visualization-service
   app.kubernetes.io/part-of: kubeflow
-  app.kubernetes.io/version: 0.2.0
+  app.kubernetes.io/version: 0.2.5
 kind: Kustomization
 resources:
 - application.yaml

--- a/pipeline/pipeline-visualization-service/overlays/use-kf-user/deployment.yaml
+++ b/pipeline/pipeline-visualization-service/overlays/use-kf-user/deployment.yaml
@@ -1,0 +1,8 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: ml-pipeline-visualizationserver
+spec:
+  template:
+    spec:
+      serviceAccountName: kf-user

--- a/pipeline/pipeline-visualization-service/overlays/use-kf-user/kustomization.yaml
+++ b/pipeline/pipeline-visualization-service/overlays/use-kf-user/kustomization.yaml
@@ -1,0 +1,6 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+bases:
+- ../../base
+kind: Kustomization
+patchesStrategicMerge:
+- deployment.yaml

--- a/pipeline/pipelines-runner/overlays/application/application.yaml
+++ b/pipeline/pipelines-runner/overlays/application/application.yaml
@@ -24,8 +24,8 @@ spec:
   selector:
     matchLabels:
       app.kubernetes.io/component: pipelines-runner
-      app.kubernetes.io/instance: pipelines-runner-0.2.0
+      app.kubernetes.io/instance: pipelines-runner-0.2.5
       app.kubernetes.io/managed-by: kfctl
       app.kubernetes.io/name: pipelines-runner
       app.kubernetes.io/part-of: kubeflow
-      app.kubernetes.io/version: 0.2.0
+      app.kubernetes.io/version: 0.2.5

--- a/pipeline/pipelines-runner/overlays/application/kustomization.yaml
+++ b/pipeline/pipelines-runner/overlays/application/kustomization.yaml
@@ -3,11 +3,11 @@ bases:
 - ../../base
 commonLabels:
   app.kubernetes.io/component: pipelines-runner
-  app.kubernetes.io/instance: pipelines-runner-0.2.0
+  app.kubernetes.io/instance: pipelines-runner-0.2.5
   app.kubernetes.io/managed-by: kfctl
   app.kubernetes.io/name: pipelines-runner
   app.kubernetes.io/part-of: kubeflow
-  app.kubernetes.io/version: 0.2.0
+  app.kubernetes.io/version: 0.2.5
 kind: Kustomization
 resources:
 - application.yaml

--- a/pipeline/pipelines-ui/base/deployment.yaml
+++ b/pipeline/pipelines-ui/base/deployment.yaml
@@ -20,8 +20,6 @@ spec:
         image: gcr.io/ml-pipeline/frontend
         imagePullPolicy: IfNotPresent
         env:
-        - name: DEPLOYMENT
-          value: KUBEFLOW
         - name: ALLOW_CUSTOM_VISUALIZATIONS
           value: "true"
         ports:

--- a/pipeline/pipelines-ui/base/deployment.yaml
+++ b/pipeline/pipelines-ui/base/deployment.yaml
@@ -19,6 +19,11 @@ spec:
       - name: ml-pipeline-ui
         image: gcr.io/ml-pipeline/frontend
         imagePullPolicy: IfNotPresent
+        env:
+        - name: DEPLOYMENT
+          value: KUBEFLOW
+        - name: ALLOW_CUSTOM_VISUALIZATIONS
+          value: "true"
         ports:
         - containerPort: 3000
       serviceAccountName: ml-pipeline-ui

--- a/pipeline/pipelines-ui/base/kustomization.yaml
+++ b/pipeline/pipelines-ui/base/kustomization.yaml
@@ -12,7 +12,7 @@ configMapGenerator:
   env: params.env
 images:
 - name: gcr.io/ml-pipeline/frontend
-  newTag: 0.2.0
+  newTag: 0.2.5
   newName: gcr.io/ml-pipeline/frontend
 vars:
 - name: ui-namespace

--- a/pipeline/pipelines-ui/overlays/application/application.yaml
+++ b/pipeline/pipelines-ui/overlays/application/application.yaml
@@ -24,8 +24,8 @@ spec:
   selector:
     matchLabels:
       app.kubernetes.io/component: pipelines-ui
-      app.kubernetes.io/instance: pipelines-ui-0.2.0
+      app.kubernetes.io/instance: pipelines-ui-0.2.5
       app.kubernetes.io/managed-by: kfctl
       app.kubernetes.io/name: pipelines-ui
       app.kubernetes.io/part-of: kubeflow
-      app.kubernetes.io/version: 0.2.0
+      app.kubernetes.io/version: 0.2.5

--- a/pipeline/pipelines-ui/overlays/application/kustomization.yaml
+++ b/pipeline/pipelines-ui/overlays/application/kustomization.yaml
@@ -3,11 +3,11 @@ bases:
 - ../../base
 commonLabels:
   app.kubernetes.io/component: pipelines-ui
-  app.kubernetes.io/instance: pipelines-ui-0.2.0
+  app.kubernetes.io/instance: pipelines-ui-0.2.5
   app.kubernetes.io/managed-by: kfctl
   app.kubernetes.io/name: pipelines-ui
   app.kubernetes.io/part-of: kubeflow
-  app.kubernetes.io/version: 0.2.0
+  app.kubernetes.io/version: 0.2.5
 kind: Kustomization
 resources:
 - application.yaml

--- a/pipeline/pipelines-viewer/base/kustomization.yaml
+++ b/pipeline/pipelines-viewer/base/kustomization.yaml
@@ -12,5 +12,5 @@ resources:
 - service-account.yaml
 images:
 - name: gcr.io/ml-pipeline/viewer-crd-controller
-  newTag: 0.2.0
+  newTag: 0.2.5
   newName: gcr.io/ml-pipeline/viewer-crd-controller

--- a/pipeline/pipelines-viewer/overlays/application/application.yaml
+++ b/pipeline/pipelines-viewer/overlays/application/application.yaml
@@ -24,8 +24,8 @@ spec:
   selector:
     matchLabels:
       app.kubernetes.io/component: pipelines-viewer
-      app.kubernetes.io/instance: pipelines-viewer-0.2.0
+      app.kubernetes.io/instance: pipelines-viewer-0.2.5
       app.kubernetes.io/managed-by: kfctl
       app.kubernetes.io/name: pipelines-viewer
       app.kubernetes.io/part-of: kubeflow
-      app.kubernetes.io/version: 0.2.0
+      app.kubernetes.io/version: 0.2.5

--- a/pipeline/pipelines-viewer/overlays/application/kustomization.yaml
+++ b/pipeline/pipelines-viewer/overlays/application/kustomization.yaml
@@ -3,11 +3,11 @@ bases:
 - ../../base
 commonLabels:
   app.kubernetes.io/component: pipelines-viewer
-  app.kubernetes.io/instance: pipelines-viewer-0.2.0
+  app.kubernetes.io/instance: pipelines-viewer-0.2.5
   app.kubernetes.io/managed-by: kfctl
   app.kubernetes.io/name: pipelines-viewer
   app.kubernetes.io/part-of: kubeflow
-  app.kubernetes.io/version: 0.2.0
+  app.kubernetes.io/version: 0.2.5
 kind: Kustomization
 resources:
 - application.yaml

--- a/pipeline/scheduledworkflow/base/kustomization.yaml
+++ b/pipeline/scheduledworkflow/base/kustomization.yaml
@@ -12,5 +12,5 @@ resources:
 - service-account.yaml
 images:
 - name: gcr.io/ml-pipeline/scheduledworkflow
-  newTag: 0.2.0
+  newTag: 0.2.5
   newName: gcr.io/ml-pipeline/scheduledworkflow

--- a/pipeline/scheduledworkflow/overlays/application/application.yaml
+++ b/pipeline/scheduledworkflow/overlays/application/application.yaml
@@ -24,8 +24,8 @@ spec:
   selector:
     matchLabels:
       app.kubernetes.io/component: scheduledworkflow
-      app.kubernetes.io/instance: scheduledworkflow-0.2.0
+      app.kubernetes.io/instance: scheduledworkflow-0.2.5
       app.kubernetes.io/managed-by: kfctl
       app.kubernetes.io/name: scheduledworkflow
       app.kubernetes.io/part-of: kubeflow
-      app.kubernetes.io/version: 0.2.0
+      app.kubernetes.io/version: 0.2.5

--- a/pipeline/scheduledworkflow/overlays/application/kustomization.yaml
+++ b/pipeline/scheduledworkflow/overlays/application/kustomization.yaml
@@ -3,11 +3,11 @@ bases:
 - ../../base
 commonLabels:
   app.kubernetes.io/component: scheduledworkflow
-  app.kubernetes.io/instance: scheduledworkflow-0.2.0
+  app.kubernetes.io/instance: scheduledworkflow-0.2.5
   app.kubernetes.io/managed-by: kfctl
   app.kubernetes.io/name: scheduledworkflow
   app.kubernetes.io/part-of: kubeflow
-  app.kubernetes.io/version: 0.2.0
+  app.kubernetes.io/version: 0.2.5
 kind: Kustomization
 resources:
 - application.yaml

--- a/tests/legacy_kustomizations/metadata/kustomization.yaml
+++ b/tests/legacy_kustomizations/metadata/kustomization.yaml
@@ -17,7 +17,7 @@ configMapGenerator:
 - behavior: merge
   envs:
   - params_1.env
-  name: metadata-grpc-configmap
+  name: grpc-configmap
 configurations:
 - ../../../metadata/overlays/istio/params.yaml
 generatorOptions:

--- a/tests/tests/legacy_kustomizations/api-service/test_data/expected/app.k8s.io_v1beta1_application_api-service.yaml
+++ b/tests/tests/legacy_kustomizations/api-service/test_data/expected/app.k8s.io_v1beta1_application_api-service.yaml
@@ -32,8 +32,8 @@ spec:
   selector:
     matchLabels:
       app.kubernetes.io/component: api-service
-      app.kubernetes.io/instance: api-service-0.2.0
+      app.kubernetes.io/instance: api-service-0.2.5
       app.kubernetes.io/managed-by: kfctl
       app.kubernetes.io/name: api-service
       app.kubernetes.io/part-of: kubeflow
-      app.kubernetes.io/version: 0.2.0
+      app.kubernetes.io/version: 0.2.5

--- a/tests/tests/legacy_kustomizations/api-service/test_data/expected/apps_v1_deployment_ml-pipeline.yaml
+++ b/tests/tests/legacy_kustomizations/api-service/test_data/expected/apps_v1_deployment_ml-pipeline.yaml
@@ -45,7 +45,7 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: metadata.namespace
-        image: gcr.io/ml-pipeline/api-server:0.2.0
+        image: gcr.io/ml-pipeline/api-server:0.2.5
         imagePullPolicy: IfNotPresent
         name: ml-pipeline-api-server
         ports:

--- a/tests/tests/legacy_kustomizations/metadata/test_data/expected/apps_v1_deployment_metadata-grpc-deployment.yaml
+++ b/tests/tests/legacy_kustomizations/metadata/test_data/expected/apps_v1_deployment_metadata-grpc-deployment.yaml
@@ -54,7 +54,7 @@ spec:
         - secretRef:
             name: metadata-db-secrets
         - configMapRef:
-            name: metadata-metadata-grpc-configmap-2dd6h7mhg6
+            name: metadata-grpc-configmap
         image: gcr.io/tfx-oss-public/ml_metadata_store_server:v0.21.1
         name: container
         ports:

--- a/tests/tests/legacy_kustomizations/metadata/test_data/expected/~g_v1_configmap_metadata-grpc-configmap.yaml
+++ b/tests/tests/legacy_kustomizations/metadata/test_data/expected/~g_v1_configmap_metadata-grpc-configmap.yaml
@@ -13,5 +13,5 @@ metadata:
     app.kubernetes.io/part-of: kubeflow
     app.kubernetes.io/version: 0.2.1
     kustomize.component: metadata
-  name: metadata-metadata-grpc-configmap-2dd6h7mhg6
+  name: metadata-grpc-configmap
   namespace: kubeflow

--- a/tests/tests/legacy_kustomizations/metadata/test_data/expected/~g_v1_configmap_metadata-ui-parameters.yaml
+++ b/tests/tests/legacy_kustomizations/metadata/test_data/expected/~g_v1_configmap_metadata-ui-parameters.yaml
@@ -12,5 +12,5 @@ metadata:
     app.kubernetes.io/part-of: kubeflow
     app.kubernetes.io/version: 0.2.1
     kustomize.component: metadata
-  name: metadata-ui-parameters-b6c8ghff7c
+  name: metadata-ui-parameters
   namespace: kubeflow

--- a/tests/tests/legacy_kustomizations/persistent-agent/test_data/expected/app.k8s.io_v1beta1_application_persistent-agent.yaml
+++ b/tests/tests/legacy_kustomizations/persistent-agent/test_data/expected/app.k8s.io_v1beta1_application_persistent-agent.yaml
@@ -32,8 +32,8 @@ spec:
   selector:
     matchLabels:
       app.kubernetes.io/component: persistent-agent
-      app.kubernetes.io/instance: persistent-agent-0.2.0
+      app.kubernetes.io/instance: persistent-agent-0.2.5
       app.kubernetes.io/managed-by: kfctl
       app.kubernetes.io/name: persistent-agent
       app.kubernetes.io/part-of: kubeflow
-      app.kubernetes.io/version: 0.2.0
+      app.kubernetes.io/version: 0.2.5

--- a/tests/tests/legacy_kustomizations/persistent-agent/test_data/expected/apps_v1_deployment_ml-pipeline-persistenceagent.yaml
+++ b/tests/tests/legacy_kustomizations/persistent-agent/test_data/expected/apps_v1_deployment_ml-pipeline-persistenceagent.yaml
@@ -40,7 +40,7 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: metadata.namespace
-        image: gcr.io/ml-pipeline/persistenceagent:0.2.0
+        image: gcr.io/ml-pipeline/persistenceagent:0.2.5
         imagePullPolicy: IfNotPresent
         name: ml-pipeline-persistenceagent
       serviceAccountName: ml-pipeline-persistenceagent

--- a/tests/tests/legacy_kustomizations/pipeline-visualization-service/test_data/expected/app.k8s.io_v1beta1_application_pipeline-visualization-service.yaml
+++ b/tests/tests/legacy_kustomizations/pipeline-visualization-service/test_data/expected/app.k8s.io_v1beta1_application_pipeline-visualization-service.yaml
@@ -32,8 +32,8 @@ spec:
   selector:
     matchLabels:
       app.kubernetes.io/component: pipeline-visualization-service
-      app.kubernetes.io/instance: pipeline-visualization-service-0.2.0
+      app.kubernetes.io/instance: pipeline-visualization-service-0.2.5
       app.kubernetes.io/managed-by: kfctl
       app.kubernetes.io/name: pipeline-visualization-service
       app.kubernetes.io/part-of: kubeflow
-      app.kubernetes.io/version: 0.2.0
+      app.kubernetes.io/version: 0.2.5

--- a/tests/tests/legacy_kustomizations/pipeline-visualization-service/test_data/expected/apps_v1_deployment_ml-pipeline-ml-pipeline-visualizationserver.yaml
+++ b/tests/tests/legacy_kustomizations/pipeline-visualization-service/test_data/expected/apps_v1_deployment_ml-pipeline-ml-pipeline-visualizationserver.yaml
@@ -35,7 +35,7 @@ spec:
         app.kubernetes.io/version: 0.2.0
     spec:
       containers:
-      - image: gcr.io/ml-pipeline/visualization-server:0.2.0
+      - image: gcr.io/ml-pipeline/visualization-server:0.2.5
         imagePullPolicy: IfNotPresent
         name: ml-pipeline-visualizationserver
         ports:

--- a/tests/tests/legacy_kustomizations/pipelines-runner/test_data/expected/app.k8s.io_v1beta1_application_pipelines-runner.yaml
+++ b/tests/tests/legacy_kustomizations/pipelines-runner/test_data/expected/app.k8s.io_v1beta1_application_pipelines-runner.yaml
@@ -32,8 +32,8 @@ spec:
   selector:
     matchLabels:
       app.kubernetes.io/component: pipelines-runner
-      app.kubernetes.io/instance: pipelines-runner-0.2.0
+      app.kubernetes.io/instance: pipelines-runner-0.2.5
       app.kubernetes.io/managed-by: kfctl
       app.kubernetes.io/name: pipelines-runner
       app.kubernetes.io/part-of: kubeflow
-      app.kubernetes.io/version: 0.2.0
+      app.kubernetes.io/version: 0.2.5

--- a/tests/tests/legacy_kustomizations/pipelines-ui/test_data/expected/app.k8s.io_v1beta1_application_pipelines-ui.yaml
+++ b/tests/tests/legacy_kustomizations/pipelines-ui/test_data/expected/app.k8s.io_v1beta1_application_pipelines-ui.yaml
@@ -32,8 +32,8 @@ spec:
   selector:
     matchLabels:
       app.kubernetes.io/component: pipelines-ui
-      app.kubernetes.io/instance: pipelines-ui-0.2.0
+      app.kubernetes.io/instance: pipelines-ui-0.2.5
       app.kubernetes.io/managed-by: kfctl
       app.kubernetes.io/name: pipelines-ui
       app.kubernetes.io/part-of: kubeflow
-      app.kubernetes.io/version: 0.2.0
+      app.kubernetes.io/version: 0.2.5

--- a/tests/tests/legacy_kustomizations/pipelines-ui/test_data/expected/apps_v1_deployment_ml-pipeline-ui.yaml
+++ b/tests/tests/legacy_kustomizations/pipelines-ui/test_data/expected/apps_v1_deployment_ml-pipeline-ui.yaml
@@ -40,7 +40,9 @@ spec:
           value: /etc/credentials/user-gcp-sa.json
         - name: VIEWER_TENSORBOARD_POD_TEMPLATE_SPEC_PATH
           value: /etc/config/viewer-pod-template.json
-        image: gcr.io/ml-pipeline/frontend:0.2.0
+        - name: ALLOW_CUSTOM_VISUALIZATIONS
+          value: "true"
+        image: gcr.io/ml-pipeline/frontend:0.2.5
         imagePullPolicy: IfNotPresent
         name: ml-pipeline-ui
         ports:

--- a/tests/tests/legacy_kustomizations/pipelines-viewer/test_data/expected/app.k8s.io_v1beta1_application_pipelines-viewer.yaml
+++ b/tests/tests/legacy_kustomizations/pipelines-viewer/test_data/expected/app.k8s.io_v1beta1_application_pipelines-viewer.yaml
@@ -32,8 +32,8 @@ spec:
   selector:
     matchLabels:
       app.kubernetes.io/component: pipelines-viewer
-      app.kubernetes.io/instance: pipelines-viewer-0.2.0
+      app.kubernetes.io/instance: pipelines-viewer-0.2.5
       app.kubernetes.io/managed-by: kfctl
       app.kubernetes.io/name: pipelines-viewer
       app.kubernetes.io/part-of: kubeflow
-      app.kubernetes.io/version: 0.2.0
+      app.kubernetes.io/version: 0.2.5

--- a/tests/tests/legacy_kustomizations/pipelines-viewer/test_data/expected/apps_v1_deployment_ml-pipeline-viewer-controller-deployment.yaml
+++ b/tests/tests/legacy_kustomizations/pipelines-viewer/test_data/expected/apps_v1_deployment_ml-pipeline-viewer-controller-deployment.yaml
@@ -40,7 +40,7 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: metadata.namespace
-        image: gcr.io/ml-pipeline/viewer-crd-controller:0.2.0
+        image: gcr.io/ml-pipeline/viewer-crd-controller:0.2.5
         imagePullPolicy: Always
         name: ml-pipeline-viewer-controller
       serviceAccountName: ml-pipeline-viewer-crd-service-account

--- a/tests/tests/legacy_kustomizations/scheduledworkflow/test_data/expected/app.k8s.io_v1beta1_application_scheduledworkflow.yaml
+++ b/tests/tests/legacy_kustomizations/scheduledworkflow/test_data/expected/app.k8s.io_v1beta1_application_scheduledworkflow.yaml
@@ -32,8 +32,8 @@ spec:
   selector:
     matchLabels:
       app.kubernetes.io/component: scheduledworkflow
-      app.kubernetes.io/instance: scheduledworkflow-0.2.0
+      app.kubernetes.io/instance: scheduledworkflow-0.2.5
       app.kubernetes.io/managed-by: kfctl
       app.kubernetes.io/name: scheduledworkflow
       app.kubernetes.io/part-of: kubeflow
-      app.kubernetes.io/version: 0.2.0
+      app.kubernetes.io/version: 0.2.5

--- a/tests/tests/legacy_kustomizations/scheduledworkflow/test_data/expected/apps_v1_deployment_ml-pipeline-scheduledworkflow.yaml
+++ b/tests/tests/legacy_kustomizations/scheduledworkflow/test_data/expected/apps_v1_deployment_ml-pipeline-scheduledworkflow.yaml
@@ -40,7 +40,7 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: metadata.namespace
-        image: gcr.io/ml-pipeline/scheduledworkflow:0.2.0
+        image: gcr.io/ml-pipeline/scheduledworkflow:0.2.5
         imagePullPolicy: IfNotPresent
         name: ml-pipeline-scheduledworkflow
       serviceAccountName: ml-pipeline-scheduledworkflow


### PR DESCRIPTION
**Which issue is resolved by this Pull Request:**
Resolves https://github.com/kubeflow/manifests/issues/984
Part of https://github.com/kubeflow/kubeflow/issues/4929

**Description of your changes:**
Bump KFP to 0.2.5

**Checklist:**
- [x] Unit tests have been rebuilt: 
    1. `cd manifests/tests`
    2. `make generate-changed-only`
    3. `make test`
