### PR TITLE
Correct XGBoostJob CRD group name and add singular name

### DIFF
--- a/xgboost-job/xgboost-operator/base/cluster-role.yaml
+++ b/xgboost-job/xgboost-operator/base/cluster-role.yaml
@@ -17,7 +17,7 @@ rules:
   - patch
   - delete
 - apiGroups:
-  - xgboostjob.kubeflow.org
+  - kubeflow.org
   resources:
   - xgboostjobs
   - xgboostjobs/status

--- a/xgboost-job/xgboost-operator/base/crd.yaml
+++ b/xgboost-job/xgboost-operator/base/crd.yaml
@@ -1,11 +1,12 @@
 apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
 metadata:
-  name: xgboostjobs.xgboostjob.kubeflow.org
+  name: xgboostjobs.kubeflow.org
 spec:
-  group: xgboostjob.kubeflow.org
+  group: kubeflow.org
   names:
     kind: XGBoostJob
+    singular: xgboostjob
     plural: xgboostjobs
   scope: Namespaced
   validation:

--- a/xgboost-job/xgboost-operator/overlays/application/application.yaml
+++ b/xgboost-job/xgboost-operator/overlays/application/application.yaml
@@ -17,7 +17,7 @@ spec:
     kind: Deployment
   - group: core
     kind: ServiceAccount
-  - group: xgboostjob.kubeflow.org
+  - group: kubeflow.org
     kind: XGBoostJob
   descriptor: 
     type: xgboostjob


### PR DESCRIPTION
**Which issue is resolved by this Pull Request:**
Resolves https://github.com/kubeflow/xgboost-operator/issues/94

**Description of your changes:**


**Checklist:**
- [x] Unit tests have been rebuilt: 
    1. `cd manifests/tests`
    2. `make generate-changed-only`
    3. `make test`
