### PR TITLE
Allow to specify paths to different Python and Kustomize binary

### DIFF
--- a/hack/generate_tests.py
+++ b/hack/generate_tests.py
@@ -1,4 +1,3 @@
-#!/usr/bin/python
 """Regenerate tests for only the files that have changed."""
 
 import argparse
@@ -58,7 +57,7 @@ def run_kustomize_build(repo_root, package_dir):
   logging.info("Creating directory %s", output_dir)
   os.makedirs(output_dir)
 
-  subprocess.check_call(["kustomize", "build", "--load_restrictor", "none",
+  subprocess.check_call([os.environ.get("KUSTOMIZE_BIN", "kustomize"), "build", "--load_restrictor", "none",
                          "-o", output_dir], cwd=os.path.join(repo_root,
                                                              package_dir))
 def find_kustomize_dirs(search_dirs):

--- a/tests/Makefile
+++ b/tests/Makefile
@@ -14,6 +14,8 @@
 #
 GOLANG_VERSION ?= 1.12.4
 GOPATH ?= $(HOME)/go
+PYTHON_BIN ?= python
+export KUSTOMIZE_BIN ?= kustomize
 
 # Comma seperated items within {} for more than one file
 # EXCLUDE ?= istio-install-base_test.go
@@ -24,11 +26,11 @@ export GO = go
 all: test
 
 generate: clean
-	../hack/generate_tests.py --all || echo done
+	$(PYTHON_BIN) ../hack/generate_tests.py --all || echo done
 	$(GO) fmt ./...
 
 generate-changed-only:
-	../hack/generate_tests.py || echo done
+	$(PYTHON_BIN) ../hack/generate_tests.py || echo done
 	$(GO) fmt ./...
 
 modules:


### PR DESCRIPTION
Signed-off-by: terrytangyuan <terrytangyuan@gmail.com>

**Which issue is resolved by this Pull Request:**
Resolves #

**Description of your changes:**

This allows users to specify paths to different Python and Kustomize binary in case they want to test out using different versions of Python or Kustomize.

**Checklist:**
- [x] Unit tests have been rebuilt: 
    1. `cd manifests/tests`
    2. `make generate-changed-only`
    3. `make test`
