### PR TITLE
remove initializers from deployment.

### DIFF
--- a/spark/spark-operator/base/deploy.yaml
+++ b/spark/spark-operator/base/deploy.yaml
@@ -18,8 +18,6 @@ spec:
         prometheus.io/port: "10254"
         prometheus.io/scrape: "true"
         sidecar.istio.io/inject: "false"
-      initializers:
-        pending: []
       labels:
         app.kubernetes.io/name: sparkoperator
         app.kubernetes.io/version: v1beta2-1.1.0-2.4.5

--- a/tests/tests/legacy_kustomizations/spark-operator/test_data/expected/apps_v1_deployment_spark-operatorsparkoperator.yaml
+++ b/tests/tests/legacy_kustomizations/spark-operator/test_data/expected/apps_v1_deployment_spark-operatorsparkoperator.yaml
@@ -31,8 +31,6 @@ spec:
         prometheus.io/port: "10254"
         prometheus.io/scrape: "true"
         sidecar.istio.io/inject: "false"
-      initializers:
-        pending: []
       labels:
         app.kubernetes.io/component: spark-operator
         app.kubernetes.io/instance: spark-operator-v1.0.0


### PR DESCRIPTION
Signed-off-by: Abhilash Pallerlamudi <stp.abhi@gmail.com>

**Which issue is resolved by this Pull Request:**
Resolves #

**Description of your changes:**
Initializers have been deprecated and removed. Check [here](https://github.com/GoogleCloudPlatform/spark-on-k8s-operator/pull/678)


**Checklist:**
- [x] Unit tests have been rebuilt: 
    1. `cd manifests/tests`
    2. `make generate-changed-only`
    3. `make test`
