### PR TITLE
Disable sidecar for activator and autoscaler

### DIFF
--- a/knative/knative-serving-install/base/deployment.yaml
+++ b/knative/knative-serving-install/base/deployment.yaml
@@ -15,7 +15,7 @@ spec:
     metadata:
       annotations:
         cluster-autoscaler.kubernetes.io/safe-to-evict: "false"
-        sidecar.istio.io/inject: "true"
+        sidecar.istio.io/inject: "false"
       labels:
         app: activator
         role: activator
@@ -145,7 +145,7 @@ spec:
     metadata:
       annotations:
         cluster-autoscaler.kubernetes.io/safe-to-evict: "false"
-        sidecar.istio.io/inject: "true"
+        sidecar.istio.io/inject: "false"
         traffic.sidecar.istio.io/includeInboundPorts: 8080,9090
       labels:
         app: autoscaler

--- a/tests/tests/legacy_kustomizations/knative-install/test_data/expected/apps_v1_deployment_activator.yaml
+++ b/tests/tests/legacy_kustomizations/knative-install/test_data/expected/apps_v1_deployment_activator.yaml
@@ -29,7 +29,7 @@ spec:
     metadata:
       annotations:
         cluster-autoscaler.kubernetes.io/safe-to-evict: "false"
-        sidecar.istio.io/inject: "true"
+        sidecar.istio.io/inject: "false"
       labels:
         app: activator
         app.kubernetes.io/component: knative-serving-install

--- a/tests/tests/legacy_kustomizations/knative-install/test_data/expected/apps_v1_deployment_autoscaler.yaml
+++ b/tests/tests/legacy_kustomizations/knative-install/test_data/expected/apps_v1_deployment_autoscaler.yaml
@@ -29,7 +29,7 @@ spec:
     metadata:
       annotations:
         cluster-autoscaler.kubernetes.io/safe-to-evict: "false"
-        sidecar.istio.io/inject: "true"
+        sidecar.istio.io/inject: "false"
         traffic.sidecar.istio.io/includeInboundPorts: 8080,9090
       labels:
         app: autoscaler


### PR DESCRIPTION
**Which issue is resolved by this Pull Request:**
Resolves https://github.com/kubeflow/manifests/issues/1339

**Description of your changes:**


**Checklist:**
- [ ] Unit tests have been rebuilt: 
    1. `cd manifests/tests`
    2. `make generate-changed-only`
    3. `make test`
