### PR TITLE
Update mxnet-operator manifest to v1

### DIFF
--- a/mxnet-job/mxnet-operator/base/crd.yaml
+++ b/mxnet-job/mxnet-operator/base/crd.yaml
@@ -4,9 +4,55 @@ metadata:
   name: mxjobs.kubeflow.org
 spec:
   group: kubeflow.org
+  version: v1
+  scope: Namespaced
   names:
     kind: MXJob
-    plural: mxjobs
     singular: mxjob
-  version: v1beta1
-  scope: Namespaced
+    plural: mxjobs
+  subresources:
+    status: {}
+  validation:
+    openAPIV3Schema:
+      properties:
+        spec:
+          properties:
+            mxReplicaSpecs:
+              properties:
+                # The validation works when the configuration contains
+                # `Worker`, `Server`, `Scheduler`, 
+                # `TunerTracker`, `TunerServer`, `Tuner`,
+                # Otherwise it will not be validated.
+                Scheduler:
+                  properties:
+                    replicas:
+                      type: integer
+                      minimum: 1
+                      maximum: 1
+                Worker:
+                  properties:
+                    replicas:
+                      type: integer
+                      minimum: 1
+                Server:
+                  properties:
+                    replicas:
+                      type: integer
+                      minimum: 1
+                TunerTracker:
+                  properties:
+                    replicas:
+                      type: integer
+                      minimum: 1
+                      maximum: 1
+                TunerServer:
+                  properties:
+                    replicas:
+                      type: integer
+                      minimum: 1
+                Tuner:
+                  properties:
+                    replicas:
+                      type: integer
+                      minimum: 1
+                      maximum: 1

--- a/mxnet-job/mxnet-operator/base/deployment.yaml
+++ b/mxnet-job/mxnet-operator/base/deployment.yaml
@@ -13,9 +13,7 @@ spec:
     spec:
       containers:
       - command:
-        - /opt/kubeflow/mxnet-operator.v1beta1
-        - --alsologtostderr
-        - -v=1
+        - /opt/kubeflow/mxnet-operator.v1
         env:
         - name: MY_POD_NAMESPACE
           valueFrom:

--- a/mxnet-job/mxnet-operator/base/kustomization.yaml
+++ b/mxnet-job/mxnet-operator/base/kustomization.yaml
@@ -11,5 +11,5 @@ commonLabels:
   kustomize.component: mxnet-operator
 images:
 - name: mxjob/mxnet-operator
-  newName: mxjob/mxnet-operator
-  newTag: v1beta1
+  newName: kubeflow/mxnet-operator
+  newTag: v1.0.0-20200625

--- a/mxnet-job/mxnet-operator/overlays/application/application.yaml
+++ b/mxnet-job/mxnet-operator/overlays/application/application.yaml
@@ -6,11 +6,11 @@ spec:
   selector:
     matchLabels:
       app.kubernetes.io/name: mxnet-operator
-      app.kubernetes.io/instance: mxnet-operator-v0.7.0
+      app.kubernetes.io/instance: mxnet-operator-v1.0.0
       app.kubernetes.io/component: mxnet
       app.kubernetes.io/part-of: kubeflow
       app.kubernetes.io/managed-by: kfctl
-      app.kubernetes.io/version: v0.7.0
+      app.kubernetes.io/version: v1.0.0
   componentKinds:
   - group: apps
     kind: Deployment
@@ -20,18 +20,22 @@ spec:
     kind: MXJob
   descriptor:
     type: "mxnet-operator"
-    version: "v1beta1"
+    version: "v1"
     description: "mxnet-operator allows users to create and manage the \"MXJob\" custom resource."
     maintainers:
     - name: Lei Su
       email: suleisl2000@hotmail.com
     - name: Yuan Tang
       email: terrytangyuan@gmail.com
+    - name: Jiaxin Shan
+      email: seedjeffwan@gmail.com
     owners:
     - name: Lei Su
       email: suleisl2000@hotmail.com
     - name: Yuan Tang
       email: terrytangyuan@gmail.com
+    - name: Jiaxin Shan
+      email: seedjeffwan@gmail.com
     keywords:
     - "MXjob"
     - "mxnet-operator"


### PR DESCRIPTION
**Which issue is resolved by this Pull Request:**
Upgrade MXNet operator manifest to v1.

**Description of your changes:**
Upgrade MXNet operator manifest to v1.

**Checklist:**
- [x] Unit tests have been rebuilt: 
    1. `cd manifests/tests`
    2. `make generate-changed-only`
    3. `make test`
