### PR TITLE
refactor: pipelines profile controller should get minio access keys from the secret

### DIFF
--- a/pipeline/installs/multi-user/pipelines-profile-controller/deployment.yaml
+++ b/pipeline/installs/multi-user/pipelines-profile-controller/deployment.yaml
@@ -16,6 +16,17 @@ spec:
         envFrom:
         - configMapRef:
             name: profile-controller-env
+        env:
+        - name: MINIO_ACCESS_KEY
+          valueFrom:
+            secretKeyRef:
+              name: mlpipeline-minio-artifact
+              key: accesskey
+        - name: MINIO_SECRET_KEY
+          valueFrom:
+            secretKeyRef:
+              name: mlpipeline-minio-artifact
+              key: secretkey
         volumeMounts:
         - name: hooks
           mountPath: /hooks

--- a/pipeline/installs/multi-user/pipelines-profile-controller/sync.py
+++ b/pipeline/installs/multi-user/pipelines-profile-controller/sync.py
@@ -15,9 +15,12 @@
 from http.server import BaseHTTPRequestHandler, HTTPServer
 import json
 import os
+import base64
 
 kfp_version = os.environ["KFP_VERSION"]
 disable_istio_sidecar = os.environ.get("DISABLE_ISTIO_SIDECAR") == "true"
+mlpipeline_minio_access_key = os.environ.get("MINIO_ACCESS_KEY")
+mlpipeline_minio_secret_key = os.environ.get("MINIO_SECRET_KEY")
 
 
 class Controller(BaseHTTPRequestHandler):
@@ -57,8 +60,8 @@ class Controller(BaseHTTPRequestHandler):
                     "namespace": namespace,
                 },
                 "data": {
-                    "accesskey": "bWluaW8=",  # base64 for minio
-                    "secretkey": "bWluaW8xMjM=",  # base64 for minio123
+                    "accesskey": base64.b64encode(mlpipeline_minio_access_key),
+                    "secretkey": base64.b64encode(mlpipeline_minio_secret_key),
                 },
             },
             {

--- a/pipeline/installs/multi-user/pipelines-profile-controller/sync.py
+++ b/pipeline/installs/multi-user/pipelines-profile-controller/sync.py
@@ -54,18 +54,6 @@ class Controller(BaseHTTPRequestHandler):
         desired_resources = [
             {
                 "apiVersion": "v1",
-                "kind": "Secret",
-                "metadata": {
-                    "name": "mlpipeline-minio-artifact",
-                    "namespace": namespace,
-                },
-                "data": {
-                    "accesskey": base64.b64encode(mlpipeline_minio_access_key),
-                    "secretkey": base64.b64encode(mlpipeline_minio_secret_key),
-                },
-            },
-            {
-                "apiVersion": "v1",
                 "kind": "ConfigMap",
                 "metadata": {
                     "name": "metadata-grpc-configmap",
@@ -258,7 +246,21 @@ class Controller(BaseHTTPRequestHandler):
                 }
             },
         ]
-        print('Received request', parent, desired_resources)
+        print('Received request:', parent)
+        print('Desired resources except secrets:', desired_resources)
+        # Moved after the print argument because this is sensitive data.
+        desired_resources.append({
+            "apiVersion": "v1",
+            "kind": "Secret",
+            "metadata": {
+                "name": "mlpipeline-minio-artifact",
+                "namespace": namespace,
+            },
+            "data": {
+                "accesskey": base64.b64encode(mlpipeline_minio_access_key),
+                "secretkey": base64.b64encode(mlpipeline_minio_secret_key),
+            },
+        })
 
         return {"status": desired_status, "children": desired_resources}
 


### PR DESCRIPTION
**Description of your changes:**
pipelines profile controller should get minio access keys from the secret.
This resolves the concern raised in https://github.com/kubeflow/manifests/pull/1342#discussion_r450852695.

Now users can customize the access key and secret in one place and the entire system should still work.

**Checklist:**
- [x] Unit tests have been rebuilt: 
    1. `cd manifests/tests`
    2. `make generate-changed-only`
    3. `make test`
