### PR TITLE
Fix the link to run_e2e_workflow.py script

### DIFF
--- a/prow_config.yaml
+++ b/prow_config.yaml
@@ -1,5 +1,5 @@
 # This file configures the workflows to trigger in our Prow jobs.
-# see kubeflow/testing/py/run_e2e_workflow.py
+# see https://github.com/kubeflow/testing/blob/master/py/kubeflow/testing/run_e2e_workflow.py
 python_paths:
   # Need to place kubeflow/testing in front of kubeflow/testing so that the package can
   # be correctly located.


### PR DESCRIPTION
**Which issue is resolved by this Pull Request:**
Resolves #

**Description of your changes:**

This script has been moved to a new location.

**Checklist:**
- [x] Unit tests have been rebuilt: 
    1. `cd manifests/tests`
    2. `make generate-changed-only`
    3. `make test`
