### PR TITLE
KFP visualization-service: Fix double ml-pipeline- prefix in names

### DIFF
--- a/pipeline/pipeline-visualization-service/base/kustomization.yaml
+++ b/pipeline/pipeline-visualization-service/base/kustomization.yaml
@@ -1,6 +1,5 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
-nameprefix: ml-pipeline-
 commonLabels:
   app: ml-pipeline-visualizationserver
 resources:

--- a/tests/tests/legacy_kustomizations/pipeline-visualization-service/test_data/expected/apps_v1_deployment_ml-pipeline-visualizationserver.yaml
+++ b/tests/tests/legacy_kustomizations/pipeline-visualization-service/test_data/expected/apps_v1_deployment_ml-pipeline-visualizationserver.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: pipeline-visualization-service
     app.kubernetes.io/part-of: kubeflow
     app.kubernetes.io/version: 0.2.0
-  name: ml-pipeline-ml-pipeline-visualizationserver
+  name: ml-pipeline-visualizationserver
   namespace: kubeflow
 spec:
   selector:

--- a/tests/tests/legacy_kustomizations/pipeline-visualization-service/test_data/expected/~g_v1_service_ml-pipeline-visualizationserver.yaml
+++ b/tests/tests/legacy_kustomizations/pipeline-visualization-service/test_data/expected/~g_v1_service_ml-pipeline-visualizationserver.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: pipeline-visualization-service
     app.kubernetes.io/part-of: kubeflow
     app.kubernetes.io/version: 0.2.0
-  name: ml-pipeline-ml-pipeline-visualizationserver
+  name: ml-pipeline-visualizationserver
   namespace: kubeflow
 spec:
   ports:


### PR DESCRIPTION
Signed-off-by: Ilias Katsakioris <elikatsis@arrikto.com>

---

Related to kubeflow/pipelines#3849.

**Checklist:**
- [x] Unit tests have been rebuilt: 
    1. `cd manifests/tests`
    2. `make generate-changed-only`
    3. `make test`
