### PR TITLE
Switch GCP to regular channel which is on GKE 1.16

### DIFF
--- a/gcp/v2/cnrm/cluster/cluster.yaml
+++ b/gcp/v2/cnrm/cluster/cluster.yaml
@@ -42,7 +42,7 @@ spec:
   releaseChannel:
     # Per https://github.com/GoogleCloudPlatform/k8s-config-connector/issues/194
     # use upper case for the channels
-    channel: STABLE
+    channel: REGULAR
   location: us-east1-d # {"type":"string","x-kustomize":{"setBy":"kpt","setter":{"name":"gcloud.compute.zone","value":"us-east1-d"}}}
   workloadIdentityConfig:
     identityNamespace: project-id.svc.id.goog # {"type":"string","x-kustomize":{"partialSetters":[{"name":"gcloud.core.project","value":"project-id"}]}}


### PR DESCRIPTION
* Stable is still on 1.14 which is getting to be quite old.
  Tekton for example requires 1.15 at least.

Related to: kubeflow/gcp-blueprints#67
