### PR TITLE
Use kubeflow userid header and prefix config for KFP servers

### DIFF
--- a/pipeline/installs/multi-user/api-service/deployment-patch.yaml
+++ b/pipeline/installs/multi-user/api-service/deployment-patch.yaml
@@ -10,3 +10,14 @@ spec:
         envFrom:
         - configMapRef:
             name: pipeline-api-server-config
+        env:
+        - name: KUBEFLOW_USERID_HEADER
+          valueFrom:
+            configMapKeyRef:
+              name: kubeflow-config
+              key: userid-header
+        - name: KUBEFLOW_USERID_PREFIX
+          valueFrom:
+            configMapKeyRef:
+              name: kubeflow-config
+              key: userid-prefix

--- a/pipeline/installs/multi-user/pipelines-ui/deployment-patch.yaml
+++ b/pipeline/installs/multi-user/pipelines-ui/deployment-patch.yaml
@@ -24,6 +24,16 @@ spec:
           value: 'true'
         - name: ENABLE_AUTHZ
           value: 'true'
+        - name: KUBEFLOW_USERID_HEADER
+          valueFrom:
+            configMapKeyRef:
+              name: kubeflow-config
+              key: userid-header
+        - name: KUBEFLOW_USERID_PREFIX
+          valueFrom:
+            configMapKeyRef:
+              name: kubeflow-config
+              key: userid-prefix
         volumeMounts:
         - name: config-volume
           mountPath: /etc/config


### PR DESCRIPTION
**Which issue is resolved by this Pull Request:**
Part of https://github.com/kubeflow/manifests/issues/1364

This let KFP servers read from common configuration for userid prefix and userid header.