### PR TITLE
Add google-cloudsql overlay for metadata

### DIFF
--- a/metadata/overlays/google-cloudsql/README.md
+++ b/metadata/overlays/google-cloudsql/README.md
@@ -1,0 +1,58 @@
+This directory contains configurations and guidelines on setting up metadata services to connect to a [Google CloudSQL](https://cloud.google.com/sql) instance.
+You will get all the benefits of using CloudSQL comparing to managing your own MySQL server in a Kubernetes cluster.
+
+Prerequisites:
+- Install [kustomize](https://github.com/kubernetes-sigs/kustomize) for building Kubernetes configurations.
+- Install [kubectl](https://kubernetes.io/docs/tasks/tools/install-kubectl/) for managing workloads on Kubernetes clusters.
+
+#### 0. Remove default metadata services.
+By default, Metadata component starts a MySQL server in `kubeflow` namespace. Since we are going to deploy metadata services with CloudSQL, you should delete the default services by running
+
+```
+kustomize build metadata/overlays/db | kubectl delete -n kubeflow -f -
+```
+
+#### 1. Create a CloudSQL instance.
+
+If you don't have an existing one, you need to [create a CloudSQL instance](https://cloud.google.com/sql/docs/mysql/create-instance) of type MySQL in your GCP project.
+If you want to connect the instance via private IP, you also need to enable the private IP configuration when creating the instance.
+
+#### 2. Create a Kubernetes secret for accessing the CloudSQL instance.
+You can follow [this guide](https://cloud.google.com/sql/docs/mysql/connect-kubernetes-engine#secrets)
+to set up a [service account with permissions](https://cloud.google.com/sql/docs/mysql/sql-proxy#create-service-account) to connect to the instance, download the JSON key file, and name it `credentials.json`.
+You need to create a secret via command:
+```
+kubectl create secret -n kubeflow generic cloudsql-instance-credentials --from-file <local_path>/credentials.json
+```
+Note that you must name the key file `credentials.json`, because we will later refer to this file name in the deployment configuration.
+
+#### 3. Create a Kubernetes secret for MySQL account and password.
+Besides the service account with permissions, the metadata services also need a MySQL account name and password to be authenticated for accessing databases. Secret is the way how Kubernetes manages sensitive information.
+
+You need to [create a secret](https://kubernetes.io/docs/concepts/configuration/secret/#creating-your-own-secrets) under `kubeflow` namespace with name `metadata-db-secrets`, containing values of `MYSQL_USERNAME` and `MYSQL_PASSWORD`.
+You should be able to see the secret after its creation via command:
+```
+kubectl describe secrets -n kubeflow metadata-db-secrets
+
+Name:         metadata-db-secrets
+Namespace:    kubeflow
+Labels:       kustomize.component=metadata
+Annotations:  
+Type:         Opaque
+
+Data
+====
+MYSQL_PASSWORD:  9 bytes
+MYSQL_USERNAME:  4 bytes
+```
+
+#### 4. Specify the instance connection name.
+Change the value of `MYSQL_INSTANCE` in `params.env` to your CloudSQL instance connection name. The connection name is in the form of `<project-id>:<region>:<instance-id>`.
+
+#### 5. Start metadata services with CloudSQL proxy.
+Start metadata services with CloudSQL proxy sidecar containers via command:
+```
+kustomize build metadata/overlays/google-cloudsql | kubectl apply -n kubeflow -f -
+```
+You may find the CloudSQL proxy container logs useful to debug connection errors.
+ 

--- a/metadata/overlays/google-cloudsql/README.md
+++ b/metadata/overlays/google-cloudsql/README.md
@@ -1,7 +1,7 @@
 This directory contains configurations and guidelines on setting up metadata services to connect to a [Google CloudSQL](https://cloud.google.com/sql) instance.
 You will get all the benefits of using CloudSQL comparing to managing your own MySQL server in a Kubernetes cluster.
 
-Prerequisites:
+#### Prerequisites
 - Install [kustomize](https://github.com/kubernetes-sigs/kustomize) for building Kubernetes configurations.
 - Install [kubectl](https://kubernetes.io/docs/tasks/tools/install-kubectl/) for managing workloads on Kubernetes clusters.
 

--- a/metadata/overlays/google-cloudsql/kustomization.yaml
+++ b/metadata/overlays/google-cloudsql/kustomization.yaml
@@ -1,0 +1,14 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+generatorOptions:
+  # name suffix hash is not propagated correctly to base resources
+  disableNameSuffixHash: true
+commonLabels:
+  kustomize.component: metadata
+configMapGenerator:
+- name: metadata-db-parameters
+  env: params.env
+bases:
+- ../../base
+patchesStrategicMerge:
+- metadata-deployment.yaml

--- a/metadata/overlays/google-cloudsql/kustomization.yaml
+++ b/metadata/overlays/google-cloudsql/kustomization.yaml
@@ -1,7 +1,8 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 generatorOptions:
-  # name suffix hash is not propagated correctly to base resources
+  # name suffix hash is not propagated correctly to base resources due to
+  # https://github.com/kubernetes-sigs/kustomize/issues/1301
   disableNameSuffixHash: true
 commonLabels:
   kustomize.component: metadata

--- a/metadata/overlays/google-cloudsql/metadata-deployment.yaml
+++ b/metadata/overlays/google-cloudsql/metadata-deployment.yaml
@@ -1,0 +1,108 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: deployment
+  labels:
+    component: server
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      component: server
+  template:
+    metadata:
+      labels:
+        component: server
+    spec:
+      volumes:
+        - name: cloudsql-instance-credentials
+          secret:
+            secretName: cloudsql-instance-credentials
+      containers:
+      - name: cloudsql-proxy
+        envFrom:
+          - configMapRef:
+              name: metadata-db-parameters
+        image: gcr.io/cloudsql-docker/gce-proxy:1.16
+        command: ["/cloud_sql_proxy",
+                  "-instances=$(MYSQL_INSTANCE)=tcp:3306",
+                  # If running on a VPC, the Cloud SQL proxy can connect via Private IP. See:
+                  # https://cloud.google.com/sql/docs/mysql/private-ip for more info.
+                  # "-ip_address_types=PRIVATE",
+                  "-credential_file=/secrets/cloudsql/credentials.json"]
+        securityContext:
+          runAsUser: 2  # non-root user
+          allowPrivilegeEscalation: false
+        volumeMounts:
+          - name: cloudsql-instance-credentials
+            mountPath: /secrets/cloudsql
+            readOnly: true
+      - name: container
+        envFrom:
+          - configMapRef:
+              name: metadata-db-parameters
+          - secretRef:
+              name: metadata-db-secrets
+        command: ["./server/server",
+                  "--http_port=8080",
+                  "--mysql_service_host=$(MYSQL_HOST)",
+                  "--mysql_service_port=$(MYSQL_PORT)",
+                  "--mysql_service_user=$(MYSQL_USERNAME)",
+                  "--mysql_service_password=$(MYSQL_PASSWORD)",
+                  "--mlmd_db_name=$(MYSQL_DATABASE)"]
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: grpc-deployment
+  labels:
+    component: grpc-server
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      component: grpc-server
+  template:
+    metadata:
+      labels:
+        component: grpc-server
+    spec:
+      volumes:
+        - name: cloudsql-instance-credentials
+          secret:
+            secretName: cloudsql-instance-credentials
+      containers:
+        - name: container
+          envFrom:
+          - configMapRef:
+              name: metadata-db-parameters
+          - secretRef:
+              name: metadata-db-secrets
+          - configMapRef:
+              name: metadata-grpc-configmap
+          args: ["--grpc_port=$(METADATA_GRPC_SERVICE_PORT)",
+                 "--mysql_config_host=$(MYSQL_HOST)",
+                 "--mysql_config_database=$(MYSQL_DATABASE)",
+                 "--mysql_config_port=$(MYSQL_PORT)",
+                 "--mysql_config_user=$(MYSQL_USERNAME)",
+                 "--mysql_config_password=$(MYSQL_PASSWORD)"
+          ]
+        - name: cloudsql-proxy
+          envFrom:
+          - configMapRef:
+              name: metadata-db-parameters
+          image: gcr.io/cloudsql-docker/gce-proxy:1.16
+          command: ["/cloud_sql_proxy",
+                    "-instances=$(MYSQL_INSTANCE)=tcp:3306",
+                    # If running on a VPC, the Cloud SQL proxy can connect via Private IP. See:
+                    # https://cloud.google.com/sql/docs/mysql/private-ip for more info.
+                    # "-ip_address_types=PRIVATE",
+                    "-credential_file=/secrets/cloudsql/credentials.json"]
+          securityContext:
+            runAsUser: 2  # non-root user
+            allowPrivilegeEscalation: false
+          volumeMounts:
+            - name: cloudsql-instance-credentials
+              mountPath: /secrets/cloudsql
+              readOnly: true
+          

--- a/metadata/overlays/google-cloudsql/params.env
+++ b/metadata/overlays/google-cloudsql/params.env
@@ -2,5 +2,4 @@ MYSQL_HOST=127.0.0.1
 MYSQL_DATABASE=metadb
 MYSQL_PORT=3306
 MYSQL_ALLOW_EMPTY_PASSWORD=true
-MYSQL_INSTANCE_1=your-project:your-region:your-mysql-instance-id
-MYSQL_INSTANCE=zhenghui-exp:us-central1:mysql-for-kf
+MYSQL_INSTANCE=your-project:your-region:your-mysql-instance-id

--- a/metadata/overlays/google-cloudsql/params.env
+++ b/metadata/overlays/google-cloudsql/params.env
@@ -1,0 +1,6 @@
+MYSQL_HOST=127.0.0.1
+MYSQL_DATABASE=metadb
+MYSQL_PORT=3306
+MYSQL_ALLOW_EMPTY_PASSWORD=true
+MYSQL_INSTANCE_1=your-project:your-region:your-mysql-instance-id
+MYSQL_INSTANCE=zhenghui-exp:us-central1:mysql-for-kf


### PR DESCRIPTION
This PR adds an overlay for metadata to use Google CloudSQL.

**Checklist:**
- [x] Unit tests have been rebuilt: 
    1. `cd manifests/tests`
    2. `make generate-changed-only`
    3. `make test`
