### PR TITLE
Enable IRSA by default for AWS users

### DIFF
--- a/kfdef/kfctl_aws.yaml
+++ b/kfdef/kfctl_aws.yaml
@@ -422,8 +422,10 @@ spec:
           password: 12341234
           username: admin@kubeflow.org
       region: us-west-2
-      roles:
-      - eksctl-kubeflow-aws-nodegroup-ng-a2-NodeInstanceRole-xxxxxxx
+      enablePodIamPolicy: true
+      # If you don't use IAM Role for Service Account, you can still use node instance roles.
+      #roles:
+      #- eksctl-kubeflow-aws-nodegroup-ng-a2-NodeInstanceRole-xxxxxxx
   repos:
   - name: manifests
     uri: https://github.com/kubeflow/manifests/archive/master.tar.gz

--- a/kfdef/kfctl_aws_cognito.yaml
+++ b/kfdef/kfctl_aws_cognito.yaml
@@ -405,8 +405,10 @@ spec:
           cognitoUserPoolArn: arn:aws:cognito-idp:us-west-2:xxxxx:userpool/us-west-2_xxxxxx
           cognitoUserPoolDomain: your-user-pool
       region: us-west-2
-      roles:
-      - eksctl-kubeflow-aws-nodegroup-ng-a2-NodeInstanceRole-xxxxx
+      enablePodIamPolicy: true
+      # If you don't use IAM Role for Service Account, you can still use node instance roles.
+      #roles:
+      #- eksctl-kubeflow-aws-nodegroup-ng-a2-NodeInstanceRole-xxxxxxx
   repos:
   - name: manifests
     uri: https://github.com/kubeflow/manifests/archive/master.tar.gz

--- a/kfdef/source/master/kfctl_aws.yaml
+++ b/kfdef/source/master/kfctl_aws.yaml
@@ -422,8 +422,10 @@ spec:
           password: 12341234
           username: admin@kubeflow.org
       region: us-west-2
-      roles:
-      - eksctl-kubeflow-aws-nodegroup-ng-a2-NodeInstanceRole-xxxxxxx
+      enablePodIamPolicy: true
+      # If you don't use IAM Role for Service Account, you can still use node instance roles.
+      #roles:
+      #- eksctl-kubeflow-aws-nodegroup-ng-a2-NodeInstanceRole-xxxxxxx
   repos:
   - name: manifests
     uri: https://github.com/kubeflow/manifests/archive/master.tar.gz

--- a/kfdef/source/master/kfctl_aws_cognito.yaml
+++ b/kfdef/source/master/kfctl_aws_cognito.yaml
@@ -405,8 +405,10 @@ spec:
           cognitoUserPoolArn: arn:aws:cognito-idp:us-west-2:xxxxx:userpool/us-west-2_xxxxxx
           cognitoUserPoolDomain: your-user-pool
       region: us-west-2
-      roles:
-      - eksctl-kubeflow-aws-nodegroup-ng-a2-NodeInstanceRole-xxxxx
+      enablePodIamPolicy: true
+      # If you don't use IAM Role for Service Account, you can still use node instance roles.
+      #roles:
+      #- eksctl-kubeflow-aws-nodegroup-ng-a2-NodeInstanceRole-xxxxxxx
   repos:
   - name: manifests
     uri: https://github.com/kubeflow/manifests/archive/master.tar.gz


### PR DESCRIPTION
**Which issue is resolved by this Pull Request:**
Resolves https://github.com/kubeflow/kubeflow/issues/5057

**Description of your changes:**
Enable IRSA by default for AWS users

**Checklist:**
- [x] Unit tests have been rebuilt: 
    1. `cd manifests/tests`
    2. `make generate-changed-only`
    3. `make test`
