### PR TITLE
feat: Use KFP multi user mode for GCP

### DIFF
--- a/pipeline/installs/multi-user/pipelines-profile-controller/deployment.yaml
+++ b/pipeline/installs/multi-user/pipelines-profile-controller/deployment.yaml
@@ -16,6 +16,17 @@ spec:
         envFrom:
         - configMapRef:
             name: profile-controller-env
+        env:
+        - name: MINIO_ACCESS_KEY
+          valueFrom:
+            secretKeyRef:
+              name: mlpipeline-minio-artifact
+              key: accesskey
+        - name: MINIO_SECRET_KEY
+          valueFrom:
+            secretKeyRef:
+              name: mlpipeline-minio-artifact
+              key: secretkey
         volumeMounts:
         - name: hooks
           mountPath: /hooks

--- a/pipeline/installs/multi-user/pipelines-profile-controller/sync.py
+++ b/pipeline/installs/multi-user/pipelines-profile-controller/sync.py
@@ -15,9 +15,12 @@
 from http.server import BaseHTTPRequestHandler, HTTPServer
 import json
 import os
+import base64
 
 kfp_version = os.environ["KFP_VERSION"]
 disable_istio_sidecar = os.environ.get("DISABLE_ISTIO_SIDECAR") == "true"
+mlpipeline_minio_access_key = os.environ.get("MINIO_ACCESS_KEY")
+mlpipeline_minio_secret_key = os.environ.get("MINIO_SECRET_KEY")
 
 
 class Controller(BaseHTTPRequestHandler):
@@ -57,8 +60,8 @@ class Controller(BaseHTTPRequestHandler):
                     "namespace": namespace,
                 },
                 "data": {
-                    "accesskey": "bWluaW8=",  # base64 for minio
-                    "secretkey": "bWluaW8xMjM=",  # base64 for minio123
+                    "accesskey": base64.b64encode(mlpipeline_minio_access_key),
+                    "secretkey": base64.b64encode(mlpipeline_minio_secret_key),
                 },
             },
             {

--- a/pipeline/installs/multi-user/pipelines-profile-controller/sync.py
+++ b/pipeline/installs/multi-user/pipelines-profile-controller/sync.py
@@ -54,18 +54,6 @@ class Controller(BaseHTTPRequestHandler):
         desired_resources = [
             {
                 "apiVersion": "v1",
-                "kind": "Secret",
-                "metadata": {
-                    "name": "mlpipeline-minio-artifact",
-                    "namespace": namespace,
-                },
-                "data": {
-                    "accesskey": base64.b64encode(mlpipeline_minio_access_key),
-                    "secretkey": base64.b64encode(mlpipeline_minio_secret_key),
-                },
-            },
-            {
-                "apiVersion": "v1",
                 "kind": "ConfigMap",
                 "metadata": {
                     "name": "metadata-grpc-configmap",
@@ -258,7 +246,21 @@ class Controller(BaseHTTPRequestHandler):
                 }
             },
         ]
-        print('Received request', parent, desired_resources)
+        print('Received request:', parent)
+        print('Desired resources except secrets:', desired_resources)
+        # Moved after the print argument because this is sensitive data.
+        desired_resources.append({
+            "apiVersion": "v1",
+            "kind": "Secret",
+            "metadata": {
+                "name": "mlpipeline-minio-artifact",
+                "namespace": namespace,
+            },
+            "data": {
+                "accesskey": base64.b64encode(mlpipeline_minio_access_key),
+                "secretkey": base64.b64encode(mlpipeline_minio_secret_key),
+            },
+        })
 
         return {"status": desired_status, "children": desired_resources}
 

--- a/stacks/gcp/kustomization.yaml
+++ b/stacks/gcp/kustomization.yaml
@@ -18,7 +18,7 @@ resources:
   - ../../argo/base_v3
   - ../../pipeline/minio/installs/gcp-pd
   - ../../pipeline/mysql/installs/gcp-pd
-  - ../../pipeline/installs/generic
+  - ../../pipeline/installs/multi-user
   - ../../metadata/v3
   # This package will create a profile resource so it needs to be installed after the profiles CR
   - ../../default-install/base

--- a/tests/stacks/examples/alice/test_data/expected/apps_v1_deployment_cache-server.yaml
+++ b/tests/stacks/examples/alice/test_data/expected/apps_v1_deployment_cache-server.yaml
@@ -53,9 +53,7 @@ spec:
               key: password
               name: mysql-secret-fd5gktm75t
         - name: NAMESPACE_TO_WATCH
-          valueFrom:
-            fieldRef:
-              fieldPath: metadata.namespace
+          value: ""
         image: gcr.io/ml-pipeline/cache-server:1.0.0-rc.3
         imagePullPolicy: Always
         name: server

--- a/tests/stacks/examples/alice/test_data/expected/apps_v1_deployment_metadata-writer.yaml
+++ b/tests/stacks/examples/alice/test_data/expected/apps_v1_deployment_metadata-writer.yaml
@@ -18,9 +18,7 @@ spec:
       containers:
       - env:
         - name: NAMESPACE_TO_WATCH
-          valueFrom:
-            fieldRef:
-              fieldPath: metadata.namespace
+          value: ""
         image: gcr.io/ml-pipeline/metadata-writer:1.0.0-rc.3
         name: main
       serviceAccountName: kubeflow-pipelines-metadata-writer

--- a/tests/stacks/examples/alice/test_data/expected/apps_v1_deployment_ml-pipeline-persistenceagent.yaml
+++ b/tests/stacks/examples/alice/test_data/expected/apps_v1_deployment_ml-pipeline-persistenceagent.yaml
@@ -17,9 +17,7 @@ spec:
       containers:
       - env:
         - name: NAMESPACE
-          valueFrom:
-            fieldRef:
-              fieldPath: metadata.namespace
+          value: ""
         image: gcr.io/ml-pipeline/persistenceagent:1.0.0-rc.3
         imagePullPolicy: IfNotPresent
         name: ml-pipeline-persistenceagent

--- a/tests/stacks/examples/alice/test_data/expected/apps_v1_deployment_ml-pipeline-scheduledworkflow.yaml
+++ b/tests/stacks/examples/alice/test_data/expected/apps_v1_deployment_ml-pipeline-scheduledworkflow.yaml
@@ -17,9 +17,7 @@ spec:
       containers:
       - env:
         - name: NAMESPACE
-          valueFrom:
-            fieldRef:
-              fieldPath: metadata.namespace
+          value: ""
         image: gcr.io/ml-pipeline/scheduledworkflow:1.0.0-rc.3
         imagePullPolicy: IfNotPresent
         name: ml-pipeline-scheduledworkflow

--- a/tests/stacks/examples/alice/test_data/expected/apps_v1_deployment_ml-pipeline-ui.yaml
+++ b/tests/stacks/examples/alice/test_data/expected/apps_v1_deployment_ml-pipeline-ui.yaml
@@ -16,6 +16,28 @@ spec:
     spec:
       containers:
       - env:
+        - name: VIEWER_TENSORBOARD_POD_TEMPLATE_SPEC_PATH
+          value: /etc/config/viewer-pod-template.json
+        - name: DEPLOYMENT
+          value: KUBEFLOW
+        - name: ARTIFACTS_SERVICE_PROXY_NAME
+          value: ml-pipeline-ui-artifact
+        - name: ARTIFACTS_SERVICE_PROXY_PORT
+          value: "80"
+        - name: ARTIFACTS_SERVICE_PROXY_ENABLED
+          value: "true"
+        - name: ENABLE_AUTHZ
+          value: "true"
+        - name: KUBEFLOW_USERID_HEADER
+          valueFrom:
+            configMapKeyRef:
+              key: userid-header
+              name: kubeflow-config-4bkkg42k5m
+        - name: KUBEFLOW_USERID_PREFIX
+          valueFrom:
+            configMapKeyRef:
+              key: userid-prefix
+              name: kubeflow-config-4bkkg42k5m
         - name: MINIO_NAMESPACE
           valueFrom:
             fieldRef:
@@ -61,4 +83,12 @@ spec:
           initialDelaySeconds: 3
           periodSeconds: 5
           timeoutSeconds: 2
+        volumeMounts:
+        - mountPath: /etc/config
+          name: config-volume
+          readOnly: true
       serviceAccountName: ml-pipeline-ui
+      volumes:
+      - configMap:
+          name: ml-pipeline-ui-configmap
+        name: config-volume

--- a/tests/stacks/examples/alice/test_data/expected/apps_v1_deployment_ml-pipeline-viewer-crd.yaml
+++ b/tests/stacks/examples/alice/test_data/expected/apps_v1_deployment_ml-pipeline-viewer-crd.yaml
@@ -16,6 +16,9 @@ spec:
     spec:
       containers:
       - env:
+        - name: NAMESPACE
+          value: ""
+          valueFrom: null
         - name: MAX_NUM_VIEWERS
           value: "50"
         - name: MINIO_NAMESPACE

--- a/tests/stacks/examples/alice/test_data/expected/apps_v1_deployment_ml-pipeline.yaml
+++ b/tests/stacks/examples/alice/test_data/expected/apps_v1_deployment_ml-pipeline.yaml
@@ -16,6 +16,16 @@ spec:
     spec:
       containers:
       - env:
+        - name: KUBEFLOW_USERID_HEADER
+          valueFrom:
+            configMapKeyRef:
+              key: userid-header
+              name: kubeflow-config-4bkkg42k5m
+        - name: KUBEFLOW_USERID_PREFIX
+          valueFrom:
+            configMapKeyRef:
+              key: userid-prefix
+              name: kubeflow-config-4bkkg42k5m
         - name: POD_NAMESPACE
           valueFrom:
             fieldRef:
@@ -62,6 +72,9 @@ spec:
             secretKeyRef:
               key: secretkey
               name: mlpipeline-minio-artifact
+        envFrom:
+        - configMapRef:
+            name: pipeline-api-server-config-f4t72426kt
         image: gcr.io/ml-pipeline/api-server:1.0.0-rc.3
         imagePullPolicy: IfNotPresent
         livenessProbe:

--- a/tests/stacks/examples/alice/test_data/expected/apps_v1beta1_deployment_kubeflow-pipelines-profile-controller.yaml
+++ b/tests/stacks/examples/alice/test_data/expected/apps_v1beta1_deployment_kubeflow-pipelines-profile-controller.yaml
@@ -1,0 +1,48 @@
+apiVersion: apps/v1beta1
+kind: Deployment
+metadata:
+  labels:
+    app: kubeflow-pipelines-profile-controller
+  name: kubeflow-pipelines-profile-controller
+  namespace: kubeflow
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: kubeflow-pipelines-profile-controller
+  template:
+    metadata:
+      annotations:
+        sidecar.istio.io/inject: "false"
+      labels:
+        app: kubeflow-pipelines-profile-controller
+    spec:
+      containers:
+      - command:
+        - python
+        - /hooks/sync.py
+        env:
+        - name: MINIO_ACCESS_KEY
+          valueFrom:
+            secretKeyRef:
+              key: accesskey
+              name: mlpipeline-minio-artifact
+        - name: MINIO_SECRET_KEY
+          valueFrom:
+            secretKeyRef:
+              key: secretkey
+              name: mlpipeline-minio-artifact
+        envFrom:
+        - configMapRef:
+            name: kubeflow-pipelines-profile-controller-env-822cf46mft
+        image: python:3.7
+        name: profile-controller
+        ports:
+        - containerPort: 80
+        volumeMounts:
+        - mountPath: /hooks
+          name: hooks
+      volumes:
+      - configMap:
+          name: kubeflow-pipelines-profile-controller-code-m828g88mtm
+        name: hooks

--- a/tests/stacks/examples/alice/test_data/expected/metacontroller.k8s.io_v1alpha1_compositecontroller_kubeflow-pipelines-profile-controller.yaml
+++ b/tests/stacks/examples/alice/test_data/expected/metacontroller.k8s.io_v1alpha1_compositecontroller_kubeflow-pipelines-profile-controller.yaml
@@ -1,0 +1,46 @@
+apiVersion: metacontroller.k8s.io/v1alpha1
+kind: CompositeController
+metadata:
+  labels:
+    app: kubeflow-pipelines-profile-controller
+  name: kubeflow-pipelines-profile-controller
+  namespace: kubeflow
+spec:
+  childResources:
+  - apiVersion: v1
+    resource: secrets
+    updateStrategy:
+      method: OnDelete
+  - apiVersion: v1
+    resource: configmaps
+    updateStrategy:
+      method: OnDelete
+  - apiVersion: apps/v1
+    resource: deployments
+    updateStrategy:
+      method: InPlace
+  - apiVersion: v1
+    resource: services
+    updateStrategy:
+      method: InPlace
+  - apiVersion: networking.istio.io/v1alpha3
+    resource: destinationrules
+    updateStrategy:
+      method: InPlace
+  - apiVersion: rbac.istio.io/v1alpha1
+    resource: serviceroles
+    updateStrategy:
+      method: InPlace
+  - apiVersion: rbac.istio.io/v1alpha1
+    resource: servicerolebindings
+    updateStrategy:
+      method: InPlace
+  generateSelector: true
+  hooks:
+    sync:
+      webhook:
+        url: http://kubeflow-pipelines-profile-controller/sync
+  parentResource:
+    apiVersion: v1
+    resource: namespaces
+  resyncPeriodSeconds: 10

--- a/tests/stacks/examples/alice/test_data/expected/networking.istio.io_v1alpha3_destinationrule_ml-pipeline-mysql.yaml
+++ b/tests/stacks/examples/alice/test_data/expected/networking.istio.io_v1alpha3_destinationrule_ml-pipeline-mysql.yaml
@@ -1,0 +1,10 @@
+apiVersion: networking.istio.io/v1alpha3
+kind: DestinationRule
+metadata:
+  name: ml-pipeline-mysql
+  namespace: kubeflow
+spec:
+  host: mysql.kubeflow.svc.cluster.local
+  trafficPolicy:
+    tls:
+      mode: ISTIO_MUTUAL

--- a/tests/stacks/examples/alice/test_data/expected/networking.istio.io_v1alpha3_destinationrule_ml-pipeline-ui.yaml
+++ b/tests/stacks/examples/alice/test_data/expected/networking.istio.io_v1alpha3_destinationrule_ml-pipeline-ui.yaml
@@ -1,0 +1,10 @@
+apiVersion: networking.istio.io/v1alpha3
+kind: DestinationRule
+metadata:
+  name: ml-pipeline-ui
+  namespace: kubeflow
+spec:
+  host: ml-pipeline-ui.kubeflow.svc.cluster.local
+  trafficPolicy:
+    tls:
+      mode: ISTIO_MUTUAL

--- a/tests/stacks/examples/alice/test_data/expected/networking.istio.io_v1alpha3_destinationrule_ml-pipeline-visualizationserver.yaml
+++ b/tests/stacks/examples/alice/test_data/expected/networking.istio.io_v1alpha3_destinationrule_ml-pipeline-visualizationserver.yaml
@@ -1,0 +1,10 @@
+apiVersion: networking.istio.io/v1alpha3
+kind: DestinationRule
+metadata:
+  name: ml-pipeline-visualizationserver
+  namespace: kubeflow
+spec:
+  host: ml-pipeline-visualizationserver.kubeflow.svc.cluster.local
+  trafficPolicy:
+    tls:
+      mode: ISTIO_MUTUAL

--- a/tests/stacks/examples/alice/test_data/expected/networking.istio.io_v1alpha3_destinationrule_ml-pipeline.yaml
+++ b/tests/stacks/examples/alice/test_data/expected/networking.istio.io_v1alpha3_destinationrule_ml-pipeline.yaml
@@ -1,0 +1,10 @@
+apiVersion: networking.istio.io/v1alpha3
+kind: DestinationRule
+metadata:
+  name: ml-pipeline
+  namespace: kubeflow
+spec:
+  host: ml-pipeline.kubeflow.svc.cluster.local
+  trafficPolicy:
+    tls:
+      mode: ISTIO_MUTUAL

--- a/tests/stacks/examples/alice/test_data/expected/rbac.authorization.k8s.io_v1_clusterrole_kubeflow-pipelines-cache-role.yaml
+++ b/tests/stacks/examples/alice/test_data/expected/rbac.authorization.k8s.io_v1_clusterrole_kubeflow-pipelines-cache-role.yaml
@@ -1,0 +1,31 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: kubeflow-pipelines-cache-role
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - pods
+  verbs:
+  - get
+  - list
+  - watch
+  - update
+  - patch
+- apiGroups:
+  - ""
+  resources:
+  - configmaps
+  verbs:
+  - get
+- apiGroups:
+  - argoproj.io
+  resources:
+  - workflows
+  verbs:
+  - get
+  - list
+  - watch
+  - update
+  - patch

--- a/tests/stacks/examples/alice/test_data/expected/rbac.authorization.k8s.io_v1_clusterrole_kubeflow-pipelines-metadata-writer-role.yaml
+++ b/tests/stacks/examples/alice/test_data/expected/rbac.authorization.k8s.io_v1_clusterrole_kubeflow-pipelines-metadata-writer-role.yaml
@@ -1,0 +1,31 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: kubeflow-pipelines-metadata-writer-role
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - pods
+  verbs:
+  - get
+  - list
+  - watch
+  - update
+  - patch
+- apiGroups:
+  - ""
+  resources:
+  - configmaps
+  verbs:
+  - get
+- apiGroups:
+  - argoproj.io
+  resources:
+  - workflows
+  verbs:
+  - get
+  - list
+  - watch
+  - update
+  - patch

--- a/tests/stacks/examples/alice/test_data/expected/rbac.authorization.k8s.io_v1_clusterrole_ml-pipeline-persistenceagent-role.yaml
+++ b/tests/stacks/examples/alice/test_data/expected/rbac.authorization.k8s.io_v1_clusterrole_ml-pipeline-persistenceagent-role.yaml
@@ -1,0 +1,21 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: ml-pipeline-persistenceagent-role
+rules:
+- apiGroups:
+  - argoproj.io
+  resources:
+  - workflows
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - kubeflow.org
+  resources:
+  - scheduledworkflows
+  verbs:
+  - get
+  - list
+  - watch

--- a/tests/stacks/examples/alice/test_data/expected/rbac.authorization.k8s.io_v1_clusterrole_ml-pipeline-scheduledworkflow-role.yaml
+++ b/tests/stacks/examples/alice/test_data/expected/rbac.authorization.k8s.io_v1_clusterrole_ml-pipeline-scheduledworkflow-role.yaml
@@ -1,0 +1,36 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: ml-pipeline-scheduledworkflow-role
+rules:
+- apiGroups:
+  - argoproj.io
+  resources:
+  - workflows
+  verbs:
+  - create
+  - get
+  - list
+  - watch
+  - update
+  - patch
+  - delete
+- apiGroups:
+  - kubeflow.org
+  resources:
+  - scheduledworkflows
+  verbs:
+  - create
+  - get
+  - list
+  - watch
+  - update
+  - patch
+  - delete
+- apiGroups:
+  - ""
+  resources:
+  - events
+  verbs:
+  - create
+  - patch

--- a/tests/stacks/examples/alice/test_data/expected/rbac.authorization.k8s.io_v1_clusterrole_ml-pipeline-ui.yaml
+++ b/tests/stacks/examples/alice/test_data/expected/rbac.authorization.k8s.io_v1_clusterrole_ml-pipeline-ui.yaml
@@ -1,0 +1,44 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  labels:
+    app: ml-pipeline-ui
+  name: ml-pipeline-ui
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - pods
+  - pods/log
+  verbs:
+  - get
+- apiGroups:
+  - ""
+  resources:
+  - events
+  verbs:
+  - list
+- apiGroups:
+  - ""
+  resources:
+  - secrets
+  verbs:
+  - get
+  - list
+- apiGroups:
+  - kubeflow.org
+  resources:
+  - viewers
+  verbs:
+  - create
+  - get
+  - list
+  - watch
+  - delete
+- apiGroups:
+  - argoproj.io
+  resources:
+  - workflows
+  verbs:
+  - get
+  - list

--- a/tests/stacks/examples/alice/test_data/expected/rbac.authorization.k8s.io_v1_clusterrole_ml-pipeline-viewer-controller-role.yaml
+++ b/tests/stacks/examples/alice/test_data/expected/rbac.authorization.k8s.io_v1_clusterrole_ml-pipeline-viewer-controller-role.yaml
@@ -1,0 +1,30 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: ml-pipeline-viewer-controller-role
+rules:
+- apiGroups:
+  - '*'
+  resources:
+  - deployments
+  - services
+  verbs:
+  - create
+  - get
+  - list
+  - watch
+  - update
+  - patch
+  - delete
+- apiGroups:
+  - kubeflow.org
+  resources:
+  - viewers
+  verbs:
+  - create
+  - get
+  - list
+  - watch
+  - update
+  - patch
+  - delete

--- a/tests/stacks/examples/alice/test_data/expected/rbac.authorization.k8s.io_v1_clusterrolebinding_kubeflow-pipelines-cache-binding.yaml
+++ b/tests/stacks/examples/alice/test_data/expected/rbac.authorization.k8s.io_v1_clusterrolebinding_kubeflow-pipelines-cache-binding.yaml
@@ -1,0 +1,12 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: kubeflow-pipelines-cache-binding
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: kubeflow-pipelines-cache-role
+subjects:
+- kind: ServiceAccount
+  name: kubeflow-pipelines-cache
+  namespace: kubeflow

--- a/tests/stacks/examples/alice/test_data/expected/rbac.authorization.k8s.io_v1_clusterrolebinding_kubeflow-pipelines-metadata-writer-binding.yaml
+++ b/tests/stacks/examples/alice/test_data/expected/rbac.authorization.k8s.io_v1_clusterrolebinding_kubeflow-pipelines-metadata-writer-binding.yaml
@@ -1,0 +1,12 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: kubeflow-pipelines-metadata-writer-binding
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: kubeflow-pipelines-metadata-writer-role
+subjects:
+- kind: ServiceAccount
+  name: kubeflow-pipelines-metadata-writer
+  namespace: kubeflow

--- a/tests/stacks/examples/alice/test_data/expected/rbac.authorization.k8s.io_v1_clusterrolebinding_ml-pipeline-persistenceagent-binding.yaml
+++ b/tests/stacks/examples/alice/test_data/expected/rbac.authorization.k8s.io_v1_clusterrolebinding_ml-pipeline-persistenceagent-binding.yaml
@@ -1,0 +1,12 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: ml-pipeline-persistenceagent-binding
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: ml-pipeline-persistenceagent-role
+subjects:
+- kind: ServiceAccount
+  name: ml-pipeline-persistenceagent
+  namespace: kubeflow

--- a/tests/stacks/examples/alice/test_data/expected/rbac.authorization.k8s.io_v1_clusterrolebinding_ml-pipeline-scheduledworkflow-binding.yaml
+++ b/tests/stacks/examples/alice/test_data/expected/rbac.authorization.k8s.io_v1_clusterrolebinding_ml-pipeline-scheduledworkflow-binding.yaml
@@ -1,0 +1,12 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: ml-pipeline-scheduledworkflow-binding
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: ml-pipeline-scheduledworkflow-role
+subjects:
+- kind: ServiceAccount
+  name: ml-pipeline-scheduledworkflow
+  namespace: kubeflow

--- a/tests/stacks/examples/alice/test_data/expected/rbac.authorization.k8s.io_v1_clusterrolebinding_ml-pipeline-ui.yaml
+++ b/tests/stacks/examples/alice/test_data/expected/rbac.authorization.k8s.io_v1_clusterrolebinding_ml-pipeline-ui.yaml
@@ -1,0 +1,14 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  labels:
+    app: ml-pipeline-ui
+  name: ml-pipeline-ui
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: ml-pipeline-ui
+subjects:
+- kind: ServiceAccount
+  name: ml-pipeline-ui
+  namespace: kubeflow

--- a/tests/stacks/examples/alice/test_data/expected/rbac.authorization.k8s.io_v1_clusterrolebinding_ml-pipeline-viewer-crd-binding.yaml
+++ b/tests/stacks/examples/alice/test_data/expected/rbac.authorization.k8s.io_v1_clusterrolebinding_ml-pipeline-viewer-crd-binding.yaml
@@ -1,0 +1,12 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: ml-pipeline-viewer-crd-binding
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: ml-pipeline-viewer-controller-role
+subjects:
+- kind: ServiceAccount
+  name: ml-pipeline-viewer-crd-service-account
+  namespace: kubeflow

--- a/tests/stacks/examples/alice/test_data/expected/rbac.authorization.k8s.io_v1beta1_clusterrole_ml-pipeline.yaml
+++ b/tests/stacks/examples/alice/test_data/expected/rbac.authorization.k8s.io_v1beta1_clusterrole_ml-pipeline.yaml
@@ -1,0 +1,34 @@
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: ClusterRole
+metadata:
+  name: ml-pipeline
+rules:
+- apiGroups:
+  - argoproj.io
+  resources:
+  - workflows
+  verbs:
+  - create
+  - get
+  - list
+  - watch
+  - update
+  - patch
+  - delete
+- apiGroups:
+  - kubeflow.org
+  resources:
+  - scheduledworkflows
+  verbs:
+  - create
+  - get
+  - list
+  - update
+  - patch
+  - delete
+- apiGroups:
+  - ""
+  resources:
+  - pods
+  verbs:
+  - delete

--- a/tests/stacks/examples/alice/test_data/expected/rbac.authorization.k8s.io_v1beta1_clusterrolebinding_ml-pipeline.yaml
+++ b/tests/stacks/examples/alice/test_data/expected/rbac.authorization.k8s.io_v1beta1_clusterrolebinding_ml-pipeline.yaml
@@ -1,0 +1,12 @@
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: ClusterRoleBinding
+metadata:
+  name: ml-pipeline
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: ml-pipeline
+subjects:
+- kind: ServiceAccount
+  name: ml-pipeline
+  namespace: kubeflow

--- a/tests/stacks/examples/alice/test_data/expected/rbac.istio.io_v1alpha1_servicerole_cache-server.yaml
+++ b/tests/stacks/examples/alice/test_data/expected/rbac.istio.io_v1alpha1_servicerole_cache-server.yaml
@@ -1,0 +1,9 @@
+apiVersion: rbac.istio.io/v1alpha1
+kind: ServiceRole
+metadata:
+  name: cache-server
+  namespace: kubeflow
+spec:
+  rules:
+  - services:
+    - cache-server.kubeflow.svc.cluster.local

--- a/tests/stacks/examples/alice/test_data/expected/rbac.istio.io_v1alpha1_servicerole_ml-pipeline-services.yaml
+++ b/tests/stacks/examples/alice/test_data/expected/rbac.istio.io_v1alpha1_servicerole_ml-pipeline-services.yaml
@@ -1,0 +1,12 @@
+apiVersion: rbac.istio.io/v1alpha1
+kind: ServiceRole
+metadata:
+  name: ml-pipeline-services
+  namespace: kubeflow
+spec:
+  rules:
+  - services:
+    - ml-pipeline.kubeflow.svc.cluster.local
+    - ml-pipeline-ui.kubeflow.svc.cluster.local
+    - ml-pipeline-visualizationserver.kubeflow.svc.cluster.local
+    - mysql.kubeflow.svc.cluster.local

--- a/tests/stacks/examples/alice/test_data/expected/rbac.istio.io_v1alpha1_servicerole_ml-pipeline-ui.yaml
+++ b/tests/stacks/examples/alice/test_data/expected/rbac.istio.io_v1alpha1_servicerole_ml-pipeline-ui.yaml
@@ -1,0 +1,9 @@
+apiVersion: rbac.istio.io/v1alpha1
+kind: ServiceRole
+metadata:
+  name: ml-pipeline-ui
+  namespace: kubeflow
+spec:
+  rules:
+  - services:
+    - ml-pipeline-ui.kubeflow.svc.cluster.local

--- a/tests/stacks/examples/alice/test_data/expected/rbac.istio.io_v1alpha1_servicerolebinding_bind-cache-server-admission-webhook.yaml
+++ b/tests/stacks/examples/alice/test_data/expected/rbac.istio.io_v1alpha1_servicerolebinding_bind-cache-server-admission-webhook.yaml
@@ -1,0 +1,11 @@
+apiVersion: rbac.istio.io/v1alpha1
+kind: ServiceRoleBinding
+metadata:
+  name: bind-cache-server-admission-webhook
+  namespace: kubeflow
+spec:
+  roleRef:
+    kind: ServiceRole
+    name: cache-server
+  subjects:
+  - user: '*'

--- a/tests/stacks/examples/alice/test_data/expected/rbac.istio.io_v1alpha1_servicerolebinding_bind-gateway-ml-pipeline-ui.yaml
+++ b/tests/stacks/examples/alice/test_data/expected/rbac.istio.io_v1alpha1_servicerolebinding_bind-gateway-ml-pipeline-ui.yaml
@@ -1,0 +1,12 @@
+apiVersion: rbac.istio.io/v1alpha1
+kind: ServiceRoleBinding
+metadata:
+  name: bind-gateway-ml-pipeline-ui
+  namespace: kubeflow
+spec:
+  roleRef:
+    kind: ServiceRole
+    name: ml-pipeline-ui
+  subjects:
+  - properties:
+      source.namespace: istio-system

--- a/tests/stacks/examples/alice/test_data/expected/rbac.istio.io_v1alpha1_servicerolebinding_bind-ml-pipeline-internal.yaml
+++ b/tests/stacks/examples/alice/test_data/expected/rbac.istio.io_v1alpha1_servicerolebinding_bind-ml-pipeline-internal.yaml
@@ -1,0 +1,22 @@
+apiVersion: rbac.istio.io/v1alpha1
+kind: ServiceRoleBinding
+metadata:
+  name: bind-ml-pipeline-internal
+  namespace: kubeflow
+spec:
+  roleRef:
+    kind: ServiceRole
+    name: ml-pipeline-services
+  subjects:
+  - properties:
+      source.principal: cluster.local/ns/kubeflow/sa/ml-pipeline
+  - properties:
+      source.principal: cluster.local/ns/kubeflow/sa/ml-pipeline-ui
+  - properties:
+      source.principal: cluster.local/ns/kubeflow/sa/ml-pipeline-persistenceagent
+  - properties:
+      source.principal: cluster.local/ns/kubeflow/sa/ml-pipeline-scheduledworkflow
+  - properties:
+      source.principal: cluster.local/ns/kubeflow/sa/ml-pipeline-viewer-crd-service-account
+  - properties:
+      source.principal: cluster.local/ns/kubeflow/sa/kubeflow-pipelines-cache

--- a/tests/stacks/examples/alice/test_data/expected/~g_v1_configmap_kubeflow-pipelines-profile-controller-code-m828g88mtm.yaml
+++ b/tests/stacks/examples/alice/test_data/expected/~g_v1_configmap_kubeflow-pipelines-profile-controller-code-m828g88mtm.yaml
@@ -1,0 +1,288 @@
+apiVersion: v1
+data:
+  sync.py: |
+    # Copyright 2020 Google LLC
+    #
+    # Licensed under the Apache License, Version 2.0 (the "License");
+    # you may not use this file except in compliance with the License.
+    # You may obtain a copy of the License at
+    #
+    #      http://www.apache.org/licenses/LICENSE-2.0
+    #
+    # Unless required by applicable law or agreed to in writing, software
+    # distributed under the License is distributed on an "AS IS" BASIS,
+    # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    # See the License for the specific language governing permissions and
+    # limitations under the License.
+
+    from http.server import BaseHTTPRequestHandler, HTTPServer
+    import json
+    import os
+    import base64
+
+    kfp_version = os.environ["KFP_VERSION"]
+    disable_istio_sidecar = os.environ.get("DISABLE_ISTIO_SIDECAR") == "true"
+    mlpipeline_minio_access_key = os.environ.get("MINIO_ACCESS_KEY")
+    mlpipeline_minio_secret_key = os.environ.get("MINIO_SECRET_KEY")
+
+
+    class Controller(BaseHTTPRequestHandler):
+        def sync(self, parent, children):
+            # HACK: Currently using serving.kubeflow.org/inferenceservice to identify
+            # kubeflow user namespaces.
+            # TODO: let Kubeflow profile controller add a pipeline specific label to
+            # user namespaces and use that label instead.
+            pipeline_enabled = parent.get("metadata", {}).get(
+                "labels", {}).get("serving.kubeflow.org/inferenceservice")
+
+            if not pipeline_enabled:
+                return {"status": {}, "children": []}
+
+            # Compute status based on observed state.
+            desired_status = {
+                "kubeflow-pipelines-ready": \
+                    len(children["Secret.v1"]) == 1 and \
+                    len(children["ConfigMap.v1"]) == 1 and \
+                    len(children["Deployment.apps/v1"]) == 2 and \
+                    len(children["Service.v1"]) == 2 and \
+                    len(children["DestinationRule.networking.istio.io/v1alpha3"]) == 1 and \
+                    len(children["ServiceRole.rbac.istio.io/v1alpha1"]) == 1 and \
+                    len(children["ServiceRoleBinding.rbac.istio.io/v1alpha1"]) == 1 and \
+                    "True" or "False"
+            }
+
+            # Generate the desired child object(s).
+            # parent is a namespace
+            namespace = parent.get("metadata", {}).get("name")
+            desired_resources = [
+                {
+                    "apiVersion": "v1",
+                    "kind": "ConfigMap",
+                    "metadata": {
+                        "name": "metadata-grpc-configmap",
+                        "namespace": namespace,
+                    },
+                    "data": {
+                        "METADATA_GRPC_SERVICE_HOST":
+                        "metadata-grpc-service.kubeflow",
+                        "METADATA_GRPC_SERVICE_PORT": "8080",
+                    },
+                },
+                # Visualization server related manifests below
+                {
+                    "apiVersion": "apps/v1",
+                    "kind": "Deployment",
+                    "metadata": {
+                        "labels": {
+                            "app": "ml-pipeline-visualizationserver"
+                        },
+                        "name": "ml-pipeline-visualizationserver",
+                        "namespace": namespace,
+                    },
+                    "spec": {
+                        "selector": {
+                            "matchLabels": {
+                                "app": "ml-pipeline-visualizationserver"
+                            },
+                        },
+                        "template": {
+                            "metadata": {
+                                "labels": {
+                                    "app": "ml-pipeline-visualizationserver"
+                                },
+                                "annotations": disable_istio_sidecar and {
+                                    "sidecar.istio.io/inject": "false"
+                                } or {},
+                            },
+                            "spec": {
+                                "containers": [{
+                                    "image":
+                                    "gcr.io/ml-pipeline/visualization-server:" +
+                                    kfp_version,
+                                    "imagePullPolicy":
+                                    "IfNotPresent",
+                                    "name":
+                                    "ml-pipeline-visualizationserver",
+                                    "ports": [{
+                                        "containerPort": 8888
+                                    }],
+                                }],
+                                "serviceAccountName":
+                                "default-editor",
+                            },
+                        },
+                    },
+                },
+                {
+                    "apiVersion": "networking.istio.io/v1alpha3",
+                    "kind": "DestinationRule",
+                    "metadata": {
+                        "name": "ml-pipeline-visualizationserver",
+                        "namespace": namespace,
+                    },
+                    "spec": {
+                        "host": "ml-pipeline-visualizationserver",
+                        "trafficPolicy": {
+                            "tls": {
+                                "mode": "ISTIO_MUTUAL"
+                            }
+                        }
+                    }
+                },
+                {
+                    "apiVersion": "rbac.istio.io/v1alpha1",
+                    "kind": "ServiceRole",
+                    "metadata": {
+                        "name": "ml-pipeline-visualizationserver",
+                        "namespace": namespace,
+                    },
+                    "spec": {
+                        "rules": [{
+                            "services": ["ml-pipeline-visualizationserver.*"]
+                        }]
+                    }
+                },
+                {
+                    "apiVersion": "rbac.istio.io/v1alpha1",
+                    "kind": "ServiceRoleBinding",
+                    "metadata": {
+                        "name": "ml-pipeline-visualizationserver",
+                        "namespace": namespace,
+                    },
+                    "spec": {
+                        "subjects": [{
+                            "properties": {
+                                "source.principal":
+                                "cluster.local/ns/kubeflow/sa/ml-pipeline"
+                            }
+                        }],
+                        "roleRef": {
+                            "kind": "ServiceRole",
+                            "name": "ml-pipeline-visualizationserver"
+                        }
+                    }
+                },
+                {
+                    "apiVersion": "v1",
+                    "kind": "Service",
+                    "metadata": {
+                        "name": "ml-pipeline-visualizationserver",
+                        "namespace": namespace,
+                    },
+                    "spec": {
+                        "ports": [{
+                            "name": "http",
+                            "port": 8888,
+                            "protocol": "TCP",
+                            "targetPort": 8888,
+                        }],
+                        "selector": {
+                            "app": "ml-pipeline-visualizationserver",
+                        },
+                    },
+                },
+                # Artifact fetcher related resources below.
+                {
+                    "apiVersion": "apps/v1",
+                    "kind": "Deployment",
+                    "metadata": {
+                        "labels": {
+                            "app": "ml-pipeline-ui-artifact"
+                        },
+                        "name": "ml-pipeline-ui-artifact",
+                        "namespace": namespace,
+                    },
+                    "spec": {
+                        "selector": {
+                            "matchLabels": {
+                                "app": "ml-pipeline-ui-artifact"
+                            }
+                        },
+                        "template": {
+                            "metadata": {
+                                "labels": {
+                                    "app": "ml-pipeline-ui-artifact"
+                                },
+                                "annotations": disable_istio_sidecar and {
+                                    "sidecar.istio.io/inject": "false"
+                                } or {},
+                            },
+                            "spec": {
+                                "containers": [{
+                                    "name":
+                                    "ml-pipeline-ui-artifact",
+                                    "image":
+                                    "gcr.io/ml-pipeline/frontend:" + kfp_version,
+                                    "imagePullPolicy":
+                                    "IfNotPresent",
+                                    "ports": [{
+                                        "containerPort": 3000
+                                    }]
+                                }],
+                                "serviceAccountName":
+                                "default-editor"
+                            }
+                        }
+                    }
+                },
+                {
+                    "apiVersion": "v1",
+                    "kind": "Service",
+                    "metadata": {
+                        "name": "ml-pipeline-ui-artifact",
+                        "namespace": namespace,
+                        "labels": {
+                            "app": "ml-pipeline-ui-artifact"
+                        }
+                    },
+                    "spec": {
+                        "ports": [{
+                            "name":
+                            "http",  # name is required to let istio understand request protocol
+                            "port": 80,
+                            "protocol": "TCP",
+                            "targetPort": 3000
+                        }],
+                        "selector": {
+                            "app": "ml-pipeline-ui-artifact"
+                        }
+                    }
+                },
+            ]
+            print('Received request:', parent)
+            print('Desired resources except secrets:', desired_resources)
+            # Moved after the print argument because this is sensitive data.
+            desired_resources.append({
+                "apiVersion": "v1",
+                "kind": "Secret",
+                "metadata": {
+                    "name": "mlpipeline-minio-artifact",
+                    "namespace": namespace,
+                },
+                "data": {
+                    "accesskey": base64.b64encode(mlpipeline_minio_access_key),
+                    "secretkey": base64.b64encode(mlpipeline_minio_secret_key),
+                },
+            })
+
+            return {"status": desired_status, "children": desired_resources}
+
+        def do_POST(self):
+            # Serve the sync() function as a JSON webhook.
+            observed = json.loads(
+                self.rfile.read(int(self.headers.get("content-length"))))
+            desired = self.sync(observed["parent"], observed["children"])
+
+            self.send_response(200)
+            self.send_header("Content-type", "application/json")
+            self.end_headers()
+            self.wfile.write(bytes(json.dumps(desired), 'utf-8'))
+
+
+    HTTPServer(("", 80), Controller).serve_forever()
+kind: ConfigMap
+metadata:
+  labels:
+    app: kubeflow-pipelines-profile-controller
+  name: kubeflow-pipelines-profile-controller-code-m828g88mtm
+  namespace: kubeflow

--- a/tests/stacks/examples/alice/test_data/expected/~g_v1_configmap_kubeflow-pipelines-profile-controller-env-822cf46mft.yaml
+++ b/tests/stacks/examples/alice/test_data/expected/~g_v1_configmap_kubeflow-pipelines-profile-controller-env-822cf46mft.yaml
@@ -1,0 +1,10 @@
+apiVersion: v1
+data:
+  DISABLE_ISTIO_SIDECAR: "false"
+  KFP_VERSION: 1.0.0-rc.3
+kind: ConfigMap
+metadata:
+  labels:
+    app: kubeflow-pipelines-profile-controller
+  name: kubeflow-pipelines-profile-controller-env-822cf46mft
+  namespace: kubeflow

--- a/tests/stacks/examples/alice/test_data/expected/~g_v1_configmap_ml-pipeline-ui-configmap.yaml
+++ b/tests/stacks/examples/alice/test_data/expected/~g_v1_configmap_ml-pipeline-ui-configmap.yaml
@@ -1,0 +1,14 @@
+apiVersion: v1
+data:
+  viewer-pod-template.json: |-
+    {
+        "spec": {
+            "serviceAccountName": "default-editor"
+        }
+    }
+kind: ConfigMap
+metadata:
+  labels:
+    app: ml-pipeline-ui
+  name: ml-pipeline-ui-configmap
+  namespace: kubeflow

--- a/tests/stacks/examples/alice/test_data/expected/~g_v1_configmap_pipeline-api-server-config-f4t72426kt.yaml
+++ b/tests/stacks/examples/alice/test_data/expected/~g_v1_configmap_pipeline-api-server-config-f4t72426kt.yaml
@@ -1,0 +1,10 @@
+apiVersion: v1
+data:
+  DEFAULTPIPELINERUNNERSERVICEACCOUNT: default-editor
+  MULTIUSER: "true"
+  VISUALIZATIONSERVICE_NAME: ml-pipeline-visualizationserver
+  VISUALIZATIONSERVICE_PORT: "8888"
+kind: ConfigMap
+metadata:
+  name: pipeline-api-server-config-f4t72426kt
+  namespace: kubeflow

--- a/tests/stacks/examples/alice/test_data/expected/~g_v1_service_kubeflow-pipelines-profile-controller.yaml
+++ b/tests/stacks/examples/alice/test_data/expected/~g_v1_service_kubeflow-pipelines-profile-controller.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    app: kubeflow-pipelines-profile-controller
+  name: kubeflow-pipelines-profile-controller
+  namespace: kubeflow
+spec:
+  ports:
+  - name: http
+    port: 80
+    protocol: TCP
+    targetPort: 80
+  selector:
+    app: kubeflow-pipelines-profile-controller

--- a/tests/stacks/gcp/test_data/expected/apps_v1_deployment_cache-server.yaml
+++ b/tests/stacks/gcp/test_data/expected/apps_v1_deployment_cache-server.yaml
@@ -53,9 +53,7 @@ spec:
               key: password
               name: mysql-secret-fd5gktm75t
         - name: NAMESPACE_TO_WATCH
-          valueFrom:
-            fieldRef:
-              fieldPath: metadata.namespace
+          value: ""
         image: gcr.io/ml-pipeline/cache-server:1.0.0-rc.3
         imagePullPolicy: Always
         name: server

--- a/tests/stacks/gcp/test_data/expected/apps_v1_deployment_metadata-writer.yaml
+++ b/tests/stacks/gcp/test_data/expected/apps_v1_deployment_metadata-writer.yaml
@@ -18,9 +18,7 @@ spec:
       containers:
       - env:
         - name: NAMESPACE_TO_WATCH
-          valueFrom:
-            fieldRef:
-              fieldPath: metadata.namespace
+          value: ""
         image: gcr.io/ml-pipeline/metadata-writer:1.0.0-rc.3
         name: main
       serviceAccountName: kubeflow-pipelines-metadata-writer

--- a/tests/stacks/gcp/test_data/expected/apps_v1_deployment_ml-pipeline-persistenceagent.yaml
+++ b/tests/stacks/gcp/test_data/expected/apps_v1_deployment_ml-pipeline-persistenceagent.yaml
@@ -17,9 +17,7 @@ spec:
       containers:
       - env:
         - name: NAMESPACE
-          valueFrom:
-            fieldRef:
-              fieldPath: metadata.namespace
+          value: ""
         image: gcr.io/ml-pipeline/persistenceagent:1.0.0-rc.3
         imagePullPolicy: IfNotPresent
         name: ml-pipeline-persistenceagent

--- a/tests/stacks/gcp/test_data/expected/apps_v1_deployment_ml-pipeline-scheduledworkflow.yaml
+++ b/tests/stacks/gcp/test_data/expected/apps_v1_deployment_ml-pipeline-scheduledworkflow.yaml
@@ -17,9 +17,7 @@ spec:
       containers:
       - env:
         - name: NAMESPACE
-          valueFrom:
-            fieldRef:
-              fieldPath: metadata.namespace
+          value: ""
         image: gcr.io/ml-pipeline/scheduledworkflow:1.0.0-rc.3
         imagePullPolicy: IfNotPresent
         name: ml-pipeline-scheduledworkflow

--- a/tests/stacks/gcp/test_data/expected/apps_v1_deployment_ml-pipeline-ui.yaml
+++ b/tests/stacks/gcp/test_data/expected/apps_v1_deployment_ml-pipeline-ui.yaml
@@ -16,6 +16,28 @@ spec:
     spec:
       containers:
       - env:
+        - name: VIEWER_TENSORBOARD_POD_TEMPLATE_SPEC_PATH
+          value: /etc/config/viewer-pod-template.json
+        - name: DEPLOYMENT
+          value: KUBEFLOW
+        - name: ARTIFACTS_SERVICE_PROXY_NAME
+          value: ml-pipeline-ui-artifact
+        - name: ARTIFACTS_SERVICE_PROXY_PORT
+          value: "80"
+        - name: ARTIFACTS_SERVICE_PROXY_ENABLED
+          value: "true"
+        - name: ENABLE_AUTHZ
+          value: "true"
+        - name: KUBEFLOW_USERID_HEADER
+          valueFrom:
+            configMapKeyRef:
+              key: userid-header
+              name: kubeflow-config-988m2m9m87
+        - name: KUBEFLOW_USERID_PREFIX
+          valueFrom:
+            configMapKeyRef:
+              key: userid-prefix
+              name: kubeflow-config-988m2m9m87
         - name: MINIO_NAMESPACE
           valueFrom:
             fieldRef:
@@ -61,4 +83,12 @@ spec:
           initialDelaySeconds: 3
           periodSeconds: 5
           timeoutSeconds: 2
+        volumeMounts:
+        - mountPath: /etc/config
+          name: config-volume
+          readOnly: true
       serviceAccountName: ml-pipeline-ui
+      volumes:
+      - configMap:
+          name: ml-pipeline-ui-configmap
+        name: config-volume

--- a/tests/stacks/gcp/test_data/expected/apps_v1_deployment_ml-pipeline-viewer-crd.yaml
+++ b/tests/stacks/gcp/test_data/expected/apps_v1_deployment_ml-pipeline-viewer-crd.yaml
@@ -16,6 +16,9 @@ spec:
     spec:
       containers:
       - env:
+        - name: NAMESPACE
+          value: ""
+          valueFrom: null
         - name: MAX_NUM_VIEWERS
           value: "50"
         - name: MINIO_NAMESPACE

--- a/tests/stacks/gcp/test_data/expected/apps_v1_deployment_ml-pipeline.yaml
+++ b/tests/stacks/gcp/test_data/expected/apps_v1_deployment_ml-pipeline.yaml
@@ -16,6 +16,16 @@ spec:
     spec:
       containers:
       - env:
+        - name: KUBEFLOW_USERID_HEADER
+          valueFrom:
+            configMapKeyRef:
+              key: userid-header
+              name: kubeflow-config-988m2m9m87
+        - name: KUBEFLOW_USERID_PREFIX
+          valueFrom:
+            configMapKeyRef:
+              key: userid-prefix
+              name: kubeflow-config-988m2m9m87
         - name: POD_NAMESPACE
           valueFrom:
             fieldRef:
@@ -62,6 +72,9 @@ spec:
             secretKeyRef:
               key: secretkey
               name: mlpipeline-minio-artifact
+        envFrom:
+        - configMapRef:
+            name: pipeline-api-server-config-f4t72426kt
         image: gcr.io/ml-pipeline/api-server:1.0.0-rc.3
         imagePullPolicy: IfNotPresent
         livenessProbe:

--- a/tests/stacks/gcp/test_data/expected/apps_v1beta1_deployment_kubeflow-pipelines-profile-controller.yaml
+++ b/tests/stacks/gcp/test_data/expected/apps_v1beta1_deployment_kubeflow-pipelines-profile-controller.yaml
@@ -1,0 +1,48 @@
+apiVersion: apps/v1beta1
+kind: Deployment
+metadata:
+  labels:
+    app: kubeflow-pipelines-profile-controller
+  name: kubeflow-pipelines-profile-controller
+  namespace: kubeflow
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: kubeflow-pipelines-profile-controller
+  template:
+    metadata:
+      annotations:
+        sidecar.istio.io/inject: "false"
+      labels:
+        app: kubeflow-pipelines-profile-controller
+    spec:
+      containers:
+      - command:
+        - python
+        - /hooks/sync.py
+        env:
+        - name: MINIO_ACCESS_KEY
+          valueFrom:
+            secretKeyRef:
+              key: accesskey
+              name: mlpipeline-minio-artifact
+        - name: MINIO_SECRET_KEY
+          valueFrom:
+            secretKeyRef:
+              key: secretkey
+              name: mlpipeline-minio-artifact
+        envFrom:
+        - configMapRef:
+            name: kubeflow-pipelines-profile-controller-env-822cf46mft
+        image: python:3.7
+        name: profile-controller
+        ports:
+        - containerPort: 80
+        volumeMounts:
+        - mountPath: /hooks
+          name: hooks
+      volumes:
+      - configMap:
+          name: kubeflow-pipelines-profile-controller-code-m828g88mtm
+        name: hooks

--- a/tests/stacks/gcp/test_data/expected/metacontroller.k8s.io_v1alpha1_compositecontroller_kubeflow-pipelines-profile-controller.yaml
+++ b/tests/stacks/gcp/test_data/expected/metacontroller.k8s.io_v1alpha1_compositecontroller_kubeflow-pipelines-profile-controller.yaml
@@ -1,0 +1,46 @@
+apiVersion: metacontroller.k8s.io/v1alpha1
+kind: CompositeController
+metadata:
+  labels:
+    app: kubeflow-pipelines-profile-controller
+  name: kubeflow-pipelines-profile-controller
+  namespace: kubeflow
+spec:
+  childResources:
+  - apiVersion: v1
+    resource: secrets
+    updateStrategy:
+      method: OnDelete
+  - apiVersion: v1
+    resource: configmaps
+    updateStrategy:
+      method: OnDelete
+  - apiVersion: apps/v1
+    resource: deployments
+    updateStrategy:
+      method: InPlace
+  - apiVersion: v1
+    resource: services
+    updateStrategy:
+      method: InPlace
+  - apiVersion: networking.istio.io/v1alpha3
+    resource: destinationrules
+    updateStrategy:
+      method: InPlace
+  - apiVersion: rbac.istio.io/v1alpha1
+    resource: serviceroles
+    updateStrategy:
+      method: InPlace
+  - apiVersion: rbac.istio.io/v1alpha1
+    resource: servicerolebindings
+    updateStrategy:
+      method: InPlace
+  generateSelector: true
+  hooks:
+    sync:
+      webhook:
+        url: http://kubeflow-pipelines-profile-controller/sync
+  parentResource:
+    apiVersion: v1
+    resource: namespaces
+  resyncPeriodSeconds: 10

--- a/tests/stacks/gcp/test_data/expected/networking.istio.io_v1alpha3_destinationrule_ml-pipeline-mysql.yaml
+++ b/tests/stacks/gcp/test_data/expected/networking.istio.io_v1alpha3_destinationrule_ml-pipeline-mysql.yaml
@@ -1,0 +1,10 @@
+apiVersion: networking.istio.io/v1alpha3
+kind: DestinationRule
+metadata:
+  name: ml-pipeline-mysql
+  namespace: kubeflow
+spec:
+  host: mysql.kubeflow.svc.cluster.local
+  trafficPolicy:
+    tls:
+      mode: ISTIO_MUTUAL

--- a/tests/stacks/gcp/test_data/expected/networking.istio.io_v1alpha3_destinationrule_ml-pipeline-ui.yaml
+++ b/tests/stacks/gcp/test_data/expected/networking.istio.io_v1alpha3_destinationrule_ml-pipeline-ui.yaml
@@ -1,0 +1,10 @@
+apiVersion: networking.istio.io/v1alpha3
+kind: DestinationRule
+metadata:
+  name: ml-pipeline-ui
+  namespace: kubeflow
+spec:
+  host: ml-pipeline-ui.kubeflow.svc.cluster.local
+  trafficPolicy:
+    tls:
+      mode: ISTIO_MUTUAL

--- a/tests/stacks/gcp/test_data/expected/networking.istio.io_v1alpha3_destinationrule_ml-pipeline-visualizationserver.yaml
+++ b/tests/stacks/gcp/test_data/expected/networking.istio.io_v1alpha3_destinationrule_ml-pipeline-visualizationserver.yaml
@@ -1,0 +1,10 @@
+apiVersion: networking.istio.io/v1alpha3
+kind: DestinationRule
+metadata:
+  name: ml-pipeline-visualizationserver
+  namespace: kubeflow
+spec:
+  host: ml-pipeline-visualizationserver.kubeflow.svc.cluster.local
+  trafficPolicy:
+    tls:
+      mode: ISTIO_MUTUAL

--- a/tests/stacks/gcp/test_data/expected/networking.istio.io_v1alpha3_destinationrule_ml-pipeline.yaml
+++ b/tests/stacks/gcp/test_data/expected/networking.istio.io_v1alpha3_destinationrule_ml-pipeline.yaml
@@ -1,0 +1,10 @@
+apiVersion: networking.istio.io/v1alpha3
+kind: DestinationRule
+metadata:
+  name: ml-pipeline
+  namespace: kubeflow
+spec:
+  host: ml-pipeline.kubeflow.svc.cluster.local
+  trafficPolicy:
+    tls:
+      mode: ISTIO_MUTUAL

--- a/tests/stacks/gcp/test_data/expected/rbac.authorization.k8s.io_v1_clusterrole_kubeflow-pipelines-cache-role.yaml
+++ b/tests/stacks/gcp/test_data/expected/rbac.authorization.k8s.io_v1_clusterrole_kubeflow-pipelines-cache-role.yaml
@@ -1,0 +1,31 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: kubeflow-pipelines-cache-role
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - pods
+  verbs:
+  - get
+  - list
+  - watch
+  - update
+  - patch
+- apiGroups:
+  - ""
+  resources:
+  - configmaps
+  verbs:
+  - get
+- apiGroups:
+  - argoproj.io
+  resources:
+  - workflows
+  verbs:
+  - get
+  - list
+  - watch
+  - update
+  - patch

--- a/tests/stacks/gcp/test_data/expected/rbac.authorization.k8s.io_v1_clusterrole_kubeflow-pipelines-metadata-writer-role.yaml
+++ b/tests/stacks/gcp/test_data/expected/rbac.authorization.k8s.io_v1_clusterrole_kubeflow-pipelines-metadata-writer-role.yaml
@@ -1,0 +1,31 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: kubeflow-pipelines-metadata-writer-role
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - pods
+  verbs:
+  - get
+  - list
+  - watch
+  - update
+  - patch
+- apiGroups:
+  - ""
+  resources:
+  - configmaps
+  verbs:
+  - get
+- apiGroups:
+  - argoproj.io
+  resources:
+  - workflows
+  verbs:
+  - get
+  - list
+  - watch
+  - update
+  - patch

--- a/tests/stacks/gcp/test_data/expected/rbac.authorization.k8s.io_v1_clusterrole_ml-pipeline-persistenceagent-role.yaml
+++ b/tests/stacks/gcp/test_data/expected/rbac.authorization.k8s.io_v1_clusterrole_ml-pipeline-persistenceagent-role.yaml
@@ -1,0 +1,21 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: ml-pipeline-persistenceagent-role
+rules:
+- apiGroups:
+  - argoproj.io
+  resources:
+  - workflows
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - kubeflow.org
+  resources:
+  - scheduledworkflows
+  verbs:
+  - get
+  - list
+  - watch

--- a/tests/stacks/gcp/test_data/expected/rbac.authorization.k8s.io_v1_clusterrole_ml-pipeline-scheduledworkflow-role.yaml
+++ b/tests/stacks/gcp/test_data/expected/rbac.authorization.k8s.io_v1_clusterrole_ml-pipeline-scheduledworkflow-role.yaml
@@ -1,0 +1,36 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: ml-pipeline-scheduledworkflow-role
+rules:
+- apiGroups:
+  - argoproj.io
+  resources:
+  - workflows
+  verbs:
+  - create
+  - get
+  - list
+  - watch
+  - update
+  - patch
+  - delete
+- apiGroups:
+  - kubeflow.org
+  resources:
+  - scheduledworkflows
+  verbs:
+  - create
+  - get
+  - list
+  - watch
+  - update
+  - patch
+  - delete
+- apiGroups:
+  - ""
+  resources:
+  - events
+  verbs:
+  - create
+  - patch

--- a/tests/stacks/gcp/test_data/expected/rbac.authorization.k8s.io_v1_clusterrole_ml-pipeline-ui.yaml
+++ b/tests/stacks/gcp/test_data/expected/rbac.authorization.k8s.io_v1_clusterrole_ml-pipeline-ui.yaml
@@ -1,0 +1,44 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  labels:
+    app: ml-pipeline-ui
+  name: ml-pipeline-ui
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - pods
+  - pods/log
+  verbs:
+  - get
+- apiGroups:
+  - ""
+  resources:
+  - events
+  verbs:
+  - list
+- apiGroups:
+  - ""
+  resources:
+  - secrets
+  verbs:
+  - get
+  - list
+- apiGroups:
+  - kubeflow.org
+  resources:
+  - viewers
+  verbs:
+  - create
+  - get
+  - list
+  - watch
+  - delete
+- apiGroups:
+  - argoproj.io
+  resources:
+  - workflows
+  verbs:
+  - get
+  - list

--- a/tests/stacks/gcp/test_data/expected/rbac.authorization.k8s.io_v1_clusterrole_ml-pipeline-viewer-controller-role.yaml
+++ b/tests/stacks/gcp/test_data/expected/rbac.authorization.k8s.io_v1_clusterrole_ml-pipeline-viewer-controller-role.yaml
@@ -1,0 +1,30 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: ml-pipeline-viewer-controller-role
+rules:
+- apiGroups:
+  - '*'
+  resources:
+  - deployments
+  - services
+  verbs:
+  - create
+  - get
+  - list
+  - watch
+  - update
+  - patch
+  - delete
+- apiGroups:
+  - kubeflow.org
+  resources:
+  - viewers
+  verbs:
+  - create
+  - get
+  - list
+  - watch
+  - update
+  - patch
+  - delete

--- a/tests/stacks/gcp/test_data/expected/rbac.authorization.k8s.io_v1_clusterrolebinding_kubeflow-pipelines-cache-binding.yaml
+++ b/tests/stacks/gcp/test_data/expected/rbac.authorization.k8s.io_v1_clusterrolebinding_kubeflow-pipelines-cache-binding.yaml
@@ -1,0 +1,12 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: kubeflow-pipelines-cache-binding
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: kubeflow-pipelines-cache-role
+subjects:
+- kind: ServiceAccount
+  name: kubeflow-pipelines-cache
+  namespace: kubeflow

--- a/tests/stacks/gcp/test_data/expected/rbac.authorization.k8s.io_v1_clusterrolebinding_kubeflow-pipelines-metadata-writer-binding.yaml
+++ b/tests/stacks/gcp/test_data/expected/rbac.authorization.k8s.io_v1_clusterrolebinding_kubeflow-pipelines-metadata-writer-binding.yaml
@@ -1,0 +1,12 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: kubeflow-pipelines-metadata-writer-binding
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: kubeflow-pipelines-metadata-writer-role
+subjects:
+- kind: ServiceAccount
+  name: kubeflow-pipelines-metadata-writer
+  namespace: kubeflow

--- a/tests/stacks/gcp/test_data/expected/rbac.authorization.k8s.io_v1_clusterrolebinding_ml-pipeline-persistenceagent-binding.yaml
+++ b/tests/stacks/gcp/test_data/expected/rbac.authorization.k8s.io_v1_clusterrolebinding_ml-pipeline-persistenceagent-binding.yaml
@@ -1,0 +1,12 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: ml-pipeline-persistenceagent-binding
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: ml-pipeline-persistenceagent-role
+subjects:
+- kind: ServiceAccount
+  name: ml-pipeline-persistenceagent
+  namespace: kubeflow

--- a/tests/stacks/gcp/test_data/expected/rbac.authorization.k8s.io_v1_clusterrolebinding_ml-pipeline-scheduledworkflow-binding.yaml
+++ b/tests/stacks/gcp/test_data/expected/rbac.authorization.k8s.io_v1_clusterrolebinding_ml-pipeline-scheduledworkflow-binding.yaml
@@ -1,0 +1,12 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: ml-pipeline-scheduledworkflow-binding
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: ml-pipeline-scheduledworkflow-role
+subjects:
+- kind: ServiceAccount
+  name: ml-pipeline-scheduledworkflow
+  namespace: kubeflow

--- a/tests/stacks/gcp/test_data/expected/rbac.authorization.k8s.io_v1_clusterrolebinding_ml-pipeline-ui.yaml
+++ b/tests/stacks/gcp/test_data/expected/rbac.authorization.k8s.io_v1_clusterrolebinding_ml-pipeline-ui.yaml
@@ -1,0 +1,14 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  labels:
+    app: ml-pipeline-ui
+  name: ml-pipeline-ui
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: ml-pipeline-ui
+subjects:
+- kind: ServiceAccount
+  name: ml-pipeline-ui
+  namespace: kubeflow

--- a/tests/stacks/gcp/test_data/expected/rbac.authorization.k8s.io_v1_clusterrolebinding_ml-pipeline-viewer-crd-binding.yaml
+++ b/tests/stacks/gcp/test_data/expected/rbac.authorization.k8s.io_v1_clusterrolebinding_ml-pipeline-viewer-crd-binding.yaml
@@ -1,0 +1,12 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: ml-pipeline-viewer-crd-binding
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: ml-pipeline-viewer-controller-role
+subjects:
+- kind: ServiceAccount
+  name: ml-pipeline-viewer-crd-service-account
+  namespace: kubeflow

--- a/tests/stacks/gcp/test_data/expected/rbac.authorization.k8s.io_v1beta1_clusterrole_ml-pipeline.yaml
+++ b/tests/stacks/gcp/test_data/expected/rbac.authorization.k8s.io_v1beta1_clusterrole_ml-pipeline.yaml
@@ -1,0 +1,34 @@
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: ClusterRole
+metadata:
+  name: ml-pipeline
+rules:
+- apiGroups:
+  - argoproj.io
+  resources:
+  - workflows
+  verbs:
+  - create
+  - get
+  - list
+  - watch
+  - update
+  - patch
+  - delete
+- apiGroups:
+  - kubeflow.org
+  resources:
+  - scheduledworkflows
+  verbs:
+  - create
+  - get
+  - list
+  - update
+  - patch
+  - delete
+- apiGroups:
+  - ""
+  resources:
+  - pods
+  verbs:
+  - delete

--- a/tests/stacks/gcp/test_data/expected/rbac.authorization.k8s.io_v1beta1_clusterrolebinding_ml-pipeline.yaml
+++ b/tests/stacks/gcp/test_data/expected/rbac.authorization.k8s.io_v1beta1_clusterrolebinding_ml-pipeline.yaml
@@ -1,0 +1,12 @@
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: ClusterRoleBinding
+metadata:
+  name: ml-pipeline
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: ml-pipeline
+subjects:
+- kind: ServiceAccount
+  name: ml-pipeline
+  namespace: kubeflow

--- a/tests/stacks/gcp/test_data/expected/rbac.istio.io_v1alpha1_servicerole_cache-server.yaml
+++ b/tests/stacks/gcp/test_data/expected/rbac.istio.io_v1alpha1_servicerole_cache-server.yaml
@@ -1,0 +1,9 @@
+apiVersion: rbac.istio.io/v1alpha1
+kind: ServiceRole
+metadata:
+  name: cache-server
+  namespace: kubeflow
+spec:
+  rules:
+  - services:
+    - cache-server.kubeflow.svc.cluster.local

--- a/tests/stacks/gcp/test_data/expected/rbac.istio.io_v1alpha1_servicerole_ml-pipeline-services.yaml
+++ b/tests/stacks/gcp/test_data/expected/rbac.istio.io_v1alpha1_servicerole_ml-pipeline-services.yaml
@@ -1,0 +1,12 @@
+apiVersion: rbac.istio.io/v1alpha1
+kind: ServiceRole
+metadata:
+  name: ml-pipeline-services
+  namespace: kubeflow
+spec:
+  rules:
+  - services:
+    - ml-pipeline.kubeflow.svc.cluster.local
+    - ml-pipeline-ui.kubeflow.svc.cluster.local
+    - ml-pipeline-visualizationserver.kubeflow.svc.cluster.local
+    - mysql.kubeflow.svc.cluster.local

--- a/tests/stacks/gcp/test_data/expected/rbac.istio.io_v1alpha1_servicerole_ml-pipeline-ui.yaml
+++ b/tests/stacks/gcp/test_data/expected/rbac.istio.io_v1alpha1_servicerole_ml-pipeline-ui.yaml
@@ -1,0 +1,9 @@
+apiVersion: rbac.istio.io/v1alpha1
+kind: ServiceRole
+metadata:
+  name: ml-pipeline-ui
+  namespace: kubeflow
+spec:
+  rules:
+  - services:
+    - ml-pipeline-ui.kubeflow.svc.cluster.local

--- a/tests/stacks/gcp/test_data/expected/rbac.istio.io_v1alpha1_servicerolebinding_bind-cache-server-admission-webhook.yaml
+++ b/tests/stacks/gcp/test_data/expected/rbac.istio.io_v1alpha1_servicerolebinding_bind-cache-server-admission-webhook.yaml
@@ -1,0 +1,11 @@
+apiVersion: rbac.istio.io/v1alpha1
+kind: ServiceRoleBinding
+metadata:
+  name: bind-cache-server-admission-webhook
+  namespace: kubeflow
+spec:
+  roleRef:
+    kind: ServiceRole
+    name: cache-server
+  subjects:
+  - user: '*'

--- a/tests/stacks/gcp/test_data/expected/rbac.istio.io_v1alpha1_servicerolebinding_bind-gateway-ml-pipeline-ui.yaml
+++ b/tests/stacks/gcp/test_data/expected/rbac.istio.io_v1alpha1_servicerolebinding_bind-gateway-ml-pipeline-ui.yaml
@@ -1,0 +1,12 @@
+apiVersion: rbac.istio.io/v1alpha1
+kind: ServiceRoleBinding
+metadata:
+  name: bind-gateway-ml-pipeline-ui
+  namespace: kubeflow
+spec:
+  roleRef:
+    kind: ServiceRole
+    name: ml-pipeline-ui
+  subjects:
+  - properties:
+      source.namespace: istio-system

--- a/tests/stacks/gcp/test_data/expected/rbac.istio.io_v1alpha1_servicerolebinding_bind-ml-pipeline-internal.yaml
+++ b/tests/stacks/gcp/test_data/expected/rbac.istio.io_v1alpha1_servicerolebinding_bind-ml-pipeline-internal.yaml
@@ -1,0 +1,22 @@
+apiVersion: rbac.istio.io/v1alpha1
+kind: ServiceRoleBinding
+metadata:
+  name: bind-ml-pipeline-internal
+  namespace: kubeflow
+spec:
+  roleRef:
+    kind: ServiceRole
+    name: ml-pipeline-services
+  subjects:
+  - properties:
+      source.principal: cluster.local/ns/kubeflow/sa/ml-pipeline
+  - properties:
+      source.principal: cluster.local/ns/kubeflow/sa/ml-pipeline-ui
+  - properties:
+      source.principal: cluster.local/ns/kubeflow/sa/ml-pipeline-persistenceagent
+  - properties:
+      source.principal: cluster.local/ns/kubeflow/sa/ml-pipeline-scheduledworkflow
+  - properties:
+      source.principal: cluster.local/ns/kubeflow/sa/ml-pipeline-viewer-crd-service-account
+  - properties:
+      source.principal: cluster.local/ns/kubeflow/sa/kubeflow-pipelines-cache

--- a/tests/stacks/gcp/test_data/expected/~g_v1_configmap_kubeflow-pipelines-profile-controller-code-m828g88mtm.yaml
+++ b/tests/stacks/gcp/test_data/expected/~g_v1_configmap_kubeflow-pipelines-profile-controller-code-m828g88mtm.yaml
@@ -1,0 +1,288 @@
+apiVersion: v1
+data:
+  sync.py: |
+    # Copyright 2020 Google LLC
+    #
+    # Licensed under the Apache License, Version 2.0 (the "License");
+    # you may not use this file except in compliance with the License.
+    # You may obtain a copy of the License at
+    #
+    #      http://www.apache.org/licenses/LICENSE-2.0
+    #
+    # Unless required by applicable law or agreed to in writing, software
+    # distributed under the License is distributed on an "AS IS" BASIS,
+    # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    # See the License for the specific language governing permissions and
+    # limitations under the License.
+
+    from http.server import BaseHTTPRequestHandler, HTTPServer
+    import json
+    import os
+    import base64
+
+    kfp_version = os.environ["KFP_VERSION"]
+    disable_istio_sidecar = os.environ.get("DISABLE_ISTIO_SIDECAR") == "true"
+    mlpipeline_minio_access_key = os.environ.get("MINIO_ACCESS_KEY")
+    mlpipeline_minio_secret_key = os.environ.get("MINIO_SECRET_KEY")
+
+
+    class Controller(BaseHTTPRequestHandler):
+        def sync(self, parent, children):
+            # HACK: Currently using serving.kubeflow.org/inferenceservice to identify
+            # kubeflow user namespaces.
+            # TODO: let Kubeflow profile controller add a pipeline specific label to
+            # user namespaces and use that label instead.
+            pipeline_enabled = parent.get("metadata", {}).get(
+                "labels", {}).get("serving.kubeflow.org/inferenceservice")
+
+            if not pipeline_enabled:
+                return {"status": {}, "children": []}
+
+            # Compute status based on observed state.
+            desired_status = {
+                "kubeflow-pipelines-ready": \
+                    len(children["Secret.v1"]) == 1 and \
+                    len(children["ConfigMap.v1"]) == 1 and \
+                    len(children["Deployment.apps/v1"]) == 2 and \
+                    len(children["Service.v1"]) == 2 and \
+                    len(children["DestinationRule.networking.istio.io/v1alpha3"]) == 1 and \
+                    len(children["ServiceRole.rbac.istio.io/v1alpha1"]) == 1 and \
+                    len(children["ServiceRoleBinding.rbac.istio.io/v1alpha1"]) == 1 and \
+                    "True" or "False"
+            }
+
+            # Generate the desired child object(s).
+            # parent is a namespace
+            namespace = parent.get("metadata", {}).get("name")
+            desired_resources = [
+                {
+                    "apiVersion": "v1",
+                    "kind": "ConfigMap",
+                    "metadata": {
+                        "name": "metadata-grpc-configmap",
+                        "namespace": namespace,
+                    },
+                    "data": {
+                        "METADATA_GRPC_SERVICE_HOST":
+                        "metadata-grpc-service.kubeflow",
+                        "METADATA_GRPC_SERVICE_PORT": "8080",
+                    },
+                },
+                # Visualization server related manifests below
+                {
+                    "apiVersion": "apps/v1",
+                    "kind": "Deployment",
+                    "metadata": {
+                        "labels": {
+                            "app": "ml-pipeline-visualizationserver"
+                        },
+                        "name": "ml-pipeline-visualizationserver",
+                        "namespace": namespace,
+                    },
+                    "spec": {
+                        "selector": {
+                            "matchLabels": {
+                                "app": "ml-pipeline-visualizationserver"
+                            },
+                        },
+                        "template": {
+                            "metadata": {
+                                "labels": {
+                                    "app": "ml-pipeline-visualizationserver"
+                                },
+                                "annotations": disable_istio_sidecar and {
+                                    "sidecar.istio.io/inject": "false"
+                                } or {},
+                            },
+                            "spec": {
+                                "containers": [{
+                                    "image":
+                                    "gcr.io/ml-pipeline/visualization-server:" +
+                                    kfp_version,
+                                    "imagePullPolicy":
+                                    "IfNotPresent",
+                                    "name":
+                                    "ml-pipeline-visualizationserver",
+                                    "ports": [{
+                                        "containerPort": 8888
+                                    }],
+                                }],
+                                "serviceAccountName":
+                                "default-editor",
+                            },
+                        },
+                    },
+                },
+                {
+                    "apiVersion": "networking.istio.io/v1alpha3",
+                    "kind": "DestinationRule",
+                    "metadata": {
+                        "name": "ml-pipeline-visualizationserver",
+                        "namespace": namespace,
+                    },
+                    "spec": {
+                        "host": "ml-pipeline-visualizationserver",
+                        "trafficPolicy": {
+                            "tls": {
+                                "mode": "ISTIO_MUTUAL"
+                            }
+                        }
+                    }
+                },
+                {
+                    "apiVersion": "rbac.istio.io/v1alpha1",
+                    "kind": "ServiceRole",
+                    "metadata": {
+                        "name": "ml-pipeline-visualizationserver",
+                        "namespace": namespace,
+                    },
+                    "spec": {
+                        "rules": [{
+                            "services": ["ml-pipeline-visualizationserver.*"]
+                        }]
+                    }
+                },
+                {
+                    "apiVersion": "rbac.istio.io/v1alpha1",
+                    "kind": "ServiceRoleBinding",
+                    "metadata": {
+                        "name": "ml-pipeline-visualizationserver",
+                        "namespace": namespace,
+                    },
+                    "spec": {
+                        "subjects": [{
+                            "properties": {
+                                "source.principal":
+                                "cluster.local/ns/kubeflow/sa/ml-pipeline"
+                            }
+                        }],
+                        "roleRef": {
+                            "kind": "ServiceRole",
+                            "name": "ml-pipeline-visualizationserver"
+                        }
+                    }
+                },
+                {
+                    "apiVersion": "v1",
+                    "kind": "Service",
+                    "metadata": {
+                        "name": "ml-pipeline-visualizationserver",
+                        "namespace": namespace,
+                    },
+                    "spec": {
+                        "ports": [{
+                            "name": "http",
+                            "port": 8888,
+                            "protocol": "TCP",
+                            "targetPort": 8888,
+                        }],
+                        "selector": {
+                            "app": "ml-pipeline-visualizationserver",
+                        },
+                    },
+                },
+                # Artifact fetcher related resources below.
+                {
+                    "apiVersion": "apps/v1",
+                    "kind": "Deployment",
+                    "metadata": {
+                        "labels": {
+                            "app": "ml-pipeline-ui-artifact"
+                        },
+                        "name": "ml-pipeline-ui-artifact",
+                        "namespace": namespace,
+                    },
+                    "spec": {
+                        "selector": {
+                            "matchLabels": {
+                                "app": "ml-pipeline-ui-artifact"
+                            }
+                        },
+                        "template": {
+                            "metadata": {
+                                "labels": {
+                                    "app": "ml-pipeline-ui-artifact"
+                                },
+                                "annotations": disable_istio_sidecar and {
+                                    "sidecar.istio.io/inject": "false"
+                                } or {},
+                            },
+                            "spec": {
+                                "containers": [{
+                                    "name":
+                                    "ml-pipeline-ui-artifact",
+                                    "image":
+                                    "gcr.io/ml-pipeline/frontend:" + kfp_version,
+                                    "imagePullPolicy":
+                                    "IfNotPresent",
+                                    "ports": [{
+                                        "containerPort": 3000
+                                    }]
+                                }],
+                                "serviceAccountName":
+                                "default-editor"
+                            }
+                        }
+                    }
+                },
+                {
+                    "apiVersion": "v1",
+                    "kind": "Service",
+                    "metadata": {
+                        "name": "ml-pipeline-ui-artifact",
+                        "namespace": namespace,
+                        "labels": {
+                            "app": "ml-pipeline-ui-artifact"
+                        }
+                    },
+                    "spec": {
+                        "ports": [{
+                            "name":
+                            "http",  # name is required to let istio understand request protocol
+                            "port": 80,
+                            "protocol": "TCP",
+                            "targetPort": 3000
+                        }],
+                        "selector": {
+                            "app": "ml-pipeline-ui-artifact"
+                        }
+                    }
+                },
+            ]
+            print('Received request:', parent)
+            print('Desired resources except secrets:', desired_resources)
+            # Moved after the print argument because this is sensitive data.
+            desired_resources.append({
+                "apiVersion": "v1",
+                "kind": "Secret",
+                "metadata": {
+                    "name": "mlpipeline-minio-artifact",
+                    "namespace": namespace,
+                },
+                "data": {
+                    "accesskey": base64.b64encode(mlpipeline_minio_access_key),
+                    "secretkey": base64.b64encode(mlpipeline_minio_secret_key),
+                },
+            })
+
+            return {"status": desired_status, "children": desired_resources}
+
+        def do_POST(self):
+            # Serve the sync() function as a JSON webhook.
+            observed = json.loads(
+                self.rfile.read(int(self.headers.get("content-length"))))
+            desired = self.sync(observed["parent"], observed["children"])
+
+            self.send_response(200)
+            self.send_header("Content-type", "application/json")
+            self.end_headers()
+            self.wfile.write(bytes(json.dumps(desired), 'utf-8'))
+
+
+    HTTPServer(("", 80), Controller).serve_forever()
+kind: ConfigMap
+metadata:
+  labels:
+    app: kubeflow-pipelines-profile-controller
+  name: kubeflow-pipelines-profile-controller-code-m828g88mtm
+  namespace: kubeflow

--- a/tests/stacks/gcp/test_data/expected/~g_v1_configmap_kubeflow-pipelines-profile-controller-env-822cf46mft.yaml
+++ b/tests/stacks/gcp/test_data/expected/~g_v1_configmap_kubeflow-pipelines-profile-controller-env-822cf46mft.yaml
@@ -1,0 +1,10 @@
+apiVersion: v1
+data:
+  DISABLE_ISTIO_SIDECAR: "false"
+  KFP_VERSION: 1.0.0-rc.3
+kind: ConfigMap
+metadata:
+  labels:
+    app: kubeflow-pipelines-profile-controller
+  name: kubeflow-pipelines-profile-controller-env-822cf46mft
+  namespace: kubeflow

--- a/tests/stacks/gcp/test_data/expected/~g_v1_configmap_ml-pipeline-ui-configmap.yaml
+++ b/tests/stacks/gcp/test_data/expected/~g_v1_configmap_ml-pipeline-ui-configmap.yaml
@@ -1,0 +1,14 @@
+apiVersion: v1
+data:
+  viewer-pod-template.json: |-
+    {
+        "spec": {
+            "serviceAccountName": "default-editor"
+        }
+    }
+kind: ConfigMap
+metadata:
+  labels:
+    app: ml-pipeline-ui
+  name: ml-pipeline-ui-configmap
+  namespace: kubeflow

--- a/tests/stacks/gcp/test_data/expected/~g_v1_configmap_pipeline-api-server-config-f4t72426kt.yaml
+++ b/tests/stacks/gcp/test_data/expected/~g_v1_configmap_pipeline-api-server-config-f4t72426kt.yaml
@@ -1,0 +1,10 @@
+apiVersion: v1
+data:
+  DEFAULTPIPELINERUNNERSERVICEACCOUNT: default-editor
+  MULTIUSER: "true"
+  VISUALIZATIONSERVICE_NAME: ml-pipeline-visualizationserver
+  VISUALIZATIONSERVICE_PORT: "8888"
+kind: ConfigMap
+metadata:
+  name: pipeline-api-server-config-f4t72426kt
+  namespace: kubeflow

--- a/tests/stacks/gcp/test_data/expected/~g_v1_service_kubeflow-pipelines-profile-controller.yaml
+++ b/tests/stacks/gcp/test_data/expected/~g_v1_service_kubeflow-pipelines-profile-controller.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    app: kubeflow-pipelines-profile-controller
+  name: kubeflow-pipelines-profile-controller
+  namespace: kubeflow
+spec:
+  ports:
+  - name: http
+    port: 80
+    protocol: TCP
+    targetPort: 80
+  selector:
+    app: kubeflow-pipelines-profile-controller


### PR DESCRIPTION
**Description of your changes:**
Turns on KFP multi user mode by switching the KFP kustomize package.
The only change in this PR is https://github.com/kubeflow/manifests/pull/1373/files#diff-6ec8c90c78121a08a3b0525dd7df6912, other changes are either snapshot diffs or changes in parent PR this depends on.

This PR is based on https://github.com/kubeflow/manifests/pull/1372. Please merge it first.

**Checklist:**
- [x] Unit tests have been rebuilt: 
    1. `cd manifests/tests`
    2. `make generate-changed-only`
    3. `make test`
