### PR TITLE
Remove plugins; applications.so

### DIFF
--- a/plugins/kustomize/plugin/kfdef.apps.kubeflow.org/v1alpha1/KfDef
+++ b/plugins/kustomize/plugin/kfdef.apps.kubeflow.org/v1alpha1/KfDef
@@ -1,4 +1,0 @@
-#!/usr/bin/env bash
-
-cat $1
-


### PR DESCRIPTION
* Remove the plugins directory; I don't know what purpose it was intended
  for but I don't think we are using it anymore.

* plugins contains a .so which based on the comments looks like it
  might be the application controller.

* This .so is 28Mb. This is almost 50% of the total size of the manifest
  repo which is 72 M

* We want to remove it because we want to make it more lightweight for
  people to fetch and check in forks of the manifests repo.

* Fix #1173
