### PR TITLE
Update PyTorch operator RBAC for Kubeflow 1.1

### DIFF
--- a/pytorch-job/pytorch-operator/base/cluster-role.yaml
+++ b/pytorch-job/pytorch-operator/base/cluster-role.yaml
@@ -10,6 +10,7 @@ rules:
   resources:
   - pytorchjobs
   - pytorchjobs/status
+  - pytorchjobs/finalizers
   verbs:
   - '*'
 - apiGroups:
@@ -56,6 +57,7 @@ rules:
   resources:
   - pytorchjobs
   - pytorchjobs/status
+  - pytorchjobs/finalizers
   verbs:
   - get
   - list
@@ -80,6 +82,7 @@ rules:
   resources:
   - pytorchjobs
   - pytorchjobs/status
+  - pytorchjobs/finalizers
   verbs:
   - get
   - list

--- a/tests/stacks/examples/alice/test_data/expected/rbac.authorization.k8s.io_v1_clusterrole_kubeflow-pytorchjobs-edit.yaml
+++ b/tests/stacks/examples/alice/test_data/expected/rbac.authorization.k8s.io_v1_clusterrole_kubeflow-pytorchjobs-edit.yaml
@@ -14,6 +14,7 @@ rules:
   resources:
   - pytorchjobs
   - pytorchjobs/status
+  - pytorchjobs/finalizers
   verbs:
   - get
   - list

--- a/tests/stacks/examples/alice/test_data/expected/rbac.authorization.k8s.io_v1_clusterrole_kubeflow-pytorchjobs-view.yaml
+++ b/tests/stacks/examples/alice/test_data/expected/rbac.authorization.k8s.io_v1_clusterrole_kubeflow-pytorchjobs-view.yaml
@@ -13,6 +13,7 @@ rules:
   resources:
   - pytorchjobs
   - pytorchjobs/status
+  - pytorchjobs/finalizers
   verbs:
   - get
   - list

--- a/tests/stacks/examples/alice/test_data/expected/rbac.authorization.k8s.io_v1beta1_clusterrole_pytorch-operator.yaml
+++ b/tests/stacks/examples/alice/test_data/expected/rbac.authorization.k8s.io_v1beta1_clusterrole_pytorch-operator.yaml
@@ -13,6 +13,7 @@ rules:
   resources:
   - pytorchjobs
   - pytorchjobs/status
+  - pytorchjobs/finalizers
   verbs:
   - '*'
 - apiGroups:

--- a/tests/stacks/generic/test_data/expected/rbac.authorization.k8s.io_v1_clusterrole_kubeflow-pytorchjobs-edit.yaml
+++ b/tests/stacks/generic/test_data/expected/rbac.authorization.k8s.io_v1_clusterrole_kubeflow-pytorchjobs-edit.yaml
@@ -14,6 +14,7 @@ rules:
   resources:
   - pytorchjobs
   - pytorchjobs/status
+  - pytorchjobs/finalizers
   verbs:
   - get
   - list

--- a/tests/stacks/generic/test_data/expected/rbac.authorization.k8s.io_v1_clusterrole_kubeflow-pytorchjobs-view.yaml
+++ b/tests/stacks/generic/test_data/expected/rbac.authorization.k8s.io_v1_clusterrole_kubeflow-pytorchjobs-view.yaml
@@ -13,6 +13,7 @@ rules:
   resources:
   - pytorchjobs
   - pytorchjobs/status
+  - pytorchjobs/finalizers
   verbs:
   - get
   - list

--- a/tests/stacks/generic/test_data/expected/rbac.authorization.k8s.io_v1beta1_clusterrole_pytorch-operator.yaml
+++ b/tests/stacks/generic/test_data/expected/rbac.authorization.k8s.io_v1beta1_clusterrole_pytorch-operator.yaml
@@ -13,6 +13,7 @@ rules:
   resources:
   - pytorchjobs
   - pytorchjobs/status
+  - pytorchjobs/finalizers
   verbs:
   - '*'
 - apiGroups:

--- a/tests/tests/legacy_kustomizations/pytorch-operator/test_data/expected/rbac.authorization.k8s.io_v1_clusterrole_kubeflow-pytorchjobs-edit.yaml
+++ b/tests/tests/legacy_kustomizations/pytorch-operator/test_data/expected/rbac.authorization.k8s.io_v1_clusterrole_kubeflow-pytorchjobs-edit.yaml
@@ -18,6 +18,7 @@ rules:
   resources:
   - pytorchjobs
   - pytorchjobs/status
+  - pytorchjobs/finalizers
   verbs:
   - get
   - list

--- a/tests/tests/legacy_kustomizations/pytorch-operator/test_data/expected/rbac.authorization.k8s.io_v1_clusterrole_kubeflow-pytorchjobs-view.yaml
+++ b/tests/tests/legacy_kustomizations/pytorch-operator/test_data/expected/rbac.authorization.k8s.io_v1_clusterrole_kubeflow-pytorchjobs-view.yaml
@@ -17,6 +17,7 @@ rules:
   resources:
   - pytorchjobs
   - pytorchjobs/status
+  - pytorchjobs/finalizers
   verbs:
   - get
   - list

--- a/tests/tests/legacy_kustomizations/pytorch-operator/test_data/expected/rbac.authorization.k8s.io_v1beta1_clusterrole_pytorch-operator.yaml
+++ b/tests/tests/legacy_kustomizations/pytorch-operator/test_data/expected/rbac.authorization.k8s.io_v1beta1_clusterrole_pytorch-operator.yaml
@@ -17,6 +17,7 @@ rules:
   resources:
   - pytorchjobs
   - pytorchjobs/status
+  - pytorchjobs/finalizers
   verbs:
   - '*'
 - apiGroups:


### PR DESCRIPTION
I added `pytorchjobs/finalizers` resource to RBAC for PyTorch operator.
See this PR: https://github.com/kubeflow/pytorch-operator/pull/276.

/assign @johnugeorge 
/cc @jlewi @vpavlin @gaocegege 
 
**Checklist:**
- [x] Unit tests have been rebuilt: 
    1. `cd manifests/tests`
    2. `make generate-changed-only`
    3. `make test`
