### PR TITLE
Fix deployment.yaml selector and template unmatched problem

### DIFF
--- a/xgboost-job/xgboost-operator/base/deployment.yaml
+++ b/xgboost-job/xgboost-operator/base/deployment.yaml
@@ -2,11 +2,13 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: deployment
+  labels:
+    app: xgboost-operator
 spec:
   replicas: 1
   selector:
     matchLabels:
-      name: xgboost-operator
+      app: xgboost-operator
   template:
     metadata:
       labels:


### PR DESCRIPTION
[**Which](d) issue is resolved by this Pull Request:**
Resolves #

**Description of your changes:**


**Checklist:**
- [ ] Unit tests have been rebuilt: 
    1. `cd manifests/tests`
    2. `make generate-changed-only`
    3. `make test`
