### PR TITLE
Installs kubeflow-gateway in ISTIO namespace

### DIFF
--- a/argo/overlays/istio/virtual-service.yaml
+++ b/argo/overlays/istio/virtual-service.yaml
@@ -3,7 +3,7 @@ kind: VirtualService
 metadata:
   name: argo-ui
 spec:
-  gateways:
+  gateways: # {"$kpt-set":"kubeflow-gateway"}
   - kubeflow-gateway
   hosts:
   - '*'

--- a/common/basic-auth/overlays/istio/kflogin-virtual-service.yaml
+++ b/common/basic-auth/overlays/istio/kflogin-virtual-service.yaml
@@ -3,7 +3,7 @@ kind: VirtualService
 metadata:
   name: basic-auth-login
 spec:
-  gateways:
+  gateways: # {"$kpt-set":"kubeflow-gateway"}
   - kubeflow-gateway
   hosts:
   - '*'

--- a/common/centraldashboard/overlays/istio/virtual-service.yaml
+++ b/common/centraldashboard/overlays/istio/virtual-service.yaml
@@ -3,7 +3,7 @@ kind: VirtualService
 metadata:
   name: centraldashboard
 spec:
-  gateways:
+  gateways: # {"$kpt-set":"kubeflow-gateway"}
   - kubeflow-gateway
   hosts:
   - '*'

--- a/dex-auth/dex-crds/overlays/github/virtual-service.yaml
+++ b/dex-auth/dex-crds/overlays/github/virtual-service.yaml
@@ -7,7 +7,7 @@ kind: VirtualService
 metadata:
   name: dex
 spec:
-  gateways:
+  gateways: # {"$kpt-set":"kubeflow-gateway"}
   - kubeflow/kubeflow-gateway
   hosts:
   - '*'

--- a/dex-auth/dex-crds/overlays/istio/virtual-service.yaml
+++ b/dex-auth/dex-crds/overlays/istio/virtual-service.yaml
@@ -7,7 +7,7 @@ kind: VirtualService
 metadata:
   name: dex
 spec:
-  gateways:
+  gateways: # {"$kpt-set":"kubeflow-gateway"}
   - kubeflow/kubeflow-gateway
   hosts:
   - '*'

--- a/dex-auth/keycloak-gatekeeper/base/virtualservice.yaml
+++ b/dex-auth/keycloak-gatekeeper/base/virtualservice.yaml
@@ -3,7 +3,7 @@ kind: VirtualService
 metadata:
   name: keycloak-gatekeeper
 spec:
-  gateways:
+  gateways: # {"$kpt-set":"kubeflow-gateway"}
   - kubeflow/kubeflow-gateway
   hosts:
   - '*'

--- a/istio/istio/base/kf-istio-resources.yaml
+++ b/istio/istio/base/kf-istio-resources.yaml
@@ -20,7 +20,7 @@ metadata:
 spec:
   hosts:
   - "*"
-  gateways:
+  gateways: # {"$kpt-set":"kubeflow-gateway"}
   - "kubeflow-gateway"
   http:
   - match:

--- a/jupyter/jupyter-web-app/overlays/istio/virtual-service.yaml
+++ b/jupyter/jupyter-web-app/overlays/istio/virtual-service.yaml
@@ -3,7 +3,7 @@ kind: VirtualService
 metadata:
   name: jupyter-web-app
 spec:
-  gateways:
+  gateways: # {"$kpt-set":"kubeflow-gateway"}
   - kubeflow-gateway
   hosts:
   - '*'

--- a/katib/katib-controller/overlays/istio/katib-ui-virtual-service.yaml
+++ b/katib/katib-controller/overlays/istio/katib-ui-virtual-service.yaml
@@ -3,7 +3,7 @@ kind: VirtualService
 metadata:
   name: katib-ui
 spec:
-  gateways:
+  gateways: # {"$kpt-set":"kubeflow-gateway"}
   - kubeflow-gateway
   hosts:
   - '*'

--- a/kubebench/overlays/istio/virtual-service.yaml
+++ b/kubebench/overlays/istio/virtual-service.yaml
@@ -3,7 +3,7 @@ kind: VirtualService
 metadata:
   name: kubebench-dashboard
 spec:
-  gateways:
+  gateways: # {"$kpt-set":"kubeflow-gateway"}
   - kubeflow-gateway
   hosts:
   - '*'

--- a/metadata/overlays/istio/virtual-service-metadata-grpc.yaml
+++ b/metadata/overlays/istio/virtual-service-metadata-grpc.yaml
@@ -3,7 +3,7 @@ kind: VirtualService
 metadata:
   name: metadata-grpc
 spec:
-  gateways:
+  gateways: # {"$kpt-set":"kubeflow-gateway"}
   - kubeflow-gateway
   hosts:
   - '*'

--- a/metadata/overlays/istio/virtual-service.yaml
+++ b/metadata/overlays/istio/virtual-service.yaml
@@ -3,7 +3,7 @@ kind: VirtualService
 metadata:
   name: metadata-ui
 spec:
-  gateways:
+  gateways: # {"$kpt-set":"kubeflow-gateway"}
   - kubeflow-gateway
   hosts:
   - '*'

--- a/pipeline/pipelines-ui/overlays/istio/virtual-service.yaml
+++ b/pipeline/pipelines-ui/overlays/istio/virtual-service.yaml
@@ -3,7 +3,7 @@ kind: VirtualService
 metadata:
   name: ml-pipeline-tensorboard-ui
 spec:
-  gateways:
+  gateways: # {"$kpt-set":"kubeflow-gateway"}
   - kubeflow-gateway
   hosts:
   - '*'
@@ -25,7 +25,7 @@ kind: VirtualService
 metadata:
   name: ml-pipeline-ui
 spec:
-  gateways:
+  gateways: # {"$kpt-set":"kubeflow-gateway"}
   - kubeflow-gateway
   hosts:
   - '*'

--- a/profiles/overlays/istio/virtual-service.yaml
+++ b/profiles/overlays/istio/virtual-service.yaml
@@ -3,7 +3,7 @@ kind: VirtualService
 metadata:
   name: kfam
 spec:
-  gateways:
+  gateways: # {"$kpt-set":"kubeflow-gateway"}
   - kubeflow-gateway
   hosts:
   - '*'

--- a/stacks/generic/Kptfile
+++ b/stacks/generic/Kptfile
@@ -1,0 +1,15 @@
+apiVersion: kpt.dev/v1alpha1
+kind: Kptfile
+metadata:
+  name: kustomize
+packageMetadata:
+  shortDescription: sample description
+openAPI:
+  definitions:
+    io.k8s.cli.setters.kubeflow-gateway:
+      type: array
+      x-k8s-cli:
+        setter:
+          name: kubeflow-gateway
+          listValues:
+          - "kubeflow/kubeflow-gateway"

--- a/tektoncd/tektoncd-dashboard/overlays/istio/virtual-service.yaml
+++ b/tektoncd/tektoncd-dashboard/overlays/istio/virtual-service.yaml
@@ -3,7 +3,7 @@ kind: VirtualService
 metadata:
   name: tektoncd-dashboard
 spec:
-  gateways:
+  gateways: # {"$kpt-set":"kubeflow-gateway"}
   - kubeflow-gateway
   hosts:
   - '*'

--- a/tektoncd/tektoncd-install/overlays/istio/virtual-service.yaml
+++ b/tektoncd/tektoncd-install/overlays/istio/virtual-service.yaml
@@ -3,7 +3,7 @@ kind: VirtualService
 metadata:
   name: tektoncd
 spec:
-  gateways:
+  gateways: # {"$kpt-set":"kubeflow-gateway"}
   - kubeflow-gateway
   hosts:
   - '*'

--- a/tensorboard/overlays/istio/virtual-service.yaml
+++ b/tensorboard/overlays/istio/virtual-service.yaml
@@ -3,7 +3,7 @@ kind: VirtualService
 metadata:
   name: tensorboard
 spec:
-  gateways:
+  gateways: # {"$kpt-set":"kubeflow-gateway"}
   - kubeflow-gateway
   hosts:
   - '*'


### PR DESCRIPTION
**Which issue is resolved by this Pull Request:**
Related to #1169

**Description of your changes:**
Installs `kubeflow-gateway`, `graphana-vs`, and default ClusterRbacConfig into namespace `istio-system` instead of namespace `kubeflow`.

According to the article [RBAC - istio v1.3](https://archive.istio.io/v1.3/docs/reference/config/authorization/istio.rbac.v1alpha1/#RbacConfig):

> The ClusterRbaConfig Custom Resource is a singleton where only one ClusterRbaConfig should be created globally in the mesh and the namespace should be the same to other Istio components, which usually is `istio-system`.

**Checklist:**
- [x] Unit tests have been rebuilt: 
    1. `cd manifests/tests`
    2. `make generate-changed-only`
    3. `make test`
