### PR TITLE
[AWS] Revert istio version in cognito manifest back to 1.1.x

### DIFF
--- a/kfdef/kfctl_aws_cognito.yaml
+++ b/kfdef/kfctl_aws_cognito.yaml
@@ -10,7 +10,7 @@ spec:
         value: istio-system
       repoRef:
         name: manifests
-        path: istio-1-3-1/istio-crds-1-3-1
+        path: istio/istio-crds
     name: istio-crds
   - kustomizeConfig:
       parameters:
@@ -18,7 +18,7 @@ spec:
         value: istio-system
       repoRef:
         name: manifests
-        path: istio-1-3-1/istio-install-1-3-1
+        path: istio/istio-install
     name: istio-install
   - kustomizeConfig:
       parameters:
@@ -26,7 +26,7 @@ spec:
         value: istio-system
       repoRef:
         name: manifests
-        path: istio-1-3-1/cluster-local-gateway-1-3-1
+        path: istio/cluster-local-gateway
     name: cluster-local-gateway
   - kustomizeConfig:
       parameters:

--- a/kfdef/source/master/kfctl_aws_cognito.yaml
+++ b/kfdef/source/master/kfctl_aws_cognito.yaml
@@ -10,7 +10,7 @@ spec:
         value: istio-system
       repoRef:
         name: manifests
-        path: istio-1-3-1/istio-crds-1-3-1
+        path: istio/istio-crds
     name: istio-crds
   - kustomizeConfig:
       parameters:
@@ -18,7 +18,7 @@ spec:
         value: istio-system
       repoRef:
         name: manifests
-        path: istio-1-3-1/istio-install-1-3-1
+        path: istio/istio-install
     name: istio-install
   - kustomizeConfig:
       parameters:
@@ -26,7 +26,7 @@ spec:
         value: istio-system
       repoRef:
         name: manifests
-        path: istio-1-3-1/cluster-local-gateway-1-3-1
+        path: istio/cluster-local-gateway
     name: cluster-local-gateway
   - kustomizeConfig:
       parameters:


### PR DESCRIPTION
**Which issue is resolved by this Pull Request:**
1.3.1 doesn't enable template CRD which means auth adapter will meet some issues. 
We will fix this after 1.1 release


**Description of your changes:**
[AWS] Revert istio version in cognito manifest back to 1.1.x

**Checklist:**
- [x] Unit tests have been rebuilt: 
    1. `cd manifests/tests`
    2. `make generate-changed-only`
    3. `make test`
