### PR TITLE
unmatched label for deployment config

### DIFF
--- a/xgboost-job/xgboost-operator/base/deployment.yaml
+++ b/xgboost-job/xgboost-operator/base/deployment.yaml
@@ -6,7 +6,7 @@ spec:
   replicas: 1
   selector:
     matchLabels:
-      name: xgboost-operator
+      app: xgboost-operator
   template:
     metadata:
       labels:


### PR DESCRIPTION
**Which issue is resolved by this Pull Request:**
Resolves #
unmatched label for deployment config

**Description of your changes:**
I updated the deployment config file two weeks ago, but I ignore a mistake, I found it when I test the xgboost-operator V1. Sorry about that.
