### PR TITLE
Automated cherry pick of #1360: Revert istio version in cognito manifest back to 1.1.x

### DIFF
--- a/kfdef/kfctl_aws_cognito.yaml
+++ b/kfdef/kfctl_aws_cognito.yaml
@@ -10,7 +10,7 @@ spec:
         value: istio-system
       repoRef:
         name: manifests
-        path: istio-1-3-1/istio-crds-1-3-1
+        path: istio/istio-crds
     name: istio-crds
   - kustomizeConfig:
       parameters:
@@ -18,7 +18,7 @@ spec:
         value: istio-system
       repoRef:
         name: manifests
-        path: istio-1-3-1/istio-install-1-3-1
+        path: istio/istio-install
     name: istio-install
   - kustomizeConfig:
       parameters:
@@ -26,7 +26,7 @@ spec:
         value: istio-system
       repoRef:
         name: manifests
-        path: istio-1-3-1/cluster-local-gateway-1-3-1
+        path: istio/cluster-local-gateway
     name: cluster-local-gateway
   - kustomizeConfig:
       parameters:

--- a/kfdef/source/master/kfctl_aws_cognito.yaml
+++ b/kfdef/source/master/kfctl_aws_cognito.yaml
@@ -10,7 +10,7 @@ spec:
         value: istio-system
       repoRef:
         name: manifests
-        path: istio-1-3-1/istio-crds-1-3-1
+        path: istio/istio-crds
     name: istio-crds
   - kustomizeConfig:
       parameters:
@@ -18,7 +18,7 @@ spec:
         value: istio-system
       repoRef:
         name: manifests
-        path: istio-1-3-1/istio-install-1-3-1
+        path: istio/istio-install
     name: istio-install
   - kustomizeConfig:
       parameters:
@@ -26,7 +26,7 @@ spec:
         value: istio-system
       repoRef:
         name: manifests
-        path: istio-1-3-1/cluster-local-gateway-1-3-1
+        path: istio/cluster-local-gateway
     name: cluster-local-gateway
   - kustomizeConfig:
       parameters:


### PR DESCRIPTION
Cherry pick of #1360 on v1.1-branch.

#1360: Revert istio version in cognito manifest back to 1.1.x

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.