### PR TITLE
Add argo to stacks/generic

### DIFF
--- a/stacks/generic/kustomization.yaml
+++ b/stacks/generic/kustomization.yaml
@@ -15,6 +15,7 @@ resources:
   - ../../pytorch-job/pytorch-operator/overlays/application
   - ../../tf-training/tf-job-crds/overlays/application
   - ../../tf-training/tf-job-operator/overlays/application
+  - ../../argo/base_v3
   # This package will create a profile resource so it needs to be installed after the profiles CR
   - ../../default-install/base
 configMapGenerator:

--- a/tests/stacks/examples/alice/test_data/expected/apiextensions.k8s.io_v1beta1_customresourcedefinition_workflows.argoproj.io.yaml
+++ b/tests/stacks/examples/alice/test_data/expected/apiextensions.k8s.io_v1beta1_customresourcedefinition_workflows.argoproj.io.yaml
@@ -1,0 +1,19 @@
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  labels:
+    app.kubernetes.io/component: argo
+    app.kubernetes.io/name: argo
+    kustomize.component: argo
+  name: workflows.argoproj.io
+spec:
+  group: argoproj.io
+  names:
+    kind: Workflow
+    listKind: WorkflowList
+    plural: workflows
+    shortNames:
+    - wf
+    singular: workflow
+  scope: Namespaced
+  version: v1alpha1

--- a/tests/stacks/examples/alice/test_data/expected/app.k8s.io_v1beta1_application_argo.yaml
+++ b/tests/stacks/examples/alice/test_data/expected/app.k8s.io_v1beta1_application_argo.yaml
@@ -1,0 +1,39 @@
+apiVersion: app.k8s.io/v1beta1
+kind: Application
+metadata:
+  labels:
+    app.kubernetes.io/component: argo
+    app.kubernetes.io/name: argo
+    kustomize.component: argo
+  name: argo
+  namespace: kubeflow
+spec:
+  addOwnerRef: true
+  componentKinds:
+  - group: core
+    kind: ConfigMap
+  - group: apps
+    kind: Deployment
+  - group: core
+    kind: ServiceAccount
+  - group: core
+    kind: Service
+  - group: networking.istio.io
+    kind: VirtualService
+  descriptor:
+    description: Argo Workflows is an open source container-native workflow engine
+      for orchestrating parallel jobs on Kubernetes
+    keywords:
+    - argo
+    - kubeflow
+    links:
+    - description: About
+      url: https://github.com/argoproj/argo
+    maintainers: []
+    owners: []
+    type: argo
+    version: v1beta1
+  selector:
+    matchLabels:
+      app.kubernetes.io/component: argo
+      app.kubernetes.io/name: argo

--- a/tests/stacks/examples/alice/test_data/expected/apps_v1_deployment_argo-ui.yaml
+++ b/tests/stacks/examples/alice/test_data/expected/apps_v1_deployment_argo-ui.yaml
@@ -1,0 +1,66 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  labels:
+    app: argo-ui
+    app.kubernetes.io/component: argo
+    app.kubernetes.io/name: argo
+    kustomize.component: argo
+  name: argo-ui
+  namespace: kubeflow
+spec:
+  progressDeadlineSeconds: 600
+  replicas: 1
+  revisionHistoryLimit: 10
+  selector:
+    matchLabels:
+      app: argo-ui
+      app.kubernetes.io/component: argo
+      app.kubernetes.io/name: argo
+      kustomize.component: argo
+  strategy:
+    rollingUpdate:
+      maxSurge: 25%
+      maxUnavailable: 25%
+    type: RollingUpdate
+  template:
+    metadata:
+      annotations:
+        sidecar.istio.io/inject: "false"
+      creationTimestamp: null
+      labels:
+        app: argo-ui
+        app.kubernetes.io/component: argo
+        app.kubernetes.io/name: argo
+        kustomize.component: argo
+    spec:
+      containers:
+      - env:
+        - name: ARGO_NAMESPACE
+          valueFrom:
+            fieldRef:
+              apiVersion: v1
+              fieldPath: metadata.namespace
+        - name: IN_CLUSTER
+          value: "true"
+        - name: ENABLE_WEB_CONSOLE
+          value: "false"
+        - name: BASE_HREF
+          value: /argo/
+        image: argoproj/argoui:v2.3.0
+        imagePullPolicy: IfNotPresent
+        name: argo-ui
+        readinessProbe:
+          httpGet:
+            path: /
+            port: 8001
+        resources: {}
+        terminationMessagePath: /dev/termination-log
+        terminationMessagePolicy: File
+      dnsPolicy: ClusterFirst
+      restartPolicy: Always
+      schedulerName: default-scheduler
+      securityContext: {}
+      serviceAccount: argo-ui
+      serviceAccountName: argo-ui
+      terminationGracePeriodSeconds: 30

--- a/tests/stacks/examples/alice/test_data/expected/apps_v1_deployment_workflow-controller.yaml
+++ b/tests/stacks/examples/alice/test_data/expected/apps_v1_deployment_workflow-controller.yaml
@@ -1,0 +1,61 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  labels:
+    app: workflow-controller
+    app.kubernetes.io/component: argo
+    app.kubernetes.io/name: argo
+    kustomize.component: argo
+  name: workflow-controller
+  namespace: kubeflow
+spec:
+  progressDeadlineSeconds: 600
+  replicas: 1
+  revisionHistoryLimit: 10
+  selector:
+    matchLabels:
+      app: workflow-controller
+      app.kubernetes.io/component: argo
+      app.kubernetes.io/name: argo
+      kustomize.component: argo
+  strategy:
+    rollingUpdate:
+      maxSurge: 25%
+      maxUnavailable: 25%
+    type: RollingUpdate
+  template:
+    metadata:
+      annotations:
+        sidecar.istio.io/inject: "false"
+      creationTimestamp: null
+      labels:
+        app: workflow-controller
+        app.kubernetes.io/component: argo
+        app.kubernetes.io/name: argo
+        kustomize.component: argo
+    spec:
+      containers:
+      - args:
+        - --configmap
+        - workflow-controller-configmap
+        command:
+        - workflow-controller
+        env:
+        - name: ARGO_NAMESPACE
+          valueFrom:
+            fieldRef:
+              apiVersion: v1
+              fieldPath: metadata.namespace
+        image: argoproj/workflow-controller:v2.3.0
+        imagePullPolicy: IfNotPresent
+        name: workflow-controller
+        resources: {}
+        terminationMessagePath: /dev/termination-log
+        terminationMessagePolicy: File
+      dnsPolicy: ClusterFirst
+      restartPolicy: Always
+      schedulerName: default-scheduler
+      securityContext: {}
+      serviceAccount: argo
+      serviceAccountName: argo
+      terminationGracePeriodSeconds: 30

--- a/tests/stacks/examples/alice/test_data/expected/networking.istio.io_v1alpha3_virtualservice_argo-ui.yaml
+++ b/tests/stacks/examples/alice/test_data/expected/networking.istio.io_v1alpha3_virtualservice_argo-ui.yaml
@@ -1,0 +1,25 @@
+apiVersion: networking.istio.io/v1alpha3
+kind: VirtualService
+metadata:
+  labels:
+    app.kubernetes.io/component: argo
+    app.kubernetes.io/name: argo
+    kustomize.component: argo
+  name: argo-ui
+  namespace: kubeflow
+spec:
+  gateways:
+  - kubeflow-gateway
+  hosts:
+  - '*'
+  http:
+  - match:
+    - uri:
+        prefix: /argo/
+    rewrite:
+      uri: /
+    route:
+    - destination:
+        host: argo-ui.kubeflow.svc.cluster.local
+        port:
+          number: 80

--- a/tests/stacks/examples/alice/test_data/expected/rbac.authorization.k8s.io_v1beta1_clusterrole_argo-ui.yaml
+++ b/tests/stacks/examples/alice/test_data/expected/rbac.authorization.k8s.io_v1beta1_clusterrole_argo-ui.yaml
@@ -1,0 +1,35 @@
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: ClusterRole
+metadata:
+  labels:
+    app: argo
+    app.kubernetes.io/component: argo
+    app.kubernetes.io/name: argo
+    kustomize.component: argo
+  name: argo-ui
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - pods
+  - pods/exec
+  - pods/log
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - secrets
+  verbs:
+  - get
+- apiGroups:
+  - argoproj.io
+  resources:
+  - workflows
+  - workflows/finalizers
+  verbs:
+  - get
+  - list
+  - watch

--- a/tests/stacks/examples/alice/test_data/expected/rbac.authorization.k8s.io_v1beta1_clusterrole_argo.yaml
+++ b/tests/stacks/examples/alice/test_data/expected/rbac.authorization.k8s.io_v1beta1_clusterrole_argo.yaml
@@ -1,0 +1,54 @@
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: ClusterRole
+metadata:
+  labels:
+    app: argo
+    app.kubernetes.io/component: argo
+    app.kubernetes.io/name: argo
+    kustomize.component: argo
+  name: argo
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - pods
+  - pods/exec
+  verbs:
+  - create
+  - get
+  - list
+  - watch
+  - update
+  - patch
+- apiGroups:
+  - ""
+  resources:
+  - configmaps
+  verbs:
+  - get
+  - watch
+  - list
+- apiGroups:
+  - ""
+  resources:
+  - persistentvolumeclaims
+  verbs:
+  - create
+  - delete
+- apiGroups:
+  - argoproj.io
+  resources:
+  - workflows
+  - workflows/finalizers
+  verbs:
+  - get
+  - list
+  - watch
+  - update
+  - patch
+- apiGroups:
+  - sparkoperator.k8s.io
+  resources:
+  - sparkapplications
+  verbs:
+  - '*'

--- a/tests/stacks/examples/alice/test_data/expected/rbac.authorization.k8s.io_v1beta1_clusterrolebinding_argo-ui.yaml
+++ b/tests/stacks/examples/alice/test_data/expected/rbac.authorization.k8s.io_v1beta1_clusterrolebinding_argo-ui.yaml
@@ -1,0 +1,17 @@
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: ClusterRoleBinding
+metadata:
+  labels:
+    app: argo-ui
+    app.kubernetes.io/component: argo
+    app.kubernetes.io/name: argo
+    kustomize.component: argo
+  name: argo-ui
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: argo-ui
+subjects:
+- kind: ServiceAccount
+  name: argo-ui
+  namespace: kubeflow

--- a/tests/stacks/examples/alice/test_data/expected/rbac.authorization.k8s.io_v1beta1_clusterrolebinding_argo.yaml
+++ b/tests/stacks/examples/alice/test_data/expected/rbac.authorization.k8s.io_v1beta1_clusterrolebinding_argo.yaml
@@ -1,0 +1,17 @@
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: ClusterRoleBinding
+metadata:
+  labels:
+    app: argo
+    app.kubernetes.io/component: argo
+    app.kubernetes.io/name: argo
+    kustomize.component: argo
+  name: argo
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: argo
+subjects:
+- kind: ServiceAccount
+  name: argo
+  namespace: kubeflow

--- a/tests/stacks/examples/alice/test_data/expected/~g_v1_configmap_workflow-controller-configmap.yaml
+++ b/tests/stacks/examples/alice/test_data/expected/~g_v1_configmap_workflow-controller-configmap.yaml
@@ -1,0 +1,32 @@
+apiVersion: v1
+data:
+  config: |
+    {
+    executorImage: argoproj/argoexec:v2.3.0,
+    containerRuntimeExecutor: docker,
+    artifactRepository:
+    {
+        s3: {
+            bucket: mlpipeline,
+            keyPrefix: artifacts,
+            endpoint: minio-service.kubeflow:9000,
+            insecure: true,
+            accessKeySecret: {
+                name: mlpipeline-minio-artifact,
+                key: accesskey
+            },
+            secretKeySecret: {
+                name: mlpipeline-minio-artifact,
+                key: secretkey
+            }
+        }
+    }
+    }
+kind: ConfigMap
+metadata:
+  labels:
+    app.kubernetes.io/component: argo
+    app.kubernetes.io/name: argo
+    kustomize.component: argo
+  name: workflow-controller-configmap
+  namespace: kubeflow

--- a/tests/stacks/examples/alice/test_data/expected/~g_v1_configmap_workflow-controller-parameters.yaml
+++ b/tests/stacks/examples/alice/test_data/expected/~g_v1_configmap_workflow-controller-parameters.yaml
@@ -1,0 +1,22 @@
+apiVersion: v1
+data:
+  artifactRepositoryAccessKeySecretKey: accesskey
+  artifactRepositoryAccessKeySecretName: mlpipeline-minio-artifact
+  artifactRepositoryBucket: mlpipeline
+  artifactRepositoryEndpoint: minio-service.kubeflow:9000
+  artifactRepositoryInsecure: "true"
+  artifactRepositoryKeyPrefix: artifacts
+  artifactRepositorySecretKeySecretKey: secretkey
+  artifactRepositorySecretKeySecretName: mlpipeline-minio-artifact
+  clusterDomain: cluster.local
+  containerRuntimeExecutor: docker
+  executorImage: argoproj/argoexec:v2.3.0
+  namespace: ""
+kind: ConfigMap
+metadata:
+  labels:
+    app.kubernetes.io/component: argo
+    app.kubernetes.io/name: argo
+    kustomize.component: argo
+  name: workflow-controller-parameters
+  namespace: kubeflow

--- a/tests/stacks/examples/alice/test_data/expected/~g_v1_service_argo-ui.yaml
+++ b/tests/stacks/examples/alice/test_data/expected/~g_v1_service_argo-ui.yaml
@@ -1,0 +1,21 @@
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    app: argo-ui
+    app.kubernetes.io/component: argo
+    app.kubernetes.io/name: argo
+    kustomize.component: argo
+  name: argo-ui
+  namespace: kubeflow
+spec:
+  ports:
+  - port: 80
+    targetPort: 8001
+  selector:
+    app: argo-ui
+    app.kubernetes.io/component: argo
+    app.kubernetes.io/name: argo
+    kustomize.component: argo
+  sessionAffinity: None
+  type: NodePort

--- a/tests/stacks/examples/alice/test_data/expected/~g_v1_serviceaccount_argo-ui.yaml
+++ b/tests/stacks/examples/alice/test_data/expected/~g_v1_serviceaccount_argo-ui.yaml
@@ -1,0 +1,9 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  labels:
+    app.kubernetes.io/component: argo
+    app.kubernetes.io/name: argo
+    kustomize.component: argo
+  name: argo-ui
+  namespace: kubeflow

--- a/tests/stacks/examples/alice/test_data/expected/~g_v1_serviceaccount_argo.yaml
+++ b/tests/stacks/examples/alice/test_data/expected/~g_v1_serviceaccount_argo.yaml
@@ -1,0 +1,9 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  labels:
+    app.kubernetes.io/component: argo
+    app.kubernetes.io/name: argo
+    kustomize.component: argo
+  name: argo
+  namespace: kubeflow

--- a/tests/stacks/generic/test_data/expected/apiextensions.k8s.io_v1beta1_customresourcedefinition_workflows.argoproj.io.yaml
+++ b/tests/stacks/generic/test_data/expected/apiextensions.k8s.io_v1beta1_customresourcedefinition_workflows.argoproj.io.yaml
@@ -1,0 +1,19 @@
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  labels:
+    app.kubernetes.io/component: argo
+    app.kubernetes.io/name: argo
+    kustomize.component: argo
+  name: workflows.argoproj.io
+spec:
+  group: argoproj.io
+  names:
+    kind: Workflow
+    listKind: WorkflowList
+    plural: workflows
+    shortNames:
+    - wf
+    singular: workflow
+  scope: Namespaced
+  version: v1alpha1

--- a/tests/stacks/generic/test_data/expected/app.k8s.io_v1beta1_application_argo.yaml
+++ b/tests/stacks/generic/test_data/expected/app.k8s.io_v1beta1_application_argo.yaml
@@ -1,0 +1,39 @@
+apiVersion: app.k8s.io/v1beta1
+kind: Application
+metadata:
+  labels:
+    app.kubernetes.io/component: argo
+    app.kubernetes.io/name: argo
+    kustomize.component: argo
+  name: argo
+  namespace: kubeflow
+spec:
+  addOwnerRef: true
+  componentKinds:
+  - group: core
+    kind: ConfigMap
+  - group: apps
+    kind: Deployment
+  - group: core
+    kind: ServiceAccount
+  - group: core
+    kind: Service
+  - group: networking.istio.io
+    kind: VirtualService
+  descriptor:
+    description: Argo Workflows is an open source container-native workflow engine
+      for orchestrating parallel jobs on Kubernetes
+    keywords:
+    - argo
+    - kubeflow
+    links:
+    - description: About
+      url: https://github.com/argoproj/argo
+    maintainers: []
+    owners: []
+    type: argo
+    version: v1beta1
+  selector:
+    matchLabels:
+      app.kubernetes.io/component: argo
+      app.kubernetes.io/name: argo

--- a/tests/stacks/generic/test_data/expected/apps_v1_deployment_argo-ui.yaml
+++ b/tests/stacks/generic/test_data/expected/apps_v1_deployment_argo-ui.yaml
@@ -1,0 +1,66 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  labels:
+    app: argo-ui
+    app.kubernetes.io/component: argo
+    app.kubernetes.io/name: argo
+    kustomize.component: argo
+  name: argo-ui
+  namespace: kubeflow
+spec:
+  progressDeadlineSeconds: 600
+  replicas: 1
+  revisionHistoryLimit: 10
+  selector:
+    matchLabels:
+      app: argo-ui
+      app.kubernetes.io/component: argo
+      app.kubernetes.io/name: argo
+      kustomize.component: argo
+  strategy:
+    rollingUpdate:
+      maxSurge: 25%
+      maxUnavailable: 25%
+    type: RollingUpdate
+  template:
+    metadata:
+      annotations:
+        sidecar.istio.io/inject: "false"
+      creationTimestamp: null
+      labels:
+        app: argo-ui
+        app.kubernetes.io/component: argo
+        app.kubernetes.io/name: argo
+        kustomize.component: argo
+    spec:
+      containers:
+      - env:
+        - name: ARGO_NAMESPACE
+          valueFrom:
+            fieldRef:
+              apiVersion: v1
+              fieldPath: metadata.namespace
+        - name: IN_CLUSTER
+          value: "true"
+        - name: ENABLE_WEB_CONSOLE
+          value: "false"
+        - name: BASE_HREF
+          value: /argo/
+        image: argoproj/argoui:v2.3.0
+        imagePullPolicy: IfNotPresent
+        name: argo-ui
+        readinessProbe:
+          httpGet:
+            path: /
+            port: 8001
+        resources: {}
+        terminationMessagePath: /dev/termination-log
+        terminationMessagePolicy: File
+      dnsPolicy: ClusterFirst
+      restartPolicy: Always
+      schedulerName: default-scheduler
+      securityContext: {}
+      serviceAccount: argo-ui
+      serviceAccountName: argo-ui
+      terminationGracePeriodSeconds: 30

--- a/tests/stacks/generic/test_data/expected/apps_v1_deployment_workflow-controller.yaml
+++ b/tests/stacks/generic/test_data/expected/apps_v1_deployment_workflow-controller.yaml
@@ -1,0 +1,61 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  labels:
+    app: workflow-controller
+    app.kubernetes.io/component: argo
+    app.kubernetes.io/name: argo
+    kustomize.component: argo
+  name: workflow-controller
+  namespace: kubeflow
+spec:
+  progressDeadlineSeconds: 600
+  replicas: 1
+  revisionHistoryLimit: 10
+  selector:
+    matchLabels:
+      app: workflow-controller
+      app.kubernetes.io/component: argo
+      app.kubernetes.io/name: argo
+      kustomize.component: argo
+  strategy:
+    rollingUpdate:
+      maxSurge: 25%
+      maxUnavailable: 25%
+    type: RollingUpdate
+  template:
+    metadata:
+      annotations:
+        sidecar.istio.io/inject: "false"
+      creationTimestamp: null
+      labels:
+        app: workflow-controller
+        app.kubernetes.io/component: argo
+        app.kubernetes.io/name: argo
+        kustomize.component: argo
+    spec:
+      containers:
+      - args:
+        - --configmap
+        - workflow-controller-configmap
+        command:
+        - workflow-controller
+        env:
+        - name: ARGO_NAMESPACE
+          valueFrom:
+            fieldRef:
+              apiVersion: v1
+              fieldPath: metadata.namespace
+        image: argoproj/workflow-controller:v2.3.0
+        imagePullPolicy: IfNotPresent
+        name: workflow-controller
+        resources: {}
+        terminationMessagePath: /dev/termination-log
+        terminationMessagePolicy: File
+      dnsPolicy: ClusterFirst
+      restartPolicy: Always
+      schedulerName: default-scheduler
+      securityContext: {}
+      serviceAccount: argo
+      serviceAccountName: argo
+      terminationGracePeriodSeconds: 30

--- a/tests/stacks/generic/test_data/expected/networking.istio.io_v1alpha3_virtualservice_argo-ui.yaml
+++ b/tests/stacks/generic/test_data/expected/networking.istio.io_v1alpha3_virtualservice_argo-ui.yaml
@@ -1,0 +1,25 @@
+apiVersion: networking.istio.io/v1alpha3
+kind: VirtualService
+metadata:
+  labels:
+    app.kubernetes.io/component: argo
+    app.kubernetes.io/name: argo
+    kustomize.component: argo
+  name: argo-ui
+  namespace: kubeflow
+spec:
+  gateways:
+  - kubeflow-gateway
+  hosts:
+  - '*'
+  http:
+  - match:
+    - uri:
+        prefix: /argo/
+    rewrite:
+      uri: /
+    route:
+    - destination:
+        host: argo-ui.kubeflow.svc.cluster.local
+        port:
+          number: 80

--- a/tests/stacks/generic/test_data/expected/rbac.authorization.k8s.io_v1beta1_clusterrole_argo-ui.yaml
+++ b/tests/stacks/generic/test_data/expected/rbac.authorization.k8s.io_v1beta1_clusterrole_argo-ui.yaml
@@ -1,0 +1,35 @@
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: ClusterRole
+metadata:
+  labels:
+    app: argo
+    app.kubernetes.io/component: argo
+    app.kubernetes.io/name: argo
+    kustomize.component: argo
+  name: argo-ui
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - pods
+  - pods/exec
+  - pods/log
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - secrets
+  verbs:
+  - get
+- apiGroups:
+  - argoproj.io
+  resources:
+  - workflows
+  - workflows/finalizers
+  verbs:
+  - get
+  - list
+  - watch

--- a/tests/stacks/generic/test_data/expected/rbac.authorization.k8s.io_v1beta1_clusterrole_argo.yaml
+++ b/tests/stacks/generic/test_data/expected/rbac.authorization.k8s.io_v1beta1_clusterrole_argo.yaml
@@ -1,0 +1,54 @@
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: ClusterRole
+metadata:
+  labels:
+    app: argo
+    app.kubernetes.io/component: argo
+    app.kubernetes.io/name: argo
+    kustomize.component: argo
+  name: argo
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - pods
+  - pods/exec
+  verbs:
+  - create
+  - get
+  - list
+  - watch
+  - update
+  - patch
+- apiGroups:
+  - ""
+  resources:
+  - configmaps
+  verbs:
+  - get
+  - watch
+  - list
+- apiGroups:
+  - ""
+  resources:
+  - persistentvolumeclaims
+  verbs:
+  - create
+  - delete
+- apiGroups:
+  - argoproj.io
+  resources:
+  - workflows
+  - workflows/finalizers
+  verbs:
+  - get
+  - list
+  - watch
+  - update
+  - patch
+- apiGroups:
+  - sparkoperator.k8s.io
+  resources:
+  - sparkapplications
+  verbs:
+  - '*'

--- a/tests/stacks/generic/test_data/expected/rbac.authorization.k8s.io_v1beta1_clusterrolebinding_argo-ui.yaml
+++ b/tests/stacks/generic/test_data/expected/rbac.authorization.k8s.io_v1beta1_clusterrolebinding_argo-ui.yaml
@@ -1,0 +1,17 @@
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: ClusterRoleBinding
+metadata:
+  labels:
+    app: argo-ui
+    app.kubernetes.io/component: argo
+    app.kubernetes.io/name: argo
+    kustomize.component: argo
+  name: argo-ui
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: argo-ui
+subjects:
+- kind: ServiceAccount
+  name: argo-ui
+  namespace: kubeflow

--- a/tests/stacks/generic/test_data/expected/rbac.authorization.k8s.io_v1beta1_clusterrolebinding_argo.yaml
+++ b/tests/stacks/generic/test_data/expected/rbac.authorization.k8s.io_v1beta1_clusterrolebinding_argo.yaml
@@ -1,0 +1,17 @@
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: ClusterRoleBinding
+metadata:
+  labels:
+    app: argo
+    app.kubernetes.io/component: argo
+    app.kubernetes.io/name: argo
+    kustomize.component: argo
+  name: argo
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: argo
+subjects:
+- kind: ServiceAccount
+  name: argo
+  namespace: kubeflow

--- a/tests/stacks/generic/test_data/expected/~g_v1_configmap_workflow-controller-configmap.yaml
+++ b/tests/stacks/generic/test_data/expected/~g_v1_configmap_workflow-controller-configmap.yaml
@@ -1,0 +1,32 @@
+apiVersion: v1
+data:
+  config: |
+    {
+    executorImage: argoproj/argoexec:v2.3.0,
+    containerRuntimeExecutor: docker,
+    artifactRepository:
+    {
+        s3: {
+            bucket: mlpipeline,
+            keyPrefix: artifacts,
+            endpoint: minio-service.kubeflow:9000,
+            insecure: true,
+            accessKeySecret: {
+                name: mlpipeline-minio-artifact,
+                key: accesskey
+            },
+            secretKeySecret: {
+                name: mlpipeline-minio-artifact,
+                key: secretkey
+            }
+        }
+    }
+    }
+kind: ConfigMap
+metadata:
+  labels:
+    app.kubernetes.io/component: argo
+    app.kubernetes.io/name: argo
+    kustomize.component: argo
+  name: workflow-controller-configmap
+  namespace: kubeflow

--- a/tests/stacks/generic/test_data/expected/~g_v1_configmap_workflow-controller-parameters.yaml
+++ b/tests/stacks/generic/test_data/expected/~g_v1_configmap_workflow-controller-parameters.yaml
@@ -1,0 +1,22 @@
+apiVersion: v1
+data:
+  artifactRepositoryAccessKeySecretKey: accesskey
+  artifactRepositoryAccessKeySecretName: mlpipeline-minio-artifact
+  artifactRepositoryBucket: mlpipeline
+  artifactRepositoryEndpoint: minio-service.kubeflow:9000
+  artifactRepositoryInsecure: "true"
+  artifactRepositoryKeyPrefix: artifacts
+  artifactRepositorySecretKeySecretKey: secretkey
+  artifactRepositorySecretKeySecretName: mlpipeline-minio-artifact
+  clusterDomain: cluster.local
+  containerRuntimeExecutor: docker
+  executorImage: argoproj/argoexec:v2.3.0
+  namespace: ""
+kind: ConfigMap
+metadata:
+  labels:
+    app.kubernetes.io/component: argo
+    app.kubernetes.io/name: argo
+    kustomize.component: argo
+  name: workflow-controller-parameters
+  namespace: kubeflow

--- a/tests/stacks/generic/test_data/expected/~g_v1_service_argo-ui.yaml
+++ b/tests/stacks/generic/test_data/expected/~g_v1_service_argo-ui.yaml
@@ -1,0 +1,21 @@
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    app: argo-ui
+    app.kubernetes.io/component: argo
+    app.kubernetes.io/name: argo
+    kustomize.component: argo
+  name: argo-ui
+  namespace: kubeflow
+spec:
+  ports:
+  - port: 80
+    targetPort: 8001
+  selector:
+    app: argo-ui
+    app.kubernetes.io/component: argo
+    app.kubernetes.io/name: argo
+    kustomize.component: argo
+  sessionAffinity: None
+  type: NodePort

--- a/tests/stacks/generic/test_data/expected/~g_v1_serviceaccount_argo-ui.yaml
+++ b/tests/stacks/generic/test_data/expected/~g_v1_serviceaccount_argo-ui.yaml
@@ -1,0 +1,9 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  labels:
+    app.kubernetes.io/component: argo
+    app.kubernetes.io/name: argo
+    kustomize.component: argo
+  name: argo-ui
+  namespace: kubeflow

--- a/tests/stacks/generic/test_data/expected/~g_v1_serviceaccount_argo.yaml
+++ b/tests/stacks/generic/test_data/expected/~g_v1_serviceaccount_argo.yaml
@@ -1,0 +1,9 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  labels:
+    app.kubernetes.io/component: argo
+    app.kubernetes.io/name: argo
+    kustomize.component: argo
+  name: argo
+  namespace: kubeflow


### PR DESCRIPTION
**Which issue is resolved by this Pull Request:**
Follow up of https://github.com/kubeflow/manifests/pull/1185
Part of https://github.com/kubeflow/manifests/issues/1090

**Description of your changes:**
Add argo to `stacks/generic`

**Checklist:**
- [x] Unit tests have been rebuilt: 
    1. `cd manifests/tests`
    2. `make generate-changed-only`
    3. `make test`
