### PR TITLE
Add support for AWS JupyterNotebook Image

### DIFF
--- a/jupyter/jupyter-web-app/overlays/aws/kustomization.yaml
+++ b/jupyter/jupyter-web-app/overlays/aws/kustomization.yaml
@@ -1,0 +1,9 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+- ../../base
+configMapGenerator:
+- name: jupyter-web-app-config
+  behavior: replace
+  files:
+  - spawner_ui_config.yaml

--- a/jupyter/jupyter-web-app/overlays/aws/spawner_ui_config.yaml
+++ b/jupyter/jupyter-web-app/overlays/aws/spawner_ui_config.yaml
@@ -1,0 +1,132 @@
+# Configuration file for the Jupyter UI.
+#
+# Each Jupyter UI option is configured by two keys: 'value' and 'readOnly'
+# - The 'value' key contains the default value
+# - The 'readOnly' key determines if the option will be available to users
+#
+# If the 'readOnly' key is present and set to 'true', the respective option
+# will be disabled for users and only set by the admin. Also when a
+# Notebook is POSTED to the API if a necessary field is not present then
+# the value from the config will be used.
+#
+# If the 'readOnly' key is missing (defaults to 'false'), the respective option
+# will be available for users to edit.
+#
+# Note that some values can be templated. Such values are the names of the
+# Volumes as well as their StorageClass
+spawnerFormDefaults:
+  image:
+    # The container Image for the user's Jupyter Notebook
+    # If readonly, this value must be a member of the list below
+    value: 527798164940.dkr.ecr.us-west-2.amazonaws.com/tensorflow-1.15.2-notebook-cpu:1.0.0
+    # The list of available standard container Images
+    options:
+      - 527798164940.dkr.ecr.us-west-2.amazonaws.com/tensorflow-1.15.2-notebook-cpu:1.0.0
+      - 527798164940.dkr.ecr.us-west-2.amazonaws.com/tensorflow-1.15.2-notebook-gpu:1.0.0
+      - 527798164940.dkr.ecr.us-west-2.amazonaws.com/tensorflow-2.1.0-notebook-cpu:1.0.0
+      - 527798164940.dkr.ecr.us-west-2.amazonaws.com/tensorflow-2.1.0-notebook-gpu:1.0.0
+      - gcr.io/kubeflow-images-public/tensorflow-1.15.2-notebook-cpu:1.0.0
+      - gcr.io/kubeflow-images-public/tensorflow-1.15.2-notebook-gpu:1.0.0
+      - gcr.io/kubeflow-images-public/tensorflow-2.1.0-notebook-cpu:1.0.0
+      - gcr.io/kubeflow-images-public/tensorflow-2.1.0-notebook-gpu:1.0.0
+    # By default, custom container Images are allowed
+    # Uncomment the following line to only enable standard container Images
+    readOnly: false
+  cpu:
+    # CPU for user's Notebook
+    value: '0.5'
+    readOnly: false
+  memory:
+    # Memory for user's Notebook
+    value: 1.0Gi
+    readOnly: false
+  workspaceVolume:
+    # Workspace Volume to be attached to user's Notebook
+    # Each Workspace Volume is declared with the following attributes:
+    # Type, Name, Size, MountPath and Access Mode
+    value:
+      type:
+        # The Type of the Workspace Volume
+        # Supported values: 'New', 'Existing'
+        value: New
+      name:
+        # The Name of the Workspace Volume
+        # Note that this is a templated value. Special values:
+        # {notebook-name}: Replaced with the name of the Notebook. The frontend
+        #                  will replace this value as the user types the name
+        value: 'workspace-{notebook-name}'
+      size:
+        # The Size of the Workspace Volume (in Gi)
+        value: '10Gi'
+      mountPath:
+        # The Path that the Workspace Volume will be mounted
+        value: /home/jovyan
+      accessModes:
+        # The Access Mode of the Workspace Volume
+        # Supported values: 'ReadWriteOnce', 'ReadWriteMany', 'ReadOnlyMany'
+        value: ReadWriteOnce
+      class:
+        # The StrageClass the PVC will use if type is New. Special values are:
+        # {none}: default StorageClass
+        # {empty}: empty string ""
+        value: '{none}'
+    readOnly: false
+  dataVolumes:
+    # List of additional Data Volumes to be attached to the user's Notebook
+    value: []
+    # Each Data Volume is declared with the following attributes:
+    # Type, Name, Size, MountPath and Access Mode
+    #
+    # For example, a list with 2 Data Volumes:
+    # value:
+    #   - value:
+    #       type:
+    #         value: New
+    #       name:
+    #         value: '{notebook-name}-vol-1'
+    #       size:
+    #         value: '10Gi'
+    #       class:
+    #         value: standard
+    #       mountPath:
+    #         value: /home/jovyan/vol-1
+    #       accessModes:
+    #         value: ReadWriteOnce
+    #       class:
+    #         value: {none}
+    #   - value:
+    #       type:
+    #         value: New
+    #       name:
+    #         value: '{notebook-name}-vol-2'
+    #       size:
+    #         value: '10Gi'
+    #       mountPath:
+    #         value: /home/jovyan/vol-2
+    #       accessModes:
+    #         value: ReadWriteMany
+    #       class:
+    #         value: {none}
+    readOnly: false
+  gpus:
+    # Number of GPUs to be assigned to the Notebook Container
+    value:
+      # values: "none", "1", "2", "4", "8"
+      num: "none"
+      # Determines what the UI will show and send to the backend
+      vendors:
+        - limitsKey: "nvidia.com/gpu"
+          uiName: "NVIDIA"
+      # Values: "" or a `limits-key` from the vendors list
+      vendor: ""
+    readOnly: false
+  shm:
+    value: true
+    readOnly: false
+  configurations:
+    # List of labels to be selected, these are the labels from PodDefaults
+    # value:
+    #   - add-gcp-secret
+    #   - default-editor
+    value: []
+    readOnly: false

--- a/kfdef/kfctl_aws.yaml
+++ b/kfdef/kfctl_aws.yaml
@@ -130,6 +130,7 @@ spec:
       overlays:
       - istio
       - application
+      - aws
       parameters:
       - name: userid-header
         value: kubeflow-userid

--- a/kfdef/kfctl_aws_cognito.yaml
+++ b/kfdef/kfctl_aws_cognito.yaml
@@ -125,6 +125,7 @@ spec:
       overlays:
       - istio
       - application
+      - aws
       parameters:
       - name: userid-header
         value: kubeflow-userid

--- a/kfdef/source/master/kfctl_aws.yaml
+++ b/kfdef/source/master/kfctl_aws.yaml
@@ -130,6 +130,7 @@ spec:
       overlays:
       - istio
       - application
+      - aws
       parameters:
       - name: userid-header
         value: kubeflow-userid

--- a/kfdef/source/master/kfctl_aws_cognito.yaml
+++ b/kfdef/source/master/kfctl_aws_cognito.yaml
@@ -125,6 +125,7 @@ spec:
       overlays:
       - istio
       - application
+      - aws
       parameters:
       - name: userid-header
         value: kubeflow-userid


### PR DESCRIPTION
**Which issue is resolved by this Pull Request:**
Resolves #1125 

AWS users require to have a by-default ECR image when creating JupyterNotebook Server. 

**Description of your changes:**
Add on overlay folder called `aws`, and create `kustomization.yaml` and `configmap_patch.yaml` files to patch the jupyter-web-app's configmap with AWS ECR Container image.

**Checklist:**
- [x] Unit tests have been rebuilt: 
    1. `cd manifests/tests`
    2. `make generate-changed-only`
    3. `make test`