### PR TITLE
Add namespace selector and test case for admission

### DIFF
--- a/admission-webhook/webhook/base/mutating-webhook-configuration.yaml
+++ b/admission-webhook/webhook/base/mutating-webhook-configuration.yaml
@@ -10,6 +10,9 @@ webhooks:
       namespace: $(podDefaultsNamespace)
       path: /apply-poddefault
   name: $(podDefaultsDeploymentName).kubeflow.org
+  namespaceSelector:
+    matchLabels:
+      app.kubernetes.io/part-of: kubeflow-profile
   rules:
   - apiGroups:
     - ""

--- a/profiles/base/kustomization.yaml
+++ b/profiles/base/kustomization.yaml
@@ -24,7 +24,7 @@ images:
   newTag: vmaster-gf3e09203
 - name: gcr.io/kubeflow-images-public/profile-controller
   newName: gcr.io/kubeflow-images-public/profile-controller
-  newTag: vmaster-g34aa47c2
+  newTag: vmaster-ga49f658f
 vars:
 - fieldref:
     fieldPath: data.admin

--- a/tests/stacks/examples/alice/test_data/expected/admissionregistration.k8s.io_v1beta1_mutatingwebhookconfiguration_admission-webhook-mutating-webhook-configuration.yaml
+++ b/tests/stacks/examples/alice/test_data/expected/admissionregistration.k8s.io_v1beta1_mutatingwebhookconfiguration_admission-webhook-mutating-webhook-configuration.yaml
@@ -17,6 +17,9 @@ webhooks:
       namespace: kubeflow
       path: /apply-poddefault
   name: admission-webhook-deployment.kubeflow.org
+  namespaceSelector:
+    matchLabels:
+      app.kubernetes.io/part-of: kubeflow-profile
   rules:
   - apiGroups:
     - ""

--- a/tests/stacks/generic/test_data/expected/admissionregistration.k8s.io_v1beta1_mutatingwebhookconfiguration_admission-webhook-mutating-webhook-configuration.yaml
+++ b/tests/stacks/generic/test_data/expected/admissionregistration.k8s.io_v1beta1_mutatingwebhookconfiguration_admission-webhook-mutating-webhook-configuration.yaml
@@ -17,6 +17,9 @@ webhooks:
       namespace: kubeflow
       path: /apply-poddefault
   name: admission-webhook-deployment.kubeflow.org
+  namespaceSelector:
+    matchLabels:
+      app.kubernetes.io/part-of: kubeflow-profile
   rules:
   - apiGroups:
     - ""

--- a/tests/tests/legacy_kustomizations/profiles/test_data/expected/apps_v1_deployment_profiles-deployment.yaml
+++ b/tests/tests/legacy_kustomizations/profiles/test_data/expected/apps_v1_deployment_profiles-deployment.yaml
@@ -45,7 +45,7 @@ spec:
         - kf-v1-0210-user@jlewi-dev.iam.gserviceaccount.com
         command:
         - /manager
-        image: gcr.io/kubeflow-images-public/profile-controller:vmaster-g34aa47c2
+        image: gcr.io/kubeflow-images-public/profile-controller:vmaster-ga49f658f
         imagePullPolicy: Always
         livenessProbe:
           httpGet:

--- a/tests/tests/legacy_kustomizations/webhook/test_data/expected/admissionregistration.k8s.io_v1beta1_mutatingwebhookconfiguration_admission-webhook-mutating-webhook-configuration.yaml
+++ b/tests/tests/legacy_kustomizations/webhook/test_data/expected/admissionregistration.k8s.io_v1beta1_mutatingwebhookconfiguration_admission-webhook-mutating-webhook-configuration.yaml
@@ -19,6 +19,9 @@ webhooks:
       namespace: kubeflow
       path: /apply-poddefault
   name: admission-webhook-deployment.kubeflow.org
+  namespaceSelector:
+    matchLabels:
+      app.kubernetes.io/part-of: kubeflow-profile
   rules:
   - apiGroups:
     - ""

--- a/tests/validate_resources_test.go
+++ b/tests/validate_resources_test.go
@@ -2,15 +2,16 @@ package tests
 
 import (
 	"bytes"
-	"github.com/ghodss/yaml"
 	"io/ioutil"
 	"os"
 	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/ghodss/yaml"
 	"sigs.k8s.io/kustomize/kyaml/kio"
 	kyaml "sigs.k8s.io/kustomize/kyaml/yaml"
 	"sigs.k8s.io/kustomize/v3/pkg/types"
-	"strings"
-	"testing"
 )
 
 const (
@@ -209,6 +210,124 @@ func TestValidK8sResources(t *testing.T) {
 			}
 
 			checkEmptyAnnotations()
+		}
+		return nil
+	})
+
+	if err != nil {
+		t.Errorf("error walking the path %v; error: %v", rootDir, err)
+	}
+}
+
+// TestCheckWebhookSelector is a test to try to ensure all the mutating webhooks
+// have either namespaceSeletor or objectSelector to avoid issues per
+// https://github.com/kubeflow/manifests/issues/1213.
+func TestCheckWebhookSelector(t *testing.T) {
+	rootDir := ".."
+
+	// Directories to exclude. Thee paths should be relative to rootDir.
+	// Subdirectories won't be searched
+	excludes := map[string]bool{
+		"tests":   true,
+		".git":    true,
+		".github": true,
+	}
+
+	err := filepath.Walk("..", func(path string, info os.FileInfo, err error) error {
+		relPath, err := filepath.Rel(rootDir, path)
+
+		if err != nil {
+			t.Fatalf("Could not compute relative path(%v, %v); error: %v", rootDir, path, err)
+		}
+
+		if _, ok := excludes[relPath]; ok {
+			return filepath.SkipDir
+		}
+
+		// skip directories
+		if info.IsDir() {
+			return nil
+		}
+
+		// Skip non YAML files
+		ext := filepath.Ext(info.Name())
+
+		if ext != ".yaml" && ext != ".yml" {
+			return nil
+		}
+		data, err := ioutil.ReadFile(path)
+
+		if err != nil {
+			t.Errorf("Error reading %v; error: %v", path, err)
+		}
+
+		input := bytes.NewReader(data)
+		reader := kio.ByteReader{
+			Reader: input,
+		}
+
+		nodes, err := reader.Read()
+
+		if err != nil {
+			t.Errorf("Error unmarshaling %v; error: %v", path, err)
+		}
+
+		for _, n := range nodes {
+			//root := n
+
+			m, err := n.GetMeta()
+			// Skip objects with no metadata
+			if err != nil {
+				continue
+			}
+
+			// Skip objects with no name or kind
+			if m.Name == "" || m.Kind == "" {
+				continue
+			}
+
+			// Skip non-mutating webhook files
+			if strings.ToLower(m.Kind) != "mutatingwebhookconfiguration" {
+				continue
+			}
+
+			// Ensure objectSelector or namespaceSelector is set for pod resource
+			if webhooks := n.Field("webhooks"); webhooks != nil {
+				webhookElements, err := webhooks.Value.Elements()
+				// Skip webhooks with no element
+				if err != nil {
+					continue
+				}
+				for _, w := range webhookElements {
+					if kyaml.IsFieldEmpty(w.Field("namespaceSelector")) && kyaml.IsFieldEmpty(w.Field("objectSelector")) {
+						// If there's no objectSelector or namespaceSelector, make sure the mutating webhook doesn't
+						// have any rule for pods.
+						if rules := w.Field("rules"); rules != nil {
+							ruleElements, err := rules.Value.Elements()
+							if err != nil {
+								continue
+							}
+							for _, rule := range ruleElements {
+								if resources := rule.Field("resources"); resources != nil {
+									resourceElements, err := resources.Value.Elements()
+									if err != nil {
+										continue
+									}
+									for _, resource := range resourceElements {
+										resourceString, err := resource.String()
+										if err != nil {
+											continue
+										}
+										if strings.TrimSpace(resourceString) == "pods" || strings.TrimSpace(resourceString) == "*" {
+											t.Errorf("Path %v; resource %v; does not have objectSelector or namespaceSelector is for mutating webhook on pods", path, m.Name)
+										}
+									}
+								}
+							}
+						}
+					}
+				}
+			}
 		}
 		return nil
 	})


### PR DESCRIPTION
**Which issue is resolved by this Pull Request:**
Resolves #1213 
Resolves kubeflow/kubeflow#4808

**Description of your changes:**
- Update the profile control to the latest version, which includes the `app.kubernetes.io/part-of: kubeflow-profile` label when creating a new namespace
- Update admission mutating webhook with namespaceSelector using the new label.
- Add new unit case to make sure all the mutating webhooks that change the pod will need to have either namespaceSelector or objectSelector.

**Checklist:**
- [x] Unit tests have been rebuilt: 
    1. `cd manifests/tests`
    2. `make generate-changed-only`
    3. `make test`
