### PR TITLE
Add GCS scope to the cluster; create an OWNERs file.

### DIFF
--- a/gcp/OWNERS
+++ b/gcp/OWNERS
@@ -1,0 +1,3 @@
+approvers:
+  - bobgy
+  - jlewi

--- a/gcp/v2/cnrm/cluster/cluster.yaml
+++ b/gcp/v2/cnrm/cluster/cluster.yaml
@@ -50,6 +50,10 @@ spec:
     machineType: n1-standard-8
     metadata:
       disable-legacy-endpoints: "true"
+    oauthScopes:
+      - https://www.googleapis.com/auth/logging.write
+      - https://www.googleapis.com/auth/monitoring
+      - https://www.googleapis.com/auth/devstorage.read_only
     serviceAccountRef:
       name: kf-name-vm # {"type":"string","x-kustomize":{"partialSetters":[{"name":"name","value":"kf-name"}]}}
     workloadMetadataConfig:


### PR DESCRIPTION
* Add GCS scope to the VM service account otherwise we won't be
  able to pull private images.

* Create an OWNERs file inside the GCP directory.
