### PR TITLE
Add knative and kfserving to GCP stack

### DIFF
--- a/kfserving/installs/generic/kustomization.yaml
+++ b/kfserving/installs/generic/kustomization.yaml
@@ -17,10 +17,7 @@ commonLabels:
   app: kfserving
   kustomize.component: kfserving
   app.kubernetes.io/component: kfserving-install
-  app.kuberenets.io/instance: kfserving-install
-  app.kuberenets.io/name: kfserving-install
-  app.kuberenets.io/managed-by: kfctl
-  app.kuberenets.io/part-of: kubeflow
+  app.kubernetes.io/name: kfserving-install  
 generatorOptions:
  disableNameSuffixHash: true
 configMapGenerator:

--- a/knative/installs/generic/kustomization.yaml
+++ b/knative/installs/generic/kustomization.yaml
@@ -22,11 +22,7 @@ resources:
 commonLabels:
   kustomize.component: knative
   app.kubernetes.io/component: knative-serving-install
-  app.kuberenets.io/instance: knative-serving-install
-  app.kuberenets.io/name: knative-serving-install
-  app.kuberenets.io/managed-by: kfctl
-  app.kuberenets.io/part-of: kubeflow
-  serving.knative.dev/release: v0.11.2
+  app.kubernetes.io/name: knative-serving-install  
 images:
 - name: gcr.io/knative-releases/knative.dev/serving/cmd/activator
   newName: gcr.io/knative-releases/knative.dev/serving/cmd/activator

--- a/stacks/gcp/kustomization.yaml
+++ b/stacks/gcp/kustomization.yaml
@@ -20,9 +20,11 @@ resources:
   - ../../pipeline/mysql/installs/gcp-pd
   - ../../pipeline/installs/multi-user
   - ../../metadata/v3
+  - ../../knative/installs/generic
+  - ../../kfserving/installs/generic
   # This package will create a profile resource so it needs to be installed after the profiles CR
   - ../../default-install/base
-  - ../../katib/installs/katib-standalone
+  - ../../katib/installs/katib-standalone  
 patchesStrategicMerge:
   - workload-identity-bindings-patch.yaml
 configMapGenerator:

--- a/tests/stacks/examples/alice/test_data/expected/admissionregistration.k8s.io_v1beta1_mutatingwebhookconfiguration_inferenceservice.serving.kubeflow.org.yaml
+++ b/tests/stacks/examples/alice/test_data/expected/admissionregistration.k8s.io_v1beta1_mutatingwebhookconfiguration_inferenceservice.serving.kubeflow.org.yaml
@@ -1,0 +1,53 @@
+apiVersion: admissionregistration.k8s.io/v1beta1
+kind: MutatingWebhookConfiguration
+metadata:
+  annotations:
+    cert-manager.io/inject-ca-from: kubeflow/serving-cert
+  creationTimestamp: null
+  labels:
+    app: kfserving
+    app.kubernetes.io/component: kfserving-install
+    app.kubernetes.io/name: kfserving-install
+    kustomize.component: kfserving
+  name: inferenceservice.serving.kubeflow.org
+webhooks:
+- clientConfig:
+    caBundle: Cg==
+    service:
+      name: kfserving-webhook-server-service
+      namespace: kubeflow
+      path: /mutate-inferenceservices
+  failurePolicy: Fail
+  name: inferenceservice.kfserving-webhook-server.defaulter
+  rules:
+  - apiGroups:
+    - serving.kubeflow.org
+    apiVersions:
+    - v1alpha2
+    operations:
+    - CREATE
+    - UPDATE
+    resources:
+    - inferenceservices
+- clientConfig:
+    caBundle: Cg==
+    service:
+      name: kfserving-webhook-server-service
+      namespace: kubeflow
+      path: /mutate-pods
+  failurePolicy: Fail
+  name: inferenceservice.kfserving-webhook-server.pod-mutator
+  namespaceSelector:
+    matchExpressions:
+    - key: control-plane
+      operator: DoesNotExist
+  rules:
+  - apiGroups:
+    - ""
+    apiVersions:
+    - v1
+    operations:
+    - CREATE
+    - UPDATE
+    resources:
+    - pods

--- a/tests/stacks/examples/alice/test_data/expected/admissionregistration.k8s.io_v1beta1_mutatingwebhookconfiguration_webhook.serving.knative.dev.yaml
+++ b/tests/stacks/examples/alice/test_data/expected/admissionregistration.k8s.io_v1beta1_mutatingwebhookconfiguration_webhook.serving.knative.dev.yaml
@@ -1,0 +1,18 @@
+apiVersion: admissionregistration.k8s.io/v1beta1
+kind: MutatingWebhookConfiguration
+metadata:
+  labels:
+    app.kubernetes.io/component: knative-serving-install
+    app.kubernetes.io/name: knative-serving-install
+    kustomize.component: knative
+    serving.knative.dev/release: v0.11.2
+  name: webhook.serving.knative.dev
+webhooks:
+- admissionReviewVersions:
+  - v1beta1
+  clientConfig:
+    service:
+      name: webhook
+      namespace: kubeflow
+  failurePolicy: Fail
+  name: webhook.serving.knative.dev

--- a/tests/stacks/examples/alice/test_data/expected/admissionregistration.k8s.io_v1beta1_validatingwebhookconfiguration_config.webhook.serving.knative.dev.yaml
+++ b/tests/stacks/examples/alice/test_data/expected/admissionregistration.k8s.io_v1beta1_validatingwebhookconfiguration_config.webhook.serving.knative.dev.yaml
@@ -1,0 +1,22 @@
+apiVersion: admissionregistration.k8s.io/v1beta1
+kind: ValidatingWebhookConfiguration
+metadata:
+  labels:
+    app.kubernetes.io/component: knative-serving-install
+    app.kubernetes.io/name: knative-serving-install
+    kustomize.component: knative
+    serving.knative.dev/release: v0.11.2
+  name: config.webhook.serving.knative.dev
+webhooks:
+- admissionReviewVersions:
+  - v1beta1
+  clientConfig:
+    service:
+      name: webhook
+      namespace: kubeflow
+  failurePolicy: Fail
+  name: config.webhook.serving.knative.dev
+  namespaceSelector:
+    matchExpressions:
+    - key: serving.knative.dev/release
+      operator: Exists

--- a/tests/stacks/examples/alice/test_data/expected/admissionregistration.k8s.io_v1beta1_validatingwebhookconfiguration_inferenceservice.serving.kubeflow.org.yaml
+++ b/tests/stacks/examples/alice/test_data/expected/admissionregistration.k8s.io_v1beta1_validatingwebhookconfiguration_inferenceservice.serving.kubeflow.org.yaml
@@ -1,0 +1,31 @@
+apiVersion: admissionregistration.k8s.io/v1beta1
+kind: ValidatingWebhookConfiguration
+metadata:
+  annotations:
+    cert-manager.io/inject-ca-from: kubeflow/serving-cert
+  creationTimestamp: null
+  labels:
+    app: kfserving
+    app.kubernetes.io/component: kfserving-install
+    app.kubernetes.io/name: kfserving-install
+    kustomize.component: kfserving
+  name: inferenceservice.serving.kubeflow.org
+webhooks:
+- clientConfig:
+    caBundle: Cg==
+    service:
+      name: kfserving-webhook-server-service
+      namespace: kubeflow
+      path: /validate-inferenceservices
+  failurePolicy: Fail
+  name: inferenceservice.kfserving-webhook-server.validator
+  rules:
+  - apiGroups:
+    - serving.kubeflow.org
+    apiVersions:
+    - v1alpha2
+    operations:
+    - CREATE
+    - UPDATE
+    resources:
+    - inferenceservices

--- a/tests/stacks/examples/alice/test_data/expected/admissionregistration.k8s.io_v1beta1_validatingwebhookconfiguration_validation.webhook.serving.knative.dev.yaml
+++ b/tests/stacks/examples/alice/test_data/expected/admissionregistration.k8s.io_v1beta1_validatingwebhookconfiguration_validation.webhook.serving.knative.dev.yaml
@@ -1,0 +1,18 @@
+apiVersion: admissionregistration.k8s.io/v1beta1
+kind: ValidatingWebhookConfiguration
+metadata:
+  labels:
+    app.kubernetes.io/component: knative-serving-install
+    app.kubernetes.io/name: knative-serving-install
+    kustomize.component: knative
+    serving.knative.dev/release: v0.11.2
+  name: validation.webhook.serving.knative.dev
+webhooks:
+- admissionReviewVersions:
+  - v1beta1
+  clientConfig:
+    service:
+      name: webhook
+      namespace: kubeflow
+  failurePolicy: Fail
+  name: validation.webhook.serving.knative.dev

--- a/tests/stacks/examples/alice/test_data/expected/apiextensions.k8s.io_v1beta1_customresourcedefinition_certificates.networking.internal.knative.dev.yaml
+++ b/tests/stacks/examples/alice/test_data/expected/apiextensions.k8s.io_v1beta1_customresourcedefinition_certificates.networking.internal.knative.dev.yaml
@@ -1,0 +1,32 @@
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  labels:
+    app.kubernetes.io/component: knative-serving-install
+    app.kubernetes.io/name: knative-serving-install
+    knative.dev/crd-install: "true"
+    kustomize.component: knative
+    serving.knative.dev/release: v0.11.2
+  name: certificates.networking.internal.knative.dev
+spec:
+  additionalPrinterColumns:
+  - JSONPath: .status.conditions[?(@.type=="Ready")].status
+    name: Ready
+    type: string
+  - JSONPath: .status.conditions[?(@.type=="Ready")].reason
+    name: Reason
+    type: string
+  group: networking.internal.knative.dev
+  names:
+    categories:
+    - knative-internal
+    - networking
+    kind: Certificate
+    plural: certificates
+    shortNames:
+    - kcert
+    singular: certificate
+  scope: Namespaced
+  subresources:
+    status: {}
+  version: v1alpha1

--- a/tests/stacks/examples/alice/test_data/expected/apiextensions.k8s.io_v1beta1_customresourcedefinition_configurations.serving.knative.dev.yaml
+++ b/tests/stacks/examples/alice/test_data/expected/apiextensions.k8s.io_v1beta1_customresourcedefinition_configurations.serving.knative.dev.yaml
@@ -1,0 +1,50 @@
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  labels:
+    app.kubernetes.io/component: knative-serving-install
+    app.kubernetes.io/name: knative-serving-install
+    duck.knative.dev/podspecable: "true"
+    knative.dev/crd-install: "true"
+    kustomize.component: knative
+    serving.knative.dev/release: v0.11.2
+  name: configurations.serving.knative.dev
+spec:
+  additionalPrinterColumns:
+  - JSONPath: .status.latestCreatedRevisionName
+    name: LatestCreated
+    type: string
+  - JSONPath: .status.latestReadyRevisionName
+    name: LatestReady
+    type: string
+  - JSONPath: .status.conditions[?(@.type=='Ready')].status
+    name: Ready
+    type: string
+  - JSONPath: .status.conditions[?(@.type=='Ready')].reason
+    name: Reason
+    type: string
+  group: serving.knative.dev
+  names:
+    categories:
+    - all
+    - knative
+    - serving
+    kind: Configuration
+    plural: configurations
+    shortNames:
+    - config
+    - cfg
+    singular: configuration
+  scope: Namespaced
+  subresources:
+    status: {}
+  versions:
+  - name: v1alpha1
+    served: true
+    storage: true
+  - name: v1beta1
+    served: true
+    storage: false
+  - name: v1
+    served: true
+    storage: false

--- a/tests/stacks/examples/alice/test_data/expected/apiextensions.k8s.io_v1beta1_customresourcedefinition_images.caching.internal.knative.dev.yaml
+++ b/tests/stacks/examples/alice/test_data/expected/apiextensions.k8s.io_v1beta1_customresourcedefinition_images.caching.internal.knative.dev.yaml
@@ -1,0 +1,24 @@
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  labels:
+    app.kubernetes.io/component: knative-serving-install
+    app.kubernetes.io/name: knative-serving-install
+    knative.dev/crd-install: "true"
+    kustomize.component: knative
+  name: images.caching.internal.knative.dev
+spec:
+  group: caching.internal.knative.dev
+  names:
+    categories:
+    - knative-internal
+    - caching
+    kind: Image
+    plural: images
+    shortNames:
+    - img
+    singular: image
+  scope: Namespaced
+  subresources:
+    status: {}
+  version: v1alpha1

--- a/tests/stacks/examples/alice/test_data/expected/apiextensions.k8s.io_v1beta1_customresourcedefinition_inferenceservices.serving.kubeflow.org.yaml
+++ b/tests/stacks/examples/alice/test_data/expected/apiextensions.k8s.io_v1beta1_customresourcedefinition_inferenceservices.serving.kubeflow.org.yaml
@@ -1,0 +1,6666 @@
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: (unknown)
+  creationTimestamp: null
+  labels:
+    app: kfserving
+    app.kubernetes.io/component: kfserving-install
+    app.kubernetes.io/name: kfserving-install
+    kustomize.component: kfserving
+  name: inferenceservices.serving.kubeflow.org
+spec:
+  additionalPrinterColumns:
+  - JSONPath: .status.url
+    name: URL
+    type: string
+  - JSONPath: .status.conditions[?(@.type=='Ready')].status
+    name: Ready
+    type: string
+  - JSONPath: .status.traffic
+    name: Default Traffic
+    type: integer
+  - JSONPath: .status.canaryTraffic
+    name: Canary Traffic
+    type: integer
+  - JSONPath: .metadata.creationTimestamp
+    name: Age
+    type: date
+  group: serving.kubeflow.org
+  names:
+    kind: InferenceService
+    listKind: InferenceServiceList
+    plural: inferenceservices
+    shortNames:
+    - inferenceservice
+    singular: inferenceservice
+  scope: Namespaced
+  subresources:
+    status: {}
+  validation:
+    openAPIV3Schema:
+      description: InferenceService is the Schema for the services API
+      properties:
+        apiVersion:
+          description: 'APIVersion defines the versioned schema of this representation
+            of an object. Servers should convert recognized schemas to the latest
+            internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#resources'
+          type: string
+        kind:
+          description: 'Kind is a string value representing the REST resource this
+            object represents. Servers may infer this from the endpoint the client
+            submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds'
+          type: string
+        metadata:
+          type: object
+        spec:
+          description: InferenceServiceSpec defines the desired state of InferenceService
+          properties:
+            canary:
+              description: Canary defines an alternate endpoints to route a percentage
+                of traffic.
+              properties:
+                explainer:
+                  description: Explainer defines the model explanation service spec,
+                    explainer service calls to predictor or transformer if it is specified.
+                  properties:
+                    alibi:
+                      description: Spec for alibi explainer
+                      properties:
+                        config:
+                          additionalProperties:
+                            type: string
+                          description: Inline custom parameter settings for explainer
+                          type: object
+                        resources:
+                          description: Defaults to requests and limits of 1CPU, 2Gb
+                            MEM.
+                          properties:
+                            limits:
+                              additionalProperties:
+                                type: string
+                              description: 'Limits describes the maximum amount of
+                                compute resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
+                              type: object
+                            requests:
+                              additionalProperties:
+                                type: string
+                              description: 'Requests describes the minimum amount
+                                of compute resources required. If Requests is omitted
+                                for a container, it defaults to Limits if that is
+                                explicitly specified, otherwise to an implementation-defined
+                                value. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
+                              type: object
+                          type: object
+                        runtimeVersion:
+                          description: Defaults to latest Alibi Version
+                          type: string
+                        storageUri:
+                          description: The location of a trained explanation model
+                          type: string
+                        type:
+                          description: The type of Alibi explainer
+                          type: string
+                      required:
+                      - type
+                      type: object
+                    custom:
+                      description: Spec for a custom explainer
+                      properties:
+                        container:
+                          description: A single application container that you want
+                            to run within a pod.
+                          properties:
+                            args:
+                              description: 'Arguments to the entrypoint. The docker
+                                image''s CMD is used if this is not provided. Variable
+                                references $(VAR_NAME) are expanded using the container''s
+                                environment. If a variable cannot be resolved, the
+                                reference in the input string will be unchanged. The
+                                $(VAR_NAME) syntax can be escaped with a double $$,
+                                ie: $$(VAR_NAME). Escaped references will never be
+                                expanded, regardless of whether the variable exists
+                                or not. Cannot be updated. More info: https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell'
+                              items:
+                                type: string
+                              type: array
+                            command:
+                              description: 'Entrypoint array. Not executed within
+                                a shell. The docker image''s ENTRYPOINT is used if
+                                this is not provided. Variable references $(VAR_NAME)
+                                are expanded using the container''s environment. If
+                                a variable cannot be resolved, the reference in the
+                                input string will be unchanged. The $(VAR_NAME) syntax
+                                can be escaped with a double $$, ie: $$(VAR_NAME).
+                                Escaped references will never be expanded, regardless
+                                of whether the variable exists or not. Cannot be updated.
+                                More info: https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell'
+                              items:
+                                type: string
+                              type: array
+                            env:
+                              description: List of environment variables to set in
+                                the container. Cannot be updated.
+                              items:
+                                description: EnvVar represents an environment variable
+                                  present in a Container.
+                                properties:
+                                  name:
+                                    description: Name of the environment variable.
+                                      Must be a C_IDENTIFIER.
+                                    type: string
+                                  value:
+                                    description: 'Variable references $(VAR_NAME)
+                                      are expanded using the previous defined environment
+                                      variables in the container and any service environment
+                                      variables. If a variable cannot be resolved,
+                                      the reference in the input string will be unchanged.
+                                      The $(VAR_NAME) syntax can be escaped with a
+                                      double $$, ie: $$(VAR_NAME). Escaped references
+                                      will never be expanded, regardless of whether
+                                      the variable exists or not. Defaults to "".'
+                                    type: string
+                                  valueFrom:
+                                    description: Source for the environment variable's
+                                      value. Cannot be used if value is not empty.
+                                    properties:
+                                      configMapKeyRef:
+                                        description: Selects a key of a ConfigMap.
+                                        properties:
+                                          key:
+                                            description: The key to select.
+                                            type: string
+                                          name:
+                                            description: 'Name of the referent. More
+                                              info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                              TODO: Add other useful fields. apiVersion,
+                                              kind, uid?'
+                                            type: string
+                                          optional:
+                                            description: Specify whether the ConfigMap
+                                              or its key must be defined
+                                            type: boolean
+                                        required:
+                                        - key
+                                        type: object
+                                      fieldRef:
+                                        description: 'Selects a field of the pod:
+                                          supports metadata.name, metadata.namespace,
+                                          metadata.labels, metadata.annotations, spec.nodeName,
+                                          spec.serviceAccountName, status.hostIP,
+                                          status.podIP.'
+                                        properties:
+                                          apiVersion:
+                                            description: Version of the schema the
+                                              FieldPath is written in terms of, defaults
+                                              to "v1".
+                                            type: string
+                                          fieldPath:
+                                            description: Path of the field to select
+                                              in the specified API version.
+                                            type: string
+                                        required:
+                                        - fieldPath
+                                        type: object
+                                      resourceFieldRef:
+                                        description: 'Selects a resource of the container:
+                                          only resources limits and requests (limits.cpu,
+                                          limits.memory, limits.ephemeral-storage,
+                                          requests.cpu, requests.memory and requests.ephemeral-storage)
+                                          are currently supported.'
+                                        properties:
+                                          containerName:
+                                            description: 'Container name: required
+                                              for volumes, optional for env vars'
+                                            type: string
+                                          divisor:
+                                            description: Specifies the output format
+                                              of the exposed resources, defaults to
+                                              "1"
+                                            type: string
+                                          resource:
+                                            description: 'Required: resource to select'
+                                            type: string
+                                        required:
+                                        - resource
+                                        type: object
+                                      secretKeyRef:
+                                        description: Selects a key of a secret in
+                                          the pod's namespace
+                                        properties:
+                                          key:
+                                            description: The key of the secret to
+                                              select from.  Must be a valid secret
+                                              key.
+                                            type: string
+                                          name:
+                                            description: 'Name of the referent. More
+                                              info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                              TODO: Add other useful fields. apiVersion,
+                                              kind, uid?'
+                                            type: string
+                                          optional:
+                                            description: Specify whether the Secret
+                                              or its key must be defined
+                                            type: boolean
+                                        required:
+                                        - key
+                                        type: object
+                                    type: object
+                                required:
+                                - name
+                                type: object
+                              type: array
+                            envFrom:
+                              description: List of sources to populate environment
+                                variables in the container. The keys defined within
+                                a source must be a C_IDENTIFIER. All invalid keys
+                                will be reported as an event when the container is
+                                starting. When a key exists in multiple sources, the
+                                value associated with the last source will take precedence.
+                                Values defined by an Env with a duplicate key will
+                                take precedence. Cannot be updated.
+                              items:
+                                description: EnvFromSource represents the source of
+                                  a set of ConfigMaps
+                                properties:
+                                  configMapRef:
+                                    description: The ConfigMap to select from
+                                    properties:
+                                      name:
+                                        description: 'Name of the referent. More info:
+                                          https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                          TODO: Add other useful fields. apiVersion,
+                                          kind, uid?'
+                                        type: string
+                                      optional:
+                                        description: Specify whether the ConfigMap
+                                          must be defined
+                                        type: boolean
+                                    type: object
+                                  prefix:
+                                    description: An optional identifier to prepend
+                                      to each key in the ConfigMap. Must be a C_IDENTIFIER.
+                                    type: string
+                                  secretRef:
+                                    description: The Secret to select from
+                                    properties:
+                                      name:
+                                        description: 'Name of the referent. More info:
+                                          https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                          TODO: Add other useful fields. apiVersion,
+                                          kind, uid?'
+                                        type: string
+                                      optional:
+                                        description: Specify whether the Secret must
+                                          be defined
+                                        type: boolean
+                                    type: object
+                                type: object
+                              type: array
+                            image:
+                              description: 'Docker image name. More info: https://kubernetes.io/docs/concepts/containers/images
+                                This field is optional to allow higher level config
+                                management to default or override container images
+                                in workload controllers like Deployments and StatefulSets.'
+                              type: string
+                            imagePullPolicy:
+                              description: 'Image pull policy. One of Always, Never,
+                                IfNotPresent. Defaults to Always if :v0.3.0 tag is
+                                specified, or IfNotPresent otherwise. Cannot be updated.
+                                More info: https://kubernetes.io/docs/concepts/containers/images#updating-images'
+                              type: string
+                            lifecycle:
+                              description: Actions that the management system should
+                                take in response to container lifecycle events. Cannot
+                                be updated.
+                              properties:
+                                postStart:
+                                  description: 'PostStart is called immediately after
+                                    a container is created. If the handler fails,
+                                    the container is terminated and restarted according
+                                    to its restart policy. Other management of the
+                                    container blocks until the hook completes. More
+                                    info: https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/#container-hooks'
+                                  properties:
+                                    exec:
+                                      description: One and only one of the following
+                                        should be specified. Exec specifies the action
+                                        to take.
+                                      properties:
+                                        command:
+                                          description: Command is the command line
+                                            to execute inside the container, the working
+                                            directory for the command  is root ('/')
+                                            in the container's filesystem. The command
+                                            is simply exec'd, it is not run inside
+                                            a shell, so traditional shell instructions
+                                            ('|', etc) won't work. To use a shell,
+                                            you need to explicitly call out to that
+                                            shell. Exit status of 0 is treated as
+                                            live/healthy and non-zero is unhealthy.
+                                          items:
+                                            type: string
+                                          type: array
+                                      type: object
+                                    httpGet:
+                                      description: HTTPGet specifies the http request
+                                        to perform.
+                                      properties:
+                                        host:
+                                          description: Host name to connect to, defaults
+                                            to the pod IP. You probably want to set
+                                            "Host" in httpHeaders instead.
+                                          type: string
+                                        httpHeaders:
+                                          description: Custom headers to set in the
+                                            request. HTTP allows repeated headers.
+                                          items:
+                                            description: HTTPHeader describes a custom
+                                              header to be used in HTTP probes
+                                            properties:
+                                              name:
+                                                description: The header field name
+                                                type: string
+                                              value:
+                                                description: The header field value
+                                                type: string
+                                            required:
+                                            - name
+                                            - value
+                                            type: object
+                                          type: array
+                                        path:
+                                          description: Path to access on the HTTP
+                                            server.
+                                          type: string
+                                        port:
+                                          anyOf:
+                                          - type: string
+                                          - type: integer
+                                          description: Name or number of the port
+                                            to access on the container. Number must
+                                            be in the range 1 to 65535. Name must
+                                            be an IANA_SVC_NAME.
+                                        scheme:
+                                          description: Scheme to use for connecting
+                                            to the host. Defaults to HTTP.
+                                          type: string
+                                      required:
+                                      - port
+                                      type: object
+                                    tcpSocket:
+                                      description: 'TCPSocket specifies an action
+                                        involving a TCP port. TCP hooks not yet supported
+                                        TODO: implement a realistic TCP lifecycle
+                                        hook'
+                                      properties:
+                                        host:
+                                          description: 'Optional: Host name to connect
+                                            to, defaults to the pod IP.'
+                                          type: string
+                                        port:
+                                          anyOf:
+                                          - type: string
+                                          - type: integer
+                                          description: Number or name of the port
+                                            to access on the container. Number must
+                                            be in the range 1 to 65535. Name must
+                                            be an IANA_SVC_NAME.
+                                      required:
+                                      - port
+                                      type: object
+                                  type: object
+                                preStop:
+                                  description: 'PreStop is called immediately before
+                                    a container is terminated due to an API request
+                                    or management event such as liveness probe failure,
+                                    preemption, resource contention, etc. The handler
+                                    is not called if the container crashes or exits.
+                                    The reason for termination is passed to the handler.
+                                    The Pod''s termination grace period countdown
+                                    begins before the PreStop hooked is executed.
+                                    Regardless of the outcome of the handler, the
+                                    container will eventually terminate within the
+                                    Pod''s termination grace period. Other management
+                                    of the container blocks until the hook completes
+                                    or until the termination grace period is reached.
+                                    More info: https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/#container-hooks'
+                                  properties:
+                                    exec:
+                                      description: One and only one of the following
+                                        should be specified. Exec specifies the action
+                                        to take.
+                                      properties:
+                                        command:
+                                          description: Command is the command line
+                                            to execute inside the container, the working
+                                            directory for the command  is root ('/')
+                                            in the container's filesystem. The command
+                                            is simply exec'd, it is not run inside
+                                            a shell, so traditional shell instructions
+                                            ('|', etc) won't work. To use a shell,
+                                            you need to explicitly call out to that
+                                            shell. Exit status of 0 is treated as
+                                            live/healthy and non-zero is unhealthy.
+                                          items:
+                                            type: string
+                                          type: array
+                                      type: object
+                                    httpGet:
+                                      description: HTTPGet specifies the http request
+                                        to perform.
+                                      properties:
+                                        host:
+                                          description: Host name to connect to, defaults
+                                            to the pod IP. You probably want to set
+                                            "Host" in httpHeaders instead.
+                                          type: string
+                                        httpHeaders:
+                                          description: Custom headers to set in the
+                                            request. HTTP allows repeated headers.
+                                          items:
+                                            description: HTTPHeader describes a custom
+                                              header to be used in HTTP probes
+                                            properties:
+                                              name:
+                                                description: The header field name
+                                                type: string
+                                              value:
+                                                description: The header field value
+                                                type: string
+                                            required:
+                                            - name
+                                            - value
+                                            type: object
+                                          type: array
+                                        path:
+                                          description: Path to access on the HTTP
+                                            server.
+                                          type: string
+                                        port:
+                                          anyOf:
+                                          - type: string
+                                          - type: integer
+                                          description: Name or number of the port
+                                            to access on the container. Number must
+                                            be in the range 1 to 65535. Name must
+                                            be an IANA_SVC_NAME.
+                                        scheme:
+                                          description: Scheme to use for connecting
+                                            to the host. Defaults to HTTP.
+                                          type: string
+                                      required:
+                                      - port
+                                      type: object
+                                    tcpSocket:
+                                      description: 'TCPSocket specifies an action
+                                        involving a TCP port. TCP hooks not yet supported
+                                        TODO: implement a realistic TCP lifecycle
+                                        hook'
+                                      properties:
+                                        host:
+                                          description: 'Optional: Host name to connect
+                                            to, defaults to the pod IP.'
+                                          type: string
+                                        port:
+                                          anyOf:
+                                          - type: string
+                                          - type: integer
+                                          description: Number or name of the port
+                                            to access on the container. Number must
+                                            be in the range 1 to 65535. Name must
+                                            be an IANA_SVC_NAME.
+                                      required:
+                                      - port
+                                      type: object
+                                  type: object
+                              type: object
+                            livenessProbe:
+                              description: 'Periodic probe of container liveness.
+                                Container will be restarted if the probe fails. Cannot
+                                be updated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                              properties:
+                                exec:
+                                  description: One and only one of the following should
+                                    be specified. Exec specifies the action to take.
+                                  properties:
+                                    command:
+                                      description: Command is the command line to
+                                        execute inside the container, the working
+                                        directory for the command  is root ('/') in
+                                        the container's filesystem. The command is
+                                        simply exec'd, it is not run inside a shell,
+                                        so traditional shell instructions ('|', etc)
+                                        won't work. To use a shell, you need to explicitly
+                                        call out to that shell. Exit status of 0 is
+                                        treated as live/healthy and non-zero is unhealthy.
+                                      items:
+                                        type: string
+                                      type: array
+                                  type: object
+                                failureThreshold:
+                                  description: Minimum consecutive failures for the
+                                    probe to be considered failed after having succeeded.
+                                    Defaults to 3. Minimum value is 1.
+                                  format: int32
+                                  type: integer
+                                httpGet:
+                                  description: HTTPGet specifies the http request
+                                    to perform.
+                                  properties:
+                                    host:
+                                      description: Host name to connect to, defaults
+                                        to the pod IP. You probably want to set "Host"
+                                        in httpHeaders instead.
+                                      type: string
+                                    httpHeaders:
+                                      description: Custom headers to set in the request.
+                                        HTTP allows repeated headers.
+                                      items:
+                                        description: HTTPHeader describes a custom
+                                          header to be used in HTTP probes
+                                        properties:
+                                          name:
+                                            description: The header field name
+                                            type: string
+                                          value:
+                                            description: The header field value
+                                            type: string
+                                        required:
+                                        - name
+                                        - value
+                                        type: object
+                                      type: array
+                                    path:
+                                      description: Path to access on the HTTP server.
+                                      type: string
+                                    port:
+                                      anyOf:
+                                      - type: string
+                                      - type: integer
+                                      description: Name or number of the port to access
+                                        on the container. Number must be in the range
+                                        1 to 65535. Name must be an IANA_SVC_NAME.
+                                    scheme:
+                                      description: Scheme to use for connecting to
+                                        the host. Defaults to HTTP.
+                                      type: string
+                                  required:
+                                  - port
+                                  type: object
+                                initialDelaySeconds:
+                                  description: 'Number of seconds after the container
+                                    has started before liveness probes are initiated.
+                                    More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                                  format: int32
+                                  type: integer
+                                periodSeconds:
+                                  description: How often (in seconds) to perform the
+                                    probe. Default to 10 seconds. Minimum value is
+                                    1.
+                                  format: int32
+                                  type: integer
+                                successThreshold:
+                                  description: Minimum consecutive successes for the
+                                    probe to be considered successful after having
+                                    failed. Defaults to 1. Must be 1 for liveness.
+                                    Minimum value is 1.
+                                  format: int32
+                                  type: integer
+                                tcpSocket:
+                                  description: 'TCPSocket specifies an action involving
+                                    a TCP port. TCP hooks not yet supported TODO:
+                                    implement a realistic TCP lifecycle hook'
+                                  properties:
+                                    host:
+                                      description: 'Optional: Host name to connect
+                                        to, defaults to the pod IP.'
+                                      type: string
+                                    port:
+                                      anyOf:
+                                      - type: string
+                                      - type: integer
+                                      description: Number or name of the port to access
+                                        on the container. Number must be in the range
+                                        1 to 65535. Name must be an IANA_SVC_NAME.
+                                  required:
+                                  - port
+                                  type: object
+                                timeoutSeconds:
+                                  description: 'Number of seconds after which the
+                                    probe times out. Defaults to 1 second. Minimum
+                                    value is 1. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                                  format: int32
+                                  type: integer
+                              type: object
+                            name:
+                              description: Name of the container specified as a DNS_LABEL.
+                                Each container in a pod must have a unique name (DNS_LABEL).
+                                Cannot be updated.
+                              type: string
+                            ports:
+                              description: List of ports to expose from the container.
+                                Exposing a port here gives the system additional information
+                                about the network connections a container uses, but
+                                is primarily informational. Not specifying a port
+                                here DOES NOT prevent that port from being exposed.
+                                Any port which is listening on the default "0.0.0.0"
+                                address inside a container will be accessible from
+                                the network. Cannot be updated.
+                              items:
+                                description: ContainerPort represents a network port
+                                  in a single container.
+                                properties:
+                                  containerPort:
+                                    description: Number of port to expose on the pod's
+                                      IP address. This must be a valid port number,
+                                      0 < x < 65536.
+                                    format: int32
+                                    type: integer
+                                  hostIP:
+                                    description: What host IP to bind the external
+                                      port to.
+                                    type: string
+                                  hostPort:
+                                    description: Number of port to expose on the host.
+                                      If specified, this must be a valid port number,
+                                      0 < x < 65536. If HostNetwork is specified,
+                                      this must match ContainerPort. Most containers
+                                      do not need this.
+                                    format: int32
+                                    type: integer
+                                  name:
+                                    description: If specified, this must be an IANA_SVC_NAME
+                                      and unique within the pod. Each named port in
+                                      a pod must have a unique name. Name for the
+                                      port that can be referred to by services.
+                                    type: string
+                                  protocol:
+                                    description: Protocol for port. Must be UDP, TCP,
+                                      or SCTP. Defaults to "TCP".
+                                    type: string
+                                required:
+                                - containerPort
+                                type: object
+                              type: array
+                            readinessProbe:
+                              description: 'Periodic probe of container service readiness.
+                                Container will be removed from service endpoints if
+                                the probe fails. Cannot be updated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                              properties:
+                                exec:
+                                  description: One and only one of the following should
+                                    be specified. Exec specifies the action to take.
+                                  properties:
+                                    command:
+                                      description: Command is the command line to
+                                        execute inside the container, the working
+                                        directory for the command  is root ('/') in
+                                        the container's filesystem. The command is
+                                        simply exec'd, it is not run inside a shell,
+                                        so traditional shell instructions ('|', etc)
+                                        won't work. To use a shell, you need to explicitly
+                                        call out to that shell. Exit status of 0 is
+                                        treated as live/healthy and non-zero is unhealthy.
+                                      items:
+                                        type: string
+                                      type: array
+                                  type: object
+                                failureThreshold:
+                                  description: Minimum consecutive failures for the
+                                    probe to be considered failed after having succeeded.
+                                    Defaults to 3. Minimum value is 1.
+                                  format: int32
+                                  type: integer
+                                httpGet:
+                                  description: HTTPGet specifies the http request
+                                    to perform.
+                                  properties:
+                                    host:
+                                      description: Host name to connect to, defaults
+                                        to the pod IP. You probably want to set "Host"
+                                        in httpHeaders instead.
+                                      type: string
+                                    httpHeaders:
+                                      description: Custom headers to set in the request.
+                                        HTTP allows repeated headers.
+                                      items:
+                                        description: HTTPHeader describes a custom
+                                          header to be used in HTTP probes
+                                        properties:
+                                          name:
+                                            description: The header field name
+                                            type: string
+                                          value:
+                                            description: The header field value
+                                            type: string
+                                        required:
+                                        - name
+                                        - value
+                                        type: object
+                                      type: array
+                                    path:
+                                      description: Path to access on the HTTP server.
+                                      type: string
+                                    port:
+                                      anyOf:
+                                      - type: string
+                                      - type: integer
+                                      description: Name or number of the port to access
+                                        on the container. Number must be in the range
+                                        1 to 65535. Name must be an IANA_SVC_NAME.
+                                    scheme:
+                                      description: Scheme to use for connecting to
+                                        the host. Defaults to HTTP.
+                                      type: string
+                                  required:
+                                  - port
+                                  type: object
+                                initialDelaySeconds:
+                                  description: 'Number of seconds after the container
+                                    has started before liveness probes are initiated.
+                                    More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                                  format: int32
+                                  type: integer
+                                periodSeconds:
+                                  description: How often (in seconds) to perform the
+                                    probe. Default to 10 seconds. Minimum value is
+                                    1.
+                                  format: int32
+                                  type: integer
+                                successThreshold:
+                                  description: Minimum consecutive successes for the
+                                    probe to be considered successful after having
+                                    failed. Defaults to 1. Must be 1 for liveness.
+                                    Minimum value is 1.
+                                  format: int32
+                                  type: integer
+                                tcpSocket:
+                                  description: 'TCPSocket specifies an action involving
+                                    a TCP port. TCP hooks not yet supported TODO:
+                                    implement a realistic TCP lifecycle hook'
+                                  properties:
+                                    host:
+                                      description: 'Optional: Host name to connect
+                                        to, defaults to the pod IP.'
+                                      type: string
+                                    port:
+                                      anyOf:
+                                      - type: string
+                                      - type: integer
+                                      description: Number or name of the port to access
+                                        on the container. Number must be in the range
+                                        1 to 65535. Name must be an IANA_SVC_NAME.
+                                  required:
+                                  - port
+                                  type: object
+                                timeoutSeconds:
+                                  description: 'Number of seconds after which the
+                                    probe times out. Defaults to 1 second. Minimum
+                                    value is 1. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                                  format: int32
+                                  type: integer
+                              type: object
+                            resources:
+                              description: 'Compute Resources required by this container.
+                                Cannot be updated. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
+                              properties:
+                                limits:
+                                  additionalProperties:
+                                    type: string
+                                  description: 'Limits describes the maximum amount
+                                    of compute resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
+                                  type: object
+                                requests:
+                                  additionalProperties:
+                                    type: string
+                                  description: 'Requests describes the minimum amount
+                                    of compute resources required. If Requests is
+                                    omitted for a container, it defaults to Limits
+                                    if that is explicitly specified, otherwise to
+                                    an implementation-defined value. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
+                                  type: object
+                              type: object
+                            securityContext:
+                              description: 'Security options the pod should run with.
+                                More info: https://kubernetes.io/docs/concepts/policy/security-context/
+                                More info: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/'
+                              properties:
+                                allowPrivilegeEscalation:
+                                  description: 'AllowPrivilegeEscalation controls
+                                    whether a process can gain more privileges than
+                                    its parent process. This bool directly controls
+                                    if the no_new_privs flag will be set on the container
+                                    process. AllowPrivilegeEscalation is true always
+                                    when the container is: 1) run as Privileged 2)
+                                    has CAP_SYS_ADMIN'
+                                  type: boolean
+                                capabilities:
+                                  description: The capabilities to add/drop when running
+                                    containers. Defaults to the default set of capabilities
+                                    granted by the container runtime.
+                                  properties:
+                                    add:
+                                      description: Added capabilities
+                                      items:
+                                        description: Capability represent POSIX capabilities
+                                          type
+                                        type: string
+                                      type: array
+                                    drop:
+                                      description: Removed capabilities
+                                      items:
+                                        description: Capability represent POSIX capabilities
+                                          type
+                                        type: string
+                                      type: array
+                                  type: object
+                                privileged:
+                                  description: Run container in privileged mode. Processes
+                                    in privileged containers are essentially equivalent
+                                    to root on the host. Defaults to false.
+                                  type: boolean
+                                procMount:
+                                  description: procMount denotes the type of proc
+                                    mount to use for the containers. The default is
+                                    DefaultProcMount which uses the container runtime
+                                    defaults for readonly paths and masked paths.
+                                    This requires the ProcMountType feature flag to
+                                    be enabled.
+                                  type: string
+                                readOnlyRootFilesystem:
+                                  description: Whether this container has a read-only
+                                    root filesystem. Default is false.
+                                  type: boolean
+                                runAsGroup:
+                                  description: The GID to run the entrypoint of the
+                                    container process. Uses runtime default if unset.
+                                    May also be set in PodSecurityContext.  If set
+                                    in both SecurityContext and PodSecurityContext,
+                                    the value specified in SecurityContext takes precedence.
+                                  format: int64
+                                  type: integer
+                                runAsNonRoot:
+                                  description: Indicates that the container must run
+                                    as a non-root user. If true, the Kubelet will
+                                    validate the image at runtime to ensure that it
+                                    does not run as UID 0 (root) and fail to start
+                                    the container if it does. If unset or false, no
+                                    such validation will be performed. May also be
+                                    set in PodSecurityContext.  If set in both SecurityContext
+                                    and PodSecurityContext, the value specified in
+                                    SecurityContext takes precedence.
+                                  type: boolean
+                                runAsUser:
+                                  description: The UID to run the entrypoint of the
+                                    container process. Defaults to user specified
+                                    in image metadata if unspecified. May also be
+                                    set in PodSecurityContext.  If set in both SecurityContext
+                                    and PodSecurityContext, the value specified in
+                                    SecurityContext takes precedence.
+                                  format: int64
+                                  type: integer
+                                seLinuxOptions:
+                                  description: The SELinux context to be applied to
+                                    the container. If unspecified, the container runtime
+                                    will allocate a random SELinux context for each
+                                    container.  May also be set in PodSecurityContext.  If
+                                    set in both SecurityContext and PodSecurityContext,
+                                    the value specified in SecurityContext takes precedence.
+                                  properties:
+                                    level:
+                                      description: Level is SELinux level label that
+                                        applies to the container.
+                                      type: string
+                                    role:
+                                      description: Role is a SELinux role label that
+                                        applies to the container.
+                                      type: string
+                                    type:
+                                      description: Type is a SELinux type label that
+                                        applies to the container.
+                                      type: string
+                                    user:
+                                      description: User is a SELinux user label that
+                                        applies to the container.
+                                      type: string
+                                  type: object
+                                windowsOptions:
+                                  description: Windows security options.
+                                  properties:
+                                    gmsaCredentialSpec:
+                                      description: GMSACredentialSpec is where the
+                                        GMSA admission webhook (https://github.com/kubernetes-sigs/windows-gmsa)
+                                        inlines the contents of the GMSA credential
+                                        spec named by the GMSACredentialSpecName field.
+                                        This field is alpha-level and is only honored
+                                        by servers that enable the WindowsGMSA feature
+                                        flag.
+                                      type: string
+                                    gmsaCredentialSpecName:
+                                      description: GMSACredentialSpecName is the name
+                                        of the GMSA credential spec to use. This field
+                                        is alpha-level and is only honored by servers
+                                        that enable the WindowsGMSA feature flag.
+                                      type: string
+                                  type: object
+                              type: object
+                            stdin:
+                              description: Whether this container should allocate
+                                a buffer for stdin in the container runtime. If this
+                                is not set, reads from stdin in the container will
+                                always result in EOF. Default is false.
+                              type: boolean
+                            stdinOnce:
+                              description: Whether the container runtime should close
+                                the stdin channel after it has been opened by a single
+                                attach. When stdin is true the stdin stream will remain
+                                open across multiple attach sessions. If stdinOnce
+                                is set to true, stdin is opened on container start,
+                                is empty until the first client attaches to stdin,
+                                and then remains open and accepts data until the client
+                                disconnects, at which time stdin is closed and remains
+                                closed until the container is restarted. If this flag
+                                is false, a container processes that reads from stdin
+                                will never receive an EOF. Default is false
+                              type: boolean
+                            terminationMessagePath:
+                              description: 'Optional: Path at which the file to which
+                                the container''s termination message will be written
+                                is mounted into the container''s filesystem. Message
+                                written is intended to be brief final status, such
+                                as an assertion failure message. Will be truncated
+                                by the node if greater than 4096 bytes. The total
+                                message length across all containers will be limited
+                                to 12kb. Defaults to /dev/termination-log. Cannot
+                                be updated.'
+                              type: string
+                            terminationMessagePolicy:
+                              description: Indicate how the termination message should
+                                be populated. File will use the contents of terminationMessagePath
+                                to populate the container status message on both success
+                                and failure. FallbackToLogsOnError will use the last
+                                chunk of container log output if the termination message
+                                file is empty and the container exited with an error.
+                                The log output is limited to 2048 bytes or 80 lines,
+                                whichever is smaller. Defaults to File. Cannot be
+                                updated.
+                              type: string
+                            tty:
+                              description: Whether this container should allocate
+                                a TTY for itself, also requires 'stdin' to be true.
+                                Default is false.
+                              type: boolean
+                            volumeDevices:
+                              description: volumeDevices is the list of block devices
+                                to be used by the container. This is a beta feature.
+                              items:
+                                description: volumeDevice describes a mapping of a
+                                  raw block device within a container.
+                                properties:
+                                  devicePath:
+                                    description: devicePath is the path inside of
+                                      the container that the device will be mapped
+                                      to.
+                                    type: string
+                                  name:
+                                    description: name must match the name of a persistentVolumeClaim
+                                      in the pod
+                                    type: string
+                                required:
+                                - devicePath
+                                - name
+                                type: object
+                              type: array
+                            volumeMounts:
+                              description: Pod volumes to mount into the container's
+                                filesystem. Cannot be updated.
+                              items:
+                                description: VolumeMount describes a mounting of a
+                                  Volume within a container.
+                                properties:
+                                  mountPath:
+                                    description: Path within the container at which
+                                      the volume should be mounted.  Must not contain
+                                      ':'.
+                                    type: string
+                                  mountPropagation:
+                                    description: mountPropagation determines how mounts
+                                      are propagated from the host to container and
+                                      the other way around. When not set, MountPropagationNone
+                                      is used. This field is beta in 1.10.
+                                    type: string
+                                  name:
+                                    description: This must match the Name of a Volume.
+                                    type: string
+                                  readOnly:
+                                    description: Mounted read-only if true, read-write
+                                      otherwise (false or unspecified). Defaults to
+                                      false.
+                                    type: boolean
+                                  subPath:
+                                    description: Path within the volume from which
+                                      the container's volume should be mounted. Defaults
+                                      to "" (volume's root).
+                                    type: string
+                                  subPathExpr:
+                                    description: Expanded path within the volume from
+                                      which the container's volume should be mounted.
+                                      Behaves similarly to SubPath but environment
+                                      variable references $(VAR_NAME) are expanded
+                                      using the container's environment. Defaults
+                                      to "" (volume's root). SubPathExpr and SubPath
+                                      are mutually exclusive. This field is beta in
+                                      1.15.
+                                    type: string
+                                required:
+                                - mountPath
+                                - name
+                                type: object
+                              type: array
+                            workingDir:
+                              description: Container's working directory. If not specified,
+                                the container runtime's default will be used, which
+                                might be configured in the container image. Cannot
+                                be updated.
+                              type: string
+                          required:
+                          - name
+                          type: object
+                      required:
+                      - container
+                      type: object
+                    logger:
+                      description: Activate request/response logging
+                      properties:
+                        mode:
+                          description: What payloads to log
+                          type: string
+                        url:
+                          description: URL to send request logging CloudEvents
+                          type: string
+                      type: object
+                    maxReplicas:
+                      description: This is the up bound for autoscaler to scale to
+                      type: integer
+                    minReplicas:
+                      description: Minimum number of replicas, pods won't scale down
+                        to 0 in case of no traffic
+                      type: integer
+                    parallelism:
+                      description: Parallelism specifies how many requests can be
+                        processed concurrently, this sets the target concurrency for
+                        Autoscaling(KPA). For model servers that support tuning parallelism
+                        will use this value, by default the parallelism is the number
+                        of the CPU cores for most of the model servers.
+                      type: integer
+                    serviceAccountName:
+                      description: ServiceAccountName is the name of the ServiceAccount
+                        to use to run the service
+                      type: string
+                  type: object
+                predictor:
+                  description: Predictor defines the model serving spec
+                  properties:
+                    custom:
+                      description: Spec for a custom predictor
+                      properties:
+                        container:
+                          description: A single application container that you want
+                            to run within a pod.
+                          properties:
+                            args:
+                              description: 'Arguments to the entrypoint. The docker
+                                image''s CMD is used if this is not provided. Variable
+                                references $(VAR_NAME) are expanded using the container''s
+                                environment. If a variable cannot be resolved, the
+                                reference in the input string will be unchanged. The
+                                $(VAR_NAME) syntax can be escaped with a double $$,
+                                ie: $$(VAR_NAME). Escaped references will never be
+                                expanded, regardless of whether the variable exists
+                                or not. Cannot be updated. More info: https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell'
+                              items:
+                                type: string
+                              type: array
+                            command:
+                              description: 'Entrypoint array. Not executed within
+                                a shell. The docker image''s ENTRYPOINT is used if
+                                this is not provided. Variable references $(VAR_NAME)
+                                are expanded using the container''s environment. If
+                                a variable cannot be resolved, the reference in the
+                                input string will be unchanged. The $(VAR_NAME) syntax
+                                can be escaped with a double $$, ie: $$(VAR_NAME).
+                                Escaped references will never be expanded, regardless
+                                of whether the variable exists or not. Cannot be updated.
+                                More info: https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell'
+                              items:
+                                type: string
+                              type: array
+                            env:
+                              description: List of environment variables to set in
+                                the container. Cannot be updated.
+                              items:
+                                description: EnvVar represents an environment variable
+                                  present in a Container.
+                                properties:
+                                  name:
+                                    description: Name of the environment variable.
+                                      Must be a C_IDENTIFIER.
+                                    type: string
+                                  value:
+                                    description: 'Variable references $(VAR_NAME)
+                                      are expanded using the previous defined environment
+                                      variables in the container and any service environment
+                                      variables. If a variable cannot be resolved,
+                                      the reference in the input string will be unchanged.
+                                      The $(VAR_NAME) syntax can be escaped with a
+                                      double $$, ie: $$(VAR_NAME). Escaped references
+                                      will never be expanded, regardless of whether
+                                      the variable exists or not. Defaults to "".'
+                                    type: string
+                                  valueFrom:
+                                    description: Source for the environment variable's
+                                      value. Cannot be used if value is not empty.
+                                    properties:
+                                      configMapKeyRef:
+                                        description: Selects a key of a ConfigMap.
+                                        properties:
+                                          key:
+                                            description: The key to select.
+                                            type: string
+                                          name:
+                                            description: 'Name of the referent. More
+                                              info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                              TODO: Add other useful fields. apiVersion,
+                                              kind, uid?'
+                                            type: string
+                                          optional:
+                                            description: Specify whether the ConfigMap
+                                              or its key must be defined
+                                            type: boolean
+                                        required:
+                                        - key
+                                        type: object
+                                      fieldRef:
+                                        description: 'Selects a field of the pod:
+                                          supports metadata.name, metadata.namespace,
+                                          metadata.labels, metadata.annotations, spec.nodeName,
+                                          spec.serviceAccountName, status.hostIP,
+                                          status.podIP.'
+                                        properties:
+                                          apiVersion:
+                                            description: Version of the schema the
+                                              FieldPath is written in terms of, defaults
+                                              to "v1".
+                                            type: string
+                                          fieldPath:
+                                            description: Path of the field to select
+                                              in the specified API version.
+                                            type: string
+                                        required:
+                                        - fieldPath
+                                        type: object
+                                      resourceFieldRef:
+                                        description: 'Selects a resource of the container:
+                                          only resources limits and requests (limits.cpu,
+                                          limits.memory, limits.ephemeral-storage,
+                                          requests.cpu, requests.memory and requests.ephemeral-storage)
+                                          are currently supported.'
+                                        properties:
+                                          containerName:
+                                            description: 'Container name: required
+                                              for volumes, optional for env vars'
+                                            type: string
+                                          divisor:
+                                            description: Specifies the output format
+                                              of the exposed resources, defaults to
+                                              "1"
+                                            type: string
+                                          resource:
+                                            description: 'Required: resource to select'
+                                            type: string
+                                        required:
+                                        - resource
+                                        type: object
+                                      secretKeyRef:
+                                        description: Selects a key of a secret in
+                                          the pod's namespace
+                                        properties:
+                                          key:
+                                            description: The key of the secret to
+                                              select from.  Must be a valid secret
+                                              key.
+                                            type: string
+                                          name:
+                                            description: 'Name of the referent. More
+                                              info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                              TODO: Add other useful fields. apiVersion,
+                                              kind, uid?'
+                                            type: string
+                                          optional:
+                                            description: Specify whether the Secret
+                                              or its key must be defined
+                                            type: boolean
+                                        required:
+                                        - key
+                                        type: object
+                                    type: object
+                                required:
+                                - name
+                                type: object
+                              type: array
+                            envFrom:
+                              description: List of sources to populate environment
+                                variables in the container. The keys defined within
+                                a source must be a C_IDENTIFIER. All invalid keys
+                                will be reported as an event when the container is
+                                starting. When a key exists in multiple sources, the
+                                value associated with the last source will take precedence.
+                                Values defined by an Env with a duplicate key will
+                                take precedence. Cannot be updated.
+                              items:
+                                description: EnvFromSource represents the source of
+                                  a set of ConfigMaps
+                                properties:
+                                  configMapRef:
+                                    description: The ConfigMap to select from
+                                    properties:
+                                      name:
+                                        description: 'Name of the referent. More info:
+                                          https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                          TODO: Add other useful fields. apiVersion,
+                                          kind, uid?'
+                                        type: string
+                                      optional:
+                                        description: Specify whether the ConfigMap
+                                          must be defined
+                                        type: boolean
+                                    type: object
+                                  prefix:
+                                    description: An optional identifier to prepend
+                                      to each key in the ConfigMap. Must be a C_IDENTIFIER.
+                                    type: string
+                                  secretRef:
+                                    description: The Secret to select from
+                                    properties:
+                                      name:
+                                        description: 'Name of the referent. More info:
+                                          https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                          TODO: Add other useful fields. apiVersion,
+                                          kind, uid?'
+                                        type: string
+                                      optional:
+                                        description: Specify whether the Secret must
+                                          be defined
+                                        type: boolean
+                                    type: object
+                                type: object
+                              type: array
+                            image:
+                              description: 'Docker image name. More info: https://kubernetes.io/docs/concepts/containers/images
+                                This field is optional to allow higher level config
+                                management to default or override container images
+                                in workload controllers like Deployments and StatefulSets.'
+                              type: string
+                            imagePullPolicy:
+                              description: 'Image pull policy. One of Always, Never,
+                                IfNotPresent. Defaults to Always if :v0.3.0 tag is
+                                specified, or IfNotPresent otherwise. Cannot be updated.
+                                More info: https://kubernetes.io/docs/concepts/containers/images#updating-images'
+                              type: string
+                            lifecycle:
+                              description: Actions that the management system should
+                                take in response to container lifecycle events. Cannot
+                                be updated.
+                              properties:
+                                postStart:
+                                  description: 'PostStart is called immediately after
+                                    a container is created. If the handler fails,
+                                    the container is terminated and restarted according
+                                    to its restart policy. Other management of the
+                                    container blocks until the hook completes. More
+                                    info: https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/#container-hooks'
+                                  properties:
+                                    exec:
+                                      description: One and only one of the following
+                                        should be specified. Exec specifies the action
+                                        to take.
+                                      properties:
+                                        command:
+                                          description: Command is the command line
+                                            to execute inside the container, the working
+                                            directory for the command  is root ('/')
+                                            in the container's filesystem. The command
+                                            is simply exec'd, it is not run inside
+                                            a shell, so traditional shell instructions
+                                            ('|', etc) won't work. To use a shell,
+                                            you need to explicitly call out to that
+                                            shell. Exit status of 0 is treated as
+                                            live/healthy and non-zero is unhealthy.
+                                          items:
+                                            type: string
+                                          type: array
+                                      type: object
+                                    httpGet:
+                                      description: HTTPGet specifies the http request
+                                        to perform.
+                                      properties:
+                                        host:
+                                          description: Host name to connect to, defaults
+                                            to the pod IP. You probably want to set
+                                            "Host" in httpHeaders instead.
+                                          type: string
+                                        httpHeaders:
+                                          description: Custom headers to set in the
+                                            request. HTTP allows repeated headers.
+                                          items:
+                                            description: HTTPHeader describes a custom
+                                              header to be used in HTTP probes
+                                            properties:
+                                              name:
+                                                description: The header field name
+                                                type: string
+                                              value:
+                                                description: The header field value
+                                                type: string
+                                            required:
+                                            - name
+                                            - value
+                                            type: object
+                                          type: array
+                                        path:
+                                          description: Path to access on the HTTP
+                                            server.
+                                          type: string
+                                        port:
+                                          anyOf:
+                                          - type: string
+                                          - type: integer
+                                          description: Name or number of the port
+                                            to access on the container. Number must
+                                            be in the range 1 to 65535. Name must
+                                            be an IANA_SVC_NAME.
+                                        scheme:
+                                          description: Scheme to use for connecting
+                                            to the host. Defaults to HTTP.
+                                          type: string
+                                      required:
+                                      - port
+                                      type: object
+                                    tcpSocket:
+                                      description: 'TCPSocket specifies an action
+                                        involving a TCP port. TCP hooks not yet supported
+                                        TODO: implement a realistic TCP lifecycle
+                                        hook'
+                                      properties:
+                                        host:
+                                          description: 'Optional: Host name to connect
+                                            to, defaults to the pod IP.'
+                                          type: string
+                                        port:
+                                          anyOf:
+                                          - type: string
+                                          - type: integer
+                                          description: Number or name of the port
+                                            to access on the container. Number must
+                                            be in the range 1 to 65535. Name must
+                                            be an IANA_SVC_NAME.
+                                      required:
+                                      - port
+                                      type: object
+                                  type: object
+                                preStop:
+                                  description: 'PreStop is called immediately before
+                                    a container is terminated due to an API request
+                                    or management event such as liveness probe failure,
+                                    preemption, resource contention, etc. The handler
+                                    is not called if the container crashes or exits.
+                                    The reason for termination is passed to the handler.
+                                    The Pod''s termination grace period countdown
+                                    begins before the PreStop hooked is executed.
+                                    Regardless of the outcome of the handler, the
+                                    container will eventually terminate within the
+                                    Pod''s termination grace period. Other management
+                                    of the container blocks until the hook completes
+                                    or until the termination grace period is reached.
+                                    More info: https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/#container-hooks'
+                                  properties:
+                                    exec:
+                                      description: One and only one of the following
+                                        should be specified. Exec specifies the action
+                                        to take.
+                                      properties:
+                                        command:
+                                          description: Command is the command line
+                                            to execute inside the container, the working
+                                            directory for the command  is root ('/')
+                                            in the container's filesystem. The command
+                                            is simply exec'd, it is not run inside
+                                            a shell, so traditional shell instructions
+                                            ('|', etc) won't work. To use a shell,
+                                            you need to explicitly call out to that
+                                            shell. Exit status of 0 is treated as
+                                            live/healthy and non-zero is unhealthy.
+                                          items:
+                                            type: string
+                                          type: array
+                                      type: object
+                                    httpGet:
+                                      description: HTTPGet specifies the http request
+                                        to perform.
+                                      properties:
+                                        host:
+                                          description: Host name to connect to, defaults
+                                            to the pod IP. You probably want to set
+                                            "Host" in httpHeaders instead.
+                                          type: string
+                                        httpHeaders:
+                                          description: Custom headers to set in the
+                                            request. HTTP allows repeated headers.
+                                          items:
+                                            description: HTTPHeader describes a custom
+                                              header to be used in HTTP probes
+                                            properties:
+                                              name:
+                                                description: The header field name
+                                                type: string
+                                              value:
+                                                description: The header field value
+                                                type: string
+                                            required:
+                                            - name
+                                            - value
+                                            type: object
+                                          type: array
+                                        path:
+                                          description: Path to access on the HTTP
+                                            server.
+                                          type: string
+                                        port:
+                                          anyOf:
+                                          - type: string
+                                          - type: integer
+                                          description: Name or number of the port
+                                            to access on the container. Number must
+                                            be in the range 1 to 65535. Name must
+                                            be an IANA_SVC_NAME.
+                                        scheme:
+                                          description: Scheme to use for connecting
+                                            to the host. Defaults to HTTP.
+                                          type: string
+                                      required:
+                                      - port
+                                      type: object
+                                    tcpSocket:
+                                      description: 'TCPSocket specifies an action
+                                        involving a TCP port. TCP hooks not yet supported
+                                        TODO: implement a realistic TCP lifecycle
+                                        hook'
+                                      properties:
+                                        host:
+                                          description: 'Optional: Host name to connect
+                                            to, defaults to the pod IP.'
+                                          type: string
+                                        port:
+                                          anyOf:
+                                          - type: string
+                                          - type: integer
+                                          description: Number or name of the port
+                                            to access on the container. Number must
+                                            be in the range 1 to 65535. Name must
+                                            be an IANA_SVC_NAME.
+                                      required:
+                                      - port
+                                      type: object
+                                  type: object
+                              type: object
+                            livenessProbe:
+                              description: 'Periodic probe of container liveness.
+                                Container will be restarted if the probe fails. Cannot
+                                be updated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                              properties:
+                                exec:
+                                  description: One and only one of the following should
+                                    be specified. Exec specifies the action to take.
+                                  properties:
+                                    command:
+                                      description: Command is the command line to
+                                        execute inside the container, the working
+                                        directory for the command  is root ('/') in
+                                        the container's filesystem. The command is
+                                        simply exec'd, it is not run inside a shell,
+                                        so traditional shell instructions ('|', etc)
+                                        won't work. To use a shell, you need to explicitly
+                                        call out to that shell. Exit status of 0 is
+                                        treated as live/healthy and non-zero is unhealthy.
+                                      items:
+                                        type: string
+                                      type: array
+                                  type: object
+                                failureThreshold:
+                                  description: Minimum consecutive failures for the
+                                    probe to be considered failed after having succeeded.
+                                    Defaults to 3. Minimum value is 1.
+                                  format: int32
+                                  type: integer
+                                httpGet:
+                                  description: HTTPGet specifies the http request
+                                    to perform.
+                                  properties:
+                                    host:
+                                      description: Host name to connect to, defaults
+                                        to the pod IP. You probably want to set "Host"
+                                        in httpHeaders instead.
+                                      type: string
+                                    httpHeaders:
+                                      description: Custom headers to set in the request.
+                                        HTTP allows repeated headers.
+                                      items:
+                                        description: HTTPHeader describes a custom
+                                          header to be used in HTTP probes
+                                        properties:
+                                          name:
+                                            description: The header field name
+                                            type: string
+                                          value:
+                                            description: The header field value
+                                            type: string
+                                        required:
+                                        - name
+                                        - value
+                                        type: object
+                                      type: array
+                                    path:
+                                      description: Path to access on the HTTP server.
+                                      type: string
+                                    port:
+                                      anyOf:
+                                      - type: string
+                                      - type: integer
+                                      description: Name or number of the port to access
+                                        on the container. Number must be in the range
+                                        1 to 65535. Name must be an IANA_SVC_NAME.
+                                    scheme:
+                                      description: Scheme to use for connecting to
+                                        the host. Defaults to HTTP.
+                                      type: string
+                                  required:
+                                  - port
+                                  type: object
+                                initialDelaySeconds:
+                                  description: 'Number of seconds after the container
+                                    has started before liveness probes are initiated.
+                                    More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                                  format: int32
+                                  type: integer
+                                periodSeconds:
+                                  description: How often (in seconds) to perform the
+                                    probe. Default to 10 seconds. Minimum value is
+                                    1.
+                                  format: int32
+                                  type: integer
+                                successThreshold:
+                                  description: Minimum consecutive successes for the
+                                    probe to be considered successful after having
+                                    failed. Defaults to 1. Must be 1 for liveness.
+                                    Minimum value is 1.
+                                  format: int32
+                                  type: integer
+                                tcpSocket:
+                                  description: 'TCPSocket specifies an action involving
+                                    a TCP port. TCP hooks not yet supported TODO:
+                                    implement a realistic TCP lifecycle hook'
+                                  properties:
+                                    host:
+                                      description: 'Optional: Host name to connect
+                                        to, defaults to the pod IP.'
+                                      type: string
+                                    port:
+                                      anyOf:
+                                      - type: string
+                                      - type: integer
+                                      description: Number or name of the port to access
+                                        on the container. Number must be in the range
+                                        1 to 65535. Name must be an IANA_SVC_NAME.
+                                  required:
+                                  - port
+                                  type: object
+                                timeoutSeconds:
+                                  description: 'Number of seconds after which the
+                                    probe times out. Defaults to 1 second. Minimum
+                                    value is 1. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                                  format: int32
+                                  type: integer
+                              type: object
+                            name:
+                              description: Name of the container specified as a DNS_LABEL.
+                                Each container in a pod must have a unique name (DNS_LABEL).
+                                Cannot be updated.
+                              type: string
+                            ports:
+                              description: List of ports to expose from the container.
+                                Exposing a port here gives the system additional information
+                                about the network connections a container uses, but
+                                is primarily informational. Not specifying a port
+                                here DOES NOT prevent that port from being exposed.
+                                Any port which is listening on the default "0.0.0.0"
+                                address inside a container will be accessible from
+                                the network. Cannot be updated.
+                              items:
+                                description: ContainerPort represents a network port
+                                  in a single container.
+                                properties:
+                                  containerPort:
+                                    description: Number of port to expose on the pod's
+                                      IP address. This must be a valid port number,
+                                      0 < x < 65536.
+                                    format: int32
+                                    type: integer
+                                  hostIP:
+                                    description: What host IP to bind the external
+                                      port to.
+                                    type: string
+                                  hostPort:
+                                    description: Number of port to expose on the host.
+                                      If specified, this must be a valid port number,
+                                      0 < x < 65536. If HostNetwork is specified,
+                                      this must match ContainerPort. Most containers
+                                      do not need this.
+                                    format: int32
+                                    type: integer
+                                  name:
+                                    description: If specified, this must be an IANA_SVC_NAME
+                                      and unique within the pod. Each named port in
+                                      a pod must have a unique name. Name for the
+                                      port that can be referred to by services.
+                                    type: string
+                                  protocol:
+                                    description: Protocol for port. Must be UDP, TCP,
+                                      or SCTP. Defaults to "TCP".
+                                    type: string
+                                required:
+                                - containerPort
+                                type: object
+                              type: array
+                            readinessProbe:
+                              description: 'Periodic probe of container service readiness.
+                                Container will be removed from service endpoints if
+                                the probe fails. Cannot be updated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                              properties:
+                                exec:
+                                  description: One and only one of the following should
+                                    be specified. Exec specifies the action to take.
+                                  properties:
+                                    command:
+                                      description: Command is the command line to
+                                        execute inside the container, the working
+                                        directory for the command  is root ('/') in
+                                        the container's filesystem. The command is
+                                        simply exec'd, it is not run inside a shell,
+                                        so traditional shell instructions ('|', etc)
+                                        won't work. To use a shell, you need to explicitly
+                                        call out to that shell. Exit status of 0 is
+                                        treated as live/healthy and non-zero is unhealthy.
+                                      items:
+                                        type: string
+                                      type: array
+                                  type: object
+                                failureThreshold:
+                                  description: Minimum consecutive failures for the
+                                    probe to be considered failed after having succeeded.
+                                    Defaults to 3. Minimum value is 1.
+                                  format: int32
+                                  type: integer
+                                httpGet:
+                                  description: HTTPGet specifies the http request
+                                    to perform.
+                                  properties:
+                                    host:
+                                      description: Host name to connect to, defaults
+                                        to the pod IP. You probably want to set "Host"
+                                        in httpHeaders instead.
+                                      type: string
+                                    httpHeaders:
+                                      description: Custom headers to set in the request.
+                                        HTTP allows repeated headers.
+                                      items:
+                                        description: HTTPHeader describes a custom
+                                          header to be used in HTTP probes
+                                        properties:
+                                          name:
+                                            description: The header field name
+                                            type: string
+                                          value:
+                                            description: The header field value
+                                            type: string
+                                        required:
+                                        - name
+                                        - value
+                                        type: object
+                                      type: array
+                                    path:
+                                      description: Path to access on the HTTP server.
+                                      type: string
+                                    port:
+                                      anyOf:
+                                      - type: string
+                                      - type: integer
+                                      description: Name or number of the port to access
+                                        on the container. Number must be in the range
+                                        1 to 65535. Name must be an IANA_SVC_NAME.
+                                    scheme:
+                                      description: Scheme to use for connecting to
+                                        the host. Defaults to HTTP.
+                                      type: string
+                                  required:
+                                  - port
+                                  type: object
+                                initialDelaySeconds:
+                                  description: 'Number of seconds after the container
+                                    has started before liveness probes are initiated.
+                                    More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                                  format: int32
+                                  type: integer
+                                periodSeconds:
+                                  description: How often (in seconds) to perform the
+                                    probe. Default to 10 seconds. Minimum value is
+                                    1.
+                                  format: int32
+                                  type: integer
+                                successThreshold:
+                                  description: Minimum consecutive successes for the
+                                    probe to be considered successful after having
+                                    failed. Defaults to 1. Must be 1 for liveness.
+                                    Minimum value is 1.
+                                  format: int32
+                                  type: integer
+                                tcpSocket:
+                                  description: 'TCPSocket specifies an action involving
+                                    a TCP port. TCP hooks not yet supported TODO:
+                                    implement a realistic TCP lifecycle hook'
+                                  properties:
+                                    host:
+                                      description: 'Optional: Host name to connect
+                                        to, defaults to the pod IP.'
+                                      type: string
+                                    port:
+                                      anyOf:
+                                      - type: string
+                                      - type: integer
+                                      description: Number or name of the port to access
+                                        on the container. Number must be in the range
+                                        1 to 65535. Name must be an IANA_SVC_NAME.
+                                  required:
+                                  - port
+                                  type: object
+                                timeoutSeconds:
+                                  description: 'Number of seconds after which the
+                                    probe times out. Defaults to 1 second. Minimum
+                                    value is 1. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                                  format: int32
+                                  type: integer
+                              type: object
+                            resources:
+                              description: 'Compute Resources required by this container.
+                                Cannot be updated. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
+                              properties:
+                                limits:
+                                  additionalProperties:
+                                    type: string
+                                  description: 'Limits describes the maximum amount
+                                    of compute resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
+                                  type: object
+                                requests:
+                                  additionalProperties:
+                                    type: string
+                                  description: 'Requests describes the minimum amount
+                                    of compute resources required. If Requests is
+                                    omitted for a container, it defaults to Limits
+                                    if that is explicitly specified, otherwise to
+                                    an implementation-defined value. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
+                                  type: object
+                              type: object
+                            securityContext:
+                              description: 'Security options the pod should run with.
+                                More info: https://kubernetes.io/docs/concepts/policy/security-context/
+                                More info: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/'
+                              properties:
+                                allowPrivilegeEscalation:
+                                  description: 'AllowPrivilegeEscalation controls
+                                    whether a process can gain more privileges than
+                                    its parent process. This bool directly controls
+                                    if the no_new_privs flag will be set on the container
+                                    process. AllowPrivilegeEscalation is true always
+                                    when the container is: 1) run as Privileged 2)
+                                    has CAP_SYS_ADMIN'
+                                  type: boolean
+                                capabilities:
+                                  description: The capabilities to add/drop when running
+                                    containers. Defaults to the default set of capabilities
+                                    granted by the container runtime.
+                                  properties:
+                                    add:
+                                      description: Added capabilities
+                                      items:
+                                        description: Capability represent POSIX capabilities
+                                          type
+                                        type: string
+                                      type: array
+                                    drop:
+                                      description: Removed capabilities
+                                      items:
+                                        description: Capability represent POSIX capabilities
+                                          type
+                                        type: string
+                                      type: array
+                                  type: object
+                                privileged:
+                                  description: Run container in privileged mode. Processes
+                                    in privileged containers are essentially equivalent
+                                    to root on the host. Defaults to false.
+                                  type: boolean
+                                procMount:
+                                  description: procMount denotes the type of proc
+                                    mount to use for the containers. The default is
+                                    DefaultProcMount which uses the container runtime
+                                    defaults for readonly paths and masked paths.
+                                    This requires the ProcMountType feature flag to
+                                    be enabled.
+                                  type: string
+                                readOnlyRootFilesystem:
+                                  description: Whether this container has a read-only
+                                    root filesystem. Default is false.
+                                  type: boolean
+                                runAsGroup:
+                                  description: The GID to run the entrypoint of the
+                                    container process. Uses runtime default if unset.
+                                    May also be set in PodSecurityContext.  If set
+                                    in both SecurityContext and PodSecurityContext,
+                                    the value specified in SecurityContext takes precedence.
+                                  format: int64
+                                  type: integer
+                                runAsNonRoot:
+                                  description: Indicates that the container must run
+                                    as a non-root user. If true, the Kubelet will
+                                    validate the image at runtime to ensure that it
+                                    does not run as UID 0 (root) and fail to start
+                                    the container if it does. If unset or false, no
+                                    such validation will be performed. May also be
+                                    set in PodSecurityContext.  If set in both SecurityContext
+                                    and PodSecurityContext, the value specified in
+                                    SecurityContext takes precedence.
+                                  type: boolean
+                                runAsUser:
+                                  description: The UID to run the entrypoint of the
+                                    container process. Defaults to user specified
+                                    in image metadata if unspecified. May also be
+                                    set in PodSecurityContext.  If set in both SecurityContext
+                                    and PodSecurityContext, the value specified in
+                                    SecurityContext takes precedence.
+                                  format: int64
+                                  type: integer
+                                seLinuxOptions:
+                                  description: The SELinux context to be applied to
+                                    the container. If unspecified, the container runtime
+                                    will allocate a random SELinux context for each
+                                    container.  May also be set in PodSecurityContext.  If
+                                    set in both SecurityContext and PodSecurityContext,
+                                    the value specified in SecurityContext takes precedence.
+                                  properties:
+                                    level:
+                                      description: Level is SELinux level label that
+                                        applies to the container.
+                                      type: string
+                                    role:
+                                      description: Role is a SELinux role label that
+                                        applies to the container.
+                                      type: string
+                                    type:
+                                      description: Type is a SELinux type label that
+                                        applies to the container.
+                                      type: string
+                                    user:
+                                      description: User is a SELinux user label that
+                                        applies to the container.
+                                      type: string
+                                  type: object
+                                windowsOptions:
+                                  description: Windows security options.
+                                  properties:
+                                    gmsaCredentialSpec:
+                                      description: GMSACredentialSpec is where the
+                                        GMSA admission webhook (https://github.com/kubernetes-sigs/windows-gmsa)
+                                        inlines the contents of the GMSA credential
+                                        spec named by the GMSACredentialSpecName field.
+                                        This field is alpha-level and is only honored
+                                        by servers that enable the WindowsGMSA feature
+                                        flag.
+                                      type: string
+                                    gmsaCredentialSpecName:
+                                      description: GMSACredentialSpecName is the name
+                                        of the GMSA credential spec to use. This field
+                                        is alpha-level and is only honored by servers
+                                        that enable the WindowsGMSA feature flag.
+                                      type: string
+                                  type: object
+                              type: object
+                            stdin:
+                              description: Whether this container should allocate
+                                a buffer for stdin in the container runtime. If this
+                                is not set, reads from stdin in the container will
+                                always result in EOF. Default is false.
+                              type: boolean
+                            stdinOnce:
+                              description: Whether the container runtime should close
+                                the stdin channel after it has been opened by a single
+                                attach. When stdin is true the stdin stream will remain
+                                open across multiple attach sessions. If stdinOnce
+                                is set to true, stdin is opened on container start,
+                                is empty until the first client attaches to stdin,
+                                and then remains open and accepts data until the client
+                                disconnects, at which time stdin is closed and remains
+                                closed until the container is restarted. If this flag
+                                is false, a container processes that reads from stdin
+                                will never receive an EOF. Default is false
+                              type: boolean
+                            terminationMessagePath:
+                              description: 'Optional: Path at which the file to which
+                                the container''s termination message will be written
+                                is mounted into the container''s filesystem. Message
+                                written is intended to be brief final status, such
+                                as an assertion failure message. Will be truncated
+                                by the node if greater than 4096 bytes. The total
+                                message length across all containers will be limited
+                                to 12kb. Defaults to /dev/termination-log. Cannot
+                                be updated.'
+                              type: string
+                            terminationMessagePolicy:
+                              description: Indicate how the termination message should
+                                be populated. File will use the contents of terminationMessagePath
+                                to populate the container status message on both success
+                                and failure. FallbackToLogsOnError will use the last
+                                chunk of container log output if the termination message
+                                file is empty and the container exited with an error.
+                                The log output is limited to 2048 bytes or 80 lines,
+                                whichever is smaller. Defaults to File. Cannot be
+                                updated.
+                              type: string
+                            tty:
+                              description: Whether this container should allocate
+                                a TTY for itself, also requires 'stdin' to be true.
+                                Default is false.
+                              type: boolean
+                            volumeDevices:
+                              description: volumeDevices is the list of block devices
+                                to be used by the container. This is a beta feature.
+                              items:
+                                description: volumeDevice describes a mapping of a
+                                  raw block device within a container.
+                                properties:
+                                  devicePath:
+                                    description: devicePath is the path inside of
+                                      the container that the device will be mapped
+                                      to.
+                                    type: string
+                                  name:
+                                    description: name must match the name of a persistentVolumeClaim
+                                      in the pod
+                                    type: string
+                                required:
+                                - devicePath
+                                - name
+                                type: object
+                              type: array
+                            volumeMounts:
+                              description: Pod volumes to mount into the container's
+                                filesystem. Cannot be updated.
+                              items:
+                                description: VolumeMount describes a mounting of a
+                                  Volume within a container.
+                                properties:
+                                  mountPath:
+                                    description: Path within the container at which
+                                      the volume should be mounted.  Must not contain
+                                      ':'.
+                                    type: string
+                                  mountPropagation:
+                                    description: mountPropagation determines how mounts
+                                      are propagated from the host to container and
+                                      the other way around. When not set, MountPropagationNone
+                                      is used. This field is beta in 1.10.
+                                    type: string
+                                  name:
+                                    description: This must match the Name of a Volume.
+                                    type: string
+                                  readOnly:
+                                    description: Mounted read-only if true, read-write
+                                      otherwise (false or unspecified). Defaults to
+                                      false.
+                                    type: boolean
+                                  subPath:
+                                    description: Path within the volume from which
+                                      the container's volume should be mounted. Defaults
+                                      to "" (volume's root).
+                                    type: string
+                                  subPathExpr:
+                                    description: Expanded path within the volume from
+                                      which the container's volume should be mounted.
+                                      Behaves similarly to SubPath but environment
+                                      variable references $(VAR_NAME) are expanded
+                                      using the container's environment. Defaults
+                                      to "" (volume's root). SubPathExpr and SubPath
+                                      are mutually exclusive. This field is beta in
+                                      1.15.
+                                    type: string
+                                required:
+                                - mountPath
+                                - name
+                                type: object
+                              type: array
+                            workingDir:
+                              description: Container's working directory. If not specified,
+                                the container runtime's default will be used, which
+                                might be configured in the container image. Cannot
+                                be updated.
+                              type: string
+                          required:
+                          - name
+                          type: object
+                      required:
+                      - container
+                      type: object
+                    logger:
+                      description: Activate request/response logging
+                      properties:
+                        mode:
+                          description: What payloads to log
+                          type: string
+                        url:
+                          description: URL to send request logging CloudEvents
+                          type: string
+                      type: object
+                    maxReplicas:
+                      description: This is the up bound for autoscaler to scale to
+                      type: integer
+                    minReplicas:
+                      description: Minimum number of replicas, pods won't scale down
+                        to 0 in case of no traffic
+                      type: integer
+                    onnx:
+                      description: Spec for ONNX runtime (https://github.com/microsoft/onnxruntime)
+                      properties:
+                        resources:
+                          description: Defaults to requests and limits of 1CPU, 2Gb
+                            MEM.
+                          properties:
+                            limits:
+                              additionalProperties:
+                                type: string
+                              description: 'Limits describes the maximum amount of
+                                compute resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
+                              type: object
+                            requests:
+                              additionalProperties:
+                                type: string
+                              description: 'Requests describes the minimum amount
+                                of compute resources required. If Requests is omitted
+                                for a container, it defaults to Limits if that is
+                                explicitly specified, otherwise to an implementation-defined
+                                value. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
+                              type: object
+                          type: object
+                        runtimeVersion:
+                          description: Allowed runtime versions are specified in the
+                            inferenceservice config map
+                          type: string
+                        storageUri:
+                          description: The location of the trained model
+                          type: string
+                      required:
+                      - storageUri
+                      type: object
+                    parallelism:
+                      description: Parallelism specifies how many requests can be
+                        processed concurrently, this sets the target concurrency for
+                        Autoscaling(KPA). For model servers that support tuning parallelism
+                        will use this value, by default the parallelism is the number
+                        of the CPU cores for most of the model servers.
+                      type: integer
+                    pytorch:
+                      description: Spec for PyTorch predictor
+                      properties:
+                        modelClassName:
+                          description: Defaults PyTorch model class name to 'PyTorchModel'
+                          type: string
+                        resources:
+                          description: Defaults to requests and limits of 1CPU, 2Gb
+                            MEM.
+                          properties:
+                            limits:
+                              additionalProperties:
+                                type: string
+                              description: 'Limits describes the maximum amount of
+                                compute resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
+                              type: object
+                            requests:
+                              additionalProperties:
+                                type: string
+                              description: 'Requests describes the minimum amount
+                                of compute resources required. If Requests is omitted
+                                for a container, it defaults to Limits if that is
+                                explicitly specified, otherwise to an implementation-defined
+                                value. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
+                              type: object
+                          type: object
+                        runtimeVersion:
+                          description: Allowed runtime versions are specified in the
+                            inferenceservice config map
+                          type: string
+                        storageUri:
+                          description: The location of the trained model
+                          type: string
+                      required:
+                      - storageUri
+                      type: object
+                    serviceAccountName:
+                      description: ServiceAccountName is the name of the ServiceAccount
+                        to use to run the service
+                      type: string
+                    sklearn:
+                      description: Spec for SKLearn predictor
+                      properties:
+                        resources:
+                          description: Defaults to requests and limits of 1CPU, 2Gb
+                            MEM.
+                          properties:
+                            limits:
+                              additionalProperties:
+                                type: string
+                              description: 'Limits describes the maximum amount of
+                                compute resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
+                              type: object
+                            requests:
+                              additionalProperties:
+                                type: string
+                              description: 'Requests describes the minimum amount
+                                of compute resources required. If Requests is omitted
+                                for a container, it defaults to Limits if that is
+                                explicitly specified, otherwise to an implementation-defined
+                                value. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
+                              type: object
+                          type: object
+                        runtimeVersion:
+                          description: Allowed runtime versions are specified in the
+                            inferenceservice config map
+                          type: string
+                        storageUri:
+                          description: The location of the trained model
+                          type: string
+                      required:
+                      - storageUri
+                      type: object
+                    tensorflow:
+                      description: Spec for Tensorflow Serving (https://github.com/tensorflow/serving)
+                      properties:
+                        resources:
+                          description: Defaults to requests and limits of 1CPU, 2Gb
+                            MEM.
+                          properties:
+                            limits:
+                              additionalProperties:
+                                type: string
+                              description: 'Limits describes the maximum amount of
+                                compute resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
+                              type: object
+                            requests:
+                              additionalProperties:
+                                type: string
+                              description: 'Requests describes the minimum amount
+                                of compute resources required. If Requests is omitted
+                                for a container, it defaults to Limits if that is
+                                explicitly specified, otherwise to an implementation-defined
+                                value. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
+                              type: object
+                          type: object
+                        runtimeVersion:
+                          description: Allowed runtime versions are specified in the
+                            inferenceservice config map.
+                          type: string
+                        storageUri:
+                          description: The location of the trained model
+                          type: string
+                      required:
+                      - storageUri
+                      type: object
+                    tensorrt:
+                      description: Spec for TensorRT Inference Server (https://github.com/NVIDIA/tensorrt-inference-server)
+                      properties:
+                        resources:
+                          description: Defaults to requests and limits of 1CPU, 2Gb
+                            MEM.
+                          properties:
+                            limits:
+                              additionalProperties:
+                                type: string
+                              description: 'Limits describes the maximum amount of
+                                compute resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
+                              type: object
+                            requests:
+                              additionalProperties:
+                                type: string
+                              description: 'Requests describes the minimum amount
+                                of compute resources required. If Requests is omitted
+                                for a container, it defaults to Limits if that is
+                                explicitly specified, otherwise to an implementation-defined
+                                value. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
+                              type: object
+                          type: object
+                        runtimeVersion:
+                          description: Allowed runtime versions are specified in the
+                            inferenceservice config map
+                          type: string
+                        storageUri:
+                          description: The location of the trained model
+                          type: string
+                      required:
+                      - storageUri
+                      type: object
+                    xgboost:
+                      description: Spec for XGBoost predictor
+                      properties:
+                        nthread:
+                          description: Number of thread to be used by XGBoost
+                          type: integer
+                        resources:
+                          description: Defaults to requests and limits of 1CPU, 2Gb
+                            MEM.
+                          properties:
+                            limits:
+                              additionalProperties:
+                                type: string
+                              description: 'Limits describes the maximum amount of
+                                compute resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
+                              type: object
+                            requests:
+                              additionalProperties:
+                                type: string
+                              description: 'Requests describes the minimum amount
+                                of compute resources required. If Requests is omitted
+                                for a container, it defaults to Limits if that is
+                                explicitly specified, otherwise to an implementation-defined
+                                value. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
+                              type: object
+                          type: object
+                        runtimeVersion:
+                          description: Allowed runtime versions are specified in the
+                            inferenceservice config map
+                          type: string
+                        storageUri:
+                          description: The location of the trained model
+                          type: string
+                      required:
+                      - storageUri
+                      type: object
+                  type: object
+                transformer:
+                  description: Transformer defines the pre/post processing before
+                    and after the predictor call, transformer service calls to predictor
+                    service.
+                  properties:
+                    custom:
+                      description: Spec for a custom transformer
+                      properties:
+                        container:
+                          description: A single application container that you want
+                            to run within a pod.
+                          properties:
+                            args:
+                              description: 'Arguments to the entrypoint. The docker
+                                image''s CMD is used if this is not provided. Variable
+                                references $(VAR_NAME) are expanded using the container''s
+                                environment. If a variable cannot be resolved, the
+                                reference in the input string will be unchanged. The
+                                $(VAR_NAME) syntax can be escaped with a double $$,
+                                ie: $$(VAR_NAME). Escaped references will never be
+                                expanded, regardless of whether the variable exists
+                                or not. Cannot be updated. More info: https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell'
+                              items:
+                                type: string
+                              type: array
+                            command:
+                              description: 'Entrypoint array. Not executed within
+                                a shell. The docker image''s ENTRYPOINT is used if
+                                this is not provided. Variable references $(VAR_NAME)
+                                are expanded using the container''s environment. If
+                                a variable cannot be resolved, the reference in the
+                                input string will be unchanged. The $(VAR_NAME) syntax
+                                can be escaped with a double $$, ie: $$(VAR_NAME).
+                                Escaped references will never be expanded, regardless
+                                of whether the variable exists or not. Cannot be updated.
+                                More info: https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell'
+                              items:
+                                type: string
+                              type: array
+                            env:
+                              description: List of environment variables to set in
+                                the container. Cannot be updated.
+                              items:
+                                description: EnvVar represents an environment variable
+                                  present in a Container.
+                                properties:
+                                  name:
+                                    description: Name of the environment variable.
+                                      Must be a C_IDENTIFIER.
+                                    type: string
+                                  value:
+                                    description: 'Variable references $(VAR_NAME)
+                                      are expanded using the previous defined environment
+                                      variables in the container and any service environment
+                                      variables. If a variable cannot be resolved,
+                                      the reference in the input string will be unchanged.
+                                      The $(VAR_NAME) syntax can be escaped with a
+                                      double $$, ie: $$(VAR_NAME). Escaped references
+                                      will never be expanded, regardless of whether
+                                      the variable exists or not. Defaults to "".'
+                                    type: string
+                                  valueFrom:
+                                    description: Source for the environment variable's
+                                      value. Cannot be used if value is not empty.
+                                    properties:
+                                      configMapKeyRef:
+                                        description: Selects a key of a ConfigMap.
+                                        properties:
+                                          key:
+                                            description: The key to select.
+                                            type: string
+                                          name:
+                                            description: 'Name of the referent. More
+                                              info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                              TODO: Add other useful fields. apiVersion,
+                                              kind, uid?'
+                                            type: string
+                                          optional:
+                                            description: Specify whether the ConfigMap
+                                              or its key must be defined
+                                            type: boolean
+                                        required:
+                                        - key
+                                        type: object
+                                      fieldRef:
+                                        description: 'Selects a field of the pod:
+                                          supports metadata.name, metadata.namespace,
+                                          metadata.labels, metadata.annotations, spec.nodeName,
+                                          spec.serviceAccountName, status.hostIP,
+                                          status.podIP.'
+                                        properties:
+                                          apiVersion:
+                                            description: Version of the schema the
+                                              FieldPath is written in terms of, defaults
+                                              to "v1".
+                                            type: string
+                                          fieldPath:
+                                            description: Path of the field to select
+                                              in the specified API version.
+                                            type: string
+                                        required:
+                                        - fieldPath
+                                        type: object
+                                      resourceFieldRef:
+                                        description: 'Selects a resource of the container:
+                                          only resources limits and requests (limits.cpu,
+                                          limits.memory, limits.ephemeral-storage,
+                                          requests.cpu, requests.memory and requests.ephemeral-storage)
+                                          are currently supported.'
+                                        properties:
+                                          containerName:
+                                            description: 'Container name: required
+                                              for volumes, optional for env vars'
+                                            type: string
+                                          divisor:
+                                            description: Specifies the output format
+                                              of the exposed resources, defaults to
+                                              "1"
+                                            type: string
+                                          resource:
+                                            description: 'Required: resource to select'
+                                            type: string
+                                        required:
+                                        - resource
+                                        type: object
+                                      secretKeyRef:
+                                        description: Selects a key of a secret in
+                                          the pod's namespace
+                                        properties:
+                                          key:
+                                            description: The key of the secret to
+                                              select from.  Must be a valid secret
+                                              key.
+                                            type: string
+                                          name:
+                                            description: 'Name of the referent. More
+                                              info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                              TODO: Add other useful fields. apiVersion,
+                                              kind, uid?'
+                                            type: string
+                                          optional:
+                                            description: Specify whether the Secret
+                                              or its key must be defined
+                                            type: boolean
+                                        required:
+                                        - key
+                                        type: object
+                                    type: object
+                                required:
+                                - name
+                                type: object
+                              type: array
+                            envFrom:
+                              description: List of sources to populate environment
+                                variables in the container. The keys defined within
+                                a source must be a C_IDENTIFIER. All invalid keys
+                                will be reported as an event when the container is
+                                starting. When a key exists in multiple sources, the
+                                value associated with the last source will take precedence.
+                                Values defined by an Env with a duplicate key will
+                                take precedence. Cannot be updated.
+                              items:
+                                description: EnvFromSource represents the source of
+                                  a set of ConfigMaps
+                                properties:
+                                  configMapRef:
+                                    description: The ConfigMap to select from
+                                    properties:
+                                      name:
+                                        description: 'Name of the referent. More info:
+                                          https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                          TODO: Add other useful fields. apiVersion,
+                                          kind, uid?'
+                                        type: string
+                                      optional:
+                                        description: Specify whether the ConfigMap
+                                          must be defined
+                                        type: boolean
+                                    type: object
+                                  prefix:
+                                    description: An optional identifier to prepend
+                                      to each key in the ConfigMap. Must be a C_IDENTIFIER.
+                                    type: string
+                                  secretRef:
+                                    description: The Secret to select from
+                                    properties:
+                                      name:
+                                        description: 'Name of the referent. More info:
+                                          https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                          TODO: Add other useful fields. apiVersion,
+                                          kind, uid?'
+                                        type: string
+                                      optional:
+                                        description: Specify whether the Secret must
+                                          be defined
+                                        type: boolean
+                                    type: object
+                                type: object
+                              type: array
+                            image:
+                              description: 'Docker image name. More info: https://kubernetes.io/docs/concepts/containers/images
+                                This field is optional to allow higher level config
+                                management to default or override container images
+                                in workload controllers like Deployments and StatefulSets.'
+                              type: string
+                            imagePullPolicy:
+                              description: 'Image pull policy. One of Always, Never,
+                                IfNotPresent. Defaults to Always if :v0.3.0 tag is
+                                specified, or IfNotPresent otherwise. Cannot be updated.
+                                More info: https://kubernetes.io/docs/concepts/containers/images#updating-images'
+                              type: string
+                            lifecycle:
+                              description: Actions that the management system should
+                                take in response to container lifecycle events. Cannot
+                                be updated.
+                              properties:
+                                postStart:
+                                  description: 'PostStart is called immediately after
+                                    a container is created. If the handler fails,
+                                    the container is terminated and restarted according
+                                    to its restart policy. Other management of the
+                                    container blocks until the hook completes. More
+                                    info: https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/#container-hooks'
+                                  properties:
+                                    exec:
+                                      description: One and only one of the following
+                                        should be specified. Exec specifies the action
+                                        to take.
+                                      properties:
+                                        command:
+                                          description: Command is the command line
+                                            to execute inside the container, the working
+                                            directory for the command  is root ('/')
+                                            in the container's filesystem. The command
+                                            is simply exec'd, it is not run inside
+                                            a shell, so traditional shell instructions
+                                            ('|', etc) won't work. To use a shell,
+                                            you need to explicitly call out to that
+                                            shell. Exit status of 0 is treated as
+                                            live/healthy and non-zero is unhealthy.
+                                          items:
+                                            type: string
+                                          type: array
+                                      type: object
+                                    httpGet:
+                                      description: HTTPGet specifies the http request
+                                        to perform.
+                                      properties:
+                                        host:
+                                          description: Host name to connect to, defaults
+                                            to the pod IP. You probably want to set
+                                            "Host" in httpHeaders instead.
+                                          type: string
+                                        httpHeaders:
+                                          description: Custom headers to set in the
+                                            request. HTTP allows repeated headers.
+                                          items:
+                                            description: HTTPHeader describes a custom
+                                              header to be used in HTTP probes
+                                            properties:
+                                              name:
+                                                description: The header field name
+                                                type: string
+                                              value:
+                                                description: The header field value
+                                                type: string
+                                            required:
+                                            - name
+                                            - value
+                                            type: object
+                                          type: array
+                                        path:
+                                          description: Path to access on the HTTP
+                                            server.
+                                          type: string
+                                        port:
+                                          anyOf:
+                                          - type: string
+                                          - type: integer
+                                          description: Name or number of the port
+                                            to access on the container. Number must
+                                            be in the range 1 to 65535. Name must
+                                            be an IANA_SVC_NAME.
+                                        scheme:
+                                          description: Scheme to use for connecting
+                                            to the host. Defaults to HTTP.
+                                          type: string
+                                      required:
+                                      - port
+                                      type: object
+                                    tcpSocket:
+                                      description: 'TCPSocket specifies an action
+                                        involving a TCP port. TCP hooks not yet supported
+                                        TODO: implement a realistic TCP lifecycle
+                                        hook'
+                                      properties:
+                                        host:
+                                          description: 'Optional: Host name to connect
+                                            to, defaults to the pod IP.'
+                                          type: string
+                                        port:
+                                          anyOf:
+                                          - type: string
+                                          - type: integer
+                                          description: Number or name of the port
+                                            to access on the container. Number must
+                                            be in the range 1 to 65535. Name must
+                                            be an IANA_SVC_NAME.
+                                      required:
+                                      - port
+                                      type: object
+                                  type: object
+                                preStop:
+                                  description: 'PreStop is called immediately before
+                                    a container is terminated due to an API request
+                                    or management event such as liveness probe failure,
+                                    preemption, resource contention, etc. The handler
+                                    is not called if the container crashes or exits.
+                                    The reason for termination is passed to the handler.
+                                    The Pod''s termination grace period countdown
+                                    begins before the PreStop hooked is executed.
+                                    Regardless of the outcome of the handler, the
+                                    container will eventually terminate within the
+                                    Pod''s termination grace period. Other management
+                                    of the container blocks until the hook completes
+                                    or until the termination grace period is reached.
+                                    More info: https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/#container-hooks'
+                                  properties:
+                                    exec:
+                                      description: One and only one of the following
+                                        should be specified. Exec specifies the action
+                                        to take.
+                                      properties:
+                                        command:
+                                          description: Command is the command line
+                                            to execute inside the container, the working
+                                            directory for the command  is root ('/')
+                                            in the container's filesystem. The command
+                                            is simply exec'd, it is not run inside
+                                            a shell, so traditional shell instructions
+                                            ('|', etc) won't work. To use a shell,
+                                            you need to explicitly call out to that
+                                            shell. Exit status of 0 is treated as
+                                            live/healthy and non-zero is unhealthy.
+                                          items:
+                                            type: string
+                                          type: array
+                                      type: object
+                                    httpGet:
+                                      description: HTTPGet specifies the http request
+                                        to perform.
+                                      properties:
+                                        host:
+                                          description: Host name to connect to, defaults
+                                            to the pod IP. You probably want to set
+                                            "Host" in httpHeaders instead.
+                                          type: string
+                                        httpHeaders:
+                                          description: Custom headers to set in the
+                                            request. HTTP allows repeated headers.
+                                          items:
+                                            description: HTTPHeader describes a custom
+                                              header to be used in HTTP probes
+                                            properties:
+                                              name:
+                                                description: The header field name
+                                                type: string
+                                              value:
+                                                description: The header field value
+                                                type: string
+                                            required:
+                                            - name
+                                            - value
+                                            type: object
+                                          type: array
+                                        path:
+                                          description: Path to access on the HTTP
+                                            server.
+                                          type: string
+                                        port:
+                                          anyOf:
+                                          - type: string
+                                          - type: integer
+                                          description: Name or number of the port
+                                            to access on the container. Number must
+                                            be in the range 1 to 65535. Name must
+                                            be an IANA_SVC_NAME.
+                                        scheme:
+                                          description: Scheme to use for connecting
+                                            to the host. Defaults to HTTP.
+                                          type: string
+                                      required:
+                                      - port
+                                      type: object
+                                    tcpSocket:
+                                      description: 'TCPSocket specifies an action
+                                        involving a TCP port. TCP hooks not yet supported
+                                        TODO: implement a realistic TCP lifecycle
+                                        hook'
+                                      properties:
+                                        host:
+                                          description: 'Optional: Host name to connect
+                                            to, defaults to the pod IP.'
+                                          type: string
+                                        port:
+                                          anyOf:
+                                          - type: string
+                                          - type: integer
+                                          description: Number or name of the port
+                                            to access on the container. Number must
+                                            be in the range 1 to 65535. Name must
+                                            be an IANA_SVC_NAME.
+                                      required:
+                                      - port
+                                      type: object
+                                  type: object
+                              type: object
+                            livenessProbe:
+                              description: 'Periodic probe of container liveness.
+                                Container will be restarted if the probe fails. Cannot
+                                be updated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                              properties:
+                                exec:
+                                  description: One and only one of the following should
+                                    be specified. Exec specifies the action to take.
+                                  properties:
+                                    command:
+                                      description: Command is the command line to
+                                        execute inside the container, the working
+                                        directory for the command  is root ('/') in
+                                        the container's filesystem. The command is
+                                        simply exec'd, it is not run inside a shell,
+                                        so traditional shell instructions ('|', etc)
+                                        won't work. To use a shell, you need to explicitly
+                                        call out to that shell. Exit status of 0 is
+                                        treated as live/healthy and non-zero is unhealthy.
+                                      items:
+                                        type: string
+                                      type: array
+                                  type: object
+                                failureThreshold:
+                                  description: Minimum consecutive failures for the
+                                    probe to be considered failed after having succeeded.
+                                    Defaults to 3. Minimum value is 1.
+                                  format: int32
+                                  type: integer
+                                httpGet:
+                                  description: HTTPGet specifies the http request
+                                    to perform.
+                                  properties:
+                                    host:
+                                      description: Host name to connect to, defaults
+                                        to the pod IP. You probably want to set "Host"
+                                        in httpHeaders instead.
+                                      type: string
+                                    httpHeaders:
+                                      description: Custom headers to set in the request.
+                                        HTTP allows repeated headers.
+                                      items:
+                                        description: HTTPHeader describes a custom
+                                          header to be used in HTTP probes
+                                        properties:
+                                          name:
+                                            description: The header field name
+                                            type: string
+                                          value:
+                                            description: The header field value
+                                            type: string
+                                        required:
+                                        - name
+                                        - value
+                                        type: object
+                                      type: array
+                                    path:
+                                      description: Path to access on the HTTP server.
+                                      type: string
+                                    port:
+                                      anyOf:
+                                      - type: string
+                                      - type: integer
+                                      description: Name or number of the port to access
+                                        on the container. Number must be in the range
+                                        1 to 65535. Name must be an IANA_SVC_NAME.
+                                    scheme:
+                                      description: Scheme to use for connecting to
+                                        the host. Defaults to HTTP.
+                                      type: string
+                                  required:
+                                  - port
+                                  type: object
+                                initialDelaySeconds:
+                                  description: 'Number of seconds after the container
+                                    has started before liveness probes are initiated.
+                                    More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                                  format: int32
+                                  type: integer
+                                periodSeconds:
+                                  description: How often (in seconds) to perform the
+                                    probe. Default to 10 seconds. Minimum value is
+                                    1.
+                                  format: int32
+                                  type: integer
+                                successThreshold:
+                                  description: Minimum consecutive successes for the
+                                    probe to be considered successful after having
+                                    failed. Defaults to 1. Must be 1 for liveness.
+                                    Minimum value is 1.
+                                  format: int32
+                                  type: integer
+                                tcpSocket:
+                                  description: 'TCPSocket specifies an action involving
+                                    a TCP port. TCP hooks not yet supported TODO:
+                                    implement a realistic TCP lifecycle hook'
+                                  properties:
+                                    host:
+                                      description: 'Optional: Host name to connect
+                                        to, defaults to the pod IP.'
+                                      type: string
+                                    port:
+                                      anyOf:
+                                      - type: string
+                                      - type: integer
+                                      description: Number or name of the port to access
+                                        on the container. Number must be in the range
+                                        1 to 65535. Name must be an IANA_SVC_NAME.
+                                  required:
+                                  - port
+                                  type: object
+                                timeoutSeconds:
+                                  description: 'Number of seconds after which the
+                                    probe times out. Defaults to 1 second. Minimum
+                                    value is 1. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                                  format: int32
+                                  type: integer
+                              type: object
+                            name:
+                              description: Name of the container specified as a DNS_LABEL.
+                                Each container in a pod must have a unique name (DNS_LABEL).
+                                Cannot be updated.
+                              type: string
+                            ports:
+                              description: List of ports to expose from the container.
+                                Exposing a port here gives the system additional information
+                                about the network connections a container uses, but
+                                is primarily informational. Not specifying a port
+                                here DOES NOT prevent that port from being exposed.
+                                Any port which is listening on the default "0.0.0.0"
+                                address inside a container will be accessible from
+                                the network. Cannot be updated.
+                              items:
+                                description: ContainerPort represents a network port
+                                  in a single container.
+                                properties:
+                                  containerPort:
+                                    description: Number of port to expose on the pod's
+                                      IP address. This must be a valid port number,
+                                      0 < x < 65536.
+                                    format: int32
+                                    type: integer
+                                  hostIP:
+                                    description: What host IP to bind the external
+                                      port to.
+                                    type: string
+                                  hostPort:
+                                    description: Number of port to expose on the host.
+                                      If specified, this must be a valid port number,
+                                      0 < x < 65536. If HostNetwork is specified,
+                                      this must match ContainerPort. Most containers
+                                      do not need this.
+                                    format: int32
+                                    type: integer
+                                  name:
+                                    description: If specified, this must be an IANA_SVC_NAME
+                                      and unique within the pod. Each named port in
+                                      a pod must have a unique name. Name for the
+                                      port that can be referred to by services.
+                                    type: string
+                                  protocol:
+                                    description: Protocol for port. Must be UDP, TCP,
+                                      or SCTP. Defaults to "TCP".
+                                    type: string
+                                required:
+                                - containerPort
+                                type: object
+                              type: array
+                            readinessProbe:
+                              description: 'Periodic probe of container service readiness.
+                                Container will be removed from service endpoints if
+                                the probe fails. Cannot be updated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                              properties:
+                                exec:
+                                  description: One and only one of the following should
+                                    be specified. Exec specifies the action to take.
+                                  properties:
+                                    command:
+                                      description: Command is the command line to
+                                        execute inside the container, the working
+                                        directory for the command  is root ('/') in
+                                        the container's filesystem. The command is
+                                        simply exec'd, it is not run inside a shell,
+                                        so traditional shell instructions ('|', etc)
+                                        won't work. To use a shell, you need to explicitly
+                                        call out to that shell. Exit status of 0 is
+                                        treated as live/healthy and non-zero is unhealthy.
+                                      items:
+                                        type: string
+                                      type: array
+                                  type: object
+                                failureThreshold:
+                                  description: Minimum consecutive failures for the
+                                    probe to be considered failed after having succeeded.
+                                    Defaults to 3. Minimum value is 1.
+                                  format: int32
+                                  type: integer
+                                httpGet:
+                                  description: HTTPGet specifies the http request
+                                    to perform.
+                                  properties:
+                                    host:
+                                      description: Host name to connect to, defaults
+                                        to the pod IP. You probably want to set "Host"
+                                        in httpHeaders instead.
+                                      type: string
+                                    httpHeaders:
+                                      description: Custom headers to set in the request.
+                                        HTTP allows repeated headers.
+                                      items:
+                                        description: HTTPHeader describes a custom
+                                          header to be used in HTTP probes
+                                        properties:
+                                          name:
+                                            description: The header field name
+                                            type: string
+                                          value:
+                                            description: The header field value
+                                            type: string
+                                        required:
+                                        - name
+                                        - value
+                                        type: object
+                                      type: array
+                                    path:
+                                      description: Path to access on the HTTP server.
+                                      type: string
+                                    port:
+                                      anyOf:
+                                      - type: string
+                                      - type: integer
+                                      description: Name or number of the port to access
+                                        on the container. Number must be in the range
+                                        1 to 65535. Name must be an IANA_SVC_NAME.
+                                    scheme:
+                                      description: Scheme to use for connecting to
+                                        the host. Defaults to HTTP.
+                                      type: string
+                                  required:
+                                  - port
+                                  type: object
+                                initialDelaySeconds:
+                                  description: 'Number of seconds after the container
+                                    has started before liveness probes are initiated.
+                                    More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                                  format: int32
+                                  type: integer
+                                periodSeconds:
+                                  description: How often (in seconds) to perform the
+                                    probe. Default to 10 seconds. Minimum value is
+                                    1.
+                                  format: int32
+                                  type: integer
+                                successThreshold:
+                                  description: Minimum consecutive successes for the
+                                    probe to be considered successful after having
+                                    failed. Defaults to 1. Must be 1 for liveness.
+                                    Minimum value is 1.
+                                  format: int32
+                                  type: integer
+                                tcpSocket:
+                                  description: 'TCPSocket specifies an action involving
+                                    a TCP port. TCP hooks not yet supported TODO:
+                                    implement a realistic TCP lifecycle hook'
+                                  properties:
+                                    host:
+                                      description: 'Optional: Host name to connect
+                                        to, defaults to the pod IP.'
+                                      type: string
+                                    port:
+                                      anyOf:
+                                      - type: string
+                                      - type: integer
+                                      description: Number or name of the port to access
+                                        on the container. Number must be in the range
+                                        1 to 65535. Name must be an IANA_SVC_NAME.
+                                  required:
+                                  - port
+                                  type: object
+                                timeoutSeconds:
+                                  description: 'Number of seconds after which the
+                                    probe times out. Defaults to 1 second. Minimum
+                                    value is 1. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                                  format: int32
+                                  type: integer
+                              type: object
+                            resources:
+                              description: 'Compute Resources required by this container.
+                                Cannot be updated. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
+                              properties:
+                                limits:
+                                  additionalProperties:
+                                    type: string
+                                  description: 'Limits describes the maximum amount
+                                    of compute resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
+                                  type: object
+                                requests:
+                                  additionalProperties:
+                                    type: string
+                                  description: 'Requests describes the minimum amount
+                                    of compute resources required. If Requests is
+                                    omitted for a container, it defaults to Limits
+                                    if that is explicitly specified, otherwise to
+                                    an implementation-defined value. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
+                                  type: object
+                              type: object
+                            securityContext:
+                              description: 'Security options the pod should run with.
+                                More info: https://kubernetes.io/docs/concepts/policy/security-context/
+                                More info: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/'
+                              properties:
+                                allowPrivilegeEscalation:
+                                  description: 'AllowPrivilegeEscalation controls
+                                    whether a process can gain more privileges than
+                                    its parent process. This bool directly controls
+                                    if the no_new_privs flag will be set on the container
+                                    process. AllowPrivilegeEscalation is true always
+                                    when the container is: 1) run as Privileged 2)
+                                    has CAP_SYS_ADMIN'
+                                  type: boolean
+                                capabilities:
+                                  description: The capabilities to add/drop when running
+                                    containers. Defaults to the default set of capabilities
+                                    granted by the container runtime.
+                                  properties:
+                                    add:
+                                      description: Added capabilities
+                                      items:
+                                        description: Capability represent POSIX capabilities
+                                          type
+                                        type: string
+                                      type: array
+                                    drop:
+                                      description: Removed capabilities
+                                      items:
+                                        description: Capability represent POSIX capabilities
+                                          type
+                                        type: string
+                                      type: array
+                                  type: object
+                                privileged:
+                                  description: Run container in privileged mode. Processes
+                                    in privileged containers are essentially equivalent
+                                    to root on the host. Defaults to false.
+                                  type: boolean
+                                procMount:
+                                  description: procMount denotes the type of proc
+                                    mount to use for the containers. The default is
+                                    DefaultProcMount which uses the container runtime
+                                    defaults for readonly paths and masked paths.
+                                    This requires the ProcMountType feature flag to
+                                    be enabled.
+                                  type: string
+                                readOnlyRootFilesystem:
+                                  description: Whether this container has a read-only
+                                    root filesystem. Default is false.
+                                  type: boolean
+                                runAsGroup:
+                                  description: The GID to run the entrypoint of the
+                                    container process. Uses runtime default if unset.
+                                    May also be set in PodSecurityContext.  If set
+                                    in both SecurityContext and PodSecurityContext,
+                                    the value specified in SecurityContext takes precedence.
+                                  format: int64
+                                  type: integer
+                                runAsNonRoot:
+                                  description: Indicates that the container must run
+                                    as a non-root user. If true, the Kubelet will
+                                    validate the image at runtime to ensure that it
+                                    does not run as UID 0 (root) and fail to start
+                                    the container if it does. If unset or false, no
+                                    such validation will be performed. May also be
+                                    set in PodSecurityContext.  If set in both SecurityContext
+                                    and PodSecurityContext, the value specified in
+                                    SecurityContext takes precedence.
+                                  type: boolean
+                                runAsUser:
+                                  description: The UID to run the entrypoint of the
+                                    container process. Defaults to user specified
+                                    in image metadata if unspecified. May also be
+                                    set in PodSecurityContext.  If set in both SecurityContext
+                                    and PodSecurityContext, the value specified in
+                                    SecurityContext takes precedence.
+                                  format: int64
+                                  type: integer
+                                seLinuxOptions:
+                                  description: The SELinux context to be applied to
+                                    the container. If unspecified, the container runtime
+                                    will allocate a random SELinux context for each
+                                    container.  May also be set in PodSecurityContext.  If
+                                    set in both SecurityContext and PodSecurityContext,
+                                    the value specified in SecurityContext takes precedence.
+                                  properties:
+                                    level:
+                                      description: Level is SELinux level label that
+                                        applies to the container.
+                                      type: string
+                                    role:
+                                      description: Role is a SELinux role label that
+                                        applies to the container.
+                                      type: string
+                                    type:
+                                      description: Type is a SELinux type label that
+                                        applies to the container.
+                                      type: string
+                                    user:
+                                      description: User is a SELinux user label that
+                                        applies to the container.
+                                      type: string
+                                  type: object
+                                windowsOptions:
+                                  description: Windows security options.
+                                  properties:
+                                    gmsaCredentialSpec:
+                                      description: GMSACredentialSpec is where the
+                                        GMSA admission webhook (https://github.com/kubernetes-sigs/windows-gmsa)
+                                        inlines the contents of the GMSA credential
+                                        spec named by the GMSACredentialSpecName field.
+                                        This field is alpha-level and is only honored
+                                        by servers that enable the WindowsGMSA feature
+                                        flag.
+                                      type: string
+                                    gmsaCredentialSpecName:
+                                      description: GMSACredentialSpecName is the name
+                                        of the GMSA credential spec to use. This field
+                                        is alpha-level and is only honored by servers
+                                        that enable the WindowsGMSA feature flag.
+                                      type: string
+                                  type: object
+                              type: object
+                            stdin:
+                              description: Whether this container should allocate
+                                a buffer for stdin in the container runtime. If this
+                                is not set, reads from stdin in the container will
+                                always result in EOF. Default is false.
+                              type: boolean
+                            stdinOnce:
+                              description: Whether the container runtime should close
+                                the stdin channel after it has been opened by a single
+                                attach. When stdin is true the stdin stream will remain
+                                open across multiple attach sessions. If stdinOnce
+                                is set to true, stdin is opened on container start,
+                                is empty until the first client attaches to stdin,
+                                and then remains open and accepts data until the client
+                                disconnects, at which time stdin is closed and remains
+                                closed until the container is restarted. If this flag
+                                is false, a container processes that reads from stdin
+                                will never receive an EOF. Default is false
+                              type: boolean
+                            terminationMessagePath:
+                              description: 'Optional: Path at which the file to which
+                                the container''s termination message will be written
+                                is mounted into the container''s filesystem. Message
+                                written is intended to be brief final status, such
+                                as an assertion failure message. Will be truncated
+                                by the node if greater than 4096 bytes. The total
+                                message length across all containers will be limited
+                                to 12kb. Defaults to /dev/termination-log. Cannot
+                                be updated.'
+                              type: string
+                            terminationMessagePolicy:
+                              description: Indicate how the termination message should
+                                be populated. File will use the contents of terminationMessagePath
+                                to populate the container status message on both success
+                                and failure. FallbackToLogsOnError will use the last
+                                chunk of container log output if the termination message
+                                file is empty and the container exited with an error.
+                                The log output is limited to 2048 bytes or 80 lines,
+                                whichever is smaller. Defaults to File. Cannot be
+                                updated.
+                              type: string
+                            tty:
+                              description: Whether this container should allocate
+                                a TTY for itself, also requires 'stdin' to be true.
+                                Default is false.
+                              type: boolean
+                            volumeDevices:
+                              description: volumeDevices is the list of block devices
+                                to be used by the container. This is a beta feature.
+                              items:
+                                description: volumeDevice describes a mapping of a
+                                  raw block device within a container.
+                                properties:
+                                  devicePath:
+                                    description: devicePath is the path inside of
+                                      the container that the device will be mapped
+                                      to.
+                                    type: string
+                                  name:
+                                    description: name must match the name of a persistentVolumeClaim
+                                      in the pod
+                                    type: string
+                                required:
+                                - devicePath
+                                - name
+                                type: object
+                              type: array
+                            volumeMounts:
+                              description: Pod volumes to mount into the container's
+                                filesystem. Cannot be updated.
+                              items:
+                                description: VolumeMount describes a mounting of a
+                                  Volume within a container.
+                                properties:
+                                  mountPath:
+                                    description: Path within the container at which
+                                      the volume should be mounted.  Must not contain
+                                      ':'.
+                                    type: string
+                                  mountPropagation:
+                                    description: mountPropagation determines how mounts
+                                      are propagated from the host to container and
+                                      the other way around. When not set, MountPropagationNone
+                                      is used. This field is beta in 1.10.
+                                    type: string
+                                  name:
+                                    description: This must match the Name of a Volume.
+                                    type: string
+                                  readOnly:
+                                    description: Mounted read-only if true, read-write
+                                      otherwise (false or unspecified). Defaults to
+                                      false.
+                                    type: boolean
+                                  subPath:
+                                    description: Path within the volume from which
+                                      the container's volume should be mounted. Defaults
+                                      to "" (volume's root).
+                                    type: string
+                                  subPathExpr:
+                                    description: Expanded path within the volume from
+                                      which the container's volume should be mounted.
+                                      Behaves similarly to SubPath but environment
+                                      variable references $(VAR_NAME) are expanded
+                                      using the container's environment. Defaults
+                                      to "" (volume's root). SubPathExpr and SubPath
+                                      are mutually exclusive. This field is beta in
+                                      1.15.
+                                    type: string
+                                required:
+                                - mountPath
+                                - name
+                                type: object
+                              type: array
+                            workingDir:
+                              description: Container's working directory. If not specified,
+                                the container runtime's default will be used, which
+                                might be configured in the container image. Cannot
+                                be updated.
+                              type: string
+                          required:
+                          - name
+                          type: object
+                      required:
+                      - container
+                      type: object
+                    logger:
+                      description: Activate request/response logging
+                      properties:
+                        mode:
+                          description: What payloads to log
+                          type: string
+                        url:
+                          description: URL to send request logging CloudEvents
+                          type: string
+                      type: object
+                    maxReplicas:
+                      description: This is the up bound for autoscaler to scale to
+                      type: integer
+                    minReplicas:
+                      description: Minimum number of replicas, pods won't scale down
+                        to 0 in case of no traffic
+                      type: integer
+                    parallelism:
+                      description: Parallelism specifies how many requests can be
+                        processed concurrently, this sets the target concurrency for
+                        Autoscaling(KPA). For model servers that support tuning parallelism
+                        will use this value, by default the parallelism is the number
+                        of the CPU cores for most of the model servers.
+                      type: integer
+                    serviceAccountName:
+                      description: ServiceAccountName is the name of the ServiceAccount
+                        to use to run the service
+                      type: string
+                  type: object
+              required:
+              - predictor
+              type: object
+            canaryTrafficPercent:
+              description: CanaryTrafficPercent defines the percentage of traffic
+                going to canary InferenceService endpoints
+              type: integer
+            default:
+              description: Default defines default InferenceService endpoints
+              properties:
+                explainer:
+                  description: Explainer defines the model explanation service spec,
+                    explainer service calls to predictor or transformer if it is specified.
+                  properties:
+                    alibi:
+                      description: Spec for alibi explainer
+                      properties:
+                        config:
+                          additionalProperties:
+                            type: string
+                          description: Inline custom parameter settings for explainer
+                          type: object
+                        resources:
+                          description: Defaults to requests and limits of 1CPU, 2Gb
+                            MEM.
+                          properties:
+                            limits:
+                              additionalProperties:
+                                type: string
+                              description: 'Limits describes the maximum amount of
+                                compute resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
+                              type: object
+                            requests:
+                              additionalProperties:
+                                type: string
+                              description: 'Requests describes the minimum amount
+                                of compute resources required. If Requests is omitted
+                                for a container, it defaults to Limits if that is
+                                explicitly specified, otherwise to an implementation-defined
+                                value. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
+                              type: object
+                          type: object
+                        runtimeVersion:
+                          description: Defaults to latest Alibi Version
+                          type: string
+                        storageUri:
+                          description: The location of a trained explanation model
+                          type: string
+                        type:
+                          description: The type of Alibi explainer
+                          type: string
+                      required:
+                      - type
+                      type: object
+                    custom:
+                      description: Spec for a custom explainer
+                      properties:
+                        container:
+                          description: A single application container that you want
+                            to run within a pod.
+                          properties:
+                            args:
+                              description: 'Arguments to the entrypoint. The docker
+                                image''s CMD is used if this is not provided. Variable
+                                references $(VAR_NAME) are expanded using the container''s
+                                environment. If a variable cannot be resolved, the
+                                reference in the input string will be unchanged. The
+                                $(VAR_NAME) syntax can be escaped with a double $$,
+                                ie: $$(VAR_NAME). Escaped references will never be
+                                expanded, regardless of whether the variable exists
+                                or not. Cannot be updated. More info: https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell'
+                              items:
+                                type: string
+                              type: array
+                            command:
+                              description: 'Entrypoint array. Not executed within
+                                a shell. The docker image''s ENTRYPOINT is used if
+                                this is not provided. Variable references $(VAR_NAME)
+                                are expanded using the container''s environment. If
+                                a variable cannot be resolved, the reference in the
+                                input string will be unchanged. The $(VAR_NAME) syntax
+                                can be escaped with a double $$, ie: $$(VAR_NAME).
+                                Escaped references will never be expanded, regardless
+                                of whether the variable exists or not. Cannot be updated.
+                                More info: https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell'
+                              items:
+                                type: string
+                              type: array
+                            env:
+                              description: List of environment variables to set in
+                                the container. Cannot be updated.
+                              items:
+                                description: EnvVar represents an environment variable
+                                  present in a Container.
+                                properties:
+                                  name:
+                                    description: Name of the environment variable.
+                                      Must be a C_IDENTIFIER.
+                                    type: string
+                                  value:
+                                    description: 'Variable references $(VAR_NAME)
+                                      are expanded using the previous defined environment
+                                      variables in the container and any service environment
+                                      variables. If a variable cannot be resolved,
+                                      the reference in the input string will be unchanged.
+                                      The $(VAR_NAME) syntax can be escaped with a
+                                      double $$, ie: $$(VAR_NAME). Escaped references
+                                      will never be expanded, regardless of whether
+                                      the variable exists or not. Defaults to "".'
+                                    type: string
+                                  valueFrom:
+                                    description: Source for the environment variable's
+                                      value. Cannot be used if value is not empty.
+                                    properties:
+                                      configMapKeyRef:
+                                        description: Selects a key of a ConfigMap.
+                                        properties:
+                                          key:
+                                            description: The key to select.
+                                            type: string
+                                          name:
+                                            description: 'Name of the referent. More
+                                              info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                              TODO: Add other useful fields. apiVersion,
+                                              kind, uid?'
+                                            type: string
+                                          optional:
+                                            description: Specify whether the ConfigMap
+                                              or its key must be defined
+                                            type: boolean
+                                        required:
+                                        - key
+                                        type: object
+                                      fieldRef:
+                                        description: 'Selects a field of the pod:
+                                          supports metadata.name, metadata.namespace,
+                                          metadata.labels, metadata.annotations, spec.nodeName,
+                                          spec.serviceAccountName, status.hostIP,
+                                          status.podIP.'
+                                        properties:
+                                          apiVersion:
+                                            description: Version of the schema the
+                                              FieldPath is written in terms of, defaults
+                                              to "v1".
+                                            type: string
+                                          fieldPath:
+                                            description: Path of the field to select
+                                              in the specified API version.
+                                            type: string
+                                        required:
+                                        - fieldPath
+                                        type: object
+                                      resourceFieldRef:
+                                        description: 'Selects a resource of the container:
+                                          only resources limits and requests (limits.cpu,
+                                          limits.memory, limits.ephemeral-storage,
+                                          requests.cpu, requests.memory and requests.ephemeral-storage)
+                                          are currently supported.'
+                                        properties:
+                                          containerName:
+                                            description: 'Container name: required
+                                              for volumes, optional for env vars'
+                                            type: string
+                                          divisor:
+                                            description: Specifies the output format
+                                              of the exposed resources, defaults to
+                                              "1"
+                                            type: string
+                                          resource:
+                                            description: 'Required: resource to select'
+                                            type: string
+                                        required:
+                                        - resource
+                                        type: object
+                                      secretKeyRef:
+                                        description: Selects a key of a secret in
+                                          the pod's namespace
+                                        properties:
+                                          key:
+                                            description: The key of the secret to
+                                              select from.  Must be a valid secret
+                                              key.
+                                            type: string
+                                          name:
+                                            description: 'Name of the referent. More
+                                              info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                              TODO: Add other useful fields. apiVersion,
+                                              kind, uid?'
+                                            type: string
+                                          optional:
+                                            description: Specify whether the Secret
+                                              or its key must be defined
+                                            type: boolean
+                                        required:
+                                        - key
+                                        type: object
+                                    type: object
+                                required:
+                                - name
+                                type: object
+                              type: array
+                            envFrom:
+                              description: List of sources to populate environment
+                                variables in the container. The keys defined within
+                                a source must be a C_IDENTIFIER. All invalid keys
+                                will be reported as an event when the container is
+                                starting. When a key exists in multiple sources, the
+                                value associated with the last source will take precedence.
+                                Values defined by an Env with a duplicate key will
+                                take precedence. Cannot be updated.
+                              items:
+                                description: EnvFromSource represents the source of
+                                  a set of ConfigMaps
+                                properties:
+                                  configMapRef:
+                                    description: The ConfigMap to select from
+                                    properties:
+                                      name:
+                                        description: 'Name of the referent. More info:
+                                          https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                          TODO: Add other useful fields. apiVersion,
+                                          kind, uid?'
+                                        type: string
+                                      optional:
+                                        description: Specify whether the ConfigMap
+                                          must be defined
+                                        type: boolean
+                                    type: object
+                                  prefix:
+                                    description: An optional identifier to prepend
+                                      to each key in the ConfigMap. Must be a C_IDENTIFIER.
+                                    type: string
+                                  secretRef:
+                                    description: The Secret to select from
+                                    properties:
+                                      name:
+                                        description: 'Name of the referent. More info:
+                                          https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                          TODO: Add other useful fields. apiVersion,
+                                          kind, uid?'
+                                        type: string
+                                      optional:
+                                        description: Specify whether the Secret must
+                                          be defined
+                                        type: boolean
+                                    type: object
+                                type: object
+                              type: array
+                            image:
+                              description: 'Docker image name. More info: https://kubernetes.io/docs/concepts/containers/images
+                                This field is optional to allow higher level config
+                                management to default or override container images
+                                in workload controllers like Deployments and StatefulSets.'
+                              type: string
+                            imagePullPolicy:
+                              description: 'Image pull policy. One of Always, Never,
+                                IfNotPresent. Defaults to Always if :v0.3.0 tag is
+                                specified, or IfNotPresent otherwise. Cannot be updated.
+                                More info: https://kubernetes.io/docs/concepts/containers/images#updating-images'
+                              type: string
+                            lifecycle:
+                              description: Actions that the management system should
+                                take in response to container lifecycle events. Cannot
+                                be updated.
+                              properties:
+                                postStart:
+                                  description: 'PostStart is called immediately after
+                                    a container is created. If the handler fails,
+                                    the container is terminated and restarted according
+                                    to its restart policy. Other management of the
+                                    container blocks until the hook completes. More
+                                    info: https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/#container-hooks'
+                                  properties:
+                                    exec:
+                                      description: One and only one of the following
+                                        should be specified. Exec specifies the action
+                                        to take.
+                                      properties:
+                                        command:
+                                          description: Command is the command line
+                                            to execute inside the container, the working
+                                            directory for the command  is root ('/')
+                                            in the container's filesystem. The command
+                                            is simply exec'd, it is not run inside
+                                            a shell, so traditional shell instructions
+                                            ('|', etc) won't work. To use a shell,
+                                            you need to explicitly call out to that
+                                            shell. Exit status of 0 is treated as
+                                            live/healthy and non-zero is unhealthy.
+                                          items:
+                                            type: string
+                                          type: array
+                                      type: object
+                                    httpGet:
+                                      description: HTTPGet specifies the http request
+                                        to perform.
+                                      properties:
+                                        host:
+                                          description: Host name to connect to, defaults
+                                            to the pod IP. You probably want to set
+                                            "Host" in httpHeaders instead.
+                                          type: string
+                                        httpHeaders:
+                                          description: Custom headers to set in the
+                                            request. HTTP allows repeated headers.
+                                          items:
+                                            description: HTTPHeader describes a custom
+                                              header to be used in HTTP probes
+                                            properties:
+                                              name:
+                                                description: The header field name
+                                                type: string
+                                              value:
+                                                description: The header field value
+                                                type: string
+                                            required:
+                                            - name
+                                            - value
+                                            type: object
+                                          type: array
+                                        path:
+                                          description: Path to access on the HTTP
+                                            server.
+                                          type: string
+                                        port:
+                                          anyOf:
+                                          - type: string
+                                          - type: integer
+                                          description: Name or number of the port
+                                            to access on the container. Number must
+                                            be in the range 1 to 65535. Name must
+                                            be an IANA_SVC_NAME.
+                                        scheme:
+                                          description: Scheme to use for connecting
+                                            to the host. Defaults to HTTP.
+                                          type: string
+                                      required:
+                                      - port
+                                      type: object
+                                    tcpSocket:
+                                      description: 'TCPSocket specifies an action
+                                        involving a TCP port. TCP hooks not yet supported
+                                        TODO: implement a realistic TCP lifecycle
+                                        hook'
+                                      properties:
+                                        host:
+                                          description: 'Optional: Host name to connect
+                                            to, defaults to the pod IP.'
+                                          type: string
+                                        port:
+                                          anyOf:
+                                          - type: string
+                                          - type: integer
+                                          description: Number or name of the port
+                                            to access on the container. Number must
+                                            be in the range 1 to 65535. Name must
+                                            be an IANA_SVC_NAME.
+                                      required:
+                                      - port
+                                      type: object
+                                  type: object
+                                preStop:
+                                  description: 'PreStop is called immediately before
+                                    a container is terminated due to an API request
+                                    or management event such as liveness probe failure,
+                                    preemption, resource contention, etc. The handler
+                                    is not called if the container crashes or exits.
+                                    The reason for termination is passed to the handler.
+                                    The Pod''s termination grace period countdown
+                                    begins before the PreStop hooked is executed.
+                                    Regardless of the outcome of the handler, the
+                                    container will eventually terminate within the
+                                    Pod''s termination grace period. Other management
+                                    of the container blocks until the hook completes
+                                    or until the termination grace period is reached.
+                                    More info: https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/#container-hooks'
+                                  properties:
+                                    exec:
+                                      description: One and only one of the following
+                                        should be specified. Exec specifies the action
+                                        to take.
+                                      properties:
+                                        command:
+                                          description: Command is the command line
+                                            to execute inside the container, the working
+                                            directory for the command  is root ('/')
+                                            in the container's filesystem. The command
+                                            is simply exec'd, it is not run inside
+                                            a shell, so traditional shell instructions
+                                            ('|', etc) won't work. To use a shell,
+                                            you need to explicitly call out to that
+                                            shell. Exit status of 0 is treated as
+                                            live/healthy and non-zero is unhealthy.
+                                          items:
+                                            type: string
+                                          type: array
+                                      type: object
+                                    httpGet:
+                                      description: HTTPGet specifies the http request
+                                        to perform.
+                                      properties:
+                                        host:
+                                          description: Host name to connect to, defaults
+                                            to the pod IP. You probably want to set
+                                            "Host" in httpHeaders instead.
+                                          type: string
+                                        httpHeaders:
+                                          description: Custom headers to set in the
+                                            request. HTTP allows repeated headers.
+                                          items:
+                                            description: HTTPHeader describes a custom
+                                              header to be used in HTTP probes
+                                            properties:
+                                              name:
+                                                description: The header field name
+                                                type: string
+                                              value:
+                                                description: The header field value
+                                                type: string
+                                            required:
+                                            - name
+                                            - value
+                                            type: object
+                                          type: array
+                                        path:
+                                          description: Path to access on the HTTP
+                                            server.
+                                          type: string
+                                        port:
+                                          anyOf:
+                                          - type: string
+                                          - type: integer
+                                          description: Name or number of the port
+                                            to access on the container. Number must
+                                            be in the range 1 to 65535. Name must
+                                            be an IANA_SVC_NAME.
+                                        scheme:
+                                          description: Scheme to use for connecting
+                                            to the host. Defaults to HTTP.
+                                          type: string
+                                      required:
+                                      - port
+                                      type: object
+                                    tcpSocket:
+                                      description: 'TCPSocket specifies an action
+                                        involving a TCP port. TCP hooks not yet supported
+                                        TODO: implement a realistic TCP lifecycle
+                                        hook'
+                                      properties:
+                                        host:
+                                          description: 'Optional: Host name to connect
+                                            to, defaults to the pod IP.'
+                                          type: string
+                                        port:
+                                          anyOf:
+                                          - type: string
+                                          - type: integer
+                                          description: Number or name of the port
+                                            to access on the container. Number must
+                                            be in the range 1 to 65535. Name must
+                                            be an IANA_SVC_NAME.
+                                      required:
+                                      - port
+                                      type: object
+                                  type: object
+                              type: object
+                            livenessProbe:
+                              description: 'Periodic probe of container liveness.
+                                Container will be restarted if the probe fails. Cannot
+                                be updated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                              properties:
+                                exec:
+                                  description: One and only one of the following should
+                                    be specified. Exec specifies the action to take.
+                                  properties:
+                                    command:
+                                      description: Command is the command line to
+                                        execute inside the container, the working
+                                        directory for the command  is root ('/') in
+                                        the container's filesystem. The command is
+                                        simply exec'd, it is not run inside a shell,
+                                        so traditional shell instructions ('|', etc)
+                                        won't work. To use a shell, you need to explicitly
+                                        call out to that shell. Exit status of 0 is
+                                        treated as live/healthy and non-zero is unhealthy.
+                                      items:
+                                        type: string
+                                      type: array
+                                  type: object
+                                failureThreshold:
+                                  description: Minimum consecutive failures for the
+                                    probe to be considered failed after having succeeded.
+                                    Defaults to 3. Minimum value is 1.
+                                  format: int32
+                                  type: integer
+                                httpGet:
+                                  description: HTTPGet specifies the http request
+                                    to perform.
+                                  properties:
+                                    host:
+                                      description: Host name to connect to, defaults
+                                        to the pod IP. You probably want to set "Host"
+                                        in httpHeaders instead.
+                                      type: string
+                                    httpHeaders:
+                                      description: Custom headers to set in the request.
+                                        HTTP allows repeated headers.
+                                      items:
+                                        description: HTTPHeader describes a custom
+                                          header to be used in HTTP probes
+                                        properties:
+                                          name:
+                                            description: The header field name
+                                            type: string
+                                          value:
+                                            description: The header field value
+                                            type: string
+                                        required:
+                                        - name
+                                        - value
+                                        type: object
+                                      type: array
+                                    path:
+                                      description: Path to access on the HTTP server.
+                                      type: string
+                                    port:
+                                      anyOf:
+                                      - type: string
+                                      - type: integer
+                                      description: Name or number of the port to access
+                                        on the container. Number must be in the range
+                                        1 to 65535. Name must be an IANA_SVC_NAME.
+                                    scheme:
+                                      description: Scheme to use for connecting to
+                                        the host. Defaults to HTTP.
+                                      type: string
+                                  required:
+                                  - port
+                                  type: object
+                                initialDelaySeconds:
+                                  description: 'Number of seconds after the container
+                                    has started before liveness probes are initiated.
+                                    More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                                  format: int32
+                                  type: integer
+                                periodSeconds:
+                                  description: How often (in seconds) to perform the
+                                    probe. Default to 10 seconds. Minimum value is
+                                    1.
+                                  format: int32
+                                  type: integer
+                                successThreshold:
+                                  description: Minimum consecutive successes for the
+                                    probe to be considered successful after having
+                                    failed. Defaults to 1. Must be 1 for liveness.
+                                    Minimum value is 1.
+                                  format: int32
+                                  type: integer
+                                tcpSocket:
+                                  description: 'TCPSocket specifies an action involving
+                                    a TCP port. TCP hooks not yet supported TODO:
+                                    implement a realistic TCP lifecycle hook'
+                                  properties:
+                                    host:
+                                      description: 'Optional: Host name to connect
+                                        to, defaults to the pod IP.'
+                                      type: string
+                                    port:
+                                      anyOf:
+                                      - type: string
+                                      - type: integer
+                                      description: Number or name of the port to access
+                                        on the container. Number must be in the range
+                                        1 to 65535. Name must be an IANA_SVC_NAME.
+                                  required:
+                                  - port
+                                  type: object
+                                timeoutSeconds:
+                                  description: 'Number of seconds after which the
+                                    probe times out. Defaults to 1 second. Minimum
+                                    value is 1. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                                  format: int32
+                                  type: integer
+                              type: object
+                            name:
+                              description: Name of the container specified as a DNS_LABEL.
+                                Each container in a pod must have a unique name (DNS_LABEL).
+                                Cannot be updated.
+                              type: string
+                            ports:
+                              description: List of ports to expose from the container.
+                                Exposing a port here gives the system additional information
+                                about the network connections a container uses, but
+                                is primarily informational. Not specifying a port
+                                here DOES NOT prevent that port from being exposed.
+                                Any port which is listening on the default "0.0.0.0"
+                                address inside a container will be accessible from
+                                the network. Cannot be updated.
+                              items:
+                                description: ContainerPort represents a network port
+                                  in a single container.
+                                properties:
+                                  containerPort:
+                                    description: Number of port to expose on the pod's
+                                      IP address. This must be a valid port number,
+                                      0 < x < 65536.
+                                    format: int32
+                                    type: integer
+                                  hostIP:
+                                    description: What host IP to bind the external
+                                      port to.
+                                    type: string
+                                  hostPort:
+                                    description: Number of port to expose on the host.
+                                      If specified, this must be a valid port number,
+                                      0 < x < 65536. If HostNetwork is specified,
+                                      this must match ContainerPort. Most containers
+                                      do not need this.
+                                    format: int32
+                                    type: integer
+                                  name:
+                                    description: If specified, this must be an IANA_SVC_NAME
+                                      and unique within the pod. Each named port in
+                                      a pod must have a unique name. Name for the
+                                      port that can be referred to by services.
+                                    type: string
+                                  protocol:
+                                    description: Protocol for port. Must be UDP, TCP,
+                                      or SCTP. Defaults to "TCP".
+                                    type: string
+                                required:
+                                - containerPort
+                                type: object
+                              type: array
+                            readinessProbe:
+                              description: 'Periodic probe of container service readiness.
+                                Container will be removed from service endpoints if
+                                the probe fails. Cannot be updated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                              properties:
+                                exec:
+                                  description: One and only one of the following should
+                                    be specified. Exec specifies the action to take.
+                                  properties:
+                                    command:
+                                      description: Command is the command line to
+                                        execute inside the container, the working
+                                        directory for the command  is root ('/') in
+                                        the container's filesystem. The command is
+                                        simply exec'd, it is not run inside a shell,
+                                        so traditional shell instructions ('|', etc)
+                                        won't work. To use a shell, you need to explicitly
+                                        call out to that shell. Exit status of 0 is
+                                        treated as live/healthy and non-zero is unhealthy.
+                                      items:
+                                        type: string
+                                      type: array
+                                  type: object
+                                failureThreshold:
+                                  description: Minimum consecutive failures for the
+                                    probe to be considered failed after having succeeded.
+                                    Defaults to 3. Minimum value is 1.
+                                  format: int32
+                                  type: integer
+                                httpGet:
+                                  description: HTTPGet specifies the http request
+                                    to perform.
+                                  properties:
+                                    host:
+                                      description: Host name to connect to, defaults
+                                        to the pod IP. You probably want to set "Host"
+                                        in httpHeaders instead.
+                                      type: string
+                                    httpHeaders:
+                                      description: Custom headers to set in the request.
+                                        HTTP allows repeated headers.
+                                      items:
+                                        description: HTTPHeader describes a custom
+                                          header to be used in HTTP probes
+                                        properties:
+                                          name:
+                                            description: The header field name
+                                            type: string
+                                          value:
+                                            description: The header field value
+                                            type: string
+                                        required:
+                                        - name
+                                        - value
+                                        type: object
+                                      type: array
+                                    path:
+                                      description: Path to access on the HTTP server.
+                                      type: string
+                                    port:
+                                      anyOf:
+                                      - type: string
+                                      - type: integer
+                                      description: Name or number of the port to access
+                                        on the container. Number must be in the range
+                                        1 to 65535. Name must be an IANA_SVC_NAME.
+                                    scheme:
+                                      description: Scheme to use for connecting to
+                                        the host. Defaults to HTTP.
+                                      type: string
+                                  required:
+                                  - port
+                                  type: object
+                                initialDelaySeconds:
+                                  description: 'Number of seconds after the container
+                                    has started before liveness probes are initiated.
+                                    More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                                  format: int32
+                                  type: integer
+                                periodSeconds:
+                                  description: How often (in seconds) to perform the
+                                    probe. Default to 10 seconds. Minimum value is
+                                    1.
+                                  format: int32
+                                  type: integer
+                                successThreshold:
+                                  description: Minimum consecutive successes for the
+                                    probe to be considered successful after having
+                                    failed. Defaults to 1. Must be 1 for liveness.
+                                    Minimum value is 1.
+                                  format: int32
+                                  type: integer
+                                tcpSocket:
+                                  description: 'TCPSocket specifies an action involving
+                                    a TCP port. TCP hooks not yet supported TODO:
+                                    implement a realistic TCP lifecycle hook'
+                                  properties:
+                                    host:
+                                      description: 'Optional: Host name to connect
+                                        to, defaults to the pod IP.'
+                                      type: string
+                                    port:
+                                      anyOf:
+                                      - type: string
+                                      - type: integer
+                                      description: Number or name of the port to access
+                                        on the container. Number must be in the range
+                                        1 to 65535. Name must be an IANA_SVC_NAME.
+                                  required:
+                                  - port
+                                  type: object
+                                timeoutSeconds:
+                                  description: 'Number of seconds after which the
+                                    probe times out. Defaults to 1 second. Minimum
+                                    value is 1. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                                  format: int32
+                                  type: integer
+                              type: object
+                            resources:
+                              description: 'Compute Resources required by this container.
+                                Cannot be updated. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
+                              properties:
+                                limits:
+                                  additionalProperties:
+                                    type: string
+                                  description: 'Limits describes the maximum amount
+                                    of compute resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
+                                  type: object
+                                requests:
+                                  additionalProperties:
+                                    type: string
+                                  description: 'Requests describes the minimum amount
+                                    of compute resources required. If Requests is
+                                    omitted for a container, it defaults to Limits
+                                    if that is explicitly specified, otherwise to
+                                    an implementation-defined value. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
+                                  type: object
+                              type: object
+                            securityContext:
+                              description: 'Security options the pod should run with.
+                                More info: https://kubernetes.io/docs/concepts/policy/security-context/
+                                More info: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/'
+                              properties:
+                                allowPrivilegeEscalation:
+                                  description: 'AllowPrivilegeEscalation controls
+                                    whether a process can gain more privileges than
+                                    its parent process. This bool directly controls
+                                    if the no_new_privs flag will be set on the container
+                                    process. AllowPrivilegeEscalation is true always
+                                    when the container is: 1) run as Privileged 2)
+                                    has CAP_SYS_ADMIN'
+                                  type: boolean
+                                capabilities:
+                                  description: The capabilities to add/drop when running
+                                    containers. Defaults to the default set of capabilities
+                                    granted by the container runtime.
+                                  properties:
+                                    add:
+                                      description: Added capabilities
+                                      items:
+                                        description: Capability represent POSIX capabilities
+                                          type
+                                        type: string
+                                      type: array
+                                    drop:
+                                      description: Removed capabilities
+                                      items:
+                                        description: Capability represent POSIX capabilities
+                                          type
+                                        type: string
+                                      type: array
+                                  type: object
+                                privileged:
+                                  description: Run container in privileged mode. Processes
+                                    in privileged containers are essentially equivalent
+                                    to root on the host. Defaults to false.
+                                  type: boolean
+                                procMount:
+                                  description: procMount denotes the type of proc
+                                    mount to use for the containers. The default is
+                                    DefaultProcMount which uses the container runtime
+                                    defaults for readonly paths and masked paths.
+                                    This requires the ProcMountType feature flag to
+                                    be enabled.
+                                  type: string
+                                readOnlyRootFilesystem:
+                                  description: Whether this container has a read-only
+                                    root filesystem. Default is false.
+                                  type: boolean
+                                runAsGroup:
+                                  description: The GID to run the entrypoint of the
+                                    container process. Uses runtime default if unset.
+                                    May also be set in PodSecurityContext.  If set
+                                    in both SecurityContext and PodSecurityContext,
+                                    the value specified in SecurityContext takes precedence.
+                                  format: int64
+                                  type: integer
+                                runAsNonRoot:
+                                  description: Indicates that the container must run
+                                    as a non-root user. If true, the Kubelet will
+                                    validate the image at runtime to ensure that it
+                                    does not run as UID 0 (root) and fail to start
+                                    the container if it does. If unset or false, no
+                                    such validation will be performed. May also be
+                                    set in PodSecurityContext.  If set in both SecurityContext
+                                    and PodSecurityContext, the value specified in
+                                    SecurityContext takes precedence.
+                                  type: boolean
+                                runAsUser:
+                                  description: The UID to run the entrypoint of the
+                                    container process. Defaults to user specified
+                                    in image metadata if unspecified. May also be
+                                    set in PodSecurityContext.  If set in both SecurityContext
+                                    and PodSecurityContext, the value specified in
+                                    SecurityContext takes precedence.
+                                  format: int64
+                                  type: integer
+                                seLinuxOptions:
+                                  description: The SELinux context to be applied to
+                                    the container. If unspecified, the container runtime
+                                    will allocate a random SELinux context for each
+                                    container.  May also be set in PodSecurityContext.  If
+                                    set in both SecurityContext and PodSecurityContext,
+                                    the value specified in SecurityContext takes precedence.
+                                  properties:
+                                    level:
+                                      description: Level is SELinux level label that
+                                        applies to the container.
+                                      type: string
+                                    role:
+                                      description: Role is a SELinux role label that
+                                        applies to the container.
+                                      type: string
+                                    type:
+                                      description: Type is a SELinux type label that
+                                        applies to the container.
+                                      type: string
+                                    user:
+                                      description: User is a SELinux user label that
+                                        applies to the container.
+                                      type: string
+                                  type: object
+                                windowsOptions:
+                                  description: Windows security options.
+                                  properties:
+                                    gmsaCredentialSpec:
+                                      description: GMSACredentialSpec is where the
+                                        GMSA admission webhook (https://github.com/kubernetes-sigs/windows-gmsa)
+                                        inlines the contents of the GMSA credential
+                                        spec named by the GMSACredentialSpecName field.
+                                        This field is alpha-level and is only honored
+                                        by servers that enable the WindowsGMSA feature
+                                        flag.
+                                      type: string
+                                    gmsaCredentialSpecName:
+                                      description: GMSACredentialSpecName is the name
+                                        of the GMSA credential spec to use. This field
+                                        is alpha-level and is only honored by servers
+                                        that enable the WindowsGMSA feature flag.
+                                      type: string
+                                  type: object
+                              type: object
+                            stdin:
+                              description: Whether this container should allocate
+                                a buffer for stdin in the container runtime. If this
+                                is not set, reads from stdin in the container will
+                                always result in EOF. Default is false.
+                              type: boolean
+                            stdinOnce:
+                              description: Whether the container runtime should close
+                                the stdin channel after it has been opened by a single
+                                attach. When stdin is true the stdin stream will remain
+                                open across multiple attach sessions. If stdinOnce
+                                is set to true, stdin is opened on container start,
+                                is empty until the first client attaches to stdin,
+                                and then remains open and accepts data until the client
+                                disconnects, at which time stdin is closed and remains
+                                closed until the container is restarted. If this flag
+                                is false, a container processes that reads from stdin
+                                will never receive an EOF. Default is false
+                              type: boolean
+                            terminationMessagePath:
+                              description: 'Optional: Path at which the file to which
+                                the container''s termination message will be written
+                                is mounted into the container''s filesystem. Message
+                                written is intended to be brief final status, such
+                                as an assertion failure message. Will be truncated
+                                by the node if greater than 4096 bytes. The total
+                                message length across all containers will be limited
+                                to 12kb. Defaults to /dev/termination-log. Cannot
+                                be updated.'
+                              type: string
+                            terminationMessagePolicy:
+                              description: Indicate how the termination message should
+                                be populated. File will use the contents of terminationMessagePath
+                                to populate the container status message on both success
+                                and failure. FallbackToLogsOnError will use the last
+                                chunk of container log output if the termination message
+                                file is empty and the container exited with an error.
+                                The log output is limited to 2048 bytes or 80 lines,
+                                whichever is smaller. Defaults to File. Cannot be
+                                updated.
+                              type: string
+                            tty:
+                              description: Whether this container should allocate
+                                a TTY for itself, also requires 'stdin' to be true.
+                                Default is false.
+                              type: boolean
+                            volumeDevices:
+                              description: volumeDevices is the list of block devices
+                                to be used by the container. This is a beta feature.
+                              items:
+                                description: volumeDevice describes a mapping of a
+                                  raw block device within a container.
+                                properties:
+                                  devicePath:
+                                    description: devicePath is the path inside of
+                                      the container that the device will be mapped
+                                      to.
+                                    type: string
+                                  name:
+                                    description: name must match the name of a persistentVolumeClaim
+                                      in the pod
+                                    type: string
+                                required:
+                                - devicePath
+                                - name
+                                type: object
+                              type: array
+                            volumeMounts:
+                              description: Pod volumes to mount into the container's
+                                filesystem. Cannot be updated.
+                              items:
+                                description: VolumeMount describes a mounting of a
+                                  Volume within a container.
+                                properties:
+                                  mountPath:
+                                    description: Path within the container at which
+                                      the volume should be mounted.  Must not contain
+                                      ':'.
+                                    type: string
+                                  mountPropagation:
+                                    description: mountPropagation determines how mounts
+                                      are propagated from the host to container and
+                                      the other way around. When not set, MountPropagationNone
+                                      is used. This field is beta in 1.10.
+                                    type: string
+                                  name:
+                                    description: This must match the Name of a Volume.
+                                    type: string
+                                  readOnly:
+                                    description: Mounted read-only if true, read-write
+                                      otherwise (false or unspecified). Defaults to
+                                      false.
+                                    type: boolean
+                                  subPath:
+                                    description: Path within the volume from which
+                                      the container's volume should be mounted. Defaults
+                                      to "" (volume's root).
+                                    type: string
+                                  subPathExpr:
+                                    description: Expanded path within the volume from
+                                      which the container's volume should be mounted.
+                                      Behaves similarly to SubPath but environment
+                                      variable references $(VAR_NAME) are expanded
+                                      using the container's environment. Defaults
+                                      to "" (volume's root). SubPathExpr and SubPath
+                                      are mutually exclusive. This field is beta in
+                                      1.15.
+                                    type: string
+                                required:
+                                - mountPath
+                                - name
+                                type: object
+                              type: array
+                            workingDir:
+                              description: Container's working directory. If not specified,
+                                the container runtime's default will be used, which
+                                might be configured in the container image. Cannot
+                                be updated.
+                              type: string
+                          required:
+                          - name
+                          type: object
+                      required:
+                      - container
+                      type: object
+                    logger:
+                      description: Activate request/response logging
+                      properties:
+                        mode:
+                          description: What payloads to log
+                          type: string
+                        url:
+                          description: URL to send request logging CloudEvents
+                          type: string
+                      type: object
+                    maxReplicas:
+                      description: This is the up bound for autoscaler to scale to
+                      type: integer
+                    minReplicas:
+                      description: Minimum number of replicas, pods won't scale down
+                        to 0 in case of no traffic
+                      type: integer
+                    parallelism:
+                      description: Parallelism specifies how many requests can be
+                        processed concurrently, this sets the target concurrency for
+                        Autoscaling(KPA). For model servers that support tuning parallelism
+                        will use this value, by default the parallelism is the number
+                        of the CPU cores for most of the model servers.
+                      type: integer
+                    serviceAccountName:
+                      description: ServiceAccountName is the name of the ServiceAccount
+                        to use to run the service
+                      type: string
+                  type: object
+                predictor:
+                  description: Predictor defines the model serving spec
+                  properties:
+                    custom:
+                      description: Spec for a custom predictor
+                      properties:
+                        container:
+                          description: A single application container that you want
+                            to run within a pod.
+                          properties:
+                            args:
+                              description: 'Arguments to the entrypoint. The docker
+                                image''s CMD is used if this is not provided. Variable
+                                references $(VAR_NAME) are expanded using the container''s
+                                environment. If a variable cannot be resolved, the
+                                reference in the input string will be unchanged. The
+                                $(VAR_NAME) syntax can be escaped with a double $$,
+                                ie: $$(VAR_NAME). Escaped references will never be
+                                expanded, regardless of whether the variable exists
+                                or not. Cannot be updated. More info: https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell'
+                              items:
+                                type: string
+                              type: array
+                            command:
+                              description: 'Entrypoint array. Not executed within
+                                a shell. The docker image''s ENTRYPOINT is used if
+                                this is not provided. Variable references $(VAR_NAME)
+                                are expanded using the container''s environment. If
+                                a variable cannot be resolved, the reference in the
+                                input string will be unchanged. The $(VAR_NAME) syntax
+                                can be escaped with a double $$, ie: $$(VAR_NAME).
+                                Escaped references will never be expanded, regardless
+                                of whether the variable exists or not. Cannot be updated.
+                                More info: https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell'
+                              items:
+                                type: string
+                              type: array
+                            env:
+                              description: List of environment variables to set in
+                                the container. Cannot be updated.
+                              items:
+                                description: EnvVar represents an environment variable
+                                  present in a Container.
+                                properties:
+                                  name:
+                                    description: Name of the environment variable.
+                                      Must be a C_IDENTIFIER.
+                                    type: string
+                                  value:
+                                    description: 'Variable references $(VAR_NAME)
+                                      are expanded using the previous defined environment
+                                      variables in the container and any service environment
+                                      variables. If a variable cannot be resolved,
+                                      the reference in the input string will be unchanged.
+                                      The $(VAR_NAME) syntax can be escaped with a
+                                      double $$, ie: $$(VAR_NAME). Escaped references
+                                      will never be expanded, regardless of whether
+                                      the variable exists or not. Defaults to "".'
+                                    type: string
+                                  valueFrom:
+                                    description: Source for the environment variable's
+                                      value. Cannot be used if value is not empty.
+                                    properties:
+                                      configMapKeyRef:
+                                        description: Selects a key of a ConfigMap.
+                                        properties:
+                                          key:
+                                            description: The key to select.
+                                            type: string
+                                          name:
+                                            description: 'Name of the referent. More
+                                              info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                              TODO: Add other useful fields. apiVersion,
+                                              kind, uid?'
+                                            type: string
+                                          optional:
+                                            description: Specify whether the ConfigMap
+                                              or its key must be defined
+                                            type: boolean
+                                        required:
+                                        - key
+                                        type: object
+                                      fieldRef:
+                                        description: 'Selects a field of the pod:
+                                          supports metadata.name, metadata.namespace,
+                                          metadata.labels, metadata.annotations, spec.nodeName,
+                                          spec.serviceAccountName, status.hostIP,
+                                          status.podIP.'
+                                        properties:
+                                          apiVersion:
+                                            description: Version of the schema the
+                                              FieldPath is written in terms of, defaults
+                                              to "v1".
+                                            type: string
+                                          fieldPath:
+                                            description: Path of the field to select
+                                              in the specified API version.
+                                            type: string
+                                        required:
+                                        - fieldPath
+                                        type: object
+                                      resourceFieldRef:
+                                        description: 'Selects a resource of the container:
+                                          only resources limits and requests (limits.cpu,
+                                          limits.memory, limits.ephemeral-storage,
+                                          requests.cpu, requests.memory and requests.ephemeral-storage)
+                                          are currently supported.'
+                                        properties:
+                                          containerName:
+                                            description: 'Container name: required
+                                              for volumes, optional for env vars'
+                                            type: string
+                                          divisor:
+                                            description: Specifies the output format
+                                              of the exposed resources, defaults to
+                                              "1"
+                                            type: string
+                                          resource:
+                                            description: 'Required: resource to select'
+                                            type: string
+                                        required:
+                                        - resource
+                                        type: object
+                                      secretKeyRef:
+                                        description: Selects a key of a secret in
+                                          the pod's namespace
+                                        properties:
+                                          key:
+                                            description: The key of the secret to
+                                              select from.  Must be a valid secret
+                                              key.
+                                            type: string
+                                          name:
+                                            description: 'Name of the referent. More
+                                              info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                              TODO: Add other useful fields. apiVersion,
+                                              kind, uid?'
+                                            type: string
+                                          optional:
+                                            description: Specify whether the Secret
+                                              or its key must be defined
+                                            type: boolean
+                                        required:
+                                        - key
+                                        type: object
+                                    type: object
+                                required:
+                                - name
+                                type: object
+                              type: array
+                            envFrom:
+                              description: List of sources to populate environment
+                                variables in the container. The keys defined within
+                                a source must be a C_IDENTIFIER. All invalid keys
+                                will be reported as an event when the container is
+                                starting. When a key exists in multiple sources, the
+                                value associated with the last source will take precedence.
+                                Values defined by an Env with a duplicate key will
+                                take precedence. Cannot be updated.
+                              items:
+                                description: EnvFromSource represents the source of
+                                  a set of ConfigMaps
+                                properties:
+                                  configMapRef:
+                                    description: The ConfigMap to select from
+                                    properties:
+                                      name:
+                                        description: 'Name of the referent. More info:
+                                          https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                          TODO: Add other useful fields. apiVersion,
+                                          kind, uid?'
+                                        type: string
+                                      optional:
+                                        description: Specify whether the ConfigMap
+                                          must be defined
+                                        type: boolean
+                                    type: object
+                                  prefix:
+                                    description: An optional identifier to prepend
+                                      to each key in the ConfigMap. Must be a C_IDENTIFIER.
+                                    type: string
+                                  secretRef:
+                                    description: The Secret to select from
+                                    properties:
+                                      name:
+                                        description: 'Name of the referent. More info:
+                                          https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                          TODO: Add other useful fields. apiVersion,
+                                          kind, uid?'
+                                        type: string
+                                      optional:
+                                        description: Specify whether the Secret must
+                                          be defined
+                                        type: boolean
+                                    type: object
+                                type: object
+                              type: array
+                            image:
+                              description: 'Docker image name. More info: https://kubernetes.io/docs/concepts/containers/images
+                                This field is optional to allow higher level config
+                                management to default or override container images
+                                in workload controllers like Deployments and StatefulSets.'
+                              type: string
+                            imagePullPolicy:
+                              description: 'Image pull policy. One of Always, Never,
+                                IfNotPresent. Defaults to Always if :v0.3.0 tag is
+                                specified, or IfNotPresent otherwise. Cannot be updated.
+                                More info: https://kubernetes.io/docs/concepts/containers/images#updating-images'
+                              type: string
+                            lifecycle:
+                              description: Actions that the management system should
+                                take in response to container lifecycle events. Cannot
+                                be updated.
+                              properties:
+                                postStart:
+                                  description: 'PostStart is called immediately after
+                                    a container is created. If the handler fails,
+                                    the container is terminated and restarted according
+                                    to its restart policy. Other management of the
+                                    container blocks until the hook completes. More
+                                    info: https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/#container-hooks'
+                                  properties:
+                                    exec:
+                                      description: One and only one of the following
+                                        should be specified. Exec specifies the action
+                                        to take.
+                                      properties:
+                                        command:
+                                          description: Command is the command line
+                                            to execute inside the container, the working
+                                            directory for the command  is root ('/')
+                                            in the container's filesystem. The command
+                                            is simply exec'd, it is not run inside
+                                            a shell, so traditional shell instructions
+                                            ('|', etc) won't work. To use a shell,
+                                            you need to explicitly call out to that
+                                            shell. Exit status of 0 is treated as
+                                            live/healthy and non-zero is unhealthy.
+                                          items:
+                                            type: string
+                                          type: array
+                                      type: object
+                                    httpGet:
+                                      description: HTTPGet specifies the http request
+                                        to perform.
+                                      properties:
+                                        host:
+                                          description: Host name to connect to, defaults
+                                            to the pod IP. You probably want to set
+                                            "Host" in httpHeaders instead.
+                                          type: string
+                                        httpHeaders:
+                                          description: Custom headers to set in the
+                                            request. HTTP allows repeated headers.
+                                          items:
+                                            description: HTTPHeader describes a custom
+                                              header to be used in HTTP probes
+                                            properties:
+                                              name:
+                                                description: The header field name
+                                                type: string
+                                              value:
+                                                description: The header field value
+                                                type: string
+                                            required:
+                                            - name
+                                            - value
+                                            type: object
+                                          type: array
+                                        path:
+                                          description: Path to access on the HTTP
+                                            server.
+                                          type: string
+                                        port:
+                                          anyOf:
+                                          - type: string
+                                          - type: integer
+                                          description: Name or number of the port
+                                            to access on the container. Number must
+                                            be in the range 1 to 65535. Name must
+                                            be an IANA_SVC_NAME.
+                                        scheme:
+                                          description: Scheme to use for connecting
+                                            to the host. Defaults to HTTP.
+                                          type: string
+                                      required:
+                                      - port
+                                      type: object
+                                    tcpSocket:
+                                      description: 'TCPSocket specifies an action
+                                        involving a TCP port. TCP hooks not yet supported
+                                        TODO: implement a realistic TCP lifecycle
+                                        hook'
+                                      properties:
+                                        host:
+                                          description: 'Optional: Host name to connect
+                                            to, defaults to the pod IP.'
+                                          type: string
+                                        port:
+                                          anyOf:
+                                          - type: string
+                                          - type: integer
+                                          description: Number or name of the port
+                                            to access on the container. Number must
+                                            be in the range 1 to 65535. Name must
+                                            be an IANA_SVC_NAME.
+                                      required:
+                                      - port
+                                      type: object
+                                  type: object
+                                preStop:
+                                  description: 'PreStop is called immediately before
+                                    a container is terminated due to an API request
+                                    or management event such as liveness probe failure,
+                                    preemption, resource contention, etc. The handler
+                                    is not called if the container crashes or exits.
+                                    The reason for termination is passed to the handler.
+                                    The Pod''s termination grace period countdown
+                                    begins before the PreStop hooked is executed.
+                                    Regardless of the outcome of the handler, the
+                                    container will eventually terminate within the
+                                    Pod''s termination grace period. Other management
+                                    of the container blocks until the hook completes
+                                    or until the termination grace period is reached.
+                                    More info: https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/#container-hooks'
+                                  properties:
+                                    exec:
+                                      description: One and only one of the following
+                                        should be specified. Exec specifies the action
+                                        to take.
+                                      properties:
+                                        command:
+                                          description: Command is the command line
+                                            to execute inside the container, the working
+                                            directory for the command  is root ('/')
+                                            in the container's filesystem. The command
+                                            is simply exec'd, it is not run inside
+                                            a shell, so traditional shell instructions
+                                            ('|', etc) won't work. To use a shell,
+                                            you need to explicitly call out to that
+                                            shell. Exit status of 0 is treated as
+                                            live/healthy and non-zero is unhealthy.
+                                          items:
+                                            type: string
+                                          type: array
+                                      type: object
+                                    httpGet:
+                                      description: HTTPGet specifies the http request
+                                        to perform.
+                                      properties:
+                                        host:
+                                          description: Host name to connect to, defaults
+                                            to the pod IP. You probably want to set
+                                            "Host" in httpHeaders instead.
+                                          type: string
+                                        httpHeaders:
+                                          description: Custom headers to set in the
+                                            request. HTTP allows repeated headers.
+                                          items:
+                                            description: HTTPHeader describes a custom
+                                              header to be used in HTTP probes
+                                            properties:
+                                              name:
+                                                description: The header field name
+                                                type: string
+                                              value:
+                                                description: The header field value
+                                                type: string
+                                            required:
+                                            - name
+                                            - value
+                                            type: object
+                                          type: array
+                                        path:
+                                          description: Path to access on the HTTP
+                                            server.
+                                          type: string
+                                        port:
+                                          anyOf:
+                                          - type: string
+                                          - type: integer
+                                          description: Name or number of the port
+                                            to access on the container. Number must
+                                            be in the range 1 to 65535. Name must
+                                            be an IANA_SVC_NAME.
+                                        scheme:
+                                          description: Scheme to use for connecting
+                                            to the host. Defaults to HTTP.
+                                          type: string
+                                      required:
+                                      - port
+                                      type: object
+                                    tcpSocket:
+                                      description: 'TCPSocket specifies an action
+                                        involving a TCP port. TCP hooks not yet supported
+                                        TODO: implement a realistic TCP lifecycle
+                                        hook'
+                                      properties:
+                                        host:
+                                          description: 'Optional: Host name to connect
+                                            to, defaults to the pod IP.'
+                                          type: string
+                                        port:
+                                          anyOf:
+                                          - type: string
+                                          - type: integer
+                                          description: Number or name of the port
+                                            to access on the container. Number must
+                                            be in the range 1 to 65535. Name must
+                                            be an IANA_SVC_NAME.
+                                      required:
+                                      - port
+                                      type: object
+                                  type: object
+                              type: object
+                            livenessProbe:
+                              description: 'Periodic probe of container liveness.
+                                Container will be restarted if the probe fails. Cannot
+                                be updated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                              properties:
+                                exec:
+                                  description: One and only one of the following should
+                                    be specified. Exec specifies the action to take.
+                                  properties:
+                                    command:
+                                      description: Command is the command line to
+                                        execute inside the container, the working
+                                        directory for the command  is root ('/') in
+                                        the container's filesystem. The command is
+                                        simply exec'd, it is not run inside a shell,
+                                        so traditional shell instructions ('|', etc)
+                                        won't work. To use a shell, you need to explicitly
+                                        call out to that shell. Exit status of 0 is
+                                        treated as live/healthy and non-zero is unhealthy.
+                                      items:
+                                        type: string
+                                      type: array
+                                  type: object
+                                failureThreshold:
+                                  description: Minimum consecutive failures for the
+                                    probe to be considered failed after having succeeded.
+                                    Defaults to 3. Minimum value is 1.
+                                  format: int32
+                                  type: integer
+                                httpGet:
+                                  description: HTTPGet specifies the http request
+                                    to perform.
+                                  properties:
+                                    host:
+                                      description: Host name to connect to, defaults
+                                        to the pod IP. You probably want to set "Host"
+                                        in httpHeaders instead.
+                                      type: string
+                                    httpHeaders:
+                                      description: Custom headers to set in the request.
+                                        HTTP allows repeated headers.
+                                      items:
+                                        description: HTTPHeader describes a custom
+                                          header to be used in HTTP probes
+                                        properties:
+                                          name:
+                                            description: The header field name
+                                            type: string
+                                          value:
+                                            description: The header field value
+                                            type: string
+                                        required:
+                                        - name
+                                        - value
+                                        type: object
+                                      type: array
+                                    path:
+                                      description: Path to access on the HTTP server.
+                                      type: string
+                                    port:
+                                      anyOf:
+                                      - type: string
+                                      - type: integer
+                                      description: Name or number of the port to access
+                                        on the container. Number must be in the range
+                                        1 to 65535. Name must be an IANA_SVC_NAME.
+                                    scheme:
+                                      description: Scheme to use for connecting to
+                                        the host. Defaults to HTTP.
+                                      type: string
+                                  required:
+                                  - port
+                                  type: object
+                                initialDelaySeconds:
+                                  description: 'Number of seconds after the container
+                                    has started before liveness probes are initiated.
+                                    More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                                  format: int32
+                                  type: integer
+                                periodSeconds:
+                                  description: How often (in seconds) to perform the
+                                    probe. Default to 10 seconds. Minimum value is
+                                    1.
+                                  format: int32
+                                  type: integer
+                                successThreshold:
+                                  description: Minimum consecutive successes for the
+                                    probe to be considered successful after having
+                                    failed. Defaults to 1. Must be 1 for liveness.
+                                    Minimum value is 1.
+                                  format: int32
+                                  type: integer
+                                tcpSocket:
+                                  description: 'TCPSocket specifies an action involving
+                                    a TCP port. TCP hooks not yet supported TODO:
+                                    implement a realistic TCP lifecycle hook'
+                                  properties:
+                                    host:
+                                      description: 'Optional: Host name to connect
+                                        to, defaults to the pod IP.'
+                                      type: string
+                                    port:
+                                      anyOf:
+                                      - type: string
+                                      - type: integer
+                                      description: Number or name of the port to access
+                                        on the container. Number must be in the range
+                                        1 to 65535. Name must be an IANA_SVC_NAME.
+                                  required:
+                                  - port
+                                  type: object
+                                timeoutSeconds:
+                                  description: 'Number of seconds after which the
+                                    probe times out. Defaults to 1 second. Minimum
+                                    value is 1. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                                  format: int32
+                                  type: integer
+                              type: object
+                            name:
+                              description: Name of the container specified as a DNS_LABEL.
+                                Each container in a pod must have a unique name (DNS_LABEL).
+                                Cannot be updated.
+                              type: string
+                            ports:
+                              description: List of ports to expose from the container.
+                                Exposing a port here gives the system additional information
+                                about the network connections a container uses, but
+                                is primarily informational. Not specifying a port
+                                here DOES NOT prevent that port from being exposed.
+                                Any port which is listening on the default "0.0.0.0"
+                                address inside a container will be accessible from
+                                the network. Cannot be updated.
+                              items:
+                                description: ContainerPort represents a network port
+                                  in a single container.
+                                properties:
+                                  containerPort:
+                                    description: Number of port to expose on the pod's
+                                      IP address. This must be a valid port number,
+                                      0 < x < 65536.
+                                    format: int32
+                                    type: integer
+                                  hostIP:
+                                    description: What host IP to bind the external
+                                      port to.
+                                    type: string
+                                  hostPort:
+                                    description: Number of port to expose on the host.
+                                      If specified, this must be a valid port number,
+                                      0 < x < 65536. If HostNetwork is specified,
+                                      this must match ContainerPort. Most containers
+                                      do not need this.
+                                    format: int32
+                                    type: integer
+                                  name:
+                                    description: If specified, this must be an IANA_SVC_NAME
+                                      and unique within the pod. Each named port in
+                                      a pod must have a unique name. Name for the
+                                      port that can be referred to by services.
+                                    type: string
+                                  protocol:
+                                    description: Protocol for port. Must be UDP, TCP,
+                                      or SCTP. Defaults to "TCP".
+                                    type: string
+                                required:
+                                - containerPort
+                                type: object
+                              type: array
+                            readinessProbe:
+                              description: 'Periodic probe of container service readiness.
+                                Container will be removed from service endpoints if
+                                the probe fails. Cannot be updated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                              properties:
+                                exec:
+                                  description: One and only one of the following should
+                                    be specified. Exec specifies the action to take.
+                                  properties:
+                                    command:
+                                      description: Command is the command line to
+                                        execute inside the container, the working
+                                        directory for the command  is root ('/') in
+                                        the container's filesystem. The command is
+                                        simply exec'd, it is not run inside a shell,
+                                        so traditional shell instructions ('|', etc)
+                                        won't work. To use a shell, you need to explicitly
+                                        call out to that shell. Exit status of 0 is
+                                        treated as live/healthy and non-zero is unhealthy.
+                                      items:
+                                        type: string
+                                      type: array
+                                  type: object
+                                failureThreshold:
+                                  description: Minimum consecutive failures for the
+                                    probe to be considered failed after having succeeded.
+                                    Defaults to 3. Minimum value is 1.
+                                  format: int32
+                                  type: integer
+                                httpGet:
+                                  description: HTTPGet specifies the http request
+                                    to perform.
+                                  properties:
+                                    host:
+                                      description: Host name to connect to, defaults
+                                        to the pod IP. You probably want to set "Host"
+                                        in httpHeaders instead.
+                                      type: string
+                                    httpHeaders:
+                                      description: Custom headers to set in the request.
+                                        HTTP allows repeated headers.
+                                      items:
+                                        description: HTTPHeader describes a custom
+                                          header to be used in HTTP probes
+                                        properties:
+                                          name:
+                                            description: The header field name
+                                            type: string
+                                          value:
+                                            description: The header field value
+                                            type: string
+                                        required:
+                                        - name
+                                        - value
+                                        type: object
+                                      type: array
+                                    path:
+                                      description: Path to access on the HTTP server.
+                                      type: string
+                                    port:
+                                      anyOf:
+                                      - type: string
+                                      - type: integer
+                                      description: Name or number of the port to access
+                                        on the container. Number must be in the range
+                                        1 to 65535. Name must be an IANA_SVC_NAME.
+                                    scheme:
+                                      description: Scheme to use for connecting to
+                                        the host. Defaults to HTTP.
+                                      type: string
+                                  required:
+                                  - port
+                                  type: object
+                                initialDelaySeconds:
+                                  description: 'Number of seconds after the container
+                                    has started before liveness probes are initiated.
+                                    More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                                  format: int32
+                                  type: integer
+                                periodSeconds:
+                                  description: How often (in seconds) to perform the
+                                    probe. Default to 10 seconds. Minimum value is
+                                    1.
+                                  format: int32
+                                  type: integer
+                                successThreshold:
+                                  description: Minimum consecutive successes for the
+                                    probe to be considered successful after having
+                                    failed. Defaults to 1. Must be 1 for liveness.
+                                    Minimum value is 1.
+                                  format: int32
+                                  type: integer
+                                tcpSocket:
+                                  description: 'TCPSocket specifies an action involving
+                                    a TCP port. TCP hooks not yet supported TODO:
+                                    implement a realistic TCP lifecycle hook'
+                                  properties:
+                                    host:
+                                      description: 'Optional: Host name to connect
+                                        to, defaults to the pod IP.'
+                                      type: string
+                                    port:
+                                      anyOf:
+                                      - type: string
+                                      - type: integer
+                                      description: Number or name of the port to access
+                                        on the container. Number must be in the range
+                                        1 to 65535. Name must be an IANA_SVC_NAME.
+                                  required:
+                                  - port
+                                  type: object
+                                timeoutSeconds:
+                                  description: 'Number of seconds after which the
+                                    probe times out. Defaults to 1 second. Minimum
+                                    value is 1. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                                  format: int32
+                                  type: integer
+                              type: object
+                            resources:
+                              description: 'Compute Resources required by this container.
+                                Cannot be updated. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
+                              properties:
+                                limits:
+                                  additionalProperties:
+                                    type: string
+                                  description: 'Limits describes the maximum amount
+                                    of compute resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
+                                  type: object
+                                requests:
+                                  additionalProperties:
+                                    type: string
+                                  description: 'Requests describes the minimum amount
+                                    of compute resources required. If Requests is
+                                    omitted for a container, it defaults to Limits
+                                    if that is explicitly specified, otherwise to
+                                    an implementation-defined value. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
+                                  type: object
+                              type: object
+                            securityContext:
+                              description: 'Security options the pod should run with.
+                                More info: https://kubernetes.io/docs/concepts/policy/security-context/
+                                More info: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/'
+                              properties:
+                                allowPrivilegeEscalation:
+                                  description: 'AllowPrivilegeEscalation controls
+                                    whether a process can gain more privileges than
+                                    its parent process. This bool directly controls
+                                    if the no_new_privs flag will be set on the container
+                                    process. AllowPrivilegeEscalation is true always
+                                    when the container is: 1) run as Privileged 2)
+                                    has CAP_SYS_ADMIN'
+                                  type: boolean
+                                capabilities:
+                                  description: The capabilities to add/drop when running
+                                    containers. Defaults to the default set of capabilities
+                                    granted by the container runtime.
+                                  properties:
+                                    add:
+                                      description: Added capabilities
+                                      items:
+                                        description: Capability represent POSIX capabilities
+                                          type
+                                        type: string
+                                      type: array
+                                    drop:
+                                      description: Removed capabilities
+                                      items:
+                                        description: Capability represent POSIX capabilities
+                                          type
+                                        type: string
+                                      type: array
+                                  type: object
+                                privileged:
+                                  description: Run container in privileged mode. Processes
+                                    in privileged containers are essentially equivalent
+                                    to root on the host. Defaults to false.
+                                  type: boolean
+                                procMount:
+                                  description: procMount denotes the type of proc
+                                    mount to use for the containers. The default is
+                                    DefaultProcMount which uses the container runtime
+                                    defaults for readonly paths and masked paths.
+                                    This requires the ProcMountType feature flag to
+                                    be enabled.
+                                  type: string
+                                readOnlyRootFilesystem:
+                                  description: Whether this container has a read-only
+                                    root filesystem. Default is false.
+                                  type: boolean
+                                runAsGroup:
+                                  description: The GID to run the entrypoint of the
+                                    container process. Uses runtime default if unset.
+                                    May also be set in PodSecurityContext.  If set
+                                    in both SecurityContext and PodSecurityContext,
+                                    the value specified in SecurityContext takes precedence.
+                                  format: int64
+                                  type: integer
+                                runAsNonRoot:
+                                  description: Indicates that the container must run
+                                    as a non-root user. If true, the Kubelet will
+                                    validate the image at runtime to ensure that it
+                                    does not run as UID 0 (root) and fail to start
+                                    the container if it does. If unset or false, no
+                                    such validation will be performed. May also be
+                                    set in PodSecurityContext.  If set in both SecurityContext
+                                    and PodSecurityContext, the value specified in
+                                    SecurityContext takes precedence.
+                                  type: boolean
+                                runAsUser:
+                                  description: The UID to run the entrypoint of the
+                                    container process. Defaults to user specified
+                                    in image metadata if unspecified. May also be
+                                    set in PodSecurityContext.  If set in both SecurityContext
+                                    and PodSecurityContext, the value specified in
+                                    SecurityContext takes precedence.
+                                  format: int64
+                                  type: integer
+                                seLinuxOptions:
+                                  description: The SELinux context to be applied to
+                                    the container. If unspecified, the container runtime
+                                    will allocate a random SELinux context for each
+                                    container.  May also be set in PodSecurityContext.  If
+                                    set in both SecurityContext and PodSecurityContext,
+                                    the value specified in SecurityContext takes precedence.
+                                  properties:
+                                    level:
+                                      description: Level is SELinux level label that
+                                        applies to the container.
+                                      type: string
+                                    role:
+                                      description: Role is a SELinux role label that
+                                        applies to the container.
+                                      type: string
+                                    type:
+                                      description: Type is a SELinux type label that
+                                        applies to the container.
+                                      type: string
+                                    user:
+                                      description: User is a SELinux user label that
+                                        applies to the container.
+                                      type: string
+                                  type: object
+                                windowsOptions:
+                                  description: Windows security options.
+                                  properties:
+                                    gmsaCredentialSpec:
+                                      description: GMSACredentialSpec is where the
+                                        GMSA admission webhook (https://github.com/kubernetes-sigs/windows-gmsa)
+                                        inlines the contents of the GMSA credential
+                                        spec named by the GMSACredentialSpecName field.
+                                        This field is alpha-level and is only honored
+                                        by servers that enable the WindowsGMSA feature
+                                        flag.
+                                      type: string
+                                    gmsaCredentialSpecName:
+                                      description: GMSACredentialSpecName is the name
+                                        of the GMSA credential spec to use. This field
+                                        is alpha-level and is only honored by servers
+                                        that enable the WindowsGMSA feature flag.
+                                      type: string
+                                  type: object
+                              type: object
+                            stdin:
+                              description: Whether this container should allocate
+                                a buffer for stdin in the container runtime. If this
+                                is not set, reads from stdin in the container will
+                                always result in EOF. Default is false.
+                              type: boolean
+                            stdinOnce:
+                              description: Whether the container runtime should close
+                                the stdin channel after it has been opened by a single
+                                attach. When stdin is true the stdin stream will remain
+                                open across multiple attach sessions. If stdinOnce
+                                is set to true, stdin is opened on container start,
+                                is empty until the first client attaches to stdin,
+                                and then remains open and accepts data until the client
+                                disconnects, at which time stdin is closed and remains
+                                closed until the container is restarted. If this flag
+                                is false, a container processes that reads from stdin
+                                will never receive an EOF. Default is false
+                              type: boolean
+                            terminationMessagePath:
+                              description: 'Optional: Path at which the file to which
+                                the container''s termination message will be written
+                                is mounted into the container''s filesystem. Message
+                                written is intended to be brief final status, such
+                                as an assertion failure message. Will be truncated
+                                by the node if greater than 4096 bytes. The total
+                                message length across all containers will be limited
+                                to 12kb. Defaults to /dev/termination-log. Cannot
+                                be updated.'
+                              type: string
+                            terminationMessagePolicy:
+                              description: Indicate how the termination message should
+                                be populated. File will use the contents of terminationMessagePath
+                                to populate the container status message on both success
+                                and failure. FallbackToLogsOnError will use the last
+                                chunk of container log output if the termination message
+                                file is empty and the container exited with an error.
+                                The log output is limited to 2048 bytes or 80 lines,
+                                whichever is smaller. Defaults to File. Cannot be
+                                updated.
+                              type: string
+                            tty:
+                              description: Whether this container should allocate
+                                a TTY for itself, also requires 'stdin' to be true.
+                                Default is false.
+                              type: boolean
+                            volumeDevices:
+                              description: volumeDevices is the list of block devices
+                                to be used by the container. This is a beta feature.
+                              items:
+                                description: volumeDevice describes a mapping of a
+                                  raw block device within a container.
+                                properties:
+                                  devicePath:
+                                    description: devicePath is the path inside of
+                                      the container that the device will be mapped
+                                      to.
+                                    type: string
+                                  name:
+                                    description: name must match the name of a persistentVolumeClaim
+                                      in the pod
+                                    type: string
+                                required:
+                                - devicePath
+                                - name
+                                type: object
+                              type: array
+                            volumeMounts:
+                              description: Pod volumes to mount into the container's
+                                filesystem. Cannot be updated.
+                              items:
+                                description: VolumeMount describes a mounting of a
+                                  Volume within a container.
+                                properties:
+                                  mountPath:
+                                    description: Path within the container at which
+                                      the volume should be mounted.  Must not contain
+                                      ':'.
+                                    type: string
+                                  mountPropagation:
+                                    description: mountPropagation determines how mounts
+                                      are propagated from the host to container and
+                                      the other way around. When not set, MountPropagationNone
+                                      is used. This field is beta in 1.10.
+                                    type: string
+                                  name:
+                                    description: This must match the Name of a Volume.
+                                    type: string
+                                  readOnly:
+                                    description: Mounted read-only if true, read-write
+                                      otherwise (false or unspecified). Defaults to
+                                      false.
+                                    type: boolean
+                                  subPath:
+                                    description: Path within the volume from which
+                                      the container's volume should be mounted. Defaults
+                                      to "" (volume's root).
+                                    type: string
+                                  subPathExpr:
+                                    description: Expanded path within the volume from
+                                      which the container's volume should be mounted.
+                                      Behaves similarly to SubPath but environment
+                                      variable references $(VAR_NAME) are expanded
+                                      using the container's environment. Defaults
+                                      to "" (volume's root). SubPathExpr and SubPath
+                                      are mutually exclusive. This field is beta in
+                                      1.15.
+                                    type: string
+                                required:
+                                - mountPath
+                                - name
+                                type: object
+                              type: array
+                            workingDir:
+                              description: Container's working directory. If not specified,
+                                the container runtime's default will be used, which
+                                might be configured in the container image. Cannot
+                                be updated.
+                              type: string
+                          required:
+                          - name
+                          type: object
+                      required:
+                      - container
+                      type: object
+                    logger:
+                      description: Activate request/response logging
+                      properties:
+                        mode:
+                          description: What payloads to log
+                          type: string
+                        url:
+                          description: URL to send request logging CloudEvents
+                          type: string
+                      type: object
+                    maxReplicas:
+                      description: This is the up bound for autoscaler to scale to
+                      type: integer
+                    minReplicas:
+                      description: Minimum number of replicas, pods won't scale down
+                        to 0 in case of no traffic
+                      type: integer
+                    onnx:
+                      description: Spec for ONNX runtime (https://github.com/microsoft/onnxruntime)
+                      properties:
+                        resources:
+                          description: Defaults to requests and limits of 1CPU, 2Gb
+                            MEM.
+                          properties:
+                            limits:
+                              additionalProperties:
+                                type: string
+                              description: 'Limits describes the maximum amount of
+                                compute resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
+                              type: object
+                            requests:
+                              additionalProperties:
+                                type: string
+                              description: 'Requests describes the minimum amount
+                                of compute resources required. If Requests is omitted
+                                for a container, it defaults to Limits if that is
+                                explicitly specified, otherwise to an implementation-defined
+                                value. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
+                              type: object
+                          type: object
+                        runtimeVersion:
+                          description: Allowed runtime versions are specified in the
+                            inferenceservice config map
+                          type: string
+                        storageUri:
+                          description: The location of the trained model
+                          type: string
+                      required:
+                      - storageUri
+                      type: object
+                    parallelism:
+                      description: Parallelism specifies how many requests can be
+                        processed concurrently, this sets the target concurrency for
+                        Autoscaling(KPA). For model servers that support tuning parallelism
+                        will use this value, by default the parallelism is the number
+                        of the CPU cores for most of the model servers.
+                      type: integer
+                    pytorch:
+                      description: Spec for PyTorch predictor
+                      properties:
+                        modelClassName:
+                          description: Defaults PyTorch model class name to 'PyTorchModel'
+                          type: string
+                        resources:
+                          description: Defaults to requests and limits of 1CPU, 2Gb
+                            MEM.
+                          properties:
+                            limits:
+                              additionalProperties:
+                                type: string
+                              description: 'Limits describes the maximum amount of
+                                compute resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
+                              type: object
+                            requests:
+                              additionalProperties:
+                                type: string
+                              description: 'Requests describes the minimum amount
+                                of compute resources required. If Requests is omitted
+                                for a container, it defaults to Limits if that is
+                                explicitly specified, otherwise to an implementation-defined
+                                value. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
+                              type: object
+                          type: object
+                        runtimeVersion:
+                          description: Allowed runtime versions are specified in the
+                            inferenceservice config map
+                          type: string
+                        storageUri:
+                          description: The location of the trained model
+                          type: string
+                      required:
+                      - storageUri
+                      type: object
+                    serviceAccountName:
+                      description: ServiceAccountName is the name of the ServiceAccount
+                        to use to run the service
+                      type: string
+                    sklearn:
+                      description: Spec for SKLearn predictor
+                      properties:
+                        resources:
+                          description: Defaults to requests and limits of 1CPU, 2Gb
+                            MEM.
+                          properties:
+                            limits:
+                              additionalProperties:
+                                type: string
+                              description: 'Limits describes the maximum amount of
+                                compute resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
+                              type: object
+                            requests:
+                              additionalProperties:
+                                type: string
+                              description: 'Requests describes the minimum amount
+                                of compute resources required. If Requests is omitted
+                                for a container, it defaults to Limits if that is
+                                explicitly specified, otherwise to an implementation-defined
+                                value. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
+                              type: object
+                          type: object
+                        runtimeVersion:
+                          description: Allowed runtime versions are specified in the
+                            inferenceservice config map
+                          type: string
+                        storageUri:
+                          description: The location of the trained model
+                          type: string
+                      required:
+                      - storageUri
+                      type: object
+                    tensorflow:
+                      description: Spec for Tensorflow Serving (https://github.com/tensorflow/serving)
+                      properties:
+                        resources:
+                          description: Defaults to requests and limits of 1CPU, 2Gb
+                            MEM.
+                          properties:
+                            limits:
+                              additionalProperties:
+                                type: string
+                              description: 'Limits describes the maximum amount of
+                                compute resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
+                              type: object
+                            requests:
+                              additionalProperties:
+                                type: string
+                              description: 'Requests describes the minimum amount
+                                of compute resources required. If Requests is omitted
+                                for a container, it defaults to Limits if that is
+                                explicitly specified, otherwise to an implementation-defined
+                                value. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
+                              type: object
+                          type: object
+                        runtimeVersion:
+                          description: Allowed runtime versions are specified in the
+                            inferenceservice config map.
+                          type: string
+                        storageUri:
+                          description: The location of the trained model
+                          type: string
+                      required:
+                      - storageUri
+                      type: object
+                    tensorrt:
+                      description: Spec for TensorRT Inference Server (https://github.com/NVIDIA/tensorrt-inference-server)
+                      properties:
+                        resources:
+                          description: Defaults to requests and limits of 1CPU, 2Gb
+                            MEM.
+                          properties:
+                            limits:
+                              additionalProperties:
+                                type: string
+                              description: 'Limits describes the maximum amount of
+                                compute resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
+                              type: object
+                            requests:
+                              additionalProperties:
+                                type: string
+                              description: 'Requests describes the minimum amount
+                                of compute resources required. If Requests is omitted
+                                for a container, it defaults to Limits if that is
+                                explicitly specified, otherwise to an implementation-defined
+                                value. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
+                              type: object
+                          type: object
+                        runtimeVersion:
+                          description: Allowed runtime versions are specified in the
+                            inferenceservice config map
+                          type: string
+                        storageUri:
+                          description: The location of the trained model
+                          type: string
+                      required:
+                      - storageUri
+                      type: object
+                    xgboost:
+                      description: Spec for XGBoost predictor
+                      properties:
+                        nthread:
+                          description: Number of thread to be used by XGBoost
+                          type: integer
+                        resources:
+                          description: Defaults to requests and limits of 1CPU, 2Gb
+                            MEM.
+                          properties:
+                            limits:
+                              additionalProperties:
+                                type: string
+                              description: 'Limits describes the maximum amount of
+                                compute resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
+                              type: object
+                            requests:
+                              additionalProperties:
+                                type: string
+                              description: 'Requests describes the minimum amount
+                                of compute resources required. If Requests is omitted
+                                for a container, it defaults to Limits if that is
+                                explicitly specified, otherwise to an implementation-defined
+                                value. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
+                              type: object
+                          type: object
+                        runtimeVersion:
+                          description: Allowed runtime versions are specified in the
+                            inferenceservice config map
+                          type: string
+                        storageUri:
+                          description: The location of the trained model
+                          type: string
+                      required:
+                      - storageUri
+                      type: object
+                  type: object
+                transformer:
+                  description: Transformer defines the pre/post processing before
+                    and after the predictor call, transformer service calls to predictor
+                    service.
+                  properties:
+                    custom:
+                      description: Spec for a custom transformer
+                      properties:
+                        container:
+                          description: A single application container that you want
+                            to run within a pod.
+                          properties:
+                            args:
+                              description: 'Arguments to the entrypoint. The docker
+                                image''s CMD is used if this is not provided. Variable
+                                references $(VAR_NAME) are expanded using the container''s
+                                environment. If a variable cannot be resolved, the
+                                reference in the input string will be unchanged. The
+                                $(VAR_NAME) syntax can be escaped with a double $$,
+                                ie: $$(VAR_NAME). Escaped references will never be
+                                expanded, regardless of whether the variable exists
+                                or not. Cannot be updated. More info: https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell'
+                              items:
+                                type: string
+                              type: array
+                            command:
+                              description: 'Entrypoint array. Not executed within
+                                a shell. The docker image''s ENTRYPOINT is used if
+                                this is not provided. Variable references $(VAR_NAME)
+                                are expanded using the container''s environment. If
+                                a variable cannot be resolved, the reference in the
+                                input string will be unchanged. The $(VAR_NAME) syntax
+                                can be escaped with a double $$, ie: $$(VAR_NAME).
+                                Escaped references will never be expanded, regardless
+                                of whether the variable exists or not. Cannot be updated.
+                                More info: https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell'
+                              items:
+                                type: string
+                              type: array
+                            env:
+                              description: List of environment variables to set in
+                                the container. Cannot be updated.
+                              items:
+                                description: EnvVar represents an environment variable
+                                  present in a Container.
+                                properties:
+                                  name:
+                                    description: Name of the environment variable.
+                                      Must be a C_IDENTIFIER.
+                                    type: string
+                                  value:
+                                    description: 'Variable references $(VAR_NAME)
+                                      are expanded using the previous defined environment
+                                      variables in the container and any service environment
+                                      variables. If a variable cannot be resolved,
+                                      the reference in the input string will be unchanged.
+                                      The $(VAR_NAME) syntax can be escaped with a
+                                      double $$, ie: $$(VAR_NAME). Escaped references
+                                      will never be expanded, regardless of whether
+                                      the variable exists or not. Defaults to "".'
+                                    type: string
+                                  valueFrom:
+                                    description: Source for the environment variable's
+                                      value. Cannot be used if value is not empty.
+                                    properties:
+                                      configMapKeyRef:
+                                        description: Selects a key of a ConfigMap.
+                                        properties:
+                                          key:
+                                            description: The key to select.
+                                            type: string
+                                          name:
+                                            description: 'Name of the referent. More
+                                              info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                              TODO: Add other useful fields. apiVersion,
+                                              kind, uid?'
+                                            type: string
+                                          optional:
+                                            description: Specify whether the ConfigMap
+                                              or its key must be defined
+                                            type: boolean
+                                        required:
+                                        - key
+                                        type: object
+                                      fieldRef:
+                                        description: 'Selects a field of the pod:
+                                          supports metadata.name, metadata.namespace,
+                                          metadata.labels, metadata.annotations, spec.nodeName,
+                                          spec.serviceAccountName, status.hostIP,
+                                          status.podIP.'
+                                        properties:
+                                          apiVersion:
+                                            description: Version of the schema the
+                                              FieldPath is written in terms of, defaults
+                                              to "v1".
+                                            type: string
+                                          fieldPath:
+                                            description: Path of the field to select
+                                              in the specified API version.
+                                            type: string
+                                        required:
+                                        - fieldPath
+                                        type: object
+                                      resourceFieldRef:
+                                        description: 'Selects a resource of the container:
+                                          only resources limits and requests (limits.cpu,
+                                          limits.memory, limits.ephemeral-storage,
+                                          requests.cpu, requests.memory and requests.ephemeral-storage)
+                                          are currently supported.'
+                                        properties:
+                                          containerName:
+                                            description: 'Container name: required
+                                              for volumes, optional for env vars'
+                                            type: string
+                                          divisor:
+                                            description: Specifies the output format
+                                              of the exposed resources, defaults to
+                                              "1"
+                                            type: string
+                                          resource:
+                                            description: 'Required: resource to select'
+                                            type: string
+                                        required:
+                                        - resource
+                                        type: object
+                                      secretKeyRef:
+                                        description: Selects a key of a secret in
+                                          the pod's namespace
+                                        properties:
+                                          key:
+                                            description: The key of the secret to
+                                              select from.  Must be a valid secret
+                                              key.
+                                            type: string
+                                          name:
+                                            description: 'Name of the referent. More
+                                              info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                              TODO: Add other useful fields. apiVersion,
+                                              kind, uid?'
+                                            type: string
+                                          optional:
+                                            description: Specify whether the Secret
+                                              or its key must be defined
+                                            type: boolean
+                                        required:
+                                        - key
+                                        type: object
+                                    type: object
+                                required:
+                                - name
+                                type: object
+                              type: array
+                            envFrom:
+                              description: List of sources to populate environment
+                                variables in the container. The keys defined within
+                                a source must be a C_IDENTIFIER. All invalid keys
+                                will be reported as an event when the container is
+                                starting. When a key exists in multiple sources, the
+                                value associated with the last source will take precedence.
+                                Values defined by an Env with a duplicate key will
+                                take precedence. Cannot be updated.
+                              items:
+                                description: EnvFromSource represents the source of
+                                  a set of ConfigMaps
+                                properties:
+                                  configMapRef:
+                                    description: The ConfigMap to select from
+                                    properties:
+                                      name:
+                                        description: 'Name of the referent. More info:
+                                          https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                          TODO: Add other useful fields. apiVersion,
+                                          kind, uid?'
+                                        type: string
+                                      optional:
+                                        description: Specify whether the ConfigMap
+                                          must be defined
+                                        type: boolean
+                                    type: object
+                                  prefix:
+                                    description: An optional identifier to prepend
+                                      to each key in the ConfigMap. Must be a C_IDENTIFIER.
+                                    type: string
+                                  secretRef:
+                                    description: The Secret to select from
+                                    properties:
+                                      name:
+                                        description: 'Name of the referent. More info:
+                                          https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                          TODO: Add other useful fields. apiVersion,
+                                          kind, uid?'
+                                        type: string
+                                      optional:
+                                        description: Specify whether the Secret must
+                                          be defined
+                                        type: boolean
+                                    type: object
+                                type: object
+                              type: array
+                            image:
+                              description: 'Docker image name. More info: https://kubernetes.io/docs/concepts/containers/images
+                                This field is optional to allow higher level config
+                                management to default or override container images
+                                in workload controllers like Deployments and StatefulSets.'
+                              type: string
+                            imagePullPolicy:
+                              description: 'Image pull policy. One of Always, Never,
+                                IfNotPresent. Defaults to Always if :v0.3.0 tag is
+                                specified, or IfNotPresent otherwise. Cannot be updated.
+                                More info: https://kubernetes.io/docs/concepts/containers/images#updating-images'
+                              type: string
+                            lifecycle:
+                              description: Actions that the management system should
+                                take in response to container lifecycle events. Cannot
+                                be updated.
+                              properties:
+                                postStart:
+                                  description: 'PostStart is called immediately after
+                                    a container is created. If the handler fails,
+                                    the container is terminated and restarted according
+                                    to its restart policy. Other management of the
+                                    container blocks until the hook completes. More
+                                    info: https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/#container-hooks'
+                                  properties:
+                                    exec:
+                                      description: One and only one of the following
+                                        should be specified. Exec specifies the action
+                                        to take.
+                                      properties:
+                                        command:
+                                          description: Command is the command line
+                                            to execute inside the container, the working
+                                            directory for the command  is root ('/')
+                                            in the container's filesystem. The command
+                                            is simply exec'd, it is not run inside
+                                            a shell, so traditional shell instructions
+                                            ('|', etc) won't work. To use a shell,
+                                            you need to explicitly call out to that
+                                            shell. Exit status of 0 is treated as
+                                            live/healthy and non-zero is unhealthy.
+                                          items:
+                                            type: string
+                                          type: array
+                                      type: object
+                                    httpGet:
+                                      description: HTTPGet specifies the http request
+                                        to perform.
+                                      properties:
+                                        host:
+                                          description: Host name to connect to, defaults
+                                            to the pod IP. You probably want to set
+                                            "Host" in httpHeaders instead.
+                                          type: string
+                                        httpHeaders:
+                                          description: Custom headers to set in the
+                                            request. HTTP allows repeated headers.
+                                          items:
+                                            description: HTTPHeader describes a custom
+                                              header to be used in HTTP probes
+                                            properties:
+                                              name:
+                                                description: The header field name
+                                                type: string
+                                              value:
+                                                description: The header field value
+                                                type: string
+                                            required:
+                                            - name
+                                            - value
+                                            type: object
+                                          type: array
+                                        path:
+                                          description: Path to access on the HTTP
+                                            server.
+                                          type: string
+                                        port:
+                                          anyOf:
+                                          - type: string
+                                          - type: integer
+                                          description: Name or number of the port
+                                            to access on the container. Number must
+                                            be in the range 1 to 65535. Name must
+                                            be an IANA_SVC_NAME.
+                                        scheme:
+                                          description: Scheme to use for connecting
+                                            to the host. Defaults to HTTP.
+                                          type: string
+                                      required:
+                                      - port
+                                      type: object
+                                    tcpSocket:
+                                      description: 'TCPSocket specifies an action
+                                        involving a TCP port. TCP hooks not yet supported
+                                        TODO: implement a realistic TCP lifecycle
+                                        hook'
+                                      properties:
+                                        host:
+                                          description: 'Optional: Host name to connect
+                                            to, defaults to the pod IP.'
+                                          type: string
+                                        port:
+                                          anyOf:
+                                          - type: string
+                                          - type: integer
+                                          description: Number or name of the port
+                                            to access on the container. Number must
+                                            be in the range 1 to 65535. Name must
+                                            be an IANA_SVC_NAME.
+                                      required:
+                                      - port
+                                      type: object
+                                  type: object
+                                preStop:
+                                  description: 'PreStop is called immediately before
+                                    a container is terminated due to an API request
+                                    or management event such as liveness probe failure,
+                                    preemption, resource contention, etc. The handler
+                                    is not called if the container crashes or exits.
+                                    The reason for termination is passed to the handler.
+                                    The Pod''s termination grace period countdown
+                                    begins before the PreStop hooked is executed.
+                                    Regardless of the outcome of the handler, the
+                                    container will eventually terminate within the
+                                    Pod''s termination grace period. Other management
+                                    of the container blocks until the hook completes
+                                    or until the termination grace period is reached.
+                                    More info: https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/#container-hooks'
+                                  properties:
+                                    exec:
+                                      description: One and only one of the following
+                                        should be specified. Exec specifies the action
+                                        to take.
+                                      properties:
+                                        command:
+                                          description: Command is the command line
+                                            to execute inside the container, the working
+                                            directory for the command  is root ('/')
+                                            in the container's filesystem. The command
+                                            is simply exec'd, it is not run inside
+                                            a shell, so traditional shell instructions
+                                            ('|', etc) won't work. To use a shell,
+                                            you need to explicitly call out to that
+                                            shell. Exit status of 0 is treated as
+                                            live/healthy and non-zero is unhealthy.
+                                          items:
+                                            type: string
+                                          type: array
+                                      type: object
+                                    httpGet:
+                                      description: HTTPGet specifies the http request
+                                        to perform.
+                                      properties:
+                                        host:
+                                          description: Host name to connect to, defaults
+                                            to the pod IP. You probably want to set
+                                            "Host" in httpHeaders instead.
+                                          type: string
+                                        httpHeaders:
+                                          description: Custom headers to set in the
+                                            request. HTTP allows repeated headers.
+                                          items:
+                                            description: HTTPHeader describes a custom
+                                              header to be used in HTTP probes
+                                            properties:
+                                              name:
+                                                description: The header field name
+                                                type: string
+                                              value:
+                                                description: The header field value
+                                                type: string
+                                            required:
+                                            - name
+                                            - value
+                                            type: object
+                                          type: array
+                                        path:
+                                          description: Path to access on the HTTP
+                                            server.
+                                          type: string
+                                        port:
+                                          anyOf:
+                                          - type: string
+                                          - type: integer
+                                          description: Name or number of the port
+                                            to access on the container. Number must
+                                            be in the range 1 to 65535. Name must
+                                            be an IANA_SVC_NAME.
+                                        scheme:
+                                          description: Scheme to use for connecting
+                                            to the host. Defaults to HTTP.
+                                          type: string
+                                      required:
+                                      - port
+                                      type: object
+                                    tcpSocket:
+                                      description: 'TCPSocket specifies an action
+                                        involving a TCP port. TCP hooks not yet supported
+                                        TODO: implement a realistic TCP lifecycle
+                                        hook'
+                                      properties:
+                                        host:
+                                          description: 'Optional: Host name to connect
+                                            to, defaults to the pod IP.'
+                                          type: string
+                                        port:
+                                          anyOf:
+                                          - type: string
+                                          - type: integer
+                                          description: Number or name of the port
+                                            to access on the container. Number must
+                                            be in the range 1 to 65535. Name must
+                                            be an IANA_SVC_NAME.
+                                      required:
+                                      - port
+                                      type: object
+                                  type: object
+                              type: object
+                            livenessProbe:
+                              description: 'Periodic probe of container liveness.
+                                Container will be restarted if the probe fails. Cannot
+                                be updated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                              properties:
+                                exec:
+                                  description: One and only one of the following should
+                                    be specified. Exec specifies the action to take.
+                                  properties:
+                                    command:
+                                      description: Command is the command line to
+                                        execute inside the container, the working
+                                        directory for the command  is root ('/') in
+                                        the container's filesystem. The command is
+                                        simply exec'd, it is not run inside a shell,
+                                        so traditional shell instructions ('|', etc)
+                                        won't work. To use a shell, you need to explicitly
+                                        call out to that shell. Exit status of 0 is
+                                        treated as live/healthy and non-zero is unhealthy.
+                                      items:
+                                        type: string
+                                      type: array
+                                  type: object
+                                failureThreshold:
+                                  description: Minimum consecutive failures for the
+                                    probe to be considered failed after having succeeded.
+                                    Defaults to 3. Minimum value is 1.
+                                  format: int32
+                                  type: integer
+                                httpGet:
+                                  description: HTTPGet specifies the http request
+                                    to perform.
+                                  properties:
+                                    host:
+                                      description: Host name to connect to, defaults
+                                        to the pod IP. You probably want to set "Host"
+                                        in httpHeaders instead.
+                                      type: string
+                                    httpHeaders:
+                                      description: Custom headers to set in the request.
+                                        HTTP allows repeated headers.
+                                      items:
+                                        description: HTTPHeader describes a custom
+                                          header to be used in HTTP probes
+                                        properties:
+                                          name:
+                                            description: The header field name
+                                            type: string
+                                          value:
+                                            description: The header field value
+                                            type: string
+                                        required:
+                                        - name
+                                        - value
+                                        type: object
+                                      type: array
+                                    path:
+                                      description: Path to access on the HTTP server.
+                                      type: string
+                                    port:
+                                      anyOf:
+                                      - type: string
+                                      - type: integer
+                                      description: Name or number of the port to access
+                                        on the container. Number must be in the range
+                                        1 to 65535. Name must be an IANA_SVC_NAME.
+                                    scheme:
+                                      description: Scheme to use for connecting to
+                                        the host. Defaults to HTTP.
+                                      type: string
+                                  required:
+                                  - port
+                                  type: object
+                                initialDelaySeconds:
+                                  description: 'Number of seconds after the container
+                                    has started before liveness probes are initiated.
+                                    More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                                  format: int32
+                                  type: integer
+                                periodSeconds:
+                                  description: How often (in seconds) to perform the
+                                    probe. Default to 10 seconds. Minimum value is
+                                    1.
+                                  format: int32
+                                  type: integer
+                                successThreshold:
+                                  description: Minimum consecutive successes for the
+                                    probe to be considered successful after having
+                                    failed. Defaults to 1. Must be 1 for liveness.
+                                    Minimum value is 1.
+                                  format: int32
+                                  type: integer
+                                tcpSocket:
+                                  description: 'TCPSocket specifies an action involving
+                                    a TCP port. TCP hooks not yet supported TODO:
+                                    implement a realistic TCP lifecycle hook'
+                                  properties:
+                                    host:
+                                      description: 'Optional: Host name to connect
+                                        to, defaults to the pod IP.'
+                                      type: string
+                                    port:
+                                      anyOf:
+                                      - type: string
+                                      - type: integer
+                                      description: Number or name of the port to access
+                                        on the container. Number must be in the range
+                                        1 to 65535. Name must be an IANA_SVC_NAME.
+                                  required:
+                                  - port
+                                  type: object
+                                timeoutSeconds:
+                                  description: 'Number of seconds after which the
+                                    probe times out. Defaults to 1 second. Minimum
+                                    value is 1. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                                  format: int32
+                                  type: integer
+                              type: object
+                            name:
+                              description: Name of the container specified as a DNS_LABEL.
+                                Each container in a pod must have a unique name (DNS_LABEL).
+                                Cannot be updated.
+                              type: string
+                            ports:
+                              description: List of ports to expose from the container.
+                                Exposing a port here gives the system additional information
+                                about the network connections a container uses, but
+                                is primarily informational. Not specifying a port
+                                here DOES NOT prevent that port from being exposed.
+                                Any port which is listening on the default "0.0.0.0"
+                                address inside a container will be accessible from
+                                the network. Cannot be updated.
+                              items:
+                                description: ContainerPort represents a network port
+                                  in a single container.
+                                properties:
+                                  containerPort:
+                                    description: Number of port to expose on the pod's
+                                      IP address. This must be a valid port number,
+                                      0 < x < 65536.
+                                    format: int32
+                                    type: integer
+                                  hostIP:
+                                    description: What host IP to bind the external
+                                      port to.
+                                    type: string
+                                  hostPort:
+                                    description: Number of port to expose on the host.
+                                      If specified, this must be a valid port number,
+                                      0 < x < 65536. If HostNetwork is specified,
+                                      this must match ContainerPort. Most containers
+                                      do not need this.
+                                    format: int32
+                                    type: integer
+                                  name:
+                                    description: If specified, this must be an IANA_SVC_NAME
+                                      and unique within the pod. Each named port in
+                                      a pod must have a unique name. Name for the
+                                      port that can be referred to by services.
+                                    type: string
+                                  protocol:
+                                    description: Protocol for port. Must be UDP, TCP,
+                                      or SCTP. Defaults to "TCP".
+                                    type: string
+                                required:
+                                - containerPort
+                                type: object
+                              type: array
+                            readinessProbe:
+                              description: 'Periodic probe of container service readiness.
+                                Container will be removed from service endpoints if
+                                the probe fails. Cannot be updated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                              properties:
+                                exec:
+                                  description: One and only one of the following should
+                                    be specified. Exec specifies the action to take.
+                                  properties:
+                                    command:
+                                      description: Command is the command line to
+                                        execute inside the container, the working
+                                        directory for the command  is root ('/') in
+                                        the container's filesystem. The command is
+                                        simply exec'd, it is not run inside a shell,
+                                        so traditional shell instructions ('|', etc)
+                                        won't work. To use a shell, you need to explicitly
+                                        call out to that shell. Exit status of 0 is
+                                        treated as live/healthy and non-zero is unhealthy.
+                                      items:
+                                        type: string
+                                      type: array
+                                  type: object
+                                failureThreshold:
+                                  description: Minimum consecutive failures for the
+                                    probe to be considered failed after having succeeded.
+                                    Defaults to 3. Minimum value is 1.
+                                  format: int32
+                                  type: integer
+                                httpGet:
+                                  description: HTTPGet specifies the http request
+                                    to perform.
+                                  properties:
+                                    host:
+                                      description: Host name to connect to, defaults
+                                        to the pod IP. You probably want to set "Host"
+                                        in httpHeaders instead.
+                                      type: string
+                                    httpHeaders:
+                                      description: Custom headers to set in the request.
+                                        HTTP allows repeated headers.
+                                      items:
+                                        description: HTTPHeader describes a custom
+                                          header to be used in HTTP probes
+                                        properties:
+                                          name:
+                                            description: The header field name
+                                            type: string
+                                          value:
+                                            description: The header field value
+                                            type: string
+                                        required:
+                                        - name
+                                        - value
+                                        type: object
+                                      type: array
+                                    path:
+                                      description: Path to access on the HTTP server.
+                                      type: string
+                                    port:
+                                      anyOf:
+                                      - type: string
+                                      - type: integer
+                                      description: Name or number of the port to access
+                                        on the container. Number must be in the range
+                                        1 to 65535. Name must be an IANA_SVC_NAME.
+                                    scheme:
+                                      description: Scheme to use for connecting to
+                                        the host. Defaults to HTTP.
+                                      type: string
+                                  required:
+                                  - port
+                                  type: object
+                                initialDelaySeconds:
+                                  description: 'Number of seconds after the container
+                                    has started before liveness probes are initiated.
+                                    More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                                  format: int32
+                                  type: integer
+                                periodSeconds:
+                                  description: How often (in seconds) to perform the
+                                    probe. Default to 10 seconds. Minimum value is
+                                    1.
+                                  format: int32
+                                  type: integer
+                                successThreshold:
+                                  description: Minimum consecutive successes for the
+                                    probe to be considered successful after having
+                                    failed. Defaults to 1. Must be 1 for liveness.
+                                    Minimum value is 1.
+                                  format: int32
+                                  type: integer
+                                tcpSocket:
+                                  description: 'TCPSocket specifies an action involving
+                                    a TCP port. TCP hooks not yet supported TODO:
+                                    implement a realistic TCP lifecycle hook'
+                                  properties:
+                                    host:
+                                      description: 'Optional: Host name to connect
+                                        to, defaults to the pod IP.'
+                                      type: string
+                                    port:
+                                      anyOf:
+                                      - type: string
+                                      - type: integer
+                                      description: Number or name of the port to access
+                                        on the container. Number must be in the range
+                                        1 to 65535. Name must be an IANA_SVC_NAME.
+                                  required:
+                                  - port
+                                  type: object
+                                timeoutSeconds:
+                                  description: 'Number of seconds after which the
+                                    probe times out. Defaults to 1 second. Minimum
+                                    value is 1. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                                  format: int32
+                                  type: integer
+                              type: object
+                            resources:
+                              description: 'Compute Resources required by this container.
+                                Cannot be updated. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
+                              properties:
+                                limits:
+                                  additionalProperties:
+                                    type: string
+                                  description: 'Limits describes the maximum amount
+                                    of compute resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
+                                  type: object
+                                requests:
+                                  additionalProperties:
+                                    type: string
+                                  description: 'Requests describes the minimum amount
+                                    of compute resources required. If Requests is
+                                    omitted for a container, it defaults to Limits
+                                    if that is explicitly specified, otherwise to
+                                    an implementation-defined value. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
+                                  type: object
+                              type: object
+                            securityContext:
+                              description: 'Security options the pod should run with.
+                                More info: https://kubernetes.io/docs/concepts/policy/security-context/
+                                More info: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/'
+                              properties:
+                                allowPrivilegeEscalation:
+                                  description: 'AllowPrivilegeEscalation controls
+                                    whether a process can gain more privileges than
+                                    its parent process. This bool directly controls
+                                    if the no_new_privs flag will be set on the container
+                                    process. AllowPrivilegeEscalation is true always
+                                    when the container is: 1) run as Privileged 2)
+                                    has CAP_SYS_ADMIN'
+                                  type: boolean
+                                capabilities:
+                                  description: The capabilities to add/drop when running
+                                    containers. Defaults to the default set of capabilities
+                                    granted by the container runtime.
+                                  properties:
+                                    add:
+                                      description: Added capabilities
+                                      items:
+                                        description: Capability represent POSIX capabilities
+                                          type
+                                        type: string
+                                      type: array
+                                    drop:
+                                      description: Removed capabilities
+                                      items:
+                                        description: Capability represent POSIX capabilities
+                                          type
+                                        type: string
+                                      type: array
+                                  type: object
+                                privileged:
+                                  description: Run container in privileged mode. Processes
+                                    in privileged containers are essentially equivalent
+                                    to root on the host. Defaults to false.
+                                  type: boolean
+                                procMount:
+                                  description: procMount denotes the type of proc
+                                    mount to use for the containers. The default is
+                                    DefaultProcMount which uses the container runtime
+                                    defaults for readonly paths and masked paths.
+                                    This requires the ProcMountType feature flag to
+                                    be enabled.
+                                  type: string
+                                readOnlyRootFilesystem:
+                                  description: Whether this container has a read-only
+                                    root filesystem. Default is false.
+                                  type: boolean
+                                runAsGroup:
+                                  description: The GID to run the entrypoint of the
+                                    container process. Uses runtime default if unset.
+                                    May also be set in PodSecurityContext.  If set
+                                    in both SecurityContext and PodSecurityContext,
+                                    the value specified in SecurityContext takes precedence.
+                                  format: int64
+                                  type: integer
+                                runAsNonRoot:
+                                  description: Indicates that the container must run
+                                    as a non-root user. If true, the Kubelet will
+                                    validate the image at runtime to ensure that it
+                                    does not run as UID 0 (root) and fail to start
+                                    the container if it does. If unset or false, no
+                                    such validation will be performed. May also be
+                                    set in PodSecurityContext.  If set in both SecurityContext
+                                    and PodSecurityContext, the value specified in
+                                    SecurityContext takes precedence.
+                                  type: boolean
+                                runAsUser:
+                                  description: The UID to run the entrypoint of the
+                                    container process. Defaults to user specified
+                                    in image metadata if unspecified. May also be
+                                    set in PodSecurityContext.  If set in both SecurityContext
+                                    and PodSecurityContext, the value specified in
+                                    SecurityContext takes precedence.
+                                  format: int64
+                                  type: integer
+                                seLinuxOptions:
+                                  description: The SELinux context to be applied to
+                                    the container. If unspecified, the container runtime
+                                    will allocate a random SELinux context for each
+                                    container.  May also be set in PodSecurityContext.  If
+                                    set in both SecurityContext and PodSecurityContext,
+                                    the value specified in SecurityContext takes precedence.
+                                  properties:
+                                    level:
+                                      description: Level is SELinux level label that
+                                        applies to the container.
+                                      type: string
+                                    role:
+                                      description: Role is a SELinux role label that
+                                        applies to the container.
+                                      type: string
+                                    type:
+                                      description: Type is a SELinux type label that
+                                        applies to the container.
+                                      type: string
+                                    user:
+                                      description: User is a SELinux user label that
+                                        applies to the container.
+                                      type: string
+                                  type: object
+                                windowsOptions:
+                                  description: Windows security options.
+                                  properties:
+                                    gmsaCredentialSpec:
+                                      description: GMSACredentialSpec is where the
+                                        GMSA admission webhook (https://github.com/kubernetes-sigs/windows-gmsa)
+                                        inlines the contents of the GMSA credential
+                                        spec named by the GMSACredentialSpecName field.
+                                        This field is alpha-level and is only honored
+                                        by servers that enable the WindowsGMSA feature
+                                        flag.
+                                      type: string
+                                    gmsaCredentialSpecName:
+                                      description: GMSACredentialSpecName is the name
+                                        of the GMSA credential spec to use. This field
+                                        is alpha-level and is only honored by servers
+                                        that enable the WindowsGMSA feature flag.
+                                      type: string
+                                  type: object
+                              type: object
+                            stdin:
+                              description: Whether this container should allocate
+                                a buffer for stdin in the container runtime. If this
+                                is not set, reads from stdin in the container will
+                                always result in EOF. Default is false.
+                              type: boolean
+                            stdinOnce:
+                              description: Whether the container runtime should close
+                                the stdin channel after it has been opened by a single
+                                attach. When stdin is true the stdin stream will remain
+                                open across multiple attach sessions. If stdinOnce
+                                is set to true, stdin is opened on container start,
+                                is empty until the first client attaches to stdin,
+                                and then remains open and accepts data until the client
+                                disconnects, at which time stdin is closed and remains
+                                closed until the container is restarted. If this flag
+                                is false, a container processes that reads from stdin
+                                will never receive an EOF. Default is false
+                              type: boolean
+                            terminationMessagePath:
+                              description: 'Optional: Path at which the file to which
+                                the container''s termination message will be written
+                                is mounted into the container''s filesystem. Message
+                                written is intended to be brief final status, such
+                                as an assertion failure message. Will be truncated
+                                by the node if greater than 4096 bytes. The total
+                                message length across all containers will be limited
+                                to 12kb. Defaults to /dev/termination-log. Cannot
+                                be updated.'
+                              type: string
+                            terminationMessagePolicy:
+                              description: Indicate how the termination message should
+                                be populated. File will use the contents of terminationMessagePath
+                                to populate the container status message on both success
+                                and failure. FallbackToLogsOnError will use the last
+                                chunk of container log output if the termination message
+                                file is empty and the container exited with an error.
+                                The log output is limited to 2048 bytes or 80 lines,
+                                whichever is smaller. Defaults to File. Cannot be
+                                updated.
+                              type: string
+                            tty:
+                              description: Whether this container should allocate
+                                a TTY for itself, also requires 'stdin' to be true.
+                                Default is false.
+                              type: boolean
+                            volumeDevices:
+                              description: volumeDevices is the list of block devices
+                                to be used by the container. This is a beta feature.
+                              items:
+                                description: volumeDevice describes a mapping of a
+                                  raw block device within a container.
+                                properties:
+                                  devicePath:
+                                    description: devicePath is the path inside of
+                                      the container that the device will be mapped
+                                      to.
+                                    type: string
+                                  name:
+                                    description: name must match the name of a persistentVolumeClaim
+                                      in the pod
+                                    type: string
+                                required:
+                                - devicePath
+                                - name
+                                type: object
+                              type: array
+                            volumeMounts:
+                              description: Pod volumes to mount into the container's
+                                filesystem. Cannot be updated.
+                              items:
+                                description: VolumeMount describes a mounting of a
+                                  Volume within a container.
+                                properties:
+                                  mountPath:
+                                    description: Path within the container at which
+                                      the volume should be mounted.  Must not contain
+                                      ':'.
+                                    type: string
+                                  mountPropagation:
+                                    description: mountPropagation determines how mounts
+                                      are propagated from the host to container and
+                                      the other way around. When not set, MountPropagationNone
+                                      is used. This field is beta in 1.10.
+                                    type: string
+                                  name:
+                                    description: This must match the Name of a Volume.
+                                    type: string
+                                  readOnly:
+                                    description: Mounted read-only if true, read-write
+                                      otherwise (false or unspecified). Defaults to
+                                      false.
+                                    type: boolean
+                                  subPath:
+                                    description: Path within the volume from which
+                                      the container's volume should be mounted. Defaults
+                                      to "" (volume's root).
+                                    type: string
+                                  subPathExpr:
+                                    description: Expanded path within the volume from
+                                      which the container's volume should be mounted.
+                                      Behaves similarly to SubPath but environment
+                                      variable references $(VAR_NAME) are expanded
+                                      using the container's environment. Defaults
+                                      to "" (volume's root). SubPathExpr and SubPath
+                                      are mutually exclusive. This field is beta in
+                                      1.15.
+                                    type: string
+                                required:
+                                - mountPath
+                                - name
+                                type: object
+                              type: array
+                            workingDir:
+                              description: Container's working directory. If not specified,
+                                the container runtime's default will be used, which
+                                might be configured in the container image. Cannot
+                                be updated.
+                              type: string
+                          required:
+                          - name
+                          type: object
+                      required:
+                      - container
+                      type: object
+                    logger:
+                      description: Activate request/response logging
+                      properties:
+                        mode:
+                          description: What payloads to log
+                          type: string
+                        url:
+                          description: URL to send request logging CloudEvents
+                          type: string
+                      type: object
+                    maxReplicas:
+                      description: This is the up bound for autoscaler to scale to
+                      type: integer
+                    minReplicas:
+                      description: Minimum number of replicas, pods won't scale down
+                        to 0 in case of no traffic
+                      type: integer
+                    parallelism:
+                      description: Parallelism specifies how many requests can be
+                        processed concurrently, this sets the target concurrency for
+                        Autoscaling(KPA). For model servers that support tuning parallelism
+                        will use this value, by default the parallelism is the number
+                        of the CPU cores for most of the model servers.
+                      type: integer
+                    serviceAccountName:
+                      description: ServiceAccountName is the name of the ServiceAccount
+                        to use to run the service
+                      type: string
+                  type: object
+              required:
+              - predictor
+              type: object
+          required:
+          - default
+          type: object
+        status:
+          description: InferenceServiceStatus defines the observed state of InferenceService
+          properties:
+            address:
+              description: Ducktype for addressable
+              properties:
+                url:
+                  description: URL is an alias of url.URL. It has custom json marshal
+                    methods that enable it to be used in K8s CRDs such that the CRD
+                    resource will have the URL but operator code can can work with
+                    url.URL struct
+                  type: string
+            canary:
+              additionalProperties:
+                description: StatusConfigurationSpec describes the state of the configuration
+                  receiving traffic.
+                properties:
+                  host:
+                    description: Host name of the service
+                    type: string
+                  name:
+                    description: Latest revision name that is in ready state
+                    type: string
+                  replicas:
+                    type: integer
+                type: object
+              description: Statuses for the canary endpoints of the InferenceService
+              type: object
+            canaryTraffic:
+              description: Traffic percentage that goes to canary services
+              type: integer
+            conditions:
+              description: Conditions the latest available observations of a resource's
+                current state. +patchMergeKey=type +patchStrategy=merge
+              items:
+                properties:
+                  lastTransitionTime:
+                    description: LastTransitionTime is the last time the condition
+                      transitioned from one status to another. We use VolatileTime
+                      in place of metav1.Time to exclude this from creating equality.Semantic
+                      differences (all other things held constant).
+                    type: string
+                  message:
+                    description: A human readable message indicating details about
+                      the transition.
+                    type: string
+                  reason:
+                    description: The reason for the condition's last transition.
+                    type: string
+                  severity:
+                    description: Severity with which to treat failures of this type
+                      of condition. When this is not specified, it defaults to Error.
+                    type: string
+                  status:
+                    description: Status of the condition, one of True, False, Unknown.
+                      +required
+                    type: string
+                  type:
+                    description: Type of condition. +required
+                    type: string
+                required:
+                - type
+                - status
+                type: object
+              type: array
+            default:
+              additionalProperties:
+                description: StatusConfigurationSpec describes the state of the configuration
+                  receiving traffic.
+                properties:
+                  host:
+                    description: Host name of the service
+                    type: string
+                  name:
+                    description: Latest revision name that is in ready state
+                    type: string
+                  replicas:
+                    type: integer
+                type: object
+              description: Statuses for the default endpoints of the InferenceService
+              type: object
+            observedGeneration:
+              description: ObservedGeneration is the 'Generation' of the Service that
+                was last processed by the controller.
+              format: int64
+              type: integer
+            traffic:
+              description: Traffic percentage that goes to default services
+              type: integer
+            url:
+              description: URL of the InferenceService
+              type: string
+          type: object
+      type: object
+  version: v1alpha2
+  versions:
+  - name: v1alpha2
+    served: true
+    storage: true

--- a/tests/stacks/examples/alice/test_data/expected/apiextensions.k8s.io_v1beta1_customresourcedefinition_ingresses.networking.internal.knative.dev.yaml
+++ b/tests/stacks/examples/alice/test_data/expected/apiextensions.k8s.io_v1beta1_customresourcedefinition_ingresses.networking.internal.knative.dev.yaml
@@ -1,0 +1,35 @@
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  labels:
+    app.kubernetes.io/component: knative-serving-install
+    app.kubernetes.io/name: knative-serving-install
+    knative.dev/crd-install: "true"
+    kustomize.component: knative
+    serving.knative.dev/release: v0.11.2
+  name: ingresses.networking.internal.knative.dev
+spec:
+  additionalPrinterColumns:
+  - JSONPath: .status.conditions[?(@.type=='Ready')].status
+    name: Ready
+    type: string
+  - JSONPath: .status.conditions[?(@.type=='Ready')].reason
+    name: Reason
+    type: string
+  group: networking.internal.knative.dev
+  names:
+    categories:
+    - knative-internal
+    - networking
+    kind: Ingress
+    plural: ingresses
+    shortNames:
+    - ing
+    singular: ingress
+  scope: Namespaced
+  subresources:
+    status: {}
+  versions:
+  - name: v1alpha1
+    served: true
+    storage: true

--- a/tests/stacks/examples/alice/test_data/expected/apiextensions.k8s.io_v1beta1_customresourcedefinition_metrics.autoscaling.internal.knative.dev.yaml
+++ b/tests/stacks/examples/alice/test_data/expected/apiextensions.k8s.io_v1beta1_customresourcedefinition_metrics.autoscaling.internal.knative.dev.yaml
@@ -1,0 +1,30 @@
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  labels:
+    app.kubernetes.io/component: knative-serving-install
+    app.kubernetes.io/name: knative-serving-install
+    knative.dev/crd-install: "true"
+    kustomize.component: knative
+    serving.knative.dev/release: v0.11.2
+  name: metrics.autoscaling.internal.knative.dev
+spec:
+  additionalPrinterColumns:
+  - JSONPath: .status.conditions[?(@.type=='Ready')].status
+    name: Ready
+    type: string
+  - JSONPath: .status.conditions[?(@.type=='Ready')].reason
+    name: Reason
+    type: string
+  group: autoscaling.internal.knative.dev
+  names:
+    categories:
+    - knative-internal
+    - autoscaling
+    kind: Metric
+    plural: metrics
+    singular: metric
+  scope: Namespaced
+  subresources:
+    status: {}
+  version: v1alpha1

--- a/tests/stacks/examples/alice/test_data/expected/apiextensions.k8s.io_v1beta1_customresourcedefinition_podautoscalers.autoscaling.internal.knative.dev.yaml
+++ b/tests/stacks/examples/alice/test_data/expected/apiextensions.k8s.io_v1beta1_customresourcedefinition_podautoscalers.autoscaling.internal.knative.dev.yaml
@@ -1,0 +1,42 @@
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  labels:
+    app.kubernetes.io/component: knative-serving-install
+    app.kubernetes.io/name: knative-serving-install
+    knative.dev/crd-install: "true"
+    kustomize.component: knative
+    serving.knative.dev/release: v0.11.2
+  name: podautoscalers.autoscaling.internal.knative.dev
+spec:
+  additionalPrinterColumns:
+  - JSONPath: .status.desiredScale
+    name: DesiredScale
+    type: integer
+  - JSONPath: .status.actualScale
+    name: ActualScale
+    type: integer
+  - JSONPath: .status.conditions[?(@.type=='Ready')].status
+    name: Ready
+    type: string
+  - JSONPath: .status.conditions[?(@.type=='Ready')].reason
+    name: Reason
+    type: string
+  group: autoscaling.internal.knative.dev
+  names:
+    categories:
+    - knative-internal
+    - autoscaling
+    kind: PodAutoscaler
+    plural: podautoscalers
+    shortNames:
+    - kpa
+    - pa
+    singular: podautoscaler
+  scope: Namespaced
+  subresources:
+    status: {}
+  versions:
+  - name: v1alpha1
+    served: true
+    storage: true

--- a/tests/stacks/examples/alice/test_data/expected/apiextensions.k8s.io_v1beta1_customresourcedefinition_revisions.serving.knative.dev.yaml
+++ b/tests/stacks/examples/alice/test_data/expected/apiextensions.k8s.io_v1beta1_customresourcedefinition_revisions.serving.knative.dev.yaml
@@ -1,0 +1,51 @@
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  labels:
+    app.kubernetes.io/component: knative-serving-install
+    app.kubernetes.io/name: knative-serving-install
+    knative.dev/crd-install: "true"
+    kustomize.component: knative
+    serving.knative.dev/release: v0.11.2
+  name: revisions.serving.knative.dev
+spec:
+  additionalPrinterColumns:
+  - JSONPath: .metadata.labels['serving\.knative\.dev/configuration']
+    name: Config Name
+    type: string
+  - JSONPath: .status.serviceName
+    name: K8s Service Name
+    type: string
+  - JSONPath: .metadata.labels['serving\.knative\.dev/configurationGeneration']
+    name: Generation
+    type: string
+  - JSONPath: .status.conditions[?(@.type=='Ready')].status
+    name: Ready
+    type: string
+  - JSONPath: .status.conditions[?(@.type=='Ready')].reason
+    name: Reason
+    type: string
+  group: serving.knative.dev
+  names:
+    categories:
+    - all
+    - knative
+    - serving
+    kind: Revision
+    plural: revisions
+    shortNames:
+    - rev
+    singular: revision
+  scope: Namespaced
+  subresources:
+    status: {}
+  versions:
+  - name: v1alpha1
+    served: true
+    storage: true
+  - name: v1beta1
+    served: true
+    storage: false
+  - name: v1
+    served: true
+    storage: false

--- a/tests/stacks/examples/alice/test_data/expected/apiextensions.k8s.io_v1beta1_customresourcedefinition_routes.serving.knative.dev.yaml
+++ b/tests/stacks/examples/alice/test_data/expected/apiextensions.k8s.io_v1beta1_customresourcedefinition_routes.serving.knative.dev.yaml
@@ -1,0 +1,46 @@
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  labels:
+    app.kubernetes.io/component: knative-serving-install
+    app.kubernetes.io/name: knative-serving-install
+    duck.knative.dev/addressable: "true"
+    knative.dev/crd-install: "true"
+    kustomize.component: knative
+    serving.knative.dev/release: v0.11.2
+  name: routes.serving.knative.dev
+spec:
+  additionalPrinterColumns:
+  - JSONPath: .status.url
+    name: URL
+    type: string
+  - JSONPath: .status.conditions[?(@.type=='Ready')].status
+    name: Ready
+    type: string
+  - JSONPath: .status.conditions[?(@.type=='Ready')].reason
+    name: Reason
+    type: string
+  group: serving.knative.dev
+  names:
+    categories:
+    - all
+    - knative
+    - serving
+    kind: Route
+    plural: routes
+    shortNames:
+    - rt
+    singular: route
+  scope: Namespaced
+  subresources:
+    status: {}
+  versions:
+  - name: v1alpha1
+    served: true
+    storage: true
+  - name: v1beta1
+    served: true
+    storage: false
+  - name: v1
+    served: true
+    storage: false

--- a/tests/stacks/examples/alice/test_data/expected/apiextensions.k8s.io_v1beta1_customresourcedefinition_serverlessservices.networking.internal.knative.dev.yaml
+++ b/tests/stacks/examples/alice/test_data/expected/apiextensions.k8s.io_v1beta1_customresourcedefinition_serverlessservices.networking.internal.knative.dev.yaml
@@ -1,0 +1,44 @@
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  labels:
+    app.kubernetes.io/component: knative-serving-install
+    app.kubernetes.io/name: knative-serving-install
+    knative.dev/crd-install: "true"
+    kustomize.component: knative
+    serving.knative.dev/release: v0.11.2
+  name: serverlessservices.networking.internal.knative.dev
+spec:
+  additionalPrinterColumns:
+  - JSONPath: .spec.mode
+    name: Mode
+    type: string
+  - JSONPath: .status.serviceName
+    name: ServiceName
+    type: string
+  - JSONPath: .status.privateServiceName
+    name: PrivateServiceName
+    type: string
+  - JSONPath: .status.conditions[?(@.type=='Ready')].status
+    name: Ready
+    type: string
+  - JSONPath: .status.conditions[?(@.type=='Ready')].reason
+    name: Reason
+    type: string
+  group: networking.internal.knative.dev
+  names:
+    categories:
+    - knative-internal
+    - networking
+    kind: ServerlessService
+    plural: serverlessservices
+    shortNames:
+    - sks
+    singular: serverlessservice
+  scope: Namespaced
+  subresources:
+    status: {}
+  versions:
+  - name: v1alpha1
+    served: true
+    storage: true

--- a/tests/stacks/examples/alice/test_data/expected/apiextensions.k8s.io_v1beta1_customresourcedefinition_services.serving.knative.dev.yaml
+++ b/tests/stacks/examples/alice/test_data/expected/apiextensions.k8s.io_v1beta1_customresourcedefinition_services.serving.knative.dev.yaml
@@ -1,0 +1,54 @@
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  labels:
+    app.kubernetes.io/component: knative-serving-install
+    app.kubernetes.io/name: knative-serving-install
+    duck.knative.dev/addressable: "true"
+    duck.knative.dev/podspecable: "true"
+    knative.dev/crd-install: "true"
+    kustomize.component: knative
+    serving.knative.dev/release: v0.11.2
+  name: services.serving.knative.dev
+spec:
+  additionalPrinterColumns:
+  - JSONPath: .status.url
+    name: URL
+    type: string
+  - JSONPath: .status.latestCreatedRevisionName
+    name: LatestCreated
+    type: string
+  - JSONPath: .status.latestReadyRevisionName
+    name: LatestReady
+    type: string
+  - JSONPath: .status.conditions[?(@.type=='Ready')].status
+    name: Ready
+    type: string
+  - JSONPath: .status.conditions[?(@.type=='Ready')].reason
+    name: Reason
+    type: string
+  group: serving.knative.dev
+  names:
+    categories:
+    - all
+    - knative
+    - serving
+    kind: Service
+    plural: services
+    shortNames:
+    - kservice
+    - ksvc
+    singular: service
+  scope: Namespaced
+  subresources:
+    status: {}
+  versions:
+  - name: v1alpha1
+    served: true
+    storage: true
+  - name: v1beta1
+    served: true
+    storage: false
+  - name: v1
+    served: true
+    storage: false

--- a/tests/stacks/examples/alice/test_data/expected/apiregistration.k8s.io_v1beta1_apiservice_v1beta1.custom.metrics.k8s.io.yaml
+++ b/tests/stacks/examples/alice/test_data/expected/apiregistration.k8s.io_v1beta1_apiservice_v1beta1.custom.metrics.k8s.io.yaml
@@ -1,0 +1,19 @@
+apiVersion: apiregistration.k8s.io/v1beta1
+kind: APIService
+metadata:
+  labels:
+    app.kubernetes.io/component: knative-serving-install
+    app.kubernetes.io/name: knative-serving-install
+    autoscaling.knative.dev/metric-provider: custom-metrics
+    kustomize.component: knative
+    serving.knative.dev/release: v0.11.2
+  name: v1beta1.custom.metrics.k8s.io
+spec:
+  group: custom.metrics.k8s.io
+  groupPriorityMinimum: 100
+  insecureSkipTLSVerify: true
+  service:
+    name: autoscaler
+    namespace: knative-serving
+  version: v1beta1
+  versionPriority: 100

--- a/tests/stacks/examples/alice/test_data/expected/app.k8s.io_v1beta1_application_kfserving-crds.yaml
+++ b/tests/stacks/examples/alice/test_data/expected/app.k8s.io_v1beta1_application_kfserving-crds.yaml
@@ -1,0 +1,37 @@
+apiVersion: app.k8s.io/v1beta1
+kind: Application
+metadata:
+  labels:
+    app: kfserving
+    app.kubernetes.io/component: kfserving-install
+    app.kubernetes.io/name: kfserving-install
+    kustomize.component: kfserving
+  name: kfserving-crds
+  namespace: kubeflow
+spec:
+  addOwnerRef: true
+  componentKinds:
+  - group: core
+    kind: ConfigMap
+  - group: apps
+    kind: Deployment
+  descriptor:
+    description: ""
+    keywords:
+    - kfserving-crds
+    - kubeflow
+    links:
+    - description: About
+      url: ""
+    maintainers: []
+    owners: []
+    type: kfserving-crds
+    version: v1beta1
+  selector:
+    matchLabels:
+      app.kubernetes.io/component: kfserving-crds
+      app.kubernetes.io/instance: kfserving-crds-v0.7.0
+      app.kubernetes.io/managed-by: kfctl
+      app.kubernetes.io/name: kfserving-crds
+      app.kubernetes.io/part-of: kubeflow
+      app.kubernetes.io/version: v0.7.0

--- a/tests/stacks/examples/alice/test_data/expected/app.k8s.io_v1beta1_application_kfserving.yaml
+++ b/tests/stacks/examples/alice/test_data/expected/app.k8s.io_v1beta1_application_kfserving.yaml
@@ -1,0 +1,47 @@
+apiVersion: app.k8s.io/v1beta1
+kind: Application
+metadata:
+  labels:
+    app: kfserving
+    app.kubernetes.io/component: kfserving-install
+    app.kubernetes.io/name: kfserving-install
+    kustomize.component: kfserving
+  name: kfserving
+  namespace: kubeflow
+spec:
+  componentKinds:
+  - group: apps/v1
+    kind: StatefulSet
+  - group: v1
+    kind: Service
+  - group: apps/v1
+    kind: Deployment
+  - group: v1
+    kind: Secret
+  - group: v1
+    kind: ConfigMap
+  description: KFServing provides a Kubernetes Custom Resource Definition for serving
+    ML Models on arbitrary frameworks
+  icons: null
+  keywords:
+  - kfserving
+  - inference
+  links:
+  - description: About
+    url: https://github.com/kubeflow/kfserving
+  maintainers:
+  - email: johnugeo@cisco.com
+    name: Johnu George
+  owners:
+  - email: johnugeo@cisco.com
+    name: Johnu George
+  selector:
+    matchLabels:
+      app.kubernetes.io/component: kfserving-install
+      app.kubernetes.io/instance: kfserving-install
+      app.kubernetes.io/managed-by: kfctl
+      app.kubernetes.io/name: kfserving-install
+      app.kubernetes.io/part-of: kubeflow
+      app.kubernetes.io/version: v0.3.0
+  type: kfserving
+  version: v1alpha2

--- a/tests/stacks/examples/alice/test_data/expected/app.k8s.io_v1beta1_application_knative-serving-crds.yaml
+++ b/tests/stacks/examples/alice/test_data/expected/app.k8s.io_v1beta1_application_knative-serving-crds.yaml
@@ -1,0 +1,36 @@
+apiVersion: app.k8s.io/v1beta1
+kind: Application
+metadata:
+  labels:
+    app.kubernetes.io/component: knative-serving-install
+    app.kubernetes.io/name: knative-serving-install
+    kustomize.component: knative
+  name: knative-serving-crds
+  namespace: kubeflow
+spec:
+  addOwnerRef: true
+  componentKinds:
+  - group: core
+    kind: ConfigMap
+  - group: apps
+    kind: Deployment
+  descriptor:
+    description: ""
+    keywords:
+    - knative-serving-crds
+    - kubeflow
+    links:
+    - description: About
+      url: ""
+    maintainers: []
+    owners: []
+    type: knative-serving-crds
+    version: v1beta1
+  selector:
+    matchLabels:
+      app.kubernetes.io/component: knative-serving-crds
+      app.kubernetes.io/instance: knative-serving-crds
+      app.kubernetes.io/managed-by: kfctl
+      app.kubernetes.io/name: knative-serving-crds
+      app.kubernetes.io/part-of: kubeflow
+      app.kubernetes.io/version: v0.11.2

--- a/tests/stacks/examples/alice/test_data/expected/app.k8s.io_v1beta1_application_knative-serving-install.yaml
+++ b/tests/stacks/examples/alice/test_data/expected/app.k8s.io_v1beta1_application_knative-serving-install.yaml
@@ -1,0 +1,36 @@
+apiVersion: app.k8s.io/v1beta1
+kind: Application
+metadata:
+  labels:
+    app.kubernetes.io/component: knative-serving-install
+    app.kubernetes.io/name: knative-serving-install
+    kustomize.component: knative
+  name: knative-serving-install
+  namespace: kubeflow
+spec:
+  addOwnerRef: true
+  componentKinds:
+  - group: core
+    kind: ConfigMap
+  - group: apps
+    kind: Deployment
+  descriptor:
+    description: ""
+    keywords:
+    - knative-serving-install
+    - kubeflow
+    links:
+    - description: About
+      url: ""
+    maintainers: []
+    owners: []
+    type: knative-serving-install
+    version: v1beta1
+  selector:
+    matchLabels:
+      app.kubernetes.io/component: knative-serving-install
+      app.kubernetes.io/instance: knative-serving-install
+      app.kubernetes.io/managed-by: kfctl
+      app.kubernetes.io/name: knative-serving-install
+      app.kubernetes.io/part-of: kubeflow
+      app.kubernetes.io/version: v0.11.2

--- a/tests/stacks/examples/alice/test_data/expected/apps_v1_deployment_activator.yaml
+++ b/tests/stacks/examples/alice/test_data/expected/apps_v1_deployment_activator.yaml
@@ -1,0 +1,87 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  labels:
+    app.kubernetes.io/component: knative-serving-install
+    app.kubernetes.io/name: knative-serving-install
+    kustomize.component: knative
+    serving.knative.dev/release: v0.11.2
+  name: activator
+  namespace: kubeflow
+spec:
+  selector:
+    matchLabels:
+      app: activator
+      app.kubernetes.io/component: knative-serving-install
+      app.kubernetes.io/name: knative-serving-install
+      kustomize.component: knative
+      role: activator
+  template:
+    metadata:
+      annotations:
+        cluster-autoscaler.kubernetes.io/safe-to-evict: "false"
+        sidecar.istio.io/inject: "false"
+      labels:
+        app: activator
+        app.kubernetes.io/component: knative-serving-install
+        app.kubernetes.io/name: knative-serving-install
+        kustomize.component: knative
+        role: activator
+        serving.knative.dev/release: v0.11.2
+    spec:
+      containers:
+      - env:
+        - name: POD_NAME
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.name
+        - name: POD_IP
+          valueFrom:
+            fieldRef:
+              fieldPath: status.podIP
+        - name: SYSTEM_NAMESPACE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace
+        - name: CONFIG_LOGGING_NAME
+          value: config-logging
+        - name: CONFIG_OBSERVABILITY_NAME
+          value: config-observability
+        - name: METRICS_DOMAIN
+          value: knative.dev/internal/serving
+        image: gcr.io/knative-releases/knative.dev/serving/cmd/activator@sha256:c51023e62e351d5910f92ee941b4929eb82539e62636dd3ccb4a016d73e86b2e
+        livenessProbe:
+          httpGet:
+            httpHeaders:
+            - name: k-kubelet-probe
+              value: activator
+            path: /healthz
+            port: 8012
+        name: activator
+        ports:
+        - containerPort: 8012
+          name: http1
+        - containerPort: 8013
+          name: h2c
+        - containerPort: 9090
+          name: metrics
+        - containerPort: 8008
+          name: profiling
+        readinessProbe:
+          httpGet:
+            httpHeaders:
+            - name: k-kubelet-probe
+              value: activator
+            path: /healthz
+            port: 8012
+        resources:
+          limits:
+            cpu: 1000m
+            memory: 600Mi
+          requests:
+            cpu: 300m
+            memory: 60Mi
+        securityContext:
+          allowPrivilegeEscalation: false
+      serviceAccountName: controller
+      terminationGracePeriodSeconds: 300

--- a/tests/stacks/examples/alice/test_data/expected/apps_v1_deployment_autoscaler-hpa.yaml
+++ b/tests/stacks/examples/alice/test_data/expected/apps_v1_deployment_autoscaler-hpa.yaml
@@ -1,0 +1,59 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  labels:
+    app.kubernetes.io/component: knative-serving-install
+    app.kubernetes.io/name: knative-serving-install
+    autoscaling.knative.dev/autoscaler-provider: hpa
+    kustomize.component: knative
+    serving.knative.dev/release: v0.11.2
+  name: autoscaler-hpa
+  namespace: kubeflow
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: autoscaler-hpa
+      app.kubernetes.io/component: knative-serving-install
+      app.kubernetes.io/name: knative-serving-install
+      kustomize.component: knative
+  template:
+    metadata:
+      annotations:
+        sidecar.istio.io/inject: "false"
+      labels:
+        app: autoscaler-hpa
+        app.kubernetes.io/component: knative-serving-install
+        app.kubernetes.io/name: knative-serving-install
+        kustomize.component: knative
+        serving.knative.dev/release: v0.11.2
+    spec:
+      containers:
+      - env:
+        - name: SYSTEM_NAMESPACE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace
+        - name: CONFIG_LOGGING_NAME
+          value: config-logging
+        - name: CONFIG_OBSERVABILITY_NAME
+          value: config-observability
+        - name: METRICS_DOMAIN
+          value: knative.dev/serving
+        image: gcr.io/knative-releases/knative.dev/serving/cmd/autoscaler-hpa@sha256:75da5ff75bc1e71799d039846b1bbd632343894c88feaa59914cfeeb1b213c81
+        name: autoscaler-hpa
+        ports:
+        - containerPort: 9090
+          name: metrics
+        - containerPort: 8008
+          name: profiling
+        resources:
+          limits:
+            cpu: 1000m
+            memory: 1000Mi
+          requests:
+            cpu: 100m
+            memory: 100Mi
+        securityContext:
+          allowPrivilegeEscalation: false
+      serviceAccountName: controller

--- a/tests/stacks/examples/alice/test_data/expected/apps_v1_deployment_autoscaler.yaml
+++ b/tests/stacks/examples/alice/test_data/expected/apps_v1_deployment_autoscaler.yaml
@@ -1,0 +1,81 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  labels:
+    app.kubernetes.io/component: knative-serving-install
+    app.kubernetes.io/name: knative-serving-install
+    kustomize.component: knative
+    serving.knative.dev/release: v0.11.2
+  name: autoscaler
+  namespace: kubeflow
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: autoscaler
+      app.kubernetes.io/component: knative-serving-install
+      app.kubernetes.io/name: knative-serving-install
+      kustomize.component: knative
+  template:
+    metadata:
+      annotations:
+        cluster-autoscaler.kubernetes.io/safe-to-evict: "false"
+        sidecar.istio.io/inject: "false"
+        traffic.sidecar.istio.io/includeInboundPorts: 8080,9090
+      labels:
+        app: autoscaler
+        app.kubernetes.io/component: knative-serving-install
+        app.kubernetes.io/name: knative-serving-install
+        kustomize.component: knative
+        serving.knative.dev/release: v0.11.2
+    spec:
+      containers:
+      - args:
+        - --secure-port=8443
+        - --cert-dir=/tmp
+        env:
+        - name: SYSTEM_NAMESPACE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace
+        - name: CONFIG_LOGGING_NAME
+          value: config-logging
+        - name: CONFIG_OBSERVABILITY_NAME
+          value: config-observability
+        - name: METRICS_DOMAIN
+          value: knative.dev/serving
+        image: gcr.io/knative-releases/knative.dev/serving/cmd/autoscaler@sha256:998a405454832cda18a4bf956d26d610a2df2130a39b834b597a89a3153c8c15
+        livenessProbe:
+          httpGet:
+            httpHeaders:
+            - name: k-kubelet-probe
+              value: autoscaler
+            path: /healthz
+            port: 8080
+        name: autoscaler
+        ports:
+        - containerPort: 8080
+          name: websocket
+        - containerPort: 9090
+          name: metrics
+        - containerPort: 8443
+          name: custom-metrics
+        - containerPort: 8008
+          name: profiling
+        readinessProbe:
+          httpGet:
+            httpHeaders:
+            - name: k-kubelet-probe
+              value: autoscaler
+            path: /healthz
+            port: 8080
+        resources:
+          limits:
+            cpu: 300m
+            memory: 400Mi
+          requests:
+            cpu: 30m
+            memory: 40Mi
+        securityContext:
+          allowPrivilegeEscalation: false
+      serviceAccountName: controller

--- a/tests/stacks/examples/alice/test_data/expected/apps_v1_deployment_controller.yaml
+++ b/tests/stacks/examples/alice/test_data/expected/apps_v1_deployment_controller.yaml
@@ -1,0 +1,58 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  labels:
+    app.kubernetes.io/component: knative-serving-install
+    app.kubernetes.io/name: knative-serving-install
+    kustomize.component: knative
+    serving.knative.dev/release: v0.11.2
+  name: controller
+  namespace: kubeflow
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: controller
+      app.kubernetes.io/component: knative-serving-install
+      app.kubernetes.io/name: knative-serving-install
+      kustomize.component: knative
+  template:
+    metadata:
+      annotations:
+        sidecar.istio.io/inject: "false"
+      labels:
+        app: controller
+        app.kubernetes.io/component: knative-serving-install
+        app.kubernetes.io/name: knative-serving-install
+        kustomize.component: knative
+        serving.knative.dev/release: v0.11.2
+    spec:
+      containers:
+      - env:
+        - name: SYSTEM_NAMESPACE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace
+        - name: CONFIG_LOGGING_NAME
+          value: config-logging
+        - name: CONFIG_OBSERVABILITY_NAME
+          value: config-observability
+        - name: METRICS_DOMAIN
+          value: knative.dev/internal/serving
+        image: gcr.io/knative-releases/knative.dev/serving/cmd/controller@sha256:1e77bdab30c8d0f0df299f5fa93d6f99eb63071b9d3329937dff0c6acb99e059
+        name: controller
+        ports:
+        - containerPort: 9090
+          name: metrics
+        - containerPort: 8008
+          name: profiling
+        resources:
+          limits:
+            cpu: 1000m
+            memory: 1000Mi
+          requests:
+            cpu: 100m
+            memory: 100Mi
+        securityContext:
+          allowPrivilegeEscalation: false
+      serviceAccountName: controller

--- a/tests/stacks/examples/alice/test_data/expected/apps_v1_deployment_networking-istio.yaml
+++ b/tests/stacks/examples/alice/test_data/expected/apps_v1_deployment_networking-istio.yaml
@@ -1,0 +1,59 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  labels:
+    app.kubernetes.io/component: knative-serving-install
+    app.kubernetes.io/name: knative-serving-install
+    kustomize.component: knative
+    networking.knative.dev/ingress-provider: istio
+    serving.knative.dev/release: v0.11.2
+  name: networking-istio
+  namespace: kubeflow
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: networking-istio
+      app.kubernetes.io/component: knative-serving-install
+      app.kubernetes.io/name: knative-serving-install
+      kustomize.component: knative
+  template:
+    metadata:
+      annotations:
+        sidecar.istio.io/inject: "false"
+      labels:
+        app: networking-istio
+        app.kubernetes.io/component: knative-serving-install
+        app.kubernetes.io/name: knative-serving-install
+        kustomize.component: knative
+        serving.knative.dev/release: v0.11.2
+    spec:
+      containers:
+      - env:
+        - name: SYSTEM_NAMESPACE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace
+        - name: CONFIG_LOGGING_NAME
+          value: config-logging
+        - name: CONFIG_OBSERVABILITY_NAME
+          value: config-observability
+        - name: METRICS_DOMAIN
+          value: knative.dev/serving
+        image: gcr.io/knative-releases/knative.dev/serving/cmd/networking/istio@sha256:61461fa789e19895d7d1e5ab96d8bb52a63788e0607e1bd2948b9570efeb6a8f
+        name: networking-istio
+        ports:
+        - containerPort: 9090
+          name: metrics
+        - containerPort: 8008
+          name: profiling
+        resources:
+          limits:
+            cpu: 1000m
+            memory: 1000Mi
+          requests:
+            cpu: 100m
+            memory: 100Mi
+        securityContext:
+          allowPrivilegeEscalation: false
+      serviceAccountName: controller

--- a/tests/stacks/examples/alice/test_data/expected/apps_v1_deployment_webhook.yaml
+++ b/tests/stacks/examples/alice/test_data/expected/apps_v1_deployment_webhook.yaml
@@ -1,0 +1,61 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  labels:
+    app.kubernetes.io/component: knative-serving-install
+    app.kubernetes.io/name: knative-serving-install
+    kustomize.component: knative
+    serving.knative.dev/release: v0.11.2
+  name: webhook
+  namespace: kubeflow
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: webhook
+      app.kubernetes.io/component: knative-serving-install
+      app.kubernetes.io/name: knative-serving-install
+      kustomize.component: knative
+      role: webhook
+  template:
+    metadata:
+      annotations:
+        cluster-autoscaler.kubernetes.io/safe-to-evict: "false"
+        sidecar.istio.io/inject: "false"
+      labels:
+        app: webhook
+        app.kubernetes.io/component: knative-serving-install
+        app.kubernetes.io/name: knative-serving-install
+        kustomize.component: knative
+        role: webhook
+        serving.knative.dev/release: v0.11.2
+    spec:
+      containers:
+      - env:
+        - name: SYSTEM_NAMESPACE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace
+        - name: CONFIG_LOGGING_NAME
+          value: config-logging
+        - name: CONFIG_OBSERVABILITY_NAME
+          value: config-observability
+        - name: METRICS_DOMAIN
+          value: knative.dev/serving
+        image: gcr.io/knative-releases/knative.dev/serving/cmd/webhook@sha256:d07560cd5548640cc79abc819608844527351f10e8b0a847988f9eb602c18972
+        name: webhook
+        ports:
+        - containerPort: 9090
+          name: metrics
+        - containerPort: 8008
+          name: profiling
+        resources:
+          limits:
+            cpu: 200m
+            memory: 200Mi
+          requests:
+            cpu: 20m
+            memory: 20Mi
+        securityContext:
+          allowPrivilegeEscalation: false
+      serviceAccountName: controller

--- a/tests/stacks/examples/alice/test_data/expected/apps_v1_statefulset_kfserving-controller-manager.yaml
+++ b/tests/stacks/examples/alice/test_data/expected/apps_v1_statefulset_kfserving-controller-manager.yaml
@@ -1,0 +1,82 @@
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  labels:
+    app: kfserving
+    app.kubernetes.io/component: kfserving-install
+    app.kubernetes.io/name: kfserving-install
+    control-plane: kfserving-controller-manager
+    controller-tools.k8s.io: "1.0"
+    kustomize.component: kfserving
+  name: kfserving-controller-manager
+  namespace: kubeflow
+spec:
+  selector:
+    matchLabels:
+      app: kfserving
+      app.kubernetes.io/component: kfserving-install
+      app.kubernetes.io/name: kfserving-install
+      control-plane: kfserving-controller-manager
+      controller-tools.k8s.io: "1.0"
+      kustomize.component: kfserving
+  serviceName: controller-manager-service
+  template:
+    metadata:
+      annotations:
+        sidecar.istio.io/inject: "false"
+      labels:
+        app: kfserving
+        app.kubernetes.io/component: kfserving-install
+        app.kubernetes.io/name: kfserving-install
+        control-plane: kfserving-controller-manager
+        controller-tools.k8s.io: "1.0"
+        kustomize.component: kfserving
+    spec:
+      containers:
+      - args:
+        - --secure-listen-address=0.0.0.0:8443
+        - --upstream=http://127.0.0.1:8080/
+        - --logtostderr=true
+        - --v=10
+        image: gcr.io/kubebuilder/kube-rbac-proxy:v0.4.0
+        name: kube-rbac-proxy
+        ports:
+        - containerPort: 8443
+          name: https
+      - args:
+        - --metrics-addr=127.0.0.1:8080
+        command:
+        - /manager
+        env:
+        - name: POD_NAMESPACE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace
+        - name: SECRET_NAME
+          value: kfserving-webhook-server-cert
+        - name: ENABLE_WEBHOOK_NAMESPACE_SELECTOR
+          value: enabled
+        image: gcr.io/kfserving/kfserving-controller:v0.3.0
+        imagePullPolicy: Always
+        name: manager
+        ports:
+        - containerPort: 443
+          name: webhook-server
+          protocol: TCP
+        resources:
+          limits:
+            cpu: 100m
+            memory: 300Mi
+          requests:
+            cpu: 100m
+            memory: 200Mi
+        volumeMounts:
+        - mountPath: /tmp/k8s-webhook-server/serving-certs
+          name: cert
+          readOnly: true
+      terminationGracePeriodSeconds: 10
+      volumes:
+      - name: cert
+        secret:
+          defaultMode: 420
+          secretName: kfserving-webhook-server-cert

--- a/tests/stacks/examples/alice/test_data/expected/autoscaling_v2beta1_horizontalpodautoscaler_activator.yaml
+++ b/tests/stacks/examples/alice/test_data/expected/autoscaling_v2beta1_horizontalpodautoscaler_activator.yaml
@@ -1,0 +1,22 @@
+apiVersion: autoscaling/v2beta1
+kind: HorizontalPodAutoscaler
+metadata:
+  labels:
+    app.kubernetes.io/component: knative-serving-install
+    app.kubernetes.io/name: knative-serving-install
+    kustomize.component: knative
+    serving.knative.dev/release: v0.11.2
+  name: activator
+  namespace: kubeflow
+spec:
+  maxReplicas: 20
+  metrics:
+  - resource:
+      name: cpu
+      targetAverageUtilization: 100
+    type: Resource
+  minReplicas: 1
+  scaleTargetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: activator

--- a/tests/stacks/examples/alice/test_data/expected/caching.internal.knative.dev_v1alpha1_image_queue-proxy.yaml
+++ b/tests/stacks/examples/alice/test_data/expected/caching.internal.knative.dev_v1alpha1_image_queue-proxy.yaml
@@ -1,0 +1,12 @@
+apiVersion: caching.internal.knative.dev/v1alpha1
+kind: Image
+metadata:
+  labels:
+    app.kubernetes.io/component: knative-serving-install
+    app.kubernetes.io/name: knative-serving-install
+    kustomize.component: knative
+    serving.knative.dev/release: v0.11.2
+  name: queue-proxy
+  namespace: kubeflow
+spec:
+  image: gcr.io/knative-releases/knative.dev/serving/cmd/queue@sha256:792f6945c7bc73a49a470a5b955c39c8bd174705743abf5fb71aa0f4c04128eb

--- a/tests/stacks/examples/alice/test_data/expected/cert-manager.io_v1alpha2_certificate_serving-cert.yaml
+++ b/tests/stacks/examples/alice/test_data/expected/cert-manager.io_v1alpha2_certificate_serving-cert.yaml
@@ -1,0 +1,18 @@
+apiVersion: cert-manager.io/v1alpha2
+kind: Certificate
+metadata:
+  labels:
+    app: kfserving
+    app.kubernetes.io/component: kfserving-install
+    app.kubernetes.io/name: kfserving-install
+    kustomize.component: kfserving
+  name: serving-cert
+  namespace: kubeflow
+spec:
+  commonName: kfserving-webhook-server-service.kubeflow.svc
+  dnsNames:
+  - kfserving-webhook-server-service.kubeflow.svc
+  issuerRef:
+    kind: Issuer
+    name: selfsigned-issuer
+  secretName: kfserving-webhook-server-cert

--- a/tests/stacks/examples/alice/test_data/expected/cert-manager.io_v1alpha2_issuer_selfsigned-issuer.yaml
+++ b/tests/stacks/examples/alice/test_data/expected/cert-manager.io_v1alpha2_issuer_selfsigned-issuer.yaml
@@ -1,0 +1,12 @@
+apiVersion: cert-manager.io/v1alpha2
+kind: Issuer
+metadata:
+  labels:
+    app: kfserving
+    app.kubernetes.io/component: kfserving-install
+    app.kubernetes.io/name: kfserving-install
+    kustomize.component: kfserving
+  name: selfsigned-issuer
+  namespace: kubeflow
+spec:
+  selfSigned: {}

--- a/tests/stacks/examples/alice/test_data/expected/networking.istio.io_v1alpha3_gateway_cluster-local-gateway.yaml
+++ b/tests/stacks/examples/alice/test_data/expected/networking.istio.io_v1alpha3_gateway_cluster-local-gateway.yaml
@@ -1,0 +1,21 @@
+apiVersion: networking.istio.io/v1alpha3
+kind: Gateway
+metadata:
+  labels:
+    app.kubernetes.io/component: knative-serving-install
+    app.kubernetes.io/name: knative-serving-install
+    kustomize.component: knative
+    networking.knative.dev/ingress-provider: istio
+    serving.knative.dev/release: v0.11.2
+  name: cluster-local-gateway
+  namespace: kubeflow
+spec:
+  selector:
+    istio: cluster-local-gateway
+  servers:
+  - hosts:
+    - '*'
+    port:
+      name: http
+      number: 80
+      protocol: HTTP

--- a/tests/stacks/examples/alice/test_data/expected/rbac.authorization.k8s.io_v1_clusterrole_custom-metrics-server-resources.yaml
+++ b/tests/stacks/examples/alice/test_data/expected/rbac.authorization.k8s.io_v1_clusterrole_custom-metrics-server-resources.yaml
@@ -1,0 +1,17 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  labels:
+    app.kubernetes.io/component: knative-serving-install
+    app.kubernetes.io/name: knative-serving-install
+    autoscaling.knative.dev/metric-provider: custom-metrics
+    kustomize.component: knative
+    serving.knative.dev/release: v0.11.2
+  name: custom-metrics-server-resources
+rules:
+- apiGroups:
+  - custom.metrics.k8s.io
+  resources:
+  - '*'
+  verbs:
+  - '*'

--- a/tests/stacks/examples/alice/test_data/expected/rbac.authorization.k8s.io_v1_clusterrole_kfserving-proxy-role.yaml
+++ b/tests/stacks/examples/alice/test_data/expected/rbac.authorization.k8s.io_v1_clusterrole_kfserving-proxy-role.yaml
@@ -1,0 +1,22 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  labels:
+    app: kfserving
+    app.kubernetes.io/component: kfserving-install
+    app.kubernetes.io/name: kfserving-install
+    kustomize.component: kfserving
+  name: kfserving-proxy-role
+rules:
+- apiGroups:
+  - authentication.k8s.io
+  resources:
+  - tokenreviews
+  verbs:
+  - create
+- apiGroups:
+  - authorization.k8s.io
+  resources:
+  - subjectaccessreviews
+  verbs:
+  - create

--- a/tests/stacks/examples/alice/test_data/expected/rbac.authorization.k8s.io_v1_clusterrole_knative-serving-addressable-resolver.yaml
+++ b/tests/stacks/examples/alice/test_data/expected/rbac.authorization.k8s.io_v1_clusterrole_knative-serving-addressable-resolver.yaml
@@ -1,0 +1,22 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  labels:
+    app.kubernetes.io/component: knative-serving-install
+    app.kubernetes.io/name: knative-serving-install
+    duck.knative.dev/addressable: "true"
+    kustomize.component: knative
+    serving.knative.dev/release: v0.11.2
+  name: knative-serving-addressable-resolver
+rules:
+- apiGroups:
+  - serving.knative.dev
+  resources:
+  - routes
+  - routes/status
+  - services
+  - services/status
+  verbs:
+  - get
+  - list
+  - watch

--- a/tests/stacks/examples/alice/test_data/expected/rbac.authorization.k8s.io_v1_clusterrole_knative-serving-admin.yaml
+++ b/tests/stacks/examples/alice/test_data/expected/rbac.authorization.k8s.io_v1_clusterrole_knative-serving-admin.yaml
@@ -1,0 +1,14 @@
+aggregationRule:
+  clusterRoleSelectors:
+  - matchLabels:
+      serving.knative.dev/controller: "true"
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  labels:
+    app.kubernetes.io/component: knative-serving-install
+    app.kubernetes.io/name: knative-serving-install
+    kustomize.component: knative
+    serving.knative.dev/release: v0.11.2
+  name: knative-serving-admin
+rules: []

--- a/tests/stacks/examples/alice/test_data/expected/rbac.authorization.k8s.io_v1_clusterrole_knative-serving-core.yaml
+++ b/tests/stacks/examples/alice/test_data/expected/rbac.authorization.k8s.io_v1_clusterrole_knative-serving-core.yaml
@@ -1,0 +1,115 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  labels:
+    app.kubernetes.io/component: knative-serving-install
+    app.kubernetes.io/name: knative-serving-install
+    kustomize.component: knative
+    serving.knative.dev/controller: "true"
+    serving.knative.dev/release: v0.11.2
+  name: knative-serving-core
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - pods
+  - namespaces
+  - secrets
+  - configmaps
+  - endpoints
+  - services
+  - events
+  - serviceaccounts
+  verbs:
+  - get
+  - list
+  - create
+  - update
+  - delete
+  - patch
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - endpoints/restricted
+  verbs:
+  - create
+- apiGroups:
+  - apps
+  resources:
+  - deployments
+  - deployments/finalizers
+  verbs:
+  - get
+  - list
+  - create
+  - update
+  - delete
+  - patch
+  - watch
+- apiGroups:
+  - admissionregistration.k8s.io
+  resources:
+  - mutatingwebhookconfigurations
+  - validatingwebhookconfigurations
+  verbs:
+  - get
+  - list
+  - create
+  - update
+  - delete
+  - patch
+  - watch
+- apiGroups:
+  - apiextensions.k8s.io
+  resources:
+  - customresourcedefinitions
+  verbs:
+  - get
+  - list
+  - create
+  - update
+  - delete
+  - patch
+  - watch
+- apiGroups:
+  - autoscaling
+  resources:
+  - horizontalpodautoscalers
+  verbs:
+  - get
+  - list
+  - create
+  - update
+  - delete
+  - patch
+  - watch
+- apiGroups:
+  - serving.knative.dev
+  - autoscaling.internal.knative.dev
+  - networking.internal.knative.dev
+  resources:
+  - '*'
+  - '*/status'
+  - '*/finalizers'
+  verbs:
+  - get
+  - list
+  - create
+  - update
+  - delete
+  - deletecollection
+  - patch
+  - watch
+- apiGroups:
+  - caching.internal.knative.dev
+  resources:
+  - images
+  verbs:
+  - get
+  - list
+  - create
+  - update
+  - delete
+  - patch
+  - watch

--- a/tests/stacks/examples/alice/test_data/expected/rbac.authorization.k8s.io_v1_clusterrole_knative-serving-istio.yaml
+++ b/tests/stacks/examples/alice/test_data/expected/rbac.authorization.k8s.io_v1_clusterrole_knative-serving-istio.yaml
@@ -1,0 +1,25 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  labels:
+    app.kubernetes.io/component: knative-serving-install
+    app.kubernetes.io/name: knative-serving-install
+    kustomize.component: knative
+    networking.knative.dev/ingress-provider: istio
+    serving.knative.dev/controller: "true"
+    serving.knative.dev/release: v0.11.2
+  name: knative-serving-istio
+rules:
+- apiGroups:
+  - networking.istio.io
+  resources:
+  - virtualservices
+  - gateways
+  verbs:
+  - get
+  - list
+  - create
+  - update
+  - delete
+  - patch
+  - watch

--- a/tests/stacks/examples/alice/test_data/expected/rbac.authorization.k8s.io_v1_clusterrole_knative-serving-namespaced-admin.yaml
+++ b/tests/stacks/examples/alice/test_data/expected/rbac.authorization.k8s.io_v1_clusterrole_knative-serving-namespaced-admin.yaml
@@ -1,0 +1,20 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  labels:
+    app.kubernetes.io/component: knative-serving-install
+    app.kubernetes.io/name: knative-serving-install
+    kustomize.component: knative
+    rbac.authorization.k8s.io/aggregate-to-admin: "true"
+    serving.knative.dev/release: v0.11.2
+  name: knative-serving-namespaced-admin
+rules:
+- apiGroups:
+  - serving.knative.dev
+  - networking.internal.knative.dev
+  - autoscaling.internal.knative.dev
+  - caching.internal.knative.dev
+  resources:
+  - '*'
+  verbs:
+  - '*'

--- a/tests/stacks/examples/alice/test_data/expected/rbac.authorization.k8s.io_v1_clusterrole_knative-serving-namespaced-edit.yaml
+++ b/tests/stacks/examples/alice/test_data/expected/rbac.authorization.k8s.io_v1_clusterrole_knative-serving-namespaced-edit.yaml
@@ -1,0 +1,23 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  labels:
+    app.kubernetes.io/component: knative-serving-install
+    app.kubernetes.io/name: knative-serving-install
+    kustomize.component: knative
+    rbac.authorization.k8s.io/aggregate-to-edit: "true"
+    serving.knative.dev/release: v0.11.2
+  name: knative-serving-namespaced-edit
+rules:
+- apiGroups:
+  - serving.knative.dev
+  - networking.internal.knative.dev
+  - autoscaling.internal.knative.dev
+  - caching.internal.knative.dev
+  resources:
+  - '*'
+  verbs:
+  - create
+  - update
+  - patch
+  - delete

--- a/tests/stacks/examples/alice/test_data/expected/rbac.authorization.k8s.io_v1_clusterrole_knative-serving-namespaced-view.yaml
+++ b/tests/stacks/examples/alice/test_data/expected/rbac.authorization.k8s.io_v1_clusterrole_knative-serving-namespaced-view.yaml
@@ -1,0 +1,22 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  labels:
+    app.kubernetes.io/component: knative-serving-install
+    app.kubernetes.io/name: knative-serving-install
+    kustomize.component: knative
+    rbac.authorization.k8s.io/aggregate-to-view: "true"
+    serving.knative.dev/release: v0.11.2
+  name: knative-serving-namespaced-view
+rules:
+- apiGroups:
+  - serving.knative.dev
+  - networking.internal.knative.dev
+  - autoscaling.internal.knative.dev
+  - caching.internal.knative.dev
+  resources:
+  - '*'
+  verbs:
+  - get
+  - list
+  - watch

--- a/tests/stacks/examples/alice/test_data/expected/rbac.authorization.k8s.io_v1_clusterrole_knative-serving-podspecable-binding.yaml
+++ b/tests/stacks/examples/alice/test_data/expected/rbac.authorization.k8s.io_v1_clusterrole_knative-serving-podspecable-binding.yaml
@@ -1,0 +1,20 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  labels:
+    app.kubernetes.io/component: knative-serving-install
+    app.kubernetes.io/name: knative-serving-install
+    duck.knative.dev/podspecable: "true"
+    kustomize.component: knative
+    serving.knative.dev/release: v0.11.2
+  name: knative-serving-podspecable-binding
+rules:
+- apiGroups:
+  - serving.knative.dev
+  resources:
+  - configurations
+  - services
+  verbs:
+  - list
+  - watch
+  - patch

--- a/tests/stacks/examples/alice/test_data/expected/rbac.authorization.k8s.io_v1_clusterrole_kubeflow-kfserving-admin.yaml
+++ b/tests/stacks/examples/alice/test_data/expected/rbac.authorization.k8s.io_v1_clusterrole_kubeflow-kfserving-admin.yaml
@@ -1,0 +1,15 @@
+aggregationRule:
+  clusterRoleSelectors:
+  - matchLabels:
+      rbac.authorization.kubeflow.org/aggregate-to-kubeflow-kfserving-admin: "true"
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  labels:
+    app: kfserving
+    app.kubernetes.io/component: kfserving-install
+    app.kubernetes.io/name: kfserving-install
+    kustomize.component: kfserving
+    rbac.authorization.kubeflow.org/aggregate-to-kubeflow-admin: "true"
+  name: kubeflow-kfserving-admin
+rules: []

--- a/tests/stacks/examples/alice/test_data/expected/rbac.authorization.k8s.io_v1_clusterrole_kubeflow-kfserving-edit.yaml
+++ b/tests/stacks/examples/alice/test_data/expected/rbac.authorization.k8s.io_v1_clusterrole_kubeflow-kfserving-edit.yaml
@@ -1,0 +1,25 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  labels:
+    app: kfserving
+    app.kubernetes.io/component: kfserving-install
+    app.kubernetes.io/name: kfserving-install
+    kustomize.component: kfserving
+    rbac.authorization.kubeflow.org/aggregate-to-kubeflow-edit: "true"
+    rbac.authorization.kubeflow.org/aggregate-to-kubeflow-kfserving-admin: "true"
+  name: kubeflow-kfserving-edit
+rules:
+- apiGroups:
+  - serving.kubeflow.org
+  resources:
+  - inferenceservices
+  verbs:
+  - get
+  - list
+  - watch
+  - create
+  - delete
+  - deletecollection
+  - patch
+  - update

--- a/tests/stacks/examples/alice/test_data/expected/rbac.authorization.k8s.io_v1_clusterrole_kubeflow-kfserving-view.yaml
+++ b/tests/stacks/examples/alice/test_data/expected/rbac.authorization.k8s.io_v1_clusterrole_kubeflow-kfserving-view.yaml
@@ -1,0 +1,19 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  labels:
+    app: kfserving
+    app.kubernetes.io/component: kfserving-install
+    app.kubernetes.io/name: kfserving-install
+    kustomize.component: kfserving
+    rbac.authorization.kubeflow.org/aggregate-to-kubeflow-view: "true"
+  name: kubeflow-kfserving-view
+rules:
+- apiGroups:
+  - serving.kubeflow.org
+  resources:
+  - inferenceservices
+  verbs:
+  - get
+  - list
+  - watch

--- a/tests/stacks/examples/alice/test_data/expected/rbac.authorization.k8s.io_v1_clusterrole_manager-role.yaml
+++ b/tests/stacks/examples/alice/test_data/expected/rbac.authorization.k8s.io_v1_clusterrole_manager-role.yaml
@@ -1,0 +1,140 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  creationTimestamp: null
+  labels:
+    app: kfserving
+    app.kubernetes.io/component: kfserving-install
+    app.kubernetes.io/name: kfserving-install
+    kustomize.component: kfserving
+  name: manager-role
+rules:
+- apiGroups:
+  - serving.knative.dev
+  resources:
+  - services
+  verbs:
+  - get
+  - list
+  - watch
+  - create
+  - update
+  - patch
+  - delete
+- apiGroups:
+  - serving.knative.dev
+  resources:
+  - services/status
+  verbs:
+  - get
+  - update
+  - patch
+- apiGroups:
+  - networking.istio.io
+  resources:
+  - virtualservices
+  verbs:
+  - get
+  - list
+  - watch
+  - create
+  - update
+  - patch
+  - delete
+- apiGroups:
+  - networking.istio.io
+  resources:
+  - virtualservices/status
+  verbs:
+  - get
+  - update
+  - patch
+- apiGroups:
+  - serving.kubeflow.org
+  resources:
+  - inferenceservices
+  verbs:
+  - get
+  - list
+  - watch
+  - create
+  - update
+  - patch
+  - delete
+- apiGroups:
+  - serving.kubeflow.org
+  resources:
+  - inferenceservices/status
+  verbs:
+  - get
+  - update
+  - patch
+- apiGroups:
+  - ""
+  resources:
+  - serviceaccounts
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - secrets
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - configmaps
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - admissionregistration.k8s.io
+  resources:
+  - mutatingwebhookconfigurations
+  - validatingwebhookconfigurations
+  verbs:
+  - get
+  - list
+  - watch
+  - create
+  - update
+  - patch
+  - delete
+- apiGroups:
+  - ""
+  resources:
+  - secrets
+  verbs:
+  - get
+  - list
+  - watch
+  - create
+  - update
+  - patch
+  - delete
+- apiGroups:
+  - ""
+  resources:
+  - services
+  verbs:
+  - get
+  - list
+  - watch
+  - create
+  - update
+  - patch
+  - delete
+- apiGroups:
+  - ""
+  resources:
+  - namespaces
+  verbs:
+  - get
+  - list
+  - watch

--- a/tests/stacks/examples/alice/test_data/expected/rbac.authorization.k8s.io_v1_clusterrolebinding_custom-metrics:system:auth-delegator.yaml
+++ b/tests/stacks/examples/alice/test_data/expected/rbac.authorization.k8s.io_v1_clusterrolebinding_custom-metrics:system:auth-delegator.yaml
@@ -1,0 +1,18 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  labels:
+    app.kubernetes.io/component: knative-serving-install
+    app.kubernetes.io/name: knative-serving-install
+    autoscaling.knative.dev/metric-provider: custom-metrics
+    kustomize.component: knative
+    serving.knative.dev/release: v0.11.2
+  name: custom-metrics:system:auth-delegator
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: system:auth-delegator
+subjects:
+- kind: ServiceAccount
+  name: controller
+  namespace: kubeflow

--- a/tests/stacks/examples/alice/test_data/expected/rbac.authorization.k8s.io_v1_clusterrolebinding_hpa-controller-custom-metrics.yaml
+++ b/tests/stacks/examples/alice/test_data/expected/rbac.authorization.k8s.io_v1_clusterrolebinding_hpa-controller-custom-metrics.yaml
@@ -1,0 +1,18 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  labels:
+    app.kubernetes.io/component: knative-serving-install
+    app.kubernetes.io/name: knative-serving-install
+    autoscaling.knative.dev/metric-provider: custom-metrics
+    kustomize.component: knative
+    serving.knative.dev/release: v0.11.2
+  name: hpa-controller-custom-metrics
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: custom-metrics-server-resources
+subjects:
+- kind: ServiceAccount
+  name: horizontal-pod-autoscaler
+  namespace: kube-system

--- a/tests/stacks/examples/alice/test_data/expected/rbac.authorization.k8s.io_v1_clusterrolebinding_kfserving-proxy-rolebinding.yaml
+++ b/tests/stacks/examples/alice/test_data/expected/rbac.authorization.k8s.io_v1_clusterrolebinding_kfserving-proxy-rolebinding.yaml
@@ -1,0 +1,17 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  labels:
+    app: kfserving
+    app.kubernetes.io/component: kfserving-install
+    app.kubernetes.io/name: kfserving-install
+    kustomize.component: kfserving
+  name: kfserving-proxy-rolebinding
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: kfserving-proxy-role
+subjects:
+- kind: ServiceAccount
+  name: default
+  namespace: kubeflow

--- a/tests/stacks/examples/alice/test_data/expected/rbac.authorization.k8s.io_v1_clusterrolebinding_knative-serving-controller-admin.yaml
+++ b/tests/stacks/examples/alice/test_data/expected/rbac.authorization.k8s.io_v1_clusterrolebinding_knative-serving-controller-admin.yaml
@@ -1,0 +1,17 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  labels:
+    app.kubernetes.io/component: knative-serving-install
+    app.kubernetes.io/name: knative-serving-install
+    kustomize.component: knative
+    serving.knative.dev/release: v0.11.2
+  name: knative-serving-controller-admin
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: knative-serving-admin
+subjects:
+- kind: ServiceAccount
+  name: controller
+  namespace: kubeflow

--- a/tests/stacks/examples/alice/test_data/expected/rbac.authorization.k8s.io_v1_clusterrolebinding_manager-rolebinding.yaml
+++ b/tests/stacks/examples/alice/test_data/expected/rbac.authorization.k8s.io_v1_clusterrolebinding_manager-rolebinding.yaml
@@ -1,0 +1,17 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  labels:
+    app: kfserving
+    app.kubernetes.io/component: kfserving-install
+    app.kubernetes.io/name: kfserving-install
+    kustomize.component: kfserving
+  name: manager-rolebinding
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: manager-role
+subjects:
+- kind: ServiceAccount
+  name: default
+  namespace: kubeflow

--- a/tests/stacks/examples/alice/test_data/expected/rbac.authorization.k8s.io_v1_rolebinding_custom-metrics-auth-reader.yaml
+++ b/tests/stacks/examples/alice/test_data/expected/rbac.authorization.k8s.io_v1_rolebinding_custom-metrics-auth-reader.yaml
@@ -1,0 +1,19 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  labels:
+    app.kubernetes.io/component: knative-serving-install
+    app.kubernetes.io/name: knative-serving-install
+    autoscaling.knative.dev/metric-provider: custom-metrics
+    kustomize.component: knative
+    serving.knative.dev/release: v0.11.2
+  name: custom-metrics-auth-reader
+  namespace: kubeflow
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: extension-apiserver-authentication-reader
+subjects:
+- kind: ServiceAccount
+  name: controller
+  namespace: kubeflow

--- a/tests/stacks/examples/alice/test_data/expected/rbac.istio.io_v1alpha1_servicerole_istio-service-role.yaml
+++ b/tests/stacks/examples/alice/test_data/expected/rbac.istio.io_v1alpha1_servicerole_istio-service-role.yaml
@@ -1,0 +1,15 @@
+apiVersion: rbac.istio.io/v1alpha1
+kind: ServiceRole
+metadata:
+  labels:
+    app.kubernetes.io/component: knative-serving-install
+    app.kubernetes.io/name: knative-serving-install
+    kustomize.component: knative
+  name: istio-service-role
+  namespace: kubeflow
+spec:
+  rules:
+  - methods:
+    - '*'
+    services:
+    - '*'

--- a/tests/stacks/examples/alice/test_data/expected/rbac.istio.io_v1alpha1_servicerolebinding_istio-service-role-binding.yaml
+++ b/tests/stacks/examples/alice/test_data/expected/rbac.istio.io_v1alpha1_servicerolebinding_istio-service-role-binding.yaml
@@ -1,0 +1,15 @@
+apiVersion: rbac.istio.io/v1alpha1
+kind: ServiceRoleBinding
+metadata:
+  labels:
+    app.kubernetes.io/component: knative-serving-install
+    app.kubernetes.io/name: knative-serving-install
+    kustomize.component: knative
+  name: istio-service-role-binding
+  namespace: kubeflow
+spec:
+  roleRef:
+    kind: ServiceRole
+    name: istio-service-role
+  subjects:
+  - user: '*'

--- a/tests/stacks/examples/alice/test_data/expected/~g_v1_configmap_config-autoscaler.yaml
+++ b/tests/stacks/examples/alice/test_data/expected/~g_v1_configmap_config-autoscaler.yaml
@@ -1,0 +1,120 @@
+apiVersion: v1
+data:
+  _example: |
+    ################################
+    #                              #
+    #    EXAMPLE CONFIGURATION     #
+    #                              #
+    ################################
+
+    # This block is not actually functional configuration,
+    # but serves to illustrate the available configuration
+    # options and document them in a way that is accessible
+    # to users that `kubectl edit` this config map.
+    #
+    # These sample configuration options may be copied out of
+    # this example block and unindented to be in the data block
+    # to actually change the configuration.
+
+    # The Revision ContainerConcurrency field specifies the maximum number
+    # of requests the Container can handle at once. Container concurrency
+    # target percentage is how much of that maximum to use in a stable
+    # state. E.g. if a Revision specifies ContainerConcurrency of 10, then
+    # the Autoscaler will try to maintain 7 concurrent connections per pod
+    # on average.
+    # Note: this limit will be applied to container concurrency set at every
+    # level (ConfigMap, Revision Spec or Annotation).
+    # For legacy and backwards compatibility reasons, this value also accepts
+    # fractional values in (0, 1] interval (i.e. 0.7 ⇒ 70%).
+    # Thus minimal percentage value must be greater than 1.0, or it will be
+    # treated as a fraction.
+    container-concurrency-target-percentage: "70"
+
+    # The container concurrency target default is what the Autoscaler will
+    # try to maintain when concurrency is used as the scaling metric for a
+    # Revision and the Revision specifies unlimited concurrency.
+    # Even when specifying unlimited concurrency, the autoscaler will
+    # horizontally scale the application based on this target concurrency.
+    # NOTE: Only one metric can be used for autoscaling a Revision.
+    container-concurrency-target-default: "100"
+
+    # The requests per second (RPS) target default is what the Autoscaler will
+    # try to maintain when RPS is used as the scaling metric for a Revision and
+    # the Revision specifies unlimited RPS. Even when specifying unlimited RPS,
+    # the autoscaler will horizontally scale the application based on this
+    # target RPS.
+    # Must be greater than 1.0.
+    # NOTE: Only one metric can be used for autoscaling a Revision.
+    requests-per-second-target-default: "200"
+
+    # The target burst capacity specifies the size of burst in concurrent
+    # requests that the system operator expects the system will receive.
+    # Autoscaler will try to protect the system from queueing by introducing
+    # Activator in the request path if the current spare capacity of the
+    # service is less than this setting.
+    # If this setting is 0, then Activator will be in the request path only
+    # when the revision is scaled to 0.
+    # If this setting is > 0 and container-concurrency-target-percentage is
+    # 100% or 1.0, then activator will always be in the request path.
+    # -1 denotes unlimited target-burst-capacity and activator will always
+    # be in the request path.
+    # Other negative values are invalid.
+    target-burst-capacity: "200"
+
+    # When operating in a stable mode, the autoscaler operates on the
+    # average concurrency over the stable window.
+    # Stable window must be in whole seconds.
+    stable-window: "60s"
+
+    # When observed average concurrency during the panic window reaches
+    # panic-threshold-percentage the target concurrency, the autoscaler
+    # enters panic mode. When operating in panic mode, the autoscaler
+    # scales on the average concurrency over the panic window which is
+    # panic-window-percentage of the stable-window.
+    # When computing the panic window it will be rounded to the closest
+    # whole second.
+    panic-window-percentage: "10.0"
+
+    # The percentage of the container concurrency target at which to
+    # enter panic mode when reached within the panic window.
+    panic-threshold-percentage: "200.0"
+
+    # Max scale up rate limits the rate at which the autoscaler will
+    # increase pod count. It is the maximum ratio of desired pods versus
+    # observed pods.
+    # Cannot less or equal to 1.
+    # I.e with value of 2.0 the number of pods can at most go N to 2N
+    # over single Autoscaler period (see tick-interval), but at least N to
+    # N+1, if Autoscaler needs to scale up.
+    max-scale-up-rate: "1000.0"
+
+    # Max scale down rate limits the rate at which the autoscaler will
+    # decrease pod count. It is the maximum ratio of observed pods versus
+    # desired pods.
+    # Cannot less or equal to 1.
+    # I.e. with value of 2.0 the number of pods can at most go N to N/2
+    # over single Autoscaler evaluation period (see tick-interval), but at
+    # least N to N-1, if Autoscaler needs to scale down.
+    # Not yet used // TODO(vagababov) remove once other parts are ready.
+    max-scale-down-rate: "2.0"
+
+    # Scale to zero feature flag
+    enable-scale-to-zero: "true"
+
+    # Tick interval is the time between autoscaling calculations.
+    tick-interval: "2s"
+
+    # Dynamic parameters (take effect when config map is updated):
+
+    # Scale to zero grace period is the time an inactive revision is left
+    # running before it is scaled to zero (min: 30s).
+    scale-to-zero-grace-period: "30s"
+kind: ConfigMap
+metadata:
+  labels:
+    app.kubernetes.io/component: knative-serving-install
+    app.kubernetes.io/name: knative-serving-install
+    kustomize.component: knative
+    serving.knative.dev/release: v0.11.2
+  name: config-autoscaler
+  namespace: kubeflow

--- a/tests/stacks/examples/alice/test_data/expected/~g_v1_configmap_config-defaults.yaml
+++ b/tests/stacks/examples/alice/test_data/expected/~g_v1_configmap_config-defaults.yaml
@@ -1,0 +1,71 @@
+apiVersion: v1
+data:
+  _example: |
+    ################################
+    #                              #
+    #    EXAMPLE CONFIGURATION     #
+    #                              #
+    ################################
+
+    # This block is not actually functional configuration,
+    # but serves to illustrate the available configuration
+    # options and document them in a way that is accessible
+    # to users that `kubectl edit` this config map.
+    #
+    # These sample configuration options may be copied out of
+    # this example block and unindented to be in the data block
+    # to actually change the configuration.
+
+    # revision-timeout-seconds contains the default number of
+    # seconds to use for the revision's per-request timeout, if
+    # none is specified.
+    revision-timeout-seconds: "300"  # 5 minutes
+
+    # max-revision-timeout-seconds contains the maximum number of
+    # seconds that can be used for revision-timeout-seconds.
+    # This value must be greater than or equal to revision-timeout-seconds.
+    # If omitted, the system default is used (600 seconds).
+    max-revision-timeout-seconds: "600"  # 10 minutes
+
+    # revision-cpu-request contains the cpu allocation to assign
+    # to revisions by default.  If omitted, no value is specified
+    # and the system default is used.
+    revision-cpu-request: "400m"  # 0.4 of a CPU (aka 400 milli-CPU)
+
+    # revision-memory-request contains the memory allocation to assign
+    # to revisions by default.  If omitted, no value is specified
+    # and the system default is used.
+    revision-memory-request: "100M"  # 100 megabytes of memory
+
+    # revision-cpu-limit contains the cpu allocation to limit
+    # revisions to by default.  If omitted, no value is specified
+    # and the system default is used.
+    revision-cpu-limit: "1000m"  # 1 CPU (aka 1000 milli-CPU)
+
+    # revision-memory-limit contains the memory allocation to limit
+    # revisions to by default.  If omitted, no value is specified
+    # and the system default is used.
+    revision-memory-limit: "200M"  # 200 megabytes of memory
+
+    # container-name-template contains a template for the default
+    # container name, if none is specified.  This field supports
+    # Go templating and is supplied with the ObjectMeta of the
+    # enclosing Service or Configuration, so values such as
+    # {{.Name}} are also valid.
+    container-name-template: "user-container"
+
+    # container-concurrency specifies the maximum number
+    # of requests the Container can handle at once, and requests
+    # above this threshold are queued.  Setting a value of zero
+    # disables this throttling and lets through as many requests as
+    # the pod receives.
+    container-concurrency: "0"
+kind: ConfigMap
+metadata:
+  labels:
+    app.kubernetes.io/component: knative-serving-install
+    app.kubernetes.io/name: knative-serving-install
+    kustomize.component: knative
+    serving.knative.dev/release: v0.11.2
+  name: config-defaults
+  namespace: kubeflow

--- a/tests/stacks/examples/alice/test_data/expected/~g_v1_configmap_config-deployment.yaml
+++ b/tests/stacks/examples/alice/test_data/expected/~g_v1_configmap_config-deployment.yaml
@@ -1,0 +1,30 @@
+apiVersion: v1
+data:
+  _example: |
+    ################################
+    #                              #
+    #    EXAMPLE CONFIGURATION     #
+    #                              #
+    ################################
+
+    # This block is not actually functional configuration,
+    # but serves to illustrate the available configuration
+    # options and document them in a way that is accessible
+    # to users that `kubectl edit` this config map.
+    #
+    # These sample configuration options may be copied out of
+    # this example block and unindented to be in the data block
+    # to actually change the configuration.
+
+    # List of repositories for which tag to digest resolving should be skipped
+    registriesSkippingTagResolving: "ko.local,dev.local"
+  queueSidecarImage: gcr.io/knative-releases/knative.dev/serving/cmd/queue@sha256:792f6945c7bc73a49a470a5b955c39c8bd174705743abf5fb71aa0f4c04128eb
+kind: ConfigMap
+metadata:
+  labels:
+    app.kubernetes.io/component: knative-serving-install
+    app.kubernetes.io/name: knative-serving-install
+    kustomize.component: knative
+    serving.knative.dev/release: v0.11.2
+  name: config-deployment
+  namespace: kubeflow

--- a/tests/stacks/examples/alice/test_data/expected/~g_v1_configmap_config-domain.yaml
+++ b/tests/stacks/examples/alice/test_data/expected/~g_v1_configmap_config-domain.yaml
@@ -1,0 +1,47 @@
+apiVersion: v1
+data:
+  _example: |
+    ################################
+    #                              #
+    #    EXAMPLE CONFIGURATION     #
+    #                              #
+    ################################
+
+    # This block is not actually functional configuration,
+    # but serves to illustrate the available configuration
+    # options and document them in a way that is accessible
+    # to users that `kubectl edit` this config map.
+    #
+    # These sample configuration options may be copied out of
+    # this example block and unindented to be in the data block
+    # to actually change the configuration.
+
+    # Default value for domain.
+    # Although it will match all routes, it is the least-specific rule so it
+    # will only be used if no other domain matches.
+    example.com: |
+
+    # These are example settings of domain.
+    # example.org will be used for routes having app=nonprofit.
+    example.org: |
+      selector:
+        app: nonprofit
+
+    # Routes having domain suffix of 'svc.cluster.local' will not be exposed
+    # through Ingress. You can define your own label selector to assign that
+    # domain suffix to your Route here, or you can set the label
+    #    "serving.knative.dev/visibility=cluster-local"
+    # to achieve the same effect.  This shows how to make routes having
+    # the label app=secret only exposed to the local cluster.
+    svc.cluster.local: |
+      selector:
+        app: secret
+kind: ConfigMap
+metadata:
+  labels:
+    app.kubernetes.io/component: knative-serving-install
+    app.kubernetes.io/name: knative-serving-install
+    kustomize.component: knative
+    serving.knative.dev/release: v0.11.2
+  name: config-domain
+  namespace: kubeflow

--- a/tests/stacks/examples/alice/test_data/expected/~g_v1_configmap_config-gc.yaml
+++ b/tests/stacks/examples/alice/test_data/expected/~g_v1_configmap_config-gc.yaml
@@ -1,0 +1,40 @@
+apiVersion: v1
+data:
+  _example: |
+    ################################
+    #                              #
+    #    EXAMPLE CONFIGURATION     #
+    #                              #
+    ################################
+
+    # This block is not actually functional configuration,
+    # but serves to illustrate the available configuration
+    # options and document them in a way that is accessible
+    # to users that `kubectl edit` this config map.
+    #
+    # These sample configuration options may be copied out of
+    # this example block and unindented to be in the data block
+    # to actually change the configuration.
+
+    # Delay after revision creation before considering it for GC
+    stale-revision-create-delay: "24h"
+
+    # Duration since a route has been pointed at a revision before it should be GC'd
+    # This minus lastpinned-debounce be longer than the controller resync period (10 hours)
+    stale-revision-timeout: "15h"
+
+    # Minimum number of generations of revisions to keep before considering for GC
+    stale-revision-minimum-generations: "1"
+
+    # To avoid constant updates, we allow an existing annotation to be stale by this
+    # amount before we update the timestamp
+    stale-revision-lastpinned-debounce: "5h"
+kind: ConfigMap
+metadata:
+  labels:
+    app.kubernetes.io/component: knative-serving-install
+    app.kubernetes.io/name: knative-serving-install
+    kustomize.component: knative
+    serving.knative.dev/release: v0.11.2
+  name: config-gc
+  namespace: kubeflow

--- a/tests/stacks/examples/alice/test_data/expected/~g_v1_configmap_config-istio.yaml
+++ b/tests/stacks/examples/alice/test_data/expected/~g_v1_configmap_config-istio.yaml
@@ -1,0 +1,16 @@
+apiVersion: v1
+data:
+  gateway.kubeflow.kubeflow-gateway: istio-ingressgateway.istio-system.svc.cluster.local
+  local-gateway.knative-serving.cluster-local-gateway: cluster-local-gateway.istio-system.svc.cluster.local
+  local-gateway.mesh: mesh
+  reconcileExternalGateway: "false"
+kind: ConfigMap
+metadata:
+  labels:
+    app.kubernetes.io/component: knative-serving-install
+    app.kubernetes.io/name: knative-serving-install
+    kustomize.component: knative
+    networking.knative.dev/ingress-provider: istio
+    serving.knative.dev/release: v0.11.2
+  name: config-istio
+  namespace: kubeflow

--- a/tests/stacks/examples/alice/test_data/expected/~g_v1_configmap_config-logging.yaml
+++ b/tests/stacks/examples/alice/test_data/expected/~g_v1_configmap_config-logging.yaml
@@ -1,0 +1,59 @@
+apiVersion: v1
+data:
+  _example: |
+    ################################
+    #                              #
+    #    EXAMPLE CONFIGURATION     #
+    #                              #
+    ################################
+
+    # This block is not actually functional configuration,
+    # but serves to illustrate the available configuration
+    # options and document them in a way that is accessible
+    # to users that `kubectl edit` this config map.
+    #
+    # These sample configuration options may be copied out of
+    # this example block and unindented to be in the data block
+    # to actually change the configuration.
+
+    # Common configuration for all Knative codebase
+    zap-logger-config: |
+      {
+        "level": "info",
+        "development": false,
+        "outputPaths": ["stdout"],
+        "errorOutputPaths": ["stderr"],
+        "encoding": "json",
+        "encoderConfig": {
+          "timeKey": "ts",
+          "levelKey": "level",
+          "nameKey": "logger",
+          "callerKey": "caller",
+          "messageKey": "msg",
+          "stacktraceKey": "stacktrace",
+          "lineEnding": "",
+          "levelEncoder": "",
+          "timeEncoder": "iso8601",
+          "durationEncoder": "",
+          "callerEncoder": ""
+        }
+      }
+
+    # Log level overrides
+    # For all components except the autoscaler and queue proxy,
+    # changes are be picked up immediately.
+    # For autoscaler and queue proxy, changes require recreation of the pods.
+    loglevel.controller: "info"
+    loglevel.autoscaler: "info"
+    loglevel.queueproxy: "info"
+    loglevel.webhook: "info"
+    loglevel.activator: "info"
+kind: ConfigMap
+metadata:
+  labels:
+    app.kubernetes.io/component: knative-serving-install
+    app.kubernetes.io/name: knative-serving-install
+    kustomize.component: knative
+    serving.knative.dev/release: v0.11.2
+  name: config-logging
+  namespace: kubeflow

--- a/tests/stacks/examples/alice/test_data/expected/~g_v1_configmap_config-network.yaml
+++ b/tests/stacks/examples/alice/test_data/expected/~g_v1_configmap_config-network.yaml
@@ -1,0 +1,127 @@
+apiVersion: v1
+data:
+  _example: |
+    ################################
+    #                              #
+    #    EXAMPLE CONFIGURATION     #
+    #                              #
+    ################################
+
+    # This block is not actually functional configuration,
+    # but serves to illustrate the available configuration
+    # options and document them in a way that is accessible
+    # to users that `kubectl edit` this config map.
+    #
+    # These sample configuration options may be copied out of
+    # this example block and unindented to be in the data block
+    # to actually change the configuration.
+
+    # istio.sidecar.includeOutboundIPRanges specifies the IP ranges that Istio sidecar
+    # will intercept.
+    #
+    # Replace this with the IP ranges of your cluster (see below for some examples).
+    # Separate multiple entries with a comma.
+    # Example: "10.4.0.0/14,10.7.240.0/20"
+    #
+    # If set to "*" Istio will intercept all traffic within
+    # the cluster as well as traffic that is going outside the cluster.
+    # Traffic going outside the cluster will be blocked unless
+    # necessary egress rules are created.
+    #
+    # If omitted or set to "", value of global.proxy.includeIPRanges
+    # provided at Istio deployment time is used. In default Knative serving
+    # deployment, global.proxy.includeIPRanges value is set to "*".
+    #
+    # If an invalid value is passed, "" is used instead.
+    #
+    # If valid set of IP address ranges are put into this value,
+    # Istio will no longer intercept traffic going to IP addresses
+    # outside the provided ranges and there is no need to specify
+    # egress rules.
+    #
+    # To determine the IP ranges of your cluster:
+    #   IBM Cloud Private: cat cluster/config.yaml | grep service_cluster_ip_range
+    #   IBM Cloud Kubernetes Service: "172.30.0.0/16,172.20.0.0/16,10.10.10.0/24"
+    #   Google Container Engine (GKE): gcloud container clusters describe $CLUSTER_NAME --zone=$CLUSTER_ZONE | grep -e clusterIpv4Cidr -e servicesIpv4Cidr
+    #   Azure Kubernetes Service (AKS): "10.0.0.0/16"
+    #   Azure Container Service (ACS; deprecated): "10.244.0.0/16,10.240.0.0/16"
+    #   Azure Container Service Engine (ACS-Engine; OSS): Configurable, but defaults to "10.0.0.0/16"
+    #   Minikube: "10.0.0.1/24"
+    #
+    # For more information, visit
+    # https://istio.io/docs/tasks/traffic-management/egress/
+    #
+    istio.sidecar.includeOutboundIPRanges: "*"
+
+    # clusteringress.class has been deprecated.   Please use ingress.class instead.
+    clusteringress.class: "istio.ingress.networking.knative.dev"
+
+    # ingress.class specifies the default ingress class
+    # to use when not dictated by Route annotation.
+    #
+    # If not specified, will use the Istio ingress.
+    #
+    # Note that changing the Ingress class of an existing Route
+    # will result in undefined behavior.  Therefore it is best to only
+    # update this value during the setup of Knative, to avoid getting
+    # undefined behavior.
+    ingress.class: "istio.ingress.networking.knative.dev"
+
+    # certificate.class specifies the default Certificate class
+    # to use when not dictated by Route annotation.
+    #
+    # If not specified, will use the Cert-Manager Certificate.
+    #
+    # Note that changing the Certificate class of an existing Route
+    # will result in undefined behavior.  Therefore it is best to only
+    # update this value during the setup of Knative, to avoid getting
+    # undefined behavior.
+    certificate.class: "cert-manager.certificate.networking.internal.knative.dev"
+
+    # domainTemplate specifies the golang text template string to use
+    # when constructing the Knative service's DNS name. The default
+    # value is "{{.Name}}.{{.Namespace}}.{{.Domain}}". And those three
+    # values (Name, Namespace, Domain) are the only variables defined.
+    #
+    # Changing this value might be necessary when the extra levels in
+    # the domain name generated is problematic for wildcard certificates
+    # that only support a single level of domain name added to the
+    # certificate's domain. In those cases you might consider using a value
+    # of "{{.Name}}-{{.Namespace}}.{{.Domain}}", or removing the Namespace
+    # entirely from the template. When choosing a new value be thoughtful
+    # of the potential for conflicts - for example, when users choose to use
+    # characters such as `-` in their service, or namespace, names.
+    # {{.Annotations}} can be used for any customization in the go template if needed.
+    # We strongly recommend keeping namespace part of the template to avoid domain name clashes
+    # Example '{{.Name}}-{{.Namespace}}.{{ index .Annotations "sub"}}.{{.Domain}}'
+    # and you have an annotation {"sub":"foo"}, then the generated template would be {Name}-{Namespace}.foo.{Domain}
+    domainTemplate: "{{.Name}}.{{.Namespace}}.{{.Domain}}"
+
+    # tagTemplate specifies the golang text template string to use
+    # when constructing the DNS name for "tags" within the traffic blocks
+    # of Routes and Configuration.  This is used in conjunction with the
+    # domainTemplate above to determine the full URL for the tag.
+    tagTemplate: "{{.Tag}}-{{.Name}}"
+
+    # Controls whether TLS certificates are automatically provisioned and
+    # installed in the Knative ingress to terminate external TLS connection.
+    # 1. Enabled: enabling auto-TLS feature.
+    # 2. Disabled: disabling auto-TLS feature.
+    autoTLS: "Disabled"
+
+    # Controls the behavior of the HTTP endpoint for the Knative ingress.
+    # It requires autoTLS to be enabled or reconcileExternalGateway in config-istio to be true.
+    # 1. Enabled: The Knative ingress will be able to serve HTTP connection.
+    # 2. Disabled: The Knative ingress will reject HTTP traffic.
+    # 3. Redirected: The Knative ingress will send a 302 redirect for all
+    # http connections, asking the clients to use HTTPS
+    httpProtocol: "Enabled"
+kind: ConfigMap
+metadata:
+  labels:
+    app.kubernetes.io/component: knative-serving-install
+    app.kubernetes.io/name: knative-serving-install
+    kustomize.component: knative
+    serving.knative.dev/release: v0.11.2
+  name: config-network
+  namespace: kubeflow

--- a/tests/stacks/examples/alice/test_data/expected/~g_v1_configmap_config-observability.yaml
+++ b/tests/stacks/examples/alice/test_data/expected/~g_v1_configmap_config-observability.yaml
@@ -1,0 +1,100 @@
+apiVersion: v1
+data:
+  _example: |
+    ################################
+    #                              #
+    #    EXAMPLE CONFIGURATION     #
+    #                              #
+    ################################
+
+    # This block is not actually functional configuration,
+    # but serves to illustrate the available configuration
+    # options and document them in a way that is accessible
+    # to users that `kubectl edit` this config map.
+    #
+    # These sample configuration options may be copied out of
+    # this example block and unindented to be in the data block
+    # to actually change the configuration.
+
+    # logging.enable-var-log-collection defaults to false.
+    # The fluentd daemon set will be set up to collect /var/log if
+    # this flag is true.
+    logging.enable-var-log-collection: "false"
+
+    # logging.revision-url-template provides a template to use for producing the
+    # logging URL that is injected into the status of each Revision.
+    # This value is what you might use the the Knative monitoring bundle, and provides
+    # access to Kibana after setting up kubectl proxy.
+    logging.revision-url-template: |
+      http://localhost:8001/api/v1/namespaces/knative-monitoring/services/kibana-logging/proxy/app/kibana#/discover?_a=(query:(match:(kubernetes.labels.serving-knative-dev%2FrevisionUID:(query:'${REVISION_UID}',type:phrase))))
+
+    # If non-empty, this enables queue proxy writing user request logs to stdout, excluding probe
+    # requests.
+    # The value determines the shape of the request logs and it must be a valid go text/template.
+    # It is important to keep this as a single line. Multiple lines are parsed as separate entities
+    # by most collection agents and will split the request logs into multiple records.
+    #
+    # The following fields and functions are available to the template:
+    #
+    # Request: An http.Request (see https://golang.org/pkg/net/http/#Request)
+    # representing an HTTP request received by the server.
+    #
+    # Response:
+    # struct {
+    #   Code    int       // HTTP status code (see https://www.iana.org/assignments/http-status-codes/http-status-codes.xhtml)
+    #   Size    int       // An int representing the size of the response.
+    #   Latency float64   // A float64 representing the latency of the response in seconds.
+    # }
+    #
+    # Revision:
+    # struct {
+    #   Name          string  // Knative revision name
+    #   Namespace     string  // Knative revision namespace
+    #   Service       string  // Knative service name
+    #   Configuration string  // Knative configuration name
+    #   PodName       string  // Name of the pod hosting the revision
+    #   PodIP         string  // IP of the pod hosting the revision
+    # }
+    #
+    logging.request-log-template: '{"httpRequest": {"requestMethod": "{{.Request.Method}}", "requestUrl": "{{js .Request.RequestURI}}", "requestSize": "{{.Request.ContentLength}}", "status": {{.Response.Code}}, "responseSize": "{{.Response.Size}}", "userAgent": "{{js .Request.UserAgent}}", "remoteIp": "{{js .Request.RemoteAddr}}", "serverIp": "{{.Revision.PodIP}}", "referer": "{{js .Request.Referer}}", "latency": "{{.Response.Latency}}s", "protocol": "{{.Request.Proto}}"}, "traceId": "{{index .Request.Header "X-B3-Traceid"}}"}'
+
+    # If true, this enables queue proxy writing request logs for probe requests to stdout.
+    # It uses the same template for user requests, i.e. logging.request-log-template.
+    logging.enable-probe-request-log: "false"
+
+    # metrics.backend-destination field specifies the system metrics destination.
+    # It supports either prometheus (the default) or stackdriver.
+    # Note: Using stackdriver will incur additional charges
+    metrics.backend-destination: prometheus
+
+    # metrics.request-metrics-backend-destination specifies the request metrics
+    # destination. It enables queue proxy to send request metrics.
+    # Currently supported values: prometheus (the default), stackdriver.
+    metrics.request-metrics-backend-destination: prometheus
+
+    # metrics.stackdriver-project-id field specifies the stackdriver project ID. This
+    # field is optional. When running on GCE, application default credentials will be
+    # used if this field is not provided.
+    metrics.stackdriver-project-id: "<your stackdriver project id>"
+
+    # metrics.allow-stackdriver-custom-metrics indicates whether it is allowed to send metrics to
+    # Stackdriver using "global" resource type and custom metric type if the
+    # metrics are not supported by "knative_revision" resource type. Setting this
+    # flag to "true" could cause extra Stackdriver charge.
+    # If metrics.backend-destination is not Stackdriver, this is ignored.
+    metrics.allow-stackdriver-custom-metrics: "false"
+
+    # profiling.enable indicates whether it is allowed to retrieve runtime profiling data from
+    # the pods via an HTTP server in the format expected by the pprof visualization tool. When
+    # enabled, the Knative Serving pods expose the profiling data on an alternate HTTP port 8008.
+    # The HTTP context root for profiling is then /debug/pprof/.
+    profiling.enable: "false"
+kind: ConfigMap
+metadata:
+  labels:
+    app.kubernetes.io/component: knative-serving-install
+    app.kubernetes.io/name: knative-serving-install
+    kustomize.component: knative
+    serving.knative.dev/release: v0.11.2
+  name: config-observability
+  namespace: kubeflow

--- a/tests/stacks/examples/alice/test_data/expected/~g_v1_configmap_config-tracing.yaml
+++ b/tests/stacks/examples/alice/test_data/expected/~g_v1_configmap_config-tracing.yaml
@@ -1,0 +1,45 @@
+apiVersion: v1
+data:
+  _example: |
+    ################################
+    #                              #
+    #    EXAMPLE CONFIGURATION     #
+    #                              #
+    ################################
+
+    # This block is not actually functional configuration,
+    # but serves to illustrate the available configuration
+    # options and document them in a way that is accessible
+    # to users that `kubectl edit` this config map.
+    #
+    # These sample configuration options may be copied out of
+    # this example block and unindented to be in the data block
+    # to actually change the configuration.
+    #
+    # This may be "zipkin" or "stackdriver", the default is "none"
+    backend: "none"
+
+    # URL to zipkin collector where traces are sent.
+    # This must be specified when backend is "zipkin"
+    zipkin-endpoint: "http://zipkin.istio-system.svc.cluster.local:9411/api/v2/spans"
+
+    # The GCP project into which stackdriver metrics will be written
+    # when backend is "stackdriver".  If unspecified, the project-id
+    # is read from GCP metadata when running on GCP.
+    stackdriver-project-id: "my-project"
+
+    # Enable zipkin debug mode. This allows all spans to be sent to the server
+    # bypassing sampling.
+    debug: "false"
+
+    # Percentage (0-1) of requests to trace
+    sample-rate: "0.1"
+kind: ConfigMap
+metadata:
+  labels:
+    app.kubernetes.io/component: knative-serving-install
+    app.kubernetes.io/name: knative-serving-install
+    kustomize.component: knative
+    serving.knative.dev/release: v0.11.2
+  name: config-tracing
+  namespace: kubeflow

--- a/tests/stacks/examples/alice/test_data/expected/~g_v1_configmap_inferenceservice-config.yaml
+++ b/tests/stacks/examples/alice/test_data/expected/~g_v1_configmap_inferenceservice-config.yaml
@@ -1,0 +1,110 @@
+apiVersion: v1
+data:
+  credentials: |-
+    {
+       "gcs": {
+           "gcsCredentialFileName": "gcloud-application-credentials.json"
+       },
+       "s3": {
+           "s3AccessKeyIDName": "awsAccessKeyID",
+           "s3SecretAccessKeyName": "awsSecretAccessKey"
+       }
+    }
+  explainers: |-
+    {
+        "alibi": {
+            "image" : "docker.io/seldonio/kfserving-alibiexplainer",
+            "defaultImageVersion": "v0.3.0",
+            "allowedImageVersions": [
+               "v0.3.0"
+            ]
+        }
+    }
+  ingress: |-
+    {
+        "ingressGateway" : "kubeflow-gateway.kubeflow",
+        "ingressService" : "istio-ingressgateway.istio-system.svc.cluster.local"
+    }
+  logger: |-
+    {
+        "image" : "gcr.io/kfserving/logger:v0.3.0",
+        "memoryRequest": "100Mi",
+        "memoryLimit": "1Gi",
+        "cpuRequest": "100m",
+        "cpuLimit": "1"
+    }
+  predictors: |-
+    {
+        "tensorflow": {
+            "image": "tensorflow/serving",
+            "defaultImageVersion": "1.14.0",
+            "defaultGpuImageVersion": "1.14.0-gpu",
+            "allowedImageVersions": [
+               "1.11.0",
+               "1.11.0-gpu",
+               "1.12.0",
+               "1.12.0-gpu",
+               "1.13.0",
+               "1.13.0-gpu",
+               "1.14.0",
+               "1.14.0-gpu"
+            ]
+        },
+        "onnx": {
+            "image": "mcr.microsoft.com/onnxruntime/server",
+            "defaultImageVersion": "v0.5.1",
+            "allowedImageVersions": [
+               "v0.5.1"
+            ]
+        },
+        "sklearn": {
+            "image": "gcr.io/kfserving/sklearnserver",
+            "defaultImageVersion": "v0.3.0",
+            "allowedImageVersions": [
+               "v0.3.0"
+            ]
+        },
+        "xgboost": {
+            "image": "gcr.io/kfserving/xgbserver",
+            "defaultImageVersion": "v0.3.0",
+            "allowedImageVersions": [
+               "v0.3.0"
+            ]
+        },
+        "pytorch": {
+            "image": "gcr.io/kfserving/pytorchserver",
+            "defaultImageVersion": "v0.3.0",
+            "defaultGpuImageVersion": "v0.3.0-gpu",
+            "allowedImageVersions": [
+               "v0.3.0",
+               "v0.3.0-gpu"
+            ]
+        },
+        "tensorrt": {
+            "image": "nvcr.io/nvidia/tensorrtserver",
+            "defaultImageVersion": "19.05-py3",
+            "allowedImageVersions": [
+               "19.05-py3"
+            ]
+        }
+    }
+  storageInitializer: |-
+    {
+        "image" : "gcr.io/kfserving/storage-initializer:v0.3.0",
+        "memoryRequest": "100Mi",
+        "memoryLimit": "1Gi",
+        "cpuRequest": "100m",
+        "cpuLimit": "1"
+    }
+  transformers: |-
+    {
+    }
+kind: ConfigMap
+metadata:
+  labels:
+    app: kfserving
+    app.kubernetes.io/component: kfserving-install
+    app.kubernetes.io/name: kfserving-install
+    kustomize.component: kfserving
+  name: inferenceservice-config
+  namespace: kubeflow

--- a/tests/stacks/examples/alice/test_data/expected/~g_v1_configmap_kfserving-config.yaml
+++ b/tests/stacks/examples/alice/test_data/expected/~g_v1_configmap_kfserving-config.yaml
@@ -1,0 +1,12 @@
+apiVersion: v1
+data:
+  registry: gcr.io/kfserving
+kind: ConfigMap
+metadata:
+  labels:
+    app: kfserving
+    app.kubernetes.io/component: kfserving-install
+    app.kubernetes.io/name: kfserving-install
+    kustomize.component: kfserving
+  name: kfserving-config
+  namespace: kubeflow

--- a/tests/stacks/examples/alice/test_data/expected/~g_v1_namespace_knative-serving.yaml
+++ b/tests/stacks/examples/alice/test_data/expected/~g_v1_namespace_knative-serving.yaml
@@ -1,0 +1,10 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  labels:
+    app.kubernetes.io/component: knative-serving-install
+    app.kubernetes.io/name: knative-serving-install
+    istio-injection: enabled
+    kustomize.component: knative
+    serving.knative.dev/release: v0.11.2
+  name: knative-serving

--- a/tests/stacks/examples/alice/test_data/expected/~g_v1_secret_kfserving-webhook-server-secret.yaml
+++ b/tests/stacks/examples/alice/test_data/expected/~g_v1_secret_kfserving-webhook-server-secret.yaml
@@ -1,0 +1,10 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  labels:
+    app: kfserving
+    app.kubernetes.io/component: kfserving-install
+    app.kubernetes.io/name: kfserving-install
+    kustomize.component: kfserving
+  name: kfserving-webhook-server-secret
+  namespace: kubeflow

--- a/tests/stacks/examples/alice/test_data/expected/~g_v1_secret_webhook-certs.yaml
+++ b/tests/stacks/examples/alice/test_data/expected/~g_v1_secret_webhook-certs.yaml
@@ -1,0 +1,10 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  labels:
+    app.kubernetes.io/component: knative-serving-install
+    app.kubernetes.io/name: knative-serving-install
+    kustomize.component: knative
+    serving.knative.dev/release: v0.11.2
+  name: webhook-certs
+  namespace: kubeflow

--- a/tests/stacks/examples/alice/test_data/expected/~g_v1_service_activator-service.yaml
+++ b/tests/stacks/examples/alice/test_data/expected/~g_v1_service_activator-service.yaml
@@ -1,0 +1,31 @@
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    app: activator
+    app.kubernetes.io/component: knative-serving-install
+    app.kubernetes.io/name: knative-serving-install
+    kustomize.component: knative
+    serving.knative.dev/release: v0.11.2
+  name: activator-service
+  namespace: kubeflow
+spec:
+  ports:
+  - name: http
+    port: 80
+    protocol: TCP
+    targetPort: 8012
+  - name: http2
+    port: 81
+    protocol: TCP
+    targetPort: 8013
+  - name: http-metrics
+    port: 9090
+    protocol: TCP
+    targetPort: 9090
+  selector:
+    app: activator
+    app.kubernetes.io/component: knative-serving-install
+    app.kubernetes.io/name: knative-serving-install
+    kustomize.component: knative
+  type: ClusterIP

--- a/tests/stacks/examples/alice/test_data/expected/~g_v1_service_autoscaler.yaml
+++ b/tests/stacks/examples/alice/test_data/expected/~g_v1_service_autoscaler.yaml
@@ -1,0 +1,30 @@
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    app: autoscaler
+    app.kubernetes.io/component: knative-serving-install
+    app.kubernetes.io/name: knative-serving-install
+    kustomize.component: knative
+    serving.knative.dev/release: v0.11.2
+  name: autoscaler
+  namespace: kubeflow
+spec:
+  ports:
+  - name: http
+    port: 8080
+    protocol: TCP
+    targetPort: 8080
+  - name: http-metrics
+    port: 9090
+    protocol: TCP
+    targetPort: 9090
+  - name: https-custom-metrics
+    port: 443
+    protocol: TCP
+    targetPort: 8443
+  selector:
+    app: autoscaler
+    app.kubernetes.io/component: knative-serving-install
+    app.kubernetes.io/name: knative-serving-install
+    kustomize.component: knative

--- a/tests/stacks/examples/alice/test_data/expected/~g_v1_service_controller.yaml
+++ b/tests/stacks/examples/alice/test_data/expected/~g_v1_service_controller.yaml
@@ -1,0 +1,22 @@
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    app: controller
+    app.kubernetes.io/component: knative-serving-install
+    app.kubernetes.io/name: knative-serving-install
+    kustomize.component: knative
+    serving.knative.dev/release: v0.11.2
+  name: controller
+  namespace: kubeflow
+spec:
+  ports:
+  - name: http-metrics
+    port: 9090
+    protocol: TCP
+    targetPort: 9090
+  selector:
+    app: controller
+    app.kubernetes.io/component: knative-serving-install
+    app.kubernetes.io/name: knative-serving-install
+    kustomize.component: knative

--- a/tests/stacks/examples/alice/test_data/expected/~g_v1_service_kfserving-controller-manager-metrics-service.yaml
+++ b/tests/stacks/examples/alice/test_data/expected/~g_v1_service_kfserving-controller-manager-metrics-service.yaml
@@ -1,0 +1,28 @@
+apiVersion: v1
+kind: Service
+metadata:
+  annotations:
+    prometheus.io/port: "8443"
+    prometheus.io/scheme: https
+    prometheus.io/scrape: "true"
+  labels:
+    app: kfserving
+    app.kubernetes.io/component: kfserving-install
+    app.kubernetes.io/name: kfserving-install
+    control-plane: controller-manager
+    controller-tools.k8s.io: "1.0"
+    kustomize.component: kfserving
+  name: kfserving-controller-manager-metrics-service
+  namespace: kubeflow
+spec:
+  ports:
+  - name: https
+    port: 8443
+    targetPort: https
+  selector:
+    app: kfserving
+    app.kubernetes.io/component: kfserving-install
+    app.kubernetes.io/name: kfserving-install
+    control-plane: controller-manager
+    controller-tools.k8s.io: "1.0"
+    kustomize.component: kfserving

--- a/tests/stacks/examples/alice/test_data/expected/~g_v1_service_kfserving-controller-manager-service.yaml
+++ b/tests/stacks/examples/alice/test_data/expected/~g_v1_service_kfserving-controller-manager-service.yaml
@@ -1,0 +1,22 @@
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    app: kfserving
+    app.kubernetes.io/component: kfserving-install
+    app.kubernetes.io/name: kfserving-install
+    control-plane: kfserving-controller-manager
+    controller-tools.k8s.io: "1.0"
+    kustomize.component: kfserving
+  name: kfserving-controller-manager-service
+  namespace: kubeflow
+spec:
+  ports:
+  - port: 443
+  selector:
+    app: kfserving
+    app.kubernetes.io/component: kfserving-install
+    app.kubernetes.io/name: kfserving-install
+    control-plane: kfserving-controller-manager
+    controller-tools.k8s.io: "1.0"
+    kustomize.component: kfserving

--- a/tests/stacks/examples/alice/test_data/expected/~g_v1_service_kfserving-webhook-server-service.yaml
+++ b/tests/stacks/examples/alice/test_data/expected/~g_v1_service_kfserving-webhook-server-service.yaml
@@ -1,0 +1,20 @@
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    app: kfserving
+    app.kubernetes.io/component: kfserving-install
+    app.kubernetes.io/name: kfserving-install
+    kustomize.component: kfserving
+  name: kfserving-webhook-server-service
+  namespace: kubeflow
+spec:
+  ports:
+  - port: 443
+    targetPort: 443
+  selector:
+    app: kfserving
+    app.kubernetes.io/component: kfserving-install
+    app.kubernetes.io/name: kfserving-install
+    control-plane: kfserving-controller-manager
+    kustomize.component: kfserving

--- a/tests/stacks/examples/alice/test_data/expected/~g_v1_service_webhook.yaml
+++ b/tests/stacks/examples/alice/test_data/expected/~g_v1_service_webhook.yaml
@@ -1,0 +1,21 @@
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    app.kubernetes.io/component: knative-serving-install
+    app.kubernetes.io/name: knative-serving-install
+    kustomize.component: knative
+    role: webhook
+    serving.knative.dev/release: v0.11.2
+  name: webhook
+  namespace: kubeflow
+spec:
+  ports:
+  - name: https-webhook
+    port: 443
+    targetPort: 8443
+  selector:
+    app.kubernetes.io/component: knative-serving-install
+    app.kubernetes.io/name: knative-serving-install
+    kustomize.component: knative
+    role: webhook

--- a/tests/stacks/examples/alice/test_data/expected/~g_v1_serviceaccount_controller.yaml
+++ b/tests/stacks/examples/alice/test_data/expected/~g_v1_serviceaccount_controller.yaml
@@ -1,0 +1,10 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  labels:
+    app.kubernetes.io/component: knative-serving-install
+    app.kubernetes.io/name: knative-serving-install
+    kustomize.component: knative
+    serving.knative.dev/release: v0.11.2
+  name: controller
+  namespace: kubeflow

--- a/tests/stacks/gcp/test_data/expected/admissionregistration.k8s.io_v1beta1_mutatingwebhookconfiguration_inferenceservice.serving.kubeflow.org.yaml
+++ b/tests/stacks/gcp/test_data/expected/admissionregistration.k8s.io_v1beta1_mutatingwebhookconfiguration_inferenceservice.serving.kubeflow.org.yaml
@@ -1,0 +1,53 @@
+apiVersion: admissionregistration.k8s.io/v1beta1
+kind: MutatingWebhookConfiguration
+metadata:
+  annotations:
+    cert-manager.io/inject-ca-from: kubeflow/serving-cert
+  creationTimestamp: null
+  labels:
+    app: kfserving
+    app.kubernetes.io/component: kfserving-install
+    app.kubernetes.io/name: kfserving-install
+    kustomize.component: kfserving
+  name: inferenceservice.serving.kubeflow.org
+webhooks:
+- clientConfig:
+    caBundle: Cg==
+    service:
+      name: kfserving-webhook-server-service
+      namespace: kubeflow
+      path: /mutate-inferenceservices
+  failurePolicy: Fail
+  name: inferenceservice.kfserving-webhook-server.defaulter
+  rules:
+  - apiGroups:
+    - serving.kubeflow.org
+    apiVersions:
+    - v1alpha2
+    operations:
+    - CREATE
+    - UPDATE
+    resources:
+    - inferenceservices
+- clientConfig:
+    caBundle: Cg==
+    service:
+      name: kfserving-webhook-server-service
+      namespace: kubeflow
+      path: /mutate-pods
+  failurePolicy: Fail
+  name: inferenceservice.kfserving-webhook-server.pod-mutator
+  namespaceSelector:
+    matchExpressions:
+    - key: control-plane
+      operator: DoesNotExist
+  rules:
+  - apiGroups:
+    - ""
+    apiVersions:
+    - v1
+    operations:
+    - CREATE
+    - UPDATE
+    resources:
+    - pods

--- a/tests/stacks/gcp/test_data/expected/admissionregistration.k8s.io_v1beta1_mutatingwebhookconfiguration_webhook.serving.knative.dev.yaml
+++ b/tests/stacks/gcp/test_data/expected/admissionregistration.k8s.io_v1beta1_mutatingwebhookconfiguration_webhook.serving.knative.dev.yaml
@@ -1,0 +1,18 @@
+apiVersion: admissionregistration.k8s.io/v1beta1
+kind: MutatingWebhookConfiguration
+metadata:
+  labels:
+    app.kubernetes.io/component: knative-serving-install
+    app.kubernetes.io/name: knative-serving-install
+    kustomize.component: knative
+    serving.knative.dev/release: v0.11.2
+  name: webhook.serving.knative.dev
+webhooks:
+- admissionReviewVersions:
+  - v1beta1
+  clientConfig:
+    service:
+      name: webhook
+      namespace: kubeflow
+  failurePolicy: Fail
+  name: webhook.serving.knative.dev

--- a/tests/stacks/gcp/test_data/expected/admissionregistration.k8s.io_v1beta1_validatingwebhookconfiguration_config.webhook.serving.knative.dev.yaml
+++ b/tests/stacks/gcp/test_data/expected/admissionregistration.k8s.io_v1beta1_validatingwebhookconfiguration_config.webhook.serving.knative.dev.yaml
@@ -1,0 +1,22 @@
+apiVersion: admissionregistration.k8s.io/v1beta1
+kind: ValidatingWebhookConfiguration
+metadata:
+  labels:
+    app.kubernetes.io/component: knative-serving-install
+    app.kubernetes.io/name: knative-serving-install
+    kustomize.component: knative
+    serving.knative.dev/release: v0.11.2
+  name: config.webhook.serving.knative.dev
+webhooks:
+- admissionReviewVersions:
+  - v1beta1
+  clientConfig:
+    service:
+      name: webhook
+      namespace: kubeflow
+  failurePolicy: Fail
+  name: config.webhook.serving.knative.dev
+  namespaceSelector:
+    matchExpressions:
+    - key: serving.knative.dev/release
+      operator: Exists

--- a/tests/stacks/gcp/test_data/expected/admissionregistration.k8s.io_v1beta1_validatingwebhookconfiguration_inferenceservice.serving.kubeflow.org.yaml
+++ b/tests/stacks/gcp/test_data/expected/admissionregistration.k8s.io_v1beta1_validatingwebhookconfiguration_inferenceservice.serving.kubeflow.org.yaml
@@ -1,0 +1,31 @@
+apiVersion: admissionregistration.k8s.io/v1beta1
+kind: ValidatingWebhookConfiguration
+metadata:
+  annotations:
+    cert-manager.io/inject-ca-from: kubeflow/serving-cert
+  creationTimestamp: null
+  labels:
+    app: kfserving
+    app.kubernetes.io/component: kfserving-install
+    app.kubernetes.io/name: kfserving-install
+    kustomize.component: kfserving
+  name: inferenceservice.serving.kubeflow.org
+webhooks:
+- clientConfig:
+    caBundle: Cg==
+    service:
+      name: kfserving-webhook-server-service
+      namespace: kubeflow
+      path: /validate-inferenceservices
+  failurePolicy: Fail
+  name: inferenceservice.kfserving-webhook-server.validator
+  rules:
+  - apiGroups:
+    - serving.kubeflow.org
+    apiVersions:
+    - v1alpha2
+    operations:
+    - CREATE
+    - UPDATE
+    resources:
+    - inferenceservices

--- a/tests/stacks/gcp/test_data/expected/admissionregistration.k8s.io_v1beta1_validatingwebhookconfiguration_validation.webhook.serving.knative.dev.yaml
+++ b/tests/stacks/gcp/test_data/expected/admissionregistration.k8s.io_v1beta1_validatingwebhookconfiguration_validation.webhook.serving.knative.dev.yaml
@@ -1,0 +1,18 @@
+apiVersion: admissionregistration.k8s.io/v1beta1
+kind: ValidatingWebhookConfiguration
+metadata:
+  labels:
+    app.kubernetes.io/component: knative-serving-install
+    app.kubernetes.io/name: knative-serving-install
+    kustomize.component: knative
+    serving.knative.dev/release: v0.11.2
+  name: validation.webhook.serving.knative.dev
+webhooks:
+- admissionReviewVersions:
+  - v1beta1
+  clientConfig:
+    service:
+      name: webhook
+      namespace: kubeflow
+  failurePolicy: Fail
+  name: validation.webhook.serving.knative.dev

--- a/tests/stacks/gcp/test_data/expected/apiextensions.k8s.io_v1beta1_customresourcedefinition_certificates.networking.internal.knative.dev.yaml
+++ b/tests/stacks/gcp/test_data/expected/apiextensions.k8s.io_v1beta1_customresourcedefinition_certificates.networking.internal.knative.dev.yaml
@@ -1,0 +1,32 @@
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  labels:
+    app.kubernetes.io/component: knative-serving-install
+    app.kubernetes.io/name: knative-serving-install
+    knative.dev/crd-install: "true"
+    kustomize.component: knative
+    serving.knative.dev/release: v0.11.2
+  name: certificates.networking.internal.knative.dev
+spec:
+  additionalPrinterColumns:
+  - JSONPath: .status.conditions[?(@.type=="Ready")].status
+    name: Ready
+    type: string
+  - JSONPath: .status.conditions[?(@.type=="Ready")].reason
+    name: Reason
+    type: string
+  group: networking.internal.knative.dev
+  names:
+    categories:
+    - knative-internal
+    - networking
+    kind: Certificate
+    plural: certificates
+    shortNames:
+    - kcert
+    singular: certificate
+  scope: Namespaced
+  subresources:
+    status: {}
+  version: v1alpha1

--- a/tests/stacks/gcp/test_data/expected/apiextensions.k8s.io_v1beta1_customresourcedefinition_configurations.serving.knative.dev.yaml
+++ b/tests/stacks/gcp/test_data/expected/apiextensions.k8s.io_v1beta1_customresourcedefinition_configurations.serving.knative.dev.yaml
@@ -1,0 +1,50 @@
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  labels:
+    app.kubernetes.io/component: knative-serving-install
+    app.kubernetes.io/name: knative-serving-install
+    duck.knative.dev/podspecable: "true"
+    knative.dev/crd-install: "true"
+    kustomize.component: knative
+    serving.knative.dev/release: v0.11.2
+  name: configurations.serving.knative.dev
+spec:
+  additionalPrinterColumns:
+  - JSONPath: .status.latestCreatedRevisionName
+    name: LatestCreated
+    type: string
+  - JSONPath: .status.latestReadyRevisionName
+    name: LatestReady
+    type: string
+  - JSONPath: .status.conditions[?(@.type=='Ready')].status
+    name: Ready
+    type: string
+  - JSONPath: .status.conditions[?(@.type=='Ready')].reason
+    name: Reason
+    type: string
+  group: serving.knative.dev
+  names:
+    categories:
+    - all
+    - knative
+    - serving
+    kind: Configuration
+    plural: configurations
+    shortNames:
+    - config
+    - cfg
+    singular: configuration
+  scope: Namespaced
+  subresources:
+    status: {}
+  versions:
+  - name: v1alpha1
+    served: true
+    storage: true
+  - name: v1beta1
+    served: true
+    storage: false
+  - name: v1
+    served: true
+    storage: false

--- a/tests/stacks/gcp/test_data/expected/apiextensions.k8s.io_v1beta1_customresourcedefinition_images.caching.internal.knative.dev.yaml
+++ b/tests/stacks/gcp/test_data/expected/apiextensions.k8s.io_v1beta1_customresourcedefinition_images.caching.internal.knative.dev.yaml
@@ -1,0 +1,24 @@
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  labels:
+    app.kubernetes.io/component: knative-serving-install
+    app.kubernetes.io/name: knative-serving-install
+    knative.dev/crd-install: "true"
+    kustomize.component: knative
+  name: images.caching.internal.knative.dev
+spec:
+  group: caching.internal.knative.dev
+  names:
+    categories:
+    - knative-internal
+    - caching
+    kind: Image
+    plural: images
+    shortNames:
+    - img
+    singular: image
+  scope: Namespaced
+  subresources:
+    status: {}
+  version: v1alpha1

--- a/tests/stacks/gcp/test_data/expected/apiextensions.k8s.io_v1beta1_customresourcedefinition_inferenceservices.serving.kubeflow.org.yaml
+++ b/tests/stacks/gcp/test_data/expected/apiextensions.k8s.io_v1beta1_customresourcedefinition_inferenceservices.serving.kubeflow.org.yaml
@@ -1,0 +1,6666 @@
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: (unknown)
+  creationTimestamp: null
+  labels:
+    app: kfserving
+    app.kubernetes.io/component: kfserving-install
+    app.kubernetes.io/name: kfserving-install
+    kustomize.component: kfserving
+  name: inferenceservices.serving.kubeflow.org
+spec:
+  additionalPrinterColumns:
+  - JSONPath: .status.url
+    name: URL
+    type: string
+  - JSONPath: .status.conditions[?(@.type=='Ready')].status
+    name: Ready
+    type: string
+  - JSONPath: .status.traffic
+    name: Default Traffic
+    type: integer
+  - JSONPath: .status.canaryTraffic
+    name: Canary Traffic
+    type: integer
+  - JSONPath: .metadata.creationTimestamp
+    name: Age
+    type: date
+  group: serving.kubeflow.org
+  names:
+    kind: InferenceService
+    listKind: InferenceServiceList
+    plural: inferenceservices
+    shortNames:
+    - inferenceservice
+    singular: inferenceservice
+  scope: Namespaced
+  subresources:
+    status: {}
+  validation:
+    openAPIV3Schema:
+      description: InferenceService is the Schema for the services API
+      properties:
+        apiVersion:
+          description: 'APIVersion defines the versioned schema of this representation
+            of an object. Servers should convert recognized schemas to the latest
+            internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#resources'
+          type: string
+        kind:
+          description: 'Kind is a string value representing the REST resource this
+            object represents. Servers may infer this from the endpoint the client
+            submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds'
+          type: string
+        metadata:
+          type: object
+        spec:
+          description: InferenceServiceSpec defines the desired state of InferenceService
+          properties:
+            canary:
+              description: Canary defines an alternate endpoints to route a percentage
+                of traffic.
+              properties:
+                explainer:
+                  description: Explainer defines the model explanation service spec,
+                    explainer service calls to predictor or transformer if it is specified.
+                  properties:
+                    alibi:
+                      description: Spec for alibi explainer
+                      properties:
+                        config:
+                          additionalProperties:
+                            type: string
+                          description: Inline custom parameter settings for explainer
+                          type: object
+                        resources:
+                          description: Defaults to requests and limits of 1CPU, 2Gb
+                            MEM.
+                          properties:
+                            limits:
+                              additionalProperties:
+                                type: string
+                              description: 'Limits describes the maximum amount of
+                                compute resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
+                              type: object
+                            requests:
+                              additionalProperties:
+                                type: string
+                              description: 'Requests describes the minimum amount
+                                of compute resources required. If Requests is omitted
+                                for a container, it defaults to Limits if that is
+                                explicitly specified, otherwise to an implementation-defined
+                                value. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
+                              type: object
+                          type: object
+                        runtimeVersion:
+                          description: Defaults to latest Alibi Version
+                          type: string
+                        storageUri:
+                          description: The location of a trained explanation model
+                          type: string
+                        type:
+                          description: The type of Alibi explainer
+                          type: string
+                      required:
+                      - type
+                      type: object
+                    custom:
+                      description: Spec for a custom explainer
+                      properties:
+                        container:
+                          description: A single application container that you want
+                            to run within a pod.
+                          properties:
+                            args:
+                              description: 'Arguments to the entrypoint. The docker
+                                image''s CMD is used if this is not provided. Variable
+                                references $(VAR_NAME) are expanded using the container''s
+                                environment. If a variable cannot be resolved, the
+                                reference in the input string will be unchanged. The
+                                $(VAR_NAME) syntax can be escaped with a double $$,
+                                ie: $$(VAR_NAME). Escaped references will never be
+                                expanded, regardless of whether the variable exists
+                                or not. Cannot be updated. More info: https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell'
+                              items:
+                                type: string
+                              type: array
+                            command:
+                              description: 'Entrypoint array. Not executed within
+                                a shell. The docker image''s ENTRYPOINT is used if
+                                this is not provided. Variable references $(VAR_NAME)
+                                are expanded using the container''s environment. If
+                                a variable cannot be resolved, the reference in the
+                                input string will be unchanged. The $(VAR_NAME) syntax
+                                can be escaped with a double $$, ie: $$(VAR_NAME).
+                                Escaped references will never be expanded, regardless
+                                of whether the variable exists or not. Cannot be updated.
+                                More info: https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell'
+                              items:
+                                type: string
+                              type: array
+                            env:
+                              description: List of environment variables to set in
+                                the container. Cannot be updated.
+                              items:
+                                description: EnvVar represents an environment variable
+                                  present in a Container.
+                                properties:
+                                  name:
+                                    description: Name of the environment variable.
+                                      Must be a C_IDENTIFIER.
+                                    type: string
+                                  value:
+                                    description: 'Variable references $(VAR_NAME)
+                                      are expanded using the previous defined environment
+                                      variables in the container and any service environment
+                                      variables. If a variable cannot be resolved,
+                                      the reference in the input string will be unchanged.
+                                      The $(VAR_NAME) syntax can be escaped with a
+                                      double $$, ie: $$(VAR_NAME). Escaped references
+                                      will never be expanded, regardless of whether
+                                      the variable exists or not. Defaults to "".'
+                                    type: string
+                                  valueFrom:
+                                    description: Source for the environment variable's
+                                      value. Cannot be used if value is not empty.
+                                    properties:
+                                      configMapKeyRef:
+                                        description: Selects a key of a ConfigMap.
+                                        properties:
+                                          key:
+                                            description: The key to select.
+                                            type: string
+                                          name:
+                                            description: 'Name of the referent. More
+                                              info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                              TODO: Add other useful fields. apiVersion,
+                                              kind, uid?'
+                                            type: string
+                                          optional:
+                                            description: Specify whether the ConfigMap
+                                              or its key must be defined
+                                            type: boolean
+                                        required:
+                                        - key
+                                        type: object
+                                      fieldRef:
+                                        description: 'Selects a field of the pod:
+                                          supports metadata.name, metadata.namespace,
+                                          metadata.labels, metadata.annotations, spec.nodeName,
+                                          spec.serviceAccountName, status.hostIP,
+                                          status.podIP.'
+                                        properties:
+                                          apiVersion:
+                                            description: Version of the schema the
+                                              FieldPath is written in terms of, defaults
+                                              to "v1".
+                                            type: string
+                                          fieldPath:
+                                            description: Path of the field to select
+                                              in the specified API version.
+                                            type: string
+                                        required:
+                                        - fieldPath
+                                        type: object
+                                      resourceFieldRef:
+                                        description: 'Selects a resource of the container:
+                                          only resources limits and requests (limits.cpu,
+                                          limits.memory, limits.ephemeral-storage,
+                                          requests.cpu, requests.memory and requests.ephemeral-storage)
+                                          are currently supported.'
+                                        properties:
+                                          containerName:
+                                            description: 'Container name: required
+                                              for volumes, optional for env vars'
+                                            type: string
+                                          divisor:
+                                            description: Specifies the output format
+                                              of the exposed resources, defaults to
+                                              "1"
+                                            type: string
+                                          resource:
+                                            description: 'Required: resource to select'
+                                            type: string
+                                        required:
+                                        - resource
+                                        type: object
+                                      secretKeyRef:
+                                        description: Selects a key of a secret in
+                                          the pod's namespace
+                                        properties:
+                                          key:
+                                            description: The key of the secret to
+                                              select from.  Must be a valid secret
+                                              key.
+                                            type: string
+                                          name:
+                                            description: 'Name of the referent. More
+                                              info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                              TODO: Add other useful fields. apiVersion,
+                                              kind, uid?'
+                                            type: string
+                                          optional:
+                                            description: Specify whether the Secret
+                                              or its key must be defined
+                                            type: boolean
+                                        required:
+                                        - key
+                                        type: object
+                                    type: object
+                                required:
+                                - name
+                                type: object
+                              type: array
+                            envFrom:
+                              description: List of sources to populate environment
+                                variables in the container. The keys defined within
+                                a source must be a C_IDENTIFIER. All invalid keys
+                                will be reported as an event when the container is
+                                starting. When a key exists in multiple sources, the
+                                value associated with the last source will take precedence.
+                                Values defined by an Env with a duplicate key will
+                                take precedence. Cannot be updated.
+                              items:
+                                description: EnvFromSource represents the source of
+                                  a set of ConfigMaps
+                                properties:
+                                  configMapRef:
+                                    description: The ConfigMap to select from
+                                    properties:
+                                      name:
+                                        description: 'Name of the referent. More info:
+                                          https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                          TODO: Add other useful fields. apiVersion,
+                                          kind, uid?'
+                                        type: string
+                                      optional:
+                                        description: Specify whether the ConfigMap
+                                          must be defined
+                                        type: boolean
+                                    type: object
+                                  prefix:
+                                    description: An optional identifier to prepend
+                                      to each key in the ConfigMap. Must be a C_IDENTIFIER.
+                                    type: string
+                                  secretRef:
+                                    description: The Secret to select from
+                                    properties:
+                                      name:
+                                        description: 'Name of the referent. More info:
+                                          https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                          TODO: Add other useful fields. apiVersion,
+                                          kind, uid?'
+                                        type: string
+                                      optional:
+                                        description: Specify whether the Secret must
+                                          be defined
+                                        type: boolean
+                                    type: object
+                                type: object
+                              type: array
+                            image:
+                              description: 'Docker image name. More info: https://kubernetes.io/docs/concepts/containers/images
+                                This field is optional to allow higher level config
+                                management to default or override container images
+                                in workload controllers like Deployments and StatefulSets.'
+                              type: string
+                            imagePullPolicy:
+                              description: 'Image pull policy. One of Always, Never,
+                                IfNotPresent. Defaults to Always if :v0.3.0 tag is
+                                specified, or IfNotPresent otherwise. Cannot be updated.
+                                More info: https://kubernetes.io/docs/concepts/containers/images#updating-images'
+                              type: string
+                            lifecycle:
+                              description: Actions that the management system should
+                                take in response to container lifecycle events. Cannot
+                                be updated.
+                              properties:
+                                postStart:
+                                  description: 'PostStart is called immediately after
+                                    a container is created. If the handler fails,
+                                    the container is terminated and restarted according
+                                    to its restart policy. Other management of the
+                                    container blocks until the hook completes. More
+                                    info: https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/#container-hooks'
+                                  properties:
+                                    exec:
+                                      description: One and only one of the following
+                                        should be specified. Exec specifies the action
+                                        to take.
+                                      properties:
+                                        command:
+                                          description: Command is the command line
+                                            to execute inside the container, the working
+                                            directory for the command  is root ('/')
+                                            in the container's filesystem. The command
+                                            is simply exec'd, it is not run inside
+                                            a shell, so traditional shell instructions
+                                            ('|', etc) won't work. To use a shell,
+                                            you need to explicitly call out to that
+                                            shell. Exit status of 0 is treated as
+                                            live/healthy and non-zero is unhealthy.
+                                          items:
+                                            type: string
+                                          type: array
+                                      type: object
+                                    httpGet:
+                                      description: HTTPGet specifies the http request
+                                        to perform.
+                                      properties:
+                                        host:
+                                          description: Host name to connect to, defaults
+                                            to the pod IP. You probably want to set
+                                            "Host" in httpHeaders instead.
+                                          type: string
+                                        httpHeaders:
+                                          description: Custom headers to set in the
+                                            request. HTTP allows repeated headers.
+                                          items:
+                                            description: HTTPHeader describes a custom
+                                              header to be used in HTTP probes
+                                            properties:
+                                              name:
+                                                description: The header field name
+                                                type: string
+                                              value:
+                                                description: The header field value
+                                                type: string
+                                            required:
+                                            - name
+                                            - value
+                                            type: object
+                                          type: array
+                                        path:
+                                          description: Path to access on the HTTP
+                                            server.
+                                          type: string
+                                        port:
+                                          anyOf:
+                                          - type: string
+                                          - type: integer
+                                          description: Name or number of the port
+                                            to access on the container. Number must
+                                            be in the range 1 to 65535. Name must
+                                            be an IANA_SVC_NAME.
+                                        scheme:
+                                          description: Scheme to use for connecting
+                                            to the host. Defaults to HTTP.
+                                          type: string
+                                      required:
+                                      - port
+                                      type: object
+                                    tcpSocket:
+                                      description: 'TCPSocket specifies an action
+                                        involving a TCP port. TCP hooks not yet supported
+                                        TODO: implement a realistic TCP lifecycle
+                                        hook'
+                                      properties:
+                                        host:
+                                          description: 'Optional: Host name to connect
+                                            to, defaults to the pod IP.'
+                                          type: string
+                                        port:
+                                          anyOf:
+                                          - type: string
+                                          - type: integer
+                                          description: Number or name of the port
+                                            to access on the container. Number must
+                                            be in the range 1 to 65535. Name must
+                                            be an IANA_SVC_NAME.
+                                      required:
+                                      - port
+                                      type: object
+                                  type: object
+                                preStop:
+                                  description: 'PreStop is called immediately before
+                                    a container is terminated due to an API request
+                                    or management event such as liveness probe failure,
+                                    preemption, resource contention, etc. The handler
+                                    is not called if the container crashes or exits.
+                                    The reason for termination is passed to the handler.
+                                    The Pod''s termination grace period countdown
+                                    begins before the PreStop hooked is executed.
+                                    Regardless of the outcome of the handler, the
+                                    container will eventually terminate within the
+                                    Pod''s termination grace period. Other management
+                                    of the container blocks until the hook completes
+                                    or until the termination grace period is reached.
+                                    More info: https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/#container-hooks'
+                                  properties:
+                                    exec:
+                                      description: One and only one of the following
+                                        should be specified. Exec specifies the action
+                                        to take.
+                                      properties:
+                                        command:
+                                          description: Command is the command line
+                                            to execute inside the container, the working
+                                            directory for the command  is root ('/')
+                                            in the container's filesystem. The command
+                                            is simply exec'd, it is not run inside
+                                            a shell, so traditional shell instructions
+                                            ('|', etc) won't work. To use a shell,
+                                            you need to explicitly call out to that
+                                            shell. Exit status of 0 is treated as
+                                            live/healthy and non-zero is unhealthy.
+                                          items:
+                                            type: string
+                                          type: array
+                                      type: object
+                                    httpGet:
+                                      description: HTTPGet specifies the http request
+                                        to perform.
+                                      properties:
+                                        host:
+                                          description: Host name to connect to, defaults
+                                            to the pod IP. You probably want to set
+                                            "Host" in httpHeaders instead.
+                                          type: string
+                                        httpHeaders:
+                                          description: Custom headers to set in the
+                                            request. HTTP allows repeated headers.
+                                          items:
+                                            description: HTTPHeader describes a custom
+                                              header to be used in HTTP probes
+                                            properties:
+                                              name:
+                                                description: The header field name
+                                                type: string
+                                              value:
+                                                description: The header field value
+                                                type: string
+                                            required:
+                                            - name
+                                            - value
+                                            type: object
+                                          type: array
+                                        path:
+                                          description: Path to access on the HTTP
+                                            server.
+                                          type: string
+                                        port:
+                                          anyOf:
+                                          - type: string
+                                          - type: integer
+                                          description: Name or number of the port
+                                            to access on the container. Number must
+                                            be in the range 1 to 65535. Name must
+                                            be an IANA_SVC_NAME.
+                                        scheme:
+                                          description: Scheme to use for connecting
+                                            to the host. Defaults to HTTP.
+                                          type: string
+                                      required:
+                                      - port
+                                      type: object
+                                    tcpSocket:
+                                      description: 'TCPSocket specifies an action
+                                        involving a TCP port. TCP hooks not yet supported
+                                        TODO: implement a realistic TCP lifecycle
+                                        hook'
+                                      properties:
+                                        host:
+                                          description: 'Optional: Host name to connect
+                                            to, defaults to the pod IP.'
+                                          type: string
+                                        port:
+                                          anyOf:
+                                          - type: string
+                                          - type: integer
+                                          description: Number or name of the port
+                                            to access on the container. Number must
+                                            be in the range 1 to 65535. Name must
+                                            be an IANA_SVC_NAME.
+                                      required:
+                                      - port
+                                      type: object
+                                  type: object
+                              type: object
+                            livenessProbe:
+                              description: 'Periodic probe of container liveness.
+                                Container will be restarted if the probe fails. Cannot
+                                be updated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                              properties:
+                                exec:
+                                  description: One and only one of the following should
+                                    be specified. Exec specifies the action to take.
+                                  properties:
+                                    command:
+                                      description: Command is the command line to
+                                        execute inside the container, the working
+                                        directory for the command  is root ('/') in
+                                        the container's filesystem. The command is
+                                        simply exec'd, it is not run inside a shell,
+                                        so traditional shell instructions ('|', etc)
+                                        won't work. To use a shell, you need to explicitly
+                                        call out to that shell. Exit status of 0 is
+                                        treated as live/healthy and non-zero is unhealthy.
+                                      items:
+                                        type: string
+                                      type: array
+                                  type: object
+                                failureThreshold:
+                                  description: Minimum consecutive failures for the
+                                    probe to be considered failed after having succeeded.
+                                    Defaults to 3. Minimum value is 1.
+                                  format: int32
+                                  type: integer
+                                httpGet:
+                                  description: HTTPGet specifies the http request
+                                    to perform.
+                                  properties:
+                                    host:
+                                      description: Host name to connect to, defaults
+                                        to the pod IP. You probably want to set "Host"
+                                        in httpHeaders instead.
+                                      type: string
+                                    httpHeaders:
+                                      description: Custom headers to set in the request.
+                                        HTTP allows repeated headers.
+                                      items:
+                                        description: HTTPHeader describes a custom
+                                          header to be used in HTTP probes
+                                        properties:
+                                          name:
+                                            description: The header field name
+                                            type: string
+                                          value:
+                                            description: The header field value
+                                            type: string
+                                        required:
+                                        - name
+                                        - value
+                                        type: object
+                                      type: array
+                                    path:
+                                      description: Path to access on the HTTP server.
+                                      type: string
+                                    port:
+                                      anyOf:
+                                      - type: string
+                                      - type: integer
+                                      description: Name or number of the port to access
+                                        on the container. Number must be in the range
+                                        1 to 65535. Name must be an IANA_SVC_NAME.
+                                    scheme:
+                                      description: Scheme to use for connecting to
+                                        the host. Defaults to HTTP.
+                                      type: string
+                                  required:
+                                  - port
+                                  type: object
+                                initialDelaySeconds:
+                                  description: 'Number of seconds after the container
+                                    has started before liveness probes are initiated.
+                                    More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                                  format: int32
+                                  type: integer
+                                periodSeconds:
+                                  description: How often (in seconds) to perform the
+                                    probe. Default to 10 seconds. Minimum value is
+                                    1.
+                                  format: int32
+                                  type: integer
+                                successThreshold:
+                                  description: Minimum consecutive successes for the
+                                    probe to be considered successful after having
+                                    failed. Defaults to 1. Must be 1 for liveness.
+                                    Minimum value is 1.
+                                  format: int32
+                                  type: integer
+                                tcpSocket:
+                                  description: 'TCPSocket specifies an action involving
+                                    a TCP port. TCP hooks not yet supported TODO:
+                                    implement a realistic TCP lifecycle hook'
+                                  properties:
+                                    host:
+                                      description: 'Optional: Host name to connect
+                                        to, defaults to the pod IP.'
+                                      type: string
+                                    port:
+                                      anyOf:
+                                      - type: string
+                                      - type: integer
+                                      description: Number or name of the port to access
+                                        on the container. Number must be in the range
+                                        1 to 65535. Name must be an IANA_SVC_NAME.
+                                  required:
+                                  - port
+                                  type: object
+                                timeoutSeconds:
+                                  description: 'Number of seconds after which the
+                                    probe times out. Defaults to 1 second. Minimum
+                                    value is 1. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                                  format: int32
+                                  type: integer
+                              type: object
+                            name:
+                              description: Name of the container specified as a DNS_LABEL.
+                                Each container in a pod must have a unique name (DNS_LABEL).
+                                Cannot be updated.
+                              type: string
+                            ports:
+                              description: List of ports to expose from the container.
+                                Exposing a port here gives the system additional information
+                                about the network connections a container uses, but
+                                is primarily informational. Not specifying a port
+                                here DOES NOT prevent that port from being exposed.
+                                Any port which is listening on the default "0.0.0.0"
+                                address inside a container will be accessible from
+                                the network. Cannot be updated.
+                              items:
+                                description: ContainerPort represents a network port
+                                  in a single container.
+                                properties:
+                                  containerPort:
+                                    description: Number of port to expose on the pod's
+                                      IP address. This must be a valid port number,
+                                      0 < x < 65536.
+                                    format: int32
+                                    type: integer
+                                  hostIP:
+                                    description: What host IP to bind the external
+                                      port to.
+                                    type: string
+                                  hostPort:
+                                    description: Number of port to expose on the host.
+                                      If specified, this must be a valid port number,
+                                      0 < x < 65536. If HostNetwork is specified,
+                                      this must match ContainerPort. Most containers
+                                      do not need this.
+                                    format: int32
+                                    type: integer
+                                  name:
+                                    description: If specified, this must be an IANA_SVC_NAME
+                                      and unique within the pod. Each named port in
+                                      a pod must have a unique name. Name for the
+                                      port that can be referred to by services.
+                                    type: string
+                                  protocol:
+                                    description: Protocol for port. Must be UDP, TCP,
+                                      or SCTP. Defaults to "TCP".
+                                    type: string
+                                required:
+                                - containerPort
+                                type: object
+                              type: array
+                            readinessProbe:
+                              description: 'Periodic probe of container service readiness.
+                                Container will be removed from service endpoints if
+                                the probe fails. Cannot be updated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                              properties:
+                                exec:
+                                  description: One and only one of the following should
+                                    be specified. Exec specifies the action to take.
+                                  properties:
+                                    command:
+                                      description: Command is the command line to
+                                        execute inside the container, the working
+                                        directory for the command  is root ('/') in
+                                        the container's filesystem. The command is
+                                        simply exec'd, it is not run inside a shell,
+                                        so traditional shell instructions ('|', etc)
+                                        won't work. To use a shell, you need to explicitly
+                                        call out to that shell. Exit status of 0 is
+                                        treated as live/healthy and non-zero is unhealthy.
+                                      items:
+                                        type: string
+                                      type: array
+                                  type: object
+                                failureThreshold:
+                                  description: Minimum consecutive failures for the
+                                    probe to be considered failed after having succeeded.
+                                    Defaults to 3. Minimum value is 1.
+                                  format: int32
+                                  type: integer
+                                httpGet:
+                                  description: HTTPGet specifies the http request
+                                    to perform.
+                                  properties:
+                                    host:
+                                      description: Host name to connect to, defaults
+                                        to the pod IP. You probably want to set "Host"
+                                        in httpHeaders instead.
+                                      type: string
+                                    httpHeaders:
+                                      description: Custom headers to set in the request.
+                                        HTTP allows repeated headers.
+                                      items:
+                                        description: HTTPHeader describes a custom
+                                          header to be used in HTTP probes
+                                        properties:
+                                          name:
+                                            description: The header field name
+                                            type: string
+                                          value:
+                                            description: The header field value
+                                            type: string
+                                        required:
+                                        - name
+                                        - value
+                                        type: object
+                                      type: array
+                                    path:
+                                      description: Path to access on the HTTP server.
+                                      type: string
+                                    port:
+                                      anyOf:
+                                      - type: string
+                                      - type: integer
+                                      description: Name or number of the port to access
+                                        on the container. Number must be in the range
+                                        1 to 65535. Name must be an IANA_SVC_NAME.
+                                    scheme:
+                                      description: Scheme to use for connecting to
+                                        the host. Defaults to HTTP.
+                                      type: string
+                                  required:
+                                  - port
+                                  type: object
+                                initialDelaySeconds:
+                                  description: 'Number of seconds after the container
+                                    has started before liveness probes are initiated.
+                                    More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                                  format: int32
+                                  type: integer
+                                periodSeconds:
+                                  description: How often (in seconds) to perform the
+                                    probe. Default to 10 seconds. Minimum value is
+                                    1.
+                                  format: int32
+                                  type: integer
+                                successThreshold:
+                                  description: Minimum consecutive successes for the
+                                    probe to be considered successful after having
+                                    failed. Defaults to 1. Must be 1 for liveness.
+                                    Minimum value is 1.
+                                  format: int32
+                                  type: integer
+                                tcpSocket:
+                                  description: 'TCPSocket specifies an action involving
+                                    a TCP port. TCP hooks not yet supported TODO:
+                                    implement a realistic TCP lifecycle hook'
+                                  properties:
+                                    host:
+                                      description: 'Optional: Host name to connect
+                                        to, defaults to the pod IP.'
+                                      type: string
+                                    port:
+                                      anyOf:
+                                      - type: string
+                                      - type: integer
+                                      description: Number or name of the port to access
+                                        on the container. Number must be in the range
+                                        1 to 65535. Name must be an IANA_SVC_NAME.
+                                  required:
+                                  - port
+                                  type: object
+                                timeoutSeconds:
+                                  description: 'Number of seconds after which the
+                                    probe times out. Defaults to 1 second. Minimum
+                                    value is 1. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                                  format: int32
+                                  type: integer
+                              type: object
+                            resources:
+                              description: 'Compute Resources required by this container.
+                                Cannot be updated. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
+                              properties:
+                                limits:
+                                  additionalProperties:
+                                    type: string
+                                  description: 'Limits describes the maximum amount
+                                    of compute resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
+                                  type: object
+                                requests:
+                                  additionalProperties:
+                                    type: string
+                                  description: 'Requests describes the minimum amount
+                                    of compute resources required. If Requests is
+                                    omitted for a container, it defaults to Limits
+                                    if that is explicitly specified, otherwise to
+                                    an implementation-defined value. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
+                                  type: object
+                              type: object
+                            securityContext:
+                              description: 'Security options the pod should run with.
+                                More info: https://kubernetes.io/docs/concepts/policy/security-context/
+                                More info: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/'
+                              properties:
+                                allowPrivilegeEscalation:
+                                  description: 'AllowPrivilegeEscalation controls
+                                    whether a process can gain more privileges than
+                                    its parent process. This bool directly controls
+                                    if the no_new_privs flag will be set on the container
+                                    process. AllowPrivilegeEscalation is true always
+                                    when the container is: 1) run as Privileged 2)
+                                    has CAP_SYS_ADMIN'
+                                  type: boolean
+                                capabilities:
+                                  description: The capabilities to add/drop when running
+                                    containers. Defaults to the default set of capabilities
+                                    granted by the container runtime.
+                                  properties:
+                                    add:
+                                      description: Added capabilities
+                                      items:
+                                        description: Capability represent POSIX capabilities
+                                          type
+                                        type: string
+                                      type: array
+                                    drop:
+                                      description: Removed capabilities
+                                      items:
+                                        description: Capability represent POSIX capabilities
+                                          type
+                                        type: string
+                                      type: array
+                                  type: object
+                                privileged:
+                                  description: Run container in privileged mode. Processes
+                                    in privileged containers are essentially equivalent
+                                    to root on the host. Defaults to false.
+                                  type: boolean
+                                procMount:
+                                  description: procMount denotes the type of proc
+                                    mount to use for the containers. The default is
+                                    DefaultProcMount which uses the container runtime
+                                    defaults for readonly paths and masked paths.
+                                    This requires the ProcMountType feature flag to
+                                    be enabled.
+                                  type: string
+                                readOnlyRootFilesystem:
+                                  description: Whether this container has a read-only
+                                    root filesystem. Default is false.
+                                  type: boolean
+                                runAsGroup:
+                                  description: The GID to run the entrypoint of the
+                                    container process. Uses runtime default if unset.
+                                    May also be set in PodSecurityContext.  If set
+                                    in both SecurityContext and PodSecurityContext,
+                                    the value specified in SecurityContext takes precedence.
+                                  format: int64
+                                  type: integer
+                                runAsNonRoot:
+                                  description: Indicates that the container must run
+                                    as a non-root user. If true, the Kubelet will
+                                    validate the image at runtime to ensure that it
+                                    does not run as UID 0 (root) and fail to start
+                                    the container if it does. If unset or false, no
+                                    such validation will be performed. May also be
+                                    set in PodSecurityContext.  If set in both SecurityContext
+                                    and PodSecurityContext, the value specified in
+                                    SecurityContext takes precedence.
+                                  type: boolean
+                                runAsUser:
+                                  description: The UID to run the entrypoint of the
+                                    container process. Defaults to user specified
+                                    in image metadata if unspecified. May also be
+                                    set in PodSecurityContext.  If set in both SecurityContext
+                                    and PodSecurityContext, the value specified in
+                                    SecurityContext takes precedence.
+                                  format: int64
+                                  type: integer
+                                seLinuxOptions:
+                                  description: The SELinux context to be applied to
+                                    the container. If unspecified, the container runtime
+                                    will allocate a random SELinux context for each
+                                    container.  May also be set in PodSecurityContext.  If
+                                    set in both SecurityContext and PodSecurityContext,
+                                    the value specified in SecurityContext takes precedence.
+                                  properties:
+                                    level:
+                                      description: Level is SELinux level label that
+                                        applies to the container.
+                                      type: string
+                                    role:
+                                      description: Role is a SELinux role label that
+                                        applies to the container.
+                                      type: string
+                                    type:
+                                      description: Type is a SELinux type label that
+                                        applies to the container.
+                                      type: string
+                                    user:
+                                      description: User is a SELinux user label that
+                                        applies to the container.
+                                      type: string
+                                  type: object
+                                windowsOptions:
+                                  description: Windows security options.
+                                  properties:
+                                    gmsaCredentialSpec:
+                                      description: GMSACredentialSpec is where the
+                                        GMSA admission webhook (https://github.com/kubernetes-sigs/windows-gmsa)
+                                        inlines the contents of the GMSA credential
+                                        spec named by the GMSACredentialSpecName field.
+                                        This field is alpha-level and is only honored
+                                        by servers that enable the WindowsGMSA feature
+                                        flag.
+                                      type: string
+                                    gmsaCredentialSpecName:
+                                      description: GMSACredentialSpecName is the name
+                                        of the GMSA credential spec to use. This field
+                                        is alpha-level and is only honored by servers
+                                        that enable the WindowsGMSA feature flag.
+                                      type: string
+                                  type: object
+                              type: object
+                            stdin:
+                              description: Whether this container should allocate
+                                a buffer for stdin in the container runtime. If this
+                                is not set, reads from stdin in the container will
+                                always result in EOF. Default is false.
+                              type: boolean
+                            stdinOnce:
+                              description: Whether the container runtime should close
+                                the stdin channel after it has been opened by a single
+                                attach. When stdin is true the stdin stream will remain
+                                open across multiple attach sessions. If stdinOnce
+                                is set to true, stdin is opened on container start,
+                                is empty until the first client attaches to stdin,
+                                and then remains open and accepts data until the client
+                                disconnects, at which time stdin is closed and remains
+                                closed until the container is restarted. If this flag
+                                is false, a container processes that reads from stdin
+                                will never receive an EOF. Default is false
+                              type: boolean
+                            terminationMessagePath:
+                              description: 'Optional: Path at which the file to which
+                                the container''s termination message will be written
+                                is mounted into the container''s filesystem. Message
+                                written is intended to be brief final status, such
+                                as an assertion failure message. Will be truncated
+                                by the node if greater than 4096 bytes. The total
+                                message length across all containers will be limited
+                                to 12kb. Defaults to /dev/termination-log. Cannot
+                                be updated.'
+                              type: string
+                            terminationMessagePolicy:
+                              description: Indicate how the termination message should
+                                be populated. File will use the contents of terminationMessagePath
+                                to populate the container status message on both success
+                                and failure. FallbackToLogsOnError will use the last
+                                chunk of container log output if the termination message
+                                file is empty and the container exited with an error.
+                                The log output is limited to 2048 bytes or 80 lines,
+                                whichever is smaller. Defaults to File. Cannot be
+                                updated.
+                              type: string
+                            tty:
+                              description: Whether this container should allocate
+                                a TTY for itself, also requires 'stdin' to be true.
+                                Default is false.
+                              type: boolean
+                            volumeDevices:
+                              description: volumeDevices is the list of block devices
+                                to be used by the container. This is a beta feature.
+                              items:
+                                description: volumeDevice describes a mapping of a
+                                  raw block device within a container.
+                                properties:
+                                  devicePath:
+                                    description: devicePath is the path inside of
+                                      the container that the device will be mapped
+                                      to.
+                                    type: string
+                                  name:
+                                    description: name must match the name of a persistentVolumeClaim
+                                      in the pod
+                                    type: string
+                                required:
+                                - devicePath
+                                - name
+                                type: object
+                              type: array
+                            volumeMounts:
+                              description: Pod volumes to mount into the container's
+                                filesystem. Cannot be updated.
+                              items:
+                                description: VolumeMount describes a mounting of a
+                                  Volume within a container.
+                                properties:
+                                  mountPath:
+                                    description: Path within the container at which
+                                      the volume should be mounted.  Must not contain
+                                      ':'.
+                                    type: string
+                                  mountPropagation:
+                                    description: mountPropagation determines how mounts
+                                      are propagated from the host to container and
+                                      the other way around. When not set, MountPropagationNone
+                                      is used. This field is beta in 1.10.
+                                    type: string
+                                  name:
+                                    description: This must match the Name of a Volume.
+                                    type: string
+                                  readOnly:
+                                    description: Mounted read-only if true, read-write
+                                      otherwise (false or unspecified). Defaults to
+                                      false.
+                                    type: boolean
+                                  subPath:
+                                    description: Path within the volume from which
+                                      the container's volume should be mounted. Defaults
+                                      to "" (volume's root).
+                                    type: string
+                                  subPathExpr:
+                                    description: Expanded path within the volume from
+                                      which the container's volume should be mounted.
+                                      Behaves similarly to SubPath but environment
+                                      variable references $(VAR_NAME) are expanded
+                                      using the container's environment. Defaults
+                                      to "" (volume's root). SubPathExpr and SubPath
+                                      are mutually exclusive. This field is beta in
+                                      1.15.
+                                    type: string
+                                required:
+                                - mountPath
+                                - name
+                                type: object
+                              type: array
+                            workingDir:
+                              description: Container's working directory. If not specified,
+                                the container runtime's default will be used, which
+                                might be configured in the container image. Cannot
+                                be updated.
+                              type: string
+                          required:
+                          - name
+                          type: object
+                      required:
+                      - container
+                      type: object
+                    logger:
+                      description: Activate request/response logging
+                      properties:
+                        mode:
+                          description: What payloads to log
+                          type: string
+                        url:
+                          description: URL to send request logging CloudEvents
+                          type: string
+                      type: object
+                    maxReplicas:
+                      description: This is the up bound for autoscaler to scale to
+                      type: integer
+                    minReplicas:
+                      description: Minimum number of replicas, pods won't scale down
+                        to 0 in case of no traffic
+                      type: integer
+                    parallelism:
+                      description: Parallelism specifies how many requests can be
+                        processed concurrently, this sets the target concurrency for
+                        Autoscaling(KPA). For model servers that support tuning parallelism
+                        will use this value, by default the parallelism is the number
+                        of the CPU cores for most of the model servers.
+                      type: integer
+                    serviceAccountName:
+                      description: ServiceAccountName is the name of the ServiceAccount
+                        to use to run the service
+                      type: string
+                  type: object
+                predictor:
+                  description: Predictor defines the model serving spec
+                  properties:
+                    custom:
+                      description: Spec for a custom predictor
+                      properties:
+                        container:
+                          description: A single application container that you want
+                            to run within a pod.
+                          properties:
+                            args:
+                              description: 'Arguments to the entrypoint. The docker
+                                image''s CMD is used if this is not provided. Variable
+                                references $(VAR_NAME) are expanded using the container''s
+                                environment. If a variable cannot be resolved, the
+                                reference in the input string will be unchanged. The
+                                $(VAR_NAME) syntax can be escaped with a double $$,
+                                ie: $$(VAR_NAME). Escaped references will never be
+                                expanded, regardless of whether the variable exists
+                                or not. Cannot be updated. More info: https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell'
+                              items:
+                                type: string
+                              type: array
+                            command:
+                              description: 'Entrypoint array. Not executed within
+                                a shell. The docker image''s ENTRYPOINT is used if
+                                this is not provided. Variable references $(VAR_NAME)
+                                are expanded using the container''s environment. If
+                                a variable cannot be resolved, the reference in the
+                                input string will be unchanged. The $(VAR_NAME) syntax
+                                can be escaped with a double $$, ie: $$(VAR_NAME).
+                                Escaped references will never be expanded, regardless
+                                of whether the variable exists or not. Cannot be updated.
+                                More info: https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell'
+                              items:
+                                type: string
+                              type: array
+                            env:
+                              description: List of environment variables to set in
+                                the container. Cannot be updated.
+                              items:
+                                description: EnvVar represents an environment variable
+                                  present in a Container.
+                                properties:
+                                  name:
+                                    description: Name of the environment variable.
+                                      Must be a C_IDENTIFIER.
+                                    type: string
+                                  value:
+                                    description: 'Variable references $(VAR_NAME)
+                                      are expanded using the previous defined environment
+                                      variables in the container and any service environment
+                                      variables. If a variable cannot be resolved,
+                                      the reference in the input string will be unchanged.
+                                      The $(VAR_NAME) syntax can be escaped with a
+                                      double $$, ie: $$(VAR_NAME). Escaped references
+                                      will never be expanded, regardless of whether
+                                      the variable exists or not. Defaults to "".'
+                                    type: string
+                                  valueFrom:
+                                    description: Source for the environment variable's
+                                      value. Cannot be used if value is not empty.
+                                    properties:
+                                      configMapKeyRef:
+                                        description: Selects a key of a ConfigMap.
+                                        properties:
+                                          key:
+                                            description: The key to select.
+                                            type: string
+                                          name:
+                                            description: 'Name of the referent. More
+                                              info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                              TODO: Add other useful fields. apiVersion,
+                                              kind, uid?'
+                                            type: string
+                                          optional:
+                                            description: Specify whether the ConfigMap
+                                              or its key must be defined
+                                            type: boolean
+                                        required:
+                                        - key
+                                        type: object
+                                      fieldRef:
+                                        description: 'Selects a field of the pod:
+                                          supports metadata.name, metadata.namespace,
+                                          metadata.labels, metadata.annotations, spec.nodeName,
+                                          spec.serviceAccountName, status.hostIP,
+                                          status.podIP.'
+                                        properties:
+                                          apiVersion:
+                                            description: Version of the schema the
+                                              FieldPath is written in terms of, defaults
+                                              to "v1".
+                                            type: string
+                                          fieldPath:
+                                            description: Path of the field to select
+                                              in the specified API version.
+                                            type: string
+                                        required:
+                                        - fieldPath
+                                        type: object
+                                      resourceFieldRef:
+                                        description: 'Selects a resource of the container:
+                                          only resources limits and requests (limits.cpu,
+                                          limits.memory, limits.ephemeral-storage,
+                                          requests.cpu, requests.memory and requests.ephemeral-storage)
+                                          are currently supported.'
+                                        properties:
+                                          containerName:
+                                            description: 'Container name: required
+                                              for volumes, optional for env vars'
+                                            type: string
+                                          divisor:
+                                            description: Specifies the output format
+                                              of the exposed resources, defaults to
+                                              "1"
+                                            type: string
+                                          resource:
+                                            description: 'Required: resource to select'
+                                            type: string
+                                        required:
+                                        - resource
+                                        type: object
+                                      secretKeyRef:
+                                        description: Selects a key of a secret in
+                                          the pod's namespace
+                                        properties:
+                                          key:
+                                            description: The key of the secret to
+                                              select from.  Must be a valid secret
+                                              key.
+                                            type: string
+                                          name:
+                                            description: 'Name of the referent. More
+                                              info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                              TODO: Add other useful fields. apiVersion,
+                                              kind, uid?'
+                                            type: string
+                                          optional:
+                                            description: Specify whether the Secret
+                                              or its key must be defined
+                                            type: boolean
+                                        required:
+                                        - key
+                                        type: object
+                                    type: object
+                                required:
+                                - name
+                                type: object
+                              type: array
+                            envFrom:
+                              description: List of sources to populate environment
+                                variables in the container. The keys defined within
+                                a source must be a C_IDENTIFIER. All invalid keys
+                                will be reported as an event when the container is
+                                starting. When a key exists in multiple sources, the
+                                value associated with the last source will take precedence.
+                                Values defined by an Env with a duplicate key will
+                                take precedence. Cannot be updated.
+                              items:
+                                description: EnvFromSource represents the source of
+                                  a set of ConfigMaps
+                                properties:
+                                  configMapRef:
+                                    description: The ConfigMap to select from
+                                    properties:
+                                      name:
+                                        description: 'Name of the referent. More info:
+                                          https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                          TODO: Add other useful fields. apiVersion,
+                                          kind, uid?'
+                                        type: string
+                                      optional:
+                                        description: Specify whether the ConfigMap
+                                          must be defined
+                                        type: boolean
+                                    type: object
+                                  prefix:
+                                    description: An optional identifier to prepend
+                                      to each key in the ConfigMap. Must be a C_IDENTIFIER.
+                                    type: string
+                                  secretRef:
+                                    description: The Secret to select from
+                                    properties:
+                                      name:
+                                        description: 'Name of the referent. More info:
+                                          https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                          TODO: Add other useful fields. apiVersion,
+                                          kind, uid?'
+                                        type: string
+                                      optional:
+                                        description: Specify whether the Secret must
+                                          be defined
+                                        type: boolean
+                                    type: object
+                                type: object
+                              type: array
+                            image:
+                              description: 'Docker image name. More info: https://kubernetes.io/docs/concepts/containers/images
+                                This field is optional to allow higher level config
+                                management to default or override container images
+                                in workload controllers like Deployments and StatefulSets.'
+                              type: string
+                            imagePullPolicy:
+                              description: 'Image pull policy. One of Always, Never,
+                                IfNotPresent. Defaults to Always if :v0.3.0 tag is
+                                specified, or IfNotPresent otherwise. Cannot be updated.
+                                More info: https://kubernetes.io/docs/concepts/containers/images#updating-images'
+                              type: string
+                            lifecycle:
+                              description: Actions that the management system should
+                                take in response to container lifecycle events. Cannot
+                                be updated.
+                              properties:
+                                postStart:
+                                  description: 'PostStart is called immediately after
+                                    a container is created. If the handler fails,
+                                    the container is terminated and restarted according
+                                    to its restart policy. Other management of the
+                                    container blocks until the hook completes. More
+                                    info: https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/#container-hooks'
+                                  properties:
+                                    exec:
+                                      description: One and only one of the following
+                                        should be specified. Exec specifies the action
+                                        to take.
+                                      properties:
+                                        command:
+                                          description: Command is the command line
+                                            to execute inside the container, the working
+                                            directory for the command  is root ('/')
+                                            in the container's filesystem. The command
+                                            is simply exec'd, it is not run inside
+                                            a shell, so traditional shell instructions
+                                            ('|', etc) won't work. To use a shell,
+                                            you need to explicitly call out to that
+                                            shell. Exit status of 0 is treated as
+                                            live/healthy and non-zero is unhealthy.
+                                          items:
+                                            type: string
+                                          type: array
+                                      type: object
+                                    httpGet:
+                                      description: HTTPGet specifies the http request
+                                        to perform.
+                                      properties:
+                                        host:
+                                          description: Host name to connect to, defaults
+                                            to the pod IP. You probably want to set
+                                            "Host" in httpHeaders instead.
+                                          type: string
+                                        httpHeaders:
+                                          description: Custom headers to set in the
+                                            request. HTTP allows repeated headers.
+                                          items:
+                                            description: HTTPHeader describes a custom
+                                              header to be used in HTTP probes
+                                            properties:
+                                              name:
+                                                description: The header field name
+                                                type: string
+                                              value:
+                                                description: The header field value
+                                                type: string
+                                            required:
+                                            - name
+                                            - value
+                                            type: object
+                                          type: array
+                                        path:
+                                          description: Path to access on the HTTP
+                                            server.
+                                          type: string
+                                        port:
+                                          anyOf:
+                                          - type: string
+                                          - type: integer
+                                          description: Name or number of the port
+                                            to access on the container. Number must
+                                            be in the range 1 to 65535. Name must
+                                            be an IANA_SVC_NAME.
+                                        scheme:
+                                          description: Scheme to use for connecting
+                                            to the host. Defaults to HTTP.
+                                          type: string
+                                      required:
+                                      - port
+                                      type: object
+                                    tcpSocket:
+                                      description: 'TCPSocket specifies an action
+                                        involving a TCP port. TCP hooks not yet supported
+                                        TODO: implement a realistic TCP lifecycle
+                                        hook'
+                                      properties:
+                                        host:
+                                          description: 'Optional: Host name to connect
+                                            to, defaults to the pod IP.'
+                                          type: string
+                                        port:
+                                          anyOf:
+                                          - type: string
+                                          - type: integer
+                                          description: Number or name of the port
+                                            to access on the container. Number must
+                                            be in the range 1 to 65535. Name must
+                                            be an IANA_SVC_NAME.
+                                      required:
+                                      - port
+                                      type: object
+                                  type: object
+                                preStop:
+                                  description: 'PreStop is called immediately before
+                                    a container is terminated due to an API request
+                                    or management event such as liveness probe failure,
+                                    preemption, resource contention, etc. The handler
+                                    is not called if the container crashes or exits.
+                                    The reason for termination is passed to the handler.
+                                    The Pod''s termination grace period countdown
+                                    begins before the PreStop hooked is executed.
+                                    Regardless of the outcome of the handler, the
+                                    container will eventually terminate within the
+                                    Pod''s termination grace period. Other management
+                                    of the container blocks until the hook completes
+                                    or until the termination grace period is reached.
+                                    More info: https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/#container-hooks'
+                                  properties:
+                                    exec:
+                                      description: One and only one of the following
+                                        should be specified. Exec specifies the action
+                                        to take.
+                                      properties:
+                                        command:
+                                          description: Command is the command line
+                                            to execute inside the container, the working
+                                            directory for the command  is root ('/')
+                                            in the container's filesystem. The command
+                                            is simply exec'd, it is not run inside
+                                            a shell, so traditional shell instructions
+                                            ('|', etc) won't work. To use a shell,
+                                            you need to explicitly call out to that
+                                            shell. Exit status of 0 is treated as
+                                            live/healthy and non-zero is unhealthy.
+                                          items:
+                                            type: string
+                                          type: array
+                                      type: object
+                                    httpGet:
+                                      description: HTTPGet specifies the http request
+                                        to perform.
+                                      properties:
+                                        host:
+                                          description: Host name to connect to, defaults
+                                            to the pod IP. You probably want to set
+                                            "Host" in httpHeaders instead.
+                                          type: string
+                                        httpHeaders:
+                                          description: Custom headers to set in the
+                                            request. HTTP allows repeated headers.
+                                          items:
+                                            description: HTTPHeader describes a custom
+                                              header to be used in HTTP probes
+                                            properties:
+                                              name:
+                                                description: The header field name
+                                                type: string
+                                              value:
+                                                description: The header field value
+                                                type: string
+                                            required:
+                                            - name
+                                            - value
+                                            type: object
+                                          type: array
+                                        path:
+                                          description: Path to access on the HTTP
+                                            server.
+                                          type: string
+                                        port:
+                                          anyOf:
+                                          - type: string
+                                          - type: integer
+                                          description: Name or number of the port
+                                            to access on the container. Number must
+                                            be in the range 1 to 65535. Name must
+                                            be an IANA_SVC_NAME.
+                                        scheme:
+                                          description: Scheme to use for connecting
+                                            to the host. Defaults to HTTP.
+                                          type: string
+                                      required:
+                                      - port
+                                      type: object
+                                    tcpSocket:
+                                      description: 'TCPSocket specifies an action
+                                        involving a TCP port. TCP hooks not yet supported
+                                        TODO: implement a realistic TCP lifecycle
+                                        hook'
+                                      properties:
+                                        host:
+                                          description: 'Optional: Host name to connect
+                                            to, defaults to the pod IP.'
+                                          type: string
+                                        port:
+                                          anyOf:
+                                          - type: string
+                                          - type: integer
+                                          description: Number or name of the port
+                                            to access on the container. Number must
+                                            be in the range 1 to 65535. Name must
+                                            be an IANA_SVC_NAME.
+                                      required:
+                                      - port
+                                      type: object
+                                  type: object
+                              type: object
+                            livenessProbe:
+                              description: 'Periodic probe of container liveness.
+                                Container will be restarted if the probe fails. Cannot
+                                be updated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                              properties:
+                                exec:
+                                  description: One and only one of the following should
+                                    be specified. Exec specifies the action to take.
+                                  properties:
+                                    command:
+                                      description: Command is the command line to
+                                        execute inside the container, the working
+                                        directory for the command  is root ('/') in
+                                        the container's filesystem. The command is
+                                        simply exec'd, it is not run inside a shell,
+                                        so traditional shell instructions ('|', etc)
+                                        won't work. To use a shell, you need to explicitly
+                                        call out to that shell. Exit status of 0 is
+                                        treated as live/healthy and non-zero is unhealthy.
+                                      items:
+                                        type: string
+                                      type: array
+                                  type: object
+                                failureThreshold:
+                                  description: Minimum consecutive failures for the
+                                    probe to be considered failed after having succeeded.
+                                    Defaults to 3. Minimum value is 1.
+                                  format: int32
+                                  type: integer
+                                httpGet:
+                                  description: HTTPGet specifies the http request
+                                    to perform.
+                                  properties:
+                                    host:
+                                      description: Host name to connect to, defaults
+                                        to the pod IP. You probably want to set "Host"
+                                        in httpHeaders instead.
+                                      type: string
+                                    httpHeaders:
+                                      description: Custom headers to set in the request.
+                                        HTTP allows repeated headers.
+                                      items:
+                                        description: HTTPHeader describes a custom
+                                          header to be used in HTTP probes
+                                        properties:
+                                          name:
+                                            description: The header field name
+                                            type: string
+                                          value:
+                                            description: The header field value
+                                            type: string
+                                        required:
+                                        - name
+                                        - value
+                                        type: object
+                                      type: array
+                                    path:
+                                      description: Path to access on the HTTP server.
+                                      type: string
+                                    port:
+                                      anyOf:
+                                      - type: string
+                                      - type: integer
+                                      description: Name or number of the port to access
+                                        on the container. Number must be in the range
+                                        1 to 65535. Name must be an IANA_SVC_NAME.
+                                    scheme:
+                                      description: Scheme to use for connecting to
+                                        the host. Defaults to HTTP.
+                                      type: string
+                                  required:
+                                  - port
+                                  type: object
+                                initialDelaySeconds:
+                                  description: 'Number of seconds after the container
+                                    has started before liveness probes are initiated.
+                                    More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                                  format: int32
+                                  type: integer
+                                periodSeconds:
+                                  description: How often (in seconds) to perform the
+                                    probe. Default to 10 seconds. Minimum value is
+                                    1.
+                                  format: int32
+                                  type: integer
+                                successThreshold:
+                                  description: Minimum consecutive successes for the
+                                    probe to be considered successful after having
+                                    failed. Defaults to 1. Must be 1 for liveness.
+                                    Minimum value is 1.
+                                  format: int32
+                                  type: integer
+                                tcpSocket:
+                                  description: 'TCPSocket specifies an action involving
+                                    a TCP port. TCP hooks not yet supported TODO:
+                                    implement a realistic TCP lifecycle hook'
+                                  properties:
+                                    host:
+                                      description: 'Optional: Host name to connect
+                                        to, defaults to the pod IP.'
+                                      type: string
+                                    port:
+                                      anyOf:
+                                      - type: string
+                                      - type: integer
+                                      description: Number or name of the port to access
+                                        on the container. Number must be in the range
+                                        1 to 65535. Name must be an IANA_SVC_NAME.
+                                  required:
+                                  - port
+                                  type: object
+                                timeoutSeconds:
+                                  description: 'Number of seconds after which the
+                                    probe times out. Defaults to 1 second. Minimum
+                                    value is 1. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                                  format: int32
+                                  type: integer
+                              type: object
+                            name:
+                              description: Name of the container specified as a DNS_LABEL.
+                                Each container in a pod must have a unique name (DNS_LABEL).
+                                Cannot be updated.
+                              type: string
+                            ports:
+                              description: List of ports to expose from the container.
+                                Exposing a port here gives the system additional information
+                                about the network connections a container uses, but
+                                is primarily informational. Not specifying a port
+                                here DOES NOT prevent that port from being exposed.
+                                Any port which is listening on the default "0.0.0.0"
+                                address inside a container will be accessible from
+                                the network. Cannot be updated.
+                              items:
+                                description: ContainerPort represents a network port
+                                  in a single container.
+                                properties:
+                                  containerPort:
+                                    description: Number of port to expose on the pod's
+                                      IP address. This must be a valid port number,
+                                      0 < x < 65536.
+                                    format: int32
+                                    type: integer
+                                  hostIP:
+                                    description: What host IP to bind the external
+                                      port to.
+                                    type: string
+                                  hostPort:
+                                    description: Number of port to expose on the host.
+                                      If specified, this must be a valid port number,
+                                      0 < x < 65536. If HostNetwork is specified,
+                                      this must match ContainerPort. Most containers
+                                      do not need this.
+                                    format: int32
+                                    type: integer
+                                  name:
+                                    description: If specified, this must be an IANA_SVC_NAME
+                                      and unique within the pod. Each named port in
+                                      a pod must have a unique name. Name for the
+                                      port that can be referred to by services.
+                                    type: string
+                                  protocol:
+                                    description: Protocol for port. Must be UDP, TCP,
+                                      or SCTP. Defaults to "TCP".
+                                    type: string
+                                required:
+                                - containerPort
+                                type: object
+                              type: array
+                            readinessProbe:
+                              description: 'Periodic probe of container service readiness.
+                                Container will be removed from service endpoints if
+                                the probe fails. Cannot be updated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                              properties:
+                                exec:
+                                  description: One and only one of the following should
+                                    be specified. Exec specifies the action to take.
+                                  properties:
+                                    command:
+                                      description: Command is the command line to
+                                        execute inside the container, the working
+                                        directory for the command  is root ('/') in
+                                        the container's filesystem. The command is
+                                        simply exec'd, it is not run inside a shell,
+                                        so traditional shell instructions ('|', etc)
+                                        won't work. To use a shell, you need to explicitly
+                                        call out to that shell. Exit status of 0 is
+                                        treated as live/healthy and non-zero is unhealthy.
+                                      items:
+                                        type: string
+                                      type: array
+                                  type: object
+                                failureThreshold:
+                                  description: Minimum consecutive failures for the
+                                    probe to be considered failed after having succeeded.
+                                    Defaults to 3. Minimum value is 1.
+                                  format: int32
+                                  type: integer
+                                httpGet:
+                                  description: HTTPGet specifies the http request
+                                    to perform.
+                                  properties:
+                                    host:
+                                      description: Host name to connect to, defaults
+                                        to the pod IP. You probably want to set "Host"
+                                        in httpHeaders instead.
+                                      type: string
+                                    httpHeaders:
+                                      description: Custom headers to set in the request.
+                                        HTTP allows repeated headers.
+                                      items:
+                                        description: HTTPHeader describes a custom
+                                          header to be used in HTTP probes
+                                        properties:
+                                          name:
+                                            description: The header field name
+                                            type: string
+                                          value:
+                                            description: The header field value
+                                            type: string
+                                        required:
+                                        - name
+                                        - value
+                                        type: object
+                                      type: array
+                                    path:
+                                      description: Path to access on the HTTP server.
+                                      type: string
+                                    port:
+                                      anyOf:
+                                      - type: string
+                                      - type: integer
+                                      description: Name or number of the port to access
+                                        on the container. Number must be in the range
+                                        1 to 65535. Name must be an IANA_SVC_NAME.
+                                    scheme:
+                                      description: Scheme to use for connecting to
+                                        the host. Defaults to HTTP.
+                                      type: string
+                                  required:
+                                  - port
+                                  type: object
+                                initialDelaySeconds:
+                                  description: 'Number of seconds after the container
+                                    has started before liveness probes are initiated.
+                                    More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                                  format: int32
+                                  type: integer
+                                periodSeconds:
+                                  description: How often (in seconds) to perform the
+                                    probe. Default to 10 seconds. Minimum value is
+                                    1.
+                                  format: int32
+                                  type: integer
+                                successThreshold:
+                                  description: Minimum consecutive successes for the
+                                    probe to be considered successful after having
+                                    failed. Defaults to 1. Must be 1 for liveness.
+                                    Minimum value is 1.
+                                  format: int32
+                                  type: integer
+                                tcpSocket:
+                                  description: 'TCPSocket specifies an action involving
+                                    a TCP port. TCP hooks not yet supported TODO:
+                                    implement a realistic TCP lifecycle hook'
+                                  properties:
+                                    host:
+                                      description: 'Optional: Host name to connect
+                                        to, defaults to the pod IP.'
+                                      type: string
+                                    port:
+                                      anyOf:
+                                      - type: string
+                                      - type: integer
+                                      description: Number or name of the port to access
+                                        on the container. Number must be in the range
+                                        1 to 65535. Name must be an IANA_SVC_NAME.
+                                  required:
+                                  - port
+                                  type: object
+                                timeoutSeconds:
+                                  description: 'Number of seconds after which the
+                                    probe times out. Defaults to 1 second. Minimum
+                                    value is 1. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                                  format: int32
+                                  type: integer
+                              type: object
+                            resources:
+                              description: 'Compute Resources required by this container.
+                                Cannot be updated. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
+                              properties:
+                                limits:
+                                  additionalProperties:
+                                    type: string
+                                  description: 'Limits describes the maximum amount
+                                    of compute resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
+                                  type: object
+                                requests:
+                                  additionalProperties:
+                                    type: string
+                                  description: 'Requests describes the minimum amount
+                                    of compute resources required. If Requests is
+                                    omitted for a container, it defaults to Limits
+                                    if that is explicitly specified, otherwise to
+                                    an implementation-defined value. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
+                                  type: object
+                              type: object
+                            securityContext:
+                              description: 'Security options the pod should run with.
+                                More info: https://kubernetes.io/docs/concepts/policy/security-context/
+                                More info: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/'
+                              properties:
+                                allowPrivilegeEscalation:
+                                  description: 'AllowPrivilegeEscalation controls
+                                    whether a process can gain more privileges than
+                                    its parent process. This bool directly controls
+                                    if the no_new_privs flag will be set on the container
+                                    process. AllowPrivilegeEscalation is true always
+                                    when the container is: 1) run as Privileged 2)
+                                    has CAP_SYS_ADMIN'
+                                  type: boolean
+                                capabilities:
+                                  description: The capabilities to add/drop when running
+                                    containers. Defaults to the default set of capabilities
+                                    granted by the container runtime.
+                                  properties:
+                                    add:
+                                      description: Added capabilities
+                                      items:
+                                        description: Capability represent POSIX capabilities
+                                          type
+                                        type: string
+                                      type: array
+                                    drop:
+                                      description: Removed capabilities
+                                      items:
+                                        description: Capability represent POSIX capabilities
+                                          type
+                                        type: string
+                                      type: array
+                                  type: object
+                                privileged:
+                                  description: Run container in privileged mode. Processes
+                                    in privileged containers are essentially equivalent
+                                    to root on the host. Defaults to false.
+                                  type: boolean
+                                procMount:
+                                  description: procMount denotes the type of proc
+                                    mount to use for the containers. The default is
+                                    DefaultProcMount which uses the container runtime
+                                    defaults for readonly paths and masked paths.
+                                    This requires the ProcMountType feature flag to
+                                    be enabled.
+                                  type: string
+                                readOnlyRootFilesystem:
+                                  description: Whether this container has a read-only
+                                    root filesystem. Default is false.
+                                  type: boolean
+                                runAsGroup:
+                                  description: The GID to run the entrypoint of the
+                                    container process. Uses runtime default if unset.
+                                    May also be set in PodSecurityContext.  If set
+                                    in both SecurityContext and PodSecurityContext,
+                                    the value specified in SecurityContext takes precedence.
+                                  format: int64
+                                  type: integer
+                                runAsNonRoot:
+                                  description: Indicates that the container must run
+                                    as a non-root user. If true, the Kubelet will
+                                    validate the image at runtime to ensure that it
+                                    does not run as UID 0 (root) and fail to start
+                                    the container if it does. If unset or false, no
+                                    such validation will be performed. May also be
+                                    set in PodSecurityContext.  If set in both SecurityContext
+                                    and PodSecurityContext, the value specified in
+                                    SecurityContext takes precedence.
+                                  type: boolean
+                                runAsUser:
+                                  description: The UID to run the entrypoint of the
+                                    container process. Defaults to user specified
+                                    in image metadata if unspecified. May also be
+                                    set in PodSecurityContext.  If set in both SecurityContext
+                                    and PodSecurityContext, the value specified in
+                                    SecurityContext takes precedence.
+                                  format: int64
+                                  type: integer
+                                seLinuxOptions:
+                                  description: The SELinux context to be applied to
+                                    the container. If unspecified, the container runtime
+                                    will allocate a random SELinux context for each
+                                    container.  May also be set in PodSecurityContext.  If
+                                    set in both SecurityContext and PodSecurityContext,
+                                    the value specified in SecurityContext takes precedence.
+                                  properties:
+                                    level:
+                                      description: Level is SELinux level label that
+                                        applies to the container.
+                                      type: string
+                                    role:
+                                      description: Role is a SELinux role label that
+                                        applies to the container.
+                                      type: string
+                                    type:
+                                      description: Type is a SELinux type label that
+                                        applies to the container.
+                                      type: string
+                                    user:
+                                      description: User is a SELinux user label that
+                                        applies to the container.
+                                      type: string
+                                  type: object
+                                windowsOptions:
+                                  description: Windows security options.
+                                  properties:
+                                    gmsaCredentialSpec:
+                                      description: GMSACredentialSpec is where the
+                                        GMSA admission webhook (https://github.com/kubernetes-sigs/windows-gmsa)
+                                        inlines the contents of the GMSA credential
+                                        spec named by the GMSACredentialSpecName field.
+                                        This field is alpha-level and is only honored
+                                        by servers that enable the WindowsGMSA feature
+                                        flag.
+                                      type: string
+                                    gmsaCredentialSpecName:
+                                      description: GMSACredentialSpecName is the name
+                                        of the GMSA credential spec to use. This field
+                                        is alpha-level and is only honored by servers
+                                        that enable the WindowsGMSA feature flag.
+                                      type: string
+                                  type: object
+                              type: object
+                            stdin:
+                              description: Whether this container should allocate
+                                a buffer for stdin in the container runtime. If this
+                                is not set, reads from stdin in the container will
+                                always result in EOF. Default is false.
+                              type: boolean
+                            stdinOnce:
+                              description: Whether the container runtime should close
+                                the stdin channel after it has been opened by a single
+                                attach. When stdin is true the stdin stream will remain
+                                open across multiple attach sessions. If stdinOnce
+                                is set to true, stdin is opened on container start,
+                                is empty until the first client attaches to stdin,
+                                and then remains open and accepts data until the client
+                                disconnects, at which time stdin is closed and remains
+                                closed until the container is restarted. If this flag
+                                is false, a container processes that reads from stdin
+                                will never receive an EOF. Default is false
+                              type: boolean
+                            terminationMessagePath:
+                              description: 'Optional: Path at which the file to which
+                                the container''s termination message will be written
+                                is mounted into the container''s filesystem. Message
+                                written is intended to be brief final status, such
+                                as an assertion failure message. Will be truncated
+                                by the node if greater than 4096 bytes. The total
+                                message length across all containers will be limited
+                                to 12kb. Defaults to /dev/termination-log. Cannot
+                                be updated.'
+                              type: string
+                            terminationMessagePolicy:
+                              description: Indicate how the termination message should
+                                be populated. File will use the contents of terminationMessagePath
+                                to populate the container status message on both success
+                                and failure. FallbackToLogsOnError will use the last
+                                chunk of container log output if the termination message
+                                file is empty and the container exited with an error.
+                                The log output is limited to 2048 bytes or 80 lines,
+                                whichever is smaller. Defaults to File. Cannot be
+                                updated.
+                              type: string
+                            tty:
+                              description: Whether this container should allocate
+                                a TTY for itself, also requires 'stdin' to be true.
+                                Default is false.
+                              type: boolean
+                            volumeDevices:
+                              description: volumeDevices is the list of block devices
+                                to be used by the container. This is a beta feature.
+                              items:
+                                description: volumeDevice describes a mapping of a
+                                  raw block device within a container.
+                                properties:
+                                  devicePath:
+                                    description: devicePath is the path inside of
+                                      the container that the device will be mapped
+                                      to.
+                                    type: string
+                                  name:
+                                    description: name must match the name of a persistentVolumeClaim
+                                      in the pod
+                                    type: string
+                                required:
+                                - devicePath
+                                - name
+                                type: object
+                              type: array
+                            volumeMounts:
+                              description: Pod volumes to mount into the container's
+                                filesystem. Cannot be updated.
+                              items:
+                                description: VolumeMount describes a mounting of a
+                                  Volume within a container.
+                                properties:
+                                  mountPath:
+                                    description: Path within the container at which
+                                      the volume should be mounted.  Must not contain
+                                      ':'.
+                                    type: string
+                                  mountPropagation:
+                                    description: mountPropagation determines how mounts
+                                      are propagated from the host to container and
+                                      the other way around. When not set, MountPropagationNone
+                                      is used. This field is beta in 1.10.
+                                    type: string
+                                  name:
+                                    description: This must match the Name of a Volume.
+                                    type: string
+                                  readOnly:
+                                    description: Mounted read-only if true, read-write
+                                      otherwise (false or unspecified). Defaults to
+                                      false.
+                                    type: boolean
+                                  subPath:
+                                    description: Path within the volume from which
+                                      the container's volume should be mounted. Defaults
+                                      to "" (volume's root).
+                                    type: string
+                                  subPathExpr:
+                                    description: Expanded path within the volume from
+                                      which the container's volume should be mounted.
+                                      Behaves similarly to SubPath but environment
+                                      variable references $(VAR_NAME) are expanded
+                                      using the container's environment. Defaults
+                                      to "" (volume's root). SubPathExpr and SubPath
+                                      are mutually exclusive. This field is beta in
+                                      1.15.
+                                    type: string
+                                required:
+                                - mountPath
+                                - name
+                                type: object
+                              type: array
+                            workingDir:
+                              description: Container's working directory. If not specified,
+                                the container runtime's default will be used, which
+                                might be configured in the container image. Cannot
+                                be updated.
+                              type: string
+                          required:
+                          - name
+                          type: object
+                      required:
+                      - container
+                      type: object
+                    logger:
+                      description: Activate request/response logging
+                      properties:
+                        mode:
+                          description: What payloads to log
+                          type: string
+                        url:
+                          description: URL to send request logging CloudEvents
+                          type: string
+                      type: object
+                    maxReplicas:
+                      description: This is the up bound for autoscaler to scale to
+                      type: integer
+                    minReplicas:
+                      description: Minimum number of replicas, pods won't scale down
+                        to 0 in case of no traffic
+                      type: integer
+                    onnx:
+                      description: Spec for ONNX runtime (https://github.com/microsoft/onnxruntime)
+                      properties:
+                        resources:
+                          description: Defaults to requests and limits of 1CPU, 2Gb
+                            MEM.
+                          properties:
+                            limits:
+                              additionalProperties:
+                                type: string
+                              description: 'Limits describes the maximum amount of
+                                compute resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
+                              type: object
+                            requests:
+                              additionalProperties:
+                                type: string
+                              description: 'Requests describes the minimum amount
+                                of compute resources required. If Requests is omitted
+                                for a container, it defaults to Limits if that is
+                                explicitly specified, otherwise to an implementation-defined
+                                value. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
+                              type: object
+                          type: object
+                        runtimeVersion:
+                          description: Allowed runtime versions are specified in the
+                            inferenceservice config map
+                          type: string
+                        storageUri:
+                          description: The location of the trained model
+                          type: string
+                      required:
+                      - storageUri
+                      type: object
+                    parallelism:
+                      description: Parallelism specifies how many requests can be
+                        processed concurrently, this sets the target concurrency for
+                        Autoscaling(KPA). For model servers that support tuning parallelism
+                        will use this value, by default the parallelism is the number
+                        of the CPU cores for most of the model servers.
+                      type: integer
+                    pytorch:
+                      description: Spec for PyTorch predictor
+                      properties:
+                        modelClassName:
+                          description: Defaults PyTorch model class name to 'PyTorchModel'
+                          type: string
+                        resources:
+                          description: Defaults to requests and limits of 1CPU, 2Gb
+                            MEM.
+                          properties:
+                            limits:
+                              additionalProperties:
+                                type: string
+                              description: 'Limits describes the maximum amount of
+                                compute resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
+                              type: object
+                            requests:
+                              additionalProperties:
+                                type: string
+                              description: 'Requests describes the minimum amount
+                                of compute resources required. If Requests is omitted
+                                for a container, it defaults to Limits if that is
+                                explicitly specified, otherwise to an implementation-defined
+                                value. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
+                              type: object
+                          type: object
+                        runtimeVersion:
+                          description: Allowed runtime versions are specified in the
+                            inferenceservice config map
+                          type: string
+                        storageUri:
+                          description: The location of the trained model
+                          type: string
+                      required:
+                      - storageUri
+                      type: object
+                    serviceAccountName:
+                      description: ServiceAccountName is the name of the ServiceAccount
+                        to use to run the service
+                      type: string
+                    sklearn:
+                      description: Spec for SKLearn predictor
+                      properties:
+                        resources:
+                          description: Defaults to requests and limits of 1CPU, 2Gb
+                            MEM.
+                          properties:
+                            limits:
+                              additionalProperties:
+                                type: string
+                              description: 'Limits describes the maximum amount of
+                                compute resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
+                              type: object
+                            requests:
+                              additionalProperties:
+                                type: string
+                              description: 'Requests describes the minimum amount
+                                of compute resources required. If Requests is omitted
+                                for a container, it defaults to Limits if that is
+                                explicitly specified, otherwise to an implementation-defined
+                                value. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
+                              type: object
+                          type: object
+                        runtimeVersion:
+                          description: Allowed runtime versions are specified in the
+                            inferenceservice config map
+                          type: string
+                        storageUri:
+                          description: The location of the trained model
+                          type: string
+                      required:
+                      - storageUri
+                      type: object
+                    tensorflow:
+                      description: Spec for Tensorflow Serving (https://github.com/tensorflow/serving)
+                      properties:
+                        resources:
+                          description: Defaults to requests and limits of 1CPU, 2Gb
+                            MEM.
+                          properties:
+                            limits:
+                              additionalProperties:
+                                type: string
+                              description: 'Limits describes the maximum amount of
+                                compute resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
+                              type: object
+                            requests:
+                              additionalProperties:
+                                type: string
+                              description: 'Requests describes the minimum amount
+                                of compute resources required. If Requests is omitted
+                                for a container, it defaults to Limits if that is
+                                explicitly specified, otherwise to an implementation-defined
+                                value. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
+                              type: object
+                          type: object
+                        runtimeVersion:
+                          description: Allowed runtime versions are specified in the
+                            inferenceservice config map.
+                          type: string
+                        storageUri:
+                          description: The location of the trained model
+                          type: string
+                      required:
+                      - storageUri
+                      type: object
+                    tensorrt:
+                      description: Spec for TensorRT Inference Server (https://github.com/NVIDIA/tensorrt-inference-server)
+                      properties:
+                        resources:
+                          description: Defaults to requests and limits of 1CPU, 2Gb
+                            MEM.
+                          properties:
+                            limits:
+                              additionalProperties:
+                                type: string
+                              description: 'Limits describes the maximum amount of
+                                compute resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
+                              type: object
+                            requests:
+                              additionalProperties:
+                                type: string
+                              description: 'Requests describes the minimum amount
+                                of compute resources required. If Requests is omitted
+                                for a container, it defaults to Limits if that is
+                                explicitly specified, otherwise to an implementation-defined
+                                value. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
+                              type: object
+                          type: object
+                        runtimeVersion:
+                          description: Allowed runtime versions are specified in the
+                            inferenceservice config map
+                          type: string
+                        storageUri:
+                          description: The location of the trained model
+                          type: string
+                      required:
+                      - storageUri
+                      type: object
+                    xgboost:
+                      description: Spec for XGBoost predictor
+                      properties:
+                        nthread:
+                          description: Number of thread to be used by XGBoost
+                          type: integer
+                        resources:
+                          description: Defaults to requests and limits of 1CPU, 2Gb
+                            MEM.
+                          properties:
+                            limits:
+                              additionalProperties:
+                                type: string
+                              description: 'Limits describes the maximum amount of
+                                compute resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
+                              type: object
+                            requests:
+                              additionalProperties:
+                                type: string
+                              description: 'Requests describes the minimum amount
+                                of compute resources required. If Requests is omitted
+                                for a container, it defaults to Limits if that is
+                                explicitly specified, otherwise to an implementation-defined
+                                value. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
+                              type: object
+                          type: object
+                        runtimeVersion:
+                          description: Allowed runtime versions are specified in the
+                            inferenceservice config map
+                          type: string
+                        storageUri:
+                          description: The location of the trained model
+                          type: string
+                      required:
+                      - storageUri
+                      type: object
+                  type: object
+                transformer:
+                  description: Transformer defines the pre/post processing before
+                    and after the predictor call, transformer service calls to predictor
+                    service.
+                  properties:
+                    custom:
+                      description: Spec for a custom transformer
+                      properties:
+                        container:
+                          description: A single application container that you want
+                            to run within a pod.
+                          properties:
+                            args:
+                              description: 'Arguments to the entrypoint. The docker
+                                image''s CMD is used if this is not provided. Variable
+                                references $(VAR_NAME) are expanded using the container''s
+                                environment. If a variable cannot be resolved, the
+                                reference in the input string will be unchanged. The
+                                $(VAR_NAME) syntax can be escaped with a double $$,
+                                ie: $$(VAR_NAME). Escaped references will never be
+                                expanded, regardless of whether the variable exists
+                                or not. Cannot be updated. More info: https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell'
+                              items:
+                                type: string
+                              type: array
+                            command:
+                              description: 'Entrypoint array. Not executed within
+                                a shell. The docker image''s ENTRYPOINT is used if
+                                this is not provided. Variable references $(VAR_NAME)
+                                are expanded using the container''s environment. If
+                                a variable cannot be resolved, the reference in the
+                                input string will be unchanged. The $(VAR_NAME) syntax
+                                can be escaped with a double $$, ie: $$(VAR_NAME).
+                                Escaped references will never be expanded, regardless
+                                of whether the variable exists or not. Cannot be updated.
+                                More info: https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell'
+                              items:
+                                type: string
+                              type: array
+                            env:
+                              description: List of environment variables to set in
+                                the container. Cannot be updated.
+                              items:
+                                description: EnvVar represents an environment variable
+                                  present in a Container.
+                                properties:
+                                  name:
+                                    description: Name of the environment variable.
+                                      Must be a C_IDENTIFIER.
+                                    type: string
+                                  value:
+                                    description: 'Variable references $(VAR_NAME)
+                                      are expanded using the previous defined environment
+                                      variables in the container and any service environment
+                                      variables. If a variable cannot be resolved,
+                                      the reference in the input string will be unchanged.
+                                      The $(VAR_NAME) syntax can be escaped with a
+                                      double $$, ie: $$(VAR_NAME). Escaped references
+                                      will never be expanded, regardless of whether
+                                      the variable exists or not. Defaults to "".'
+                                    type: string
+                                  valueFrom:
+                                    description: Source for the environment variable's
+                                      value. Cannot be used if value is not empty.
+                                    properties:
+                                      configMapKeyRef:
+                                        description: Selects a key of a ConfigMap.
+                                        properties:
+                                          key:
+                                            description: The key to select.
+                                            type: string
+                                          name:
+                                            description: 'Name of the referent. More
+                                              info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                              TODO: Add other useful fields. apiVersion,
+                                              kind, uid?'
+                                            type: string
+                                          optional:
+                                            description: Specify whether the ConfigMap
+                                              or its key must be defined
+                                            type: boolean
+                                        required:
+                                        - key
+                                        type: object
+                                      fieldRef:
+                                        description: 'Selects a field of the pod:
+                                          supports metadata.name, metadata.namespace,
+                                          metadata.labels, metadata.annotations, spec.nodeName,
+                                          spec.serviceAccountName, status.hostIP,
+                                          status.podIP.'
+                                        properties:
+                                          apiVersion:
+                                            description: Version of the schema the
+                                              FieldPath is written in terms of, defaults
+                                              to "v1".
+                                            type: string
+                                          fieldPath:
+                                            description: Path of the field to select
+                                              in the specified API version.
+                                            type: string
+                                        required:
+                                        - fieldPath
+                                        type: object
+                                      resourceFieldRef:
+                                        description: 'Selects a resource of the container:
+                                          only resources limits and requests (limits.cpu,
+                                          limits.memory, limits.ephemeral-storage,
+                                          requests.cpu, requests.memory and requests.ephemeral-storage)
+                                          are currently supported.'
+                                        properties:
+                                          containerName:
+                                            description: 'Container name: required
+                                              for volumes, optional for env vars'
+                                            type: string
+                                          divisor:
+                                            description: Specifies the output format
+                                              of the exposed resources, defaults to
+                                              "1"
+                                            type: string
+                                          resource:
+                                            description: 'Required: resource to select'
+                                            type: string
+                                        required:
+                                        - resource
+                                        type: object
+                                      secretKeyRef:
+                                        description: Selects a key of a secret in
+                                          the pod's namespace
+                                        properties:
+                                          key:
+                                            description: The key of the secret to
+                                              select from.  Must be a valid secret
+                                              key.
+                                            type: string
+                                          name:
+                                            description: 'Name of the referent. More
+                                              info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                              TODO: Add other useful fields. apiVersion,
+                                              kind, uid?'
+                                            type: string
+                                          optional:
+                                            description: Specify whether the Secret
+                                              or its key must be defined
+                                            type: boolean
+                                        required:
+                                        - key
+                                        type: object
+                                    type: object
+                                required:
+                                - name
+                                type: object
+                              type: array
+                            envFrom:
+                              description: List of sources to populate environment
+                                variables in the container. The keys defined within
+                                a source must be a C_IDENTIFIER. All invalid keys
+                                will be reported as an event when the container is
+                                starting. When a key exists in multiple sources, the
+                                value associated with the last source will take precedence.
+                                Values defined by an Env with a duplicate key will
+                                take precedence. Cannot be updated.
+                              items:
+                                description: EnvFromSource represents the source of
+                                  a set of ConfigMaps
+                                properties:
+                                  configMapRef:
+                                    description: The ConfigMap to select from
+                                    properties:
+                                      name:
+                                        description: 'Name of the referent. More info:
+                                          https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                          TODO: Add other useful fields. apiVersion,
+                                          kind, uid?'
+                                        type: string
+                                      optional:
+                                        description: Specify whether the ConfigMap
+                                          must be defined
+                                        type: boolean
+                                    type: object
+                                  prefix:
+                                    description: An optional identifier to prepend
+                                      to each key in the ConfigMap. Must be a C_IDENTIFIER.
+                                    type: string
+                                  secretRef:
+                                    description: The Secret to select from
+                                    properties:
+                                      name:
+                                        description: 'Name of the referent. More info:
+                                          https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                          TODO: Add other useful fields. apiVersion,
+                                          kind, uid?'
+                                        type: string
+                                      optional:
+                                        description: Specify whether the Secret must
+                                          be defined
+                                        type: boolean
+                                    type: object
+                                type: object
+                              type: array
+                            image:
+                              description: 'Docker image name. More info: https://kubernetes.io/docs/concepts/containers/images
+                                This field is optional to allow higher level config
+                                management to default or override container images
+                                in workload controllers like Deployments and StatefulSets.'
+                              type: string
+                            imagePullPolicy:
+                              description: 'Image pull policy. One of Always, Never,
+                                IfNotPresent. Defaults to Always if :v0.3.0 tag is
+                                specified, or IfNotPresent otherwise. Cannot be updated.
+                                More info: https://kubernetes.io/docs/concepts/containers/images#updating-images'
+                              type: string
+                            lifecycle:
+                              description: Actions that the management system should
+                                take in response to container lifecycle events. Cannot
+                                be updated.
+                              properties:
+                                postStart:
+                                  description: 'PostStart is called immediately after
+                                    a container is created. If the handler fails,
+                                    the container is terminated and restarted according
+                                    to its restart policy. Other management of the
+                                    container blocks until the hook completes. More
+                                    info: https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/#container-hooks'
+                                  properties:
+                                    exec:
+                                      description: One and only one of the following
+                                        should be specified. Exec specifies the action
+                                        to take.
+                                      properties:
+                                        command:
+                                          description: Command is the command line
+                                            to execute inside the container, the working
+                                            directory for the command  is root ('/')
+                                            in the container's filesystem. The command
+                                            is simply exec'd, it is not run inside
+                                            a shell, so traditional shell instructions
+                                            ('|', etc) won't work. To use a shell,
+                                            you need to explicitly call out to that
+                                            shell. Exit status of 0 is treated as
+                                            live/healthy and non-zero is unhealthy.
+                                          items:
+                                            type: string
+                                          type: array
+                                      type: object
+                                    httpGet:
+                                      description: HTTPGet specifies the http request
+                                        to perform.
+                                      properties:
+                                        host:
+                                          description: Host name to connect to, defaults
+                                            to the pod IP. You probably want to set
+                                            "Host" in httpHeaders instead.
+                                          type: string
+                                        httpHeaders:
+                                          description: Custom headers to set in the
+                                            request. HTTP allows repeated headers.
+                                          items:
+                                            description: HTTPHeader describes a custom
+                                              header to be used in HTTP probes
+                                            properties:
+                                              name:
+                                                description: The header field name
+                                                type: string
+                                              value:
+                                                description: The header field value
+                                                type: string
+                                            required:
+                                            - name
+                                            - value
+                                            type: object
+                                          type: array
+                                        path:
+                                          description: Path to access on the HTTP
+                                            server.
+                                          type: string
+                                        port:
+                                          anyOf:
+                                          - type: string
+                                          - type: integer
+                                          description: Name or number of the port
+                                            to access on the container. Number must
+                                            be in the range 1 to 65535. Name must
+                                            be an IANA_SVC_NAME.
+                                        scheme:
+                                          description: Scheme to use for connecting
+                                            to the host. Defaults to HTTP.
+                                          type: string
+                                      required:
+                                      - port
+                                      type: object
+                                    tcpSocket:
+                                      description: 'TCPSocket specifies an action
+                                        involving a TCP port. TCP hooks not yet supported
+                                        TODO: implement a realistic TCP lifecycle
+                                        hook'
+                                      properties:
+                                        host:
+                                          description: 'Optional: Host name to connect
+                                            to, defaults to the pod IP.'
+                                          type: string
+                                        port:
+                                          anyOf:
+                                          - type: string
+                                          - type: integer
+                                          description: Number or name of the port
+                                            to access on the container. Number must
+                                            be in the range 1 to 65535. Name must
+                                            be an IANA_SVC_NAME.
+                                      required:
+                                      - port
+                                      type: object
+                                  type: object
+                                preStop:
+                                  description: 'PreStop is called immediately before
+                                    a container is terminated due to an API request
+                                    or management event such as liveness probe failure,
+                                    preemption, resource contention, etc. The handler
+                                    is not called if the container crashes or exits.
+                                    The reason for termination is passed to the handler.
+                                    The Pod''s termination grace period countdown
+                                    begins before the PreStop hooked is executed.
+                                    Regardless of the outcome of the handler, the
+                                    container will eventually terminate within the
+                                    Pod''s termination grace period. Other management
+                                    of the container blocks until the hook completes
+                                    or until the termination grace period is reached.
+                                    More info: https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/#container-hooks'
+                                  properties:
+                                    exec:
+                                      description: One and only one of the following
+                                        should be specified. Exec specifies the action
+                                        to take.
+                                      properties:
+                                        command:
+                                          description: Command is the command line
+                                            to execute inside the container, the working
+                                            directory for the command  is root ('/')
+                                            in the container's filesystem. The command
+                                            is simply exec'd, it is not run inside
+                                            a shell, so traditional shell instructions
+                                            ('|', etc) won't work. To use a shell,
+                                            you need to explicitly call out to that
+                                            shell. Exit status of 0 is treated as
+                                            live/healthy and non-zero is unhealthy.
+                                          items:
+                                            type: string
+                                          type: array
+                                      type: object
+                                    httpGet:
+                                      description: HTTPGet specifies the http request
+                                        to perform.
+                                      properties:
+                                        host:
+                                          description: Host name to connect to, defaults
+                                            to the pod IP. You probably want to set
+                                            "Host" in httpHeaders instead.
+                                          type: string
+                                        httpHeaders:
+                                          description: Custom headers to set in the
+                                            request. HTTP allows repeated headers.
+                                          items:
+                                            description: HTTPHeader describes a custom
+                                              header to be used in HTTP probes
+                                            properties:
+                                              name:
+                                                description: The header field name
+                                                type: string
+                                              value:
+                                                description: The header field value
+                                                type: string
+                                            required:
+                                            - name
+                                            - value
+                                            type: object
+                                          type: array
+                                        path:
+                                          description: Path to access on the HTTP
+                                            server.
+                                          type: string
+                                        port:
+                                          anyOf:
+                                          - type: string
+                                          - type: integer
+                                          description: Name or number of the port
+                                            to access on the container. Number must
+                                            be in the range 1 to 65535. Name must
+                                            be an IANA_SVC_NAME.
+                                        scheme:
+                                          description: Scheme to use for connecting
+                                            to the host. Defaults to HTTP.
+                                          type: string
+                                      required:
+                                      - port
+                                      type: object
+                                    tcpSocket:
+                                      description: 'TCPSocket specifies an action
+                                        involving a TCP port. TCP hooks not yet supported
+                                        TODO: implement a realistic TCP lifecycle
+                                        hook'
+                                      properties:
+                                        host:
+                                          description: 'Optional: Host name to connect
+                                            to, defaults to the pod IP.'
+                                          type: string
+                                        port:
+                                          anyOf:
+                                          - type: string
+                                          - type: integer
+                                          description: Number or name of the port
+                                            to access on the container. Number must
+                                            be in the range 1 to 65535. Name must
+                                            be an IANA_SVC_NAME.
+                                      required:
+                                      - port
+                                      type: object
+                                  type: object
+                              type: object
+                            livenessProbe:
+                              description: 'Periodic probe of container liveness.
+                                Container will be restarted if the probe fails. Cannot
+                                be updated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                              properties:
+                                exec:
+                                  description: One and only one of the following should
+                                    be specified. Exec specifies the action to take.
+                                  properties:
+                                    command:
+                                      description: Command is the command line to
+                                        execute inside the container, the working
+                                        directory for the command  is root ('/') in
+                                        the container's filesystem. The command is
+                                        simply exec'd, it is not run inside a shell,
+                                        so traditional shell instructions ('|', etc)
+                                        won't work. To use a shell, you need to explicitly
+                                        call out to that shell. Exit status of 0 is
+                                        treated as live/healthy and non-zero is unhealthy.
+                                      items:
+                                        type: string
+                                      type: array
+                                  type: object
+                                failureThreshold:
+                                  description: Minimum consecutive failures for the
+                                    probe to be considered failed after having succeeded.
+                                    Defaults to 3. Minimum value is 1.
+                                  format: int32
+                                  type: integer
+                                httpGet:
+                                  description: HTTPGet specifies the http request
+                                    to perform.
+                                  properties:
+                                    host:
+                                      description: Host name to connect to, defaults
+                                        to the pod IP. You probably want to set "Host"
+                                        in httpHeaders instead.
+                                      type: string
+                                    httpHeaders:
+                                      description: Custom headers to set in the request.
+                                        HTTP allows repeated headers.
+                                      items:
+                                        description: HTTPHeader describes a custom
+                                          header to be used in HTTP probes
+                                        properties:
+                                          name:
+                                            description: The header field name
+                                            type: string
+                                          value:
+                                            description: The header field value
+                                            type: string
+                                        required:
+                                        - name
+                                        - value
+                                        type: object
+                                      type: array
+                                    path:
+                                      description: Path to access on the HTTP server.
+                                      type: string
+                                    port:
+                                      anyOf:
+                                      - type: string
+                                      - type: integer
+                                      description: Name or number of the port to access
+                                        on the container. Number must be in the range
+                                        1 to 65535. Name must be an IANA_SVC_NAME.
+                                    scheme:
+                                      description: Scheme to use for connecting to
+                                        the host. Defaults to HTTP.
+                                      type: string
+                                  required:
+                                  - port
+                                  type: object
+                                initialDelaySeconds:
+                                  description: 'Number of seconds after the container
+                                    has started before liveness probes are initiated.
+                                    More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                                  format: int32
+                                  type: integer
+                                periodSeconds:
+                                  description: How often (in seconds) to perform the
+                                    probe. Default to 10 seconds. Minimum value is
+                                    1.
+                                  format: int32
+                                  type: integer
+                                successThreshold:
+                                  description: Minimum consecutive successes for the
+                                    probe to be considered successful after having
+                                    failed. Defaults to 1. Must be 1 for liveness.
+                                    Minimum value is 1.
+                                  format: int32
+                                  type: integer
+                                tcpSocket:
+                                  description: 'TCPSocket specifies an action involving
+                                    a TCP port. TCP hooks not yet supported TODO:
+                                    implement a realistic TCP lifecycle hook'
+                                  properties:
+                                    host:
+                                      description: 'Optional: Host name to connect
+                                        to, defaults to the pod IP.'
+                                      type: string
+                                    port:
+                                      anyOf:
+                                      - type: string
+                                      - type: integer
+                                      description: Number or name of the port to access
+                                        on the container. Number must be in the range
+                                        1 to 65535. Name must be an IANA_SVC_NAME.
+                                  required:
+                                  - port
+                                  type: object
+                                timeoutSeconds:
+                                  description: 'Number of seconds after which the
+                                    probe times out. Defaults to 1 second. Minimum
+                                    value is 1. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                                  format: int32
+                                  type: integer
+                              type: object
+                            name:
+                              description: Name of the container specified as a DNS_LABEL.
+                                Each container in a pod must have a unique name (DNS_LABEL).
+                                Cannot be updated.
+                              type: string
+                            ports:
+                              description: List of ports to expose from the container.
+                                Exposing a port here gives the system additional information
+                                about the network connections a container uses, but
+                                is primarily informational. Not specifying a port
+                                here DOES NOT prevent that port from being exposed.
+                                Any port which is listening on the default "0.0.0.0"
+                                address inside a container will be accessible from
+                                the network. Cannot be updated.
+                              items:
+                                description: ContainerPort represents a network port
+                                  in a single container.
+                                properties:
+                                  containerPort:
+                                    description: Number of port to expose on the pod's
+                                      IP address. This must be a valid port number,
+                                      0 < x < 65536.
+                                    format: int32
+                                    type: integer
+                                  hostIP:
+                                    description: What host IP to bind the external
+                                      port to.
+                                    type: string
+                                  hostPort:
+                                    description: Number of port to expose on the host.
+                                      If specified, this must be a valid port number,
+                                      0 < x < 65536. If HostNetwork is specified,
+                                      this must match ContainerPort. Most containers
+                                      do not need this.
+                                    format: int32
+                                    type: integer
+                                  name:
+                                    description: If specified, this must be an IANA_SVC_NAME
+                                      and unique within the pod. Each named port in
+                                      a pod must have a unique name. Name for the
+                                      port that can be referred to by services.
+                                    type: string
+                                  protocol:
+                                    description: Protocol for port. Must be UDP, TCP,
+                                      or SCTP. Defaults to "TCP".
+                                    type: string
+                                required:
+                                - containerPort
+                                type: object
+                              type: array
+                            readinessProbe:
+                              description: 'Periodic probe of container service readiness.
+                                Container will be removed from service endpoints if
+                                the probe fails. Cannot be updated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                              properties:
+                                exec:
+                                  description: One and only one of the following should
+                                    be specified. Exec specifies the action to take.
+                                  properties:
+                                    command:
+                                      description: Command is the command line to
+                                        execute inside the container, the working
+                                        directory for the command  is root ('/') in
+                                        the container's filesystem. The command is
+                                        simply exec'd, it is not run inside a shell,
+                                        so traditional shell instructions ('|', etc)
+                                        won't work. To use a shell, you need to explicitly
+                                        call out to that shell. Exit status of 0 is
+                                        treated as live/healthy and non-zero is unhealthy.
+                                      items:
+                                        type: string
+                                      type: array
+                                  type: object
+                                failureThreshold:
+                                  description: Minimum consecutive failures for the
+                                    probe to be considered failed after having succeeded.
+                                    Defaults to 3. Minimum value is 1.
+                                  format: int32
+                                  type: integer
+                                httpGet:
+                                  description: HTTPGet specifies the http request
+                                    to perform.
+                                  properties:
+                                    host:
+                                      description: Host name to connect to, defaults
+                                        to the pod IP. You probably want to set "Host"
+                                        in httpHeaders instead.
+                                      type: string
+                                    httpHeaders:
+                                      description: Custom headers to set in the request.
+                                        HTTP allows repeated headers.
+                                      items:
+                                        description: HTTPHeader describes a custom
+                                          header to be used in HTTP probes
+                                        properties:
+                                          name:
+                                            description: The header field name
+                                            type: string
+                                          value:
+                                            description: The header field value
+                                            type: string
+                                        required:
+                                        - name
+                                        - value
+                                        type: object
+                                      type: array
+                                    path:
+                                      description: Path to access on the HTTP server.
+                                      type: string
+                                    port:
+                                      anyOf:
+                                      - type: string
+                                      - type: integer
+                                      description: Name or number of the port to access
+                                        on the container. Number must be in the range
+                                        1 to 65535. Name must be an IANA_SVC_NAME.
+                                    scheme:
+                                      description: Scheme to use for connecting to
+                                        the host. Defaults to HTTP.
+                                      type: string
+                                  required:
+                                  - port
+                                  type: object
+                                initialDelaySeconds:
+                                  description: 'Number of seconds after the container
+                                    has started before liveness probes are initiated.
+                                    More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                                  format: int32
+                                  type: integer
+                                periodSeconds:
+                                  description: How often (in seconds) to perform the
+                                    probe. Default to 10 seconds. Minimum value is
+                                    1.
+                                  format: int32
+                                  type: integer
+                                successThreshold:
+                                  description: Minimum consecutive successes for the
+                                    probe to be considered successful after having
+                                    failed. Defaults to 1. Must be 1 for liveness.
+                                    Minimum value is 1.
+                                  format: int32
+                                  type: integer
+                                tcpSocket:
+                                  description: 'TCPSocket specifies an action involving
+                                    a TCP port. TCP hooks not yet supported TODO:
+                                    implement a realistic TCP lifecycle hook'
+                                  properties:
+                                    host:
+                                      description: 'Optional: Host name to connect
+                                        to, defaults to the pod IP.'
+                                      type: string
+                                    port:
+                                      anyOf:
+                                      - type: string
+                                      - type: integer
+                                      description: Number or name of the port to access
+                                        on the container. Number must be in the range
+                                        1 to 65535. Name must be an IANA_SVC_NAME.
+                                  required:
+                                  - port
+                                  type: object
+                                timeoutSeconds:
+                                  description: 'Number of seconds after which the
+                                    probe times out. Defaults to 1 second. Minimum
+                                    value is 1. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                                  format: int32
+                                  type: integer
+                              type: object
+                            resources:
+                              description: 'Compute Resources required by this container.
+                                Cannot be updated. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
+                              properties:
+                                limits:
+                                  additionalProperties:
+                                    type: string
+                                  description: 'Limits describes the maximum amount
+                                    of compute resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
+                                  type: object
+                                requests:
+                                  additionalProperties:
+                                    type: string
+                                  description: 'Requests describes the minimum amount
+                                    of compute resources required. If Requests is
+                                    omitted for a container, it defaults to Limits
+                                    if that is explicitly specified, otherwise to
+                                    an implementation-defined value. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
+                                  type: object
+                              type: object
+                            securityContext:
+                              description: 'Security options the pod should run with.
+                                More info: https://kubernetes.io/docs/concepts/policy/security-context/
+                                More info: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/'
+                              properties:
+                                allowPrivilegeEscalation:
+                                  description: 'AllowPrivilegeEscalation controls
+                                    whether a process can gain more privileges than
+                                    its parent process. This bool directly controls
+                                    if the no_new_privs flag will be set on the container
+                                    process. AllowPrivilegeEscalation is true always
+                                    when the container is: 1) run as Privileged 2)
+                                    has CAP_SYS_ADMIN'
+                                  type: boolean
+                                capabilities:
+                                  description: The capabilities to add/drop when running
+                                    containers. Defaults to the default set of capabilities
+                                    granted by the container runtime.
+                                  properties:
+                                    add:
+                                      description: Added capabilities
+                                      items:
+                                        description: Capability represent POSIX capabilities
+                                          type
+                                        type: string
+                                      type: array
+                                    drop:
+                                      description: Removed capabilities
+                                      items:
+                                        description: Capability represent POSIX capabilities
+                                          type
+                                        type: string
+                                      type: array
+                                  type: object
+                                privileged:
+                                  description: Run container in privileged mode. Processes
+                                    in privileged containers are essentially equivalent
+                                    to root on the host. Defaults to false.
+                                  type: boolean
+                                procMount:
+                                  description: procMount denotes the type of proc
+                                    mount to use for the containers. The default is
+                                    DefaultProcMount which uses the container runtime
+                                    defaults for readonly paths and masked paths.
+                                    This requires the ProcMountType feature flag to
+                                    be enabled.
+                                  type: string
+                                readOnlyRootFilesystem:
+                                  description: Whether this container has a read-only
+                                    root filesystem. Default is false.
+                                  type: boolean
+                                runAsGroup:
+                                  description: The GID to run the entrypoint of the
+                                    container process. Uses runtime default if unset.
+                                    May also be set in PodSecurityContext.  If set
+                                    in both SecurityContext and PodSecurityContext,
+                                    the value specified in SecurityContext takes precedence.
+                                  format: int64
+                                  type: integer
+                                runAsNonRoot:
+                                  description: Indicates that the container must run
+                                    as a non-root user. If true, the Kubelet will
+                                    validate the image at runtime to ensure that it
+                                    does not run as UID 0 (root) and fail to start
+                                    the container if it does. If unset or false, no
+                                    such validation will be performed. May also be
+                                    set in PodSecurityContext.  If set in both SecurityContext
+                                    and PodSecurityContext, the value specified in
+                                    SecurityContext takes precedence.
+                                  type: boolean
+                                runAsUser:
+                                  description: The UID to run the entrypoint of the
+                                    container process. Defaults to user specified
+                                    in image metadata if unspecified. May also be
+                                    set in PodSecurityContext.  If set in both SecurityContext
+                                    and PodSecurityContext, the value specified in
+                                    SecurityContext takes precedence.
+                                  format: int64
+                                  type: integer
+                                seLinuxOptions:
+                                  description: The SELinux context to be applied to
+                                    the container. If unspecified, the container runtime
+                                    will allocate a random SELinux context for each
+                                    container.  May also be set in PodSecurityContext.  If
+                                    set in both SecurityContext and PodSecurityContext,
+                                    the value specified in SecurityContext takes precedence.
+                                  properties:
+                                    level:
+                                      description: Level is SELinux level label that
+                                        applies to the container.
+                                      type: string
+                                    role:
+                                      description: Role is a SELinux role label that
+                                        applies to the container.
+                                      type: string
+                                    type:
+                                      description: Type is a SELinux type label that
+                                        applies to the container.
+                                      type: string
+                                    user:
+                                      description: User is a SELinux user label that
+                                        applies to the container.
+                                      type: string
+                                  type: object
+                                windowsOptions:
+                                  description: Windows security options.
+                                  properties:
+                                    gmsaCredentialSpec:
+                                      description: GMSACredentialSpec is where the
+                                        GMSA admission webhook (https://github.com/kubernetes-sigs/windows-gmsa)
+                                        inlines the contents of the GMSA credential
+                                        spec named by the GMSACredentialSpecName field.
+                                        This field is alpha-level and is only honored
+                                        by servers that enable the WindowsGMSA feature
+                                        flag.
+                                      type: string
+                                    gmsaCredentialSpecName:
+                                      description: GMSACredentialSpecName is the name
+                                        of the GMSA credential spec to use. This field
+                                        is alpha-level and is only honored by servers
+                                        that enable the WindowsGMSA feature flag.
+                                      type: string
+                                  type: object
+                              type: object
+                            stdin:
+                              description: Whether this container should allocate
+                                a buffer for stdin in the container runtime. If this
+                                is not set, reads from stdin in the container will
+                                always result in EOF. Default is false.
+                              type: boolean
+                            stdinOnce:
+                              description: Whether the container runtime should close
+                                the stdin channel after it has been opened by a single
+                                attach. When stdin is true the stdin stream will remain
+                                open across multiple attach sessions. If stdinOnce
+                                is set to true, stdin is opened on container start,
+                                is empty until the first client attaches to stdin,
+                                and then remains open and accepts data until the client
+                                disconnects, at which time stdin is closed and remains
+                                closed until the container is restarted. If this flag
+                                is false, a container processes that reads from stdin
+                                will never receive an EOF. Default is false
+                              type: boolean
+                            terminationMessagePath:
+                              description: 'Optional: Path at which the file to which
+                                the container''s termination message will be written
+                                is mounted into the container''s filesystem. Message
+                                written is intended to be brief final status, such
+                                as an assertion failure message. Will be truncated
+                                by the node if greater than 4096 bytes. The total
+                                message length across all containers will be limited
+                                to 12kb. Defaults to /dev/termination-log. Cannot
+                                be updated.'
+                              type: string
+                            terminationMessagePolicy:
+                              description: Indicate how the termination message should
+                                be populated. File will use the contents of terminationMessagePath
+                                to populate the container status message on both success
+                                and failure. FallbackToLogsOnError will use the last
+                                chunk of container log output if the termination message
+                                file is empty and the container exited with an error.
+                                The log output is limited to 2048 bytes or 80 lines,
+                                whichever is smaller. Defaults to File. Cannot be
+                                updated.
+                              type: string
+                            tty:
+                              description: Whether this container should allocate
+                                a TTY for itself, also requires 'stdin' to be true.
+                                Default is false.
+                              type: boolean
+                            volumeDevices:
+                              description: volumeDevices is the list of block devices
+                                to be used by the container. This is a beta feature.
+                              items:
+                                description: volumeDevice describes a mapping of a
+                                  raw block device within a container.
+                                properties:
+                                  devicePath:
+                                    description: devicePath is the path inside of
+                                      the container that the device will be mapped
+                                      to.
+                                    type: string
+                                  name:
+                                    description: name must match the name of a persistentVolumeClaim
+                                      in the pod
+                                    type: string
+                                required:
+                                - devicePath
+                                - name
+                                type: object
+                              type: array
+                            volumeMounts:
+                              description: Pod volumes to mount into the container's
+                                filesystem. Cannot be updated.
+                              items:
+                                description: VolumeMount describes a mounting of a
+                                  Volume within a container.
+                                properties:
+                                  mountPath:
+                                    description: Path within the container at which
+                                      the volume should be mounted.  Must not contain
+                                      ':'.
+                                    type: string
+                                  mountPropagation:
+                                    description: mountPropagation determines how mounts
+                                      are propagated from the host to container and
+                                      the other way around. When not set, MountPropagationNone
+                                      is used. This field is beta in 1.10.
+                                    type: string
+                                  name:
+                                    description: This must match the Name of a Volume.
+                                    type: string
+                                  readOnly:
+                                    description: Mounted read-only if true, read-write
+                                      otherwise (false or unspecified). Defaults to
+                                      false.
+                                    type: boolean
+                                  subPath:
+                                    description: Path within the volume from which
+                                      the container's volume should be mounted. Defaults
+                                      to "" (volume's root).
+                                    type: string
+                                  subPathExpr:
+                                    description: Expanded path within the volume from
+                                      which the container's volume should be mounted.
+                                      Behaves similarly to SubPath but environment
+                                      variable references $(VAR_NAME) are expanded
+                                      using the container's environment. Defaults
+                                      to "" (volume's root). SubPathExpr and SubPath
+                                      are mutually exclusive. This field is beta in
+                                      1.15.
+                                    type: string
+                                required:
+                                - mountPath
+                                - name
+                                type: object
+                              type: array
+                            workingDir:
+                              description: Container's working directory. If not specified,
+                                the container runtime's default will be used, which
+                                might be configured in the container image. Cannot
+                                be updated.
+                              type: string
+                          required:
+                          - name
+                          type: object
+                      required:
+                      - container
+                      type: object
+                    logger:
+                      description: Activate request/response logging
+                      properties:
+                        mode:
+                          description: What payloads to log
+                          type: string
+                        url:
+                          description: URL to send request logging CloudEvents
+                          type: string
+                      type: object
+                    maxReplicas:
+                      description: This is the up bound for autoscaler to scale to
+                      type: integer
+                    minReplicas:
+                      description: Minimum number of replicas, pods won't scale down
+                        to 0 in case of no traffic
+                      type: integer
+                    parallelism:
+                      description: Parallelism specifies how many requests can be
+                        processed concurrently, this sets the target concurrency for
+                        Autoscaling(KPA). For model servers that support tuning parallelism
+                        will use this value, by default the parallelism is the number
+                        of the CPU cores for most of the model servers.
+                      type: integer
+                    serviceAccountName:
+                      description: ServiceAccountName is the name of the ServiceAccount
+                        to use to run the service
+                      type: string
+                  type: object
+              required:
+              - predictor
+              type: object
+            canaryTrafficPercent:
+              description: CanaryTrafficPercent defines the percentage of traffic
+                going to canary InferenceService endpoints
+              type: integer
+            default:
+              description: Default defines default InferenceService endpoints
+              properties:
+                explainer:
+                  description: Explainer defines the model explanation service spec,
+                    explainer service calls to predictor or transformer if it is specified.
+                  properties:
+                    alibi:
+                      description: Spec for alibi explainer
+                      properties:
+                        config:
+                          additionalProperties:
+                            type: string
+                          description: Inline custom parameter settings for explainer
+                          type: object
+                        resources:
+                          description: Defaults to requests and limits of 1CPU, 2Gb
+                            MEM.
+                          properties:
+                            limits:
+                              additionalProperties:
+                                type: string
+                              description: 'Limits describes the maximum amount of
+                                compute resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
+                              type: object
+                            requests:
+                              additionalProperties:
+                                type: string
+                              description: 'Requests describes the minimum amount
+                                of compute resources required. If Requests is omitted
+                                for a container, it defaults to Limits if that is
+                                explicitly specified, otherwise to an implementation-defined
+                                value. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
+                              type: object
+                          type: object
+                        runtimeVersion:
+                          description: Defaults to latest Alibi Version
+                          type: string
+                        storageUri:
+                          description: The location of a trained explanation model
+                          type: string
+                        type:
+                          description: The type of Alibi explainer
+                          type: string
+                      required:
+                      - type
+                      type: object
+                    custom:
+                      description: Spec for a custom explainer
+                      properties:
+                        container:
+                          description: A single application container that you want
+                            to run within a pod.
+                          properties:
+                            args:
+                              description: 'Arguments to the entrypoint. The docker
+                                image''s CMD is used if this is not provided. Variable
+                                references $(VAR_NAME) are expanded using the container''s
+                                environment. If a variable cannot be resolved, the
+                                reference in the input string will be unchanged. The
+                                $(VAR_NAME) syntax can be escaped with a double $$,
+                                ie: $$(VAR_NAME). Escaped references will never be
+                                expanded, regardless of whether the variable exists
+                                or not. Cannot be updated. More info: https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell'
+                              items:
+                                type: string
+                              type: array
+                            command:
+                              description: 'Entrypoint array. Not executed within
+                                a shell. The docker image''s ENTRYPOINT is used if
+                                this is not provided. Variable references $(VAR_NAME)
+                                are expanded using the container''s environment. If
+                                a variable cannot be resolved, the reference in the
+                                input string will be unchanged. The $(VAR_NAME) syntax
+                                can be escaped with a double $$, ie: $$(VAR_NAME).
+                                Escaped references will never be expanded, regardless
+                                of whether the variable exists or not. Cannot be updated.
+                                More info: https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell'
+                              items:
+                                type: string
+                              type: array
+                            env:
+                              description: List of environment variables to set in
+                                the container. Cannot be updated.
+                              items:
+                                description: EnvVar represents an environment variable
+                                  present in a Container.
+                                properties:
+                                  name:
+                                    description: Name of the environment variable.
+                                      Must be a C_IDENTIFIER.
+                                    type: string
+                                  value:
+                                    description: 'Variable references $(VAR_NAME)
+                                      are expanded using the previous defined environment
+                                      variables in the container and any service environment
+                                      variables. If a variable cannot be resolved,
+                                      the reference in the input string will be unchanged.
+                                      The $(VAR_NAME) syntax can be escaped with a
+                                      double $$, ie: $$(VAR_NAME). Escaped references
+                                      will never be expanded, regardless of whether
+                                      the variable exists or not. Defaults to "".'
+                                    type: string
+                                  valueFrom:
+                                    description: Source for the environment variable's
+                                      value. Cannot be used if value is not empty.
+                                    properties:
+                                      configMapKeyRef:
+                                        description: Selects a key of a ConfigMap.
+                                        properties:
+                                          key:
+                                            description: The key to select.
+                                            type: string
+                                          name:
+                                            description: 'Name of the referent. More
+                                              info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                              TODO: Add other useful fields. apiVersion,
+                                              kind, uid?'
+                                            type: string
+                                          optional:
+                                            description: Specify whether the ConfigMap
+                                              or its key must be defined
+                                            type: boolean
+                                        required:
+                                        - key
+                                        type: object
+                                      fieldRef:
+                                        description: 'Selects a field of the pod:
+                                          supports metadata.name, metadata.namespace,
+                                          metadata.labels, metadata.annotations, spec.nodeName,
+                                          spec.serviceAccountName, status.hostIP,
+                                          status.podIP.'
+                                        properties:
+                                          apiVersion:
+                                            description: Version of the schema the
+                                              FieldPath is written in terms of, defaults
+                                              to "v1".
+                                            type: string
+                                          fieldPath:
+                                            description: Path of the field to select
+                                              in the specified API version.
+                                            type: string
+                                        required:
+                                        - fieldPath
+                                        type: object
+                                      resourceFieldRef:
+                                        description: 'Selects a resource of the container:
+                                          only resources limits and requests (limits.cpu,
+                                          limits.memory, limits.ephemeral-storage,
+                                          requests.cpu, requests.memory and requests.ephemeral-storage)
+                                          are currently supported.'
+                                        properties:
+                                          containerName:
+                                            description: 'Container name: required
+                                              for volumes, optional for env vars'
+                                            type: string
+                                          divisor:
+                                            description: Specifies the output format
+                                              of the exposed resources, defaults to
+                                              "1"
+                                            type: string
+                                          resource:
+                                            description: 'Required: resource to select'
+                                            type: string
+                                        required:
+                                        - resource
+                                        type: object
+                                      secretKeyRef:
+                                        description: Selects a key of a secret in
+                                          the pod's namespace
+                                        properties:
+                                          key:
+                                            description: The key of the secret to
+                                              select from.  Must be a valid secret
+                                              key.
+                                            type: string
+                                          name:
+                                            description: 'Name of the referent. More
+                                              info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                              TODO: Add other useful fields. apiVersion,
+                                              kind, uid?'
+                                            type: string
+                                          optional:
+                                            description: Specify whether the Secret
+                                              or its key must be defined
+                                            type: boolean
+                                        required:
+                                        - key
+                                        type: object
+                                    type: object
+                                required:
+                                - name
+                                type: object
+                              type: array
+                            envFrom:
+                              description: List of sources to populate environment
+                                variables in the container. The keys defined within
+                                a source must be a C_IDENTIFIER. All invalid keys
+                                will be reported as an event when the container is
+                                starting. When a key exists in multiple sources, the
+                                value associated with the last source will take precedence.
+                                Values defined by an Env with a duplicate key will
+                                take precedence. Cannot be updated.
+                              items:
+                                description: EnvFromSource represents the source of
+                                  a set of ConfigMaps
+                                properties:
+                                  configMapRef:
+                                    description: The ConfigMap to select from
+                                    properties:
+                                      name:
+                                        description: 'Name of the referent. More info:
+                                          https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                          TODO: Add other useful fields. apiVersion,
+                                          kind, uid?'
+                                        type: string
+                                      optional:
+                                        description: Specify whether the ConfigMap
+                                          must be defined
+                                        type: boolean
+                                    type: object
+                                  prefix:
+                                    description: An optional identifier to prepend
+                                      to each key in the ConfigMap. Must be a C_IDENTIFIER.
+                                    type: string
+                                  secretRef:
+                                    description: The Secret to select from
+                                    properties:
+                                      name:
+                                        description: 'Name of the referent. More info:
+                                          https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                          TODO: Add other useful fields. apiVersion,
+                                          kind, uid?'
+                                        type: string
+                                      optional:
+                                        description: Specify whether the Secret must
+                                          be defined
+                                        type: boolean
+                                    type: object
+                                type: object
+                              type: array
+                            image:
+                              description: 'Docker image name. More info: https://kubernetes.io/docs/concepts/containers/images
+                                This field is optional to allow higher level config
+                                management to default or override container images
+                                in workload controllers like Deployments and StatefulSets.'
+                              type: string
+                            imagePullPolicy:
+                              description: 'Image pull policy. One of Always, Never,
+                                IfNotPresent. Defaults to Always if :v0.3.0 tag is
+                                specified, or IfNotPresent otherwise. Cannot be updated.
+                                More info: https://kubernetes.io/docs/concepts/containers/images#updating-images'
+                              type: string
+                            lifecycle:
+                              description: Actions that the management system should
+                                take in response to container lifecycle events. Cannot
+                                be updated.
+                              properties:
+                                postStart:
+                                  description: 'PostStart is called immediately after
+                                    a container is created. If the handler fails,
+                                    the container is terminated and restarted according
+                                    to its restart policy. Other management of the
+                                    container blocks until the hook completes. More
+                                    info: https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/#container-hooks'
+                                  properties:
+                                    exec:
+                                      description: One and only one of the following
+                                        should be specified. Exec specifies the action
+                                        to take.
+                                      properties:
+                                        command:
+                                          description: Command is the command line
+                                            to execute inside the container, the working
+                                            directory for the command  is root ('/')
+                                            in the container's filesystem. The command
+                                            is simply exec'd, it is not run inside
+                                            a shell, so traditional shell instructions
+                                            ('|', etc) won't work. To use a shell,
+                                            you need to explicitly call out to that
+                                            shell. Exit status of 0 is treated as
+                                            live/healthy and non-zero is unhealthy.
+                                          items:
+                                            type: string
+                                          type: array
+                                      type: object
+                                    httpGet:
+                                      description: HTTPGet specifies the http request
+                                        to perform.
+                                      properties:
+                                        host:
+                                          description: Host name to connect to, defaults
+                                            to the pod IP. You probably want to set
+                                            "Host" in httpHeaders instead.
+                                          type: string
+                                        httpHeaders:
+                                          description: Custom headers to set in the
+                                            request. HTTP allows repeated headers.
+                                          items:
+                                            description: HTTPHeader describes a custom
+                                              header to be used in HTTP probes
+                                            properties:
+                                              name:
+                                                description: The header field name
+                                                type: string
+                                              value:
+                                                description: The header field value
+                                                type: string
+                                            required:
+                                            - name
+                                            - value
+                                            type: object
+                                          type: array
+                                        path:
+                                          description: Path to access on the HTTP
+                                            server.
+                                          type: string
+                                        port:
+                                          anyOf:
+                                          - type: string
+                                          - type: integer
+                                          description: Name or number of the port
+                                            to access on the container. Number must
+                                            be in the range 1 to 65535. Name must
+                                            be an IANA_SVC_NAME.
+                                        scheme:
+                                          description: Scheme to use for connecting
+                                            to the host. Defaults to HTTP.
+                                          type: string
+                                      required:
+                                      - port
+                                      type: object
+                                    tcpSocket:
+                                      description: 'TCPSocket specifies an action
+                                        involving a TCP port. TCP hooks not yet supported
+                                        TODO: implement a realistic TCP lifecycle
+                                        hook'
+                                      properties:
+                                        host:
+                                          description: 'Optional: Host name to connect
+                                            to, defaults to the pod IP.'
+                                          type: string
+                                        port:
+                                          anyOf:
+                                          - type: string
+                                          - type: integer
+                                          description: Number or name of the port
+                                            to access on the container. Number must
+                                            be in the range 1 to 65535. Name must
+                                            be an IANA_SVC_NAME.
+                                      required:
+                                      - port
+                                      type: object
+                                  type: object
+                                preStop:
+                                  description: 'PreStop is called immediately before
+                                    a container is terminated due to an API request
+                                    or management event such as liveness probe failure,
+                                    preemption, resource contention, etc. The handler
+                                    is not called if the container crashes or exits.
+                                    The reason for termination is passed to the handler.
+                                    The Pod''s termination grace period countdown
+                                    begins before the PreStop hooked is executed.
+                                    Regardless of the outcome of the handler, the
+                                    container will eventually terminate within the
+                                    Pod''s termination grace period. Other management
+                                    of the container blocks until the hook completes
+                                    or until the termination grace period is reached.
+                                    More info: https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/#container-hooks'
+                                  properties:
+                                    exec:
+                                      description: One and only one of the following
+                                        should be specified. Exec specifies the action
+                                        to take.
+                                      properties:
+                                        command:
+                                          description: Command is the command line
+                                            to execute inside the container, the working
+                                            directory for the command  is root ('/')
+                                            in the container's filesystem. The command
+                                            is simply exec'd, it is not run inside
+                                            a shell, so traditional shell instructions
+                                            ('|', etc) won't work. To use a shell,
+                                            you need to explicitly call out to that
+                                            shell. Exit status of 0 is treated as
+                                            live/healthy and non-zero is unhealthy.
+                                          items:
+                                            type: string
+                                          type: array
+                                      type: object
+                                    httpGet:
+                                      description: HTTPGet specifies the http request
+                                        to perform.
+                                      properties:
+                                        host:
+                                          description: Host name to connect to, defaults
+                                            to the pod IP. You probably want to set
+                                            "Host" in httpHeaders instead.
+                                          type: string
+                                        httpHeaders:
+                                          description: Custom headers to set in the
+                                            request. HTTP allows repeated headers.
+                                          items:
+                                            description: HTTPHeader describes a custom
+                                              header to be used in HTTP probes
+                                            properties:
+                                              name:
+                                                description: The header field name
+                                                type: string
+                                              value:
+                                                description: The header field value
+                                                type: string
+                                            required:
+                                            - name
+                                            - value
+                                            type: object
+                                          type: array
+                                        path:
+                                          description: Path to access on the HTTP
+                                            server.
+                                          type: string
+                                        port:
+                                          anyOf:
+                                          - type: string
+                                          - type: integer
+                                          description: Name or number of the port
+                                            to access on the container. Number must
+                                            be in the range 1 to 65535. Name must
+                                            be an IANA_SVC_NAME.
+                                        scheme:
+                                          description: Scheme to use for connecting
+                                            to the host. Defaults to HTTP.
+                                          type: string
+                                      required:
+                                      - port
+                                      type: object
+                                    tcpSocket:
+                                      description: 'TCPSocket specifies an action
+                                        involving a TCP port. TCP hooks not yet supported
+                                        TODO: implement a realistic TCP lifecycle
+                                        hook'
+                                      properties:
+                                        host:
+                                          description: 'Optional: Host name to connect
+                                            to, defaults to the pod IP.'
+                                          type: string
+                                        port:
+                                          anyOf:
+                                          - type: string
+                                          - type: integer
+                                          description: Number or name of the port
+                                            to access on the container. Number must
+                                            be in the range 1 to 65535. Name must
+                                            be an IANA_SVC_NAME.
+                                      required:
+                                      - port
+                                      type: object
+                                  type: object
+                              type: object
+                            livenessProbe:
+                              description: 'Periodic probe of container liveness.
+                                Container will be restarted if the probe fails. Cannot
+                                be updated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                              properties:
+                                exec:
+                                  description: One and only one of the following should
+                                    be specified. Exec specifies the action to take.
+                                  properties:
+                                    command:
+                                      description: Command is the command line to
+                                        execute inside the container, the working
+                                        directory for the command  is root ('/') in
+                                        the container's filesystem. The command is
+                                        simply exec'd, it is not run inside a shell,
+                                        so traditional shell instructions ('|', etc)
+                                        won't work. To use a shell, you need to explicitly
+                                        call out to that shell. Exit status of 0 is
+                                        treated as live/healthy and non-zero is unhealthy.
+                                      items:
+                                        type: string
+                                      type: array
+                                  type: object
+                                failureThreshold:
+                                  description: Minimum consecutive failures for the
+                                    probe to be considered failed after having succeeded.
+                                    Defaults to 3. Minimum value is 1.
+                                  format: int32
+                                  type: integer
+                                httpGet:
+                                  description: HTTPGet specifies the http request
+                                    to perform.
+                                  properties:
+                                    host:
+                                      description: Host name to connect to, defaults
+                                        to the pod IP. You probably want to set "Host"
+                                        in httpHeaders instead.
+                                      type: string
+                                    httpHeaders:
+                                      description: Custom headers to set in the request.
+                                        HTTP allows repeated headers.
+                                      items:
+                                        description: HTTPHeader describes a custom
+                                          header to be used in HTTP probes
+                                        properties:
+                                          name:
+                                            description: The header field name
+                                            type: string
+                                          value:
+                                            description: The header field value
+                                            type: string
+                                        required:
+                                        - name
+                                        - value
+                                        type: object
+                                      type: array
+                                    path:
+                                      description: Path to access on the HTTP server.
+                                      type: string
+                                    port:
+                                      anyOf:
+                                      - type: string
+                                      - type: integer
+                                      description: Name or number of the port to access
+                                        on the container. Number must be in the range
+                                        1 to 65535. Name must be an IANA_SVC_NAME.
+                                    scheme:
+                                      description: Scheme to use for connecting to
+                                        the host. Defaults to HTTP.
+                                      type: string
+                                  required:
+                                  - port
+                                  type: object
+                                initialDelaySeconds:
+                                  description: 'Number of seconds after the container
+                                    has started before liveness probes are initiated.
+                                    More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                                  format: int32
+                                  type: integer
+                                periodSeconds:
+                                  description: How often (in seconds) to perform the
+                                    probe. Default to 10 seconds. Minimum value is
+                                    1.
+                                  format: int32
+                                  type: integer
+                                successThreshold:
+                                  description: Minimum consecutive successes for the
+                                    probe to be considered successful after having
+                                    failed. Defaults to 1. Must be 1 for liveness.
+                                    Minimum value is 1.
+                                  format: int32
+                                  type: integer
+                                tcpSocket:
+                                  description: 'TCPSocket specifies an action involving
+                                    a TCP port. TCP hooks not yet supported TODO:
+                                    implement a realistic TCP lifecycle hook'
+                                  properties:
+                                    host:
+                                      description: 'Optional: Host name to connect
+                                        to, defaults to the pod IP.'
+                                      type: string
+                                    port:
+                                      anyOf:
+                                      - type: string
+                                      - type: integer
+                                      description: Number or name of the port to access
+                                        on the container. Number must be in the range
+                                        1 to 65535. Name must be an IANA_SVC_NAME.
+                                  required:
+                                  - port
+                                  type: object
+                                timeoutSeconds:
+                                  description: 'Number of seconds after which the
+                                    probe times out. Defaults to 1 second. Minimum
+                                    value is 1. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                                  format: int32
+                                  type: integer
+                              type: object
+                            name:
+                              description: Name of the container specified as a DNS_LABEL.
+                                Each container in a pod must have a unique name (DNS_LABEL).
+                                Cannot be updated.
+                              type: string
+                            ports:
+                              description: List of ports to expose from the container.
+                                Exposing a port here gives the system additional information
+                                about the network connections a container uses, but
+                                is primarily informational. Not specifying a port
+                                here DOES NOT prevent that port from being exposed.
+                                Any port which is listening on the default "0.0.0.0"
+                                address inside a container will be accessible from
+                                the network. Cannot be updated.
+                              items:
+                                description: ContainerPort represents a network port
+                                  in a single container.
+                                properties:
+                                  containerPort:
+                                    description: Number of port to expose on the pod's
+                                      IP address. This must be a valid port number,
+                                      0 < x < 65536.
+                                    format: int32
+                                    type: integer
+                                  hostIP:
+                                    description: What host IP to bind the external
+                                      port to.
+                                    type: string
+                                  hostPort:
+                                    description: Number of port to expose on the host.
+                                      If specified, this must be a valid port number,
+                                      0 < x < 65536. If HostNetwork is specified,
+                                      this must match ContainerPort. Most containers
+                                      do not need this.
+                                    format: int32
+                                    type: integer
+                                  name:
+                                    description: If specified, this must be an IANA_SVC_NAME
+                                      and unique within the pod. Each named port in
+                                      a pod must have a unique name. Name for the
+                                      port that can be referred to by services.
+                                    type: string
+                                  protocol:
+                                    description: Protocol for port. Must be UDP, TCP,
+                                      or SCTP. Defaults to "TCP".
+                                    type: string
+                                required:
+                                - containerPort
+                                type: object
+                              type: array
+                            readinessProbe:
+                              description: 'Periodic probe of container service readiness.
+                                Container will be removed from service endpoints if
+                                the probe fails. Cannot be updated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                              properties:
+                                exec:
+                                  description: One and only one of the following should
+                                    be specified. Exec specifies the action to take.
+                                  properties:
+                                    command:
+                                      description: Command is the command line to
+                                        execute inside the container, the working
+                                        directory for the command  is root ('/') in
+                                        the container's filesystem. The command is
+                                        simply exec'd, it is not run inside a shell,
+                                        so traditional shell instructions ('|', etc)
+                                        won't work. To use a shell, you need to explicitly
+                                        call out to that shell. Exit status of 0 is
+                                        treated as live/healthy and non-zero is unhealthy.
+                                      items:
+                                        type: string
+                                      type: array
+                                  type: object
+                                failureThreshold:
+                                  description: Minimum consecutive failures for the
+                                    probe to be considered failed after having succeeded.
+                                    Defaults to 3. Minimum value is 1.
+                                  format: int32
+                                  type: integer
+                                httpGet:
+                                  description: HTTPGet specifies the http request
+                                    to perform.
+                                  properties:
+                                    host:
+                                      description: Host name to connect to, defaults
+                                        to the pod IP. You probably want to set "Host"
+                                        in httpHeaders instead.
+                                      type: string
+                                    httpHeaders:
+                                      description: Custom headers to set in the request.
+                                        HTTP allows repeated headers.
+                                      items:
+                                        description: HTTPHeader describes a custom
+                                          header to be used in HTTP probes
+                                        properties:
+                                          name:
+                                            description: The header field name
+                                            type: string
+                                          value:
+                                            description: The header field value
+                                            type: string
+                                        required:
+                                        - name
+                                        - value
+                                        type: object
+                                      type: array
+                                    path:
+                                      description: Path to access on the HTTP server.
+                                      type: string
+                                    port:
+                                      anyOf:
+                                      - type: string
+                                      - type: integer
+                                      description: Name or number of the port to access
+                                        on the container. Number must be in the range
+                                        1 to 65535. Name must be an IANA_SVC_NAME.
+                                    scheme:
+                                      description: Scheme to use for connecting to
+                                        the host. Defaults to HTTP.
+                                      type: string
+                                  required:
+                                  - port
+                                  type: object
+                                initialDelaySeconds:
+                                  description: 'Number of seconds after the container
+                                    has started before liveness probes are initiated.
+                                    More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                                  format: int32
+                                  type: integer
+                                periodSeconds:
+                                  description: How often (in seconds) to perform the
+                                    probe. Default to 10 seconds. Minimum value is
+                                    1.
+                                  format: int32
+                                  type: integer
+                                successThreshold:
+                                  description: Minimum consecutive successes for the
+                                    probe to be considered successful after having
+                                    failed. Defaults to 1. Must be 1 for liveness.
+                                    Minimum value is 1.
+                                  format: int32
+                                  type: integer
+                                tcpSocket:
+                                  description: 'TCPSocket specifies an action involving
+                                    a TCP port. TCP hooks not yet supported TODO:
+                                    implement a realistic TCP lifecycle hook'
+                                  properties:
+                                    host:
+                                      description: 'Optional: Host name to connect
+                                        to, defaults to the pod IP.'
+                                      type: string
+                                    port:
+                                      anyOf:
+                                      - type: string
+                                      - type: integer
+                                      description: Number or name of the port to access
+                                        on the container. Number must be in the range
+                                        1 to 65535. Name must be an IANA_SVC_NAME.
+                                  required:
+                                  - port
+                                  type: object
+                                timeoutSeconds:
+                                  description: 'Number of seconds after which the
+                                    probe times out. Defaults to 1 second. Minimum
+                                    value is 1. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                                  format: int32
+                                  type: integer
+                              type: object
+                            resources:
+                              description: 'Compute Resources required by this container.
+                                Cannot be updated. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
+                              properties:
+                                limits:
+                                  additionalProperties:
+                                    type: string
+                                  description: 'Limits describes the maximum amount
+                                    of compute resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
+                                  type: object
+                                requests:
+                                  additionalProperties:
+                                    type: string
+                                  description: 'Requests describes the minimum amount
+                                    of compute resources required. If Requests is
+                                    omitted for a container, it defaults to Limits
+                                    if that is explicitly specified, otherwise to
+                                    an implementation-defined value. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
+                                  type: object
+                              type: object
+                            securityContext:
+                              description: 'Security options the pod should run with.
+                                More info: https://kubernetes.io/docs/concepts/policy/security-context/
+                                More info: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/'
+                              properties:
+                                allowPrivilegeEscalation:
+                                  description: 'AllowPrivilegeEscalation controls
+                                    whether a process can gain more privileges than
+                                    its parent process. This bool directly controls
+                                    if the no_new_privs flag will be set on the container
+                                    process. AllowPrivilegeEscalation is true always
+                                    when the container is: 1) run as Privileged 2)
+                                    has CAP_SYS_ADMIN'
+                                  type: boolean
+                                capabilities:
+                                  description: The capabilities to add/drop when running
+                                    containers. Defaults to the default set of capabilities
+                                    granted by the container runtime.
+                                  properties:
+                                    add:
+                                      description: Added capabilities
+                                      items:
+                                        description: Capability represent POSIX capabilities
+                                          type
+                                        type: string
+                                      type: array
+                                    drop:
+                                      description: Removed capabilities
+                                      items:
+                                        description: Capability represent POSIX capabilities
+                                          type
+                                        type: string
+                                      type: array
+                                  type: object
+                                privileged:
+                                  description: Run container in privileged mode. Processes
+                                    in privileged containers are essentially equivalent
+                                    to root on the host. Defaults to false.
+                                  type: boolean
+                                procMount:
+                                  description: procMount denotes the type of proc
+                                    mount to use for the containers. The default is
+                                    DefaultProcMount which uses the container runtime
+                                    defaults for readonly paths and masked paths.
+                                    This requires the ProcMountType feature flag to
+                                    be enabled.
+                                  type: string
+                                readOnlyRootFilesystem:
+                                  description: Whether this container has a read-only
+                                    root filesystem. Default is false.
+                                  type: boolean
+                                runAsGroup:
+                                  description: The GID to run the entrypoint of the
+                                    container process. Uses runtime default if unset.
+                                    May also be set in PodSecurityContext.  If set
+                                    in both SecurityContext and PodSecurityContext,
+                                    the value specified in SecurityContext takes precedence.
+                                  format: int64
+                                  type: integer
+                                runAsNonRoot:
+                                  description: Indicates that the container must run
+                                    as a non-root user. If true, the Kubelet will
+                                    validate the image at runtime to ensure that it
+                                    does not run as UID 0 (root) and fail to start
+                                    the container if it does. If unset or false, no
+                                    such validation will be performed. May also be
+                                    set in PodSecurityContext.  If set in both SecurityContext
+                                    and PodSecurityContext, the value specified in
+                                    SecurityContext takes precedence.
+                                  type: boolean
+                                runAsUser:
+                                  description: The UID to run the entrypoint of the
+                                    container process. Defaults to user specified
+                                    in image metadata if unspecified. May also be
+                                    set in PodSecurityContext.  If set in both SecurityContext
+                                    and PodSecurityContext, the value specified in
+                                    SecurityContext takes precedence.
+                                  format: int64
+                                  type: integer
+                                seLinuxOptions:
+                                  description: The SELinux context to be applied to
+                                    the container. If unspecified, the container runtime
+                                    will allocate a random SELinux context for each
+                                    container.  May also be set in PodSecurityContext.  If
+                                    set in both SecurityContext and PodSecurityContext,
+                                    the value specified in SecurityContext takes precedence.
+                                  properties:
+                                    level:
+                                      description: Level is SELinux level label that
+                                        applies to the container.
+                                      type: string
+                                    role:
+                                      description: Role is a SELinux role label that
+                                        applies to the container.
+                                      type: string
+                                    type:
+                                      description: Type is a SELinux type label that
+                                        applies to the container.
+                                      type: string
+                                    user:
+                                      description: User is a SELinux user label that
+                                        applies to the container.
+                                      type: string
+                                  type: object
+                                windowsOptions:
+                                  description: Windows security options.
+                                  properties:
+                                    gmsaCredentialSpec:
+                                      description: GMSACredentialSpec is where the
+                                        GMSA admission webhook (https://github.com/kubernetes-sigs/windows-gmsa)
+                                        inlines the contents of the GMSA credential
+                                        spec named by the GMSACredentialSpecName field.
+                                        This field is alpha-level and is only honored
+                                        by servers that enable the WindowsGMSA feature
+                                        flag.
+                                      type: string
+                                    gmsaCredentialSpecName:
+                                      description: GMSACredentialSpecName is the name
+                                        of the GMSA credential spec to use. This field
+                                        is alpha-level and is only honored by servers
+                                        that enable the WindowsGMSA feature flag.
+                                      type: string
+                                  type: object
+                              type: object
+                            stdin:
+                              description: Whether this container should allocate
+                                a buffer for stdin in the container runtime. If this
+                                is not set, reads from stdin in the container will
+                                always result in EOF. Default is false.
+                              type: boolean
+                            stdinOnce:
+                              description: Whether the container runtime should close
+                                the stdin channel after it has been opened by a single
+                                attach. When stdin is true the stdin stream will remain
+                                open across multiple attach sessions. If stdinOnce
+                                is set to true, stdin is opened on container start,
+                                is empty until the first client attaches to stdin,
+                                and then remains open and accepts data until the client
+                                disconnects, at which time stdin is closed and remains
+                                closed until the container is restarted. If this flag
+                                is false, a container processes that reads from stdin
+                                will never receive an EOF. Default is false
+                              type: boolean
+                            terminationMessagePath:
+                              description: 'Optional: Path at which the file to which
+                                the container''s termination message will be written
+                                is mounted into the container''s filesystem. Message
+                                written is intended to be brief final status, such
+                                as an assertion failure message. Will be truncated
+                                by the node if greater than 4096 bytes. The total
+                                message length across all containers will be limited
+                                to 12kb. Defaults to /dev/termination-log. Cannot
+                                be updated.'
+                              type: string
+                            terminationMessagePolicy:
+                              description: Indicate how the termination message should
+                                be populated. File will use the contents of terminationMessagePath
+                                to populate the container status message on both success
+                                and failure. FallbackToLogsOnError will use the last
+                                chunk of container log output if the termination message
+                                file is empty and the container exited with an error.
+                                The log output is limited to 2048 bytes or 80 lines,
+                                whichever is smaller. Defaults to File. Cannot be
+                                updated.
+                              type: string
+                            tty:
+                              description: Whether this container should allocate
+                                a TTY for itself, also requires 'stdin' to be true.
+                                Default is false.
+                              type: boolean
+                            volumeDevices:
+                              description: volumeDevices is the list of block devices
+                                to be used by the container. This is a beta feature.
+                              items:
+                                description: volumeDevice describes a mapping of a
+                                  raw block device within a container.
+                                properties:
+                                  devicePath:
+                                    description: devicePath is the path inside of
+                                      the container that the device will be mapped
+                                      to.
+                                    type: string
+                                  name:
+                                    description: name must match the name of a persistentVolumeClaim
+                                      in the pod
+                                    type: string
+                                required:
+                                - devicePath
+                                - name
+                                type: object
+                              type: array
+                            volumeMounts:
+                              description: Pod volumes to mount into the container's
+                                filesystem. Cannot be updated.
+                              items:
+                                description: VolumeMount describes a mounting of a
+                                  Volume within a container.
+                                properties:
+                                  mountPath:
+                                    description: Path within the container at which
+                                      the volume should be mounted.  Must not contain
+                                      ':'.
+                                    type: string
+                                  mountPropagation:
+                                    description: mountPropagation determines how mounts
+                                      are propagated from the host to container and
+                                      the other way around. When not set, MountPropagationNone
+                                      is used. This field is beta in 1.10.
+                                    type: string
+                                  name:
+                                    description: This must match the Name of a Volume.
+                                    type: string
+                                  readOnly:
+                                    description: Mounted read-only if true, read-write
+                                      otherwise (false or unspecified). Defaults to
+                                      false.
+                                    type: boolean
+                                  subPath:
+                                    description: Path within the volume from which
+                                      the container's volume should be mounted. Defaults
+                                      to "" (volume's root).
+                                    type: string
+                                  subPathExpr:
+                                    description: Expanded path within the volume from
+                                      which the container's volume should be mounted.
+                                      Behaves similarly to SubPath but environment
+                                      variable references $(VAR_NAME) are expanded
+                                      using the container's environment. Defaults
+                                      to "" (volume's root). SubPathExpr and SubPath
+                                      are mutually exclusive. This field is beta in
+                                      1.15.
+                                    type: string
+                                required:
+                                - mountPath
+                                - name
+                                type: object
+                              type: array
+                            workingDir:
+                              description: Container's working directory. If not specified,
+                                the container runtime's default will be used, which
+                                might be configured in the container image. Cannot
+                                be updated.
+                              type: string
+                          required:
+                          - name
+                          type: object
+                      required:
+                      - container
+                      type: object
+                    logger:
+                      description: Activate request/response logging
+                      properties:
+                        mode:
+                          description: What payloads to log
+                          type: string
+                        url:
+                          description: URL to send request logging CloudEvents
+                          type: string
+                      type: object
+                    maxReplicas:
+                      description: This is the up bound for autoscaler to scale to
+                      type: integer
+                    minReplicas:
+                      description: Minimum number of replicas, pods won't scale down
+                        to 0 in case of no traffic
+                      type: integer
+                    parallelism:
+                      description: Parallelism specifies how many requests can be
+                        processed concurrently, this sets the target concurrency for
+                        Autoscaling(KPA). For model servers that support tuning parallelism
+                        will use this value, by default the parallelism is the number
+                        of the CPU cores for most of the model servers.
+                      type: integer
+                    serviceAccountName:
+                      description: ServiceAccountName is the name of the ServiceAccount
+                        to use to run the service
+                      type: string
+                  type: object
+                predictor:
+                  description: Predictor defines the model serving spec
+                  properties:
+                    custom:
+                      description: Spec for a custom predictor
+                      properties:
+                        container:
+                          description: A single application container that you want
+                            to run within a pod.
+                          properties:
+                            args:
+                              description: 'Arguments to the entrypoint. The docker
+                                image''s CMD is used if this is not provided. Variable
+                                references $(VAR_NAME) are expanded using the container''s
+                                environment. If a variable cannot be resolved, the
+                                reference in the input string will be unchanged. The
+                                $(VAR_NAME) syntax can be escaped with a double $$,
+                                ie: $$(VAR_NAME). Escaped references will never be
+                                expanded, regardless of whether the variable exists
+                                or not. Cannot be updated. More info: https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell'
+                              items:
+                                type: string
+                              type: array
+                            command:
+                              description: 'Entrypoint array. Not executed within
+                                a shell. The docker image''s ENTRYPOINT is used if
+                                this is not provided. Variable references $(VAR_NAME)
+                                are expanded using the container''s environment. If
+                                a variable cannot be resolved, the reference in the
+                                input string will be unchanged. The $(VAR_NAME) syntax
+                                can be escaped with a double $$, ie: $$(VAR_NAME).
+                                Escaped references will never be expanded, regardless
+                                of whether the variable exists or not. Cannot be updated.
+                                More info: https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell'
+                              items:
+                                type: string
+                              type: array
+                            env:
+                              description: List of environment variables to set in
+                                the container. Cannot be updated.
+                              items:
+                                description: EnvVar represents an environment variable
+                                  present in a Container.
+                                properties:
+                                  name:
+                                    description: Name of the environment variable.
+                                      Must be a C_IDENTIFIER.
+                                    type: string
+                                  value:
+                                    description: 'Variable references $(VAR_NAME)
+                                      are expanded using the previous defined environment
+                                      variables in the container and any service environment
+                                      variables. If a variable cannot be resolved,
+                                      the reference in the input string will be unchanged.
+                                      The $(VAR_NAME) syntax can be escaped with a
+                                      double $$, ie: $$(VAR_NAME). Escaped references
+                                      will never be expanded, regardless of whether
+                                      the variable exists or not. Defaults to "".'
+                                    type: string
+                                  valueFrom:
+                                    description: Source for the environment variable's
+                                      value. Cannot be used if value is not empty.
+                                    properties:
+                                      configMapKeyRef:
+                                        description: Selects a key of a ConfigMap.
+                                        properties:
+                                          key:
+                                            description: The key to select.
+                                            type: string
+                                          name:
+                                            description: 'Name of the referent. More
+                                              info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                              TODO: Add other useful fields. apiVersion,
+                                              kind, uid?'
+                                            type: string
+                                          optional:
+                                            description: Specify whether the ConfigMap
+                                              or its key must be defined
+                                            type: boolean
+                                        required:
+                                        - key
+                                        type: object
+                                      fieldRef:
+                                        description: 'Selects a field of the pod:
+                                          supports metadata.name, metadata.namespace,
+                                          metadata.labels, metadata.annotations, spec.nodeName,
+                                          spec.serviceAccountName, status.hostIP,
+                                          status.podIP.'
+                                        properties:
+                                          apiVersion:
+                                            description: Version of the schema the
+                                              FieldPath is written in terms of, defaults
+                                              to "v1".
+                                            type: string
+                                          fieldPath:
+                                            description: Path of the field to select
+                                              in the specified API version.
+                                            type: string
+                                        required:
+                                        - fieldPath
+                                        type: object
+                                      resourceFieldRef:
+                                        description: 'Selects a resource of the container:
+                                          only resources limits and requests (limits.cpu,
+                                          limits.memory, limits.ephemeral-storage,
+                                          requests.cpu, requests.memory and requests.ephemeral-storage)
+                                          are currently supported.'
+                                        properties:
+                                          containerName:
+                                            description: 'Container name: required
+                                              for volumes, optional for env vars'
+                                            type: string
+                                          divisor:
+                                            description: Specifies the output format
+                                              of the exposed resources, defaults to
+                                              "1"
+                                            type: string
+                                          resource:
+                                            description: 'Required: resource to select'
+                                            type: string
+                                        required:
+                                        - resource
+                                        type: object
+                                      secretKeyRef:
+                                        description: Selects a key of a secret in
+                                          the pod's namespace
+                                        properties:
+                                          key:
+                                            description: The key of the secret to
+                                              select from.  Must be a valid secret
+                                              key.
+                                            type: string
+                                          name:
+                                            description: 'Name of the referent. More
+                                              info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                              TODO: Add other useful fields. apiVersion,
+                                              kind, uid?'
+                                            type: string
+                                          optional:
+                                            description: Specify whether the Secret
+                                              or its key must be defined
+                                            type: boolean
+                                        required:
+                                        - key
+                                        type: object
+                                    type: object
+                                required:
+                                - name
+                                type: object
+                              type: array
+                            envFrom:
+                              description: List of sources to populate environment
+                                variables in the container. The keys defined within
+                                a source must be a C_IDENTIFIER. All invalid keys
+                                will be reported as an event when the container is
+                                starting. When a key exists in multiple sources, the
+                                value associated with the last source will take precedence.
+                                Values defined by an Env with a duplicate key will
+                                take precedence. Cannot be updated.
+                              items:
+                                description: EnvFromSource represents the source of
+                                  a set of ConfigMaps
+                                properties:
+                                  configMapRef:
+                                    description: The ConfigMap to select from
+                                    properties:
+                                      name:
+                                        description: 'Name of the referent. More info:
+                                          https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                          TODO: Add other useful fields. apiVersion,
+                                          kind, uid?'
+                                        type: string
+                                      optional:
+                                        description: Specify whether the ConfigMap
+                                          must be defined
+                                        type: boolean
+                                    type: object
+                                  prefix:
+                                    description: An optional identifier to prepend
+                                      to each key in the ConfigMap. Must be a C_IDENTIFIER.
+                                    type: string
+                                  secretRef:
+                                    description: The Secret to select from
+                                    properties:
+                                      name:
+                                        description: 'Name of the referent. More info:
+                                          https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                          TODO: Add other useful fields. apiVersion,
+                                          kind, uid?'
+                                        type: string
+                                      optional:
+                                        description: Specify whether the Secret must
+                                          be defined
+                                        type: boolean
+                                    type: object
+                                type: object
+                              type: array
+                            image:
+                              description: 'Docker image name. More info: https://kubernetes.io/docs/concepts/containers/images
+                                This field is optional to allow higher level config
+                                management to default or override container images
+                                in workload controllers like Deployments and StatefulSets.'
+                              type: string
+                            imagePullPolicy:
+                              description: 'Image pull policy. One of Always, Never,
+                                IfNotPresent. Defaults to Always if :v0.3.0 tag is
+                                specified, or IfNotPresent otherwise. Cannot be updated.
+                                More info: https://kubernetes.io/docs/concepts/containers/images#updating-images'
+                              type: string
+                            lifecycle:
+                              description: Actions that the management system should
+                                take in response to container lifecycle events. Cannot
+                                be updated.
+                              properties:
+                                postStart:
+                                  description: 'PostStart is called immediately after
+                                    a container is created. If the handler fails,
+                                    the container is terminated and restarted according
+                                    to its restart policy. Other management of the
+                                    container blocks until the hook completes. More
+                                    info: https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/#container-hooks'
+                                  properties:
+                                    exec:
+                                      description: One and only one of the following
+                                        should be specified. Exec specifies the action
+                                        to take.
+                                      properties:
+                                        command:
+                                          description: Command is the command line
+                                            to execute inside the container, the working
+                                            directory for the command  is root ('/')
+                                            in the container's filesystem. The command
+                                            is simply exec'd, it is not run inside
+                                            a shell, so traditional shell instructions
+                                            ('|', etc) won't work. To use a shell,
+                                            you need to explicitly call out to that
+                                            shell. Exit status of 0 is treated as
+                                            live/healthy and non-zero is unhealthy.
+                                          items:
+                                            type: string
+                                          type: array
+                                      type: object
+                                    httpGet:
+                                      description: HTTPGet specifies the http request
+                                        to perform.
+                                      properties:
+                                        host:
+                                          description: Host name to connect to, defaults
+                                            to the pod IP. You probably want to set
+                                            "Host" in httpHeaders instead.
+                                          type: string
+                                        httpHeaders:
+                                          description: Custom headers to set in the
+                                            request. HTTP allows repeated headers.
+                                          items:
+                                            description: HTTPHeader describes a custom
+                                              header to be used in HTTP probes
+                                            properties:
+                                              name:
+                                                description: The header field name
+                                                type: string
+                                              value:
+                                                description: The header field value
+                                                type: string
+                                            required:
+                                            - name
+                                            - value
+                                            type: object
+                                          type: array
+                                        path:
+                                          description: Path to access on the HTTP
+                                            server.
+                                          type: string
+                                        port:
+                                          anyOf:
+                                          - type: string
+                                          - type: integer
+                                          description: Name or number of the port
+                                            to access on the container. Number must
+                                            be in the range 1 to 65535. Name must
+                                            be an IANA_SVC_NAME.
+                                        scheme:
+                                          description: Scheme to use for connecting
+                                            to the host. Defaults to HTTP.
+                                          type: string
+                                      required:
+                                      - port
+                                      type: object
+                                    tcpSocket:
+                                      description: 'TCPSocket specifies an action
+                                        involving a TCP port. TCP hooks not yet supported
+                                        TODO: implement a realistic TCP lifecycle
+                                        hook'
+                                      properties:
+                                        host:
+                                          description: 'Optional: Host name to connect
+                                            to, defaults to the pod IP.'
+                                          type: string
+                                        port:
+                                          anyOf:
+                                          - type: string
+                                          - type: integer
+                                          description: Number or name of the port
+                                            to access on the container. Number must
+                                            be in the range 1 to 65535. Name must
+                                            be an IANA_SVC_NAME.
+                                      required:
+                                      - port
+                                      type: object
+                                  type: object
+                                preStop:
+                                  description: 'PreStop is called immediately before
+                                    a container is terminated due to an API request
+                                    or management event such as liveness probe failure,
+                                    preemption, resource contention, etc. The handler
+                                    is not called if the container crashes or exits.
+                                    The reason for termination is passed to the handler.
+                                    The Pod''s termination grace period countdown
+                                    begins before the PreStop hooked is executed.
+                                    Regardless of the outcome of the handler, the
+                                    container will eventually terminate within the
+                                    Pod''s termination grace period. Other management
+                                    of the container blocks until the hook completes
+                                    or until the termination grace period is reached.
+                                    More info: https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/#container-hooks'
+                                  properties:
+                                    exec:
+                                      description: One and only one of the following
+                                        should be specified. Exec specifies the action
+                                        to take.
+                                      properties:
+                                        command:
+                                          description: Command is the command line
+                                            to execute inside the container, the working
+                                            directory for the command  is root ('/')
+                                            in the container's filesystem. The command
+                                            is simply exec'd, it is not run inside
+                                            a shell, so traditional shell instructions
+                                            ('|', etc) won't work. To use a shell,
+                                            you need to explicitly call out to that
+                                            shell. Exit status of 0 is treated as
+                                            live/healthy and non-zero is unhealthy.
+                                          items:
+                                            type: string
+                                          type: array
+                                      type: object
+                                    httpGet:
+                                      description: HTTPGet specifies the http request
+                                        to perform.
+                                      properties:
+                                        host:
+                                          description: Host name to connect to, defaults
+                                            to the pod IP. You probably want to set
+                                            "Host" in httpHeaders instead.
+                                          type: string
+                                        httpHeaders:
+                                          description: Custom headers to set in the
+                                            request. HTTP allows repeated headers.
+                                          items:
+                                            description: HTTPHeader describes a custom
+                                              header to be used in HTTP probes
+                                            properties:
+                                              name:
+                                                description: The header field name
+                                                type: string
+                                              value:
+                                                description: The header field value
+                                                type: string
+                                            required:
+                                            - name
+                                            - value
+                                            type: object
+                                          type: array
+                                        path:
+                                          description: Path to access on the HTTP
+                                            server.
+                                          type: string
+                                        port:
+                                          anyOf:
+                                          - type: string
+                                          - type: integer
+                                          description: Name or number of the port
+                                            to access on the container. Number must
+                                            be in the range 1 to 65535. Name must
+                                            be an IANA_SVC_NAME.
+                                        scheme:
+                                          description: Scheme to use for connecting
+                                            to the host. Defaults to HTTP.
+                                          type: string
+                                      required:
+                                      - port
+                                      type: object
+                                    tcpSocket:
+                                      description: 'TCPSocket specifies an action
+                                        involving a TCP port. TCP hooks not yet supported
+                                        TODO: implement a realistic TCP lifecycle
+                                        hook'
+                                      properties:
+                                        host:
+                                          description: 'Optional: Host name to connect
+                                            to, defaults to the pod IP.'
+                                          type: string
+                                        port:
+                                          anyOf:
+                                          - type: string
+                                          - type: integer
+                                          description: Number or name of the port
+                                            to access on the container. Number must
+                                            be in the range 1 to 65535. Name must
+                                            be an IANA_SVC_NAME.
+                                      required:
+                                      - port
+                                      type: object
+                                  type: object
+                              type: object
+                            livenessProbe:
+                              description: 'Periodic probe of container liveness.
+                                Container will be restarted if the probe fails. Cannot
+                                be updated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                              properties:
+                                exec:
+                                  description: One and only one of the following should
+                                    be specified. Exec specifies the action to take.
+                                  properties:
+                                    command:
+                                      description: Command is the command line to
+                                        execute inside the container, the working
+                                        directory for the command  is root ('/') in
+                                        the container's filesystem. The command is
+                                        simply exec'd, it is not run inside a shell,
+                                        so traditional shell instructions ('|', etc)
+                                        won't work. To use a shell, you need to explicitly
+                                        call out to that shell. Exit status of 0 is
+                                        treated as live/healthy and non-zero is unhealthy.
+                                      items:
+                                        type: string
+                                      type: array
+                                  type: object
+                                failureThreshold:
+                                  description: Minimum consecutive failures for the
+                                    probe to be considered failed after having succeeded.
+                                    Defaults to 3. Minimum value is 1.
+                                  format: int32
+                                  type: integer
+                                httpGet:
+                                  description: HTTPGet specifies the http request
+                                    to perform.
+                                  properties:
+                                    host:
+                                      description: Host name to connect to, defaults
+                                        to the pod IP. You probably want to set "Host"
+                                        in httpHeaders instead.
+                                      type: string
+                                    httpHeaders:
+                                      description: Custom headers to set in the request.
+                                        HTTP allows repeated headers.
+                                      items:
+                                        description: HTTPHeader describes a custom
+                                          header to be used in HTTP probes
+                                        properties:
+                                          name:
+                                            description: The header field name
+                                            type: string
+                                          value:
+                                            description: The header field value
+                                            type: string
+                                        required:
+                                        - name
+                                        - value
+                                        type: object
+                                      type: array
+                                    path:
+                                      description: Path to access on the HTTP server.
+                                      type: string
+                                    port:
+                                      anyOf:
+                                      - type: string
+                                      - type: integer
+                                      description: Name or number of the port to access
+                                        on the container. Number must be in the range
+                                        1 to 65535. Name must be an IANA_SVC_NAME.
+                                    scheme:
+                                      description: Scheme to use for connecting to
+                                        the host. Defaults to HTTP.
+                                      type: string
+                                  required:
+                                  - port
+                                  type: object
+                                initialDelaySeconds:
+                                  description: 'Number of seconds after the container
+                                    has started before liveness probes are initiated.
+                                    More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                                  format: int32
+                                  type: integer
+                                periodSeconds:
+                                  description: How often (in seconds) to perform the
+                                    probe. Default to 10 seconds. Minimum value is
+                                    1.
+                                  format: int32
+                                  type: integer
+                                successThreshold:
+                                  description: Minimum consecutive successes for the
+                                    probe to be considered successful after having
+                                    failed. Defaults to 1. Must be 1 for liveness.
+                                    Minimum value is 1.
+                                  format: int32
+                                  type: integer
+                                tcpSocket:
+                                  description: 'TCPSocket specifies an action involving
+                                    a TCP port. TCP hooks not yet supported TODO:
+                                    implement a realistic TCP lifecycle hook'
+                                  properties:
+                                    host:
+                                      description: 'Optional: Host name to connect
+                                        to, defaults to the pod IP.'
+                                      type: string
+                                    port:
+                                      anyOf:
+                                      - type: string
+                                      - type: integer
+                                      description: Number or name of the port to access
+                                        on the container. Number must be in the range
+                                        1 to 65535. Name must be an IANA_SVC_NAME.
+                                  required:
+                                  - port
+                                  type: object
+                                timeoutSeconds:
+                                  description: 'Number of seconds after which the
+                                    probe times out. Defaults to 1 second. Minimum
+                                    value is 1. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                                  format: int32
+                                  type: integer
+                              type: object
+                            name:
+                              description: Name of the container specified as a DNS_LABEL.
+                                Each container in a pod must have a unique name (DNS_LABEL).
+                                Cannot be updated.
+                              type: string
+                            ports:
+                              description: List of ports to expose from the container.
+                                Exposing a port here gives the system additional information
+                                about the network connections a container uses, but
+                                is primarily informational. Not specifying a port
+                                here DOES NOT prevent that port from being exposed.
+                                Any port which is listening on the default "0.0.0.0"
+                                address inside a container will be accessible from
+                                the network. Cannot be updated.
+                              items:
+                                description: ContainerPort represents a network port
+                                  in a single container.
+                                properties:
+                                  containerPort:
+                                    description: Number of port to expose on the pod's
+                                      IP address. This must be a valid port number,
+                                      0 < x < 65536.
+                                    format: int32
+                                    type: integer
+                                  hostIP:
+                                    description: What host IP to bind the external
+                                      port to.
+                                    type: string
+                                  hostPort:
+                                    description: Number of port to expose on the host.
+                                      If specified, this must be a valid port number,
+                                      0 < x < 65536. If HostNetwork is specified,
+                                      this must match ContainerPort. Most containers
+                                      do not need this.
+                                    format: int32
+                                    type: integer
+                                  name:
+                                    description: If specified, this must be an IANA_SVC_NAME
+                                      and unique within the pod. Each named port in
+                                      a pod must have a unique name. Name for the
+                                      port that can be referred to by services.
+                                    type: string
+                                  protocol:
+                                    description: Protocol for port. Must be UDP, TCP,
+                                      or SCTP. Defaults to "TCP".
+                                    type: string
+                                required:
+                                - containerPort
+                                type: object
+                              type: array
+                            readinessProbe:
+                              description: 'Periodic probe of container service readiness.
+                                Container will be removed from service endpoints if
+                                the probe fails. Cannot be updated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                              properties:
+                                exec:
+                                  description: One and only one of the following should
+                                    be specified. Exec specifies the action to take.
+                                  properties:
+                                    command:
+                                      description: Command is the command line to
+                                        execute inside the container, the working
+                                        directory for the command  is root ('/') in
+                                        the container's filesystem. The command is
+                                        simply exec'd, it is not run inside a shell,
+                                        so traditional shell instructions ('|', etc)
+                                        won't work. To use a shell, you need to explicitly
+                                        call out to that shell. Exit status of 0 is
+                                        treated as live/healthy and non-zero is unhealthy.
+                                      items:
+                                        type: string
+                                      type: array
+                                  type: object
+                                failureThreshold:
+                                  description: Minimum consecutive failures for the
+                                    probe to be considered failed after having succeeded.
+                                    Defaults to 3. Minimum value is 1.
+                                  format: int32
+                                  type: integer
+                                httpGet:
+                                  description: HTTPGet specifies the http request
+                                    to perform.
+                                  properties:
+                                    host:
+                                      description: Host name to connect to, defaults
+                                        to the pod IP. You probably want to set "Host"
+                                        in httpHeaders instead.
+                                      type: string
+                                    httpHeaders:
+                                      description: Custom headers to set in the request.
+                                        HTTP allows repeated headers.
+                                      items:
+                                        description: HTTPHeader describes a custom
+                                          header to be used in HTTP probes
+                                        properties:
+                                          name:
+                                            description: The header field name
+                                            type: string
+                                          value:
+                                            description: The header field value
+                                            type: string
+                                        required:
+                                        - name
+                                        - value
+                                        type: object
+                                      type: array
+                                    path:
+                                      description: Path to access on the HTTP server.
+                                      type: string
+                                    port:
+                                      anyOf:
+                                      - type: string
+                                      - type: integer
+                                      description: Name or number of the port to access
+                                        on the container. Number must be in the range
+                                        1 to 65535. Name must be an IANA_SVC_NAME.
+                                    scheme:
+                                      description: Scheme to use for connecting to
+                                        the host. Defaults to HTTP.
+                                      type: string
+                                  required:
+                                  - port
+                                  type: object
+                                initialDelaySeconds:
+                                  description: 'Number of seconds after the container
+                                    has started before liveness probes are initiated.
+                                    More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                                  format: int32
+                                  type: integer
+                                periodSeconds:
+                                  description: How often (in seconds) to perform the
+                                    probe. Default to 10 seconds. Minimum value is
+                                    1.
+                                  format: int32
+                                  type: integer
+                                successThreshold:
+                                  description: Minimum consecutive successes for the
+                                    probe to be considered successful after having
+                                    failed. Defaults to 1. Must be 1 for liveness.
+                                    Minimum value is 1.
+                                  format: int32
+                                  type: integer
+                                tcpSocket:
+                                  description: 'TCPSocket specifies an action involving
+                                    a TCP port. TCP hooks not yet supported TODO:
+                                    implement a realistic TCP lifecycle hook'
+                                  properties:
+                                    host:
+                                      description: 'Optional: Host name to connect
+                                        to, defaults to the pod IP.'
+                                      type: string
+                                    port:
+                                      anyOf:
+                                      - type: string
+                                      - type: integer
+                                      description: Number or name of the port to access
+                                        on the container. Number must be in the range
+                                        1 to 65535. Name must be an IANA_SVC_NAME.
+                                  required:
+                                  - port
+                                  type: object
+                                timeoutSeconds:
+                                  description: 'Number of seconds after which the
+                                    probe times out. Defaults to 1 second. Minimum
+                                    value is 1. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                                  format: int32
+                                  type: integer
+                              type: object
+                            resources:
+                              description: 'Compute Resources required by this container.
+                                Cannot be updated. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
+                              properties:
+                                limits:
+                                  additionalProperties:
+                                    type: string
+                                  description: 'Limits describes the maximum amount
+                                    of compute resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
+                                  type: object
+                                requests:
+                                  additionalProperties:
+                                    type: string
+                                  description: 'Requests describes the minimum amount
+                                    of compute resources required. If Requests is
+                                    omitted for a container, it defaults to Limits
+                                    if that is explicitly specified, otherwise to
+                                    an implementation-defined value. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
+                                  type: object
+                              type: object
+                            securityContext:
+                              description: 'Security options the pod should run with.
+                                More info: https://kubernetes.io/docs/concepts/policy/security-context/
+                                More info: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/'
+                              properties:
+                                allowPrivilegeEscalation:
+                                  description: 'AllowPrivilegeEscalation controls
+                                    whether a process can gain more privileges than
+                                    its parent process. This bool directly controls
+                                    if the no_new_privs flag will be set on the container
+                                    process. AllowPrivilegeEscalation is true always
+                                    when the container is: 1) run as Privileged 2)
+                                    has CAP_SYS_ADMIN'
+                                  type: boolean
+                                capabilities:
+                                  description: The capabilities to add/drop when running
+                                    containers. Defaults to the default set of capabilities
+                                    granted by the container runtime.
+                                  properties:
+                                    add:
+                                      description: Added capabilities
+                                      items:
+                                        description: Capability represent POSIX capabilities
+                                          type
+                                        type: string
+                                      type: array
+                                    drop:
+                                      description: Removed capabilities
+                                      items:
+                                        description: Capability represent POSIX capabilities
+                                          type
+                                        type: string
+                                      type: array
+                                  type: object
+                                privileged:
+                                  description: Run container in privileged mode. Processes
+                                    in privileged containers are essentially equivalent
+                                    to root on the host. Defaults to false.
+                                  type: boolean
+                                procMount:
+                                  description: procMount denotes the type of proc
+                                    mount to use for the containers. The default is
+                                    DefaultProcMount which uses the container runtime
+                                    defaults for readonly paths and masked paths.
+                                    This requires the ProcMountType feature flag to
+                                    be enabled.
+                                  type: string
+                                readOnlyRootFilesystem:
+                                  description: Whether this container has a read-only
+                                    root filesystem. Default is false.
+                                  type: boolean
+                                runAsGroup:
+                                  description: The GID to run the entrypoint of the
+                                    container process. Uses runtime default if unset.
+                                    May also be set in PodSecurityContext.  If set
+                                    in both SecurityContext and PodSecurityContext,
+                                    the value specified in SecurityContext takes precedence.
+                                  format: int64
+                                  type: integer
+                                runAsNonRoot:
+                                  description: Indicates that the container must run
+                                    as a non-root user. If true, the Kubelet will
+                                    validate the image at runtime to ensure that it
+                                    does not run as UID 0 (root) and fail to start
+                                    the container if it does. If unset or false, no
+                                    such validation will be performed. May also be
+                                    set in PodSecurityContext.  If set in both SecurityContext
+                                    and PodSecurityContext, the value specified in
+                                    SecurityContext takes precedence.
+                                  type: boolean
+                                runAsUser:
+                                  description: The UID to run the entrypoint of the
+                                    container process. Defaults to user specified
+                                    in image metadata if unspecified. May also be
+                                    set in PodSecurityContext.  If set in both SecurityContext
+                                    and PodSecurityContext, the value specified in
+                                    SecurityContext takes precedence.
+                                  format: int64
+                                  type: integer
+                                seLinuxOptions:
+                                  description: The SELinux context to be applied to
+                                    the container. If unspecified, the container runtime
+                                    will allocate a random SELinux context for each
+                                    container.  May also be set in PodSecurityContext.  If
+                                    set in both SecurityContext and PodSecurityContext,
+                                    the value specified in SecurityContext takes precedence.
+                                  properties:
+                                    level:
+                                      description: Level is SELinux level label that
+                                        applies to the container.
+                                      type: string
+                                    role:
+                                      description: Role is a SELinux role label that
+                                        applies to the container.
+                                      type: string
+                                    type:
+                                      description: Type is a SELinux type label that
+                                        applies to the container.
+                                      type: string
+                                    user:
+                                      description: User is a SELinux user label that
+                                        applies to the container.
+                                      type: string
+                                  type: object
+                                windowsOptions:
+                                  description: Windows security options.
+                                  properties:
+                                    gmsaCredentialSpec:
+                                      description: GMSACredentialSpec is where the
+                                        GMSA admission webhook (https://github.com/kubernetes-sigs/windows-gmsa)
+                                        inlines the contents of the GMSA credential
+                                        spec named by the GMSACredentialSpecName field.
+                                        This field is alpha-level and is only honored
+                                        by servers that enable the WindowsGMSA feature
+                                        flag.
+                                      type: string
+                                    gmsaCredentialSpecName:
+                                      description: GMSACredentialSpecName is the name
+                                        of the GMSA credential spec to use. This field
+                                        is alpha-level and is only honored by servers
+                                        that enable the WindowsGMSA feature flag.
+                                      type: string
+                                  type: object
+                              type: object
+                            stdin:
+                              description: Whether this container should allocate
+                                a buffer for stdin in the container runtime. If this
+                                is not set, reads from stdin in the container will
+                                always result in EOF. Default is false.
+                              type: boolean
+                            stdinOnce:
+                              description: Whether the container runtime should close
+                                the stdin channel after it has been opened by a single
+                                attach. When stdin is true the stdin stream will remain
+                                open across multiple attach sessions. If stdinOnce
+                                is set to true, stdin is opened on container start,
+                                is empty until the first client attaches to stdin,
+                                and then remains open and accepts data until the client
+                                disconnects, at which time stdin is closed and remains
+                                closed until the container is restarted. If this flag
+                                is false, a container processes that reads from stdin
+                                will never receive an EOF. Default is false
+                              type: boolean
+                            terminationMessagePath:
+                              description: 'Optional: Path at which the file to which
+                                the container''s termination message will be written
+                                is mounted into the container''s filesystem. Message
+                                written is intended to be brief final status, such
+                                as an assertion failure message. Will be truncated
+                                by the node if greater than 4096 bytes. The total
+                                message length across all containers will be limited
+                                to 12kb. Defaults to /dev/termination-log. Cannot
+                                be updated.'
+                              type: string
+                            terminationMessagePolicy:
+                              description: Indicate how the termination message should
+                                be populated. File will use the contents of terminationMessagePath
+                                to populate the container status message on both success
+                                and failure. FallbackToLogsOnError will use the last
+                                chunk of container log output if the termination message
+                                file is empty and the container exited with an error.
+                                The log output is limited to 2048 bytes or 80 lines,
+                                whichever is smaller. Defaults to File. Cannot be
+                                updated.
+                              type: string
+                            tty:
+                              description: Whether this container should allocate
+                                a TTY for itself, also requires 'stdin' to be true.
+                                Default is false.
+                              type: boolean
+                            volumeDevices:
+                              description: volumeDevices is the list of block devices
+                                to be used by the container. This is a beta feature.
+                              items:
+                                description: volumeDevice describes a mapping of a
+                                  raw block device within a container.
+                                properties:
+                                  devicePath:
+                                    description: devicePath is the path inside of
+                                      the container that the device will be mapped
+                                      to.
+                                    type: string
+                                  name:
+                                    description: name must match the name of a persistentVolumeClaim
+                                      in the pod
+                                    type: string
+                                required:
+                                - devicePath
+                                - name
+                                type: object
+                              type: array
+                            volumeMounts:
+                              description: Pod volumes to mount into the container's
+                                filesystem. Cannot be updated.
+                              items:
+                                description: VolumeMount describes a mounting of a
+                                  Volume within a container.
+                                properties:
+                                  mountPath:
+                                    description: Path within the container at which
+                                      the volume should be mounted.  Must not contain
+                                      ':'.
+                                    type: string
+                                  mountPropagation:
+                                    description: mountPropagation determines how mounts
+                                      are propagated from the host to container and
+                                      the other way around. When not set, MountPropagationNone
+                                      is used. This field is beta in 1.10.
+                                    type: string
+                                  name:
+                                    description: This must match the Name of a Volume.
+                                    type: string
+                                  readOnly:
+                                    description: Mounted read-only if true, read-write
+                                      otherwise (false or unspecified). Defaults to
+                                      false.
+                                    type: boolean
+                                  subPath:
+                                    description: Path within the volume from which
+                                      the container's volume should be mounted. Defaults
+                                      to "" (volume's root).
+                                    type: string
+                                  subPathExpr:
+                                    description: Expanded path within the volume from
+                                      which the container's volume should be mounted.
+                                      Behaves similarly to SubPath but environment
+                                      variable references $(VAR_NAME) are expanded
+                                      using the container's environment. Defaults
+                                      to "" (volume's root). SubPathExpr and SubPath
+                                      are mutually exclusive. This field is beta in
+                                      1.15.
+                                    type: string
+                                required:
+                                - mountPath
+                                - name
+                                type: object
+                              type: array
+                            workingDir:
+                              description: Container's working directory. If not specified,
+                                the container runtime's default will be used, which
+                                might be configured in the container image. Cannot
+                                be updated.
+                              type: string
+                          required:
+                          - name
+                          type: object
+                      required:
+                      - container
+                      type: object
+                    logger:
+                      description: Activate request/response logging
+                      properties:
+                        mode:
+                          description: What payloads to log
+                          type: string
+                        url:
+                          description: URL to send request logging CloudEvents
+                          type: string
+                      type: object
+                    maxReplicas:
+                      description: This is the up bound for autoscaler to scale to
+                      type: integer
+                    minReplicas:
+                      description: Minimum number of replicas, pods won't scale down
+                        to 0 in case of no traffic
+                      type: integer
+                    onnx:
+                      description: Spec for ONNX runtime (https://github.com/microsoft/onnxruntime)
+                      properties:
+                        resources:
+                          description: Defaults to requests and limits of 1CPU, 2Gb
+                            MEM.
+                          properties:
+                            limits:
+                              additionalProperties:
+                                type: string
+                              description: 'Limits describes the maximum amount of
+                                compute resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
+                              type: object
+                            requests:
+                              additionalProperties:
+                                type: string
+                              description: 'Requests describes the minimum amount
+                                of compute resources required. If Requests is omitted
+                                for a container, it defaults to Limits if that is
+                                explicitly specified, otherwise to an implementation-defined
+                                value. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
+                              type: object
+                          type: object
+                        runtimeVersion:
+                          description: Allowed runtime versions are specified in the
+                            inferenceservice config map
+                          type: string
+                        storageUri:
+                          description: The location of the trained model
+                          type: string
+                      required:
+                      - storageUri
+                      type: object
+                    parallelism:
+                      description: Parallelism specifies how many requests can be
+                        processed concurrently, this sets the target concurrency for
+                        Autoscaling(KPA). For model servers that support tuning parallelism
+                        will use this value, by default the parallelism is the number
+                        of the CPU cores for most of the model servers.
+                      type: integer
+                    pytorch:
+                      description: Spec for PyTorch predictor
+                      properties:
+                        modelClassName:
+                          description: Defaults PyTorch model class name to 'PyTorchModel'
+                          type: string
+                        resources:
+                          description: Defaults to requests and limits of 1CPU, 2Gb
+                            MEM.
+                          properties:
+                            limits:
+                              additionalProperties:
+                                type: string
+                              description: 'Limits describes the maximum amount of
+                                compute resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
+                              type: object
+                            requests:
+                              additionalProperties:
+                                type: string
+                              description: 'Requests describes the minimum amount
+                                of compute resources required. If Requests is omitted
+                                for a container, it defaults to Limits if that is
+                                explicitly specified, otherwise to an implementation-defined
+                                value. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
+                              type: object
+                          type: object
+                        runtimeVersion:
+                          description: Allowed runtime versions are specified in the
+                            inferenceservice config map
+                          type: string
+                        storageUri:
+                          description: The location of the trained model
+                          type: string
+                      required:
+                      - storageUri
+                      type: object
+                    serviceAccountName:
+                      description: ServiceAccountName is the name of the ServiceAccount
+                        to use to run the service
+                      type: string
+                    sklearn:
+                      description: Spec for SKLearn predictor
+                      properties:
+                        resources:
+                          description: Defaults to requests and limits of 1CPU, 2Gb
+                            MEM.
+                          properties:
+                            limits:
+                              additionalProperties:
+                                type: string
+                              description: 'Limits describes the maximum amount of
+                                compute resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
+                              type: object
+                            requests:
+                              additionalProperties:
+                                type: string
+                              description: 'Requests describes the minimum amount
+                                of compute resources required. If Requests is omitted
+                                for a container, it defaults to Limits if that is
+                                explicitly specified, otherwise to an implementation-defined
+                                value. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
+                              type: object
+                          type: object
+                        runtimeVersion:
+                          description: Allowed runtime versions are specified in the
+                            inferenceservice config map
+                          type: string
+                        storageUri:
+                          description: The location of the trained model
+                          type: string
+                      required:
+                      - storageUri
+                      type: object
+                    tensorflow:
+                      description: Spec for Tensorflow Serving (https://github.com/tensorflow/serving)
+                      properties:
+                        resources:
+                          description: Defaults to requests and limits of 1CPU, 2Gb
+                            MEM.
+                          properties:
+                            limits:
+                              additionalProperties:
+                                type: string
+                              description: 'Limits describes the maximum amount of
+                                compute resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
+                              type: object
+                            requests:
+                              additionalProperties:
+                                type: string
+                              description: 'Requests describes the minimum amount
+                                of compute resources required. If Requests is omitted
+                                for a container, it defaults to Limits if that is
+                                explicitly specified, otherwise to an implementation-defined
+                                value. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
+                              type: object
+                          type: object
+                        runtimeVersion:
+                          description: Allowed runtime versions are specified in the
+                            inferenceservice config map.
+                          type: string
+                        storageUri:
+                          description: The location of the trained model
+                          type: string
+                      required:
+                      - storageUri
+                      type: object
+                    tensorrt:
+                      description: Spec for TensorRT Inference Server (https://github.com/NVIDIA/tensorrt-inference-server)
+                      properties:
+                        resources:
+                          description: Defaults to requests and limits of 1CPU, 2Gb
+                            MEM.
+                          properties:
+                            limits:
+                              additionalProperties:
+                                type: string
+                              description: 'Limits describes the maximum amount of
+                                compute resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
+                              type: object
+                            requests:
+                              additionalProperties:
+                                type: string
+                              description: 'Requests describes the minimum amount
+                                of compute resources required. If Requests is omitted
+                                for a container, it defaults to Limits if that is
+                                explicitly specified, otherwise to an implementation-defined
+                                value. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
+                              type: object
+                          type: object
+                        runtimeVersion:
+                          description: Allowed runtime versions are specified in the
+                            inferenceservice config map
+                          type: string
+                        storageUri:
+                          description: The location of the trained model
+                          type: string
+                      required:
+                      - storageUri
+                      type: object
+                    xgboost:
+                      description: Spec for XGBoost predictor
+                      properties:
+                        nthread:
+                          description: Number of thread to be used by XGBoost
+                          type: integer
+                        resources:
+                          description: Defaults to requests and limits of 1CPU, 2Gb
+                            MEM.
+                          properties:
+                            limits:
+                              additionalProperties:
+                                type: string
+                              description: 'Limits describes the maximum amount of
+                                compute resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
+                              type: object
+                            requests:
+                              additionalProperties:
+                                type: string
+                              description: 'Requests describes the minimum amount
+                                of compute resources required. If Requests is omitted
+                                for a container, it defaults to Limits if that is
+                                explicitly specified, otherwise to an implementation-defined
+                                value. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
+                              type: object
+                          type: object
+                        runtimeVersion:
+                          description: Allowed runtime versions are specified in the
+                            inferenceservice config map
+                          type: string
+                        storageUri:
+                          description: The location of the trained model
+                          type: string
+                      required:
+                      - storageUri
+                      type: object
+                  type: object
+                transformer:
+                  description: Transformer defines the pre/post processing before
+                    and after the predictor call, transformer service calls to predictor
+                    service.
+                  properties:
+                    custom:
+                      description: Spec for a custom transformer
+                      properties:
+                        container:
+                          description: A single application container that you want
+                            to run within a pod.
+                          properties:
+                            args:
+                              description: 'Arguments to the entrypoint. The docker
+                                image''s CMD is used if this is not provided. Variable
+                                references $(VAR_NAME) are expanded using the container''s
+                                environment. If a variable cannot be resolved, the
+                                reference in the input string will be unchanged. The
+                                $(VAR_NAME) syntax can be escaped with a double $$,
+                                ie: $$(VAR_NAME). Escaped references will never be
+                                expanded, regardless of whether the variable exists
+                                or not. Cannot be updated. More info: https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell'
+                              items:
+                                type: string
+                              type: array
+                            command:
+                              description: 'Entrypoint array. Not executed within
+                                a shell. The docker image''s ENTRYPOINT is used if
+                                this is not provided. Variable references $(VAR_NAME)
+                                are expanded using the container''s environment. If
+                                a variable cannot be resolved, the reference in the
+                                input string will be unchanged. The $(VAR_NAME) syntax
+                                can be escaped with a double $$, ie: $$(VAR_NAME).
+                                Escaped references will never be expanded, regardless
+                                of whether the variable exists or not. Cannot be updated.
+                                More info: https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell'
+                              items:
+                                type: string
+                              type: array
+                            env:
+                              description: List of environment variables to set in
+                                the container. Cannot be updated.
+                              items:
+                                description: EnvVar represents an environment variable
+                                  present in a Container.
+                                properties:
+                                  name:
+                                    description: Name of the environment variable.
+                                      Must be a C_IDENTIFIER.
+                                    type: string
+                                  value:
+                                    description: 'Variable references $(VAR_NAME)
+                                      are expanded using the previous defined environment
+                                      variables in the container and any service environment
+                                      variables. If a variable cannot be resolved,
+                                      the reference in the input string will be unchanged.
+                                      The $(VAR_NAME) syntax can be escaped with a
+                                      double $$, ie: $$(VAR_NAME). Escaped references
+                                      will never be expanded, regardless of whether
+                                      the variable exists or not. Defaults to "".'
+                                    type: string
+                                  valueFrom:
+                                    description: Source for the environment variable's
+                                      value. Cannot be used if value is not empty.
+                                    properties:
+                                      configMapKeyRef:
+                                        description: Selects a key of a ConfigMap.
+                                        properties:
+                                          key:
+                                            description: The key to select.
+                                            type: string
+                                          name:
+                                            description: 'Name of the referent. More
+                                              info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                              TODO: Add other useful fields. apiVersion,
+                                              kind, uid?'
+                                            type: string
+                                          optional:
+                                            description: Specify whether the ConfigMap
+                                              or its key must be defined
+                                            type: boolean
+                                        required:
+                                        - key
+                                        type: object
+                                      fieldRef:
+                                        description: 'Selects a field of the pod:
+                                          supports metadata.name, metadata.namespace,
+                                          metadata.labels, metadata.annotations, spec.nodeName,
+                                          spec.serviceAccountName, status.hostIP,
+                                          status.podIP.'
+                                        properties:
+                                          apiVersion:
+                                            description: Version of the schema the
+                                              FieldPath is written in terms of, defaults
+                                              to "v1".
+                                            type: string
+                                          fieldPath:
+                                            description: Path of the field to select
+                                              in the specified API version.
+                                            type: string
+                                        required:
+                                        - fieldPath
+                                        type: object
+                                      resourceFieldRef:
+                                        description: 'Selects a resource of the container:
+                                          only resources limits and requests (limits.cpu,
+                                          limits.memory, limits.ephemeral-storage,
+                                          requests.cpu, requests.memory and requests.ephemeral-storage)
+                                          are currently supported.'
+                                        properties:
+                                          containerName:
+                                            description: 'Container name: required
+                                              for volumes, optional for env vars'
+                                            type: string
+                                          divisor:
+                                            description: Specifies the output format
+                                              of the exposed resources, defaults to
+                                              "1"
+                                            type: string
+                                          resource:
+                                            description: 'Required: resource to select'
+                                            type: string
+                                        required:
+                                        - resource
+                                        type: object
+                                      secretKeyRef:
+                                        description: Selects a key of a secret in
+                                          the pod's namespace
+                                        properties:
+                                          key:
+                                            description: The key of the secret to
+                                              select from.  Must be a valid secret
+                                              key.
+                                            type: string
+                                          name:
+                                            description: 'Name of the referent. More
+                                              info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                              TODO: Add other useful fields. apiVersion,
+                                              kind, uid?'
+                                            type: string
+                                          optional:
+                                            description: Specify whether the Secret
+                                              or its key must be defined
+                                            type: boolean
+                                        required:
+                                        - key
+                                        type: object
+                                    type: object
+                                required:
+                                - name
+                                type: object
+                              type: array
+                            envFrom:
+                              description: List of sources to populate environment
+                                variables in the container. The keys defined within
+                                a source must be a C_IDENTIFIER. All invalid keys
+                                will be reported as an event when the container is
+                                starting. When a key exists in multiple sources, the
+                                value associated with the last source will take precedence.
+                                Values defined by an Env with a duplicate key will
+                                take precedence. Cannot be updated.
+                              items:
+                                description: EnvFromSource represents the source of
+                                  a set of ConfigMaps
+                                properties:
+                                  configMapRef:
+                                    description: The ConfigMap to select from
+                                    properties:
+                                      name:
+                                        description: 'Name of the referent. More info:
+                                          https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                          TODO: Add other useful fields. apiVersion,
+                                          kind, uid?'
+                                        type: string
+                                      optional:
+                                        description: Specify whether the ConfigMap
+                                          must be defined
+                                        type: boolean
+                                    type: object
+                                  prefix:
+                                    description: An optional identifier to prepend
+                                      to each key in the ConfigMap. Must be a C_IDENTIFIER.
+                                    type: string
+                                  secretRef:
+                                    description: The Secret to select from
+                                    properties:
+                                      name:
+                                        description: 'Name of the referent. More info:
+                                          https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                          TODO: Add other useful fields. apiVersion,
+                                          kind, uid?'
+                                        type: string
+                                      optional:
+                                        description: Specify whether the Secret must
+                                          be defined
+                                        type: boolean
+                                    type: object
+                                type: object
+                              type: array
+                            image:
+                              description: 'Docker image name. More info: https://kubernetes.io/docs/concepts/containers/images
+                                This field is optional to allow higher level config
+                                management to default or override container images
+                                in workload controllers like Deployments and StatefulSets.'
+                              type: string
+                            imagePullPolicy:
+                              description: 'Image pull policy. One of Always, Never,
+                                IfNotPresent. Defaults to Always if :v0.3.0 tag is
+                                specified, or IfNotPresent otherwise. Cannot be updated.
+                                More info: https://kubernetes.io/docs/concepts/containers/images#updating-images'
+                              type: string
+                            lifecycle:
+                              description: Actions that the management system should
+                                take in response to container lifecycle events. Cannot
+                                be updated.
+                              properties:
+                                postStart:
+                                  description: 'PostStart is called immediately after
+                                    a container is created. If the handler fails,
+                                    the container is terminated and restarted according
+                                    to its restart policy. Other management of the
+                                    container blocks until the hook completes. More
+                                    info: https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/#container-hooks'
+                                  properties:
+                                    exec:
+                                      description: One and only one of the following
+                                        should be specified. Exec specifies the action
+                                        to take.
+                                      properties:
+                                        command:
+                                          description: Command is the command line
+                                            to execute inside the container, the working
+                                            directory for the command  is root ('/')
+                                            in the container's filesystem. The command
+                                            is simply exec'd, it is not run inside
+                                            a shell, so traditional shell instructions
+                                            ('|', etc) won't work. To use a shell,
+                                            you need to explicitly call out to that
+                                            shell. Exit status of 0 is treated as
+                                            live/healthy and non-zero is unhealthy.
+                                          items:
+                                            type: string
+                                          type: array
+                                      type: object
+                                    httpGet:
+                                      description: HTTPGet specifies the http request
+                                        to perform.
+                                      properties:
+                                        host:
+                                          description: Host name to connect to, defaults
+                                            to the pod IP. You probably want to set
+                                            "Host" in httpHeaders instead.
+                                          type: string
+                                        httpHeaders:
+                                          description: Custom headers to set in the
+                                            request. HTTP allows repeated headers.
+                                          items:
+                                            description: HTTPHeader describes a custom
+                                              header to be used in HTTP probes
+                                            properties:
+                                              name:
+                                                description: The header field name
+                                                type: string
+                                              value:
+                                                description: The header field value
+                                                type: string
+                                            required:
+                                            - name
+                                            - value
+                                            type: object
+                                          type: array
+                                        path:
+                                          description: Path to access on the HTTP
+                                            server.
+                                          type: string
+                                        port:
+                                          anyOf:
+                                          - type: string
+                                          - type: integer
+                                          description: Name or number of the port
+                                            to access on the container. Number must
+                                            be in the range 1 to 65535. Name must
+                                            be an IANA_SVC_NAME.
+                                        scheme:
+                                          description: Scheme to use for connecting
+                                            to the host. Defaults to HTTP.
+                                          type: string
+                                      required:
+                                      - port
+                                      type: object
+                                    tcpSocket:
+                                      description: 'TCPSocket specifies an action
+                                        involving a TCP port. TCP hooks not yet supported
+                                        TODO: implement a realistic TCP lifecycle
+                                        hook'
+                                      properties:
+                                        host:
+                                          description: 'Optional: Host name to connect
+                                            to, defaults to the pod IP.'
+                                          type: string
+                                        port:
+                                          anyOf:
+                                          - type: string
+                                          - type: integer
+                                          description: Number or name of the port
+                                            to access on the container. Number must
+                                            be in the range 1 to 65535. Name must
+                                            be an IANA_SVC_NAME.
+                                      required:
+                                      - port
+                                      type: object
+                                  type: object
+                                preStop:
+                                  description: 'PreStop is called immediately before
+                                    a container is terminated due to an API request
+                                    or management event such as liveness probe failure,
+                                    preemption, resource contention, etc. The handler
+                                    is not called if the container crashes or exits.
+                                    The reason for termination is passed to the handler.
+                                    The Pod''s termination grace period countdown
+                                    begins before the PreStop hooked is executed.
+                                    Regardless of the outcome of the handler, the
+                                    container will eventually terminate within the
+                                    Pod''s termination grace period. Other management
+                                    of the container blocks until the hook completes
+                                    or until the termination grace period is reached.
+                                    More info: https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/#container-hooks'
+                                  properties:
+                                    exec:
+                                      description: One and only one of the following
+                                        should be specified. Exec specifies the action
+                                        to take.
+                                      properties:
+                                        command:
+                                          description: Command is the command line
+                                            to execute inside the container, the working
+                                            directory for the command  is root ('/')
+                                            in the container's filesystem. The command
+                                            is simply exec'd, it is not run inside
+                                            a shell, so traditional shell instructions
+                                            ('|', etc) won't work. To use a shell,
+                                            you need to explicitly call out to that
+                                            shell. Exit status of 0 is treated as
+                                            live/healthy and non-zero is unhealthy.
+                                          items:
+                                            type: string
+                                          type: array
+                                      type: object
+                                    httpGet:
+                                      description: HTTPGet specifies the http request
+                                        to perform.
+                                      properties:
+                                        host:
+                                          description: Host name to connect to, defaults
+                                            to the pod IP. You probably want to set
+                                            "Host" in httpHeaders instead.
+                                          type: string
+                                        httpHeaders:
+                                          description: Custom headers to set in the
+                                            request. HTTP allows repeated headers.
+                                          items:
+                                            description: HTTPHeader describes a custom
+                                              header to be used in HTTP probes
+                                            properties:
+                                              name:
+                                                description: The header field name
+                                                type: string
+                                              value:
+                                                description: The header field value
+                                                type: string
+                                            required:
+                                            - name
+                                            - value
+                                            type: object
+                                          type: array
+                                        path:
+                                          description: Path to access on the HTTP
+                                            server.
+                                          type: string
+                                        port:
+                                          anyOf:
+                                          - type: string
+                                          - type: integer
+                                          description: Name or number of the port
+                                            to access on the container. Number must
+                                            be in the range 1 to 65535. Name must
+                                            be an IANA_SVC_NAME.
+                                        scheme:
+                                          description: Scheme to use for connecting
+                                            to the host. Defaults to HTTP.
+                                          type: string
+                                      required:
+                                      - port
+                                      type: object
+                                    tcpSocket:
+                                      description: 'TCPSocket specifies an action
+                                        involving a TCP port. TCP hooks not yet supported
+                                        TODO: implement a realistic TCP lifecycle
+                                        hook'
+                                      properties:
+                                        host:
+                                          description: 'Optional: Host name to connect
+                                            to, defaults to the pod IP.'
+                                          type: string
+                                        port:
+                                          anyOf:
+                                          - type: string
+                                          - type: integer
+                                          description: Number or name of the port
+                                            to access on the container. Number must
+                                            be in the range 1 to 65535. Name must
+                                            be an IANA_SVC_NAME.
+                                      required:
+                                      - port
+                                      type: object
+                                  type: object
+                              type: object
+                            livenessProbe:
+                              description: 'Periodic probe of container liveness.
+                                Container will be restarted if the probe fails. Cannot
+                                be updated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                              properties:
+                                exec:
+                                  description: One and only one of the following should
+                                    be specified. Exec specifies the action to take.
+                                  properties:
+                                    command:
+                                      description: Command is the command line to
+                                        execute inside the container, the working
+                                        directory for the command  is root ('/') in
+                                        the container's filesystem. The command is
+                                        simply exec'd, it is not run inside a shell,
+                                        so traditional shell instructions ('|', etc)
+                                        won't work. To use a shell, you need to explicitly
+                                        call out to that shell. Exit status of 0 is
+                                        treated as live/healthy and non-zero is unhealthy.
+                                      items:
+                                        type: string
+                                      type: array
+                                  type: object
+                                failureThreshold:
+                                  description: Minimum consecutive failures for the
+                                    probe to be considered failed after having succeeded.
+                                    Defaults to 3. Minimum value is 1.
+                                  format: int32
+                                  type: integer
+                                httpGet:
+                                  description: HTTPGet specifies the http request
+                                    to perform.
+                                  properties:
+                                    host:
+                                      description: Host name to connect to, defaults
+                                        to the pod IP. You probably want to set "Host"
+                                        in httpHeaders instead.
+                                      type: string
+                                    httpHeaders:
+                                      description: Custom headers to set in the request.
+                                        HTTP allows repeated headers.
+                                      items:
+                                        description: HTTPHeader describes a custom
+                                          header to be used in HTTP probes
+                                        properties:
+                                          name:
+                                            description: The header field name
+                                            type: string
+                                          value:
+                                            description: The header field value
+                                            type: string
+                                        required:
+                                        - name
+                                        - value
+                                        type: object
+                                      type: array
+                                    path:
+                                      description: Path to access on the HTTP server.
+                                      type: string
+                                    port:
+                                      anyOf:
+                                      - type: string
+                                      - type: integer
+                                      description: Name or number of the port to access
+                                        on the container. Number must be in the range
+                                        1 to 65535. Name must be an IANA_SVC_NAME.
+                                    scheme:
+                                      description: Scheme to use for connecting to
+                                        the host. Defaults to HTTP.
+                                      type: string
+                                  required:
+                                  - port
+                                  type: object
+                                initialDelaySeconds:
+                                  description: 'Number of seconds after the container
+                                    has started before liveness probes are initiated.
+                                    More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                                  format: int32
+                                  type: integer
+                                periodSeconds:
+                                  description: How often (in seconds) to perform the
+                                    probe. Default to 10 seconds. Minimum value is
+                                    1.
+                                  format: int32
+                                  type: integer
+                                successThreshold:
+                                  description: Minimum consecutive successes for the
+                                    probe to be considered successful after having
+                                    failed. Defaults to 1. Must be 1 for liveness.
+                                    Minimum value is 1.
+                                  format: int32
+                                  type: integer
+                                tcpSocket:
+                                  description: 'TCPSocket specifies an action involving
+                                    a TCP port. TCP hooks not yet supported TODO:
+                                    implement a realistic TCP lifecycle hook'
+                                  properties:
+                                    host:
+                                      description: 'Optional: Host name to connect
+                                        to, defaults to the pod IP.'
+                                      type: string
+                                    port:
+                                      anyOf:
+                                      - type: string
+                                      - type: integer
+                                      description: Number or name of the port to access
+                                        on the container. Number must be in the range
+                                        1 to 65535. Name must be an IANA_SVC_NAME.
+                                  required:
+                                  - port
+                                  type: object
+                                timeoutSeconds:
+                                  description: 'Number of seconds after which the
+                                    probe times out. Defaults to 1 second. Minimum
+                                    value is 1. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                                  format: int32
+                                  type: integer
+                              type: object
+                            name:
+                              description: Name of the container specified as a DNS_LABEL.
+                                Each container in a pod must have a unique name (DNS_LABEL).
+                                Cannot be updated.
+                              type: string
+                            ports:
+                              description: List of ports to expose from the container.
+                                Exposing a port here gives the system additional information
+                                about the network connections a container uses, but
+                                is primarily informational. Not specifying a port
+                                here DOES NOT prevent that port from being exposed.
+                                Any port which is listening on the default "0.0.0.0"
+                                address inside a container will be accessible from
+                                the network. Cannot be updated.
+                              items:
+                                description: ContainerPort represents a network port
+                                  in a single container.
+                                properties:
+                                  containerPort:
+                                    description: Number of port to expose on the pod's
+                                      IP address. This must be a valid port number,
+                                      0 < x < 65536.
+                                    format: int32
+                                    type: integer
+                                  hostIP:
+                                    description: What host IP to bind the external
+                                      port to.
+                                    type: string
+                                  hostPort:
+                                    description: Number of port to expose on the host.
+                                      If specified, this must be a valid port number,
+                                      0 < x < 65536. If HostNetwork is specified,
+                                      this must match ContainerPort. Most containers
+                                      do not need this.
+                                    format: int32
+                                    type: integer
+                                  name:
+                                    description: If specified, this must be an IANA_SVC_NAME
+                                      and unique within the pod. Each named port in
+                                      a pod must have a unique name. Name for the
+                                      port that can be referred to by services.
+                                    type: string
+                                  protocol:
+                                    description: Protocol for port. Must be UDP, TCP,
+                                      or SCTP. Defaults to "TCP".
+                                    type: string
+                                required:
+                                - containerPort
+                                type: object
+                              type: array
+                            readinessProbe:
+                              description: 'Periodic probe of container service readiness.
+                                Container will be removed from service endpoints if
+                                the probe fails. Cannot be updated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                              properties:
+                                exec:
+                                  description: One and only one of the following should
+                                    be specified. Exec specifies the action to take.
+                                  properties:
+                                    command:
+                                      description: Command is the command line to
+                                        execute inside the container, the working
+                                        directory for the command  is root ('/') in
+                                        the container's filesystem. The command is
+                                        simply exec'd, it is not run inside a shell,
+                                        so traditional shell instructions ('|', etc)
+                                        won't work. To use a shell, you need to explicitly
+                                        call out to that shell. Exit status of 0 is
+                                        treated as live/healthy and non-zero is unhealthy.
+                                      items:
+                                        type: string
+                                      type: array
+                                  type: object
+                                failureThreshold:
+                                  description: Minimum consecutive failures for the
+                                    probe to be considered failed after having succeeded.
+                                    Defaults to 3. Minimum value is 1.
+                                  format: int32
+                                  type: integer
+                                httpGet:
+                                  description: HTTPGet specifies the http request
+                                    to perform.
+                                  properties:
+                                    host:
+                                      description: Host name to connect to, defaults
+                                        to the pod IP. You probably want to set "Host"
+                                        in httpHeaders instead.
+                                      type: string
+                                    httpHeaders:
+                                      description: Custom headers to set in the request.
+                                        HTTP allows repeated headers.
+                                      items:
+                                        description: HTTPHeader describes a custom
+                                          header to be used in HTTP probes
+                                        properties:
+                                          name:
+                                            description: The header field name
+                                            type: string
+                                          value:
+                                            description: The header field value
+                                            type: string
+                                        required:
+                                        - name
+                                        - value
+                                        type: object
+                                      type: array
+                                    path:
+                                      description: Path to access on the HTTP server.
+                                      type: string
+                                    port:
+                                      anyOf:
+                                      - type: string
+                                      - type: integer
+                                      description: Name or number of the port to access
+                                        on the container. Number must be in the range
+                                        1 to 65535. Name must be an IANA_SVC_NAME.
+                                    scheme:
+                                      description: Scheme to use for connecting to
+                                        the host. Defaults to HTTP.
+                                      type: string
+                                  required:
+                                  - port
+                                  type: object
+                                initialDelaySeconds:
+                                  description: 'Number of seconds after the container
+                                    has started before liveness probes are initiated.
+                                    More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                                  format: int32
+                                  type: integer
+                                periodSeconds:
+                                  description: How often (in seconds) to perform the
+                                    probe. Default to 10 seconds. Minimum value is
+                                    1.
+                                  format: int32
+                                  type: integer
+                                successThreshold:
+                                  description: Minimum consecutive successes for the
+                                    probe to be considered successful after having
+                                    failed. Defaults to 1. Must be 1 for liveness.
+                                    Minimum value is 1.
+                                  format: int32
+                                  type: integer
+                                tcpSocket:
+                                  description: 'TCPSocket specifies an action involving
+                                    a TCP port. TCP hooks not yet supported TODO:
+                                    implement a realistic TCP lifecycle hook'
+                                  properties:
+                                    host:
+                                      description: 'Optional: Host name to connect
+                                        to, defaults to the pod IP.'
+                                      type: string
+                                    port:
+                                      anyOf:
+                                      - type: string
+                                      - type: integer
+                                      description: Number or name of the port to access
+                                        on the container. Number must be in the range
+                                        1 to 65535. Name must be an IANA_SVC_NAME.
+                                  required:
+                                  - port
+                                  type: object
+                                timeoutSeconds:
+                                  description: 'Number of seconds after which the
+                                    probe times out. Defaults to 1 second. Minimum
+                                    value is 1. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                                  format: int32
+                                  type: integer
+                              type: object
+                            resources:
+                              description: 'Compute Resources required by this container.
+                                Cannot be updated. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
+                              properties:
+                                limits:
+                                  additionalProperties:
+                                    type: string
+                                  description: 'Limits describes the maximum amount
+                                    of compute resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
+                                  type: object
+                                requests:
+                                  additionalProperties:
+                                    type: string
+                                  description: 'Requests describes the minimum amount
+                                    of compute resources required. If Requests is
+                                    omitted for a container, it defaults to Limits
+                                    if that is explicitly specified, otherwise to
+                                    an implementation-defined value. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
+                                  type: object
+                              type: object
+                            securityContext:
+                              description: 'Security options the pod should run with.
+                                More info: https://kubernetes.io/docs/concepts/policy/security-context/
+                                More info: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/'
+                              properties:
+                                allowPrivilegeEscalation:
+                                  description: 'AllowPrivilegeEscalation controls
+                                    whether a process can gain more privileges than
+                                    its parent process. This bool directly controls
+                                    if the no_new_privs flag will be set on the container
+                                    process. AllowPrivilegeEscalation is true always
+                                    when the container is: 1) run as Privileged 2)
+                                    has CAP_SYS_ADMIN'
+                                  type: boolean
+                                capabilities:
+                                  description: The capabilities to add/drop when running
+                                    containers. Defaults to the default set of capabilities
+                                    granted by the container runtime.
+                                  properties:
+                                    add:
+                                      description: Added capabilities
+                                      items:
+                                        description: Capability represent POSIX capabilities
+                                          type
+                                        type: string
+                                      type: array
+                                    drop:
+                                      description: Removed capabilities
+                                      items:
+                                        description: Capability represent POSIX capabilities
+                                          type
+                                        type: string
+                                      type: array
+                                  type: object
+                                privileged:
+                                  description: Run container in privileged mode. Processes
+                                    in privileged containers are essentially equivalent
+                                    to root on the host. Defaults to false.
+                                  type: boolean
+                                procMount:
+                                  description: procMount denotes the type of proc
+                                    mount to use for the containers. The default is
+                                    DefaultProcMount which uses the container runtime
+                                    defaults for readonly paths and masked paths.
+                                    This requires the ProcMountType feature flag to
+                                    be enabled.
+                                  type: string
+                                readOnlyRootFilesystem:
+                                  description: Whether this container has a read-only
+                                    root filesystem. Default is false.
+                                  type: boolean
+                                runAsGroup:
+                                  description: The GID to run the entrypoint of the
+                                    container process. Uses runtime default if unset.
+                                    May also be set in PodSecurityContext.  If set
+                                    in both SecurityContext and PodSecurityContext,
+                                    the value specified in SecurityContext takes precedence.
+                                  format: int64
+                                  type: integer
+                                runAsNonRoot:
+                                  description: Indicates that the container must run
+                                    as a non-root user. If true, the Kubelet will
+                                    validate the image at runtime to ensure that it
+                                    does not run as UID 0 (root) and fail to start
+                                    the container if it does. If unset or false, no
+                                    such validation will be performed. May also be
+                                    set in PodSecurityContext.  If set in both SecurityContext
+                                    and PodSecurityContext, the value specified in
+                                    SecurityContext takes precedence.
+                                  type: boolean
+                                runAsUser:
+                                  description: The UID to run the entrypoint of the
+                                    container process. Defaults to user specified
+                                    in image metadata if unspecified. May also be
+                                    set in PodSecurityContext.  If set in both SecurityContext
+                                    and PodSecurityContext, the value specified in
+                                    SecurityContext takes precedence.
+                                  format: int64
+                                  type: integer
+                                seLinuxOptions:
+                                  description: The SELinux context to be applied to
+                                    the container. If unspecified, the container runtime
+                                    will allocate a random SELinux context for each
+                                    container.  May also be set in PodSecurityContext.  If
+                                    set in both SecurityContext and PodSecurityContext,
+                                    the value specified in SecurityContext takes precedence.
+                                  properties:
+                                    level:
+                                      description: Level is SELinux level label that
+                                        applies to the container.
+                                      type: string
+                                    role:
+                                      description: Role is a SELinux role label that
+                                        applies to the container.
+                                      type: string
+                                    type:
+                                      description: Type is a SELinux type label that
+                                        applies to the container.
+                                      type: string
+                                    user:
+                                      description: User is a SELinux user label that
+                                        applies to the container.
+                                      type: string
+                                  type: object
+                                windowsOptions:
+                                  description: Windows security options.
+                                  properties:
+                                    gmsaCredentialSpec:
+                                      description: GMSACredentialSpec is where the
+                                        GMSA admission webhook (https://github.com/kubernetes-sigs/windows-gmsa)
+                                        inlines the contents of the GMSA credential
+                                        spec named by the GMSACredentialSpecName field.
+                                        This field is alpha-level and is only honored
+                                        by servers that enable the WindowsGMSA feature
+                                        flag.
+                                      type: string
+                                    gmsaCredentialSpecName:
+                                      description: GMSACredentialSpecName is the name
+                                        of the GMSA credential spec to use. This field
+                                        is alpha-level and is only honored by servers
+                                        that enable the WindowsGMSA feature flag.
+                                      type: string
+                                  type: object
+                              type: object
+                            stdin:
+                              description: Whether this container should allocate
+                                a buffer for stdin in the container runtime. If this
+                                is not set, reads from stdin in the container will
+                                always result in EOF. Default is false.
+                              type: boolean
+                            stdinOnce:
+                              description: Whether the container runtime should close
+                                the stdin channel after it has been opened by a single
+                                attach. When stdin is true the stdin stream will remain
+                                open across multiple attach sessions. If stdinOnce
+                                is set to true, stdin is opened on container start,
+                                is empty until the first client attaches to stdin,
+                                and then remains open and accepts data until the client
+                                disconnects, at which time stdin is closed and remains
+                                closed until the container is restarted. If this flag
+                                is false, a container processes that reads from stdin
+                                will never receive an EOF. Default is false
+                              type: boolean
+                            terminationMessagePath:
+                              description: 'Optional: Path at which the file to which
+                                the container''s termination message will be written
+                                is mounted into the container''s filesystem. Message
+                                written is intended to be brief final status, such
+                                as an assertion failure message. Will be truncated
+                                by the node if greater than 4096 bytes. The total
+                                message length across all containers will be limited
+                                to 12kb. Defaults to /dev/termination-log. Cannot
+                                be updated.'
+                              type: string
+                            terminationMessagePolicy:
+                              description: Indicate how the termination message should
+                                be populated. File will use the contents of terminationMessagePath
+                                to populate the container status message on both success
+                                and failure. FallbackToLogsOnError will use the last
+                                chunk of container log output if the termination message
+                                file is empty and the container exited with an error.
+                                The log output is limited to 2048 bytes or 80 lines,
+                                whichever is smaller. Defaults to File. Cannot be
+                                updated.
+                              type: string
+                            tty:
+                              description: Whether this container should allocate
+                                a TTY for itself, also requires 'stdin' to be true.
+                                Default is false.
+                              type: boolean
+                            volumeDevices:
+                              description: volumeDevices is the list of block devices
+                                to be used by the container. This is a beta feature.
+                              items:
+                                description: volumeDevice describes a mapping of a
+                                  raw block device within a container.
+                                properties:
+                                  devicePath:
+                                    description: devicePath is the path inside of
+                                      the container that the device will be mapped
+                                      to.
+                                    type: string
+                                  name:
+                                    description: name must match the name of a persistentVolumeClaim
+                                      in the pod
+                                    type: string
+                                required:
+                                - devicePath
+                                - name
+                                type: object
+                              type: array
+                            volumeMounts:
+                              description: Pod volumes to mount into the container's
+                                filesystem. Cannot be updated.
+                              items:
+                                description: VolumeMount describes a mounting of a
+                                  Volume within a container.
+                                properties:
+                                  mountPath:
+                                    description: Path within the container at which
+                                      the volume should be mounted.  Must not contain
+                                      ':'.
+                                    type: string
+                                  mountPropagation:
+                                    description: mountPropagation determines how mounts
+                                      are propagated from the host to container and
+                                      the other way around. When not set, MountPropagationNone
+                                      is used. This field is beta in 1.10.
+                                    type: string
+                                  name:
+                                    description: This must match the Name of a Volume.
+                                    type: string
+                                  readOnly:
+                                    description: Mounted read-only if true, read-write
+                                      otherwise (false or unspecified). Defaults to
+                                      false.
+                                    type: boolean
+                                  subPath:
+                                    description: Path within the volume from which
+                                      the container's volume should be mounted. Defaults
+                                      to "" (volume's root).
+                                    type: string
+                                  subPathExpr:
+                                    description: Expanded path within the volume from
+                                      which the container's volume should be mounted.
+                                      Behaves similarly to SubPath but environment
+                                      variable references $(VAR_NAME) are expanded
+                                      using the container's environment. Defaults
+                                      to "" (volume's root). SubPathExpr and SubPath
+                                      are mutually exclusive. This field is beta in
+                                      1.15.
+                                    type: string
+                                required:
+                                - mountPath
+                                - name
+                                type: object
+                              type: array
+                            workingDir:
+                              description: Container's working directory. If not specified,
+                                the container runtime's default will be used, which
+                                might be configured in the container image. Cannot
+                                be updated.
+                              type: string
+                          required:
+                          - name
+                          type: object
+                      required:
+                      - container
+                      type: object
+                    logger:
+                      description: Activate request/response logging
+                      properties:
+                        mode:
+                          description: What payloads to log
+                          type: string
+                        url:
+                          description: URL to send request logging CloudEvents
+                          type: string
+                      type: object
+                    maxReplicas:
+                      description: This is the up bound for autoscaler to scale to
+                      type: integer
+                    minReplicas:
+                      description: Minimum number of replicas, pods won't scale down
+                        to 0 in case of no traffic
+                      type: integer
+                    parallelism:
+                      description: Parallelism specifies how many requests can be
+                        processed concurrently, this sets the target concurrency for
+                        Autoscaling(KPA). For model servers that support tuning parallelism
+                        will use this value, by default the parallelism is the number
+                        of the CPU cores for most of the model servers.
+                      type: integer
+                    serviceAccountName:
+                      description: ServiceAccountName is the name of the ServiceAccount
+                        to use to run the service
+                      type: string
+                  type: object
+              required:
+              - predictor
+              type: object
+          required:
+          - default
+          type: object
+        status:
+          description: InferenceServiceStatus defines the observed state of InferenceService
+          properties:
+            address:
+              description: Ducktype for addressable
+              properties:
+                url:
+                  description: URL is an alias of url.URL. It has custom json marshal
+                    methods that enable it to be used in K8s CRDs such that the CRD
+                    resource will have the URL but operator code can can work with
+                    url.URL struct
+                  type: string
+            canary:
+              additionalProperties:
+                description: StatusConfigurationSpec describes the state of the configuration
+                  receiving traffic.
+                properties:
+                  host:
+                    description: Host name of the service
+                    type: string
+                  name:
+                    description: Latest revision name that is in ready state
+                    type: string
+                  replicas:
+                    type: integer
+                type: object
+              description: Statuses for the canary endpoints of the InferenceService
+              type: object
+            canaryTraffic:
+              description: Traffic percentage that goes to canary services
+              type: integer
+            conditions:
+              description: Conditions the latest available observations of a resource's
+                current state. +patchMergeKey=type +patchStrategy=merge
+              items:
+                properties:
+                  lastTransitionTime:
+                    description: LastTransitionTime is the last time the condition
+                      transitioned from one status to another. We use VolatileTime
+                      in place of metav1.Time to exclude this from creating equality.Semantic
+                      differences (all other things held constant).
+                    type: string
+                  message:
+                    description: A human readable message indicating details about
+                      the transition.
+                    type: string
+                  reason:
+                    description: The reason for the condition's last transition.
+                    type: string
+                  severity:
+                    description: Severity with which to treat failures of this type
+                      of condition. When this is not specified, it defaults to Error.
+                    type: string
+                  status:
+                    description: Status of the condition, one of True, False, Unknown.
+                      +required
+                    type: string
+                  type:
+                    description: Type of condition. +required
+                    type: string
+                required:
+                - type
+                - status
+                type: object
+              type: array
+            default:
+              additionalProperties:
+                description: StatusConfigurationSpec describes the state of the configuration
+                  receiving traffic.
+                properties:
+                  host:
+                    description: Host name of the service
+                    type: string
+                  name:
+                    description: Latest revision name that is in ready state
+                    type: string
+                  replicas:
+                    type: integer
+                type: object
+              description: Statuses for the default endpoints of the InferenceService
+              type: object
+            observedGeneration:
+              description: ObservedGeneration is the 'Generation' of the Service that
+                was last processed by the controller.
+              format: int64
+              type: integer
+            traffic:
+              description: Traffic percentage that goes to default services
+              type: integer
+            url:
+              description: URL of the InferenceService
+              type: string
+          type: object
+      type: object
+  version: v1alpha2
+  versions:
+  - name: v1alpha2
+    served: true
+    storage: true

--- a/tests/stacks/gcp/test_data/expected/apiextensions.k8s.io_v1beta1_customresourcedefinition_ingresses.networking.internal.knative.dev.yaml
+++ b/tests/stacks/gcp/test_data/expected/apiextensions.k8s.io_v1beta1_customresourcedefinition_ingresses.networking.internal.knative.dev.yaml
@@ -1,0 +1,35 @@
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  labels:
+    app.kubernetes.io/component: knative-serving-install
+    app.kubernetes.io/name: knative-serving-install
+    knative.dev/crd-install: "true"
+    kustomize.component: knative
+    serving.knative.dev/release: v0.11.2
+  name: ingresses.networking.internal.knative.dev
+spec:
+  additionalPrinterColumns:
+  - JSONPath: .status.conditions[?(@.type=='Ready')].status
+    name: Ready
+    type: string
+  - JSONPath: .status.conditions[?(@.type=='Ready')].reason
+    name: Reason
+    type: string
+  group: networking.internal.knative.dev
+  names:
+    categories:
+    - knative-internal
+    - networking
+    kind: Ingress
+    plural: ingresses
+    shortNames:
+    - ing
+    singular: ingress
+  scope: Namespaced
+  subresources:
+    status: {}
+  versions:
+  - name: v1alpha1
+    served: true
+    storage: true

--- a/tests/stacks/gcp/test_data/expected/apiextensions.k8s.io_v1beta1_customresourcedefinition_metrics.autoscaling.internal.knative.dev.yaml
+++ b/tests/stacks/gcp/test_data/expected/apiextensions.k8s.io_v1beta1_customresourcedefinition_metrics.autoscaling.internal.knative.dev.yaml
@@ -1,0 +1,30 @@
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  labels:
+    app.kubernetes.io/component: knative-serving-install
+    app.kubernetes.io/name: knative-serving-install
+    knative.dev/crd-install: "true"
+    kustomize.component: knative
+    serving.knative.dev/release: v0.11.2
+  name: metrics.autoscaling.internal.knative.dev
+spec:
+  additionalPrinterColumns:
+  - JSONPath: .status.conditions[?(@.type=='Ready')].status
+    name: Ready
+    type: string
+  - JSONPath: .status.conditions[?(@.type=='Ready')].reason
+    name: Reason
+    type: string
+  group: autoscaling.internal.knative.dev
+  names:
+    categories:
+    - knative-internal
+    - autoscaling
+    kind: Metric
+    plural: metrics
+    singular: metric
+  scope: Namespaced
+  subresources:
+    status: {}
+  version: v1alpha1

--- a/tests/stacks/gcp/test_data/expected/apiextensions.k8s.io_v1beta1_customresourcedefinition_podautoscalers.autoscaling.internal.knative.dev.yaml
+++ b/tests/stacks/gcp/test_data/expected/apiextensions.k8s.io_v1beta1_customresourcedefinition_podautoscalers.autoscaling.internal.knative.dev.yaml
@@ -1,0 +1,42 @@
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  labels:
+    app.kubernetes.io/component: knative-serving-install
+    app.kubernetes.io/name: knative-serving-install
+    knative.dev/crd-install: "true"
+    kustomize.component: knative
+    serving.knative.dev/release: v0.11.2
+  name: podautoscalers.autoscaling.internal.knative.dev
+spec:
+  additionalPrinterColumns:
+  - JSONPath: .status.desiredScale
+    name: DesiredScale
+    type: integer
+  - JSONPath: .status.actualScale
+    name: ActualScale
+    type: integer
+  - JSONPath: .status.conditions[?(@.type=='Ready')].status
+    name: Ready
+    type: string
+  - JSONPath: .status.conditions[?(@.type=='Ready')].reason
+    name: Reason
+    type: string
+  group: autoscaling.internal.knative.dev
+  names:
+    categories:
+    - knative-internal
+    - autoscaling
+    kind: PodAutoscaler
+    plural: podautoscalers
+    shortNames:
+    - kpa
+    - pa
+    singular: podautoscaler
+  scope: Namespaced
+  subresources:
+    status: {}
+  versions:
+  - name: v1alpha1
+    served: true
+    storage: true

--- a/tests/stacks/gcp/test_data/expected/apiextensions.k8s.io_v1beta1_customresourcedefinition_revisions.serving.knative.dev.yaml
+++ b/tests/stacks/gcp/test_data/expected/apiextensions.k8s.io_v1beta1_customresourcedefinition_revisions.serving.knative.dev.yaml
@@ -1,0 +1,51 @@
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  labels:
+    app.kubernetes.io/component: knative-serving-install
+    app.kubernetes.io/name: knative-serving-install
+    knative.dev/crd-install: "true"
+    kustomize.component: knative
+    serving.knative.dev/release: v0.11.2
+  name: revisions.serving.knative.dev
+spec:
+  additionalPrinterColumns:
+  - JSONPath: .metadata.labels['serving\.knative\.dev/configuration']
+    name: Config Name
+    type: string
+  - JSONPath: .status.serviceName
+    name: K8s Service Name
+    type: string
+  - JSONPath: .metadata.labels['serving\.knative\.dev/configurationGeneration']
+    name: Generation
+    type: string
+  - JSONPath: .status.conditions[?(@.type=='Ready')].status
+    name: Ready
+    type: string
+  - JSONPath: .status.conditions[?(@.type=='Ready')].reason
+    name: Reason
+    type: string
+  group: serving.knative.dev
+  names:
+    categories:
+    - all
+    - knative
+    - serving
+    kind: Revision
+    plural: revisions
+    shortNames:
+    - rev
+    singular: revision
+  scope: Namespaced
+  subresources:
+    status: {}
+  versions:
+  - name: v1alpha1
+    served: true
+    storage: true
+  - name: v1beta1
+    served: true
+    storage: false
+  - name: v1
+    served: true
+    storage: false

--- a/tests/stacks/gcp/test_data/expected/apiextensions.k8s.io_v1beta1_customresourcedefinition_routes.serving.knative.dev.yaml
+++ b/tests/stacks/gcp/test_data/expected/apiextensions.k8s.io_v1beta1_customresourcedefinition_routes.serving.knative.dev.yaml
@@ -1,0 +1,46 @@
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  labels:
+    app.kubernetes.io/component: knative-serving-install
+    app.kubernetes.io/name: knative-serving-install
+    duck.knative.dev/addressable: "true"
+    knative.dev/crd-install: "true"
+    kustomize.component: knative
+    serving.knative.dev/release: v0.11.2
+  name: routes.serving.knative.dev
+spec:
+  additionalPrinterColumns:
+  - JSONPath: .status.url
+    name: URL
+    type: string
+  - JSONPath: .status.conditions[?(@.type=='Ready')].status
+    name: Ready
+    type: string
+  - JSONPath: .status.conditions[?(@.type=='Ready')].reason
+    name: Reason
+    type: string
+  group: serving.knative.dev
+  names:
+    categories:
+    - all
+    - knative
+    - serving
+    kind: Route
+    plural: routes
+    shortNames:
+    - rt
+    singular: route
+  scope: Namespaced
+  subresources:
+    status: {}
+  versions:
+  - name: v1alpha1
+    served: true
+    storage: true
+  - name: v1beta1
+    served: true
+    storage: false
+  - name: v1
+    served: true
+    storage: false

--- a/tests/stacks/gcp/test_data/expected/apiextensions.k8s.io_v1beta1_customresourcedefinition_serverlessservices.networking.internal.knative.dev.yaml
+++ b/tests/stacks/gcp/test_data/expected/apiextensions.k8s.io_v1beta1_customresourcedefinition_serverlessservices.networking.internal.knative.dev.yaml
@@ -1,0 +1,44 @@
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  labels:
+    app.kubernetes.io/component: knative-serving-install
+    app.kubernetes.io/name: knative-serving-install
+    knative.dev/crd-install: "true"
+    kustomize.component: knative
+    serving.knative.dev/release: v0.11.2
+  name: serverlessservices.networking.internal.knative.dev
+spec:
+  additionalPrinterColumns:
+  - JSONPath: .spec.mode
+    name: Mode
+    type: string
+  - JSONPath: .status.serviceName
+    name: ServiceName
+    type: string
+  - JSONPath: .status.privateServiceName
+    name: PrivateServiceName
+    type: string
+  - JSONPath: .status.conditions[?(@.type=='Ready')].status
+    name: Ready
+    type: string
+  - JSONPath: .status.conditions[?(@.type=='Ready')].reason
+    name: Reason
+    type: string
+  group: networking.internal.knative.dev
+  names:
+    categories:
+    - knative-internal
+    - networking
+    kind: ServerlessService
+    plural: serverlessservices
+    shortNames:
+    - sks
+    singular: serverlessservice
+  scope: Namespaced
+  subresources:
+    status: {}
+  versions:
+  - name: v1alpha1
+    served: true
+    storage: true

--- a/tests/stacks/gcp/test_data/expected/apiextensions.k8s.io_v1beta1_customresourcedefinition_services.serving.knative.dev.yaml
+++ b/tests/stacks/gcp/test_data/expected/apiextensions.k8s.io_v1beta1_customresourcedefinition_services.serving.knative.dev.yaml
@@ -1,0 +1,54 @@
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  labels:
+    app.kubernetes.io/component: knative-serving-install
+    app.kubernetes.io/name: knative-serving-install
+    duck.knative.dev/addressable: "true"
+    duck.knative.dev/podspecable: "true"
+    knative.dev/crd-install: "true"
+    kustomize.component: knative
+    serving.knative.dev/release: v0.11.2
+  name: services.serving.knative.dev
+spec:
+  additionalPrinterColumns:
+  - JSONPath: .status.url
+    name: URL
+    type: string
+  - JSONPath: .status.latestCreatedRevisionName
+    name: LatestCreated
+    type: string
+  - JSONPath: .status.latestReadyRevisionName
+    name: LatestReady
+    type: string
+  - JSONPath: .status.conditions[?(@.type=='Ready')].status
+    name: Ready
+    type: string
+  - JSONPath: .status.conditions[?(@.type=='Ready')].reason
+    name: Reason
+    type: string
+  group: serving.knative.dev
+  names:
+    categories:
+    - all
+    - knative
+    - serving
+    kind: Service
+    plural: services
+    shortNames:
+    - kservice
+    - ksvc
+    singular: service
+  scope: Namespaced
+  subresources:
+    status: {}
+  versions:
+  - name: v1alpha1
+    served: true
+    storage: true
+  - name: v1beta1
+    served: true
+    storage: false
+  - name: v1
+    served: true
+    storage: false

--- a/tests/stacks/gcp/test_data/expected/apiregistration.k8s.io_v1beta1_apiservice_v1beta1.custom.metrics.k8s.io.yaml
+++ b/tests/stacks/gcp/test_data/expected/apiregistration.k8s.io_v1beta1_apiservice_v1beta1.custom.metrics.k8s.io.yaml
@@ -1,0 +1,19 @@
+apiVersion: apiregistration.k8s.io/v1beta1
+kind: APIService
+metadata:
+  labels:
+    app.kubernetes.io/component: knative-serving-install
+    app.kubernetes.io/name: knative-serving-install
+    autoscaling.knative.dev/metric-provider: custom-metrics
+    kustomize.component: knative
+    serving.knative.dev/release: v0.11.2
+  name: v1beta1.custom.metrics.k8s.io
+spec:
+  group: custom.metrics.k8s.io
+  groupPriorityMinimum: 100
+  insecureSkipTLSVerify: true
+  service:
+    name: autoscaler
+    namespace: knative-serving
+  version: v1beta1
+  versionPriority: 100

--- a/tests/stacks/gcp/test_data/expected/app.k8s.io_v1beta1_application_kfserving-crds.yaml
+++ b/tests/stacks/gcp/test_data/expected/app.k8s.io_v1beta1_application_kfserving-crds.yaml
@@ -1,0 +1,37 @@
+apiVersion: app.k8s.io/v1beta1
+kind: Application
+metadata:
+  labels:
+    app: kfserving
+    app.kubernetes.io/component: kfserving-install
+    app.kubernetes.io/name: kfserving-install
+    kustomize.component: kfserving
+  name: kfserving-crds
+  namespace: kubeflow
+spec:
+  addOwnerRef: true
+  componentKinds:
+  - group: core
+    kind: ConfigMap
+  - group: apps
+    kind: Deployment
+  descriptor:
+    description: ""
+    keywords:
+    - kfserving-crds
+    - kubeflow
+    links:
+    - description: About
+      url: ""
+    maintainers: []
+    owners: []
+    type: kfserving-crds
+    version: v1beta1
+  selector:
+    matchLabels:
+      app.kubernetes.io/component: kfserving-crds
+      app.kubernetes.io/instance: kfserving-crds-v0.7.0
+      app.kubernetes.io/managed-by: kfctl
+      app.kubernetes.io/name: kfserving-crds
+      app.kubernetes.io/part-of: kubeflow
+      app.kubernetes.io/version: v0.7.0

--- a/tests/stacks/gcp/test_data/expected/app.k8s.io_v1beta1_application_kfserving.yaml
+++ b/tests/stacks/gcp/test_data/expected/app.k8s.io_v1beta1_application_kfserving.yaml
@@ -1,0 +1,47 @@
+apiVersion: app.k8s.io/v1beta1
+kind: Application
+metadata:
+  labels:
+    app: kfserving
+    app.kubernetes.io/component: kfserving-install
+    app.kubernetes.io/name: kfserving-install
+    kustomize.component: kfserving
+  name: kfserving
+  namespace: kubeflow
+spec:
+  componentKinds:
+  - group: apps/v1
+    kind: StatefulSet
+  - group: v1
+    kind: Service
+  - group: apps/v1
+    kind: Deployment
+  - group: v1
+    kind: Secret
+  - group: v1
+    kind: ConfigMap
+  description: KFServing provides a Kubernetes Custom Resource Definition for serving
+    ML Models on arbitrary frameworks
+  icons: null
+  keywords:
+  - kfserving
+  - inference
+  links:
+  - description: About
+    url: https://github.com/kubeflow/kfserving
+  maintainers:
+  - email: johnugeo@cisco.com
+    name: Johnu George
+  owners:
+  - email: johnugeo@cisco.com
+    name: Johnu George
+  selector:
+    matchLabels:
+      app.kubernetes.io/component: kfserving-install
+      app.kubernetes.io/instance: kfserving-install
+      app.kubernetes.io/managed-by: kfctl
+      app.kubernetes.io/name: kfserving-install
+      app.kubernetes.io/part-of: kubeflow
+      app.kubernetes.io/version: v0.3.0
+  type: kfserving
+  version: v1alpha2

--- a/tests/stacks/gcp/test_data/expected/app.k8s.io_v1beta1_application_knative-serving-crds.yaml
+++ b/tests/stacks/gcp/test_data/expected/app.k8s.io_v1beta1_application_knative-serving-crds.yaml
@@ -1,0 +1,36 @@
+apiVersion: app.k8s.io/v1beta1
+kind: Application
+metadata:
+  labels:
+    app.kubernetes.io/component: knative-serving-install
+    app.kubernetes.io/name: knative-serving-install
+    kustomize.component: knative
+  name: knative-serving-crds
+  namespace: kubeflow
+spec:
+  addOwnerRef: true
+  componentKinds:
+  - group: core
+    kind: ConfigMap
+  - group: apps
+    kind: Deployment
+  descriptor:
+    description: ""
+    keywords:
+    - knative-serving-crds
+    - kubeflow
+    links:
+    - description: About
+      url: ""
+    maintainers: []
+    owners: []
+    type: knative-serving-crds
+    version: v1beta1
+  selector:
+    matchLabels:
+      app.kubernetes.io/component: knative-serving-crds
+      app.kubernetes.io/instance: knative-serving-crds
+      app.kubernetes.io/managed-by: kfctl
+      app.kubernetes.io/name: knative-serving-crds
+      app.kubernetes.io/part-of: kubeflow
+      app.kubernetes.io/version: v0.11.2

--- a/tests/stacks/gcp/test_data/expected/app.k8s.io_v1beta1_application_knative-serving-install.yaml
+++ b/tests/stacks/gcp/test_data/expected/app.k8s.io_v1beta1_application_knative-serving-install.yaml
@@ -1,0 +1,36 @@
+apiVersion: app.k8s.io/v1beta1
+kind: Application
+metadata:
+  labels:
+    app.kubernetes.io/component: knative-serving-install
+    app.kubernetes.io/name: knative-serving-install
+    kustomize.component: knative
+  name: knative-serving-install
+  namespace: kubeflow
+spec:
+  addOwnerRef: true
+  componentKinds:
+  - group: core
+    kind: ConfigMap
+  - group: apps
+    kind: Deployment
+  descriptor:
+    description: ""
+    keywords:
+    - knative-serving-install
+    - kubeflow
+    links:
+    - description: About
+      url: ""
+    maintainers: []
+    owners: []
+    type: knative-serving-install
+    version: v1beta1
+  selector:
+    matchLabels:
+      app.kubernetes.io/component: knative-serving-install
+      app.kubernetes.io/instance: knative-serving-install
+      app.kubernetes.io/managed-by: kfctl
+      app.kubernetes.io/name: knative-serving-install
+      app.kubernetes.io/part-of: kubeflow
+      app.kubernetes.io/version: v0.11.2

--- a/tests/stacks/gcp/test_data/expected/apps_v1_deployment_activator.yaml
+++ b/tests/stacks/gcp/test_data/expected/apps_v1_deployment_activator.yaml
@@ -1,0 +1,87 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  labels:
+    app.kubernetes.io/component: knative-serving-install
+    app.kubernetes.io/name: knative-serving-install
+    kustomize.component: knative
+    serving.knative.dev/release: v0.11.2
+  name: activator
+  namespace: kubeflow
+spec:
+  selector:
+    matchLabels:
+      app: activator
+      app.kubernetes.io/component: knative-serving-install
+      app.kubernetes.io/name: knative-serving-install
+      kustomize.component: knative
+      role: activator
+  template:
+    metadata:
+      annotations:
+        cluster-autoscaler.kubernetes.io/safe-to-evict: "false"
+        sidecar.istio.io/inject: "false"
+      labels:
+        app: activator
+        app.kubernetes.io/component: knative-serving-install
+        app.kubernetes.io/name: knative-serving-install
+        kustomize.component: knative
+        role: activator
+        serving.knative.dev/release: v0.11.2
+    spec:
+      containers:
+      - env:
+        - name: POD_NAME
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.name
+        - name: POD_IP
+          valueFrom:
+            fieldRef:
+              fieldPath: status.podIP
+        - name: SYSTEM_NAMESPACE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace
+        - name: CONFIG_LOGGING_NAME
+          value: config-logging
+        - name: CONFIG_OBSERVABILITY_NAME
+          value: config-observability
+        - name: METRICS_DOMAIN
+          value: knative.dev/internal/serving
+        image: gcr.io/knative-releases/knative.dev/serving/cmd/activator@sha256:c51023e62e351d5910f92ee941b4929eb82539e62636dd3ccb4a016d73e86b2e
+        livenessProbe:
+          httpGet:
+            httpHeaders:
+            - name: k-kubelet-probe
+              value: activator
+            path: /healthz
+            port: 8012
+        name: activator
+        ports:
+        - containerPort: 8012
+          name: http1
+        - containerPort: 8013
+          name: h2c
+        - containerPort: 9090
+          name: metrics
+        - containerPort: 8008
+          name: profiling
+        readinessProbe:
+          httpGet:
+            httpHeaders:
+            - name: k-kubelet-probe
+              value: activator
+            path: /healthz
+            port: 8012
+        resources:
+          limits:
+            cpu: 1000m
+            memory: 600Mi
+          requests:
+            cpu: 300m
+            memory: 60Mi
+        securityContext:
+          allowPrivilegeEscalation: false
+      serviceAccountName: controller
+      terminationGracePeriodSeconds: 300

--- a/tests/stacks/gcp/test_data/expected/apps_v1_deployment_autoscaler-hpa.yaml
+++ b/tests/stacks/gcp/test_data/expected/apps_v1_deployment_autoscaler-hpa.yaml
@@ -1,0 +1,59 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  labels:
+    app.kubernetes.io/component: knative-serving-install
+    app.kubernetes.io/name: knative-serving-install
+    autoscaling.knative.dev/autoscaler-provider: hpa
+    kustomize.component: knative
+    serving.knative.dev/release: v0.11.2
+  name: autoscaler-hpa
+  namespace: kubeflow
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: autoscaler-hpa
+      app.kubernetes.io/component: knative-serving-install
+      app.kubernetes.io/name: knative-serving-install
+      kustomize.component: knative
+  template:
+    metadata:
+      annotations:
+        sidecar.istio.io/inject: "false"
+      labels:
+        app: autoscaler-hpa
+        app.kubernetes.io/component: knative-serving-install
+        app.kubernetes.io/name: knative-serving-install
+        kustomize.component: knative
+        serving.knative.dev/release: v0.11.2
+    spec:
+      containers:
+      - env:
+        - name: SYSTEM_NAMESPACE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace
+        - name: CONFIG_LOGGING_NAME
+          value: config-logging
+        - name: CONFIG_OBSERVABILITY_NAME
+          value: config-observability
+        - name: METRICS_DOMAIN
+          value: knative.dev/serving
+        image: gcr.io/knative-releases/knative.dev/serving/cmd/autoscaler-hpa@sha256:75da5ff75bc1e71799d039846b1bbd632343894c88feaa59914cfeeb1b213c81
+        name: autoscaler-hpa
+        ports:
+        - containerPort: 9090
+          name: metrics
+        - containerPort: 8008
+          name: profiling
+        resources:
+          limits:
+            cpu: 1000m
+            memory: 1000Mi
+          requests:
+            cpu: 100m
+            memory: 100Mi
+        securityContext:
+          allowPrivilegeEscalation: false
+      serviceAccountName: controller

--- a/tests/stacks/gcp/test_data/expected/apps_v1_deployment_autoscaler.yaml
+++ b/tests/stacks/gcp/test_data/expected/apps_v1_deployment_autoscaler.yaml
@@ -1,0 +1,81 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  labels:
+    app.kubernetes.io/component: knative-serving-install
+    app.kubernetes.io/name: knative-serving-install
+    kustomize.component: knative
+    serving.knative.dev/release: v0.11.2
+  name: autoscaler
+  namespace: kubeflow
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: autoscaler
+      app.kubernetes.io/component: knative-serving-install
+      app.kubernetes.io/name: knative-serving-install
+      kustomize.component: knative
+  template:
+    metadata:
+      annotations:
+        cluster-autoscaler.kubernetes.io/safe-to-evict: "false"
+        sidecar.istio.io/inject: "false"
+        traffic.sidecar.istio.io/includeInboundPorts: 8080,9090
+      labels:
+        app: autoscaler
+        app.kubernetes.io/component: knative-serving-install
+        app.kubernetes.io/name: knative-serving-install
+        kustomize.component: knative
+        serving.knative.dev/release: v0.11.2
+    spec:
+      containers:
+      - args:
+        - --secure-port=8443
+        - --cert-dir=/tmp
+        env:
+        - name: SYSTEM_NAMESPACE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace
+        - name: CONFIG_LOGGING_NAME
+          value: config-logging
+        - name: CONFIG_OBSERVABILITY_NAME
+          value: config-observability
+        - name: METRICS_DOMAIN
+          value: knative.dev/serving
+        image: gcr.io/knative-releases/knative.dev/serving/cmd/autoscaler@sha256:998a405454832cda18a4bf956d26d610a2df2130a39b834b597a89a3153c8c15
+        livenessProbe:
+          httpGet:
+            httpHeaders:
+            - name: k-kubelet-probe
+              value: autoscaler
+            path: /healthz
+            port: 8080
+        name: autoscaler
+        ports:
+        - containerPort: 8080
+          name: websocket
+        - containerPort: 9090
+          name: metrics
+        - containerPort: 8443
+          name: custom-metrics
+        - containerPort: 8008
+          name: profiling
+        readinessProbe:
+          httpGet:
+            httpHeaders:
+            - name: k-kubelet-probe
+              value: autoscaler
+            path: /healthz
+            port: 8080
+        resources:
+          limits:
+            cpu: 300m
+            memory: 400Mi
+          requests:
+            cpu: 30m
+            memory: 40Mi
+        securityContext:
+          allowPrivilegeEscalation: false
+      serviceAccountName: controller

--- a/tests/stacks/gcp/test_data/expected/apps_v1_deployment_controller.yaml
+++ b/tests/stacks/gcp/test_data/expected/apps_v1_deployment_controller.yaml
@@ -1,0 +1,58 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  labels:
+    app.kubernetes.io/component: knative-serving-install
+    app.kubernetes.io/name: knative-serving-install
+    kustomize.component: knative
+    serving.knative.dev/release: v0.11.2
+  name: controller
+  namespace: kubeflow
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: controller
+      app.kubernetes.io/component: knative-serving-install
+      app.kubernetes.io/name: knative-serving-install
+      kustomize.component: knative
+  template:
+    metadata:
+      annotations:
+        sidecar.istio.io/inject: "false"
+      labels:
+        app: controller
+        app.kubernetes.io/component: knative-serving-install
+        app.kubernetes.io/name: knative-serving-install
+        kustomize.component: knative
+        serving.knative.dev/release: v0.11.2
+    spec:
+      containers:
+      - env:
+        - name: SYSTEM_NAMESPACE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace
+        - name: CONFIG_LOGGING_NAME
+          value: config-logging
+        - name: CONFIG_OBSERVABILITY_NAME
+          value: config-observability
+        - name: METRICS_DOMAIN
+          value: knative.dev/internal/serving
+        image: gcr.io/knative-releases/knative.dev/serving/cmd/controller@sha256:1e77bdab30c8d0f0df299f5fa93d6f99eb63071b9d3329937dff0c6acb99e059
+        name: controller
+        ports:
+        - containerPort: 9090
+          name: metrics
+        - containerPort: 8008
+          name: profiling
+        resources:
+          limits:
+            cpu: 1000m
+            memory: 1000Mi
+          requests:
+            cpu: 100m
+            memory: 100Mi
+        securityContext:
+          allowPrivilegeEscalation: false
+      serviceAccountName: controller

--- a/tests/stacks/gcp/test_data/expected/apps_v1_deployment_networking-istio.yaml
+++ b/tests/stacks/gcp/test_data/expected/apps_v1_deployment_networking-istio.yaml
@@ -1,0 +1,59 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  labels:
+    app.kubernetes.io/component: knative-serving-install
+    app.kubernetes.io/name: knative-serving-install
+    kustomize.component: knative
+    networking.knative.dev/ingress-provider: istio
+    serving.knative.dev/release: v0.11.2
+  name: networking-istio
+  namespace: kubeflow
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: networking-istio
+      app.kubernetes.io/component: knative-serving-install
+      app.kubernetes.io/name: knative-serving-install
+      kustomize.component: knative
+  template:
+    metadata:
+      annotations:
+        sidecar.istio.io/inject: "false"
+      labels:
+        app: networking-istio
+        app.kubernetes.io/component: knative-serving-install
+        app.kubernetes.io/name: knative-serving-install
+        kustomize.component: knative
+        serving.knative.dev/release: v0.11.2
+    spec:
+      containers:
+      - env:
+        - name: SYSTEM_NAMESPACE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace
+        - name: CONFIG_LOGGING_NAME
+          value: config-logging
+        - name: CONFIG_OBSERVABILITY_NAME
+          value: config-observability
+        - name: METRICS_DOMAIN
+          value: knative.dev/serving
+        image: gcr.io/knative-releases/knative.dev/serving/cmd/networking/istio@sha256:61461fa789e19895d7d1e5ab96d8bb52a63788e0607e1bd2948b9570efeb6a8f
+        name: networking-istio
+        ports:
+        - containerPort: 9090
+          name: metrics
+        - containerPort: 8008
+          name: profiling
+        resources:
+          limits:
+            cpu: 1000m
+            memory: 1000Mi
+          requests:
+            cpu: 100m
+            memory: 100Mi
+        securityContext:
+          allowPrivilegeEscalation: false
+      serviceAccountName: controller

--- a/tests/stacks/gcp/test_data/expected/apps_v1_deployment_webhook.yaml
+++ b/tests/stacks/gcp/test_data/expected/apps_v1_deployment_webhook.yaml
@@ -1,0 +1,61 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  labels:
+    app.kubernetes.io/component: knative-serving-install
+    app.kubernetes.io/name: knative-serving-install
+    kustomize.component: knative
+    serving.knative.dev/release: v0.11.2
+  name: webhook
+  namespace: kubeflow
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: webhook
+      app.kubernetes.io/component: knative-serving-install
+      app.kubernetes.io/name: knative-serving-install
+      kustomize.component: knative
+      role: webhook
+  template:
+    metadata:
+      annotations:
+        cluster-autoscaler.kubernetes.io/safe-to-evict: "false"
+        sidecar.istio.io/inject: "false"
+      labels:
+        app: webhook
+        app.kubernetes.io/component: knative-serving-install
+        app.kubernetes.io/name: knative-serving-install
+        kustomize.component: knative
+        role: webhook
+        serving.knative.dev/release: v0.11.2
+    spec:
+      containers:
+      - env:
+        - name: SYSTEM_NAMESPACE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace
+        - name: CONFIG_LOGGING_NAME
+          value: config-logging
+        - name: CONFIG_OBSERVABILITY_NAME
+          value: config-observability
+        - name: METRICS_DOMAIN
+          value: knative.dev/serving
+        image: gcr.io/knative-releases/knative.dev/serving/cmd/webhook@sha256:d07560cd5548640cc79abc819608844527351f10e8b0a847988f9eb602c18972
+        name: webhook
+        ports:
+        - containerPort: 9090
+          name: metrics
+        - containerPort: 8008
+          name: profiling
+        resources:
+          limits:
+            cpu: 200m
+            memory: 200Mi
+          requests:
+            cpu: 20m
+            memory: 20Mi
+        securityContext:
+          allowPrivilegeEscalation: false
+      serviceAccountName: controller

--- a/tests/stacks/gcp/test_data/expected/apps_v1_statefulset_kfserving-controller-manager.yaml
+++ b/tests/stacks/gcp/test_data/expected/apps_v1_statefulset_kfserving-controller-manager.yaml
@@ -1,0 +1,82 @@
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  labels:
+    app: kfserving
+    app.kubernetes.io/component: kfserving-install
+    app.kubernetes.io/name: kfserving-install
+    control-plane: kfserving-controller-manager
+    controller-tools.k8s.io: "1.0"
+    kustomize.component: kfserving
+  name: kfserving-controller-manager
+  namespace: kubeflow
+spec:
+  selector:
+    matchLabels:
+      app: kfserving
+      app.kubernetes.io/component: kfserving-install
+      app.kubernetes.io/name: kfserving-install
+      control-plane: kfserving-controller-manager
+      controller-tools.k8s.io: "1.0"
+      kustomize.component: kfserving
+  serviceName: controller-manager-service
+  template:
+    metadata:
+      annotations:
+        sidecar.istio.io/inject: "false"
+      labels:
+        app: kfserving
+        app.kubernetes.io/component: kfserving-install
+        app.kubernetes.io/name: kfserving-install
+        control-plane: kfserving-controller-manager
+        controller-tools.k8s.io: "1.0"
+        kustomize.component: kfserving
+    spec:
+      containers:
+      - args:
+        - --secure-listen-address=0.0.0.0:8443
+        - --upstream=http://127.0.0.1:8080/
+        - --logtostderr=true
+        - --v=10
+        image: gcr.io/kubebuilder/kube-rbac-proxy:v0.4.0
+        name: kube-rbac-proxy
+        ports:
+        - containerPort: 8443
+          name: https
+      - args:
+        - --metrics-addr=127.0.0.1:8080
+        command:
+        - /manager
+        env:
+        - name: POD_NAMESPACE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace
+        - name: SECRET_NAME
+          value: kfserving-webhook-server-cert
+        - name: ENABLE_WEBHOOK_NAMESPACE_SELECTOR
+          value: enabled
+        image: gcr.io/kfserving/kfserving-controller:v0.3.0
+        imagePullPolicy: Always
+        name: manager
+        ports:
+        - containerPort: 443
+          name: webhook-server
+          protocol: TCP
+        resources:
+          limits:
+            cpu: 100m
+            memory: 300Mi
+          requests:
+            cpu: 100m
+            memory: 200Mi
+        volumeMounts:
+        - mountPath: /tmp/k8s-webhook-server/serving-certs
+          name: cert
+          readOnly: true
+      terminationGracePeriodSeconds: 10
+      volumes:
+      - name: cert
+        secret:
+          defaultMode: 420
+          secretName: kfserving-webhook-server-cert

--- a/tests/stacks/gcp/test_data/expected/autoscaling_v2beta1_horizontalpodautoscaler_activator.yaml
+++ b/tests/stacks/gcp/test_data/expected/autoscaling_v2beta1_horizontalpodautoscaler_activator.yaml
@@ -1,0 +1,22 @@
+apiVersion: autoscaling/v2beta1
+kind: HorizontalPodAutoscaler
+metadata:
+  labels:
+    app.kubernetes.io/component: knative-serving-install
+    app.kubernetes.io/name: knative-serving-install
+    kustomize.component: knative
+    serving.knative.dev/release: v0.11.2
+  name: activator
+  namespace: kubeflow
+spec:
+  maxReplicas: 20
+  metrics:
+  - resource:
+      name: cpu
+      targetAverageUtilization: 100
+    type: Resource
+  minReplicas: 1
+  scaleTargetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: activator

--- a/tests/stacks/gcp/test_data/expected/caching.internal.knative.dev_v1alpha1_image_queue-proxy.yaml
+++ b/tests/stacks/gcp/test_data/expected/caching.internal.knative.dev_v1alpha1_image_queue-proxy.yaml
@@ -1,0 +1,12 @@
+apiVersion: caching.internal.knative.dev/v1alpha1
+kind: Image
+metadata:
+  labels:
+    app.kubernetes.io/component: knative-serving-install
+    app.kubernetes.io/name: knative-serving-install
+    kustomize.component: knative
+    serving.knative.dev/release: v0.11.2
+  name: queue-proxy
+  namespace: kubeflow
+spec:
+  image: gcr.io/knative-releases/knative.dev/serving/cmd/queue@sha256:792f6945c7bc73a49a470a5b955c39c8bd174705743abf5fb71aa0f4c04128eb

--- a/tests/stacks/gcp/test_data/expected/cert-manager.io_v1alpha2_certificate_serving-cert.yaml
+++ b/tests/stacks/gcp/test_data/expected/cert-manager.io_v1alpha2_certificate_serving-cert.yaml
@@ -1,0 +1,18 @@
+apiVersion: cert-manager.io/v1alpha2
+kind: Certificate
+metadata:
+  labels:
+    app: kfserving
+    app.kubernetes.io/component: kfserving-install
+    app.kubernetes.io/name: kfserving-install
+    kustomize.component: kfserving
+  name: serving-cert
+  namespace: kubeflow
+spec:
+  commonName: kfserving-webhook-server-service.kubeflow.svc
+  dnsNames:
+  - kfserving-webhook-server-service.kubeflow.svc
+  issuerRef:
+    kind: Issuer
+    name: selfsigned-issuer
+  secretName: kfserving-webhook-server-cert

--- a/tests/stacks/gcp/test_data/expected/cert-manager.io_v1alpha2_issuer_selfsigned-issuer.yaml
+++ b/tests/stacks/gcp/test_data/expected/cert-manager.io_v1alpha2_issuer_selfsigned-issuer.yaml
@@ -1,0 +1,12 @@
+apiVersion: cert-manager.io/v1alpha2
+kind: Issuer
+metadata:
+  labels:
+    app: kfserving
+    app.kubernetes.io/component: kfserving-install
+    app.kubernetes.io/name: kfserving-install
+    kustomize.component: kfserving
+  name: selfsigned-issuer
+  namespace: kubeflow
+spec:
+  selfSigned: {}

--- a/tests/stacks/gcp/test_data/expected/networking.istio.io_v1alpha3_gateway_cluster-local-gateway.yaml
+++ b/tests/stacks/gcp/test_data/expected/networking.istio.io_v1alpha3_gateway_cluster-local-gateway.yaml
@@ -1,0 +1,21 @@
+apiVersion: networking.istio.io/v1alpha3
+kind: Gateway
+metadata:
+  labels:
+    app.kubernetes.io/component: knative-serving-install
+    app.kubernetes.io/name: knative-serving-install
+    kustomize.component: knative
+    networking.knative.dev/ingress-provider: istio
+    serving.knative.dev/release: v0.11.2
+  name: cluster-local-gateway
+  namespace: kubeflow
+spec:
+  selector:
+    istio: cluster-local-gateway
+  servers:
+  - hosts:
+    - '*'
+    port:
+      name: http
+      number: 80
+      protocol: HTTP

--- a/tests/stacks/gcp/test_data/expected/rbac.authorization.k8s.io_v1_clusterrole_custom-metrics-server-resources.yaml
+++ b/tests/stacks/gcp/test_data/expected/rbac.authorization.k8s.io_v1_clusterrole_custom-metrics-server-resources.yaml
@@ -1,0 +1,17 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  labels:
+    app.kubernetes.io/component: knative-serving-install
+    app.kubernetes.io/name: knative-serving-install
+    autoscaling.knative.dev/metric-provider: custom-metrics
+    kustomize.component: knative
+    serving.knative.dev/release: v0.11.2
+  name: custom-metrics-server-resources
+rules:
+- apiGroups:
+  - custom.metrics.k8s.io
+  resources:
+  - '*'
+  verbs:
+  - '*'

--- a/tests/stacks/gcp/test_data/expected/rbac.authorization.k8s.io_v1_clusterrole_kfserving-proxy-role.yaml
+++ b/tests/stacks/gcp/test_data/expected/rbac.authorization.k8s.io_v1_clusterrole_kfserving-proxy-role.yaml
@@ -1,0 +1,22 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  labels:
+    app: kfserving
+    app.kubernetes.io/component: kfserving-install
+    app.kubernetes.io/name: kfserving-install
+    kustomize.component: kfserving
+  name: kfserving-proxy-role
+rules:
+- apiGroups:
+  - authentication.k8s.io
+  resources:
+  - tokenreviews
+  verbs:
+  - create
+- apiGroups:
+  - authorization.k8s.io
+  resources:
+  - subjectaccessreviews
+  verbs:
+  - create

--- a/tests/stacks/gcp/test_data/expected/rbac.authorization.k8s.io_v1_clusterrole_knative-serving-addressable-resolver.yaml
+++ b/tests/stacks/gcp/test_data/expected/rbac.authorization.k8s.io_v1_clusterrole_knative-serving-addressable-resolver.yaml
@@ -1,0 +1,22 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  labels:
+    app.kubernetes.io/component: knative-serving-install
+    app.kubernetes.io/name: knative-serving-install
+    duck.knative.dev/addressable: "true"
+    kustomize.component: knative
+    serving.knative.dev/release: v0.11.2
+  name: knative-serving-addressable-resolver
+rules:
+- apiGroups:
+  - serving.knative.dev
+  resources:
+  - routes
+  - routes/status
+  - services
+  - services/status
+  verbs:
+  - get
+  - list
+  - watch

--- a/tests/stacks/gcp/test_data/expected/rbac.authorization.k8s.io_v1_clusterrole_knative-serving-admin.yaml
+++ b/tests/stacks/gcp/test_data/expected/rbac.authorization.k8s.io_v1_clusterrole_knative-serving-admin.yaml
@@ -1,0 +1,14 @@
+aggregationRule:
+  clusterRoleSelectors:
+  - matchLabels:
+      serving.knative.dev/controller: "true"
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  labels:
+    app.kubernetes.io/component: knative-serving-install
+    app.kubernetes.io/name: knative-serving-install
+    kustomize.component: knative
+    serving.knative.dev/release: v0.11.2
+  name: knative-serving-admin
+rules: []

--- a/tests/stacks/gcp/test_data/expected/rbac.authorization.k8s.io_v1_clusterrole_knative-serving-core.yaml
+++ b/tests/stacks/gcp/test_data/expected/rbac.authorization.k8s.io_v1_clusterrole_knative-serving-core.yaml
@@ -1,0 +1,115 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  labels:
+    app.kubernetes.io/component: knative-serving-install
+    app.kubernetes.io/name: knative-serving-install
+    kustomize.component: knative
+    serving.knative.dev/controller: "true"
+    serving.knative.dev/release: v0.11.2
+  name: knative-serving-core
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - pods
+  - namespaces
+  - secrets
+  - configmaps
+  - endpoints
+  - services
+  - events
+  - serviceaccounts
+  verbs:
+  - get
+  - list
+  - create
+  - update
+  - delete
+  - patch
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - endpoints/restricted
+  verbs:
+  - create
+- apiGroups:
+  - apps
+  resources:
+  - deployments
+  - deployments/finalizers
+  verbs:
+  - get
+  - list
+  - create
+  - update
+  - delete
+  - patch
+  - watch
+- apiGroups:
+  - admissionregistration.k8s.io
+  resources:
+  - mutatingwebhookconfigurations
+  - validatingwebhookconfigurations
+  verbs:
+  - get
+  - list
+  - create
+  - update
+  - delete
+  - patch
+  - watch
+- apiGroups:
+  - apiextensions.k8s.io
+  resources:
+  - customresourcedefinitions
+  verbs:
+  - get
+  - list
+  - create
+  - update
+  - delete
+  - patch
+  - watch
+- apiGroups:
+  - autoscaling
+  resources:
+  - horizontalpodautoscalers
+  verbs:
+  - get
+  - list
+  - create
+  - update
+  - delete
+  - patch
+  - watch
+- apiGroups:
+  - serving.knative.dev
+  - autoscaling.internal.knative.dev
+  - networking.internal.knative.dev
+  resources:
+  - '*'
+  - '*/status'
+  - '*/finalizers'
+  verbs:
+  - get
+  - list
+  - create
+  - update
+  - delete
+  - deletecollection
+  - patch
+  - watch
+- apiGroups:
+  - caching.internal.knative.dev
+  resources:
+  - images
+  verbs:
+  - get
+  - list
+  - create
+  - update
+  - delete
+  - patch
+  - watch

--- a/tests/stacks/gcp/test_data/expected/rbac.authorization.k8s.io_v1_clusterrole_knative-serving-istio.yaml
+++ b/tests/stacks/gcp/test_data/expected/rbac.authorization.k8s.io_v1_clusterrole_knative-serving-istio.yaml
@@ -1,0 +1,25 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  labels:
+    app.kubernetes.io/component: knative-serving-install
+    app.kubernetes.io/name: knative-serving-install
+    kustomize.component: knative
+    networking.knative.dev/ingress-provider: istio
+    serving.knative.dev/controller: "true"
+    serving.knative.dev/release: v0.11.2
+  name: knative-serving-istio
+rules:
+- apiGroups:
+  - networking.istio.io
+  resources:
+  - virtualservices
+  - gateways
+  verbs:
+  - get
+  - list
+  - create
+  - update
+  - delete
+  - patch
+  - watch

--- a/tests/stacks/gcp/test_data/expected/rbac.authorization.k8s.io_v1_clusterrole_knative-serving-namespaced-admin.yaml
+++ b/tests/stacks/gcp/test_data/expected/rbac.authorization.k8s.io_v1_clusterrole_knative-serving-namespaced-admin.yaml
@@ -1,0 +1,20 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  labels:
+    app.kubernetes.io/component: knative-serving-install
+    app.kubernetes.io/name: knative-serving-install
+    kustomize.component: knative
+    rbac.authorization.k8s.io/aggregate-to-admin: "true"
+    serving.knative.dev/release: v0.11.2
+  name: knative-serving-namespaced-admin
+rules:
+- apiGroups:
+  - serving.knative.dev
+  - networking.internal.knative.dev
+  - autoscaling.internal.knative.dev
+  - caching.internal.knative.dev
+  resources:
+  - '*'
+  verbs:
+  - '*'

--- a/tests/stacks/gcp/test_data/expected/rbac.authorization.k8s.io_v1_clusterrole_knative-serving-namespaced-edit.yaml
+++ b/tests/stacks/gcp/test_data/expected/rbac.authorization.k8s.io_v1_clusterrole_knative-serving-namespaced-edit.yaml
@@ -1,0 +1,23 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  labels:
+    app.kubernetes.io/component: knative-serving-install
+    app.kubernetes.io/name: knative-serving-install
+    kustomize.component: knative
+    rbac.authorization.k8s.io/aggregate-to-edit: "true"
+    serving.knative.dev/release: v0.11.2
+  name: knative-serving-namespaced-edit
+rules:
+- apiGroups:
+  - serving.knative.dev
+  - networking.internal.knative.dev
+  - autoscaling.internal.knative.dev
+  - caching.internal.knative.dev
+  resources:
+  - '*'
+  verbs:
+  - create
+  - update
+  - patch
+  - delete

--- a/tests/stacks/gcp/test_data/expected/rbac.authorization.k8s.io_v1_clusterrole_knative-serving-namespaced-view.yaml
+++ b/tests/stacks/gcp/test_data/expected/rbac.authorization.k8s.io_v1_clusterrole_knative-serving-namespaced-view.yaml
@@ -1,0 +1,22 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  labels:
+    app.kubernetes.io/component: knative-serving-install
+    app.kubernetes.io/name: knative-serving-install
+    kustomize.component: knative
+    rbac.authorization.k8s.io/aggregate-to-view: "true"
+    serving.knative.dev/release: v0.11.2
+  name: knative-serving-namespaced-view
+rules:
+- apiGroups:
+  - serving.knative.dev
+  - networking.internal.knative.dev
+  - autoscaling.internal.knative.dev
+  - caching.internal.knative.dev
+  resources:
+  - '*'
+  verbs:
+  - get
+  - list
+  - watch

--- a/tests/stacks/gcp/test_data/expected/rbac.authorization.k8s.io_v1_clusterrole_knative-serving-podspecable-binding.yaml
+++ b/tests/stacks/gcp/test_data/expected/rbac.authorization.k8s.io_v1_clusterrole_knative-serving-podspecable-binding.yaml
@@ -1,0 +1,20 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  labels:
+    app.kubernetes.io/component: knative-serving-install
+    app.kubernetes.io/name: knative-serving-install
+    duck.knative.dev/podspecable: "true"
+    kustomize.component: knative
+    serving.knative.dev/release: v0.11.2
+  name: knative-serving-podspecable-binding
+rules:
+- apiGroups:
+  - serving.knative.dev
+  resources:
+  - configurations
+  - services
+  verbs:
+  - list
+  - watch
+  - patch

--- a/tests/stacks/gcp/test_data/expected/rbac.authorization.k8s.io_v1_clusterrole_kubeflow-kfserving-admin.yaml
+++ b/tests/stacks/gcp/test_data/expected/rbac.authorization.k8s.io_v1_clusterrole_kubeflow-kfserving-admin.yaml
@@ -1,0 +1,15 @@
+aggregationRule:
+  clusterRoleSelectors:
+  - matchLabels:
+      rbac.authorization.kubeflow.org/aggregate-to-kubeflow-kfserving-admin: "true"
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  labels:
+    app: kfserving
+    app.kubernetes.io/component: kfserving-install
+    app.kubernetes.io/name: kfserving-install
+    kustomize.component: kfserving
+    rbac.authorization.kubeflow.org/aggregate-to-kubeflow-admin: "true"
+  name: kubeflow-kfserving-admin
+rules: []

--- a/tests/stacks/gcp/test_data/expected/rbac.authorization.k8s.io_v1_clusterrole_kubeflow-kfserving-edit.yaml
+++ b/tests/stacks/gcp/test_data/expected/rbac.authorization.k8s.io_v1_clusterrole_kubeflow-kfserving-edit.yaml
@@ -1,0 +1,25 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  labels:
+    app: kfserving
+    app.kubernetes.io/component: kfserving-install
+    app.kubernetes.io/name: kfserving-install
+    kustomize.component: kfserving
+    rbac.authorization.kubeflow.org/aggregate-to-kubeflow-edit: "true"
+    rbac.authorization.kubeflow.org/aggregate-to-kubeflow-kfserving-admin: "true"
+  name: kubeflow-kfserving-edit
+rules:
+- apiGroups:
+  - serving.kubeflow.org
+  resources:
+  - inferenceservices
+  verbs:
+  - get
+  - list
+  - watch
+  - create
+  - delete
+  - deletecollection
+  - patch
+  - update

--- a/tests/stacks/gcp/test_data/expected/rbac.authorization.k8s.io_v1_clusterrole_kubeflow-kfserving-view.yaml
+++ b/tests/stacks/gcp/test_data/expected/rbac.authorization.k8s.io_v1_clusterrole_kubeflow-kfserving-view.yaml
@@ -1,0 +1,19 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  labels:
+    app: kfserving
+    app.kubernetes.io/component: kfserving-install
+    app.kubernetes.io/name: kfserving-install
+    kustomize.component: kfserving
+    rbac.authorization.kubeflow.org/aggregate-to-kubeflow-view: "true"
+  name: kubeflow-kfserving-view
+rules:
+- apiGroups:
+  - serving.kubeflow.org
+  resources:
+  - inferenceservices
+  verbs:
+  - get
+  - list
+  - watch

--- a/tests/stacks/gcp/test_data/expected/rbac.authorization.k8s.io_v1_clusterrole_manager-role.yaml
+++ b/tests/stacks/gcp/test_data/expected/rbac.authorization.k8s.io_v1_clusterrole_manager-role.yaml
@@ -1,0 +1,140 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  creationTimestamp: null
+  labels:
+    app: kfserving
+    app.kubernetes.io/component: kfserving-install
+    app.kubernetes.io/name: kfserving-install
+    kustomize.component: kfserving
+  name: manager-role
+rules:
+- apiGroups:
+  - serving.knative.dev
+  resources:
+  - services
+  verbs:
+  - get
+  - list
+  - watch
+  - create
+  - update
+  - patch
+  - delete
+- apiGroups:
+  - serving.knative.dev
+  resources:
+  - services/status
+  verbs:
+  - get
+  - update
+  - patch
+- apiGroups:
+  - networking.istio.io
+  resources:
+  - virtualservices
+  verbs:
+  - get
+  - list
+  - watch
+  - create
+  - update
+  - patch
+  - delete
+- apiGroups:
+  - networking.istio.io
+  resources:
+  - virtualservices/status
+  verbs:
+  - get
+  - update
+  - patch
+- apiGroups:
+  - serving.kubeflow.org
+  resources:
+  - inferenceservices
+  verbs:
+  - get
+  - list
+  - watch
+  - create
+  - update
+  - patch
+  - delete
+- apiGroups:
+  - serving.kubeflow.org
+  resources:
+  - inferenceservices/status
+  verbs:
+  - get
+  - update
+  - patch
+- apiGroups:
+  - ""
+  resources:
+  - serviceaccounts
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - secrets
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - configmaps
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - admissionregistration.k8s.io
+  resources:
+  - mutatingwebhookconfigurations
+  - validatingwebhookconfigurations
+  verbs:
+  - get
+  - list
+  - watch
+  - create
+  - update
+  - patch
+  - delete
+- apiGroups:
+  - ""
+  resources:
+  - secrets
+  verbs:
+  - get
+  - list
+  - watch
+  - create
+  - update
+  - patch
+  - delete
+- apiGroups:
+  - ""
+  resources:
+  - services
+  verbs:
+  - get
+  - list
+  - watch
+  - create
+  - update
+  - patch
+  - delete
+- apiGroups:
+  - ""
+  resources:
+  - namespaces
+  verbs:
+  - get
+  - list
+  - watch

--- a/tests/stacks/gcp/test_data/expected/rbac.authorization.k8s.io_v1_clusterrolebinding_custom-metrics:system:auth-delegator.yaml
+++ b/tests/stacks/gcp/test_data/expected/rbac.authorization.k8s.io_v1_clusterrolebinding_custom-metrics:system:auth-delegator.yaml
@@ -1,0 +1,18 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  labels:
+    app.kubernetes.io/component: knative-serving-install
+    app.kubernetes.io/name: knative-serving-install
+    autoscaling.knative.dev/metric-provider: custom-metrics
+    kustomize.component: knative
+    serving.knative.dev/release: v0.11.2
+  name: custom-metrics:system:auth-delegator
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: system:auth-delegator
+subjects:
+- kind: ServiceAccount
+  name: controller
+  namespace: kubeflow

--- a/tests/stacks/gcp/test_data/expected/rbac.authorization.k8s.io_v1_clusterrolebinding_hpa-controller-custom-metrics.yaml
+++ b/tests/stacks/gcp/test_data/expected/rbac.authorization.k8s.io_v1_clusterrolebinding_hpa-controller-custom-metrics.yaml
@@ -1,0 +1,18 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  labels:
+    app.kubernetes.io/component: knative-serving-install
+    app.kubernetes.io/name: knative-serving-install
+    autoscaling.knative.dev/metric-provider: custom-metrics
+    kustomize.component: knative
+    serving.knative.dev/release: v0.11.2
+  name: hpa-controller-custom-metrics
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: custom-metrics-server-resources
+subjects:
+- kind: ServiceAccount
+  name: horizontal-pod-autoscaler
+  namespace: kube-system

--- a/tests/stacks/gcp/test_data/expected/rbac.authorization.k8s.io_v1_clusterrolebinding_kfserving-proxy-rolebinding.yaml
+++ b/tests/stacks/gcp/test_data/expected/rbac.authorization.k8s.io_v1_clusterrolebinding_kfserving-proxy-rolebinding.yaml
@@ -1,0 +1,17 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  labels:
+    app: kfserving
+    app.kubernetes.io/component: kfserving-install
+    app.kubernetes.io/name: kfserving-install
+    kustomize.component: kfserving
+  name: kfserving-proxy-rolebinding
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: kfserving-proxy-role
+subjects:
+- kind: ServiceAccount
+  name: default
+  namespace: kubeflow

--- a/tests/stacks/gcp/test_data/expected/rbac.authorization.k8s.io_v1_clusterrolebinding_knative-serving-controller-admin.yaml
+++ b/tests/stacks/gcp/test_data/expected/rbac.authorization.k8s.io_v1_clusterrolebinding_knative-serving-controller-admin.yaml
@@ -1,0 +1,17 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  labels:
+    app.kubernetes.io/component: knative-serving-install
+    app.kubernetes.io/name: knative-serving-install
+    kustomize.component: knative
+    serving.knative.dev/release: v0.11.2
+  name: knative-serving-controller-admin
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: knative-serving-admin
+subjects:
+- kind: ServiceAccount
+  name: controller
+  namespace: kubeflow

--- a/tests/stacks/gcp/test_data/expected/rbac.authorization.k8s.io_v1_clusterrolebinding_manager-rolebinding.yaml
+++ b/tests/stacks/gcp/test_data/expected/rbac.authorization.k8s.io_v1_clusterrolebinding_manager-rolebinding.yaml
@@ -1,0 +1,17 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  labels:
+    app: kfserving
+    app.kubernetes.io/component: kfserving-install
+    app.kubernetes.io/name: kfserving-install
+    kustomize.component: kfserving
+  name: manager-rolebinding
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: manager-role
+subjects:
+- kind: ServiceAccount
+  name: default
+  namespace: kubeflow

--- a/tests/stacks/gcp/test_data/expected/rbac.authorization.k8s.io_v1_rolebinding_custom-metrics-auth-reader.yaml
+++ b/tests/stacks/gcp/test_data/expected/rbac.authorization.k8s.io_v1_rolebinding_custom-metrics-auth-reader.yaml
@@ -1,0 +1,19 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  labels:
+    app.kubernetes.io/component: knative-serving-install
+    app.kubernetes.io/name: knative-serving-install
+    autoscaling.knative.dev/metric-provider: custom-metrics
+    kustomize.component: knative
+    serving.knative.dev/release: v0.11.2
+  name: custom-metrics-auth-reader
+  namespace: kubeflow
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: extension-apiserver-authentication-reader
+subjects:
+- kind: ServiceAccount
+  name: controller
+  namespace: kubeflow

--- a/tests/stacks/gcp/test_data/expected/rbac.istio.io_v1alpha1_servicerole_istio-service-role.yaml
+++ b/tests/stacks/gcp/test_data/expected/rbac.istio.io_v1alpha1_servicerole_istio-service-role.yaml
@@ -1,0 +1,15 @@
+apiVersion: rbac.istio.io/v1alpha1
+kind: ServiceRole
+metadata:
+  labels:
+    app.kubernetes.io/component: knative-serving-install
+    app.kubernetes.io/name: knative-serving-install
+    kustomize.component: knative
+  name: istio-service-role
+  namespace: kubeflow
+spec:
+  rules:
+  - methods:
+    - '*'
+    services:
+    - '*'

--- a/tests/stacks/gcp/test_data/expected/rbac.istio.io_v1alpha1_servicerolebinding_istio-service-role-binding.yaml
+++ b/tests/stacks/gcp/test_data/expected/rbac.istio.io_v1alpha1_servicerolebinding_istio-service-role-binding.yaml
@@ -1,0 +1,15 @@
+apiVersion: rbac.istio.io/v1alpha1
+kind: ServiceRoleBinding
+metadata:
+  labels:
+    app.kubernetes.io/component: knative-serving-install
+    app.kubernetes.io/name: knative-serving-install
+    kustomize.component: knative
+  name: istio-service-role-binding
+  namespace: kubeflow
+spec:
+  roleRef:
+    kind: ServiceRole
+    name: istio-service-role
+  subjects:
+  - user: '*'

--- a/tests/stacks/gcp/test_data/expected/~g_v1_configmap_config-autoscaler.yaml
+++ b/tests/stacks/gcp/test_data/expected/~g_v1_configmap_config-autoscaler.yaml
@@ -1,0 +1,120 @@
+apiVersion: v1
+data:
+  _example: |
+    ################################
+    #                              #
+    #    EXAMPLE CONFIGURATION     #
+    #                              #
+    ################################
+
+    # This block is not actually functional configuration,
+    # but serves to illustrate the available configuration
+    # options and document them in a way that is accessible
+    # to users that `kubectl edit` this config map.
+    #
+    # These sample configuration options may be copied out of
+    # this example block and unindented to be in the data block
+    # to actually change the configuration.
+
+    # The Revision ContainerConcurrency field specifies the maximum number
+    # of requests the Container can handle at once. Container concurrency
+    # target percentage is how much of that maximum to use in a stable
+    # state. E.g. if a Revision specifies ContainerConcurrency of 10, then
+    # the Autoscaler will try to maintain 7 concurrent connections per pod
+    # on average.
+    # Note: this limit will be applied to container concurrency set at every
+    # level (ConfigMap, Revision Spec or Annotation).
+    # For legacy and backwards compatibility reasons, this value also accepts
+    # fractional values in (0, 1] interval (i.e. 0.7 ⇒ 70%).
+    # Thus minimal percentage value must be greater than 1.0, or it will be
+    # treated as a fraction.
+    container-concurrency-target-percentage: "70"
+
+    # The container concurrency target default is what the Autoscaler will
+    # try to maintain when concurrency is used as the scaling metric for a
+    # Revision and the Revision specifies unlimited concurrency.
+    # Even when specifying unlimited concurrency, the autoscaler will
+    # horizontally scale the application based on this target concurrency.
+    # NOTE: Only one metric can be used for autoscaling a Revision.
+    container-concurrency-target-default: "100"
+
+    # The requests per second (RPS) target default is what the Autoscaler will
+    # try to maintain when RPS is used as the scaling metric for a Revision and
+    # the Revision specifies unlimited RPS. Even when specifying unlimited RPS,
+    # the autoscaler will horizontally scale the application based on this
+    # target RPS.
+    # Must be greater than 1.0.
+    # NOTE: Only one metric can be used for autoscaling a Revision.
+    requests-per-second-target-default: "200"
+
+    # The target burst capacity specifies the size of burst in concurrent
+    # requests that the system operator expects the system will receive.
+    # Autoscaler will try to protect the system from queueing by introducing
+    # Activator in the request path if the current spare capacity of the
+    # service is less than this setting.
+    # If this setting is 0, then Activator will be in the request path only
+    # when the revision is scaled to 0.
+    # If this setting is > 0 and container-concurrency-target-percentage is
+    # 100% or 1.0, then activator will always be in the request path.
+    # -1 denotes unlimited target-burst-capacity and activator will always
+    # be in the request path.
+    # Other negative values are invalid.
+    target-burst-capacity: "200"
+
+    # When operating in a stable mode, the autoscaler operates on the
+    # average concurrency over the stable window.
+    # Stable window must be in whole seconds.
+    stable-window: "60s"
+
+    # When observed average concurrency during the panic window reaches
+    # panic-threshold-percentage the target concurrency, the autoscaler
+    # enters panic mode. When operating in panic mode, the autoscaler
+    # scales on the average concurrency over the panic window which is
+    # panic-window-percentage of the stable-window.
+    # When computing the panic window it will be rounded to the closest
+    # whole second.
+    panic-window-percentage: "10.0"
+
+    # The percentage of the container concurrency target at which to
+    # enter panic mode when reached within the panic window.
+    panic-threshold-percentage: "200.0"
+
+    # Max scale up rate limits the rate at which the autoscaler will
+    # increase pod count. It is the maximum ratio of desired pods versus
+    # observed pods.
+    # Cannot less or equal to 1.
+    # I.e with value of 2.0 the number of pods can at most go N to 2N
+    # over single Autoscaler period (see tick-interval), but at least N to
+    # N+1, if Autoscaler needs to scale up.
+    max-scale-up-rate: "1000.0"
+
+    # Max scale down rate limits the rate at which the autoscaler will
+    # decrease pod count. It is the maximum ratio of observed pods versus
+    # desired pods.
+    # Cannot less or equal to 1.
+    # I.e. with value of 2.0 the number of pods can at most go N to N/2
+    # over single Autoscaler evaluation period (see tick-interval), but at
+    # least N to N-1, if Autoscaler needs to scale down.
+    # Not yet used // TODO(vagababov) remove once other parts are ready.
+    max-scale-down-rate: "2.0"
+
+    # Scale to zero feature flag
+    enable-scale-to-zero: "true"
+
+    # Tick interval is the time between autoscaling calculations.
+    tick-interval: "2s"
+
+    # Dynamic parameters (take effect when config map is updated):
+
+    # Scale to zero grace period is the time an inactive revision is left
+    # running before it is scaled to zero (min: 30s).
+    scale-to-zero-grace-period: "30s"
+kind: ConfigMap
+metadata:
+  labels:
+    app.kubernetes.io/component: knative-serving-install
+    app.kubernetes.io/name: knative-serving-install
+    kustomize.component: knative
+    serving.knative.dev/release: v0.11.2
+  name: config-autoscaler
+  namespace: kubeflow

--- a/tests/stacks/gcp/test_data/expected/~g_v1_configmap_config-defaults.yaml
+++ b/tests/stacks/gcp/test_data/expected/~g_v1_configmap_config-defaults.yaml
@@ -1,0 +1,71 @@
+apiVersion: v1
+data:
+  _example: |
+    ################################
+    #                              #
+    #    EXAMPLE CONFIGURATION     #
+    #                              #
+    ################################
+
+    # This block is not actually functional configuration,
+    # but serves to illustrate the available configuration
+    # options and document them in a way that is accessible
+    # to users that `kubectl edit` this config map.
+    #
+    # These sample configuration options may be copied out of
+    # this example block and unindented to be in the data block
+    # to actually change the configuration.
+
+    # revision-timeout-seconds contains the default number of
+    # seconds to use for the revision's per-request timeout, if
+    # none is specified.
+    revision-timeout-seconds: "300"  # 5 minutes
+
+    # max-revision-timeout-seconds contains the maximum number of
+    # seconds that can be used for revision-timeout-seconds.
+    # This value must be greater than or equal to revision-timeout-seconds.
+    # If omitted, the system default is used (600 seconds).
+    max-revision-timeout-seconds: "600"  # 10 minutes
+
+    # revision-cpu-request contains the cpu allocation to assign
+    # to revisions by default.  If omitted, no value is specified
+    # and the system default is used.
+    revision-cpu-request: "400m"  # 0.4 of a CPU (aka 400 milli-CPU)
+
+    # revision-memory-request contains the memory allocation to assign
+    # to revisions by default.  If omitted, no value is specified
+    # and the system default is used.
+    revision-memory-request: "100M"  # 100 megabytes of memory
+
+    # revision-cpu-limit contains the cpu allocation to limit
+    # revisions to by default.  If omitted, no value is specified
+    # and the system default is used.
+    revision-cpu-limit: "1000m"  # 1 CPU (aka 1000 milli-CPU)
+
+    # revision-memory-limit contains the memory allocation to limit
+    # revisions to by default.  If omitted, no value is specified
+    # and the system default is used.
+    revision-memory-limit: "200M"  # 200 megabytes of memory
+
+    # container-name-template contains a template for the default
+    # container name, if none is specified.  This field supports
+    # Go templating and is supplied with the ObjectMeta of the
+    # enclosing Service or Configuration, so values such as
+    # {{.Name}} are also valid.
+    container-name-template: "user-container"
+
+    # container-concurrency specifies the maximum number
+    # of requests the Container can handle at once, and requests
+    # above this threshold are queued.  Setting a value of zero
+    # disables this throttling and lets through as many requests as
+    # the pod receives.
+    container-concurrency: "0"
+kind: ConfigMap
+metadata:
+  labels:
+    app.kubernetes.io/component: knative-serving-install
+    app.kubernetes.io/name: knative-serving-install
+    kustomize.component: knative
+    serving.knative.dev/release: v0.11.2
+  name: config-defaults
+  namespace: kubeflow

--- a/tests/stacks/gcp/test_data/expected/~g_v1_configmap_config-deployment.yaml
+++ b/tests/stacks/gcp/test_data/expected/~g_v1_configmap_config-deployment.yaml
@@ -1,0 +1,30 @@
+apiVersion: v1
+data:
+  _example: |
+    ################################
+    #                              #
+    #    EXAMPLE CONFIGURATION     #
+    #                              #
+    ################################
+
+    # This block is not actually functional configuration,
+    # but serves to illustrate the available configuration
+    # options and document them in a way that is accessible
+    # to users that `kubectl edit` this config map.
+    #
+    # These sample configuration options may be copied out of
+    # this example block and unindented to be in the data block
+    # to actually change the configuration.
+
+    # List of repositories for which tag to digest resolving should be skipped
+    registriesSkippingTagResolving: "ko.local,dev.local"
+  queueSidecarImage: gcr.io/knative-releases/knative.dev/serving/cmd/queue@sha256:792f6945c7bc73a49a470a5b955c39c8bd174705743abf5fb71aa0f4c04128eb
+kind: ConfigMap
+metadata:
+  labels:
+    app.kubernetes.io/component: knative-serving-install
+    app.kubernetes.io/name: knative-serving-install
+    kustomize.component: knative
+    serving.knative.dev/release: v0.11.2
+  name: config-deployment
+  namespace: kubeflow

--- a/tests/stacks/gcp/test_data/expected/~g_v1_configmap_config-domain.yaml
+++ b/tests/stacks/gcp/test_data/expected/~g_v1_configmap_config-domain.yaml
@@ -1,0 +1,47 @@
+apiVersion: v1
+data:
+  _example: |
+    ################################
+    #                              #
+    #    EXAMPLE CONFIGURATION     #
+    #                              #
+    ################################
+
+    # This block is not actually functional configuration,
+    # but serves to illustrate the available configuration
+    # options and document them in a way that is accessible
+    # to users that `kubectl edit` this config map.
+    #
+    # These sample configuration options may be copied out of
+    # this example block and unindented to be in the data block
+    # to actually change the configuration.
+
+    # Default value for domain.
+    # Although it will match all routes, it is the least-specific rule so it
+    # will only be used if no other domain matches.
+    example.com: |
+
+    # These are example settings of domain.
+    # example.org will be used for routes having app=nonprofit.
+    example.org: |
+      selector:
+        app: nonprofit
+
+    # Routes having domain suffix of 'svc.cluster.local' will not be exposed
+    # through Ingress. You can define your own label selector to assign that
+    # domain suffix to your Route here, or you can set the label
+    #    "serving.knative.dev/visibility=cluster-local"
+    # to achieve the same effect.  This shows how to make routes having
+    # the label app=secret only exposed to the local cluster.
+    svc.cluster.local: |
+      selector:
+        app: secret
+kind: ConfigMap
+metadata:
+  labels:
+    app.kubernetes.io/component: knative-serving-install
+    app.kubernetes.io/name: knative-serving-install
+    kustomize.component: knative
+    serving.knative.dev/release: v0.11.2
+  name: config-domain
+  namespace: kubeflow

--- a/tests/stacks/gcp/test_data/expected/~g_v1_configmap_config-gc.yaml
+++ b/tests/stacks/gcp/test_data/expected/~g_v1_configmap_config-gc.yaml
@@ -1,0 +1,40 @@
+apiVersion: v1
+data:
+  _example: |
+    ################################
+    #                              #
+    #    EXAMPLE CONFIGURATION     #
+    #                              #
+    ################################
+
+    # This block is not actually functional configuration,
+    # but serves to illustrate the available configuration
+    # options and document them in a way that is accessible
+    # to users that `kubectl edit` this config map.
+    #
+    # These sample configuration options may be copied out of
+    # this example block and unindented to be in the data block
+    # to actually change the configuration.
+
+    # Delay after revision creation before considering it for GC
+    stale-revision-create-delay: "24h"
+
+    # Duration since a route has been pointed at a revision before it should be GC'd
+    # This minus lastpinned-debounce be longer than the controller resync period (10 hours)
+    stale-revision-timeout: "15h"
+
+    # Minimum number of generations of revisions to keep before considering for GC
+    stale-revision-minimum-generations: "1"
+
+    # To avoid constant updates, we allow an existing annotation to be stale by this
+    # amount before we update the timestamp
+    stale-revision-lastpinned-debounce: "5h"
+kind: ConfigMap
+metadata:
+  labels:
+    app.kubernetes.io/component: knative-serving-install
+    app.kubernetes.io/name: knative-serving-install
+    kustomize.component: knative
+    serving.knative.dev/release: v0.11.2
+  name: config-gc
+  namespace: kubeflow

--- a/tests/stacks/gcp/test_data/expected/~g_v1_configmap_config-istio.yaml
+++ b/tests/stacks/gcp/test_data/expected/~g_v1_configmap_config-istio.yaml
@@ -1,0 +1,16 @@
+apiVersion: v1
+data:
+  gateway.kubeflow.kubeflow-gateway: istio-ingressgateway.istio-system.svc.cluster.local
+  local-gateway.knative-serving.cluster-local-gateway: cluster-local-gateway.istio-system.svc.cluster.local
+  local-gateway.mesh: mesh
+  reconcileExternalGateway: "false"
+kind: ConfigMap
+metadata:
+  labels:
+    app.kubernetes.io/component: knative-serving-install
+    app.kubernetes.io/name: knative-serving-install
+    kustomize.component: knative
+    networking.knative.dev/ingress-provider: istio
+    serving.knative.dev/release: v0.11.2
+  name: config-istio
+  namespace: kubeflow

--- a/tests/stacks/gcp/test_data/expected/~g_v1_configmap_config-logging.yaml
+++ b/tests/stacks/gcp/test_data/expected/~g_v1_configmap_config-logging.yaml
@@ -1,0 +1,59 @@
+apiVersion: v1
+data:
+  _example: |
+    ################################
+    #                              #
+    #    EXAMPLE CONFIGURATION     #
+    #                              #
+    ################################
+
+    # This block is not actually functional configuration,
+    # but serves to illustrate the available configuration
+    # options and document them in a way that is accessible
+    # to users that `kubectl edit` this config map.
+    #
+    # These sample configuration options may be copied out of
+    # this example block and unindented to be in the data block
+    # to actually change the configuration.
+
+    # Common configuration for all Knative codebase
+    zap-logger-config: |
+      {
+        "level": "info",
+        "development": false,
+        "outputPaths": ["stdout"],
+        "errorOutputPaths": ["stderr"],
+        "encoding": "json",
+        "encoderConfig": {
+          "timeKey": "ts",
+          "levelKey": "level",
+          "nameKey": "logger",
+          "callerKey": "caller",
+          "messageKey": "msg",
+          "stacktraceKey": "stacktrace",
+          "lineEnding": "",
+          "levelEncoder": "",
+          "timeEncoder": "iso8601",
+          "durationEncoder": "",
+          "callerEncoder": ""
+        }
+      }
+
+    # Log level overrides
+    # For all components except the autoscaler and queue proxy,
+    # changes are be picked up immediately.
+    # For autoscaler and queue proxy, changes require recreation of the pods.
+    loglevel.controller: "info"
+    loglevel.autoscaler: "info"
+    loglevel.queueproxy: "info"
+    loglevel.webhook: "info"
+    loglevel.activator: "info"
+kind: ConfigMap
+metadata:
+  labels:
+    app.kubernetes.io/component: knative-serving-install
+    app.kubernetes.io/name: knative-serving-install
+    kustomize.component: knative
+    serving.knative.dev/release: v0.11.2
+  name: config-logging
+  namespace: kubeflow

--- a/tests/stacks/gcp/test_data/expected/~g_v1_configmap_config-network.yaml
+++ b/tests/stacks/gcp/test_data/expected/~g_v1_configmap_config-network.yaml
@@ -1,0 +1,127 @@
+apiVersion: v1
+data:
+  _example: |
+    ################################
+    #                              #
+    #    EXAMPLE CONFIGURATION     #
+    #                              #
+    ################################
+
+    # This block is not actually functional configuration,
+    # but serves to illustrate the available configuration
+    # options and document them in a way that is accessible
+    # to users that `kubectl edit` this config map.
+    #
+    # These sample configuration options may be copied out of
+    # this example block and unindented to be in the data block
+    # to actually change the configuration.
+
+    # istio.sidecar.includeOutboundIPRanges specifies the IP ranges that Istio sidecar
+    # will intercept.
+    #
+    # Replace this with the IP ranges of your cluster (see below for some examples).
+    # Separate multiple entries with a comma.
+    # Example: "10.4.0.0/14,10.7.240.0/20"
+    #
+    # If set to "*" Istio will intercept all traffic within
+    # the cluster as well as traffic that is going outside the cluster.
+    # Traffic going outside the cluster will be blocked unless
+    # necessary egress rules are created.
+    #
+    # If omitted or set to "", value of global.proxy.includeIPRanges
+    # provided at Istio deployment time is used. In default Knative serving
+    # deployment, global.proxy.includeIPRanges value is set to "*".
+    #
+    # If an invalid value is passed, "" is used instead.
+    #
+    # If valid set of IP address ranges are put into this value,
+    # Istio will no longer intercept traffic going to IP addresses
+    # outside the provided ranges and there is no need to specify
+    # egress rules.
+    #
+    # To determine the IP ranges of your cluster:
+    #   IBM Cloud Private: cat cluster/config.yaml | grep service_cluster_ip_range
+    #   IBM Cloud Kubernetes Service: "172.30.0.0/16,172.20.0.0/16,10.10.10.0/24"
+    #   Google Container Engine (GKE): gcloud container clusters describe $CLUSTER_NAME --zone=$CLUSTER_ZONE | grep -e clusterIpv4Cidr -e servicesIpv4Cidr
+    #   Azure Kubernetes Service (AKS): "10.0.0.0/16"
+    #   Azure Container Service (ACS; deprecated): "10.244.0.0/16,10.240.0.0/16"
+    #   Azure Container Service Engine (ACS-Engine; OSS): Configurable, but defaults to "10.0.0.0/16"
+    #   Minikube: "10.0.0.1/24"
+    #
+    # For more information, visit
+    # https://istio.io/docs/tasks/traffic-management/egress/
+    #
+    istio.sidecar.includeOutboundIPRanges: "*"
+
+    # clusteringress.class has been deprecated.   Please use ingress.class instead.
+    clusteringress.class: "istio.ingress.networking.knative.dev"
+
+    # ingress.class specifies the default ingress class
+    # to use when not dictated by Route annotation.
+    #
+    # If not specified, will use the Istio ingress.
+    #
+    # Note that changing the Ingress class of an existing Route
+    # will result in undefined behavior.  Therefore it is best to only
+    # update this value during the setup of Knative, to avoid getting
+    # undefined behavior.
+    ingress.class: "istio.ingress.networking.knative.dev"
+
+    # certificate.class specifies the default Certificate class
+    # to use when not dictated by Route annotation.
+    #
+    # If not specified, will use the Cert-Manager Certificate.
+    #
+    # Note that changing the Certificate class of an existing Route
+    # will result in undefined behavior.  Therefore it is best to only
+    # update this value during the setup of Knative, to avoid getting
+    # undefined behavior.
+    certificate.class: "cert-manager.certificate.networking.internal.knative.dev"
+
+    # domainTemplate specifies the golang text template string to use
+    # when constructing the Knative service's DNS name. The default
+    # value is "{{.Name}}.{{.Namespace}}.{{.Domain}}". And those three
+    # values (Name, Namespace, Domain) are the only variables defined.
+    #
+    # Changing this value might be necessary when the extra levels in
+    # the domain name generated is problematic for wildcard certificates
+    # that only support a single level of domain name added to the
+    # certificate's domain. In those cases you might consider using a value
+    # of "{{.Name}}-{{.Namespace}}.{{.Domain}}", or removing the Namespace
+    # entirely from the template. When choosing a new value be thoughtful
+    # of the potential for conflicts - for example, when users choose to use
+    # characters such as `-` in their service, or namespace, names.
+    # {{.Annotations}} can be used for any customization in the go template if needed.
+    # We strongly recommend keeping namespace part of the template to avoid domain name clashes
+    # Example '{{.Name}}-{{.Namespace}}.{{ index .Annotations "sub"}}.{{.Domain}}'
+    # and you have an annotation {"sub":"foo"}, then the generated template would be {Name}-{Namespace}.foo.{Domain}
+    domainTemplate: "{{.Name}}.{{.Namespace}}.{{.Domain}}"
+
+    # tagTemplate specifies the golang text template string to use
+    # when constructing the DNS name for "tags" within the traffic blocks
+    # of Routes and Configuration.  This is used in conjunction with the
+    # domainTemplate above to determine the full URL for the tag.
+    tagTemplate: "{{.Tag}}-{{.Name}}"
+
+    # Controls whether TLS certificates are automatically provisioned and
+    # installed in the Knative ingress to terminate external TLS connection.
+    # 1. Enabled: enabling auto-TLS feature.
+    # 2. Disabled: disabling auto-TLS feature.
+    autoTLS: "Disabled"
+
+    # Controls the behavior of the HTTP endpoint for the Knative ingress.
+    # It requires autoTLS to be enabled or reconcileExternalGateway in config-istio to be true.
+    # 1. Enabled: The Knative ingress will be able to serve HTTP connection.
+    # 2. Disabled: The Knative ingress will reject HTTP traffic.
+    # 3. Redirected: The Knative ingress will send a 302 redirect for all
+    # http connections, asking the clients to use HTTPS
+    httpProtocol: "Enabled"
+kind: ConfigMap
+metadata:
+  labels:
+    app.kubernetes.io/component: knative-serving-install
+    app.kubernetes.io/name: knative-serving-install
+    kustomize.component: knative
+    serving.knative.dev/release: v0.11.2
+  name: config-network
+  namespace: kubeflow

--- a/tests/stacks/gcp/test_data/expected/~g_v1_configmap_config-observability.yaml
+++ b/tests/stacks/gcp/test_data/expected/~g_v1_configmap_config-observability.yaml
@@ -1,0 +1,100 @@
+apiVersion: v1
+data:
+  _example: |
+    ################################
+    #                              #
+    #    EXAMPLE CONFIGURATION     #
+    #                              #
+    ################################
+
+    # This block is not actually functional configuration,
+    # but serves to illustrate the available configuration
+    # options and document them in a way that is accessible
+    # to users that `kubectl edit` this config map.
+    #
+    # These sample configuration options may be copied out of
+    # this example block and unindented to be in the data block
+    # to actually change the configuration.
+
+    # logging.enable-var-log-collection defaults to false.
+    # The fluentd daemon set will be set up to collect /var/log if
+    # this flag is true.
+    logging.enable-var-log-collection: "false"
+
+    # logging.revision-url-template provides a template to use for producing the
+    # logging URL that is injected into the status of each Revision.
+    # This value is what you might use the the Knative monitoring bundle, and provides
+    # access to Kibana after setting up kubectl proxy.
+    logging.revision-url-template: |
+      http://localhost:8001/api/v1/namespaces/knative-monitoring/services/kibana-logging/proxy/app/kibana#/discover?_a=(query:(match:(kubernetes.labels.serving-knative-dev%2FrevisionUID:(query:'${REVISION_UID}',type:phrase))))
+
+    # If non-empty, this enables queue proxy writing user request logs to stdout, excluding probe
+    # requests.
+    # The value determines the shape of the request logs and it must be a valid go text/template.
+    # It is important to keep this as a single line. Multiple lines are parsed as separate entities
+    # by most collection agents and will split the request logs into multiple records.
+    #
+    # The following fields and functions are available to the template:
+    #
+    # Request: An http.Request (see https://golang.org/pkg/net/http/#Request)
+    # representing an HTTP request received by the server.
+    #
+    # Response:
+    # struct {
+    #   Code    int       // HTTP status code (see https://www.iana.org/assignments/http-status-codes/http-status-codes.xhtml)
+    #   Size    int       // An int representing the size of the response.
+    #   Latency float64   // A float64 representing the latency of the response in seconds.
+    # }
+    #
+    # Revision:
+    # struct {
+    #   Name          string  // Knative revision name
+    #   Namespace     string  // Knative revision namespace
+    #   Service       string  // Knative service name
+    #   Configuration string  // Knative configuration name
+    #   PodName       string  // Name of the pod hosting the revision
+    #   PodIP         string  // IP of the pod hosting the revision
+    # }
+    #
+    logging.request-log-template: '{"httpRequest": {"requestMethod": "{{.Request.Method}}", "requestUrl": "{{js .Request.RequestURI}}", "requestSize": "{{.Request.ContentLength}}", "status": {{.Response.Code}}, "responseSize": "{{.Response.Size}}", "userAgent": "{{js .Request.UserAgent}}", "remoteIp": "{{js .Request.RemoteAddr}}", "serverIp": "{{.Revision.PodIP}}", "referer": "{{js .Request.Referer}}", "latency": "{{.Response.Latency}}s", "protocol": "{{.Request.Proto}}"}, "traceId": "{{index .Request.Header "X-B3-Traceid"}}"}'
+
+    # If true, this enables queue proxy writing request logs for probe requests to stdout.
+    # It uses the same template for user requests, i.e. logging.request-log-template.
+    logging.enable-probe-request-log: "false"
+
+    # metrics.backend-destination field specifies the system metrics destination.
+    # It supports either prometheus (the default) or stackdriver.
+    # Note: Using stackdriver will incur additional charges
+    metrics.backend-destination: prometheus
+
+    # metrics.request-metrics-backend-destination specifies the request metrics
+    # destination. It enables queue proxy to send request metrics.
+    # Currently supported values: prometheus (the default), stackdriver.
+    metrics.request-metrics-backend-destination: prometheus
+
+    # metrics.stackdriver-project-id field specifies the stackdriver project ID. This
+    # field is optional. When running on GCE, application default credentials will be
+    # used if this field is not provided.
+    metrics.stackdriver-project-id: "<your stackdriver project id>"
+
+    # metrics.allow-stackdriver-custom-metrics indicates whether it is allowed to send metrics to
+    # Stackdriver using "global" resource type and custom metric type if the
+    # metrics are not supported by "knative_revision" resource type. Setting this
+    # flag to "true" could cause extra Stackdriver charge.
+    # If metrics.backend-destination is not Stackdriver, this is ignored.
+    metrics.allow-stackdriver-custom-metrics: "false"
+
+    # profiling.enable indicates whether it is allowed to retrieve runtime profiling data from
+    # the pods via an HTTP server in the format expected by the pprof visualization tool. When
+    # enabled, the Knative Serving pods expose the profiling data on an alternate HTTP port 8008.
+    # The HTTP context root for profiling is then /debug/pprof/.
+    profiling.enable: "false"
+kind: ConfigMap
+metadata:
+  labels:
+    app.kubernetes.io/component: knative-serving-install
+    app.kubernetes.io/name: knative-serving-install
+    kustomize.component: knative
+    serving.knative.dev/release: v0.11.2
+  name: config-observability
+  namespace: kubeflow

--- a/tests/stacks/gcp/test_data/expected/~g_v1_configmap_config-tracing.yaml
+++ b/tests/stacks/gcp/test_data/expected/~g_v1_configmap_config-tracing.yaml
@@ -1,0 +1,45 @@
+apiVersion: v1
+data:
+  _example: |
+    ################################
+    #                              #
+    #    EXAMPLE CONFIGURATION     #
+    #                              #
+    ################################
+
+    # This block is not actually functional configuration,
+    # but serves to illustrate the available configuration
+    # options and document them in a way that is accessible
+    # to users that `kubectl edit` this config map.
+    #
+    # These sample configuration options may be copied out of
+    # this example block and unindented to be in the data block
+    # to actually change the configuration.
+    #
+    # This may be "zipkin" or "stackdriver", the default is "none"
+    backend: "none"
+
+    # URL to zipkin collector where traces are sent.
+    # This must be specified when backend is "zipkin"
+    zipkin-endpoint: "http://zipkin.istio-system.svc.cluster.local:9411/api/v2/spans"
+
+    # The GCP project into which stackdriver metrics will be written
+    # when backend is "stackdriver".  If unspecified, the project-id
+    # is read from GCP metadata when running on GCP.
+    stackdriver-project-id: "my-project"
+
+    # Enable zipkin debug mode. This allows all spans to be sent to the server
+    # bypassing sampling.
+    debug: "false"
+
+    # Percentage (0-1) of requests to trace
+    sample-rate: "0.1"
+kind: ConfigMap
+metadata:
+  labels:
+    app.kubernetes.io/component: knative-serving-install
+    app.kubernetes.io/name: knative-serving-install
+    kustomize.component: knative
+    serving.knative.dev/release: v0.11.2
+  name: config-tracing
+  namespace: kubeflow

--- a/tests/stacks/gcp/test_data/expected/~g_v1_configmap_inferenceservice-config.yaml
+++ b/tests/stacks/gcp/test_data/expected/~g_v1_configmap_inferenceservice-config.yaml
@@ -1,0 +1,110 @@
+apiVersion: v1
+data:
+  credentials: |-
+    {
+       "gcs": {
+           "gcsCredentialFileName": "gcloud-application-credentials.json"
+       },
+       "s3": {
+           "s3AccessKeyIDName": "awsAccessKeyID",
+           "s3SecretAccessKeyName": "awsSecretAccessKey"
+       }
+    }
+  explainers: |-
+    {
+        "alibi": {
+            "image" : "docker.io/seldonio/kfserving-alibiexplainer",
+            "defaultImageVersion": "v0.3.0",
+            "allowedImageVersions": [
+               "v0.3.0"
+            ]
+        }
+    }
+  ingress: |-
+    {
+        "ingressGateway" : "kubeflow-gateway.kubeflow",
+        "ingressService" : "istio-ingressgateway.istio-system.svc.cluster.local"
+    }
+  logger: |-
+    {
+        "image" : "gcr.io/kfserving/logger:v0.3.0",
+        "memoryRequest": "100Mi",
+        "memoryLimit": "1Gi",
+        "cpuRequest": "100m",
+        "cpuLimit": "1"
+    }
+  predictors: |-
+    {
+        "tensorflow": {
+            "image": "tensorflow/serving",
+            "defaultImageVersion": "1.14.0",
+            "defaultGpuImageVersion": "1.14.0-gpu",
+            "allowedImageVersions": [
+               "1.11.0",
+               "1.11.0-gpu",
+               "1.12.0",
+               "1.12.0-gpu",
+               "1.13.0",
+               "1.13.0-gpu",
+               "1.14.0",
+               "1.14.0-gpu"
+            ]
+        },
+        "onnx": {
+            "image": "mcr.microsoft.com/onnxruntime/server",
+            "defaultImageVersion": "v0.5.1",
+            "allowedImageVersions": [
+               "v0.5.1"
+            ]
+        },
+        "sklearn": {
+            "image": "gcr.io/kfserving/sklearnserver",
+            "defaultImageVersion": "v0.3.0",
+            "allowedImageVersions": [
+               "v0.3.0"
+            ]
+        },
+        "xgboost": {
+            "image": "gcr.io/kfserving/xgbserver",
+            "defaultImageVersion": "v0.3.0",
+            "allowedImageVersions": [
+               "v0.3.0"
+            ]
+        },
+        "pytorch": {
+            "image": "gcr.io/kfserving/pytorchserver",
+            "defaultImageVersion": "v0.3.0",
+            "defaultGpuImageVersion": "v0.3.0-gpu",
+            "allowedImageVersions": [
+               "v0.3.0",
+               "v0.3.0-gpu"
+            ]
+        },
+        "tensorrt": {
+            "image": "nvcr.io/nvidia/tensorrtserver",
+            "defaultImageVersion": "19.05-py3",
+            "allowedImageVersions": [
+               "19.05-py3"
+            ]
+        }
+    }
+  storageInitializer: |-
+    {
+        "image" : "gcr.io/kfserving/storage-initializer:v0.3.0",
+        "memoryRequest": "100Mi",
+        "memoryLimit": "1Gi",
+        "cpuRequest": "100m",
+        "cpuLimit": "1"
+    }
+  transformers: |-
+    {
+    }
+kind: ConfigMap
+metadata:
+  labels:
+    app: kfserving
+    app.kubernetes.io/component: kfserving-install
+    app.kubernetes.io/name: kfserving-install
+    kustomize.component: kfserving
+  name: inferenceservice-config
+  namespace: kubeflow

--- a/tests/stacks/gcp/test_data/expected/~g_v1_configmap_kfserving-config.yaml
+++ b/tests/stacks/gcp/test_data/expected/~g_v1_configmap_kfserving-config.yaml
@@ -1,0 +1,12 @@
+apiVersion: v1
+data:
+  registry: gcr.io/kfserving
+kind: ConfigMap
+metadata:
+  labels:
+    app: kfserving
+    app.kubernetes.io/component: kfserving-install
+    app.kubernetes.io/name: kfserving-install
+    kustomize.component: kfserving
+  name: kfserving-config
+  namespace: kubeflow

--- a/tests/stacks/gcp/test_data/expected/~g_v1_namespace_knative-serving.yaml
+++ b/tests/stacks/gcp/test_data/expected/~g_v1_namespace_knative-serving.yaml
@@ -1,0 +1,10 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  labels:
+    app.kubernetes.io/component: knative-serving-install
+    app.kubernetes.io/name: knative-serving-install
+    istio-injection: enabled
+    kustomize.component: knative
+    serving.knative.dev/release: v0.11.2
+  name: knative-serving

--- a/tests/stacks/gcp/test_data/expected/~g_v1_secret_kfserving-webhook-server-secret.yaml
+++ b/tests/stacks/gcp/test_data/expected/~g_v1_secret_kfserving-webhook-server-secret.yaml
@@ -1,0 +1,10 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  labels:
+    app: kfserving
+    app.kubernetes.io/component: kfserving-install
+    app.kubernetes.io/name: kfserving-install
+    kustomize.component: kfserving
+  name: kfserving-webhook-server-secret
+  namespace: kubeflow

--- a/tests/stacks/gcp/test_data/expected/~g_v1_secret_webhook-certs.yaml
+++ b/tests/stacks/gcp/test_data/expected/~g_v1_secret_webhook-certs.yaml
@@ -1,0 +1,10 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  labels:
+    app.kubernetes.io/component: knative-serving-install
+    app.kubernetes.io/name: knative-serving-install
+    kustomize.component: knative
+    serving.knative.dev/release: v0.11.2
+  name: webhook-certs
+  namespace: kubeflow

--- a/tests/stacks/gcp/test_data/expected/~g_v1_service_activator-service.yaml
+++ b/tests/stacks/gcp/test_data/expected/~g_v1_service_activator-service.yaml
@@ -1,0 +1,31 @@
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    app: activator
+    app.kubernetes.io/component: knative-serving-install
+    app.kubernetes.io/name: knative-serving-install
+    kustomize.component: knative
+    serving.knative.dev/release: v0.11.2
+  name: activator-service
+  namespace: kubeflow
+spec:
+  ports:
+  - name: http
+    port: 80
+    protocol: TCP
+    targetPort: 8012
+  - name: http2
+    port: 81
+    protocol: TCP
+    targetPort: 8013
+  - name: http-metrics
+    port: 9090
+    protocol: TCP
+    targetPort: 9090
+  selector:
+    app: activator
+    app.kubernetes.io/component: knative-serving-install
+    app.kubernetes.io/name: knative-serving-install
+    kustomize.component: knative
+  type: ClusterIP

--- a/tests/stacks/gcp/test_data/expected/~g_v1_service_autoscaler.yaml
+++ b/tests/stacks/gcp/test_data/expected/~g_v1_service_autoscaler.yaml
@@ -1,0 +1,30 @@
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    app: autoscaler
+    app.kubernetes.io/component: knative-serving-install
+    app.kubernetes.io/name: knative-serving-install
+    kustomize.component: knative
+    serving.knative.dev/release: v0.11.2
+  name: autoscaler
+  namespace: kubeflow
+spec:
+  ports:
+  - name: http
+    port: 8080
+    protocol: TCP
+    targetPort: 8080
+  - name: http-metrics
+    port: 9090
+    protocol: TCP
+    targetPort: 9090
+  - name: https-custom-metrics
+    port: 443
+    protocol: TCP
+    targetPort: 8443
+  selector:
+    app: autoscaler
+    app.kubernetes.io/component: knative-serving-install
+    app.kubernetes.io/name: knative-serving-install
+    kustomize.component: knative

--- a/tests/stacks/gcp/test_data/expected/~g_v1_service_controller.yaml
+++ b/tests/stacks/gcp/test_data/expected/~g_v1_service_controller.yaml
@@ -1,0 +1,22 @@
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    app: controller
+    app.kubernetes.io/component: knative-serving-install
+    app.kubernetes.io/name: knative-serving-install
+    kustomize.component: knative
+    serving.knative.dev/release: v0.11.2
+  name: controller
+  namespace: kubeflow
+spec:
+  ports:
+  - name: http-metrics
+    port: 9090
+    protocol: TCP
+    targetPort: 9090
+  selector:
+    app: controller
+    app.kubernetes.io/component: knative-serving-install
+    app.kubernetes.io/name: knative-serving-install
+    kustomize.component: knative

--- a/tests/stacks/gcp/test_data/expected/~g_v1_service_kfserving-controller-manager-metrics-service.yaml
+++ b/tests/stacks/gcp/test_data/expected/~g_v1_service_kfserving-controller-manager-metrics-service.yaml
@@ -1,0 +1,28 @@
+apiVersion: v1
+kind: Service
+metadata:
+  annotations:
+    prometheus.io/port: "8443"
+    prometheus.io/scheme: https
+    prometheus.io/scrape: "true"
+  labels:
+    app: kfserving
+    app.kubernetes.io/component: kfserving-install
+    app.kubernetes.io/name: kfserving-install
+    control-plane: controller-manager
+    controller-tools.k8s.io: "1.0"
+    kustomize.component: kfserving
+  name: kfserving-controller-manager-metrics-service
+  namespace: kubeflow
+spec:
+  ports:
+  - name: https
+    port: 8443
+    targetPort: https
+  selector:
+    app: kfserving
+    app.kubernetes.io/component: kfserving-install
+    app.kubernetes.io/name: kfserving-install
+    control-plane: controller-manager
+    controller-tools.k8s.io: "1.0"
+    kustomize.component: kfserving

--- a/tests/stacks/gcp/test_data/expected/~g_v1_service_kfserving-controller-manager-service.yaml
+++ b/tests/stacks/gcp/test_data/expected/~g_v1_service_kfserving-controller-manager-service.yaml
@@ -1,0 +1,22 @@
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    app: kfserving
+    app.kubernetes.io/component: kfserving-install
+    app.kubernetes.io/name: kfserving-install
+    control-plane: kfserving-controller-manager
+    controller-tools.k8s.io: "1.0"
+    kustomize.component: kfserving
+  name: kfserving-controller-manager-service
+  namespace: kubeflow
+spec:
+  ports:
+  - port: 443
+  selector:
+    app: kfserving
+    app.kubernetes.io/component: kfserving-install
+    app.kubernetes.io/name: kfserving-install
+    control-plane: kfserving-controller-manager
+    controller-tools.k8s.io: "1.0"
+    kustomize.component: kfserving

--- a/tests/stacks/gcp/test_data/expected/~g_v1_service_kfserving-webhook-server-service.yaml
+++ b/tests/stacks/gcp/test_data/expected/~g_v1_service_kfserving-webhook-server-service.yaml
@@ -1,0 +1,20 @@
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    app: kfserving
+    app.kubernetes.io/component: kfserving-install
+    app.kubernetes.io/name: kfserving-install
+    kustomize.component: kfserving
+  name: kfserving-webhook-server-service
+  namespace: kubeflow
+spec:
+  ports:
+  - port: 443
+    targetPort: 443
+  selector:
+    app: kfserving
+    app.kubernetes.io/component: kfserving-install
+    app.kubernetes.io/name: kfserving-install
+    control-plane: kfserving-controller-manager
+    kustomize.component: kfserving

--- a/tests/stacks/gcp/test_data/expected/~g_v1_service_webhook.yaml
+++ b/tests/stacks/gcp/test_data/expected/~g_v1_service_webhook.yaml
@@ -1,0 +1,21 @@
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    app.kubernetes.io/component: knative-serving-install
+    app.kubernetes.io/name: knative-serving-install
+    kustomize.component: knative
+    role: webhook
+    serving.knative.dev/release: v0.11.2
+  name: webhook
+  namespace: kubeflow
+spec:
+  ports:
+  - name: https-webhook
+    port: 443
+    targetPort: 8443
+  selector:
+    app.kubernetes.io/component: knative-serving-install
+    app.kubernetes.io/name: knative-serving-install
+    kustomize.component: knative
+    role: webhook

--- a/tests/stacks/gcp/test_data/expected/~g_v1_serviceaccount_controller.yaml
+++ b/tests/stacks/gcp/test_data/expected/~g_v1_serviceaccount_controller.yaml
@@ -1,0 +1,10 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  labels:
+    app.kubernetes.io/component: knative-serving-install
+    app.kubernetes.io/name: knative-serving-install
+    kustomize.component: knative
+    serving.knative.dev/release: v0.11.2
+  name: controller
+  namespace: kubeflow

--- a/tests/validate_resources_test.go
+++ b/tests/validate_resources_test.go
@@ -49,6 +49,10 @@ func TestCommonLabelsImmutable(t *testing.T) {
 	}
 
 	// These labels are likely to be mutable and should not be part of commonLabels
+	// TODO(jlewi): In 1.0 and prior versions the convention was to use mutable values that contained the
+	// version number. That was the original reason we made these forbidden labels; it was to stop people
+	// from attaching mutable versions that would break upgrades. Post 1.1 we might want to start relaxing that
+	// and allow applications to start using these labels but in an immutable fashion.
 	forbiddenLabels := []string{VersionLabel, ManagedByLabel, InstanceLabel, PartOfLabel}
 
 	err := filepath.Walk("..", func(path string, info os.FileInfo, err error) error {


### PR DESCRIPTION
* Related to: kubeflow/gcp-blueprints#74

Fix common labels for knative and kfserving.

  * There were typos and they were including labels that by convention
    we currently don't want in common labels.
