### PR TITLE
OWNERS for TF and PyTorch operators

### DIFF
--- a/pytorch-job/OWNERS
+++ b/pytorch-job/OWNERS
@@ -1,0 +1,4 @@
+approvers:
+  - andreyvelich
+  - gaocegege
+  - johnugeorge

--- a/tests/OWNERS
+++ b/tests/OWNERS
@@ -1,4 +1,7 @@
 approvers:
+  - andreyvelich
   - Bobgy
+  - gaocegege
   - jeffwan
+  - johnugeorge
   - krishnadurai

--- a/tf-training/OWNERS
+++ b/tf-training/OWNERS
@@ -1,0 +1,4 @@
+approvers:
+  - andreyvelich
+  - gaocegege
+  - johnugeorge


### PR DESCRIPTION
I added OWNERS file for TF and PyTorch operators.
See comment: https://github.com/kubeflow/manifests/pull/1283#issuecomment-646598494

/assign @jlewi 
/cc @gaocegege @johnugeorge 

**Checklist:**
- [x] Unit tests have been rebuilt: 
    1. `cd manifests/tests`
    2. `make generate-changed-only`
    3. `make test`
