### PR TITLE
[pending] Uses standard header "Authorization" instead of "X-Auth-Token" for Kubeflow with oidc-authservice + dex

### DIFF
--- a/istio/oidc-authservice/base/envoy-filter.yaml
+++ b/istio/oidc-authservice/base/envoy-filter.yaml
@@ -17,7 +17,7 @@ spec:
           allowedHeaders:
             patterns:
             - exact: "cookie"
-            - exact: "X-Auth-Token"
+            - exact: "authorization"
         authorizationResponse:
           allowedUpstreamHeaders:
             patterns:

--- a/istio/oidc-authservice/base/statefulset.yaml
+++ b/istio/oidc-authservice/base/statefulset.yaml
@@ -17,7 +17,7 @@ spec:
     spec:
       containers:
       - name: authservice
-        image: gcr.io/arrikto/kubeflow/oidc-authservice:6ac9400
+        image: gcr.io/arrikto/kubeflow/oidc-authservice:fef11c3
         imagePullPolicy: Always
         ports:
         - name: http-api

--- a/tests/stacks/aws/application/oidc-authservice/test_data/expected/networking.istio.io_v1alpha3_envoyfilter_authn-filter.yaml
+++ b/tests/stacks/aws/application/oidc-authservice/test_data/expected/networking.istio.io_v1alpha3_envoyfilter_authn-filter.yaml
@@ -14,7 +14,7 @@ spec:
           allowedHeaders:
             patterns:
             - exact: cookie
-            - exact: X-Auth-Token
+            - exact: authorization
         authorizationResponse:
           allowedUpstreamHeaders:
             patterns:

--- a/tests/stacks/ibm/application/oidc-authservice/test_data/expected/networking.istio.io_v1alpha3_envoyfilter_authn-filter.yaml
+++ b/tests/stacks/ibm/application/oidc-authservice/test_data/expected/networking.istio.io_v1alpha3_envoyfilter_authn-filter.yaml
@@ -14,7 +14,7 @@ spec:
           allowedHeaders:
             patterns:
             - exact: cookie
-            - exact: X-Auth-Token
+            - exact: authorization
         authorizationResponse:
           allowedUpstreamHeaders:
             patterns:


### PR DESCRIPTION
…I clients like kfp SDK.

**Which issue is resolved by this Pull Request:**
Supports https://github.com/kubeflow/kubeflow/issues/4912#issuecomment-665387957

**Description of your changes:**
When using KFP SDK to access pipelines via public endpoint, the `existing_token` argument will be sent over request header `Authorization` which will NOT be accepted without this change. since it already used the standard header name `Authorization` in `arrikto/oidc-authservice` from https://github.com/arrikto/oidc-authservice/pull/25, it should pick it up for kubeflow that depends on it.

**Checklist:**
- [x] Unit tests have been rebuilt: 
    1. `cd manifests/tests`
    2. `make generate-changed-only`
    3. `make test`
