### PR TITLE
Changed OIDC EnvoyFilter to fit recent API

### DIFF
--- a/istio/oidc-authservice/base/envoy-filter.yaml
+++ b/istio/oidc-authservice/base/envoy-filter.yaml
@@ -3,30 +3,32 @@ kind: EnvoyFilter
 metadata:
   name: authn-filter
 spec:
-  workloadLabels:
-    istio: ingressgateway
-  filters:
-  - filterConfig:
-      httpService:
-        serverUri:
-          uri: http://authservice.$(namespace).svc.cluster.local
-          cluster: outbound|8080||authservice.$(namespace).svc.cluster.local
-          failureModeAllow: false
-          timeout: 10s
-        authorizationRequest:
-          allowedHeaders:
-            patterns:
-            - exact: "cookie"
-            - exact: "X-Auth-Token"
-        authorizationResponse:
-          allowedUpstreamHeaders:
-            patterns:
-            - exact: "kubeflow-userid"
-      statusOnError:
-        code: GatewayTimeout
-    filterName: envoy.ext_authz
-    filterType: HTTP
-    insertPosition:
-      index: FIRST
-    listenerMatch:
-      listenerType: GATEWAY
+  workloadSelector:
+    labels:
+      istio: ingressgateway
+  configPatches:
+  - applyTo: HTTP_FILTER
+    match:
+      context: GATEWAY
+    patch:
+      operation: INSERT_BEFORE # INSERT_FIRST added on istio v1.5
+      value:
+        name: envoy.ext_authz
+        config:
+          httpService:
+            authorizationRequest:
+              allowedHeaders:
+                patterns:
+                - exact: cookie
+                - exact: X-Auth-Token
+            authorizationResponse:
+              allowedUpstreamHeaders:
+                patterns:
+                - exact: kubeflow-userid
+            serverUri:
+              cluster: outbound|8080||authservice.istio-system.svc.cluster.local
+              failureModeAllow: false
+              timeout: 10s
+              uri: http://authservice.istio-system.svc.cluster.local
+          statusOnError:
+            code: GatewayTimeout


### PR DESCRIPTION
The method of describing envoy filters in istio has changed since v1.3. The manifest of kubeflow-istio-dex uses version 1.3 of istio, but envoyfilter follows the old api format. Since istio moved to 1.6 (latest version), the API format is in place, and since this API format can express more abundantly, I think it is correct to change to the latest API format.


**Checklist:**
- [ ] Unit tests have been rebuilt: 
    1. `cd manifests/tests`
    2. `make generate-changed-only`
    3. `make test`
