### PR TITLE
Automated cherry pick of #1353: Upgrade istio auth adapter version

### DIFF
--- a/aws/aws-istio-authz-adaptor/base/kustomization.yaml
+++ b/aws/aws-istio-authz-adaptor/base/kustomization.yaml
@@ -14,7 +14,7 @@ commonLabels:
 images:
 - name: seedjeffwan/istio-adapter
   newName: seedjeffwan/istio-adapter
-  newTag: "0.1"
+  newTag: "0.2"
 configMapGenerator:
   - name: aws-authzadaptor-parameters
     envs:


### PR DESCRIPTION
Cherry pick of #1353 on v1.1-branch.

#1353: Upgrade istio auth adapter version

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.