### PR TITLE
Upgrade aws cognito manifest istio version to 1.3.1

### DIFF
--- a/kfdef/kfctl_aws_cognito.yaml
+++ b/kfdef/kfctl_aws_cognito.yaml
@@ -10,7 +10,7 @@ spec:
         value: istio-system
       repoRef:
         name: manifests
-        path: istio/istio-crds
+        path: istio-1-3-1/istio-crds-1-3-1
     name: istio-crds
   - kustomizeConfig:
       parameters:
@@ -18,7 +18,7 @@ spec:
         value: istio-system
       repoRef:
         name: manifests
-        path: istio/istio-install
+        path: istio-1-3-1/istio-install-1-3-1
     name: istio-install
   - kustomizeConfig:
       parameters:
@@ -26,7 +26,7 @@ spec:
         value: istio-system
       repoRef:
         name: manifests
-        path: istio/cluster-local-gateway
+        path: istio-1-3-1/cluster-local-gateway-1-3-1
     name: cluster-local-gateway
   - kustomizeConfig:
       parameters:

--- a/kfdef/source/master/kfctl_aws_cognito.yaml
+++ b/kfdef/source/master/kfctl_aws_cognito.yaml
@@ -10,7 +10,7 @@ spec:
         value: istio-system
       repoRef:
         name: manifests
-        path: istio/istio-crds
+        path: istio-1-3-1/istio-crds-1-3-1
     name: istio-crds
   - kustomizeConfig:
       parameters:
@@ -18,7 +18,7 @@ spec:
         value: istio-system
       repoRef:
         name: manifests
-        path: istio/istio-install
+        path: istio-1-3-1/istio-install-1-3-1
     name: istio-install
   - kustomizeConfig:
       parameters:
@@ -26,7 +26,7 @@ spec:
         value: istio-system
       repoRef:
         name: manifests
-        path: istio/cluster-local-gateway
+        path: istio-1-3-1/cluster-local-gateway-1-3-1
     name: cluster-local-gateway
   - kustomizeConfig:
       parameters:


### PR DESCRIPTION
**Which issue is resolved by this Pull Request:**
Resolves https://github.com/kubeflow/kubeflow/issues/5057

**Description of your changes:**
Upgrade istio in aws cognito kfdef from 1.1.x to 1.3.1

**Checklist:**
- [X] Unit tests have been rebuilt: 
    1. `cd manifests/tests`
    2. `make generate-changed-only`
    3. `make test`
