### PR TITLE
Correct MPIJob CRD's apiVersion

### DIFF
--- a/mpi-job/mpi-operator/base/crd.yaml
+++ b/mpi-job/mpi-operator/base/crd.yaml
@@ -1,4 +1,4 @@
-apiVersion: apiextensions.k8s.io/v1
+apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
 metadata:
   name: mpijobs.kubeflow.org


### PR DESCRIPTION
Signed-off-by: terrytangyuan <terrytangyuan@gmail.com>

**Which issue is resolved by this Pull Request:**
Resolves #1166

/cc @apryiomka @stpabhi

**Description of your changes:**

Fixes the following issue:
```
time="2020-05-14T22:16:48Z" level=warning msg="Encountered error applying application mpi-operator: (kubeflow.error): Code 500 with message: Apply.Run Error unable to recognize "/tmp/kout844630924": no matches for kind "CustomResourceDefinition" in version "apiextensions.k8s.io/v1"" filename="kustomize/kustomize.go:202"
```

**Checklist:**
- [x] Unit tests have been rebuilt: 
    1. `cd manifests/tests`
    2. `make generate-changed-only`
    3. `make test`
