### PR TITLE
Bring back some istio virtual services back to kubeflow namespace

### DIFF
--- a/kfdef/kfctl_aws.yaml
+++ b/kfdef/kfctl_aws.yaml
@@ -7,6 +7,11 @@ spec:
   - kustomizeConfig:
       repoRef:
         name: manifests
+        path: namespaces/base
+    name: namespaces
+  - kustomizeConfig:
+      repoRef:
+        name: manifests
         path: application/v3
     name: application
   - kustomizeConfig:
@@ -74,11 +79,6 @@ spec:
         name: manifests
         path: aws/istio-ingress/base_v3
     name: istio-ingress
-  - kustomizeConfig:
-      repoRef:
-        name: manifests
-        path: metadata/v3
-    name: metadata
   - kustomizeConfig:
       repoRef:
         name: manifests

--- a/kfdef/kfctl_aws_cognito.yaml
+++ b/kfdef/kfctl_aws_cognito.yaml
@@ -7,6 +7,11 @@ spec:
   - kustomizeConfig:
       repoRef:
         name: manifests
+        path: namespaces/base
+    name: namespaces
+  - kustomizeConfig:
+      repoRef:
+        name: manifests
         path: stacks/aws/application/istio-stack
     name: istio-stack
   - kustomizeConfig:
@@ -54,11 +59,6 @@ spec:
         name: manifests
         path: spark/spark-operator/overlays/application
     name: spark-operator
-  - kustomizeConfig:
-      repoRef:
-        name: manifests
-        path: metadata/v3
-    name: metadata
   - kustomizeConfig:
       repoRef:
         name: manifests

--- a/stacks/aws/kustomization.yaml
+++ b/stacks/aws/kustomization.yaml
@@ -33,6 +33,8 @@ resources:
   - ../../aws/nvidia-device-plugin/overlays/application
   # Kubernetes resources - anonymous user
   - ../../default-install/base
+  # Metadata
+  - ../../metadata/v3
 generatorOptions:
   disableNameSuffixHash: true
 configMapGenerator:

--- a/tests/stacks/aws/test_data/expected/apps_v1_deployment_metadata-db.yaml
+++ b/tests/stacks/aws/test_data/expected/apps_v1_deployment_metadata-db.yaml
@@ -1,0 +1,53 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  labels:
+    component: db
+    kustomize.component: metadata
+  name: metadata-db
+  namespace: kubeflow
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      component: db
+      kustomize.component: metadata
+  template:
+    metadata:
+      annotations:
+        sidecar.istio.io/inject: "false"
+      labels:
+        component: db
+        kustomize.component: metadata
+      name: db
+    spec:
+      containers:
+      - args:
+        - --datadir
+        - /var/lib/mysql/datadir
+        envFrom:
+        - configMapRef:
+            name: metadata-db-parameters
+        - secretRef:
+            name: metadata-db-secrets
+        image: mysql:8.0.3
+        name: db-container
+        ports:
+        - containerPort: 3306
+          name: dbapi
+        readinessProbe:
+          exec:
+            command:
+            - /bin/bash
+            - -c
+            - mysql -D $$MYSQL_DATABASE -p$$MYSQL_ROOT_PASSWORD -e 'SELECT 1'
+          initialDelaySeconds: 5
+          periodSeconds: 2
+          timeoutSeconds: 1
+        volumeMounts:
+        - mountPath: /var/lib/mysql
+          name: metadata-mysql
+      volumes:
+      - name: metadata-mysql
+        persistentVolumeClaim:
+          claimName: metadata-mysql

--- a/tests/stacks/aws/test_data/expected/apps_v1_deployment_metadata-deployment.yaml
+++ b/tests/stacks/aws/test_data/expected/apps_v1_deployment_metadata-deployment.yaml
@@ -1,0 +1,61 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  labels:
+    component: server
+    kustomize.component: metadata
+  name: metadata-deployment
+  namespace: kubeflow
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      component: server
+      kustomize.component: metadata
+  template:
+    metadata:
+      annotations:
+        sidecar.istio.io/inject: "false"
+      labels:
+        component: server
+        kustomize.component: metadata
+    spec:
+      containers:
+      - command:
+        - ./server/server
+        - --http_port=8080
+        - --mysql_service_host=metadata-db
+        - --mysql_service_port=$(MYSQL_PORT)
+        - --mysql_service_user=$(MYSQL_USER_NAME)
+        - --mysql_service_password=$(MYSQL_ROOT_PASSWORD)
+        - --mlmd_db_name=$(MYSQL_DATABASE)
+        envFrom:
+        - configMapRef:
+            name: metadata-db-parameters
+        - secretRef:
+            name: metadata-db-secrets
+        image: gcr.io/kubeflow-images-public/metadata:v0.1.11
+        livenessProbe:
+          httpGet:
+            httpHeaders:
+            - name: ContentType
+              value: application/json
+            path: /api/v1alpha1/artifact_types
+            port: backendapi
+          initialDelaySeconds: 3
+          periodSeconds: 5
+          timeoutSeconds: 2
+        name: container
+        ports:
+        - containerPort: 8080
+          name: backendapi
+        readinessProbe:
+          httpGet:
+            httpHeaders:
+            - name: ContentType
+              value: application/json
+            path: /api/v1alpha1/artifact_types
+            port: backendapi
+          initialDelaySeconds: 3
+          periodSeconds: 5
+          timeoutSeconds: 2

--- a/tests/stacks/aws/test_data/expected/apps_v1_deployment_metadata-envoy-deployment.yaml
+++ b/tests/stacks/aws/test_data/expected/apps_v1_deployment_metadata-envoy-deployment.yaml
@@ -1,0 +1,30 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  labels:
+    component: envoy
+    kustomize.component: metadata
+  name: metadata-envoy-deployment
+  namespace: kubeflow
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      component: envoy
+      kustomize.component: metadata
+  template:
+    metadata:
+      annotations:
+        sidecar.istio.io/inject: "false"
+      labels:
+        component: envoy
+        kustomize.component: metadata
+    spec:
+      containers:
+      - image: gcr.io/ml-pipeline/envoy:metadata-grpc
+        name: container
+        ports:
+        - containerPort: 9090
+          name: md-envoy
+        - containerPort: 9901
+          name: envoy-admin

--- a/tests/stacks/aws/test_data/expected/apps_v1_deployment_metadata-grpc-deployment.yaml
+++ b/tests/stacks/aws/test_data/expected/apps_v1_deployment_metadata-grpc-deployment.yaml
@@ -1,0 +1,44 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  labels:
+    component: grpc-server
+    kustomize.component: metadata
+  name: metadata-grpc-deployment
+  namespace: kubeflow
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      component: grpc-server
+      kustomize.component: metadata
+  template:
+    metadata:
+      annotations:
+        sidecar.istio.io/inject: "false"
+      labels:
+        component: grpc-server
+        kustomize.component: metadata
+    spec:
+      containers:
+      - args:
+        - --grpc_port=$(METADATA_GRPC_SERVICE_PORT)
+        - --mysql_config_host=metadata-db
+        - --mysql_config_database=$(MYSQL_DATABASE)
+        - --mysql_config_port=$(MYSQL_PORT)
+        - --mysql_config_user=$(MYSQL_USER_NAME)
+        - --mysql_config_password=$(MYSQL_ROOT_PASSWORD)
+        command:
+        - /bin/metadata_store_server
+        envFrom:
+        - configMapRef:
+            name: metadata-db-parameters
+        - secretRef:
+            name: metadata-db-secrets
+        - configMapRef:
+            name: metadata-grpc-configmap
+        image: gcr.io/tfx-oss-public/ml_metadata_store_server:v0.21.1
+        name: container
+        ports:
+        - containerPort: 8080
+          name: grpc-backendapi

--- a/tests/stacks/aws/test_data/expected/apps_v1_deployment_metadata-ui.yaml
+++ b/tests/stacks/aws/test_data/expected/apps_v1_deployment_metadata-ui.yaml
@@ -1,0 +1,29 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  labels:
+    app: metadata-ui
+    kustomize.component: metadata
+  name: metadata-ui
+  namespace: kubeflow
+spec:
+  selector:
+    matchLabels:
+      app: metadata-ui
+      kustomize.component: metadata
+  template:
+    metadata:
+      annotations:
+        sidecar.istio.io/inject: "false"
+      labels:
+        app: metadata-ui
+        kustomize.component: metadata
+      name: ui
+    spec:
+      containers:
+      - image: gcr.io/kubeflow-images-public/metadata-frontend:v0.1.8
+        imagePullPolicy: IfNotPresent
+        name: metadata-ui
+        ports:
+        - containerPort: 3000
+      serviceAccountName: metadata-ui

--- a/tests/stacks/aws/test_data/expected/networking.istio.io_v1alpha3_virtualservice_metadata-grpc.yaml
+++ b/tests/stacks/aws/test_data/expected/networking.istio.io_v1alpha3_virtualservice_metadata-grpc.yaml
@@ -1,0 +1,22 @@
+apiVersion: networking.istio.io/v1alpha3
+kind: VirtualService
+metadata:
+  name: metadata-grpc
+  namespace: kubeflow
+spec:
+  gateways:
+  - kubeflow-gateway
+  hosts:
+  - '*'
+  http:
+  - match:
+    - uri:
+        prefix: /ml_metadata
+    rewrite:
+      uri: /ml_metadata
+    route:
+    - destination:
+        host: metadata-envoy-service.kubeflow.svc.cluster.local
+        port:
+          number: 9090
+    timeout: 300s

--- a/tests/stacks/aws/test_data/expected/networking.istio.io_v1alpha3_virtualservice_metadata-ui.yaml
+++ b/tests/stacks/aws/test_data/expected/networking.istio.io_v1alpha3_virtualservice_metadata-ui.yaml
@@ -1,0 +1,22 @@
+apiVersion: networking.istio.io/v1alpha3
+kind: VirtualService
+metadata:
+  name: metadata-ui
+  namespace: kubeflow
+spec:
+  gateways:
+  - kubeflow-gateway
+  hosts:
+  - '*'
+  http:
+  - match:
+    - uri:
+        prefix: /metadata
+    rewrite:
+      uri: /metadata
+    route:
+    - destination:
+        host: metadata-ui.kubeflow.svc.cluster.local
+        port:
+          number: 80
+    timeout: 300s

--- a/tests/stacks/aws/test_data/expected/rbac.authorization.k8s.io_v1beta1_role_metadata-ui.yaml
+++ b/tests/stacks/aws/test_data/expected/rbac.authorization.k8s.io_v1beta1_role_metadata-ui.yaml
@@ -1,0 +1,28 @@
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: Role
+metadata:
+  labels:
+    app: metadata-ui
+    kustomize.component: metadata
+  name: metadata-ui
+  namespace: kubeflow
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - pods
+  - pods/log
+  verbs:
+  - create
+  - get
+  - list
+- apiGroups:
+  - kubeflow.org
+  resources:
+  - viewers
+  verbs:
+  - create
+  - get
+  - list
+  - watch
+  - delete

--- a/tests/stacks/aws/test_data/expected/rbac.authorization.k8s.io_v1beta1_rolebinding_metadata-ui.yaml
+++ b/tests/stacks/aws/test_data/expected/rbac.authorization.k8s.io_v1beta1_rolebinding_metadata-ui.yaml
@@ -1,0 +1,16 @@
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: RoleBinding
+metadata:
+  labels:
+    app: metadata-ui
+    kustomize.component: metadata
+  name: metadata-ui
+  namespace: kubeflow
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: metadata-ui
+subjects:
+- kind: ServiceAccount
+  name: ui
+  namespace: kubeflow

--- a/tests/stacks/aws/test_data/expected/~g_v1_configmap_metadata-db-parameters.yaml
+++ b/tests/stacks/aws/test_data/expected/~g_v1_configmap_metadata-db-parameters.yaml
@@ -1,0 +1,11 @@
+apiVersion: v1
+data:
+  MYSQL_ALLOW_EMPTY_PASSWORD: "true"
+  MYSQL_DATABASE: metadb
+  MYSQL_PORT: "3306"
+kind: ConfigMap
+metadata:
+  labels:
+    kustomize.component: metadata
+  name: metadata-db-parameters
+  namespace: kubeflow

--- a/tests/stacks/aws/test_data/expected/~g_v1_configmap_metadata-grpc-configmap.yaml
+++ b/tests/stacks/aws/test_data/expected/~g_v1_configmap_metadata-grpc-configmap.yaml
@@ -1,0 +1,10 @@
+apiVersion: v1
+data:
+  METADATA_GRPC_SERVICE_HOST: metadata-grpc-service
+  METADATA_GRPC_SERVICE_PORT: "8080"
+kind: ConfigMap
+metadata:
+  labels:
+    kustomize.component: metadata
+  name: metadata-grpc-configmap
+  namespace: kubeflow

--- a/tests/stacks/aws/test_data/expected/~g_v1_configmap_metadata-ui-parameters.yaml
+++ b/tests/stacks/aws/test_data/expected/~g_v1_configmap_metadata-ui-parameters.yaml
@@ -1,0 +1,9 @@
+apiVersion: v1
+data:
+  uiClusterDomain: cluster.local
+kind: ConfigMap
+metadata:
+  labels:
+    kustomize.component: metadata
+  name: metadata-ui-parameters
+  namespace: kubeflow

--- a/tests/stacks/aws/test_data/expected/~g_v1_persistentvolumeclaim_metadata-mysql.yaml
+++ b/tests/stacks/aws/test_data/expected/~g_v1_persistentvolumeclaim_metadata-mysql.yaml
@@ -1,0 +1,13 @@
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  labels:
+    kustomize.component: metadata
+  name: metadata-mysql
+  namespace: kubeflow
+spec:
+  accessModes:
+  - ReadWriteOnce
+  resources:
+    requests:
+      storage: 10Gi

--- a/tests/stacks/aws/test_data/expected/~g_v1_secret_metadata-db-secrets.yaml
+++ b/tests/stacks/aws/test_data/expected/~g_v1_secret_metadata-db-secrets.yaml
@@ -1,0 +1,11 @@
+apiVersion: v1
+data:
+  MYSQL_ROOT_PASSWORD: dGVzdA==
+  MYSQL_USER_NAME: cm9vdA==
+kind: Secret
+metadata:
+  labels:
+    kustomize.component: metadata
+  name: metadata-db-secrets
+  namespace: kubeflow
+type: Opaque

--- a/tests/stacks/aws/test_data/expected/~g_v1_service_metadata-db.yaml
+++ b/tests/stacks/aws/test_data/expected/~g_v1_service_metadata-db.yaml
@@ -1,0 +1,17 @@
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    component: db
+    kustomize.component: metadata
+  name: metadata-db
+  namespace: kubeflow
+spec:
+  ports:
+  - name: dbapi
+    port: 3306
+    protocol: TCP
+  selector:
+    component: db
+    kustomize.component: metadata
+  type: ClusterIP

--- a/tests/stacks/aws/test_data/expected/~g_v1_service_metadata-envoy-service.yaml
+++ b/tests/stacks/aws/test_data/expected/~g_v1_service_metadata-envoy-service.yaml
@@ -1,0 +1,17 @@
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    app: metadata
+    kustomize.component: metadata
+  name: metadata-envoy-service
+  namespace: kubeflow
+spec:
+  ports:
+  - name: md-envoy
+    port: 9090
+    protocol: TCP
+  selector:
+    component: envoy
+    kustomize.component: metadata
+  type: ClusterIP

--- a/tests/stacks/aws/test_data/expected/~g_v1_service_metadata-grpc-service.yaml
+++ b/tests/stacks/aws/test_data/expected/~g_v1_service_metadata-grpc-service.yaml
@@ -1,0 +1,17 @@
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    app: grpc-metadata
+    kustomize.component: metadata
+  name: metadata-grpc-service
+  namespace: kubeflow
+spec:
+  ports:
+  - name: grpc-backendapi
+    port: 8080
+    protocol: TCP
+  selector:
+    component: grpc-server
+    kustomize.component: metadata
+  type: ClusterIP

--- a/tests/stacks/aws/test_data/expected/~g_v1_service_metadata-service.yaml
+++ b/tests/stacks/aws/test_data/expected/~g_v1_service_metadata-service.yaml
@@ -1,0 +1,17 @@
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    app: metadata
+    kustomize.component: metadata
+  name: metadata-service
+  namespace: kubeflow
+spec:
+  ports:
+  - name: backendapi
+    port: 8080
+    protocol: TCP
+  selector:
+    component: server
+    kustomize.component: metadata
+  type: ClusterIP

--- a/tests/stacks/aws/test_data/expected/~g_v1_service_metadata-ui.yaml
+++ b/tests/stacks/aws/test_data/expected/~g_v1_service_metadata-ui.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    app: metadata-ui
+    kustomize.component: metadata
+  name: metadata-ui
+  namespace: kubeflow
+spec:
+  ports:
+  - port: 80
+    targetPort: 3000
+  selector:
+    app: metadata-ui
+    kustomize.component: metadata

--- a/tests/stacks/aws/test_data/expected/~g_v1_serviceaccount_metadata-ui.yaml
+++ b/tests/stacks/aws/test_data/expected/~g_v1_serviceaccount_metadata-ui.yaml
@@ -1,0 +1,7 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  labels:
+    kustomize.component: metadata
+  name: metadata-ui
+  namespace: kubeflow


### PR DESCRIPTION
**Which issue is resolved by this Pull Request:**
Resolves #1427

**Description of your changes:**
Bring back components whose namespace is kubeflow into `stacks/aws/kustomization.yaml`.

So for now, we're able to see `Artifact Store` page under KF dashboard.

**Checklist:**
- [x] Unit tests have been rebuilt: 
    1. `cd manifests/tests`
    2. `make generate-changed-only`
    3. `make test`
