### PR TITLE
Add missing finalizers for Katib experiment

### DIFF
--- a/katib/katib-controller/base/katib-controller-rbac.yaml
+++ b/katib/katib-controller/base/katib-controller-rbac.yaml
@@ -54,10 +54,13 @@ rules:
   resources:
   - experiments
   - experiments/status
+  - experiments/finalizers
   - trials
   - trials/status
+  - trials/finalizers
   - suggestions
   - suggestions/status
+  - suggestions/finalizers
   verbs:
   - "*"
 - apiGroups:

--- a/tests/katib/installs/katib-external-db/test_data/expected/rbac.authorization.k8s.io_v1_clusterrole_katib-controller.yaml
+++ b/tests/katib/installs/katib-external-db/test_data/expected/rbac.authorization.k8s.io_v1_clusterrole_katib-controller.yaml
@@ -57,10 +57,13 @@ rules:
   resources:
   - experiments
   - experiments/status
+  - experiments/finalizers
   - trials
   - trials/status
+  - trials/finalizers
   - suggestions
   - suggestions/status
+  - suggestions/finalizers
   verbs:
   - '*'
 - apiGroups:

--- a/tests/katib/installs/katib-standalone-ibm/test_data/expected/rbac.authorization.k8s.io_v1_clusterrole_katib-controller.yaml
+++ b/tests/katib/installs/katib-standalone-ibm/test_data/expected/rbac.authorization.k8s.io_v1_clusterrole_katib-controller.yaml
@@ -57,10 +57,13 @@ rules:
   resources:
   - experiments
   - experiments/status
+  - experiments/finalizers
   - trials
   - trials/status
+  - trials/finalizers
   - suggestions
   - suggestions/status
+  - suggestions/finalizers
   verbs:
   - '*'
 - apiGroups:

--- a/tests/katib/installs/katib-standalone/test_data/expected/rbac.authorization.k8s.io_v1_clusterrole_katib-controller.yaml
+++ b/tests/katib/installs/katib-standalone/test_data/expected/rbac.authorization.k8s.io_v1_clusterrole_katib-controller.yaml
@@ -57,10 +57,13 @@ rules:
   resources:
   - experiments
   - experiments/status
+  - experiments/finalizers
   - trials
   - trials/status
+  - trials/finalizers
   - suggestions
   - suggestions/status
+  - suggestions/finalizers
   verbs:
   - '*'
 - apiGroups:

--- a/tests/stacks/examples/alice/test_data/expected/rbac.authorization.k8s.io_v1_clusterrole_katib-controller.yaml
+++ b/tests/stacks/examples/alice/test_data/expected/rbac.authorization.k8s.io_v1_clusterrole_katib-controller.yaml
@@ -57,10 +57,13 @@ rules:
   resources:
   - experiments
   - experiments/status
+  - experiments/finalizers
   - trials
   - trials/status
+  - trials/finalizers
   - suggestions
   - suggestions/status
+  - suggestions/finalizers
   verbs:
   - '*'
 - apiGroups:

--- a/tests/stacks/gcp/test_data/expected/rbac.authorization.k8s.io_v1_clusterrole_katib-controller.yaml
+++ b/tests/stacks/gcp/test_data/expected/rbac.authorization.k8s.io_v1_clusterrole_katib-controller.yaml
@@ -57,10 +57,13 @@ rules:
   resources:
   - experiments
   - experiments/status
+  - experiments/finalizers
   - trials
   - trials/status
+  - trials/finalizers
   - suggestions
   - suggestions/status
+  - suggestions/finalizers
   verbs:
   - '*'
 - apiGroups:

--- a/tests/stacks/generic/test_data/expected/rbac.authorization.k8s.io_v1_clusterrole_katib-controller.yaml
+++ b/tests/stacks/generic/test_data/expected/rbac.authorization.k8s.io_v1_clusterrole_katib-controller.yaml
@@ -57,10 +57,13 @@ rules:
   resources:
   - experiments
   - experiments/status
+  - experiments/finalizers
   - trials
   - trials/status
+  - trials/finalizers
   - suggestions
   - suggestions/status
+  - suggestions/finalizers
   verbs:
   - '*'
 - apiGroups:

--- a/tests/stacks/ibm/test_data/expected/rbac.authorization.k8s.io_v1_clusterrole_katib-controller.yaml
+++ b/tests/stacks/ibm/test_data/expected/rbac.authorization.k8s.io_v1_clusterrole_katib-controller.yaml
@@ -57,10 +57,13 @@ rules:
   resources:
   - experiments
   - experiments/status
+  - experiments/finalizers
   - trials
   - trials/status
+  - trials/finalizers
   - suggestions
   - suggestions/status
+  - suggestions/finalizers
   verbs:
   - '*'
 - apiGroups:

--- a/tests/tests/legacy_kustomizations/katib-controller/test_data/expected/rbac.authorization.k8s.io_v1_clusterrole_katib-controller.yaml
+++ b/tests/tests/legacy_kustomizations/katib-controller/test_data/expected/rbac.authorization.k8s.io_v1_clusterrole_katib-controller.yaml
@@ -61,10 +61,13 @@ rules:
   resources:
   - experiments
   - experiments/status
+  - experiments/finalizers
   - trials
   - trials/status
+  - trials/finalizers
   - suggestions
   - suggestions/status
+  - suggestions/finalizers
   verbs:
   - '*'
 - apiGroups:


### PR DESCRIPTION
**Which issue is resolved by this Pull Request:**
Resolves #1323 

This is necessary for being able to run Katib on OpenShift

**Description of your changes:**
Adding resource/finalizers to the Role

**Checklist:**
- [ ] Unit tests have been rebuilt: 
    1. `cd manifests/tests`
    2. `make generate-changed-only`
    3. `make test`
