### PR TITLE
Correct AWS authz adaptor header

### DIFF
--- a/aws/aws-istio-authz-adaptor/base/params.env
+++ b/aws/aws-istio-authz-adaptor/base/params.env
@@ -1,3 +1,4 @@
-origin-header=x-amzn-oidc-header
+origin-header=x-amzn-oidc-data
 custom-header=kubeflow-userid
 istio-namespace=istio-system
+


### PR DESCRIPTION
**Which issue is resolved by this Pull Request:**


**Description of your changes:**
Correct AWS authz adaptor header.  Change from `x-amzn-oidc-header` to `x-amzn-oidc-data`. `x-amzn-oidc-header` is incorrect. We used overrides in the past, however, this was not taken care of during manifest v3 upgrade and brings some regression issue. 

https://github.com/kubeflow/manifests/search?q=x-amzn-oidc-data&unscoped_q=x-amzn-oidc-data

Issues:

```
ERROR User None is not authorized to list kubeflow.org.v1beta1.notebooks for namespace: admin
```

**Checklist:**
- [x] Unit tests have been rebuilt: 
    1. `cd manifests/tests`
    2. `make generate-changed-only`
    3. `make test`
