### PR TITLE
CRDs should not have status field.

### DIFF
--- a/application/application-crds/base/crd.yaml
+++ b/application/application-crds/base/crd.yaml
@@ -231,9 +231,3 @@ spec:
               type: integer
           type: object
   version: v1beta1
-status:
-  acceptedNames:
-    kind: ""
-    plural: ""
-  conditions: []
-  storedVersions: []

--- a/aws/aws-istio-authz-adaptor/overlays/application/application.yaml
+++ b/aws/aws-istio-authz-adaptor/overlays/application/application.yaml
@@ -21,11 +21,11 @@ spec:
     version: v0.1
     description: Authorization adpator to append header for AWS application load balancer
     maintainers:
-      - name: Jiaxin Shan
-        email: shjiaxin@amazon.com
-      owners:
-      - name: Jiaxin Shan
-        email: shjiaxin@amazon.com
+    - name: Jiaxin Shan
+      email: shjiaxin@amazon.com
+    owners:
+    - name: Jiaxin Shan
+      email: shjiaxin@amazon.com
     keywords:
      - aws
      - istio

--- a/aws/nvidia-device-plugin/overlays/application/application.yaml
+++ b/aws/nvidia-device-plugin/overlays/application/application.yaml
@@ -21,11 +21,11 @@ spec:
     version: v1.0.0-beta
     description: Nvidia Device Plugin for GPU nodes
     maintainers:
-      - name: Jiaxin Shan
-        email: shjiaxin@amazon.com
-      owners:
-      - name: Jiaxin Shan
-        email: shjiaxin@amazon.com
+    - name: Jiaxin Shan
+      email: shjiaxin@amazon.com
+    owners:
+    - name: Jiaxin Shan
+      email: shjiaxin@amazon.com
     keywords:
      - aws
      - nvidia

--- a/cert-manager/cert-manager-crds/base/crd.yaml
+++ b/cert-manager/cert-manager-crds/base/crd.yaml
@@ -1367,12 +1367,6 @@ spec:
   - name: v1alpha2
     served: true
     storage: true
-status:
-  acceptedNames:
-    kind: ""
-    plural: ""
-  conditions: []
-  storedVersions: []
 
 ---
 apiVersion: apiextensions.k8s.io/v1beta1
@@ -1575,12 +1569,6 @@ spec:
   - name: v1alpha2
     served: true
     storage: true
-status:
-  acceptedNames:
-    kind: ""
-    plural: ""
-  conditions: []
-  storedVersions: []
 
 ---
 apiVersion: apiextensions.k8s.io/v1beta1
@@ -1764,12 +1752,6 @@ spec:
   - name: v1alpha2
     served: true
     storage: true
-status:
-  acceptedNames:
-    kind: ""
-    plural: ""
-  conditions: []
-  storedVersions: []
 
 ---
 
@@ -2008,12 +1990,6 @@ spec:
   - name: v1alpha2
     served: true
     storage: true
-status:
-  acceptedNames:
-    kind: ""
-    plural: ""
-  conditions: []
-  storedVersions: []
 
 ---
 
@@ -5336,9 +5312,3 @@ spec:
   - name: v1alpha2
     served: true
     storage: true
-status:
-  acceptedNames:
-    kind: ""
-    plural: ""
-  conditions: []
-  storedVersions: []

--- a/jupyter/notebook-controller/base/crd.yaml
+++ b/jupyter/notebook-controller/base/crd.yaml
@@ -62,10 +62,3 @@ spec:
           required:
           - conditions
           type: object
-status:
-  acceptedNames:
-    kind: ""
-    plural: ""
-  conditions: []
-  storedVersions: []
-

--- a/kfserving/kfserving-crds/base/crd.yaml
+++ b/kfserving/kfserving-crds/base/crd.yaml
@@ -605,9 +605,3 @@ spec:
               type: string
           type: object
   version: v1alpha2
-status:
-  acceptedNames:
-    kind: ""
-    plural: ""
-  conditions: []
-  storedVersions: []

--- a/profiles/base/crd.yaml
+++ b/profiles/base/crd.yaml
@@ -154,9 +154,3 @@ spec:
     - name: v1beta1
       served: true
       storage: false
-status:
-  acceptedNames:
-    kind: ""
-    plural: ""
-  conditions: []
-  storedVersions: []

--- a/spark/spark-operator/base/scheduledsparkapplications.sparkoperator.k8s.io-crd.yaml
+++ b/spark/spark-operator/base/scheduledsparkapplications.sparkoperator.k8s.io-crd.yaml
@@ -2544,9 +2544,3 @@ spec:
   - name: v1beta2
     served: true
     storage: true
-status:
-  acceptedNames:
-    kind: ""
-    plural: ""
-  conditions: []
-  storedVersions: []

--- a/spark/spark-operator/base/sparkapplications.sparkoperator.k8s.io-crd.yaml
+++ b/spark/spark-operator/base/sparkapplications.sparkoperator.k8s.io-crd.yaml
@@ -2526,9 +2526,3 @@ spec:
   - name: v1beta2
     served: true
     storage: true
-status:
-  acceptedNames:
-    kind: ""
-    plural: ""
-  conditions: []
-  storedVersions: []

--- a/tests/stacks/examples/alice_gcp/test_data/expected/apiextensions.k8s.io_v1beta1_customresourcedefinition_notebooks.kubeflow.org.yaml
+++ b/tests/stacks/examples/alice_gcp/test_data/expected/apiextensions.k8s.io_v1beta1_customresourcedefinition_notebooks.kubeflow.org.yaml
@@ -67,9 +67,3 @@ spec:
   - name: v1
     served: true
     storage: false
-status:
-  acceptedNames:
-    kind: ""
-    plural: ""
-  conditions: []
-  storedVersions: []

--- a/tests/stacks/examples/alice_gcp/test_data/expected/apiextensions.k8s.io_v1beta1_customresourcedefinition_profiles.kubeflow.org.yaml
+++ b/tests/stacks/examples/alice_gcp/test_data/expected/apiextensions.k8s.io_v1beta1_customresourcedefinition_profiles.kubeflow.org.yaml
@@ -156,9 +156,3 @@ spec:
   - name: v1beta1
     served: true
     storage: false
-status:
-  acceptedNames:
-    kind: ""
-    plural: ""
-  conditions: []
-  storedVersions: []

--- a/tests/stacks/gcp/test_data/expected/apiextensions.k8s.io_v1beta1_customresourcedefinition_notebooks.kubeflow.org.yaml
+++ b/tests/stacks/gcp/test_data/expected/apiextensions.k8s.io_v1beta1_customresourcedefinition_notebooks.kubeflow.org.yaml
@@ -67,9 +67,3 @@ spec:
   - name: v1
     served: true
     storage: false
-status:
-  acceptedNames:
-    kind: ""
-    plural: ""
-  conditions: []
-  storedVersions: []

--- a/tests/stacks/gcp/test_data/expected/apiextensions.k8s.io_v1beta1_customresourcedefinition_profiles.kubeflow.org.yaml
+++ b/tests/stacks/gcp/test_data/expected/apiextensions.k8s.io_v1beta1_customresourcedefinition_profiles.kubeflow.org.yaml
@@ -156,9 +156,3 @@ spec:
   - name: v1beta1
     served: true
     storage: false
-status:
-  acceptedNames:
-    kind: ""
-    plural: ""
-  conditions: []
-  storedVersions: []

--- a/tests/tests/legacy_kustomizations/application-crds/test_data/expected/apiextensions.k8s.io_v1beta1_customresourcedefinition_applications.app.k8s.io.yaml
+++ b/tests/tests/legacy_kustomizations/application-crds/test_data/expected/apiextensions.k8s.io_v1beta1_customresourcedefinition_applications.app.k8s.io.yaml
@@ -231,9 +231,3 @@ spec:
               type: integer
           type: object
   version: v1beta1
-status:
-  acceptedNames:
-    kind: ""
-    plural: ""
-  conditions: []
-  storedVersions: []

--- a/tests/tests/legacy_kustomizations/cert-manager-crds/test_data/expected/apiextensions.k8s.io_v1beta1_customresourcedefinition_certificaterequests.cert-manager.io.yaml
+++ b/tests/tests/legacy_kustomizations/cert-manager-crds/test_data/expected/apiextensions.k8s.io_v1beta1_customresourcedefinition_certificaterequests.cert-manager.io.yaml
@@ -179,9 +179,3 @@ spec:
   - name: v1alpha2
     served: true
     storage: true
-status:
-  acceptedNames:
-    kind: ""
-    plural: ""
-  conditions: []
-  storedVersions: []

--- a/tests/tests/legacy_kustomizations/cert-manager-crds/test_data/expected/apiextensions.k8s.io_v1beta1_customresourcedefinition_certificates.cert-manager.io.yaml
+++ b/tests/tests/legacy_kustomizations/cert-manager-crds/test_data/expected/apiextensions.k8s.io_v1beta1_customresourcedefinition_certificates.cert-manager.io.yaml
@@ -233,9 +233,3 @@ spec:
   - name: v1alpha2
     served: true
     storage: true
-status:
-  acceptedNames:
-    kind: ""
-    plural: ""
-  conditions: []
-  storedVersions: []

--- a/tests/tests/legacy_kustomizations/cert-manager-crds/test_data/expected/apiextensions.k8s.io_v1beta1_customresourcedefinition_challenges.acme.cert-manager.io.yaml
+++ b/tests/tests/legacy_kustomizations/cert-manager-crds/test_data/expected/apiextensions.k8s.io_v1beta1_customresourcedefinition_challenges.acme.cert-manager.io.yaml
@@ -1367,9 +1367,3 @@ spec:
   - name: v1alpha2
     served: true
     storage: true
-status:
-  acceptedNames:
-    kind: ""
-    plural: ""
-  conditions: []
-  storedVersions: []

--- a/tests/tests/legacy_kustomizations/cert-manager-crds/test_data/expected/apiextensions.k8s.io_v1beta1_customresourcedefinition_issuers.cert-manager.io.yaml
+++ b/tests/tests/legacy_kustomizations/cert-manager-crds/test_data/expected/apiextensions.k8s.io_v1beta1_customresourcedefinition_issuers.cert-manager.io.yaml
@@ -1653,9 +1653,3 @@ spec:
   - name: v1alpha2
     served: true
     storage: true
-status:
-  acceptedNames:
-    kind: ""
-    plural: ""
-  conditions: []
-  storedVersions: []

--- a/tests/tests/legacy_kustomizations/cert-manager-crds/test_data/expected/apiextensions.k8s.io_v1beta1_customresourcedefinition_orders.acme.cert-manager.io.yaml
+++ b/tests/tests/legacy_kustomizations/cert-manager-crds/test_data/expected/apiextensions.k8s.io_v1beta1_customresourcedefinition_orders.acme.cert-manager.io.yaml
@@ -198,9 +198,3 @@ spec:
   - name: v1alpha2
     served: true
     storage: true
-status:
-  acceptedNames:
-    kind: ""
-    plural: ""
-  conditions: []
-  storedVersions: []

--- a/tests/tests/legacy_kustomizations/kfserving-crds/test_data/expected/apiextensions.k8s.io_v1beta1_customresourcedefinition_inferenceservices.serving.kubeflow.org.yaml
+++ b/tests/tests/legacy_kustomizations/kfserving-crds/test_data/expected/apiextensions.k8s.io_v1beta1_customresourcedefinition_inferenceservices.serving.kubeflow.org.yaml
@@ -611,9 +611,3 @@ spec:
               type: string
           type: object
   version: v1alpha2
-status:
-  acceptedNames:
-    kind: ""
-    plural: ""
-  conditions: []
-  storedVersions: []

--- a/tests/tests/legacy_kustomizations/notebook-controller/test_data/expected/apiextensions.k8s.io_v1beta1_customresourcedefinition_notebooks.kubeflow.org.yaml
+++ b/tests/tests/legacy_kustomizations/notebook-controller/test_data/expected/apiextensions.k8s.io_v1beta1_customresourcedefinition_notebooks.kubeflow.org.yaml
@@ -71,9 +71,3 @@ spec:
   - name: v1
     served: true
     storage: false
-status:
-  acceptedNames:
-    kind: ""
-    plural: ""
-  conditions: []
-  storedVersions: []

--- a/tests/tests/legacy_kustomizations/profiles/test_data/expected/apiextensions.k8s.io_v1beta1_customresourcedefinition_profiles.kubeflow.org.yaml
+++ b/tests/tests/legacy_kustomizations/profiles/test_data/expected/apiextensions.k8s.io_v1beta1_customresourcedefinition_profiles.kubeflow.org.yaml
@@ -162,9 +162,3 @@ spec:
   - name: v1beta1
     served: true
     storage: false
-status:
-  acceptedNames:
-    kind: ""
-    plural: ""
-  conditions: []
-  storedVersions: []

--- a/tests/tests/legacy_kustomizations/spark-operator/test_data/expected/apiextensions.k8s.io_v1beta1_customresourcedefinition_scheduledsparkapplications.sparkoperator.k8s.io.yaml
+++ b/tests/tests/legacy_kustomizations/spark-operator/test_data/expected/apiextensions.k8s.io_v1beta1_customresourcedefinition_scheduledsparkapplications.sparkoperator.k8s.io.yaml
@@ -2552,9 +2552,3 @@ spec:
   - name: v1beta2
     served: true
     storage: true
-status:
-  acceptedNames:
-    kind: ""
-    plural: ""
-  conditions: []
-  storedVersions: []

--- a/tests/tests/legacy_kustomizations/spark-operator/test_data/expected/apiextensions.k8s.io_v1beta1_customresourcedefinition_sparkapplications.sparkoperator.k8s.io.yaml
+++ b/tests/tests/legacy_kustomizations/spark-operator/test_data/expected/apiextensions.k8s.io_v1beta1_customresourcedefinition_sparkapplications.sparkoperator.k8s.io.yaml
@@ -2534,9 +2534,3 @@ spec:
   - name: v1beta2
     served: true
     storage: true
-status:
-  acceptedNames:
-    kind: ""
-    plural: ""
-  conditions: []
-  storedVersions: []

--- a/tests/validate_resources_test.go
+++ b/tests/validate_resources_test.go
@@ -102,9 +102,9 @@ func TestNoStatus(t *testing.T) {
 	// Directories to exclude. Thee paths should be relative to rootDir.
 	// Subdirectories won't be searched
 	excludes := map[string]bool{
-		"tests":   true,
-		".git":    true,
-		".github": true,
+		"tests":                  true,
+		".git":                   true,
+		".github":                true,
 		"profiles/overlays/test": true,
 		// Skip cnrm-install. We don't install this with ACM so we don't need to fix it.
 		// It seems like if this is an issue it should eventually get fixed in upstream cnrm configs.

--- a/tests/validate_resources_test.go
+++ b/tests/validate_resources_test.go
@@ -3,8 +3,10 @@ package tests
 import (
 	"github.com/ghodss/yaml"
 	"io/ioutil"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"os"
 	"path/filepath"
+	"regexp"
 	"sigs.k8s.io/kustomize/v3/pkg/types"
 	"testing"
 )
@@ -82,6 +84,73 @@ func TestCommonLabelsImmutable(t *testing.T) {
 			if _, ok := k.CommonLabels[l]; ok {
 				t.Errorf("%v has forbidden commonLabel %v", path, l)
 			}
+		}
+		return nil
+	})
+
+	if err != nil {
+		t.Errorf("error walking the path %v; error: %v", rootDir, err)
+
+	}
+}
+
+// TestNoStatus is a test to try to ensure we don't include status in resources
+// as this causes validation issues: https://github.com/kubeflow/manifests/issues/1174
+func TestNoStatus(t *testing.T) {
+	rootDir := ".."
+
+	// Directories to exclude. Thee paths should be relative to rootDir.
+	// Subdirectories won't be searched
+	excludes := map[string]bool{
+		"tests":   true,
+		".git":    true,
+		".github": true,
+		"profiles/overlays/test": true,
+		// Skip cnrm-install. We don't install this with ACM so we don't need to fix it.
+		// It seems like if this is an issue it should eventually get fixed in upstream cnrm configs.
+		"gcp/v2/management/cnrm-install": true,
+	}
+
+	err := filepath.Walk("..", func(path string, info os.FileInfo, err error) error {
+		relPath, err := filepath.Rel(rootDir, path)
+
+		if err != nil {
+			t.Fatalf("Could not compute relative path(%v, %v); error: %v", rootDir, path, err)
+		}
+
+		if _, ok := excludes[relPath]; ok {
+			return filepath.SkipDir
+		}
+
+		// skip directories
+		if info.IsDir() {
+			return nil
+		}
+
+		// Skip non YAML files
+		ext := filepath.Ext(info.Name())
+
+		if ext != ".yaml" && ext != ".yml" {
+			return nil
+		}
+		data, err := ioutil.ReadFile(path)
+
+		if err != nil {
+			t.Errorf("Error reading %v; error: %v", path, err)
+		}
+
+		u := &unstructured.Unstructured{}
+
+		if err = yaml.Unmarshal(data, u); err != nil {
+			if match, _ := regexp.MatchString(".*Object 'Kind' is missing.*", err.Error()); match {
+				t.Logf("Skipping %v; not a K8s resource;", path)
+				return nil
+			}
+			t.Errorf("Error unmarshaling %v; error: %v", path, err)
+		}
+
+		if _, ok := u.UnstructuredContent()["status"]; ok {
+			t.Errorf("Path %v; has status field", path)
 		}
 		return nil
 	})

--- a/xgboost-job/xgboost-operator/base/crd.yaml
+++ b/xgboost-job/xgboost-operator/base/crd.yaml
@@ -119,9 +119,3 @@ spec:
           - replicaStatuses
           type: object
   version: v1alpha1
-status:
-  acceptedNames:
-    kind: ""
-    plural: ""
-  conditions: []
-  storedVersions: []


### PR DESCRIPTION
* kubeflow/manifests#1174 lots of CRDs have status fields which
  causes ACM to complain that the CRD is invalid.

* This PR cleans up those CRDs and adds an appropriate validation test.

* Fix typos in AWS application specs (kubeflow/testing#668)
