### PR TITLE
add parameter for istio gateway in oidc-authservice

### DIFF
--- a/istio/oidc-authservice/base/envoy-filter.yaml
+++ b/istio/oidc-authservice/base/envoy-filter.yaml
@@ -4,7 +4,7 @@ metadata:
   name: authn-filter
 spec:
   workloadLabels:
-    istio: ingressgateway
+    istio: $(gatewaySelector)
   filters:
   - filterConfig:
       httpService:

--- a/istio/oidc-authservice/base/kustomization.yaml
+++ b/istio/oidc-authservice/base/kustomization.yaml
@@ -80,6 +80,13 @@ vars:
     apiVersion: v1
   fieldref:
     fieldpath: data.namespace
+- name: gatewaySelector
+  objref:
+    kind: ConfigMap
+    name: oidc-authservice-parameters
+    apiVersion: v1
+  fieldref:
+    fieldpath: data.gatewaySelector
 configurations:
 - params.yaml
 images:

--- a/istio/oidc-authservice/base/params.env
+++ b/istio/oidc-authservice/base/params.env
@@ -7,3 +7,4 @@ skip_auth_uri=
 userid-header=
 userid-prefix=
 namespace=istio-system
+gatewaySelector=ingressgateway

--- a/istio/oidc-authservice/base/params.yaml
+++ b/istio/oidc-authservice/base/params.yaml
@@ -5,3 +5,5 @@ varReference:
   kind: EnvoyFilter
 - path: spec/filters/filterConfig/httpService/serverUri/cluster
   kind: EnvoyFilter
+- path: spec/workloadLabels/istio
+  kind: EnvoyFilter

--- a/tests/stacks/aws/application/oidc-authservice/test_data/expected/~g_v1_configmap_oidc-authservice-parameters.yaml
+++ b/tests/stacks/aws/application/oidc-authservice/test_data/expected/~g_v1_configmap_oidc-authservice-parameters.yaml
@@ -2,6 +2,7 @@ apiVersion: v1
 data:
   application_secret: pUBnBOY80SnXgjibTYM9ZWNzY2xreNGQok
   client_id: kubeflow-oidc-authservice
+  gatewaySelector: ingressgateway
   namespace: istio-system
   oidc_auth_url: /dex/auth
   oidc_provider: http://dex.auth.svc.cluster.local:5556/dex

--- a/tests/stacks/ibm/application/oidc-authservice/test_data/expected/~g_v1_configmap_oidc-authservice-parameters.yaml
+++ b/tests/stacks/ibm/application/oidc-authservice/test_data/expected/~g_v1_configmap_oidc-authservice-parameters.yaml
@@ -2,6 +2,7 @@ apiVersion: v1
 data:
   application_secret: pUBnBOY80SnXgjibTYM9ZWNzY2xreNGQok
   client_id: kubeflow-oidc-authservice
+  gatewaySelector: ingressgateway
   namespace: istio-system
   oidc_auth_url: /dex/auth
   oidc_provider: http://dex.auth.svc.cluster.local:5556/dex

--- a/tests/stacks/kubernetes/application/oidc-authservice/test_data/expected/~g_v1_configmap_oidc-authservice-parameters.yaml
+++ b/tests/stacks/kubernetes/application/oidc-authservice/test_data/expected/~g_v1_configmap_oidc-authservice-parameters.yaml
@@ -2,6 +2,7 @@ apiVersion: v1
 data:
   application_secret: pUBnBOY80SnXgjibTYM9ZWNzY2xreNGQok
   client_id: kubeflow-oidc-authservice
+  gatewaySelector: ingressgateway
   namespace: istio-system
   oidc_auth_url: /dex/auth
   oidc_provider: http://dex.auth.svc.cluster.local:5556/dex


### PR DESCRIPTION
**Description of your changes:**
this allows the use of non-default istio ingress gateways, by implementing a kustomize parameter

**Checklist:**
- [X] Unit tests have been rebuilt: 
    1. `cd manifests/tests`
    2. `make generate-changed-only`
    3. `make test`
