### PR TITLE
Updated cluster-role.yaml to run Kubeflow Faring from Kubeflow Pipeline

### DIFF
--- a/pipeline/pipelines-runner/base/cluster-role.yaml
+++ b/pipeline/pipelines-runner/base/cluster-role.yaml
@@ -9,6 +9,7 @@ rules:
   - secrets
   verbs:
   - get
+  - list
 - apiGroups:
   - ""
   resources:

--- a/tests/stacks/ibm/test_data/expected/rbac.authorization.k8s.io_v1beta1_clusterrole_pipeline-runner.yaml
+++ b/tests/stacks/ibm/test_data/expected/rbac.authorization.k8s.io_v1beta1_clusterrole_pipeline-runner.yaml
@@ -13,6 +13,7 @@ rules:
   - secrets
   verbs:
   - get
+  - list
 - apiGroups:
   - ""
   resources:

--- a/tests/tests/legacy_kustomizations/pipelines-runner/test_data/expected/rbac.authorization.k8s.io_v1beta1_clusterrole_pipeline-runner.yaml
+++ b/tests/tests/legacy_kustomizations/pipelines-runner/test_data/expected/rbac.authorization.k8s.io_v1beta1_clusterrole_pipeline-runner.yaml
@@ -17,6 +17,7 @@ rules:
   - secrets
   verbs:
   - get
+  - list
 - apiGroups:
   - ""
   resources:


### PR DESCRIPTION
**Which issue is resolved by this Pull Request:**
Resolves #1209 
When someone runs Kubeflow Faring from Kubeflow Pipeline, he/she will get below error:
IOError: [Errno 2] No such file or directory: ‘/etc/secrets/user-gcp-sa.json’

**Reason:**
When Kubeflow Fairing tries to launch the pod for model training like LightGBM distributed parallel training, it tries to check the presence of the secret by using list instead of get and when list fails due to lack of permission, it just does not attach any secrets to the pod. This causes the whole Kubeflow pipeline to fail.

**Description of your changes:**
Updated the pipeline-runner ClusterRole to allow the pipeline-runner to list the secrets. This helped me run Kubeflow fairing from the Kubeflow pipeline successfully.

**Checklist:**
- [x] Unit tests have been rebuilt: 
    1. `cd manifests/tests`
    2. `make generate-changed-only`
    3. `make test`
