### PR TITLE
Automated cherry pick of #1435: Correct AWS authz adaptor header

### DIFF
--- a/aws/aws-istio-authz-adaptor/base/params.env
+++ b/aws/aws-istio-authz-adaptor/base/params.env
@@ -1,3 +1,4 @@
-origin-header=x-amzn-oidc-header
+origin-header=x-amzn-oidc-data
 custom-header=kubeflow-userid
 istio-namespace=istio-system
+


### PR DESCRIPTION
Cherry pick of #1435 on v1.1-branch.

#1435: Correct AWS authz adaptor header

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.