### PR TITLE
fix(gcp): default workload identity bindings

### DIFF
--- a/gcp/v2/cnrm/iam/kf-admin-policy.yaml
+++ b/gcp/v2/cnrm/iam/kf-admin-policy.yaml
@@ -165,3 +165,17 @@ spec:
     apiVersion: resourcemanager.cnrm.cloud.google.com/v1beta1
     kind: Project
     external: projects/project-id # {"type":"string","x-kustomize":{"setBy":"kpt","partialSetters":[{"name":"gcloud.core.project","value":"project-id"}]}}
+---
+apiVersion: iam.cnrm.cloud.google.com/v1beta1
+kind: IAMPolicy
+metadata:
+  name: name-admin-workload-identity-users # {"type":"string","x-kustomize":{"setBy":"kpt","partialSetters":[{"name":"name","value":"name"}]}}
+spec:
+  resourceRef:
+    apiVersion: iam.cnrm.cloud.google.com/v1beta1
+    kind: IAMServiceAccount
+    name: name-admin # {"type":"string","x-kustomize":{"setBy":"kpt","partialSetters":[{"name":"name","value":"name"}]}}
+  bindings:
+  - role: roles/iam.workloadIdentityUser
+    members:
+    - serviceAccount:project-id.svc.id.goog[kubeflow/profiles-controller-service-account] # {"type":"string","x-kustomize":{"setBy":"kpt","partialSetters":[{"name":"gcloud.core.project","value":"project-id"}]}}

--- a/gcp/v2/cnrm/iam/kf-user-policy.yaml
+++ b/gcp/v2/cnrm/iam/kf-user-policy.yaml
@@ -141,3 +141,19 @@ spec:
     apiVersion: resourcemanager.cnrm.cloud.google.com/v1beta1
     kind: Project
     external: projects/project-id # {"type":"string","x-kustomize":{"setBy":"kpt","partialSetters":[{"name":"gcloud.core.project","value":"project-id"}]}}
+---
+apiVersion: iam.cnrm.cloud.google.com/v1beta1
+kind: IAMPolicy
+metadata:
+  name: name-user-workload-identity-users # {"type":"string","x-kustomize":{"setBy":"kpt","partialSetters":[{"name":"name","value":"name"}]}}
+spec:
+  resourceRef:
+    apiVersion: iam.cnrm.cloud.google.com/v1beta1
+    kind: IAMServiceAccount
+    name: name-user # {"type":"string","x-kustomize":{"setBy":"kpt","partialSetters":[{"name":"name","value":"name"}]}}
+  bindings:
+  - role: roles/iam.workloadIdentityUser
+    members:
+    - serviceAccount:project-id.svc.id.goog[kubeflow/ml-pipeline-ui] # {"type":"string","x-kustomize":{"setBy":"kpt","partialSetters":[{"name":"gcloud.core.project","value":"project-id"}]}}
+    - serviceAccount:project-id.svc.id.goog[kubeflow/ml-pipeline-visualizationserver] # {"type":"string","x-kustomize":{"setBy":"kpt","partialSetters":[{"name":"gcloud.core.project","value":"project-id"}]}}
+    - serviceAccount:project-id.svc.id.goog[kubeflow/pipeline-runner] # {"type":"string","x-kustomize":{"setBy":"kpt","partialSetters":[{"name":"gcloud.core.project","value":"project-id"}]}}

--- a/stacks/gcp/kustomization.yaml
+++ b/stacks/gcp/kustomization.yaml
@@ -23,6 +23,8 @@ resources:
   # This package will create a profile resource so it needs to be installed after the profiles CR
   - ../../default-install/base
   - ../../katib/installs/katib-standalone
+patchesStrategicMerge:
+  - workload-identity-bindings-patch.yaml
 configMapGenerator:
 - envs:
   - ./config/params.env

--- a/stacks/gcp/workload-identity-bindings-patch.yaml
+++ b/stacks/gcp/workload-identity-bindings-patch.yaml
@@ -1,0 +1,27 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: profiles-controller-service-account
+  annotations:
+    iam.gke.io/gcp-service-account: name-admin@project-id.iam.gserviceaccount.com # {"type":"string","x-kustomize":{"setBy":"kpt","partialSetters":[{"name":"name","value":"name"},{"name":"gcloud.core.project","value":"project-id"}]}}
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: ml-pipeline-ui
+  annotations:
+    iam.gke.io/gcp-service-account: name-user@project-id.iam.gserviceaccount.com # {"type":"string","x-kustomize":{"setBy":"kpt","partialSetters":[{"name":"name","value":"name"},{"name":"gcloud.core.project","value":"project-id"}]}}
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: ml-pipeline-visualizationserver
+  annotations:
+    iam.gke.io/gcp-service-account: name-user@project-id.iam.gserviceaccount.com # {"type":"string","x-kustomize":{"setBy":"kpt","partialSetters":[{"name":"name","value":"name"},{"name":"gcloud.core.project","value":"project-id"}]}}
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: pipeline-runner
+  annotations:
+    iam.gke.io/gcp-service-account: name-user@project-id.iam.gserviceaccount.com # {"type":"string","x-kustomize":{"setBy":"kpt","partialSetters":[{"name":"name","value":"name"},{"name":"gcloud.core.project","value":"project-id"}]}}

--- a/tests/stacks/examples/alice/test_data/expected/~g_v1_serviceaccount_ml-pipeline-ui.yaml
+++ b/tests/stacks/examples/alice/test_data/expected/~g_v1_serviceaccount_ml-pipeline-ui.yaml
@@ -1,5 +1,7 @@
 apiVersion: v1
 kind: ServiceAccount
 metadata:
+  annotations:
+    iam.gke.io/gcp-service-account: name-user@project-id.iam.gserviceaccount.com
   name: ml-pipeline-ui
   namespace: kubeflow

--- a/tests/stacks/examples/alice/test_data/expected/~g_v1_serviceaccount_ml-pipeline-visualizationserver.yaml
+++ b/tests/stacks/examples/alice/test_data/expected/~g_v1_serviceaccount_ml-pipeline-visualizationserver.yaml
@@ -1,5 +1,7 @@
 apiVersion: v1
 kind: ServiceAccount
 metadata:
+  annotations:
+    iam.gke.io/gcp-service-account: name-user@project-id.iam.gserviceaccount.com
   name: ml-pipeline-visualizationserver
   namespace: kubeflow

--- a/tests/stacks/examples/alice/test_data/expected/~g_v1_serviceaccount_pipeline-runner.yaml
+++ b/tests/stacks/examples/alice/test_data/expected/~g_v1_serviceaccount_pipeline-runner.yaml
@@ -1,5 +1,7 @@
 apiVersion: v1
 kind: ServiceAccount
 metadata:
+  annotations:
+    iam.gke.io/gcp-service-account: name-user@project-id.iam.gserviceaccount.com
   name: pipeline-runner
   namespace: kubeflow

--- a/tests/stacks/examples/alice/test_data/expected/~g_v1_serviceaccount_profiles-controller-service-account.yaml
+++ b/tests/stacks/examples/alice/test_data/expected/~g_v1_serviceaccount_profiles-controller-service-account.yaml
@@ -1,6 +1,8 @@
 apiVersion: v1
 kind: ServiceAccount
 metadata:
+  annotations:
+    iam.gke.io/gcp-service-account: name-admin@project-id.iam.gserviceaccount.com
   labels:
     kustomize.component: profiles
   name: profiles-controller-service-account

--- a/tests/stacks/gcp/test_data/expected/~g_v1_serviceaccount_ml-pipeline-ui.yaml
+++ b/tests/stacks/gcp/test_data/expected/~g_v1_serviceaccount_ml-pipeline-ui.yaml
@@ -1,5 +1,7 @@
 apiVersion: v1
 kind: ServiceAccount
 metadata:
+  annotations:
+    iam.gke.io/gcp-service-account: name-user@project-id.iam.gserviceaccount.com
   name: ml-pipeline-ui
   namespace: kubeflow

--- a/tests/stacks/gcp/test_data/expected/~g_v1_serviceaccount_ml-pipeline-visualizationserver.yaml
+++ b/tests/stacks/gcp/test_data/expected/~g_v1_serviceaccount_ml-pipeline-visualizationserver.yaml
@@ -1,5 +1,7 @@
 apiVersion: v1
 kind: ServiceAccount
 metadata:
+  annotations:
+    iam.gke.io/gcp-service-account: name-user@project-id.iam.gserviceaccount.com
   name: ml-pipeline-visualizationserver
   namespace: kubeflow

--- a/tests/stacks/gcp/test_data/expected/~g_v1_serviceaccount_pipeline-runner.yaml
+++ b/tests/stacks/gcp/test_data/expected/~g_v1_serviceaccount_pipeline-runner.yaml
@@ -1,5 +1,7 @@
 apiVersion: v1
 kind: ServiceAccount
 metadata:
+  annotations:
+    iam.gke.io/gcp-service-account: name-user@project-id.iam.gserviceaccount.com
   name: pipeline-runner
   namespace: kubeflow

--- a/tests/stacks/gcp/test_data/expected/~g_v1_serviceaccount_profiles-controller-service-account.yaml
+++ b/tests/stacks/gcp/test_data/expected/~g_v1_serviceaccount_profiles-controller-service-account.yaml
@@ -1,6 +1,8 @@
 apiVersion: v1
 kind: ServiceAccount
 metadata:
+  annotations:
+    iam.gke.io/gcp-service-account: name-admin@project-id.iam.gserviceaccount.com
   labels:
     kustomize.component: profiles
   name: profiles-controller-service-account


### PR DESCRIPTION
**Which issue is resolved by this Pull Request:**
Related to https://github.com/kubeflow/gcp-blueprints/issues/61

**Description of your changes:**
Add default workload identity bindings for GSAs.

**Checklist:**
- [x] Unit tests have been rebuilt: 
    1. `cd manifests/tests`
    2. `make generate-changed-only`
    3. `make test`
