### PR TITLE
fix roles binding namespace reference

### DIFF
--- a/common/centraldashboard/base/clusterrole-binding.yaml
+++ b/common/centraldashboard/base/clusterrole-binding.yaml
@@ -11,4 +11,4 @@ roleRef:
 subjects:
 - kind: ServiceAccount
   name: centraldashboard
-  namespace: kubeflow
+  namespace: $(namespace)

--- a/common/centraldashboard/base/kustomization.yaml
+++ b/common/centraldashboard/base/kustomization.yaml
@@ -11,7 +11,6 @@ resources:
 - service.yaml
 patchesStrategicMerge:
 - deployment_patch.yaml
-namespace: kubeflow
 commonLabels:
   kustomize.component: centraldashboard
 images:

--- a/common/centraldashboard/base/params.yaml
+++ b/common/centraldashboard/base/params.yaml
@@ -7,3 +7,7 @@ varReference:
   kind: Deployment
 - path: spec/template/spec/containers/0/env/1/value
   kind: Deployment
+- path: subjects/namespace
+  kind: ClusterRoleBinding
+- path: subjects/namespace
+  kind: RoleBinding

--- a/common/centraldashboard/base/role-binding.yaml
+++ b/common/centraldashboard/base/role-binding.yaml
@@ -11,4 +11,4 @@ roleRef:
 subjects:
 - kind: ServiceAccount
   name: centraldashboard
-  namespace: kubeflow
+  namespace: $(namespace)


### PR DESCRIPTION
**Description of your changes:**
this fixes an issue introduced in #962, which causes the role bindings to be in the wrong namespace if the user is not using `kubeflow`

**Checklist:**
- [ ] Unit tests have been rebuilt: 
    1. `cd manifests/tests`
    2. `make generate-changed-only`
    3. `make test`
