### PR TITLE
Update applications overlays for aws components

### DIFF
--- a/aws/aws-efs-csi-driver/overlays/application/application.yaml
+++ b/aws/aws-efs-csi-driver/overlays/application/application.yaml
@@ -1,0 +1,36 @@
+apiVersion: app.k8s.io/v1beta1
+kind: Application
+metadata:
+  name: aws-efs-csi-driver
+spec:
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: aws-efs-csi-driver
+      app.kubernetes.io/instance: aws-efs-csi-driver-v1.0.0
+      app.kubernetes.io/managed-by: kfctl
+      app.kubernetes.io/component: aws-efs-csi-driver
+      app.kubernetes.io/part-of: kubeflow
+      app.kubernetes.io/version: v1.0.0
+  componentKinds:
+  - group: apps
+    kind: DaemonSet
+  - group: storage
+    kind: CSIDriver
+  descriptor:
+    type: aws-efs-csi-driver
+    version: v0.3.0
+    description: The Amazon EFS Container Storage Interface (CSI) driver provides a CSI interface that allows Amazon EKS clusters to manage the lifecycle of Amazon EFS file systems.
+    maintainers:
+    - name: Jiaxin Shan
+      email: shjiaxin@amazon.com
+    owners:
+    - name: Jiaxin Shan
+      email: shjiaxin@amazon.com
+    keywords:
+     - aws
+     - kubeflow
+    links:
+    - description: About
+      url: https://github.com/kubernetes-sigs/aws-efs-csi-driver
+  addOwnerRef: true
+

--- a/aws/aws-efs-csi-driver/overlays/application/kustomization.yaml
+++ b/aws/aws-efs-csi-driver/overlays/application/kustomization.yaml
@@ -1,0 +1,7 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+commonLabels:
+  app.kubernetes.io/component: aws-efs-csi-driver
+  app.kubernetes.io/name: aws-efs-csi-driver
+kind: Kustomization
+resources:
+- application.yaml

--- a/aws/aws-fsx-csi-driver/overlays/application/application.yaml
+++ b/aws/aws-fsx-csi-driver/overlays/application/application.yaml
@@ -1,0 +1,44 @@
+apiVersion: app.k8s.io/v1beta1
+kind: Application
+metadata:
+  name: aws-fsx-csi-driver
+spec:
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: aws-fsx-csi-driver
+      app.kubernetes.io/instance: aws-fsx-csi-driver-v1.0.0
+      app.kubernetes.io/managed-by: kfctl
+      app.kubernetes.io/component: aws-fsx-csi-driver
+      app.kubernetes.io/part-of: kubeflow
+      app.kubernetes.io/version: v1.0.0
+  componentKinds:
+  - group: apps
+    kind: Deployment
+  - group: apps
+    kind: DaemonSet
+  - group: storage
+    kind: CSIDriver
+  - group: core
+    kind: ServiceAccount
+  - group: rbac
+    kind: ClusterRoleBinding
+  - group: rbac
+    kind: ClusterRole
+  descriptor:
+    type: aws-efs-csi-driver
+    version: v0.3.0
+    description: The Amazon FSx for Lustre Container Storage Interface (CSI) driver provides a CSI interface that allows Amazon EKS clusters to manage the lifecycle of Amazon FSx for Lustre file systems.
+    maintainers:
+    - name: Jiaxin Shan
+      email: shjiaxin@amazon.com
+    owners:
+    - name: Jiaxin Shan
+      email: shjiaxin@amazon.com
+    keywords:
+     - aws
+     - kubeflow
+    links:
+    - description: About
+      url: https://github.com/kubernetes-sigs/aws-fsx-csi-driver
+  addOwnerRef: true
+

--- a/aws/aws-fsx-csi-driver/overlays/application/kustomization.yaml
+++ b/aws/aws-fsx-csi-driver/overlays/application/kustomization.yaml
@@ -1,0 +1,7 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+commonLabels:
+  app.kubernetes.io/component: aws-fsx-csi-driver
+  app.kubernetes.io/name: aws-fsx-csi-driver
+kind: Kustomization
+resources:
+- application.yaml

--- a/aws/aws-istio-authz-adaptor/overlays/application/application.yaml
+++ b/aws/aws-istio-authz-adaptor/overlays/application/application.yaml
@@ -6,11 +6,11 @@ spec:
   selector:
     matchLabels:
       app.kubernetes.io/name: aws-istio-authz-adaptor
-      app.kubernetes.io/instance: aws-istio-authz-adaptor-0.1
+      app.kubernetes.io/instance: aws-istio-authz-adaptor-v1.0.0
       app.kubernetes.io/managed-by: kfctl
       app.kubernetes.io/component: aws-istio-authz-adaptor
       app.kubernetes.io/part-of: kubeflow
-      app.kubernetes.io/version: "0.1"
+      app.kubernetes.io/version: v1.0.0
   componentKinds:
   - group: apps
     kind: Service
@@ -18,10 +18,14 @@ spec:
     kind: Deployment
   descriptor:
     type: aws-istio-authz-adaptor
-    version: "0.1"
+    version: v0.1
     description: Authorization adpator to append header for AWS application load balancer
-    maintainers: []
-    owners: []
+    maintainers:
+      - name: Jiaxin Shan
+        email: shjiaxin@amazon.com
+      owners:
+      - name: Jiaxin Shan
+        email: shjiaxin@amazon.com
     keywords:
      - aws
      - istio

--- a/aws/fluentd-cloud-watch/overlays/application/application.yaml
+++ b/aws/fluentd-cloud-watch/overlays/application/application.yaml
@@ -1,25 +1,27 @@
 apiVersion: app.k8s.io/v1beta1
 kind: Application
 metadata:
-  name: aws-alb-ingress-controller
+  name: aws-fluentd-cloud-watch
 spec:
   selector:
     matchLabels:
-      app.kubernetes.io/name: aws-alb-ingress-controller
-      app.kubernetes.io/instance: aws-alb-ingress-controller-v1.0.0
+      app.kubernetes.io/name: aws-fluentd-cloud-watch
+      app.kubernetes.io/instance: aws-fluentd-cloud-watch-v1.0.0
       app.kubernetes.io/managed-by: kfctl
-      app.kubernetes.io/component: aws-alb-ingress-controller
+      app.kubernetes.io/component: aws-fluentd-cloud-watch
       app.kubernetes.io/part-of: kubeflow
       app.kubernetes.io/version: v1.0.0
   componentKinds:
   - group: apps
-    kind: Deployment
+    kind: DaemonSet
+  - group: core
+    kind: ConfigMap
   - group: core
     kind: ServiceAccount
   descriptor:
-    type: aws-alb-ingress-controller
-    version: v1beta1
-    description: Application Load Balancer (ALB) Ingress Controller Deployment Manifest provides sensible defaults for deploying an ALB Ingress Controller
+    type: aws-fluentd-cloud-watch
+    version: v1.7.3-debian-cloudwatch-1.0
+    description: A Fluentd DaemonSet which collects logs from Kubenertes and ship to CloudWatch.
     maintainers:
     - name: Jiaxin Shan
       email: shjiaxin@amazon.com
@@ -28,9 +30,10 @@ spec:
       email: shjiaxin@amazon.com
     keywords:
      - aws
+     - logs
      - kubeflow
     links:
     - description: About
-      url: https://github.com/kubernetes-sigs/aws-alb-ingress-controller
+      url: https://github.com/fluent/fluentd-kubernetes-daemonset
   addOwnerRef: true
 

--- a/aws/fluentd-cloud-watch/overlays/application/kustomization.yaml
+++ b/aws/fluentd-cloud-watch/overlays/application/kustomization.yaml
@@ -1,0 +1,7 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+commonLabels:
+  app.kubernetes.io/component: aws-fluentd-cloud-watch
+  app.kubernetes.io/name: aws-fluentd-cloud-watch
+kind: Kustomization
+resources:
+- application.yaml

--- a/aws/nvidia-device-plugin/overlays/application/application.yaml
+++ b/aws/nvidia-device-plugin/overlays/application/application.yaml
@@ -1,16 +1,16 @@
 apiVersion: app.k8s.io/v1beta1
 kind: Application
 metadata:
-  name: nvidia-device-plugin
+  name: aws-nvidia-device-plugin
 spec:
   selector:
     matchLabels:
-      app.kubernetes.io/name: nvidia-device-plugin
-      app.kubernetes.io/instance: nvidia-device-plugin-1.0.0-beta
+      app.kubernetes.io/name: aws-nvidia-device-plugin
+      app.kubernetes.io/instance: nvidia-device-plugin-v1.0.0
       app.kubernetes.io/managed-by: kfctl
-      app.kubernetes.io/component: nvidia-device-plugin
+      app.kubernetes.io/component: aws-nvidia-device-plugin
       app.kubernetes.io/part-of: kubeflow
-      app.kubernetes.io/version: v1.0.0-beta
+      app.kubernetes.io/version: v1.0.0
   componentKinds:
   - group: core
     kind: ConfigMap
@@ -18,10 +18,14 @@ spec:
     kind: DaemonSet
   descriptor:
     type: nvidia-device-plugin
-    version: v1beta1
-    description: Nvidia Device Plugin for aws
-    maintainers: []
-    owners: []
+    version: v1.0.0-beta
+    description: Nvidia Device Plugin for GPU nodes
+    maintainers:
+      - name: Jiaxin Shan
+        email: shjiaxin@amazon.com
+      owners:
+      - name: Jiaxin Shan
+        email: shjiaxin@amazon.com
     keywords:
      - aws
      - nvidia

--- a/aws/nvidia-device-plugin/overlays/application/kustomization.yaml
+++ b/aws/nvidia-device-plugin/overlays/application/kustomization.yaml
@@ -2,8 +2,8 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 bases:
 - ../../base
 commonLabels:
-  app.kubernetes.io/component: nvidia-device-plugin
-  app.kubernetes.io/name: nvidia-device-plugin
+  app.kubernetes.io/component: aws-nvidia-device-plugin
+  app.kubernetes.io/name: aws-nvidia-device-plugin
 kind: Kustomization
 resources:
 - application.yaml


### PR DESCRIPTION
Signed-off-by: Jiaxin Shan <seedjeffwan@gmail.com>

**Which issue is resolved by this Pull Request:**
Resolves #

In progress of moving to v3 compatible manifest, I'd like to submit this as independent changes.


**Description of your changes:**
Add and update application overlays for aws components.

**Checklist:**
- [x] Unit tests have been rebuilt: 
    1. `cd manifests/tests`
    2. `make generate-changed-only`
    3. `make test`
