### PR TITLE
Update ObjectStoreConfig.PipelineFolder in api-server configmap

### DIFF
--- a/pipeline/api-service/base/config-map.yaml
+++ b/pipeline/api-service/base/config-map.yaml
@@ -15,6 +15,7 @@ data:
         "AccessKey": "minio",
         "SecretAccessKey": "minio123",
         "BucketName": "mlpipeline",
+        "PipelineFolder": "pipelines",
         "Secure": false
       },
       "InitConnectionTimeout": "6m",


### PR DESCRIPTION
**Description of your changes:**
This PR adds a missing parameter in manifests/apiserver which was added by kubeflow/pipelines#2080 

This parameter is crucial for Kubeflow 1.0.2 deployments as it breaks the Pipeline UI functionality: kubeflow/pipelines#4254

**Which issue is resolved by this Pull Request:**
Resolves kubeflow/pipelines#4254

**Checklist:**
- [ ] Unit tests have been rebuilt: 
    1. `cd manifests/tests`
    2. `make generate-changed-only`
    3. `make test`
