### PR TITLE
Updated cluster-role.yaml to run Kubeflow Faring from Kubeflow Pipeline

### DIFF
--- a/pipeline/pipelines-runner/base/cluster-role.yaml
+++ b/pipeline/pipelines-runner/base/cluster-role.yaml
@@ -9,6 +9,7 @@ rules:
   - secrets
   verbs:
   - get
+  - list
 - apiGroups:
   - ""
   resources:

--- a/tests/stacks/examples/alice_gcp/test_data/expected/apps_v1_deployment_jupyter-web-app-deployment.yaml
+++ b/tests/stacks/examples/alice_gcp/test_data/expected/apps_v1_deployment_jupyter-web-app-deployment.yaml
@@ -26,12 +26,12 @@ spec:
           valueFrom:
             configMapKeyRef:
               key: userid-header
-              name: kubeflow-config-4bkkg42k5m
+              name: kubeflow-config
         - name: USERID_PREFIX
           valueFrom:
             configMapKeyRef:
               key: userid-prefix
-              name: kubeflow-config-4bkkg42k5m
+              name: kubeflow-config
         image: gcr.io/kubeflow-images-public/jupyter-web-app:vmaster-gd9be4b9e
         name: jupyter-web-app
         ports:

--- a/tests/stacks/examples/alice_gcp/test_data/expected/apps_v1_deployment_profiles-deployment.yaml
+++ b/tests/stacks/examples/alice_gcp/test_data/expected/apps_v1_deployment_profiles-deployment.yaml
@@ -32,12 +32,12 @@ spec:
           valueFrom:
             configMapKeyRef:
               key: userid-header
-              name: kubeflow-config-4bkkg42k5m
+              name: kubeflow-config
         - name: USERID_PREFIX
           valueFrom:
             configMapKeyRef:
               key: userid-prefix
-              name: kubeflow-config-4bkkg42k5m
+              name: kubeflow-config
         - name: WORKLOAD_IDENTITY
           valueFrom:
             configMapKeyRef:
@@ -68,12 +68,12 @@ spec:
           valueFrom:
             configMapKeyRef:
               key: userid-header
-              name: kubeflow-config-4bkkg42k5m
+              name: kubeflow-config
         - name: USERID_PREFIX
           valueFrom:
             configMapKeyRef:
               key: userid-prefix
-              name: kubeflow-config-4bkkg42k5m
+              name: kubeflow-config
         - name: CLUSTER_ADMIN
           valueFrom:
             configMapKeyRef:

--- a/tests/tests/legacy_kustomizations/pipelines-runner/test_data/expected/rbac.authorization.k8s.io_v1beta1_clusterrole_pipeline-runner.yaml
+++ b/tests/tests/legacy_kustomizations/pipelines-runner/test_data/expected/rbac.authorization.k8s.io_v1beta1_clusterrole_pipeline-runner.yaml
@@ -17,6 +17,7 @@ rules:
   - secrets
   verbs:
   - get
+  - list
 - apiGroups:
   - ""
   resources:


### PR DESCRIPTION
**Which issue is resolved by this Pull Request:**
Resolves #
When someone runs Kubeflow Faring from Kubeflow Pipeline, he/she will get below error:
**IOError: [Errno 2] No such file or directory: ‘/etc/secrets/user-gcp-sa.json’**

**Reason:**
When Kubeflow Fairing tries to launch the pod for model training like LightGBM distributed parallel training, it tries to check the presence of the secret by using list instead of get and when list fails due to lack of permission, it just does not attach any secrets to the pod. This causes the whole Kubeflow pipeline to fail.


**Description of your changes:**
Updated the pipeline-runner ClusterRole to allow the pipeline-runner to list the secrets. This helped me run Kubeflow fairing from the Kubeflow pipeline successfully.

**Checklist:**
- [x] Unit tests have been rebuilt: 
    1. `cd manifests/tests`
    2. `make generate-changed-only`
    3. `make test`
