### PR TITLE
Fix formatting issue in aws/nvidia-device-plugin manifest

### DIFF
--- a/aws/nvidia-device-plugin/overlays/application/application.yaml
+++ b/aws/nvidia-device-plugin/overlays/application/application.yaml
@@ -23,7 +23,7 @@ spec:
     maintainers:
       - name: Jiaxin Shan
         email: shjiaxin@amazon.com
-      owners:
+    owners:
       - name: Jiaxin Shan
         email: shjiaxin@amazon.com
     keywords:


### PR DESCRIPTION
**Which issue is resolved by this Pull Request:**
Resolves #1166
cc @apryiomka
/cc @Jeffwan 

**Description of your changes:**

Fixes the following error:
```
Error: failed to apply: (kubeflow.error): Code 500 with message: kfApp Apply failed for kustomize: (kubeflow.error): Code 500 with message: error evaluating kustomization manifest for nvidia-device-plugin Error accumulating resources: accumulating resources from 'overlays/application/application.yaml': YAML file [overlays/application/application.yaml] encounters a format error.
error converting YAML to JSON: yaml: line 25: did not find expected '-' indicator
```

**Checklist:**
- [x] Unit tests have been rebuilt: 
    1. `cd manifests/tests`
    2. `make generate-changed-only`
    3. `make test`
