### PR TITLE
added support for registration flow env variable

### DIFF
--- a/common/centraldashboard/base/deployment_patch.yaml
+++ b/common/centraldashboard/base/deployment_patch.yaml
@@ -14,3 +14,5 @@ spec:
           value: $(userid-prefix)
         - name: PROFILES_KFAM_SERVICE_HOST
           value: profiles-kfam.kubeflow
+        - name: REGISTRATION_FLOW
+          value: $(registration-flow)

--- a/common/centraldashboard/base/kustomization.yaml
+++ b/common/centraldashboard/base/kustomization.yaml
@@ -53,5 +53,12 @@ vars:
     apiVersion: v1
     kind: ConfigMap
     name: parameters
+- fieldref:
+    fieldPath: data.registration-flow
+  name: registration-flow
+  objref:
+    apiVersion: v1
+    kind: ConfigMap
+    name: parameters
 configurations:
 - params.yaml

--- a/common/centraldashboard/base/params.env
+++ b/common/centraldashboard/base/params.env
@@ -1,3 +1,4 @@
 clusterDomain=cluster.local
 userid-header=
 userid-prefix=
+registration-flow=true

--- a/tests/tests/legacy_kustomizations/centraldashboard/test_data/expected/apps_v1_deployment_centraldashboard.yaml
+++ b/tests/tests/legacy_kustomizations/centraldashboard/test_data/expected/apps_v1_deployment_centraldashboard.yaml
@@ -46,6 +46,8 @@ spec:
           value: 'accounts.google.com:'
         - name: PROFILES_KFAM_SERVICE_HOST
           value: profiles-kfam.kubeflow
+        - name: REGISTRATION_FLOW
+          value: "true"
         image: gcr.io/kubeflow-images-public/centraldashboard:vmaster-gf39279c0
         imagePullPolicy: IfNotPresent
         livenessProbe:

--- a/tests/tests/legacy_kustomizations/centraldashboard/test_data/expected/~g_v1_configmap_parameters.yaml
+++ b/tests/tests/legacy_kustomizations/centraldashboard/test_data/expected/~g_v1_configmap_parameters.yaml
@@ -1,6 +1,7 @@
 apiVersion: v1
 data:
   clusterDomain: cluster.local
+  registration-flow: "true"
   userid-header: X-Goog-Authenticated-User-Email
   userid-prefix: 'accounts.google.com:'
 kind: ConfigMap


### PR DESCRIPTION
**Which issue is resolved by this Pull Request:**
Resolves # https://github.com/kubeflow/kubeflow/issues/4889

**Description of your changes:**

This addresses the support needed to disable the registration flow on issue 4889. 

I modified the deployment patch, base kustomization and params.env for /common/centraldashboard to add another environment variable called REGISTRATION_FLOW which by default is set to "true". If the user wants to disable the registration flow they have to modify the definitions for the central-dashboard, add the registration-flow variable and set it to "false".

```
  - kustomizeConfig:
      overlays:
      - istio
      - application
      parameters:
      - name: userid-header
        value: kubeflow-userid
      - name: registration-flow
        value: "false"
      repoRef:
        name: manifests
        path: common/centraldashboard
    name: centraldashboard
```

**Checklist:**
- [x] Unit tests have been rebuilt: 
    1. `cd manifests/tests`
    2. `make generate-changed-only`
    3. `make test`
