### PR TITLE
Standardize names for management blueprint.

### DIFF
--- a/gcp/v2/management/cluster/cluster.yaml
+++ b/gcp/v2/management/cluster/cluster.yaml
@@ -12,7 +12,7 @@ spec: {}
 apiVersion: container.cnrm.cloud.google.com/v1alpha2
 kind: ContainerCluster
 metadata:
-  name: cluster-name # {"type":"string","x-kustomize":{"setter":{"name":"cluster-name","value":"cluster-name"}}}
+  name: cluster-name # {"type":"string","x-kustomize":{"setter":{"name":"name","value":"cluster-name"}}}
 spec:
   # Use a regional cluster. Regional offer higher availability and the cluster management fee is the same.
   location: us-central1-f

--- a/gcp/v2/management/cluster/nodepool.yaml
+++ b/gcp/v2/management/cluster/nodepool.yaml
@@ -1,9 +1,8 @@
 apiVersion: container.cnrm.cloud.google.com/v1alpha2
 kind: ContainerNodePool
 metadata:
-  clusterName: "project-id/us-central1-f/cluster-name" # {"type":"string","x-kustomize":{"partialSetters":[{"name":"gcloud.core.project","value":"project-id"},{"name":"cluster-name","value":"cluster-name"},{"name":"gcloud.compute.zone","value":"us-central1-f"}]}}
-  name: default-pool
-  namespace: "project-id" # {"type":"string","x-kustomize":{"setter":{"name":"gcloud.core.project","value":"project-id"}}}
+  clusterName: "project-id/us-central1-f/cluster-name" # {"type":"string","x-kustomize":{"partialSetters":[{"name":"gcloud.core.project","value":"project-id"},{"name":"name","value":"cluster-name"},{"name":"location","value":"us-central1-f"}]}}
+  name: cluster-name-pool  # {"type":"string","x-kustomize":{"partialSetters":[{"name":"gcloud.core.project","value":"project-id"},{"name":"name","value":"cluster-name"},{"name":"location","value":"us-central1-f"}]}}
 spec:
   autoscaling:
     minNodeCount: 1
@@ -26,4 +25,4 @@ spec:
     autoRepair: true
     autoUpgrade: true
   clusterRef:
-    name: cluster-name # {"type":"string","x-kustomize":{"setter":{"name":"cluster-name","value":"cluster-name"}}}
+    name: cluster-name # {"type":"string","x-kustomize":{"setter":{"name":"name","value":"cluster-name"}}}


### PR DESCRIPTION
* Use name; not cluster-name
* Use location; not zone

* Fix the nodepool otherwise anthoscli will give an error.