### PR TITLE
GCP stack

### DIFF
--- a/stacks/gcp/OWNERS
+++ b/stacks/gcp/OWNERS
@@ -1,0 +1,4 @@
+# Owners file should only contain Googlers
+# since these are Google's oppinionated configs.
+approvers:
+- jlewi

--- a/stacks/gcp/config/params.env
+++ b/stacks/gcp/config/params.env
@@ -1,0 +1,3 @@
+clusterDomain=cluster.local
+userid-header=X-Goog-Authenticated-User-Email
+userid-prefix=accounts.google.com:

--- a/stacks/gcp/kustomization.yaml
+++ b/stacks/gcp/kustomization.yaml
@@ -1,0 +1,53 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+namespace: kubeflow
+resources:
+  # List the Kubeflow applications that should be included 
+  # TODO(https://github.com/kubeflow/manifests/issues/1073): 
+  # We need to switch the admission webhook to use cert-manager.
+  - ../../admission-webhook/webhook/v3
+  - ../../common/centraldashboard/overlays/stacks
+  - ../../kubeflow-roles/base
+  - ../../jupyter/jupyter-web-app/base_v3
+  - ../../jupyter/notebook-controller/base_v3
+  - ../../profiles/base_v3
+  - ../../pytorch-job/pytorch-job-crds/overlays/application
+  - ../../pytorch-job/pytorch-operator/overlays/application
+  - ../../tf-training/tf-job-crds/overlays/application
+  - ../../tf-training/tf-job-operator/overlays/application
+  - ../../argo/base_v3
+  - ../../pipeline/minio/installs/generic
+  - ../../pipeline/mysql/installs/generic
+  - ../../pipeline/installs/generic
+  - ../../metadata/v3
+  # This package will create a profile resource so it needs to be installed after the profiles CR
+  - ../../default-install/base
+  - ../../katib/installs/katib-standalone
+configMapGenerator:
+- envs:
+  - ./config/params.env
+  name: kubeflow-config
+vars:
+# We need to define vars at the top level otherwise we will get
+# conflicts. 
+- fieldref:
+    fieldPath: data.clusterDomain
+  name: clusterDomain
+  objref:
+    apiVersion: v1
+    kind: ConfigMap
+    name: kubeflow-config
+- fieldref:
+    fieldPath: metadata.namespace
+  name: namespace
+  objref:
+    apiVersion: v1
+    kind: ConfigMap
+    name: kubeflow-config
+- fieldref:
+    fieldpath: metadata.namespace
+  name: katib-ui-namespace
+  objref:
+    kind: Service
+    name: katib-ui
+    apiVersion: v1

--- a/stacks/gcp/kustomization.yaml
+++ b/stacks/gcp/kustomization.yaml
@@ -16,8 +16,8 @@ resources:
   - ../../tf-training/tf-job-crds/overlays/application
   - ../../tf-training/tf-job-operator/overlays/application
   - ../../argo/base_v3
-  - ../../pipeline/minio/installs/generic
-  - ../../pipeline/mysql/installs/generic
+  - ../../pipeline/minio/installs/gcp-pd
+  - ../../pipeline/mysql/installs/gcp-pd
   - ../../pipeline/installs/generic
   - ../../metadata/v3
   # This package will create a profile resource so it needs to be installed after the profiles CR

--- a/stacks/generic/OWNERS
+++ b/stacks/generic/OWNERS
@@ -1,4 +1,2 @@
-# Owners file should only contain Googlers
-# since these are Google's oppinionated configs.
 approvers:
 - jlewi


### PR DESCRIPTION
**Which issue is resolved by this Pull Request:**
Part of https://github.com/kubeflow/gcp-blueprints/issues/55

**Description of your changes:**
Add gcp stack back
diff between gcp stack and general stack is that: kfp uses parameterized gcp-pd as storage

**Checklist:**
- [x] Unit tests have been rebuilt: 
    1. `cd manifests/tests`
    2. `make generate-changed-only`
    3. `make test`
