### PR TITLE
[AWS] Upgrade ingress APIVersion to support k8s 1.16

### DIFF
--- a/aws/istio-ingress/base/ingress.yaml
+++ b/aws/istio-ingress/base/ingress.yaml
@@ -1,4 +1,4 @@
-apiVersion: extensions/v1beta1 # networking.k8s.io/v1beta1
+apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
   annotations:


### PR DESCRIPTION
**Which issue is resolved by this Pull Request:**
Resolves #869 

**Description of your changes:**
NetworkPolicy in the extensions/v1beta1 API version is no longer served is 1.16. We migrate to use the networking.k8s.io/v1 API version, available since v1.8. 

**Checklist:**
- [x] Unit tests have been rebuilt: 
    1. `cd manifests/tests`
    2. `make generate-changed-only`
    3. `make test`