### PR TITLE
Use stable release channel for the GKE management cluster.

### DIFF
--- a/gcp/v2/management/cluster/cluster.yaml
+++ b/gcp/v2/management/cluster/cluster.yaml
@@ -21,7 +21,6 @@ spec:
   ipAllocationPolicy:
     useIpAliases: true
   releaseChannel:
-    # TODO(jlewi): Should we switch to a stable channel?
-    channel: RAPID
+    channel: stable
   clusterTelemetry:
     type: enabled


### PR DESCRIPTION
* Releated to kubeflow/gcp-blueprints#12
