### PR TITLE
Add mxnet-operator to aws kfdefs

### DIFF
--- a/kfdef/kfctl_aws.yaml
+++ b/kfdef/kfctl_aws.yaml
@@ -282,6 +282,13 @@ spec:
       - application
       repoRef:
         name: manifests
+        path: mxnet-job/mxnet-operator
+    name: mxnet-operator
+  - kustomizeConfig:
+      overlays:
+      - application
+      repoRef:
+        name: manifests
         path: katib/katib-crds
     name: katib-crds
   - kustomizeConfig:

--- a/kfdef/kfctl_aws_cognito.yaml
+++ b/kfdef/kfctl_aws_cognito.yaml
@@ -243,6 +243,13 @@ spec:
       - application
       repoRef:
         name: manifests
+        path: mxnet-job/mxnet-operator
+    name: mxnet-operator
+  - kustomizeConfig:
+      overlays:
+      - application
+      repoRef:
+        name: manifests
         path: katib/katib-crds
     name: katib-crds
   - kustomizeConfig:

--- a/kfdef/source/master/kfctl_aws.yaml
+++ b/kfdef/source/master/kfctl_aws.yaml
@@ -282,6 +282,13 @@ spec:
       - application
       repoRef:
         name: manifests
+        path: mxnet-job/mxnet-operator
+    name: mxnet-operator
+  - kustomizeConfig:
+      overlays:
+      - application
+      repoRef:
+        name: manifests
         path: katib/katib-crds
     name: katib-crds
   - kustomizeConfig:

--- a/kfdef/source/master/kfctl_aws_cognito.yaml
+++ b/kfdef/source/master/kfctl_aws_cognito.yaml
@@ -243,6 +243,13 @@ spec:
       - application
       repoRef:
         name: manifests
+        path: mxnet-job/mxnet-operator
+    name: mxnet-operator
+  - kustomizeConfig:
+      overlays:
+      - application
+      repoRef:
+        name: manifests
         path: katib/katib-crds
     name: katib-crds
   - kustomizeConfig:


### PR DESCRIPTION
**Which issue is resolved by this Pull Request:**
Resolves part of  https://github.com/kubeflow/kubeflow/issues/5057

**Description of your changes:**
Add mxnet-operator to aws kfdefs

**Checklist:**
- [x] Unit tests have been rebuilt: 
    1. `cd manifests/tests`
    2. `make generate-changed-only`
    3. `make test`
