### PR TITLE
Fix certmanager race condition and version numbers.

### DIFF
--- a/cert-manager/cert-manager/kubeflow-issuer/kustomization.yaml
+++ b/cert-manager/cert-manager/kubeflow-issuer/kustomization.yaml
@@ -1,0 +1,6 @@
+# Define the self-signed issuer for Kubeflow
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+namespace: cert-manager
+resources:
+- ../overlays/self-signed/cluster-issuer.yaml 

--- a/cert-manager/cert-manager/overlays/application/application.yaml
+++ b/cert-manager/cert-manager/overlays/application/application.yaml
@@ -6,11 +6,10 @@ spec:
   selector:
     matchLabels:
       app.kubernetes.io/name: cert-manager
-      app.kubernetes.io/instance: cert-manager-v0.7.0
+      app.kubernetes.io/instance: cert-manager
       app.kubernetes.io/managed-by: kfctl
       app.kubernetes.io/component: cert-manager
-      app.kubernetes.io/part-of: kubeflow
-      app.kubernetes.io/version: v0.7.0
+      app.kubernetes.io/part-of: kubeflow      
   componentKinds:
   - group: rbac
     kind: ClusterRole

--- a/cert-manager/cert-manager/overlays/application/kustomization.yaml
+++ b/cert-manager/cert-manager/overlays/application/kustomization.yaml
@@ -8,8 +8,8 @@ configurations:
 - params.yaml
 commonLabels:
   app.kubernetes.io/name: cert-manager
-  app.kubernetes.io/instance: cert-manager-v0.7.0
+  app.kubernetes.io/instance: cert-manager
   app.kubernetes.io/managed-by: kfctl
   app.kubernetes.io/component: cert-manager
   app.kubernetes.io/part-of: kubeflow
-  app.kubernetes.io/version: v0.7.0
+  

--- a/cert-manager/cert-manager/overlays/self-signed/kustomization.yaml
+++ b/cert-manager/cert-manager/overlays/self-signed/kustomization.yaml
@@ -1,3 +1,6 @@
+# TODO(https://github.com/kubeflow/manifests/issues/1052) clean up 
+# the manifests after the refactor is done. We should move
+# cluster-issuer into the kubeflow-issuer package.
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 bases:

--- a/cert-manager/cert-manager/v3/kustomization.yaml
+++ b/cert-manager/cert-manager/v3/kustomization.yaml
@@ -5,11 +5,9 @@ kind: Kustomization
 namespace: cert-manager
 commonLabels:
   app.kubernetes.io/name: cert-manager
-  app.kubernetes.io/instance: cert-manager-v0.7.0
+  app.kubernetes.io/instance: cert-manager
   app.kubernetes.io/managed-by: kfctl
   app.kubernetes.io/component: cert-manager
-  app.kubernetes.io/part-of: kubeflow
-  app.kubernetes.io/version: v0.7.0
+  app.kubernetes.io/part-of: kubeflow  
 resources:
-- ../overlays/self-signed
 - ../overlays/application/application.yaml

--- a/tests/tests/legacy_kustomizations/cert-manager/test_data/expected/app.k8s.io_v1beta1_application_cert-manager.yaml
+++ b/tests/tests/legacy_kustomizations/cert-manager/test_data/expected/app.k8s.io_v1beta1_application_cert-manager.yaml
@@ -38,8 +38,7 @@ spec:
   selector:
     matchLabels:
       app.kubernetes.io/component: cert-manager
-      app.kubernetes.io/instance: cert-manager-v0.7.0
+      app.kubernetes.io/instance: cert-manager
       app.kubernetes.io/managed-by: kfctl
       app.kubernetes.io/name: cert-manager
       app.kubernetes.io/part-of: kubeflow
-      app.kubernetes.io/version: v0.7.0


### PR DESCRIPTION
* To fix the race condition with certmanager (#1121) we move the KF
  issuer into a separate package from the package deploying kubeflow.
  This way we can wait for cert-manager to start before deploying resources.

* Labels need to be immutable otherwise upgrades won't work (see #1131).
  So remove version number from common labels and application selector
  so that apply will work to update resources.
