### PR TITLE
Automated cherry-pick of #1387: Remove katib-metricscollector-injection label from Kubeflow namespace on v1.1-branch

### DIFF
--- a/namespaces/base/namespaces.yaml
+++ b/namespaces/base/namespaces.yaml
@@ -5,7 +5,6 @@ metadata:
   labels:
     control-plane: kubeflow
     istio-injection: enabled
-    katib-metricscollector-injection: enabled
 ---
 apiVersion: v1
 kind: Namespace


### PR DESCRIPTION
Related: https://github.com/kubeflow/manifests/pull/1387#issuecomment-658466481.

/assign @jlewi 

**Checklist:**
- [x] Unit tests have been rebuilt: 
    1. `cd manifests/tests`
    2. `make generate-changed-only`
    3. `make test`
