### PR TITLE
replace `env:` with `envs:` in Kustomization resources

### DIFF
--- a/admission-webhook/bootstrap/base/kustomization.yaml
+++ b/admission-webhook/bootstrap/base/kustomization.yaml
@@ -21,7 +21,8 @@ namespace: kubeflow
 configMapGenerator:
 - name: config-map
   behavior: merge
-  env: params.env
+  envs:
+  - params.env
 vars:
 - name: webhookNamePrefix
   objref:

--- a/admission-webhook/webhook/overlays/cert-manager/kustomization.yaml
+++ b/admission-webhook/webhook/overlays/cert-manager/kustomization.yaml
@@ -17,7 +17,8 @@ patchesStrategicMerge:
 configMapGenerator:
 - name: admission-webhook-parameters
   behavior: merge
-  env: params.env
+  envs:
+  - params.env
 generatorOptions:
   disableNameSuffixHash: true
 

--- a/application/application/base/kustomization.yaml
+++ b/application/application/base/kustomization.yaml
@@ -10,7 +10,8 @@ namespace: kubeflow
 nameprefix: application-controller-
 configMapGenerator:
 - name: parameters
-  env: params.env
+  envs:
+  - params.env
 generatorOptions:
   disableNameSuffixHash: true
 images:

--- a/argo/base/kustomization.yaml
+++ b/argo/base/kustomization.yaml
@@ -19,7 +19,8 @@ images:
   newTag: v2.3.0
 configMapGenerator:
 - name: workflow-controller-parameters
-  env: params.env
+  envs:
+  - params.env
 generatorOptions:
   disableNameSuffixHash: true
 vars:

--- a/argo/base_v3/kustomization.yaml
+++ b/argo/base_v3/kustomization.yaml
@@ -23,7 +23,8 @@ images:
   newTag: v2.3.0
 configMapGenerator:
 - name: workflow-controller-parameters
-  env: ../base/params.env
+  envs:
+  - ../base/params.env
 generatorOptions:
   disableNameSuffixHash: true
 vars:

--- a/aws/aws-alb-ingress-controller/base/kustomization.yaml
+++ b/aws/aws-alb-ingress-controller/base/kustomization.yaml
@@ -16,7 +16,8 @@ images:
   newTag: v1.1.5
 configMapGenerator:
 - name: alb-ingress-controller-parameters
-  env: params.env
+  envs:
+  - params.env
 vars:
 - name: CLUSTER_NAME
   objref:

--- a/aws/aws-alb-ingress-controller/overlays/vpc/kustomization.yaml
+++ b/aws/aws-alb-ingress-controller/overlays/vpc/kustomization.yaml
@@ -6,7 +6,8 @@ patchesStrategicMerge:
 - vpc.yaml
 configMapGenerator:
 - name: alb-ingress-controller-vpc-parameters
-  env: params.env
+  envs:
+  - params.env
 vars:
 - name: VPC_ID
   objref:

--- a/aws/aws-istio-authz-adaptor/base/kustomization.yaml
+++ b/aws/aws-istio-authz-adaptor/base/kustomization.yaml
@@ -17,7 +17,8 @@ images:
   newTag: "0.1"
 configMapGenerator:
   - name: aws-authzadaptor-parameters
-    env: params.env
+    envs:
+    - params.env
 generatorOptions:
   disableNameSuffixHash: true
 vars:

--- a/aws/fluentd-cloud-watch/base/kustomization.yaml
+++ b/aws/fluentd-cloud-watch/base/kustomization.yaml
@@ -17,7 +17,8 @@ images:
   newTag: v1.7.3-debian-cloudwatch-1.0
 configMapGenerator:
 - name: fluentd-cloud-watch-parameters
-  env: params.env
+  envs:
+  - params.env
 vars:
 - name: CLUSTER_NAME
   objref:

--- a/aws/istio-ingress/base/kustomization.yaml
+++ b/aws/istio-ingress/base/kustomization.yaml
@@ -6,7 +6,8 @@ commonLabels:
   kustomize.component: istio-ingress
 configMapGenerator:
 - name: istio-ingress-parameters
-  env: params.env
+  envs:
+  - params.env
 generatorOptions:
   disableNameSuffixHash: true
 vars:

--- a/aws/istio-ingress/overlays/cognito/kustomization.yaml
+++ b/aws/istio-ingress/overlays/cognito/kustomization.yaml
@@ -4,7 +4,8 @@ patchesStrategicMerge:
 - ingress.yaml
 configMapGenerator:
 - name: istio-ingress-cognito-parameters
-  env: params.env
+  envs:
+  - params.env
 vars:
 - name: CognitoUserPoolArn
   objref:

--- a/aws/istio-ingress/overlays/oidc/kustomization.yaml
+++ b/aws/istio-ingress/overlays/oidc/kustomization.yaml
@@ -5,10 +5,12 @@ patchesStrategicMerge:
 #- oidc-secret.yaml
 secretGenerator:
 - name: istio-oidc-secret
-  env: secrets.env
+  envs:
+  - secrets.env
 configMapGenerator:
 - name: istio-ingress-oidc-parameters
-  env: params.env
+  envs:
+  - params.env
 vars:
 - name: oidcIssuer
   objref:

--- a/aws/istio-ingress/overlays/secure/kustomization.yaml
+++ b/aws/istio-ingress/overlays/secure/kustomization.yaml
@@ -5,7 +5,8 @@ patchesStrategicMerge:
 configMapGenerator:
 - name: istio-ingress-parameters
   behavior: merge
-  env: params.env
+  envs:
+  - params.env
 generatorOptions:
   disableNameSuffixHash: true
 vars:

--- a/cert-manager/cert-manager-kube-system-resources/base/kustomization.yaml
+++ b/cert-manager/cert-manager-kube-system-resources/base/kustomization.yaml
@@ -8,7 +8,8 @@ commonLabels:
   kustomize.component: cert-manager
 configMapGenerator:
 - name: cert-manager-kube-params-parameters
-  env: params.env
+  envs:
+  - params.env
 generatorOptions:
   disableNameSuffixHash: true
 vars:

--- a/cert-manager/cert-manager/base/kustomization.yaml
+++ b/cert-manager/cert-manager/base/kustomization.yaml
@@ -25,7 +25,8 @@ images:
   newTag: v0.11.0
 configMapGenerator:
 - name: cert-manager-parameters
-  env: params.env
+  envs:
+  - params.env
 generatorOptions:
   disableNameSuffixHash: true
 vars:

--- a/cert-manager/cert-manager/overlays/letsencrypt/kustomization.yaml
+++ b/cert-manager/cert-manager/overlays/letsencrypt/kustomization.yaml
@@ -10,7 +10,8 @@ commonLabels:
 configMapGenerator:
 - name: cert-manager-parameters
   behavior: merge
-  env: params.env
+  envs:
+  - params.env
 generatorOptions:
   disableNameSuffixHash: true
 vars:

--- a/common/basic-auth/base/kustomization.yaml
+++ b/common/basic-auth/base/kustomization.yaml
@@ -19,7 +19,8 @@ generatorOptions:
   disableNameSuffixHash: true
 configMapGenerator:
 - name: basic-auth-parameters
-  env: params.env
+  envs:
+  - params.env
 vars:
 - name: service-namespace
   objref:

--- a/common/spartakus/base/kustomization.yaml
+++ b/common/spartakus/base/kustomization.yaml
@@ -14,7 +14,8 @@ images:
   newTag: v1.1.0
 configMapGenerator:
 - name: spartakus-config
-  env: params.env
+  envs:
+  - params.env
 generatorOptions:
   disableNameSuffixHash: true
 configurations:

--- a/default-install/base/kustomization.yaml
+++ b/default-install/base/kustomization.yaml
@@ -6,7 +6,8 @@ resources:
 - profile-instance.yaml
 configMapGenerator:
 - name: default-install-config
-  env: params.env
+  envs:
+  - params.env
 vars:
 # These vars are used for substituing in the parameters from the config map
 # into the Profiles custom resource.

--- a/dex-auth/dex-authenticator/base/kustomization.yaml
+++ b/dex-auth/dex-authenticator/base/kustomization.yaml
@@ -8,7 +8,8 @@ resources:
 - service.yaml
 configMapGenerator:
 - name: dex-authn-parameters
-  env: params.env
+  envs:
+  - params.env
 vars:
 - name: issuer
   objref:

--- a/dex-auth/dex-crds/base/kustomization.yaml
+++ b/dex-auth/dex-crds/base/kustomization.yaml
@@ -9,7 +9,8 @@ resources:
 - service.yaml
 configMapGenerator:
 - name: dex-parameters
-  env: params.env
+  envs:
+  - params.env
 generatorOptions:
   disableNameSuffixHash: true
 vars:

--- a/dex-auth/dex-crds/overlays/github/kustomization.yaml
+++ b/dex-auth/dex-crds/overlays/github/kustomization.yaml
@@ -12,7 +12,8 @@ patchesStrategicMerge:
 configMapGenerator:
 - name: dex-parameters
   behavior: merge
-  env: params.env
+  envs:
+  - params.env
 generatorOptions:
   disableNameSuffixHash: true
 vars:

--- a/dex-auth/dex-crds/overlays/istio/kustomization.yaml
+++ b/dex-auth/dex-crds/overlays/istio/kustomization.yaml
@@ -8,7 +8,8 @@ resources:
 configMapGenerator:
 - name: dex-parameters
   behavior: merge
-  env: params.env
+  envs:
+  - params.env
 generatorOptions:
   disableNameSuffixHash: true
 vars:

--- a/dex-auth/dex-crds/overlays/ldap/kustomization.yaml
+++ b/dex-auth/dex-crds/overlays/ldap/kustomization.yaml
@@ -11,7 +11,8 @@ patchesStrategicMerge:
 configMapGenerator:
 - name: dex-parameters
   behavior: merge
-  env: params.env
+  envs:
+  - params.env
 generatorOptions:
   disableNameSuffixHash: true
 vars:

--- a/dex-auth/keycloak-gatekeeper/base/kustomization.yaml
+++ b/dex-auth/keycloak-gatekeeper/base/kustomization.yaml
@@ -11,7 +11,8 @@ resources:
 
 configMapGenerator:
 - name: keycloak-gatekeeper-parameters
-  env: params.env
+  envs:
+  - params.env
 generatorOptions:
   disableNameSuffixHash: true
 

--- a/docs/dex-auth/examples/authentication/Istio/base/kustomization.yaml
+++ b/docs/dex-auth/examples/authentication/Istio/base/kustomization.yaml
@@ -7,7 +7,8 @@ resources:
 
 configMapGenerator:
 - name: auth-parameters
-  env: params.env
+  envs:
+  - params.env
 
 vars:
 - name: issuer

--- a/gcp/basic-auth-ingress/base/kustomization.yaml
+++ b/gcp/basic-auth-ingress/base/kustomization.yaml
@@ -24,7 +24,8 @@ images:
   newTag: 1.0.0
 configMapGenerator:
 - name: basic-auth-ingress-parameters
-  env: params.env
+  envs:
+  - params.env
 generatorOptions:
   disableNameSuffixHash: true
 vars:

--- a/gcp/cloud-endpoints/base/kustomization.yaml
+++ b/gcp/cloud-endpoints/base/kustomization.yaml
@@ -18,7 +18,8 @@ images:
   newTag: 0.2.1
 configMapGenerator:
 - name: cloud-endpoints-parameters
-  env: params.env
+  envs:
+  - params.env
 generatorOptions:
   disableNameSuffixHash: true
 vars:

--- a/gcp/iap-ingress/base/kustomization.yaml
+++ b/gcp/iap-ingress/base/kustomization.yaml
@@ -29,7 +29,8 @@ images:
   newTag: 1.0.0
 configMapGenerator:
 - name: parameters
-  env: params.env
+  envs:
+  - params.env
 generatorOptions:
   disableNameSuffixHash: true
 vars:

--- a/gcp/prometheus/base/kustomization.yaml
+++ b/gcp/prometheus/base/kustomization.yaml
@@ -6,7 +6,8 @@ commonLabels:
   kustomize.component: prometheus
 configMapGenerator:
 - name: prometheus-parameters
-  env: params.env
+  envs:
+  - params.env
 images:
 - name: gcr.io/stackdriver-prometheus/stackdriver-prometheus
   newName: gcr.io/stackdriver-prometheus/stackdriver-prometheus

--- a/istio-1-3-1/istio-install-1-3-1/base/kustomization.yaml
+++ b/istio-1-3-1/istio-install-1-3-1/base/kustomization.yaml
@@ -2,7 +2,8 @@
 # one ConfigMap resource (it's a generator of n maps).
 configMapGenerator:
 - name: istio-install-parameters
-  env: params.env
+  envs:
+  - params.env
 
 # Images modify the tags for images without
 # creating patches.

--- a/istio/ingressgateway-self-signed-cert/base/kustomization.yaml
+++ b/istio/ingressgateway-self-signed-cert/base/kustomization.yaml
@@ -6,7 +6,8 @@ resources:
 
 configMapGenerator:
 - name: ingressgateway-self-signed-cert-parameters
-  env: params.env
+  envs:
+  - params.env
 generatorOptions:
   disableNameSuffixHash: true
 

--- a/istio/istio/base/kustomization.yaml
+++ b/istio/istio/base/kustomization.yaml
@@ -6,7 +6,8 @@ resources:
 namespace: kubeflow
 configMapGenerator:
 - name: istio-parameters
-  env: params.env
+  envs:
+  - params.env
 vars:
 - name: clusterRbacConfig
   objref:

--- a/istio/istio/overlays/https-gateway/kustomization.yaml
+++ b/istio/istio/overlays/https-gateway/kustomization.yaml
@@ -8,6 +8,7 @@ patchesStrategicMerge:
 configMapGenerator:
 - name: istio-parameters
   behavior: merge
-  env: params.env
+  envs:
+  - params.env
 configurations:
 - params.yaml

--- a/istio/oidc-authservice/base/kustomization.yaml
+++ b/istio/oidc-authservice/base/kustomization.yaml
@@ -11,7 +11,8 @@ namespace: istio-system
 
 configMapGenerator:
 - name: oidc-authservice-parameters
-  env: params.env
+  envs:
+  - params.env
 generatorOptions:
   disableNameSuffixHash: true
 

--- a/jupyter/notebook-controller/overlays/istio/kustomization.yaml
+++ b/jupyter/notebook-controller/overlays/istio/kustomization.yaml
@@ -7,6 +7,7 @@ patchesStrategicMerge:
 configMapGenerator:
 - name: parameters
   behavior: merge
-  env: params.env
+  envs:
+  - params.env
 generatorOptions:
   disableNameSuffixHash: true

--- a/katib/installs/katib-external-db/kustomization.yaml
+++ b/katib/installs/katib-external-db/kustomization.yaml
@@ -9,7 +9,8 @@ patchesStrategicMerge:
   - katib-db-manager-deployment.yaml
 secretGenerator:
   - name: katib-mysql-secrets
-    env: secrets.env
+    envs:
+    - secrets.env
 commonLabels:
   app.kubernetes.io/component: katib
   app.kubernetes.io/name: katib-controller

--- a/katib/katib-controller/base/kustomization.yaml
+++ b/katib/katib-controller/base/kustomization.yaml
@@ -18,7 +18,8 @@ resources:
 - trial-template-configmap-labeled.yaml
 configMapGenerator:
 - name: katib-parameters
-  env: params.env
+  envs:
+  - params.env
 generatorOptions:
   disableNameSuffixHash: true
 images:

--- a/kubebench/base/kustomization.yaml
+++ b/kubebench/base/kustomization.yaml
@@ -12,7 +12,8 @@ commonLabels:
   kustomize.component: kubebench
 configMapGenerator:
 - name: parameters
-  env: params.env
+  envs:
+  - params.env
 images:
   # NOTE: the image for workflow agent should be configured in config-map.yaml
   - name:  gcr.io/kubeflow-images-public/kubebench/kubebench-operator-v1alpha2

--- a/metadata/base/kustomization.yaml
+++ b/metadata/base/kustomization.yaml
@@ -5,9 +5,11 @@ commonLabels:
   kustomize.component: metadata
 configMapGenerator:
 - name: ui-parameters
-  env: params.env
+  envs:
+  - params.env
 - name: grpc-configmap
-  env: grpc-params.env
+  envs:
+  - grpc-params.env
 generatorOptions:
   # TFX pipelines use metadata-grpc-configmap for finding grpc server host and
   # port at runtime. Because they don't know the suffix, we have to disable it.

--- a/metadata/overlays/db/kustomization.yaml
+++ b/metadata/overlays/db/kustomization.yaml
@@ -8,10 +8,12 @@ generatorOptions:
   disableNameSuffixHash: true
 configMapGenerator:
 - name: metadata-db-parameters
-  env: params.env
+  envs:
+  - params.env
 secretGenerator:
 - name: metadata-db-secrets
-  env: secrets.env
+  envs:
+  - secrets.env
 bases:
 - ../../base
 resources:

--- a/metadata/overlays/external-mysql/kustomization.yaml
+++ b/metadata/overlays/external-mysql/kustomization.yaml
@@ -4,10 +4,12 @@ commonLabels:
   kustomize.component: metadata
 configMapGenerator:
 - name: metadata-db-parameters
-  env: params.env
+  envs:
+  - params.env
 secretGenerator:
 - name: metadata-db-secrets
-  env: secrets.env
+  envs:
+  - secrets.env
 bases:
 - ../../base
 patchesStrategicMerge:

--- a/metadata/overlays/google-cloudsql/kustomization.yaml
+++ b/metadata/overlays/google-cloudsql/kustomization.yaml
@@ -8,7 +8,8 @@ commonLabels:
   kustomize.component: metadata
 configMapGenerator:
 - name: metadata-db-parameters
-  env: params.env
+  envs:
+  - params.env
 bases:
 - ../../base
 patchesStrategicMerge:

--- a/pipeline/api-service/overlays/external-mysql/kustomization.yaml
+++ b/pipeline/api-service/overlays/external-mysql/kustomization.yaml
@@ -6,7 +6,8 @@ patchesStrategicMerge:
 - config-map.yaml
 configMapGenerator:
 - name: pipeline-external-mysql-parameters
-  env: params.env
+  envs:
+  - params.env
 generatorOptions:
   disableNameSuffixHash: true
 vars:

--- a/pipeline/minio/base/kustomization.yaml
+++ b/pipeline/minio/base/kustomization.yaml
@@ -9,7 +9,8 @@ resources:
 - persistent-volume-claim.yaml
 configMapGenerator:
 - name: pipeline-minio-parameters
-  env: params.env
+  envs:
+  - params.env
 generatorOptions:
   disableNameSuffixHash: true
 vars:

--- a/pipeline/minio/installs/gcp-pd/kustomization.yaml
+++ b/pipeline/minio/installs/gcp-pd/kustomization.yaml
@@ -12,7 +12,8 @@ patchesStrategicMerge:
 - persistent-volume-claim.yaml
 configMapGenerator:
 - name: pipeline-minio-install-config
-  env: params.env
+  envs:
+  - params.env
 vars:
 - name: kfpMinioPd
   objref:

--- a/pipeline/minio/overlays/minioPd/kustomization.yaml
+++ b/pipeline/minio/overlays/minioPd/kustomization.yaml
@@ -9,7 +9,8 @@ patchesStrategicMerge:
 configMapGenerator:
 - name: pipeline-minio-parameters
   behavior: merge
-  env: params.env
+  envs:
+  - params.env
 generatorOptions:
   disableNameSuffixHash: true
 vars:

--- a/pipeline/mysql/base/kustomization.yaml
+++ b/pipeline/mysql/base/kustomization.yaml
@@ -8,7 +8,8 @@ resources:
 - persistent-volume-claim.yaml
 configMapGenerator:
 - name: pipeline-mysql-parameters
-  env: params.env
+  envs:
+  - params.env
 generatorOptions:
   disableNameSuffixHash: true
 vars:

--- a/pipeline/mysql/installs/gcp-pd/kustomization.yaml
+++ b/pipeline/mysql/installs/gcp-pd/kustomization.yaml
@@ -16,7 +16,8 @@ images:
   newName: gcr.io/ml-pipeline/mysql
 configMapGenerator:
 - name: pipeline-mysql-install-config
-  env: params.env
+  envs:
+  - params.env
 vars:
 - name: kfpMysqlPd
   objref:

--- a/pipeline/mysql/overlays/mysqlPd/kustomization.yaml
+++ b/pipeline/mysql/overlays/mysqlPd/kustomization.yaml
@@ -9,7 +9,8 @@ patchesStrategicMerge:
 configMapGenerator:
 - name: pipeline-mysql-parameters
   behavior: merge
-  env: params.env
+  envs:
+  - params.env
 generatorOptions:
   disableNameSuffixHash: true
 vars:

--- a/pipeline/pipelines-ui/base/kustomization.yaml
+++ b/pipeline/pipelines-ui/base/kustomization.yaml
@@ -9,7 +9,8 @@ resources:
 - service.yaml
 configMapGenerator:
 - name: ui-parameters
-  env: params.env
+  envs:
+  - params.env
 images:
 - name: gcr.io/ml-pipeline/frontend
   newTag: 0.2.5

--- a/pipeline/upstream/base/kustomization.yaml
+++ b/pipeline/upstream/base/kustomization.yaml
@@ -32,10 +32,12 @@ images:
 # Used by Kustomize
 configMapGenerator:
 - name: pipeline-install-config
-  env: params.env
+  envs:
+  - params.env
 secretGenerator:
 - name: mysql-secret
-  env: params-db-secret.env
+  envs:
+  - params-db-secret.env
 vars:
 - name: NAMESPACE
   objref:

--- a/pipeline/upstream/cluster-scoped-resources/kustomization.yaml
+++ b/pipeline/upstream/cluster-scoped-resources/kustomization.yaml
@@ -13,7 +13,8 @@ resources:
 # Used by Kustomize
 configMapGenerator:
   - name: pipeline-cluster-scoped-install-config
-    env: params.env
+    envs:
+    - params.env
 
 vars:
   - name: NAMESPACE

--- a/pipeline/upstream/env/gcp/kustomization.yaml
+++ b/pipeline/upstream/env/gcp/kustomization.yaml
@@ -24,7 +24,8 @@ patchesStrategicMerge:
 # Used by Kustomize
 configMapGenerator:
   - name: pipeline-install-config
-    env: params.env
+    envs:
+    - params.env
     behavior: merge
 
 vars:

--- a/pipeline/upstream/sample/cluster-scoped-resources/kustomization.yaml
+++ b/pipeline/upstream/sample/cluster-scoped-resources/kustomization.yaml
@@ -8,5 +8,6 @@ bases:
 # Change the value in params.env to yours.
 configMapGenerator:
   - name: pipeline-cluster-scoped-install-config
-    env: params.env
+    envs:
+    - params.env
     behavior: merge

--- a/pipeline/upstream/sample/kustomization.yaml
+++ b/pipeline/upstream/sample/kustomization.yaml
@@ -14,12 +14,14 @@ commonLabels:
 # Used by Kustomize
 configMapGenerator:
   - name: pipeline-install-config
-    env: params.env
+    envs:
+    - params.env
     behavior: merge
 
 secretGenerator:
   - name: mysql-secret
-    env: params-db-secret.env
+    envs:
+    - params-db-secret.env
     behavior: merge
 
 # !!! If you want to customize the namespace,

--- a/profiles/overlays/debug/kustomization.yaml
+++ b/profiles/overlays/debug/kustomization.yaml
@@ -6,7 +6,8 @@ patchesStrategicMerge:
 - deployment.yaml
 configMapGenerator:
 - name: parameters
-  env: params.env
+  envs:
+  - params.env
 generatorOptions:
   disableNameSuffixHash: true
 vars:

--- a/tektoncd/tektoncd-dashboard/overlays/application/kustomization.yaml
+++ b/tektoncd/tektoncd-dashboard/overlays/application/kustomization.yaml
@@ -6,7 +6,8 @@ commonLabels:
   app.kubernetes.io/component: tektoncd
   app.kubernetes.io/name: tektoncd-dashboard
 configMapGenerator:
-- env: params.env
+- envs:
+  - params.env
   name: tektoncd-dashboard-app-parameters
 configurations:
 - params.yaml

--- a/tektoncd/tektoncd-dashboard/overlays/istio/kustomization.yaml
+++ b/tektoncd/tektoncd-dashboard/overlays/istio/kustomization.yaml
@@ -6,7 +6,8 @@ resources:
 - virtual-service.yaml
 configMapGenerator:
 - name: tektoncd-dashboard-parameters
-  env: params.env
+  envs:
+  - params.env
 vars:
 - name: namespace
   objref:

--- a/tektoncd/tektoncd-install/base/kustomization.yaml
+++ b/tektoncd/tektoncd-install/base/kustomization.yaml
@@ -13,7 +13,8 @@ resources:
 namespace: tekton-pipelines
 configMapGenerator:
 - name: tektoncd-parameters
-  env: params.env
+  envs:
+  - params.env
 generatorOptions:
   disableNameSuffixHash: true
 vars:

--- a/tektoncd/tektoncd-install/overlays/application/kustomization.yaml
+++ b/tektoncd/tektoncd-install/overlays/application/kustomization.yaml
@@ -5,7 +5,8 @@ commonLabels:
   app.kubernetes.io/component: kubeflow
   app.kubernetes.io/name: tektoncd-install
 configMapGenerator:
-- env: params.env
+- envs:
+  - params.env
   name: tektoncd-install-parameters
 configurations:
 - params.yaml

--- a/tektoncd/tektoncd-install/overlays/istio/kustomization.yaml
+++ b/tektoncd/tektoncd-install/overlays/istio/kustomization.yaml
@@ -6,7 +6,8 @@ resources:
 - virtual-service.yaml
 configMapGenerator:
 - name: tektoncd-install-istio-parameters
-  env: params.env
+  envs:
+  - params.env
 generatorOptions:
   disableNameSuffixHash: true
 vars:

--- a/tensorboard/base/kustomization.yaml
+++ b/tensorboard/base/kustomization.yaml
@@ -8,7 +8,8 @@ commonLabels:
   kustomize.component: tensorboard
 configMapGenerator:
 - name: parameters
-  env: params.env
+  envs:
+  - params.env
 vars:
 - name: namespace
   objref:

--- a/xgboost-job/xgboost-operator/base/kustomization.yaml
+++ b/xgboost-job/xgboost-operator/base/kustomization.yaml
@@ -11,7 +11,8 @@ namespace: kubeflow
 nameprefix: xgboost-operator-
 configMapGenerator:
 - name: xgboost-operator-config
-  env: params.env
+  envs:
+  - params.env
 images:
   - name: gcr.io/kubeflow-images-public/xgboost-operator
     newName: gcr.io/kubeflow-images-public/xgboost-operator


### PR DESCRIPTION
Related to #538
Supersedes: #887 

**Description of your changes:**
As the `env:` syntax has been deprecated in Kustomize, we must move to the new syntax.

**Checklist:**
- [ ] Unit tests have been rebuilt: 
    1. `cd manifests/tests`
    2. `make generate-changed-only`
    3. `make test`
