### PR TITLE
Add Katib CRD to components

### DIFF
--- a/katib/components/katib-crds/kustomization.yaml
+++ b/katib/components/katib-crds/kustomization.yaml
@@ -1,0 +1,11 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+namespace: kubeflow
+resources:
+  - ../../katib-crds/base/experiment-crd.yaml
+  - ../../katib-crds/base/suggestion-crd.yaml
+  - ../../katib-crds/base/trial-crd.yaml
+  - ../../katib-crds/overlays/application/application.yaml
+commonLabels:
+  app.kubernetes.io/component: katib
+  app.kubernetes.io/name: katib-crds

--- a/katib/components/katib-db-manager/kustomization.yaml
+++ b/katib/components/katib-db-manager/kustomization.yaml
@@ -8,3 +8,6 @@ images:
   - name: gcr.io/kubeflow-images-public/katib/v1alpha3/katib-db-manager
     newTag: v0.8.0
     newName: gcr.io/kubeflow-images-public/katib/v1alpha3/katib-db-manager
+commonLabels:
+  app.kubernetes.io/component: katib
+  app.kubernetes.io/name: katib-controller

--- a/katib/components/katib-db-mysql/kustomization.yaml
+++ b/katib/components/katib-db-mysql/kustomization.yaml
@@ -10,3 +10,6 @@ images:
   - name: mysql
     newTag: "8"
     newName: mysql
+commonLabels:
+  app.kubernetes.io/component: katib
+  app.kubernetes.io/name: katib-controller

--- a/katib/installs/katib-external-db/kustomization.yaml
+++ b/katib/installs/katib-external-db/kustomization.yaml
@@ -10,3 +10,6 @@ patchesStrategicMerge:
 secretGenerator:
   - name: katib-mysql-secrets
     env: secrets.env
+commonLabels:
+  app.kubernetes.io/component: katib
+  app.kubernetes.io/name: katib-controller

--- a/katib/installs/katib-external-db/kustomization.yaml
+++ b/katib/installs/katib-external-db/kustomization.yaml
@@ -2,13 +2,11 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 namespace: kubeflow
 resources:
+  - ../../components/katib-crds
   - ../../components/katib-controller
   - ../../components/katib-db-manager
 patchesStrategicMerge:
   - katib-db-manager-deployment.yaml
 secretGenerator:
-- name: katib-mysql-secrets
-  env: secrets.env
-commonLabels:
-  app.kubernetes.io/component: katib
-  app.kubernetes.io/name: katib-controller
+  - name: katib-mysql-secrets
+    env: secrets.env

--- a/katib/installs/katib-standalone/kustomization.yaml
+++ b/katib/installs/katib-standalone/kustomization.yaml
@@ -2,9 +2,7 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 namespace: kubeflow
 resources:
+  - ../../components/katib-crds
   - ../../components/katib-controller
   - ../../components/katib-db-manager
   - ../../components/katib-db-mysql
-commonLabels:
-  app.kubernetes.io/component: katib
-  app.kubernetes.io/name: katib-controller

--- a/tests/katib/installs/katib-external-db/test_data/expected/apiextensions.k8s.io_v1beta1_customresourcedefinition_experiments.kubeflow.org.yaml
+++ b/tests/katib/installs/katib-external-db/test_data/expected/apiextensions.k8s.io_v1beta1_customresourcedefinition_experiments.kubeflow.org.yaml
@@ -1,0 +1,28 @@
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  labels:
+    app.kubernetes.io/component: katib
+    app.kubernetes.io/name: katib-controller
+  name: experiments.kubeflow.org
+spec:
+  additionalPrinterColumns:
+  - JSONPath: .status.conditions[-1:].type
+    name: Status
+    type: string
+  - JSONPath: .metadata.creationTimestamp
+    name: Age
+    type: date
+  group: kubeflow.org
+  names:
+    categories:
+    - all
+    - kubeflow
+    - katib
+    kind: Experiment
+    plural: experiments
+    singular: experiment
+  scope: Namespaced
+  subresources:
+    status: {}
+  version: v1alpha3

--- a/tests/katib/installs/katib-external-db/test_data/expected/apiextensions.k8s.io_v1beta1_customresourcedefinition_suggestions.kubeflow.org.yaml
+++ b/tests/katib/installs/katib-external-db/test_data/expected/apiextensions.k8s.io_v1beta1_customresourcedefinition_suggestions.kubeflow.org.yaml
@@ -1,0 +1,37 @@
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  labels:
+    app.kubernetes.io/component: katib
+    app.kubernetes.io/name: katib-controller
+  name: suggestions.kubeflow.org
+spec:
+  additionalPrinterColumns:
+  - JSONPath: .status.conditions[-1:].type
+    name: Type
+    type: string
+  - JSONPath: .status.conditions[-1:].status
+    name: Status
+    type: string
+  - JSONPath: .spec.requests
+    name: Requested
+    type: string
+  - JSONPath: .status.suggestionCount
+    name: Assigned
+    type: string
+  - JSONPath: .metadata.creationTimestamp
+    name: Age
+    type: date
+  group: kubeflow.org
+  names:
+    categories:
+    - all
+    - kubeflow
+    - katib
+    kind: Suggestion
+    plural: suggestions
+    singular: suggestion
+  scope: Namespaced
+  subresources:
+    status: {}
+  version: v1alpha3

--- a/tests/katib/installs/katib-external-db/test_data/expected/apiextensions.k8s.io_v1beta1_customresourcedefinition_trials.kubeflow.org.yaml
+++ b/tests/katib/installs/katib-external-db/test_data/expected/apiextensions.k8s.io_v1beta1_customresourcedefinition_trials.kubeflow.org.yaml
@@ -1,0 +1,31 @@
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  labels:
+    app.kubernetes.io/component: katib
+    app.kubernetes.io/name: katib-controller
+  name: trials.kubeflow.org
+spec:
+  additionalPrinterColumns:
+  - JSONPath: .status.conditions[-1:].type
+    name: Type
+    type: string
+  - JSONPath: .status.conditions[-1:].status
+    name: Status
+    type: string
+  - JSONPath: .metadata.creationTimestamp
+    name: Age
+    type: date
+  group: kubeflow.org
+  names:
+    categories:
+    - all
+    - kubeflow
+    - katib
+    kind: Trial
+    plural: trials
+    singular: trial
+  scope: Namespaced
+  subresources:
+    status: {}
+  version: v1alpha3

--- a/tests/katib/installs/katib-external-db/test_data/expected/app.k8s.io_v1beta1_application_katib-crds.yaml
+++ b/tests/katib/installs/katib-external-db/test_data/expected/app.k8s.io_v1beta1_application_katib-crds.yaml
@@ -1,0 +1,68 @@
+apiVersion: app.k8s.io/v1beta1
+kind: Application
+metadata:
+  labels:
+    app.kubernetes.io/component: katib
+    app.kubernetes.io/name: katib-controller
+  name: katib-crds
+  namespace: kubeflow
+spec:
+  addOwnerRef: true
+  componentKinds:
+  - group: core
+    kind: Service
+  - group: apps
+    kind: Deployment
+  - group: core
+    kind: ServiceAccount
+  - group: kubeflow.org
+    kind: Experiment
+  - group: kubeflow.org
+    kind: Suggestion
+  - group: kubeflow.org
+    kind: Trial
+  descriptor:
+    description: Katib is a service for hyperparameter tuning and neural architecture
+      search.
+    keywords:
+    - katib
+    - katib-controller
+    - hyperparameter tuning
+    links:
+    - description: About
+      url: https://github.com/kubeflow/katib
+    maintainers:
+    - email: gaoce@caicloud.io
+      name: Ce Gao
+    - email: johnugeo@cisco.com
+      name: Johnu George
+    - email: liuhougang6@126.com
+      name: Hougang Liu
+    - email: ricliu@google.com
+      name: Richard Liu
+    - email: yuji.oshima0x3fd@gmail.com
+      name: YujiOshima
+    - email: andrey.velichkevich@gmail.com
+      name: Andrey Velichkevich
+    owners:
+    - email: gaoce@caicloud.io
+      name: Ce Gao
+    - email: johnugeo@cisco.com
+      name: Johnu George
+    - email: liuhougang6@126.com
+      name: Hougang Liu
+    - email: ricliu@google.com
+      name: Richard Liu
+    - email: yuji.oshima0x3fd@gmail.com
+      name: YujiOshima
+    - email: andrey.velichkevich@gmail.com
+      name: Andrey Velichkevich
+    type: katib
+    version: v1alpha3
+  selector:
+    matchLabels:
+      app.kubernetes.io/component: katib
+      app.kubernetes.io/instance: katib-crds
+      app.kubernetes.io/managed-by: kfctl
+      app.kubernetes.io/name: katib-crds
+      app.kubernetes.io/part-of: kubeflow

--- a/tests/katib/installs/katib-standalone-ibm/test_data/expected/apiextensions.k8s.io_v1beta1_customresourcedefinition_experiments.kubeflow.org.yaml
+++ b/tests/katib/installs/katib-standalone-ibm/test_data/expected/apiextensions.k8s.io_v1beta1_customresourcedefinition_experiments.kubeflow.org.yaml
@@ -1,0 +1,28 @@
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  labels:
+    app.kubernetes.io/component: katib
+    app.kubernetes.io/name: katib-crds
+  name: experiments.kubeflow.org
+spec:
+  additionalPrinterColumns:
+  - JSONPath: .status.conditions[-1:].type
+    name: Status
+    type: string
+  - JSONPath: .metadata.creationTimestamp
+    name: Age
+    type: date
+  group: kubeflow.org
+  names:
+    categories:
+    - all
+    - kubeflow
+    - katib
+    kind: Experiment
+    plural: experiments
+    singular: experiment
+  scope: Namespaced
+  subresources:
+    status: {}
+  version: v1alpha3

--- a/tests/katib/installs/katib-standalone-ibm/test_data/expected/apiextensions.k8s.io_v1beta1_customresourcedefinition_suggestions.kubeflow.org.yaml
+++ b/tests/katib/installs/katib-standalone-ibm/test_data/expected/apiextensions.k8s.io_v1beta1_customresourcedefinition_suggestions.kubeflow.org.yaml
@@ -1,0 +1,37 @@
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  labels:
+    app.kubernetes.io/component: katib
+    app.kubernetes.io/name: katib-crds
+  name: suggestions.kubeflow.org
+spec:
+  additionalPrinterColumns:
+  - JSONPath: .status.conditions[-1:].type
+    name: Type
+    type: string
+  - JSONPath: .status.conditions[-1:].status
+    name: Status
+    type: string
+  - JSONPath: .spec.requests
+    name: Requested
+    type: string
+  - JSONPath: .status.suggestionCount
+    name: Assigned
+    type: string
+  - JSONPath: .metadata.creationTimestamp
+    name: Age
+    type: date
+  group: kubeflow.org
+  names:
+    categories:
+    - all
+    - kubeflow
+    - katib
+    kind: Suggestion
+    plural: suggestions
+    singular: suggestion
+  scope: Namespaced
+  subresources:
+    status: {}
+  version: v1alpha3

--- a/tests/katib/installs/katib-standalone-ibm/test_data/expected/apiextensions.k8s.io_v1beta1_customresourcedefinition_trials.kubeflow.org.yaml
+++ b/tests/katib/installs/katib-standalone-ibm/test_data/expected/apiextensions.k8s.io_v1beta1_customresourcedefinition_trials.kubeflow.org.yaml
@@ -1,0 +1,31 @@
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  labels:
+    app.kubernetes.io/component: katib
+    app.kubernetes.io/name: katib-crds
+  name: trials.kubeflow.org
+spec:
+  additionalPrinterColumns:
+  - JSONPath: .status.conditions[-1:].type
+    name: Type
+    type: string
+  - JSONPath: .status.conditions[-1:].status
+    name: Status
+    type: string
+  - JSONPath: .metadata.creationTimestamp
+    name: Age
+    type: date
+  group: kubeflow.org
+  names:
+    categories:
+    - all
+    - kubeflow
+    - katib
+    kind: Trial
+    plural: trials
+    singular: trial
+  scope: Namespaced
+  subresources:
+    status: {}
+  version: v1alpha3

--- a/tests/katib/installs/katib-standalone-ibm/test_data/expected/app.k8s.io_v1beta1_application_katib-crds.yaml
+++ b/tests/katib/installs/katib-standalone-ibm/test_data/expected/app.k8s.io_v1beta1_application_katib-crds.yaml
@@ -1,0 +1,68 @@
+apiVersion: app.k8s.io/v1beta1
+kind: Application
+metadata:
+  labels:
+    app.kubernetes.io/component: katib
+    app.kubernetes.io/name: katib-crds
+  name: katib-crds
+  namespace: kubeflow
+spec:
+  addOwnerRef: true
+  componentKinds:
+  - group: core
+    kind: Service
+  - group: apps
+    kind: Deployment
+  - group: core
+    kind: ServiceAccount
+  - group: kubeflow.org
+    kind: Experiment
+  - group: kubeflow.org
+    kind: Suggestion
+  - group: kubeflow.org
+    kind: Trial
+  descriptor:
+    description: Katib is a service for hyperparameter tuning and neural architecture
+      search.
+    keywords:
+    - katib
+    - katib-controller
+    - hyperparameter tuning
+    links:
+    - description: About
+      url: https://github.com/kubeflow/katib
+    maintainers:
+    - email: gaoce@caicloud.io
+      name: Ce Gao
+    - email: johnugeo@cisco.com
+      name: Johnu George
+    - email: liuhougang6@126.com
+      name: Hougang Liu
+    - email: ricliu@google.com
+      name: Richard Liu
+    - email: yuji.oshima0x3fd@gmail.com
+      name: YujiOshima
+    - email: andrey.velichkevich@gmail.com
+      name: Andrey Velichkevich
+    owners:
+    - email: gaoce@caicloud.io
+      name: Ce Gao
+    - email: johnugeo@cisco.com
+      name: Johnu George
+    - email: liuhougang6@126.com
+      name: Hougang Liu
+    - email: ricliu@google.com
+      name: Richard Liu
+    - email: yuji.oshima0x3fd@gmail.com
+      name: YujiOshima
+    - email: andrey.velichkevich@gmail.com
+      name: Andrey Velichkevich
+    type: katib
+    version: v1alpha3
+  selector:
+    matchLabels:
+      app.kubernetes.io/component: katib
+      app.kubernetes.io/instance: katib-crds
+      app.kubernetes.io/managed-by: kfctl
+      app.kubernetes.io/name: katib-crds
+      app.kubernetes.io/part-of: kubeflow

--- a/tests/katib/installs/katib-standalone/test_data/expected/apiextensions.k8s.io_v1beta1_customresourcedefinition_experiments.kubeflow.org.yaml
+++ b/tests/katib/installs/katib-standalone/test_data/expected/apiextensions.k8s.io_v1beta1_customresourcedefinition_experiments.kubeflow.org.yaml
@@ -1,0 +1,28 @@
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  labels:
+    app.kubernetes.io/component: katib
+    app.kubernetes.io/name: katib-crds
+  name: experiments.kubeflow.org
+spec:
+  additionalPrinterColumns:
+  - JSONPath: .status.conditions[-1:].type
+    name: Status
+    type: string
+  - JSONPath: .metadata.creationTimestamp
+    name: Age
+    type: date
+  group: kubeflow.org
+  names:
+    categories:
+    - all
+    - kubeflow
+    - katib
+    kind: Experiment
+    plural: experiments
+    singular: experiment
+  scope: Namespaced
+  subresources:
+    status: {}
+  version: v1alpha3

--- a/tests/katib/installs/katib-standalone/test_data/expected/apiextensions.k8s.io_v1beta1_customresourcedefinition_suggestions.kubeflow.org.yaml
+++ b/tests/katib/installs/katib-standalone/test_data/expected/apiextensions.k8s.io_v1beta1_customresourcedefinition_suggestions.kubeflow.org.yaml
@@ -1,0 +1,37 @@
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  labels:
+    app.kubernetes.io/component: katib
+    app.kubernetes.io/name: katib-crds
+  name: suggestions.kubeflow.org
+spec:
+  additionalPrinterColumns:
+  - JSONPath: .status.conditions[-1:].type
+    name: Type
+    type: string
+  - JSONPath: .status.conditions[-1:].status
+    name: Status
+    type: string
+  - JSONPath: .spec.requests
+    name: Requested
+    type: string
+  - JSONPath: .status.suggestionCount
+    name: Assigned
+    type: string
+  - JSONPath: .metadata.creationTimestamp
+    name: Age
+    type: date
+  group: kubeflow.org
+  names:
+    categories:
+    - all
+    - kubeflow
+    - katib
+    kind: Suggestion
+    plural: suggestions
+    singular: suggestion
+  scope: Namespaced
+  subresources:
+    status: {}
+  version: v1alpha3

--- a/tests/katib/installs/katib-standalone/test_data/expected/apiextensions.k8s.io_v1beta1_customresourcedefinition_trials.kubeflow.org.yaml
+++ b/tests/katib/installs/katib-standalone/test_data/expected/apiextensions.k8s.io_v1beta1_customresourcedefinition_trials.kubeflow.org.yaml
@@ -1,0 +1,31 @@
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  labels:
+    app.kubernetes.io/component: katib
+    app.kubernetes.io/name: katib-crds
+  name: trials.kubeflow.org
+spec:
+  additionalPrinterColumns:
+  - JSONPath: .status.conditions[-1:].type
+    name: Type
+    type: string
+  - JSONPath: .status.conditions[-1:].status
+    name: Status
+    type: string
+  - JSONPath: .metadata.creationTimestamp
+    name: Age
+    type: date
+  group: kubeflow.org
+  names:
+    categories:
+    - all
+    - kubeflow
+    - katib
+    kind: Trial
+    plural: trials
+    singular: trial
+  scope: Namespaced
+  subresources:
+    status: {}
+  version: v1alpha3

--- a/tests/katib/installs/katib-standalone/test_data/expected/app.k8s.io_v1beta1_application_katib-crds.yaml
+++ b/tests/katib/installs/katib-standalone/test_data/expected/app.k8s.io_v1beta1_application_katib-crds.yaml
@@ -1,0 +1,68 @@
+apiVersion: app.k8s.io/v1beta1
+kind: Application
+metadata:
+  labels:
+    app.kubernetes.io/component: katib
+    app.kubernetes.io/name: katib-crds
+  name: katib-crds
+  namespace: kubeflow
+spec:
+  addOwnerRef: true
+  componentKinds:
+  - group: core
+    kind: Service
+  - group: apps
+    kind: Deployment
+  - group: core
+    kind: ServiceAccount
+  - group: kubeflow.org
+    kind: Experiment
+  - group: kubeflow.org
+    kind: Suggestion
+  - group: kubeflow.org
+    kind: Trial
+  descriptor:
+    description: Katib is a service for hyperparameter tuning and neural architecture
+      search.
+    keywords:
+    - katib
+    - katib-controller
+    - hyperparameter tuning
+    links:
+    - description: About
+      url: https://github.com/kubeflow/katib
+    maintainers:
+    - email: gaoce@caicloud.io
+      name: Ce Gao
+    - email: johnugeo@cisco.com
+      name: Johnu George
+    - email: liuhougang6@126.com
+      name: Hougang Liu
+    - email: ricliu@google.com
+      name: Richard Liu
+    - email: yuji.oshima0x3fd@gmail.com
+      name: YujiOshima
+    - email: andrey.velichkevich@gmail.com
+      name: Andrey Velichkevich
+    owners:
+    - email: gaoce@caicloud.io
+      name: Ce Gao
+    - email: johnugeo@cisco.com
+      name: Johnu George
+    - email: liuhougang6@126.com
+      name: Hougang Liu
+    - email: ricliu@google.com
+      name: Richard Liu
+    - email: yuji.oshima0x3fd@gmail.com
+      name: YujiOshima
+    - email: andrey.velichkevich@gmail.com
+      name: Andrey Velichkevich
+    type: katib
+    version: v1alpha3
+  selector:
+    matchLabels:
+      app.kubernetes.io/component: katib
+      app.kubernetes.io/instance: katib-crds
+      app.kubernetes.io/managed-by: kfctl
+      app.kubernetes.io/name: katib-crds
+      app.kubernetes.io/part-of: kubeflow


### PR DESCRIPTION
I added Katib CRDs to components, see discussion: https://github.com/kubeflow/manifests/pull/1124#issuecomment-618634808.

Also, I added `commonLabels` to `components/katib-db-manager` and `components/katib-db-mysql` and I removed `commonLabels` from `installs/katib-standalone` since it is not required.

@jlewi What do you think about Katib manifests v3 version? `katib/installs` and `katib/components` satisfies the V3 manifests rules.
I can delete current v3 manifests and make `installs` and `components` under `v3` folder.

/assign @jlewi @gaocegege @johnugeorge 

**Checklist:**
- [x] Unit tests have been rebuilt: 
    1. `cd manifests/tests`
    2. `make generate-changed-only`
    3. `make test`
