### PR TITLE
Moving central dashboard links to configmap

### DIFF
--- a/common/centraldashboard/base/deployment_patch.yaml
+++ b/common/centraldashboard/base/deployment_patch.yaml
@@ -16,3 +16,5 @@ spec:
           value: profiles-kfam.kubeflow
         - name: REGISTRATION_FLOW
           value: $(registration-flow)
+        - name: DASHBOARD_LINKS_CONFIGMAP
+          value: centraldashboard-links-config

--- a/common/centraldashboard/base/links-configmap.yaml
+++ b/common/centraldashboard/base/links-configmap.yaml
@@ -1,0 +1,91 @@
+apiVersion: v1
+data:
+  links: |-
+    {
+      "menuLinks": [
+        {
+          "link": "/pipeline/",
+          "text": "Pipelines"
+        },
+        {
+          "link": "/jupyter/",
+          "text": "Notebook Servers"
+        },
+        {
+          "link": "/katib/",
+          "text": "Katib"
+        },
+        {
+          "link": "/metadata/",
+          "text": "Artifact Store"
+        }
+      ],
+      "externalLinks": [],
+      "quickLinks": [
+        {
+          "text": "Upload a pipeline",
+          "desc": "Pipelines",
+          "link": "/pipeline/"
+        },
+        {
+          "text": "View all pipeline runs",
+          "desc": "Pipelines",
+          "link": "/pipeline/#/runs"
+        },
+        {
+          "text": "Create a new Notebook server",
+          "desc": "Notebook Servers",
+          "link": "/jupyter/new?namespace=kubeflow"
+        },
+        {
+          "text": "View Katib Experiments",
+          "desc": "Katib",
+          "link": "/katib/"
+        },
+        {
+          "text": "View Metadata Artifacts",
+          "desc": "Artifact Store",
+          "link": "/metadata/"
+        }
+      ],
+      "documentationItems": [
+        {
+          "text": "Getting Started with Kubeflow",
+          "desc": "Get your machine-learning workflow up and running on Kubeflow",
+          "link": "https://www.kubeflow.org/docs/started/getting-started/"
+        },
+        {
+          "text": "MiniKF",
+          "desc": "A fast and easy way to deploy Kubeflow locally",
+          "link": "https://www.kubeflow.org/docs/started/getting-started-minikf/"
+        },
+        {
+          "text": "Microk8s for Kubeflow",
+          "desc": "Quickly get Kubeflow running locally on native hypervisors",
+          "link": "https://www.kubeflow.org/docs/started/getting-started-multipass/"
+        },
+        {
+          "text": "Minikube for Kubeflow",
+          "desc": "Quickly get Kubeflow running locally",
+          "link": "https://www.kubeflow.org/docs/started/getting-started-minikube/"
+        },
+        {
+          "text": "Kubeflow on GCP",
+          "desc": "Running Kubeflow on Kubernetes Engine and Google Cloud Platform",
+          "link": "https://www.kubeflow.org/docs/gke/"
+        },
+        {
+          "text": "Kubeflow on AWS",
+          "desc": "Running Kubeflow on Elastic Container Service and Amazon Web Services",
+          "link": "https://www.kubeflow.org/docs/aws/"
+        },
+        {
+          "text": "Requirements for Kubeflow",
+          "desc": "Get more detailed information about using Kubeflow and its components",
+          "link": "https://www.kubeflow.org/docs/started/requirements/"
+        }
+      ]
+    }
+kind: ConfigMap
+metadata:
+  name: centraldashboard-links-config

--- a/common/centraldashboard/base/role.yaml
+++ b/common/centraldashboard/base/role.yaml
@@ -21,5 +21,6 @@ rules:
   - ""
   resources:
   - secrets
+  - configmaps
   verbs:
   - get

--- a/tests/stacks/examples/alice/test_data/expected/rbac.authorization.k8s.io_v1_role_centraldashboard.yaml
+++ b/tests/stacks/examples/alice/test_data/expected/rbac.authorization.k8s.io_v1_role_centraldashboard.yaml
@@ -24,5 +24,6 @@ rules:
   - ""
   resources:
   - secrets
+  - configmaps
   verbs:
   - get

--- a/tests/stacks/gcp/test_data/expected/rbac.authorization.k8s.io_v1_role_centraldashboard.yaml
+++ b/tests/stacks/gcp/test_data/expected/rbac.authorization.k8s.io_v1_role_centraldashboard.yaml
@@ -24,5 +24,6 @@ rules:
   - ""
   resources:
   - secrets
+  - configmaps
   verbs:
   - get

--- a/tests/stacks/generic/test_data/expected/rbac.authorization.k8s.io_v1_role_centraldashboard.yaml
+++ b/tests/stacks/generic/test_data/expected/rbac.authorization.k8s.io_v1_role_centraldashboard.yaml
@@ -24,5 +24,6 @@ rules:
   - ""
   resources:
   - secrets
+  - configmaps
   verbs:
   - get

--- a/tests/stacks/ibm/test_data/expected/rbac.authorization.k8s.io_v1_role_centraldashboard.yaml
+++ b/tests/stacks/ibm/test_data/expected/rbac.authorization.k8s.io_v1_role_centraldashboard.yaml
@@ -24,5 +24,6 @@ rules:
   - ""
   resources:
   - secrets
+  - configmaps
   verbs:
   - get

--- a/tests/tests/legacy_kustomizations/centraldashboard/test_data/expected/apps_v1_deployment_centraldashboard.yaml
+++ b/tests/tests/legacy_kustomizations/centraldashboard/test_data/expected/apps_v1_deployment_centraldashboard.yaml
@@ -48,6 +48,8 @@ spec:
           value: profiles-kfam.kubeflow
         - name: REGISTRATION_FLOW
           value: "true"
+        - name: DASHBOARD_LINKS_CONFIGMAP
+          value: centraldashboard-links-config
         image: gcr.io/kubeflow-images-public/centraldashboard:vmaster-gf39279c0
         imagePullPolicy: IfNotPresent
         livenessProbe:

--- a/tests/tests/legacy_kustomizations/centraldashboard/test_data/expected/rbac.authorization.k8s.io_v1_role_centraldashboard.yaml
+++ b/tests/tests/legacy_kustomizations/centraldashboard/test_data/expected/rbac.authorization.k8s.io_v1_role_centraldashboard.yaml
@@ -29,5 +29,6 @@ rules:
   - ""
   resources:
   - secrets
+  - configmaps
   verbs:
   - get


### PR DESCRIPTION
**Description of your changes:**
Related to https://github.com/kubeflow/kubeflow/pull/5147 (To be merged after central dashboard PR merges)

**Checklist:**
- [x] Unit tests have been rebuilt: 
    1. `cd manifests/tests`
    2. `make generate-changed-only`
    3. `make test`
