### PR TITLE
Fix meshID and gcloud.compute.zone parameter set by kpt

### DIFF
--- a/gcp/v2/asm/istio-operator.yaml
+++ b/gcp/v2/asm/istio-operator.yaml
@@ -25,8 +25,7 @@ spec:
       istio-ingressgateway:
         type: NodePort
     global:
-      #meshID: "jlewi-dev_us-central1_kf-bp-0420-002" # {"type":"string","x-kustomize":{"setBy":"kpt","partialSetters":[{"name":"gcloud.core.project","value":"jlewi-dev"},{"name":"name","value":"kf-bp-0420-002"},{"name":"location","value":"us-central1"}]}}
-      meshID: "jlewi-dev_us-central1_kf-bp-0420-002" # 
+      meshID: "jlewi-dev_us-central1_kf-bp-0420-002" # {"type":"string","x-kustomize":{"setBy":"kpt","partialSetters":[{"name":"gcloud.core.project","value":"jlewi-dev"},{"name":"name","value":"kf-bp-0420-002"},{"name":"location","value":"us-central1"}]}}
       trustDomain: "jlewi-dev.svc.id.goog" # {"type":"string","x-kustomize":{"partialSetters":[{"name":"gcloud.core.project","value":"jlewi-dev"}]}}
       sds:
         token:

--- a/gcp/v2/asm/istio-operator.yaml
+++ b/gcp/v2/asm/istio-operator.yaml
@@ -32,7 +32,7 @@ spec:
           aud: "jlewi-dev.svc.id.goog" # {"type":"string","x-kustomize":{"partialSetters":[{"name":"gcloud.core.project","value":"jlewi-dev"}]}}
       proxy:
         env:
-          GCP_METADATA: "jlewi-dev|147474701642|asm-cluster|us-central1" # {"type":"string","x-kustomize":{"partialSetters":[{"name":"gcloud.core.project","value":"jlewi-dev"},{"name":"gcloud.project.projectNumber","value":"147474701642"},{"name":"name","value":"asm-cluster"},{"name":"gcloud.compute.zone","value":"us-central1-c"}]}}
+          GCP_METADATA: "jlewi-dev|147474701642|asm-cluster|us-central1-c" # {"type":"string","x-kustomize":{"partialSetters":[{"name":"gcloud.core.project","value":"jlewi-dev"},{"name":"gcloud.project.projectNumber","value":"147474701642"},{"name":"name","value":"asm-cluster"},{"name":"gcloud.compute.zone","value":"us-central1-c"}]}}
     nodeagent:
       env:
         GKE_CLUSTER_URL: "https://container.googleapis.com/v1/projects/jlewi-dev/locations/us-central1/clusters/kf-bp-0420-002" # {"type":"string","x-kustomize":{"setBy":"kpt","partialSetters":[{"name":"gcloud.core.project","value":"jlewi-dev"},{"name":"name","value":"kf-bp-0420-002"},{"name":"location","value":"us-central1"}]}}


### PR DESCRIPTION
**Which issue is resolved by this Pull Request:**
Deploy by https://github.com/kubeflow/gcp-blueprints got this problem

**Description of your changes:**


**Checklist:**
- [ ] Unit tests have been rebuilt: 
    1. `cd manifests/tests`
    2. `make generate-changed-only`
    3. `make test`
