### PR TITLE
upgrade mpi-operator manifests to v1

### DIFF
--- a/mpi-job/mpi-operator/base/cluster-role.yaml
+++ b/mpi-job/mpi-operator/base/cluster-role.yaml
@@ -20,12 +20,22 @@ rules:
   - pods
   verbs:
   - get
+  - list
+  - watch
 - apiGroups:
   - ""
   resources:
   - pods/exec
   verbs:
   - create
+- apiGroups:
+  - ""
+  resources:
+  - endpoints
+  verbs:
+  - create
+  - get
+  - update
 - apiGroups:
   - ""
   resources:
@@ -41,6 +51,15 @@ rules:
   verbs:
   - create
   - list
+  - watch
+- apiGroups:
+  - policy
+  resources:
+  - poddisruptionbudgets
+  verbs:
+  - create
+  - list
+  - update
   - watch
 - apiGroups:
   - apps
@@ -61,14 +80,6 @@ rules:
   - update
   - watch
 - apiGroups:
-  - policy
-  resources:
-  - poddisruptionbudgets
-  verbs:
-  - create
-  - list
-  - watch
-- apiGroups:
   - apiextensions.k8s.io
   resources:
   - customresourcedefinitions
@@ -79,8 +90,18 @@ rules:
   - kubeflow.org
   resources:
   - mpijobs
+  - mpijobs/finalizers
+  - mpijobs/status
   verbs:
-  - '*'
+  - "*"
+- apiGroups:
+  - scheduling.incubator.k8s.io
+  - scheduling.sigs.dev
+  resources:
+  - queues
+  - podgroups
+  verbs:
+  - "*"
 
 ---
 
@@ -93,7 +114,7 @@ metadata:
 aggregationRule:
   clusterRoleSelectors:
   - matchLabels:
-    rbac.authorization.kubeflow.org/aggregate-to-kubeflow-mpijobs-admin: "true"
+      rbac.authorization.kubeflow.org/aggregate-to-kubeflow-mpijobs-admin: "true"
 rules: []
 
 ---

--- a/mpi-job/mpi-operator/base/crd.yaml
+++ b/mpi-job/mpi-operator/base/crd.yaml
@@ -1,10 +1,9 @@
-apiVersion: apiextensions.k8s.io/v1beta1
+apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   name: mpijobs.kubeflow.org
 spec:
   group: kubeflow.org
-  version: v1alpha1
   scope: Namespaced
   names:
     plural: mpijobs
@@ -13,87 +12,139 @@ spec:
     shortNames:
     - mj
     - mpij
-  validation:
-    openAPIV3Schema:
-      properties:
-        spec:
-          title: The MPIJob spec
-          description: Only one of gpus, processingUnits, or replicas should be specified
-          oneOf:
-          - properties:
-              gpus:
-                title: Total number of GPUs
-                description: Valid values are 1, 2, 4, or any multiple of 8
-                oneOf:
-                - type: integer
+  versions:
+  - name: v1alpha1
+    served: false
+    storage: false
+    schema:
+      openAPIV3Schema:
+        properties:
+          spec:
+            title: The MPIJob spec
+            description: Only one of gpus, processingUnits, or replicas should be specified
+            oneOf:
+            - properties:
+                gpus:
+                  title: Total number of GPUs
+                  description: Valid values are 1, 2, 4, or any multiple of 8
+                  oneOf:
+                  - type: integer
+                    enum:
+                    - 1
+                    - 2
+                    - 4
+                  - type: integer
+                    multipleOf: 8
+                    minimum: 8
+                slotsPerWorker:
+                  title: The number of slots per worker used in hostfile
+                  description: Defaults to the number of processing units per worker
+                  type: integer
+                  minimum: 1
+                gpusPerNode:
+                  title: The maximum number of GPUs available per node
+                  description: Defaults to the number of GPUs per worker
+                  type: integer
+                  minimum: 1
+              required:
+              - gpus
+            - properties:
+                processingUnits:
+                  title: Total number of processing units
+                  description: Valid values are 1, 2, 4, or any multiple of 8
+                  oneOf:
+                  - type: integer
+                    enum:
+                    - 1
+                    - 2
+                    - 4
+                  - type: integer
+                    multipleOf: 8
+                    minimum: 8
+                slotsPerWorker:
+                  title: The number of slots per worker used in hostfile
+                  description: Defaults to the number of processing units per worker
+                  type: integer
+                  minimum: 1
+                processingUnitsPerNode:
+                  title: The maximum number of processing units available per node
+                  description: Defaults to the number of processing units per worker
+                  type: integer
+                  minimum: 1
+                processingResourceType:
+                  title: The processing resource type, e.g. 'nvidia.com/gpu' or 'cpu'
+                  description: Defaults to 'nvidia.com/gpu'
+                  type: string
                   enum:
-                  - 1
-                  - 2
-                  - 4
-                - type: integer
-                  multipleOf: 8
-                  minimum: 8
-              slotsPerWorker:
-                title: The number of slots per worker used in hostfile
-                description: Defaults to the number of processing units per worker
-                type: integer
-                minimum: 1
-              gpusPerNode:
-                title: The maximum number of GPUs available per node
-                description: Defaults to the number of GPUs per worker
-                type: integer
-                minimum: 1
-            required:
-            - gpus
-          - properties:
-              processingUnits:
-                title: Total number of processing units
-                description: Valid values are 1, 2, 4, or any multiple of 8
-                oneOf:
-                - type: integer
+                  - nvidia.com/gpu
+                  - cpu
+              required:
+              - processingUnits
+            - properties:
+                replicas:
+                  title: Total number of replicas
+                  description: The processing resource limit should be specified for each replica
+                  type: integer
+                  minimum: 1
+                slotsPerWorker:
+                  title: The number of slots per worker used in hostfile
+                  description: Defaults to the number of processing units per worker
+                  type: integer
+                  minimum: 1
+                processingResourceType:
+                  title: The processing resource type, e.g. 'nvidia.com/gpu' or 'cpu'
+                  description: Defaults to 'nvidia.com/gpu'
+                  type: string
                   enum:
-                  - 1
-                  - 2
-                  - 4
-                - type: integer
-                  multipleOf: 8
-                  minimum: 8
+                  - nvidia.com/gpu
+                  - cpu
+              required:
+              - replicas
+  - name: v1alpha2
+    served: true
+    storage: false
+    schema:
+      openAPIV3Schema:
+        properties:
+          spec:
+            properties:
               slotsPerWorker:
-                title: The number of slots per worker used in hostfile
-                description: Defaults to the number of processing units per worker
                 type: integer
                 minimum: 1
-              processingUnitsPerNode:
-                title: The maximum number of processing units available per node
-                description: Defaults to the number of processing units per worker
-                type: integer
-                minimum: 1
-              processingResourceType:
-                title: The processing resource type, e.g. 'nvidia.com/gpu' or 'cpu'
-                description: Defaults to 'nvidia.com/gpu'
-                type: string
-                enum:
-                - nvidia.com/gpu
-                - cpu
-            required:
-            - processingUnits
-          - properties:
-              replicas:
-                title: Total number of replicas
-                description: The processing resource limit should be specified for each replica
-                type: integer
-                minimum: 1
+              mpiReplicaSpecs:
+                properties:
+                  Launcher:
+                    properties:
+                      replicas:
+                        type: integer
+                        minimum: 1
+                        maximum: 1
+                  Worker:
+                    properties:
+                      replicas:
+                        type: integer
+                        minimum: 1
+  - name: v1
+    served: true
+    storage: true
+    schema:
+      openAPIV3Schema:
+        properties:
+          spec:
+            properties:
               slotsPerWorker:
-                title: The number of slots per worker used in hostfile
-                description: Defaults to the number of processing units per worker
                 type: integer
                 minimum: 1
-              processingResourceType:
-                title: The processing resource type, e.g. 'nvidia.com/gpu' or 'cpu'
-                description: Defaults to 'nvidia.com/gpu'
-                type: string
-                enum:
-                - nvidia.com/gpu
-                - cpu
-            required:
-            - replicas
+              mpiReplicaSpecs:
+                properties:
+                  Launcher:
+                    properties:
+                      replicas:
+                        type: integer
+                        minimum: 1
+                        maximum: 1
+                  Worker:
+                    properties:
+                      replicas:
+                        type: integer
+                        minimum: 1

--- a/mpi-job/mpi-operator/base/deployment.yaml
+++ b/mpi-job/mpi-operator/base/deployment.yaml
@@ -16,11 +16,12 @@ spec:
     spec:
       containers:
       - args:
-        - --gpus-per-node
-        - "8"
+        - -alsologtostderr
+        - --lock-namespace
+        - $(lock-namespace)
         - --kubectl-delivery-image
         - $(kubectl-delivery-image)
-        image: mpioperator/mpi-operator:0.1.0
+        image: mpioperator/mpi-operator:latest
         imagePullPolicy: Always
         name: mpi-operator
       serviceAccountName: mpi-operator

--- a/mpi-job/mpi-operator/base/kustomization.yaml
+++ b/mpi-job/mpi-operator/base/kustomization.yaml
@@ -12,10 +12,11 @@ commonLabels:
 images:
 - name: mpioperator/mpi-operator
   newName: mpioperator/mpi-operator
-  newTag: 0.1.0
+  newTag: latest
 configMapGenerator:
 - name: mpi-operator-config
-  env: params.env
+  envs:
+  - params.env
 generatorOptions:
   disableNameSuffixHash: true
 vars:
@@ -26,3 +27,10 @@ vars:
     apiVersion: v1
   fieldref:
     fieldpath: data.kubectl-delivery-image
+- name: lock-namespace
+  objref:
+    kind: ConfigMap
+    name: mpi-operator-config
+    apiVersion: v1
+  fieldref:
+    fieldpath: data.lock-namespace

--- a/mpi-job/mpi-operator/base/params.env
+++ b/mpi-job/mpi-operator/base/params.env
@@ -1,1 +1,2 @@
 kubectl-delivery-image=mpioperator/kubectl-delivery:latest
+lock-namespace=kubeflow

--- a/mpi-job/mpi-operator/overlays/application/application.yaml
+++ b/mpi-job/mpi-operator/overlays/application/application.yaml
@@ -10,7 +10,7 @@ spec:
       app.kubernetes.io/managed-by: kfctl
       app.kubernetes.io/component: mpijob
       app.kubernetes.io/part-of: kubeflow
-      app.kubernetes.io/version: v0.7
+      app.kubernetes.io/version: v1.0
   componentKinds:
   - group: apps
     kind: Deployment
@@ -20,7 +20,7 @@ spec:
     kind: MPIJob
   descriptor:
     type: "mpi-operator"
-    version: "v1alpha1"
+    version: "v1"
     description: "Mpi-operator allows users to create and manage the \"MPIJob\" custom resource."
     maintainers:
     - name: Rong Ou

--- a/mpi-job/mpi-operator/overlays/application/kustomization.yaml
+++ b/mpi-job/mpi-operator/overlays/application/kustomization.yaml
@@ -10,4 +10,4 @@ commonLabels:
   app.kubernetes.io/managed-by: kfctl
   app.kubernetes.io/component: mpijob
   app.kubernetes.io/part-of: kubeflow
-  app.kubernetes.io/version: v0.7
+  app.kubernetes.io/version: v1.0


### PR DESCRIPTION
Signed-off-by: Abhilash Pallerlamudi <stp.abhi@gmail.com>

**Which issue is resolved by this Pull Request:**
Resolves https://github.com/kubeflow/mpi-operator/issues/227.

**Description of your changes:**
This PR upgrades mpi-operator manifests to v1

**Checklist:**
- [x] Unit tests have been rebuilt: 
    1. `cd manifests/tests`
    2. `make generate-changed-only`
    3. `make test`
