### PR TITLE
Revert CRD status exception and remove status from Seldon CRD

### DIFF
--- a/seldon/seldon-core-operator/base/resources.yaml
+++ b/seldon/seldon-core-operator/base/resources.yaml
@@ -4238,12 +4238,6 @@ spec:
   - name: v1alpha3
     served: true
     storage: false
-status:
-  acceptedNames:
-    kind: ''
-    plural: ''
-  conditions: []
-  storedVersions: []
 ---
 # Source: seldon-core-operator/templates/clusterrole_seldon-manager-role.yaml
 apiVersion: rbac.authorization.k8s.io/v1

--- a/tests/stacks/ibm/test_data/expected/apiextensions.k8s.io_v1beta1_customresourcedefinition_seldondeployments.machinelearning.seldon.io.yaml
+++ b/tests/stacks/ibm/test_data/expected/apiextensions.k8s.io_v1beta1_customresourcedefinition_seldondeployments.machinelearning.seldon.io.yaml
@@ -6920,9 +6920,3 @@ spec:
   - name: v1alpha3
     served: true
     storage: false
-status:
-  acceptedNames:
-    kind: ""
-    plural: ""
-  conditions: []
-  storedVersions: []

--- a/tests/tests/legacy_kustomizations/seldon-core-operator/test_data/expected/apiextensions.k8s.io_v1beta1_customresourcedefinition_seldondeployments.machinelearning.seldon.io.yaml
+++ b/tests/tests/legacy_kustomizations/seldon-core-operator/test_data/expected/apiextensions.k8s.io_v1beta1_customresourcedefinition_seldondeployments.machinelearning.seldon.io.yaml
@@ -6922,9 +6922,3 @@ spec:
   - name: v1alpha3
     served: true
     storage: false
-status:
-  acceptedNames:
-    kind: ""
-    plural: ""
-  conditions: []
-  storedVersions: []

--- a/tests/validate_resources_test.go
+++ b/tests/validate_resources_test.go
@@ -229,11 +229,6 @@ func TestValidK8sResources(t *testing.T) {
 				t.Errorf("Path %v; resource %v; has version and kind %v which should be changed to %v", path, m.Name, vAndK, v)
 			}
 
-			//Skip Custom resource Definitions as they can have a status field
-			if m.Kind == "CustomResourceDefinition" {
-				continue
-			}
-
 			// Ensure status isn't set
 			f := n.Field("status")
 


### PR DESCRIPTION
**Which issue is resolved by this Pull Request:**
Resolves #1386 

**Description of your changes:**

 * Revert exception in manifest test to again enforce status for all resources
 * Remove `status` section from Seldon CRD.

**Checklist:**
- [x] Unit tests have been rebuilt: 
    1. `cd manifests/tests`
    2. `make generate-changed-only`
    3. `make test`
