### PR TITLE
Fix unittests by upgrading to go 1.14

### DIFF
--- a/tests/workflows/components/workflows.libsonnet
+++ b/tests/workflows/components/workflows.libsonnet
@@ -46,7 +46,7 @@
       local srcRootDir = testDir + "/src";
       // The directory containing the kubeflow/manifests repo
       local srcDir = srcRootDir + "/kubeflow/manifests";
-      local testWorkerImage = "gcr.io/kubeflow-ci/test-worker:latest";
+      local testWorkerImage = "gcr.io/kubeflow-ci/test-worker-py3:e9afed1-dirty";
       local golangImage = "golang:1.9.4-stretch";
       // TODO(jose5918) Build our own helm image
       local pythonImage = "python:3.6-jessie";


### PR DESCRIPTION
* Presubmits are broken #1103.
* There is an error fetching go modules. The error appears to be related
  to using go 1.12. This PR updates the worker image to a newly built test
  worker image which uses go 1.14. When I ran the tests in the newly
  built image they passed.
