### PR TITLE
Remove katib-metricscollector-injection label from Kubeflow namespace

### DIFF
--- a/namespaces/base/namespaces.yaml
+++ b/namespaces/base/namespaces.yaml
@@ -5,7 +5,6 @@ metadata:
   labels:
     control-plane: kubeflow
     istio-injection: enabled
-    katib-metricscollector-injection: enabled
 ---
 apiVersion: v1
 kind: Namespace


### PR DESCRIPTION
**Which issue is resolved by this Pull Request:**
Related: https://github.com/kubeflow/manifests/issues/1380.

**Description of your changes:**
I deleted `katib-metricscollector-injection: enabled` label from Kubeflow namespace. 

I believe in kfctl this label was added in this PR: https://github.com/kubeflow/kfctl/pull/72.
Let me know if we need to update kfctl also.

/assign @jlewi 
/cc @gaocegege @johnugeorge 

**Checklist:**
- [x] Unit tests have been rebuilt: 
    1. `cd manifests/tests`
    2. `make generate-changed-only`
    3. `make test`
