### PR TITLE
v3 versions of default-install, kubeflow-roles, and spartakus

### DIFF
--- a/common/spartakus/base/deployment.yaml
+++ b/common/spartakus/base/deployment.yaml
@@ -16,8 +16,14 @@ spec:
       containers:
       - args:
         - volunteer
-        - --cluster-id=$(usageId)
+        - --cluster-id=$(USAGE_ID)
         - --database=https://stats-collector.kubeflow.org
         image: gcr.io/google_containers/spartakus-amd64:v1.1.0
         name: volunteer
+        env:
+        - name: USAGE_ID
+          valueFrom:
+            configMapKeyRef:
+              name: spartakus-config
+              key: usageId
       serviceAccountName: spartakus

--- a/common/spartakus/base/kustomization.yaml
+++ b/common/spartakus/base/kustomization.yaml
@@ -1,5 +1,6 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
+namespace: kubeflow
 resources:
 - cluster-role-binding.yaml
 - cluster-role.yaml
@@ -12,17 +13,9 @@ images:
   newName: gcr.io/google_containers/spartakus-amd64
   newTag: v1.1.0
 configMapGenerator:
-- name: spartakus-parameters
+- name: spartakus-config
   env: params.env
 generatorOptions:
   disableNameSuffixHash: true
-vars:
-- name: usageId
-  objref:
-    kind: ConfigMap
-    name: spartakus-parameters
-    apiVersion: v1
-  fieldref:
-    fieldpath: data.usageId
 configurations:
 - params.yaml

--- a/default-install/base/kustomization.yaml
+++ b/default-install/base/kustomization.yaml
@@ -1,22 +1,26 @@
+# This is a kustomization package used to allow kfctl to
+# bootstrap a profile for the user running kfctl.
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
 - profile-instance.yaml
 configMapGenerator:
-- name: default-install-parameters
+- name: default-install-config
   env: params.env
 vars:
+# These vars are used for substituing in the parameters from the config map
+# into the Profiles custom resource.
 - name: user
   objref:
     kind: ConfigMap
-    name: default-install-parameters
+    name: default-install-config
     apiVersion: v1
   fieldref:
     fieldpath: data.user
 - name: profile-name
   objref:
     kind: ConfigMap
-    name: default-install-parameters
+    name: default-install-config
     apiVersion: v1
   fieldref:
     fieldpath: data.profile-name

--- a/stacks/examples/kfctl_gcp_stacks.experimental.yaml
+++ b/stacks/examples/kfctl_gcp_stacks.experimental.yaml
@@ -65,6 +65,13 @@ spec:
         name: manifests
         path: stacks/gcp
     name: kubeflow-apps
+  # Spartakus is a separate applications so that kfctl can remove it
+  # to disable usage reporting
+  - kustomizeConfig:
+      repoRef:
+        name: manifests
+        path: common/spartakus/overlays/application
+    name: spartakus
   plugins:
   # TODO(jlewi): The plugin is currently commented out because we don't want to run the
   # generate logic

--- a/stacks/gcp/kustomization.yaml
+++ b/stacks/gcp/kustomization.yaml
@@ -15,6 +15,7 @@ resources:
   - ../../pytorch-job/pytorch-operator/overlays/application
   - ../../tf-training/tf-job-crds/overlays/application
   - ../../tf-training/tf-job-operator/overlays/application
+  - ../../default-install/base
 configMapGenerator:
 - envs:
   - ./config/params.env

--- a/stacks/gcp/kustomization.yaml
+++ b/stacks/gcp/kustomization.yaml
@@ -8,6 +8,7 @@ resources:
   - ../../admission-webhook/webhook/v3
   - ../../common/centraldashboard/overlays/stacks
   - ../../gcp/gpu-driver/overlays/application/
+  - ../../kubeflow-roles/base
   - ../../jupyter/jupyter-web-app/base_v3
   - ../../jupyter/notebook-controller/base_v3
   - ../../profiles/base_v3
@@ -15,6 +16,7 @@ resources:
   - ../../pytorch-job/pytorch-operator/overlays/application
   - ../../tf-training/tf-job-crds/overlays/application
   - ../../tf-training/tf-job-operator/overlays/application
+  # This package will create a profile resource so it needs to be installed after the profiles CR
   - ../../default-install/base
 configMapGenerator:
 - envs:

--- a/tests/legacy_kustomizations/default-install/kustomization.yaml
+++ b/tests/legacy_kustomizations/default-install/kustomization.yaml
@@ -5,7 +5,7 @@ configMapGenerator:
 - behavior: merge
   envs:
   - params_0.env
-  name: default-install-parameters
+  name: default-install-config
 configurations: []
 kind: Kustomization
 namespace: kubeflow

--- a/tests/legacy_kustomizations/spartakus/kustomization.yaml
+++ b/tests/legacy_kustomizations/spartakus/kustomization.yaml
@@ -12,7 +12,7 @@ configMapGenerator:
 - behavior: merge
   envs:
   - params_0.env
-  name: spartakus-parameters
+  name: spartakus-config
 configurations: []
 kind: Kustomization
 namespace: kubeflow

--- a/tests/stacks/examples/alice_gcp/test_data/expected/kubeflow.org_v1beta1_profile_anonymous.yaml
+++ b/tests/stacks/examples/alice_gcp/test_data/expected/kubeflow.org_v1beta1_profile_anonymous.yaml
@@ -1,0 +1,9 @@
+apiVersion: kubeflow.org/v1beta1
+kind: Profile
+metadata:
+  name: anonymous
+  namespace: kubeflow
+spec:
+  owner:
+    kind: User
+    name: anonymous

--- a/tests/stacks/examples/alice_gcp/test_data/expected/rbac.authorization.k8s.io_v1_clusterrole_kubeflow-admin.yaml
+++ b/tests/stacks/examples/alice_gcp/test_data/expected/rbac.authorization.k8s.io_v1_clusterrole_kubeflow-admin.yaml
@@ -1,0 +1,9 @@
+aggregationRule:
+  clusterRoleSelectors:
+  - matchLabels:
+      rbac.authorization.kubeflow.org/aggregate-to-kubeflow-admin: "true"
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: kubeflow-admin
+rules: []

--- a/tests/stacks/examples/alice_gcp/test_data/expected/rbac.authorization.k8s.io_v1_clusterrole_kubeflow-edit.yaml
+++ b/tests/stacks/examples/alice_gcp/test_data/expected/rbac.authorization.k8s.io_v1_clusterrole_kubeflow-edit.yaml
@@ -1,0 +1,11 @@
+aggregationRule:
+  clusterRoleSelectors:
+  - matchLabels:
+      rbac.authorization.kubeflow.org/aggregate-to-kubeflow-edit: "true"
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  labels:
+    rbac.authorization.kubeflow.org/aggregate-to-kubeflow-admin: "true"
+  name: kubeflow-edit
+rules: []

--- a/tests/stacks/examples/alice_gcp/test_data/expected/rbac.authorization.k8s.io_v1_clusterrole_kubeflow-kubernetes-admin.yaml
+++ b/tests/stacks/examples/alice_gcp/test_data/expected/rbac.authorization.k8s.io_v1_clusterrole_kubeflow-kubernetes-admin.yaml
@@ -1,0 +1,27 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  labels:
+    rbac.authorization.kubeflow.org/aggregate-to-kubeflow-admin: "true"
+  name: kubeflow-kubernetes-admin
+rules:
+- apiGroups:
+  - authorization.k8s.io
+  resources:
+  - localsubjectaccessreviews
+  verbs:
+  - create
+- apiGroups:
+  - rbac.authorization.k8s.io
+  resources:
+  - rolebindings
+  - roles
+  verbs:
+  - create
+  - delete
+  - deletecollection
+  - get
+  - list
+  - patch
+  - update
+  - watch

--- a/tests/stacks/examples/alice_gcp/test_data/expected/rbac.authorization.k8s.io_v1_clusterrole_kubeflow-kubernetes-edit.yaml
+++ b/tests/stacks/examples/alice_gcp/test_data/expected/rbac.authorization.k8s.io_v1_clusterrole_kubeflow-kubernetes-edit.yaml
@@ -1,0 +1,135 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  labels:
+    rbac.authorization.kubeflow.org/aggregate-to-kubeflow-edit: "true"
+  name: kubeflow-kubernetes-edit
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - pods/attach
+  - pods/exec
+  - pods/portforward
+  - pods/proxy
+  - secrets
+  - services/proxy
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - serviceaccounts
+  verbs:
+  - impersonate
+- apiGroups:
+  - ""
+  resources:
+  - pods
+  - pods/attach
+  - pods/exec
+  - pods/portforward
+  - pods/proxy
+  verbs:
+  - create
+  - delete
+  - deletecollection
+  - patch
+  - update
+- apiGroups:
+  - ""
+  resources:
+  - configmaps
+  - endpoints
+  - persistentvolumeclaims
+  - replicationcontrollers
+  - replicationcontrollers/scale
+  - secrets
+  - serviceaccounts
+  - services
+  - services/proxy
+  verbs:
+  - create
+  - delete
+  - deletecollection
+  - patch
+  - update
+- apiGroups:
+  - apps
+  resources:
+  - daemonsets
+  - deployments
+  - deployments/rollback
+  - deployments/scale
+  - replicasets
+  - replicasets/scale
+  - statefulsets
+  - statefulsets/scale
+  verbs:
+  - create
+  - delete
+  - deletecollection
+  - patch
+  - update
+- apiGroups:
+  - autoscaling
+  resources:
+  - horizontalpodautoscalers
+  verbs:
+  - create
+  - delete
+  - deletecollection
+  - patch
+  - update
+- apiGroups:
+  - batch
+  resources:
+  - cronjobs
+  - jobs
+  verbs:
+  - create
+  - delete
+  - deletecollection
+  - patch
+  - update
+- apiGroups:
+  - extensions
+  resources:
+  - daemonsets
+  - deployments
+  - deployments/rollback
+  - deployments/scale
+  - ingresses
+  - networkpolicies
+  - replicasets
+  - replicasets/scale
+  - replicationcontrollers/scale
+  verbs:
+  - create
+  - delete
+  - deletecollection
+  - patch
+  - update
+- apiGroups:
+  - policy
+  resources:
+  - poddisruptionbudgets
+  verbs:
+  - create
+  - delete
+  - deletecollection
+  - patch
+  - update
+- apiGroups:
+  - networking.k8s.io
+  resources:
+  - ingresses
+  - networkpolicies
+  verbs:
+  - create
+  - delete
+  - deletecollection
+  - patch
+  - update

--- a/tests/stacks/examples/alice_gcp/test_data/expected/rbac.authorization.k8s.io_v1_clusterrole_kubeflow-kubernetes-view.yaml
+++ b/tests/stacks/examples/alice_gcp/test_data/expected/rbac.authorization.k8s.io_v1_clusterrole_kubeflow-kubernetes-view.yaml
@@ -1,0 +1,125 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  labels:
+    rbac.authorization.kubeflow.org/aggregate-to-kubeflow-view: "true"
+  name: kubeflow-kubernetes-view
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - configmaps
+  - endpoints
+  - persistentvolumeclaims
+  - persistentvolumeclaims/status
+  - pods
+  - replicationcontrollers
+  - replicationcontrollers/scale
+  - serviceaccounts
+  - services
+  - services/status
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - bindings
+  - events
+  - limitranges
+  - namespaces/status
+  - pods/log
+  - pods/status
+  - replicationcontrollers/status
+  - resourcequotas
+  - resourcequotas/status
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - namespaces
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - apps
+  resources:
+  - controllerrevisions
+  - daemonsets
+  - daemonsets/status
+  - deployments
+  - deployments/scale
+  - deployments/status
+  - replicasets
+  - replicasets/scale
+  - replicasets/status
+  - statefulsets
+  - statefulsets/scale
+  - statefulsets/status
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - autoscaling
+  resources:
+  - horizontalpodautoscalers
+  - horizontalpodautoscalers/status
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - batch
+  resources:
+  - cronjobs
+  - cronjobs/status
+  - jobs
+  - jobs/status
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - extensions
+  resources:
+  - daemonsets
+  - daemonsets/status
+  - deployments
+  - deployments/scale
+  - deployments/status
+  - ingresses
+  - ingresses/status
+  - networkpolicies
+  - replicasets
+  - replicasets/scale
+  - replicasets/status
+  - replicationcontrollers/scale
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - policy
+  resources:
+  - poddisruptionbudgets
+  - poddisruptionbudgets/status
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - networking.k8s.io
+  resources:
+  - ingresses
+  - ingresses/status
+  - networkpolicies
+  verbs:
+  - get
+  - list
+  - watch

--- a/tests/stacks/examples/alice_gcp/test_data/expected/rbac.authorization.k8s.io_v1_clusterrole_kubeflow-view.yaml
+++ b/tests/stacks/examples/alice_gcp/test_data/expected/rbac.authorization.k8s.io_v1_clusterrole_kubeflow-view.yaml
@@ -1,0 +1,11 @@
+aggregationRule:
+  clusterRoleSelectors:
+  - matchLabels:
+      rbac.authorization.kubeflow.org/aggregate-to-kubeflow-view: "true"
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  labels:
+    rbac.authorization.kubeflow.org/aggregate-to-kubeflow-edit: "true"
+  name: kubeflow-view
+rules: []

--- a/tests/stacks/examples/alice_gcp/test_data/expected/~g_v1_configmap_default-install-config-h877hbtmf7.yaml
+++ b/tests/stacks/examples/alice_gcp/test_data/expected/~g_v1_configmap_default-install-config-h877hbtmf7.yaml
@@ -1,0 +1,8 @@
+apiVersion: v1
+data:
+  profile-name: anonymous
+  user: anonymous
+kind: ConfigMap
+metadata:
+  name: default-install-config-h877hbtmf7
+  namespace: kubeflow

--- a/tests/stacks/gcp/test_data/expected/kubeflow.org_v1beta1_profile_anonymous.yaml
+++ b/tests/stacks/gcp/test_data/expected/kubeflow.org_v1beta1_profile_anonymous.yaml
@@ -1,0 +1,9 @@
+apiVersion: kubeflow.org/v1beta1
+kind: Profile
+metadata:
+  name: anonymous
+  namespace: kubeflow
+spec:
+  owner:
+    kind: User
+    name: anonymous

--- a/tests/stacks/gcp/test_data/expected/rbac.authorization.k8s.io_v1_clusterrole_kubeflow-admin.yaml
+++ b/tests/stacks/gcp/test_data/expected/rbac.authorization.k8s.io_v1_clusterrole_kubeflow-admin.yaml
@@ -1,0 +1,9 @@
+aggregationRule:
+  clusterRoleSelectors:
+  - matchLabels:
+      rbac.authorization.kubeflow.org/aggregate-to-kubeflow-admin: "true"
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: kubeflow-admin
+rules: []

--- a/tests/stacks/gcp/test_data/expected/rbac.authorization.k8s.io_v1_clusterrole_kubeflow-edit.yaml
+++ b/tests/stacks/gcp/test_data/expected/rbac.authorization.k8s.io_v1_clusterrole_kubeflow-edit.yaml
@@ -1,0 +1,11 @@
+aggregationRule:
+  clusterRoleSelectors:
+  - matchLabels:
+      rbac.authorization.kubeflow.org/aggregate-to-kubeflow-edit: "true"
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  labels:
+    rbac.authorization.kubeflow.org/aggregate-to-kubeflow-admin: "true"
+  name: kubeflow-edit
+rules: []

--- a/tests/stacks/gcp/test_data/expected/rbac.authorization.k8s.io_v1_clusterrole_kubeflow-kubernetes-admin.yaml
+++ b/tests/stacks/gcp/test_data/expected/rbac.authorization.k8s.io_v1_clusterrole_kubeflow-kubernetes-admin.yaml
@@ -1,0 +1,27 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  labels:
+    rbac.authorization.kubeflow.org/aggregate-to-kubeflow-admin: "true"
+  name: kubeflow-kubernetes-admin
+rules:
+- apiGroups:
+  - authorization.k8s.io
+  resources:
+  - localsubjectaccessreviews
+  verbs:
+  - create
+- apiGroups:
+  - rbac.authorization.k8s.io
+  resources:
+  - rolebindings
+  - roles
+  verbs:
+  - create
+  - delete
+  - deletecollection
+  - get
+  - list
+  - patch
+  - update
+  - watch

--- a/tests/stacks/gcp/test_data/expected/rbac.authorization.k8s.io_v1_clusterrole_kubeflow-kubernetes-edit.yaml
+++ b/tests/stacks/gcp/test_data/expected/rbac.authorization.k8s.io_v1_clusterrole_kubeflow-kubernetes-edit.yaml
@@ -1,0 +1,135 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  labels:
+    rbac.authorization.kubeflow.org/aggregate-to-kubeflow-edit: "true"
+  name: kubeflow-kubernetes-edit
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - pods/attach
+  - pods/exec
+  - pods/portforward
+  - pods/proxy
+  - secrets
+  - services/proxy
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - serviceaccounts
+  verbs:
+  - impersonate
+- apiGroups:
+  - ""
+  resources:
+  - pods
+  - pods/attach
+  - pods/exec
+  - pods/portforward
+  - pods/proxy
+  verbs:
+  - create
+  - delete
+  - deletecollection
+  - patch
+  - update
+- apiGroups:
+  - ""
+  resources:
+  - configmaps
+  - endpoints
+  - persistentvolumeclaims
+  - replicationcontrollers
+  - replicationcontrollers/scale
+  - secrets
+  - serviceaccounts
+  - services
+  - services/proxy
+  verbs:
+  - create
+  - delete
+  - deletecollection
+  - patch
+  - update
+- apiGroups:
+  - apps
+  resources:
+  - daemonsets
+  - deployments
+  - deployments/rollback
+  - deployments/scale
+  - replicasets
+  - replicasets/scale
+  - statefulsets
+  - statefulsets/scale
+  verbs:
+  - create
+  - delete
+  - deletecollection
+  - patch
+  - update
+- apiGroups:
+  - autoscaling
+  resources:
+  - horizontalpodautoscalers
+  verbs:
+  - create
+  - delete
+  - deletecollection
+  - patch
+  - update
+- apiGroups:
+  - batch
+  resources:
+  - cronjobs
+  - jobs
+  verbs:
+  - create
+  - delete
+  - deletecollection
+  - patch
+  - update
+- apiGroups:
+  - extensions
+  resources:
+  - daemonsets
+  - deployments
+  - deployments/rollback
+  - deployments/scale
+  - ingresses
+  - networkpolicies
+  - replicasets
+  - replicasets/scale
+  - replicationcontrollers/scale
+  verbs:
+  - create
+  - delete
+  - deletecollection
+  - patch
+  - update
+- apiGroups:
+  - policy
+  resources:
+  - poddisruptionbudgets
+  verbs:
+  - create
+  - delete
+  - deletecollection
+  - patch
+  - update
+- apiGroups:
+  - networking.k8s.io
+  resources:
+  - ingresses
+  - networkpolicies
+  verbs:
+  - create
+  - delete
+  - deletecollection
+  - patch
+  - update

--- a/tests/stacks/gcp/test_data/expected/rbac.authorization.k8s.io_v1_clusterrole_kubeflow-kubernetes-view.yaml
+++ b/tests/stacks/gcp/test_data/expected/rbac.authorization.k8s.io_v1_clusterrole_kubeflow-kubernetes-view.yaml
@@ -1,0 +1,125 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  labels:
+    rbac.authorization.kubeflow.org/aggregate-to-kubeflow-view: "true"
+  name: kubeflow-kubernetes-view
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - configmaps
+  - endpoints
+  - persistentvolumeclaims
+  - persistentvolumeclaims/status
+  - pods
+  - replicationcontrollers
+  - replicationcontrollers/scale
+  - serviceaccounts
+  - services
+  - services/status
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - bindings
+  - events
+  - limitranges
+  - namespaces/status
+  - pods/log
+  - pods/status
+  - replicationcontrollers/status
+  - resourcequotas
+  - resourcequotas/status
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - namespaces
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - apps
+  resources:
+  - controllerrevisions
+  - daemonsets
+  - daemonsets/status
+  - deployments
+  - deployments/scale
+  - deployments/status
+  - replicasets
+  - replicasets/scale
+  - replicasets/status
+  - statefulsets
+  - statefulsets/scale
+  - statefulsets/status
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - autoscaling
+  resources:
+  - horizontalpodautoscalers
+  - horizontalpodautoscalers/status
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - batch
+  resources:
+  - cronjobs
+  - cronjobs/status
+  - jobs
+  - jobs/status
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - extensions
+  resources:
+  - daemonsets
+  - daemonsets/status
+  - deployments
+  - deployments/scale
+  - deployments/status
+  - ingresses
+  - ingresses/status
+  - networkpolicies
+  - replicasets
+  - replicasets/scale
+  - replicasets/status
+  - replicationcontrollers/scale
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - policy
+  resources:
+  - poddisruptionbudgets
+  - poddisruptionbudgets/status
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - networking.k8s.io
+  resources:
+  - ingresses
+  - ingresses/status
+  - networkpolicies
+  verbs:
+  - get
+  - list
+  - watch

--- a/tests/stacks/gcp/test_data/expected/rbac.authorization.k8s.io_v1_clusterrole_kubeflow-view.yaml
+++ b/tests/stacks/gcp/test_data/expected/rbac.authorization.k8s.io_v1_clusterrole_kubeflow-view.yaml
@@ -1,0 +1,11 @@
+aggregationRule:
+  clusterRoleSelectors:
+  - matchLabels:
+      rbac.authorization.kubeflow.org/aggregate-to-kubeflow-view: "true"
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  labels:
+    rbac.authorization.kubeflow.org/aggregate-to-kubeflow-edit: "true"
+  name: kubeflow-view
+rules: []

--- a/tests/stacks/gcp/test_data/expected/~g_v1_configmap_default-install-config-h877hbtmf7.yaml
+++ b/tests/stacks/gcp/test_data/expected/~g_v1_configmap_default-install-config-h877hbtmf7.yaml
@@ -1,0 +1,8 @@
+apiVersion: v1
+data:
+  profile-name: anonymous
+  user: anonymous
+kind: ConfigMap
+metadata:
+  name: default-install-config-h877hbtmf7
+  namespace: kubeflow

--- a/tests/tests/legacy_kustomizations/default-install/test_data/expected/~g_v1_configmap_default-install-config-6mcgbmmtg6.yaml
+++ b/tests/tests/legacy_kustomizations/default-install/test_data/expected/~g_v1_configmap_default-install-config-6mcgbmmtg6.yaml
@@ -6,5 +6,5 @@ kind: ConfigMap
 metadata:
   annotations: {}
   labels: {}
-  name: default-install-parameters-7kd9mfhcgk
+  name: default-install-config-6mcgbmmtg6
   namespace: kubeflow

--- a/tests/tests/legacy_kustomizations/spartakus/test_data/expected/apps_v1_deployment_spartakus-volunteer.yaml
+++ b/tests/tests/legacy_kustomizations/spartakus/test_data/expected/apps_v1_deployment_spartakus-volunteer.yaml
@@ -40,8 +40,14 @@ spec:
       containers:
       - args:
         - volunteer
-        - --cluster-id=6123692046963347097
+        - --cluster-id=$(USAGE_ID)
         - --database=https://stats-collector.kubeflow.org
+        env:
+        - name: USAGE_ID
+          valueFrom:
+            configMapKeyRef:
+              key: usageId
+              name: spartakus-config
         image: gcr.io/google_containers/spartakus-amd64:v1.1.0
         name: volunteer
       serviceAccountName: spartakus

--- a/tests/tests/legacy_kustomizations/spartakus/test_data/expected/~g_v1_configmap_spartakus-config.yaml
+++ b/tests/tests/legacy_kustomizations/spartakus/test_data/expected/~g_v1_configmap_spartakus-config.yaml
@@ -12,5 +12,5 @@ metadata:
     app.kubernetes.io/part-of: kubeflow
     app.kubernetes.io/version: v1.0.0
     kustomize.component: spartakus
-  name: spartakus-parameters
+  name: spartakus-config
   namespace: kubeflow


### PR DESCRIPTION
* Convert default-install and spartakus to v3.

* For default-install we need to change the name of the configmap to match
  the configmap that will be generated by kfctl.

* Modify spartakus to work with v3 and stacks; we need to change the
  config map name to match the config map generated by kfctl with
  application parameters.

* To fix the tests we need to change the name of the config maps.

Related to #1062