### PR TITLE
Fix aws ingress api version bug

### DIFF
--- a/aws/istio-ingress/base/ingress.yaml
+++ b/aws/istio-ingress/base/ingress.yaml
@@ -1,4 +1,4 @@
-apiVersion: networking.k8s.io/v1
+apiVersion: networking.k8s.io/v1beta1
 kind: Ingress
 metadata:
   annotations:

--- a/tests/stacks/gcp/test_data/expected/apps_v1_deployment_tf-job-operator.yaml
+++ b/tests/stacks/gcp/test_data/expected/apps_v1_deployment_tf-job-operator.yaml
@@ -38,6 +38,6 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: metadata.name
-        image: gcr.io/kubeflow-images-public/tf_operator:vmaster-gd455e6ef
+        image: gcr.io/kubeflow-images-public/tf_operator:vmaster-ga2ae7bff
         name: tf-job-operator
       serviceAccountName: tf-job-operator


### PR DESCRIPTION
**Which issue is resolved by this Pull Request:**
Resolves #1291

**Description of your changes:**
Fix ingress api version from v1 to v1beta1. This is bug found by Jeremy. Appreciate that!

**Checklist:**
- [x] Unit tests have been rebuilt: 
    1. `cd manifests/tests`
    2. `make generate-changed-only`
    3. `make test`