### PR TITLE
Update Katib image tag to ce89cbf on master

### DIFF
--- a/katib/components/katib-controller/kustomization.yaml
+++ b/katib/components/katib-controller/kustomization.yaml
@@ -16,10 +16,10 @@ resources:
   - ../../katib-controller/overlays/istio/katib-ui-virtual-service.yaml
 images:
   - name: gcr.io/kubeflow-images-public/katib/v1alpha3/katib-controller
-    newTag: c3b38d8
+    newTag: ce89cbf
     newName: gcr.io/kubeflow-images-public/katib/v1alpha3/katib-controller
   - name: gcr.io/kubeflow-images-public/katib/v1alpha3/katib-ui
-    newTag: c3b38d8
+    newTag: ce89cbf
     newName: gcr.io/kubeflow-images-public/katib/v1alpha3/katib-ui
 commonLabels:
   app.kubernetes.io/component: katib

--- a/katib/components/katib-db-manager/kustomization.yaml
+++ b/katib/components/katib-db-manager/kustomization.yaml
@@ -6,7 +6,7 @@ resources:
   - ../../katib-controller/base/katib-db-manager-service.yaml
 images:
   - name: gcr.io/kubeflow-images-public/katib/v1alpha3/katib-db-manager
-    newTag: c3b38d8
+    newTag: ce89cbf
     newName: gcr.io/kubeflow-images-public/katib/v1alpha3/katib-db-manager
 commonLabels:
   app.kubernetes.io/component: katib

--- a/katib/katib-controller/base/katib-configmap.yaml
+++ b/katib/katib-controller/base/katib-configmap.yaml
@@ -6,13 +6,13 @@ data:
   metrics-collector-sidecar: |-
     {
       "StdOut": {
-        "image": "gcr.io/kubeflow-images-public/katib/v1alpha3/file-metrics-collector:c3b38d8"
+        "image": "gcr.io/kubeflow-images-public/katib/v1alpha3/file-metrics-collector:ce89cbf"
       },
       "File": {
-        "image": "gcr.io/kubeflow-images-public/katib/v1alpha3/file-metrics-collector:c3b38d8"
+        "image": "gcr.io/kubeflow-images-public/katib/v1alpha3/file-metrics-collector:ce89cbf"
       },
       "TensorFlowEvent": {
-        "image": "gcr.io/kubeflow-images-public/katib/v1alpha3/tfevent-metrics-collector:c3b38d8",
+        "image": "gcr.io/kubeflow-images-public/katib/v1alpha3/tfevent-metrics-collector:ce89cbf",
         "resources": {
           "limits": {
             "memory": "1Gi"
@@ -23,22 +23,22 @@ data:
   suggestion: |-
     {
       "random": {
-        "image": "gcr.io/kubeflow-images-public/katib/v1alpha3/suggestion-hyperopt:c3b38d8"
+        "image": "gcr.io/kubeflow-images-public/katib/v1alpha3/suggestion-hyperopt:ce89cbf"
       },
       "grid": {
-        "image": "gcr.io/kubeflow-images-public/katib/v1alpha3/suggestion-chocolate:c3b38d8"
+        "image": "gcr.io/kubeflow-images-public/katib/v1alpha3/suggestion-chocolate:ce89cbf"
       },
       "hyperband": {
-        "image": "gcr.io/kubeflow-images-public/katib/v1alpha3/suggestion-hyperband:c3b38d8"
+        "image": "gcr.io/kubeflow-images-public/katib/v1alpha3/suggestion-hyperband:ce89cbf"
       },
       "bayesianoptimization": {
-        "image": "gcr.io/kubeflow-images-public/katib/v1alpha3/suggestion-skopt:c3b38d8"
+        "image": "gcr.io/kubeflow-images-public/katib/v1alpha3/suggestion-skopt:ce89cbf"
       },
       "tpe": {
-        "image": "gcr.io/kubeflow-images-public/katib/v1alpha3/suggestion-hyperopt:c3b38d8"
+        "image": "gcr.io/kubeflow-images-public/katib/v1alpha3/suggestion-hyperopt:ce89cbf"
       },
       "enas": {
-        "image": "gcr.io/kubeflow-images-public/katib/v1alpha3/suggestion-enas:c3b38d8",
+        "image": "gcr.io/kubeflow-images-public/katib/v1alpha3/suggestion-enas:ce89cbf",
         "imagePullPolicy": "Always",
         "resources": {
           "limits": {
@@ -47,9 +47,9 @@ data:
         }
       },
       "cmaes": {
-        "image": "gcr.io/kubeflow-images-public/katib/v1alpha3/suggestion-goptuna:c3b38d8"
+        "image": "gcr.io/kubeflow-images-public/katib/v1alpha3/suggestion-goptuna:ce89cbf"
       },
       "darts": {
-        "image": "gcr.io/kubeflow-images-public/katib/v1alpha3/suggestion-darts:c3b38d8"
+        "image": "gcr.io/kubeflow-images-public/katib/v1alpha3/suggestion-darts:ce89cbf"
       }
     }

--- a/katib/katib-controller/base/kustomization.yaml
+++ b/katib/katib-controller/base/kustomization.yaml
@@ -24,13 +24,13 @@ generatorOptions:
   disableNameSuffixHash: true
 images:
 - name: gcr.io/kubeflow-images-public/katib/v1alpha3/katib-controller
-  newTag: c3b38d8
+  newTag: ce89cbf
   newName: gcr.io/kubeflow-images-public/katib/v1alpha3/katib-controller
 - name: gcr.io/kubeflow-images-public/katib/v1alpha3/katib-db-manager
-  newTag: c3b38d8
+  newTag: ce89cbf
   newName: gcr.io/kubeflow-images-public/katib/v1alpha3/katib-db-manager
 - name: gcr.io/kubeflow-images-public/katib/v1alpha3/katib-ui
-  newTag: c3b38d8
+  newTag: ce89cbf
   newName: gcr.io/kubeflow-images-public/katib/v1alpha3/katib-ui
 - name: mysql
   newTag: "8"

--- a/tests/katib/installs/katib-external-db/test_data/expected/apps_v1_deployment_katib-controller.yaml
+++ b/tests/katib/installs/katib-external-db/test_data/expected/apps_v1_deployment_katib-controller.yaml
@@ -34,7 +34,7 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: metadata.namespace
-        image: gcr.io/kubeflow-images-public/katib/v1alpha3/katib-controller:c3b38d8
+        image: gcr.io/kubeflow-images-public/katib/v1alpha3/katib-controller:ce89cbf
         imagePullPolicy: IfNotPresent
         name: katib-controller
         ports:

--- a/tests/katib/installs/katib-external-db/test_data/expected/apps_v1_deployment_katib-db-manager.yaml
+++ b/tests/katib/installs/katib-external-db/test_data/expected/apps_v1_deployment_katib-db-manager.yaml
@@ -58,7 +58,7 @@ spec:
             secretKeyRef:
               key: KATIB_MYSQL_DB_PORT
               name: katib-mysql-secrets-kmcg6hfkfg
-        image: gcr.io/kubeflow-images-public/katib/v1alpha3/katib-db-manager:c3b38d8
+        image: gcr.io/kubeflow-images-public/katib/v1alpha3/katib-db-manager:ce89cbf
         imagePullPolicy: IfNotPresent
         livenessProbe:
           exec:

--- a/tests/katib/installs/katib-external-db/test_data/expected/apps_v1_deployment_katib-ui.yaml
+++ b/tests/katib/installs/katib-external-db/test_data/expected/apps_v1_deployment_katib-ui.yaml
@@ -37,7 +37,7 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: metadata.namespace
-        image: gcr.io/kubeflow-images-public/katib/v1alpha3/katib-ui:c3b38d8
+        image: gcr.io/kubeflow-images-public/katib/v1alpha3/katib-ui:ce89cbf
         imagePullPolicy: IfNotPresent
         name: katib-ui
         ports:

--- a/tests/katib/installs/katib-external-db/test_data/expected/~g_v1_configmap_katib-config.yaml
+++ b/tests/katib/installs/katib-external-db/test_data/expected/~g_v1_configmap_katib-config.yaml
@@ -3,13 +3,13 @@ data:
   metrics-collector-sidecar: |-
     {
       "StdOut": {
-        "image": "gcr.io/kubeflow-images-public/katib/v1alpha3/file-metrics-collector:c3b38d8"
+        "image": "gcr.io/kubeflow-images-public/katib/v1alpha3/file-metrics-collector:ce89cbf"
       },
       "File": {
-        "image": "gcr.io/kubeflow-images-public/katib/v1alpha3/file-metrics-collector:c3b38d8"
+        "image": "gcr.io/kubeflow-images-public/katib/v1alpha3/file-metrics-collector:ce89cbf"
       },
       "TensorFlowEvent": {
-        "image": "gcr.io/kubeflow-images-public/katib/v1alpha3/tfevent-metrics-collector:c3b38d8",
+        "image": "gcr.io/kubeflow-images-public/katib/v1alpha3/tfevent-metrics-collector:ce89cbf",
         "resources": {
           "limits": {
             "memory": "1Gi"
@@ -20,22 +20,22 @@ data:
   suggestion: |-
     {
       "random": {
-        "image": "gcr.io/kubeflow-images-public/katib/v1alpha3/suggestion-hyperopt:c3b38d8"
+        "image": "gcr.io/kubeflow-images-public/katib/v1alpha3/suggestion-hyperopt:ce89cbf"
       },
       "grid": {
-        "image": "gcr.io/kubeflow-images-public/katib/v1alpha3/suggestion-chocolate:c3b38d8"
+        "image": "gcr.io/kubeflow-images-public/katib/v1alpha3/suggestion-chocolate:ce89cbf"
       },
       "hyperband": {
-        "image": "gcr.io/kubeflow-images-public/katib/v1alpha3/suggestion-hyperband:c3b38d8"
+        "image": "gcr.io/kubeflow-images-public/katib/v1alpha3/suggestion-hyperband:ce89cbf"
       },
       "bayesianoptimization": {
-        "image": "gcr.io/kubeflow-images-public/katib/v1alpha3/suggestion-skopt:c3b38d8"
+        "image": "gcr.io/kubeflow-images-public/katib/v1alpha3/suggestion-skopt:ce89cbf"
       },
       "tpe": {
-        "image": "gcr.io/kubeflow-images-public/katib/v1alpha3/suggestion-hyperopt:c3b38d8"
+        "image": "gcr.io/kubeflow-images-public/katib/v1alpha3/suggestion-hyperopt:ce89cbf"
       },
       "enas": {
-        "image": "gcr.io/kubeflow-images-public/katib/v1alpha3/suggestion-enas:c3b38d8",
+        "image": "gcr.io/kubeflow-images-public/katib/v1alpha3/suggestion-enas:ce89cbf",
         "imagePullPolicy": "Always",
         "resources": {
           "limits": {
@@ -44,10 +44,10 @@ data:
         }
       },
       "cmaes": {
-        "image": "gcr.io/kubeflow-images-public/katib/v1alpha3/suggestion-goptuna:c3b38d8"
+        "image": "gcr.io/kubeflow-images-public/katib/v1alpha3/suggestion-goptuna:ce89cbf"
       },
       "darts": {
-        "image": "gcr.io/kubeflow-images-public/katib/v1alpha3/suggestion-darts:c3b38d8"
+        "image": "gcr.io/kubeflow-images-public/katib/v1alpha3/suggestion-darts:ce89cbf"
       }
     }
 kind: ConfigMap

--- a/tests/katib/installs/katib-standalone-ibm/test_data/expected/apps_v1_deployment_katib-controller.yaml
+++ b/tests/katib/installs/katib-standalone-ibm/test_data/expected/apps_v1_deployment_katib-controller.yaml
@@ -34,7 +34,7 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: metadata.namespace
-        image: gcr.io/kubeflow-images-public/katib/v1alpha3/katib-controller:c3b38d8
+        image: gcr.io/kubeflow-images-public/katib/v1alpha3/katib-controller:ce89cbf
         imagePullPolicy: IfNotPresent
         name: katib-controller
         ports:

--- a/tests/katib/installs/katib-standalone-ibm/test_data/expected/apps_v1_deployment_katib-db-manager.yaml
+++ b/tests/katib/installs/katib-standalone-ibm/test_data/expected/apps_v1_deployment_katib-db-manager.yaml
@@ -38,7 +38,7 @@ spec:
             secretKeyRef:
               key: MYSQL_ROOT_PASSWORD
               name: katib-mysql-secrets
-        image: gcr.io/kubeflow-images-public/katib/v1alpha3/katib-db-manager:c3b38d8
+        image: gcr.io/kubeflow-images-public/katib/v1alpha3/katib-db-manager:ce89cbf
         imagePullPolicy: IfNotPresent
         livenessProbe:
           exec:

--- a/tests/katib/installs/katib-standalone-ibm/test_data/expected/apps_v1_deployment_katib-ui.yaml
+++ b/tests/katib/installs/katib-standalone-ibm/test_data/expected/apps_v1_deployment_katib-ui.yaml
@@ -37,7 +37,7 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: metadata.namespace
-        image: gcr.io/kubeflow-images-public/katib/v1alpha3/katib-ui:c3b38d8
+        image: gcr.io/kubeflow-images-public/katib/v1alpha3/katib-ui:ce89cbf
         imagePullPolicy: IfNotPresent
         name: katib-ui
         ports:

--- a/tests/katib/installs/katib-standalone-ibm/test_data/expected/~g_v1_configmap_katib-config.yaml
+++ b/tests/katib/installs/katib-standalone-ibm/test_data/expected/~g_v1_configmap_katib-config.yaml
@@ -3,13 +3,13 @@ data:
   metrics-collector-sidecar: |-
     {
       "StdOut": {
-        "image": "gcr.io/kubeflow-images-public/katib/v1alpha3/file-metrics-collector:c3b38d8"
+        "image": "gcr.io/kubeflow-images-public/katib/v1alpha3/file-metrics-collector:ce89cbf"
       },
       "File": {
-        "image": "gcr.io/kubeflow-images-public/katib/v1alpha3/file-metrics-collector:c3b38d8"
+        "image": "gcr.io/kubeflow-images-public/katib/v1alpha3/file-metrics-collector:ce89cbf"
       },
       "TensorFlowEvent": {
-        "image": "gcr.io/kubeflow-images-public/katib/v1alpha3/tfevent-metrics-collector:c3b38d8",
+        "image": "gcr.io/kubeflow-images-public/katib/v1alpha3/tfevent-metrics-collector:ce89cbf",
         "resources": {
           "limits": {
             "memory": "1Gi"
@@ -20,22 +20,22 @@ data:
   suggestion: |-
     {
       "random": {
-        "image": "gcr.io/kubeflow-images-public/katib/v1alpha3/suggestion-hyperopt:c3b38d8"
+        "image": "gcr.io/kubeflow-images-public/katib/v1alpha3/suggestion-hyperopt:ce89cbf"
       },
       "grid": {
-        "image": "gcr.io/kubeflow-images-public/katib/v1alpha3/suggestion-chocolate:c3b38d8"
+        "image": "gcr.io/kubeflow-images-public/katib/v1alpha3/suggestion-chocolate:ce89cbf"
       },
       "hyperband": {
-        "image": "gcr.io/kubeflow-images-public/katib/v1alpha3/suggestion-hyperband:c3b38d8"
+        "image": "gcr.io/kubeflow-images-public/katib/v1alpha3/suggestion-hyperband:ce89cbf"
       },
       "bayesianoptimization": {
-        "image": "gcr.io/kubeflow-images-public/katib/v1alpha3/suggestion-skopt:c3b38d8"
+        "image": "gcr.io/kubeflow-images-public/katib/v1alpha3/suggestion-skopt:ce89cbf"
       },
       "tpe": {
-        "image": "gcr.io/kubeflow-images-public/katib/v1alpha3/suggestion-hyperopt:c3b38d8"
+        "image": "gcr.io/kubeflow-images-public/katib/v1alpha3/suggestion-hyperopt:ce89cbf"
       },
       "enas": {
-        "image": "gcr.io/kubeflow-images-public/katib/v1alpha3/suggestion-enas:c3b38d8",
+        "image": "gcr.io/kubeflow-images-public/katib/v1alpha3/suggestion-enas:ce89cbf",
         "imagePullPolicy": "Always",
         "resources": {
           "limits": {
@@ -44,10 +44,10 @@ data:
         }
       },
       "cmaes": {
-        "image": "gcr.io/kubeflow-images-public/katib/v1alpha3/suggestion-goptuna:c3b38d8"
+        "image": "gcr.io/kubeflow-images-public/katib/v1alpha3/suggestion-goptuna:ce89cbf"
       },
       "darts": {
-        "image": "gcr.io/kubeflow-images-public/katib/v1alpha3/suggestion-darts:c3b38d8"
+        "image": "gcr.io/kubeflow-images-public/katib/v1alpha3/suggestion-darts:ce89cbf"
       }
     }
 kind: ConfigMap

--- a/tests/katib/installs/katib-standalone/test_data/expected/apps_v1_deployment_katib-controller.yaml
+++ b/tests/katib/installs/katib-standalone/test_data/expected/apps_v1_deployment_katib-controller.yaml
@@ -34,7 +34,7 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: metadata.namespace
-        image: gcr.io/kubeflow-images-public/katib/v1alpha3/katib-controller:c3b38d8
+        image: gcr.io/kubeflow-images-public/katib/v1alpha3/katib-controller:ce89cbf
         imagePullPolicy: IfNotPresent
         name: katib-controller
         ports:

--- a/tests/katib/installs/katib-standalone/test_data/expected/apps_v1_deployment_katib-db-manager.yaml
+++ b/tests/katib/installs/katib-standalone/test_data/expected/apps_v1_deployment_katib-db-manager.yaml
@@ -38,7 +38,7 @@ spec:
             secretKeyRef:
               key: MYSQL_ROOT_PASSWORD
               name: katib-mysql-secrets
-        image: gcr.io/kubeflow-images-public/katib/v1alpha3/katib-db-manager:c3b38d8
+        image: gcr.io/kubeflow-images-public/katib/v1alpha3/katib-db-manager:ce89cbf
         imagePullPolicy: IfNotPresent
         livenessProbe:
           exec:

--- a/tests/katib/installs/katib-standalone/test_data/expected/apps_v1_deployment_katib-ui.yaml
+++ b/tests/katib/installs/katib-standalone/test_data/expected/apps_v1_deployment_katib-ui.yaml
@@ -37,7 +37,7 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: metadata.namespace
-        image: gcr.io/kubeflow-images-public/katib/v1alpha3/katib-ui:c3b38d8
+        image: gcr.io/kubeflow-images-public/katib/v1alpha3/katib-ui:ce89cbf
         imagePullPolicy: IfNotPresent
         name: katib-ui
         ports:

--- a/tests/katib/installs/katib-standalone/test_data/expected/~g_v1_configmap_katib-config.yaml
+++ b/tests/katib/installs/katib-standalone/test_data/expected/~g_v1_configmap_katib-config.yaml
@@ -3,13 +3,13 @@ data:
   metrics-collector-sidecar: |-
     {
       "StdOut": {
-        "image": "gcr.io/kubeflow-images-public/katib/v1alpha3/file-metrics-collector:c3b38d8"
+        "image": "gcr.io/kubeflow-images-public/katib/v1alpha3/file-metrics-collector:ce89cbf"
       },
       "File": {
-        "image": "gcr.io/kubeflow-images-public/katib/v1alpha3/file-metrics-collector:c3b38d8"
+        "image": "gcr.io/kubeflow-images-public/katib/v1alpha3/file-metrics-collector:ce89cbf"
       },
       "TensorFlowEvent": {
-        "image": "gcr.io/kubeflow-images-public/katib/v1alpha3/tfevent-metrics-collector:c3b38d8",
+        "image": "gcr.io/kubeflow-images-public/katib/v1alpha3/tfevent-metrics-collector:ce89cbf",
         "resources": {
           "limits": {
             "memory": "1Gi"
@@ -20,22 +20,22 @@ data:
   suggestion: |-
     {
       "random": {
-        "image": "gcr.io/kubeflow-images-public/katib/v1alpha3/suggestion-hyperopt:c3b38d8"
+        "image": "gcr.io/kubeflow-images-public/katib/v1alpha3/suggestion-hyperopt:ce89cbf"
       },
       "grid": {
-        "image": "gcr.io/kubeflow-images-public/katib/v1alpha3/suggestion-chocolate:c3b38d8"
+        "image": "gcr.io/kubeflow-images-public/katib/v1alpha3/suggestion-chocolate:ce89cbf"
       },
       "hyperband": {
-        "image": "gcr.io/kubeflow-images-public/katib/v1alpha3/suggestion-hyperband:c3b38d8"
+        "image": "gcr.io/kubeflow-images-public/katib/v1alpha3/suggestion-hyperband:ce89cbf"
       },
       "bayesianoptimization": {
-        "image": "gcr.io/kubeflow-images-public/katib/v1alpha3/suggestion-skopt:c3b38d8"
+        "image": "gcr.io/kubeflow-images-public/katib/v1alpha3/suggestion-skopt:ce89cbf"
       },
       "tpe": {
-        "image": "gcr.io/kubeflow-images-public/katib/v1alpha3/suggestion-hyperopt:c3b38d8"
+        "image": "gcr.io/kubeflow-images-public/katib/v1alpha3/suggestion-hyperopt:ce89cbf"
       },
       "enas": {
-        "image": "gcr.io/kubeflow-images-public/katib/v1alpha3/suggestion-enas:c3b38d8",
+        "image": "gcr.io/kubeflow-images-public/katib/v1alpha3/suggestion-enas:ce89cbf",
         "imagePullPolicy": "Always",
         "resources": {
           "limits": {
@@ -44,10 +44,10 @@ data:
         }
       },
       "cmaes": {
-        "image": "gcr.io/kubeflow-images-public/katib/v1alpha3/suggestion-goptuna:c3b38d8"
+        "image": "gcr.io/kubeflow-images-public/katib/v1alpha3/suggestion-goptuna:ce89cbf"
       },
       "darts": {
-        "image": "gcr.io/kubeflow-images-public/katib/v1alpha3/suggestion-darts:c3b38d8"
+        "image": "gcr.io/kubeflow-images-public/katib/v1alpha3/suggestion-darts:ce89cbf"
       }
     }
 kind: ConfigMap

--- a/tests/stacks/aws/test_data/expected/apps_v1_deployment_katib-controller.yaml
+++ b/tests/stacks/aws/test_data/expected/apps_v1_deployment_katib-controller.yaml
@@ -34,7 +34,7 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: metadata.namespace
-        image: gcr.io/kubeflow-images-public/katib/v1alpha3/katib-controller:c3b38d8
+        image: gcr.io/kubeflow-images-public/katib/v1alpha3/katib-controller:ce89cbf
         imagePullPolicy: IfNotPresent
         name: katib-controller
         ports:

--- a/tests/stacks/aws/test_data/expected/apps_v1_deployment_katib-db-manager.yaml
+++ b/tests/stacks/aws/test_data/expected/apps_v1_deployment_katib-db-manager.yaml
@@ -38,7 +38,7 @@ spec:
             secretKeyRef:
               key: MYSQL_ROOT_PASSWORD
               name: katib-mysql-secrets
-        image: gcr.io/kubeflow-images-public/katib/v1alpha3/katib-db-manager:c3b38d8
+        image: gcr.io/kubeflow-images-public/katib/v1alpha3/katib-db-manager:ce89cbf
         imagePullPolicy: IfNotPresent
         livenessProbe:
           exec:

--- a/tests/stacks/aws/test_data/expected/apps_v1_deployment_katib-ui.yaml
+++ b/tests/stacks/aws/test_data/expected/apps_v1_deployment_katib-ui.yaml
@@ -37,7 +37,7 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: metadata.namespace
-        image: gcr.io/kubeflow-images-public/katib/v1alpha3/katib-ui:c3b38d8
+        image: gcr.io/kubeflow-images-public/katib/v1alpha3/katib-ui:ce89cbf
         imagePullPolicy: IfNotPresent
         name: katib-ui
         ports:

--- a/tests/stacks/aws/test_data/expected/~g_v1_configmap_katib-config.yaml
+++ b/tests/stacks/aws/test_data/expected/~g_v1_configmap_katib-config.yaml
@@ -3,13 +3,13 @@ data:
   metrics-collector-sidecar: |-
     {
       "StdOut": {
-        "image": "gcr.io/kubeflow-images-public/katib/v1alpha3/file-metrics-collector:c3b38d8"
+        "image": "gcr.io/kubeflow-images-public/katib/v1alpha3/file-metrics-collector:ce89cbf"
       },
       "File": {
-        "image": "gcr.io/kubeflow-images-public/katib/v1alpha3/file-metrics-collector:c3b38d8"
+        "image": "gcr.io/kubeflow-images-public/katib/v1alpha3/file-metrics-collector:ce89cbf"
       },
       "TensorFlowEvent": {
-        "image": "gcr.io/kubeflow-images-public/katib/v1alpha3/tfevent-metrics-collector:c3b38d8",
+        "image": "gcr.io/kubeflow-images-public/katib/v1alpha3/tfevent-metrics-collector:ce89cbf",
         "resources": {
           "limits": {
             "memory": "1Gi"
@@ -20,22 +20,22 @@ data:
   suggestion: |-
     {
       "random": {
-        "image": "gcr.io/kubeflow-images-public/katib/v1alpha3/suggestion-hyperopt:c3b38d8"
+        "image": "gcr.io/kubeflow-images-public/katib/v1alpha3/suggestion-hyperopt:ce89cbf"
       },
       "grid": {
-        "image": "gcr.io/kubeflow-images-public/katib/v1alpha3/suggestion-chocolate:c3b38d8"
+        "image": "gcr.io/kubeflow-images-public/katib/v1alpha3/suggestion-chocolate:ce89cbf"
       },
       "hyperband": {
-        "image": "gcr.io/kubeflow-images-public/katib/v1alpha3/suggestion-hyperband:c3b38d8"
+        "image": "gcr.io/kubeflow-images-public/katib/v1alpha3/suggestion-hyperband:ce89cbf"
       },
       "bayesianoptimization": {
-        "image": "gcr.io/kubeflow-images-public/katib/v1alpha3/suggestion-skopt:c3b38d8"
+        "image": "gcr.io/kubeflow-images-public/katib/v1alpha3/suggestion-skopt:ce89cbf"
       },
       "tpe": {
-        "image": "gcr.io/kubeflow-images-public/katib/v1alpha3/suggestion-hyperopt:c3b38d8"
+        "image": "gcr.io/kubeflow-images-public/katib/v1alpha3/suggestion-hyperopt:ce89cbf"
       },
       "enas": {
-        "image": "gcr.io/kubeflow-images-public/katib/v1alpha3/suggestion-enas:c3b38d8",
+        "image": "gcr.io/kubeflow-images-public/katib/v1alpha3/suggestion-enas:ce89cbf",
         "imagePullPolicy": "Always",
         "resources": {
           "limits": {
@@ -44,10 +44,10 @@ data:
         }
       },
       "cmaes": {
-        "image": "gcr.io/kubeflow-images-public/katib/v1alpha3/suggestion-goptuna:c3b38d8"
+        "image": "gcr.io/kubeflow-images-public/katib/v1alpha3/suggestion-goptuna:ce89cbf"
       },
       "darts": {
-        "image": "gcr.io/kubeflow-images-public/katib/v1alpha3/suggestion-darts:c3b38d8"
+        "image": "gcr.io/kubeflow-images-public/katib/v1alpha3/suggestion-darts:ce89cbf"
       }
     }
 kind: ConfigMap

--- a/tests/stacks/examples/alice/test_data/expected/apps_v1_deployment_katib-controller.yaml
+++ b/tests/stacks/examples/alice/test_data/expected/apps_v1_deployment_katib-controller.yaml
@@ -34,7 +34,7 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: metadata.namespace
-        image: gcr.io/kubeflow-images-public/katib/v1alpha3/katib-controller:c3b38d8
+        image: gcr.io/kubeflow-images-public/katib/v1alpha3/katib-controller:ce89cbf
         imagePullPolicy: IfNotPresent
         name: katib-controller
         ports:

--- a/tests/stacks/examples/alice/test_data/expected/apps_v1_deployment_katib-db-manager.yaml
+++ b/tests/stacks/examples/alice/test_data/expected/apps_v1_deployment_katib-db-manager.yaml
@@ -38,7 +38,7 @@ spec:
             secretKeyRef:
               key: MYSQL_ROOT_PASSWORD
               name: katib-mysql-secrets
-        image: gcr.io/kubeflow-images-public/katib/v1alpha3/katib-db-manager:c3b38d8
+        image: gcr.io/kubeflow-images-public/katib/v1alpha3/katib-db-manager:ce89cbf
         imagePullPolicy: IfNotPresent
         livenessProbe:
           exec:

--- a/tests/stacks/examples/alice/test_data/expected/apps_v1_deployment_katib-ui.yaml
+++ b/tests/stacks/examples/alice/test_data/expected/apps_v1_deployment_katib-ui.yaml
@@ -37,7 +37,7 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: metadata.namespace
-        image: gcr.io/kubeflow-images-public/katib/v1alpha3/katib-ui:c3b38d8
+        image: gcr.io/kubeflow-images-public/katib/v1alpha3/katib-ui:ce89cbf
         imagePullPolicy: IfNotPresent
         name: katib-ui
         ports:

--- a/tests/stacks/examples/alice/test_data/expected/~g_v1_configmap_katib-config.yaml
+++ b/tests/stacks/examples/alice/test_data/expected/~g_v1_configmap_katib-config.yaml
@@ -3,13 +3,13 @@ data:
   metrics-collector-sidecar: |-
     {
       "StdOut": {
-        "image": "gcr.io/kubeflow-images-public/katib/v1alpha3/file-metrics-collector:c3b38d8"
+        "image": "gcr.io/kubeflow-images-public/katib/v1alpha3/file-metrics-collector:ce89cbf"
       },
       "File": {
-        "image": "gcr.io/kubeflow-images-public/katib/v1alpha3/file-metrics-collector:c3b38d8"
+        "image": "gcr.io/kubeflow-images-public/katib/v1alpha3/file-metrics-collector:ce89cbf"
       },
       "TensorFlowEvent": {
-        "image": "gcr.io/kubeflow-images-public/katib/v1alpha3/tfevent-metrics-collector:c3b38d8",
+        "image": "gcr.io/kubeflow-images-public/katib/v1alpha3/tfevent-metrics-collector:ce89cbf",
         "resources": {
           "limits": {
             "memory": "1Gi"
@@ -20,22 +20,22 @@ data:
   suggestion: |-
     {
       "random": {
-        "image": "gcr.io/kubeflow-images-public/katib/v1alpha3/suggestion-hyperopt:c3b38d8"
+        "image": "gcr.io/kubeflow-images-public/katib/v1alpha3/suggestion-hyperopt:ce89cbf"
       },
       "grid": {
-        "image": "gcr.io/kubeflow-images-public/katib/v1alpha3/suggestion-chocolate:c3b38d8"
+        "image": "gcr.io/kubeflow-images-public/katib/v1alpha3/suggestion-chocolate:ce89cbf"
       },
       "hyperband": {
-        "image": "gcr.io/kubeflow-images-public/katib/v1alpha3/suggestion-hyperband:c3b38d8"
+        "image": "gcr.io/kubeflow-images-public/katib/v1alpha3/suggestion-hyperband:ce89cbf"
       },
       "bayesianoptimization": {
-        "image": "gcr.io/kubeflow-images-public/katib/v1alpha3/suggestion-skopt:c3b38d8"
+        "image": "gcr.io/kubeflow-images-public/katib/v1alpha3/suggestion-skopt:ce89cbf"
       },
       "tpe": {
-        "image": "gcr.io/kubeflow-images-public/katib/v1alpha3/suggestion-hyperopt:c3b38d8"
+        "image": "gcr.io/kubeflow-images-public/katib/v1alpha3/suggestion-hyperopt:ce89cbf"
       },
       "enas": {
-        "image": "gcr.io/kubeflow-images-public/katib/v1alpha3/suggestion-enas:c3b38d8",
+        "image": "gcr.io/kubeflow-images-public/katib/v1alpha3/suggestion-enas:ce89cbf",
         "imagePullPolicy": "Always",
         "resources": {
           "limits": {
@@ -44,10 +44,10 @@ data:
         }
       },
       "cmaes": {
-        "image": "gcr.io/kubeflow-images-public/katib/v1alpha3/suggestion-goptuna:c3b38d8"
+        "image": "gcr.io/kubeflow-images-public/katib/v1alpha3/suggestion-goptuna:ce89cbf"
       },
       "darts": {
-        "image": "gcr.io/kubeflow-images-public/katib/v1alpha3/suggestion-darts:c3b38d8"
+        "image": "gcr.io/kubeflow-images-public/katib/v1alpha3/suggestion-darts:ce89cbf"
       }
     }
 kind: ConfigMap

--- a/tests/stacks/gcp/test_data/expected/apps_v1_deployment_katib-controller.yaml
+++ b/tests/stacks/gcp/test_data/expected/apps_v1_deployment_katib-controller.yaml
@@ -34,7 +34,7 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: metadata.namespace
-        image: gcr.io/kubeflow-images-public/katib/v1alpha3/katib-controller:c3b38d8
+        image: gcr.io/kubeflow-images-public/katib/v1alpha3/katib-controller:ce89cbf
         imagePullPolicy: IfNotPresent
         name: katib-controller
         ports:

--- a/tests/stacks/gcp/test_data/expected/apps_v1_deployment_katib-db-manager.yaml
+++ b/tests/stacks/gcp/test_data/expected/apps_v1_deployment_katib-db-manager.yaml
@@ -38,7 +38,7 @@ spec:
             secretKeyRef:
               key: MYSQL_ROOT_PASSWORD
               name: katib-mysql-secrets
-        image: gcr.io/kubeflow-images-public/katib/v1alpha3/katib-db-manager:c3b38d8
+        image: gcr.io/kubeflow-images-public/katib/v1alpha3/katib-db-manager:ce89cbf
         imagePullPolicy: IfNotPresent
         livenessProbe:
           exec:

--- a/tests/stacks/gcp/test_data/expected/apps_v1_deployment_katib-ui.yaml
+++ b/tests/stacks/gcp/test_data/expected/apps_v1_deployment_katib-ui.yaml
@@ -37,7 +37,7 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: metadata.namespace
-        image: gcr.io/kubeflow-images-public/katib/v1alpha3/katib-ui:c3b38d8
+        image: gcr.io/kubeflow-images-public/katib/v1alpha3/katib-ui:ce89cbf
         imagePullPolicy: IfNotPresent
         name: katib-ui
         ports:

--- a/tests/stacks/gcp/test_data/expected/~g_v1_configmap_katib-config.yaml
+++ b/tests/stacks/gcp/test_data/expected/~g_v1_configmap_katib-config.yaml
@@ -3,13 +3,13 @@ data:
   metrics-collector-sidecar: |-
     {
       "StdOut": {
-        "image": "gcr.io/kubeflow-images-public/katib/v1alpha3/file-metrics-collector:c3b38d8"
+        "image": "gcr.io/kubeflow-images-public/katib/v1alpha3/file-metrics-collector:ce89cbf"
       },
       "File": {
-        "image": "gcr.io/kubeflow-images-public/katib/v1alpha3/file-metrics-collector:c3b38d8"
+        "image": "gcr.io/kubeflow-images-public/katib/v1alpha3/file-metrics-collector:ce89cbf"
       },
       "TensorFlowEvent": {
-        "image": "gcr.io/kubeflow-images-public/katib/v1alpha3/tfevent-metrics-collector:c3b38d8",
+        "image": "gcr.io/kubeflow-images-public/katib/v1alpha3/tfevent-metrics-collector:ce89cbf",
         "resources": {
           "limits": {
             "memory": "1Gi"
@@ -20,22 +20,22 @@ data:
   suggestion: |-
     {
       "random": {
-        "image": "gcr.io/kubeflow-images-public/katib/v1alpha3/suggestion-hyperopt:c3b38d8"
+        "image": "gcr.io/kubeflow-images-public/katib/v1alpha3/suggestion-hyperopt:ce89cbf"
       },
       "grid": {
-        "image": "gcr.io/kubeflow-images-public/katib/v1alpha3/suggestion-chocolate:c3b38d8"
+        "image": "gcr.io/kubeflow-images-public/katib/v1alpha3/suggestion-chocolate:ce89cbf"
       },
       "hyperband": {
-        "image": "gcr.io/kubeflow-images-public/katib/v1alpha3/suggestion-hyperband:c3b38d8"
+        "image": "gcr.io/kubeflow-images-public/katib/v1alpha3/suggestion-hyperband:ce89cbf"
       },
       "bayesianoptimization": {
-        "image": "gcr.io/kubeflow-images-public/katib/v1alpha3/suggestion-skopt:c3b38d8"
+        "image": "gcr.io/kubeflow-images-public/katib/v1alpha3/suggestion-skopt:ce89cbf"
       },
       "tpe": {
-        "image": "gcr.io/kubeflow-images-public/katib/v1alpha3/suggestion-hyperopt:c3b38d8"
+        "image": "gcr.io/kubeflow-images-public/katib/v1alpha3/suggestion-hyperopt:ce89cbf"
       },
       "enas": {
-        "image": "gcr.io/kubeflow-images-public/katib/v1alpha3/suggestion-enas:c3b38d8",
+        "image": "gcr.io/kubeflow-images-public/katib/v1alpha3/suggestion-enas:ce89cbf",
         "imagePullPolicy": "Always",
         "resources": {
           "limits": {
@@ -44,10 +44,10 @@ data:
         }
       },
       "cmaes": {
-        "image": "gcr.io/kubeflow-images-public/katib/v1alpha3/suggestion-goptuna:c3b38d8"
+        "image": "gcr.io/kubeflow-images-public/katib/v1alpha3/suggestion-goptuna:ce89cbf"
       },
       "darts": {
-        "image": "gcr.io/kubeflow-images-public/katib/v1alpha3/suggestion-darts:c3b38d8"
+        "image": "gcr.io/kubeflow-images-public/katib/v1alpha3/suggestion-darts:ce89cbf"
       }
     }
 kind: ConfigMap

--- a/tests/stacks/generic/test_data/expected/apps_v1_deployment_katib-controller.yaml
+++ b/tests/stacks/generic/test_data/expected/apps_v1_deployment_katib-controller.yaml
@@ -34,7 +34,7 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: metadata.namespace
-        image: gcr.io/kubeflow-images-public/katib/v1alpha3/katib-controller:c3b38d8
+        image: gcr.io/kubeflow-images-public/katib/v1alpha3/katib-controller:ce89cbf
         imagePullPolicy: IfNotPresent
         name: katib-controller
         ports:

--- a/tests/stacks/generic/test_data/expected/apps_v1_deployment_katib-db-manager.yaml
+++ b/tests/stacks/generic/test_data/expected/apps_v1_deployment_katib-db-manager.yaml
@@ -38,7 +38,7 @@ spec:
             secretKeyRef:
               key: MYSQL_ROOT_PASSWORD
               name: katib-mysql-secrets
-        image: gcr.io/kubeflow-images-public/katib/v1alpha3/katib-db-manager:c3b38d8
+        image: gcr.io/kubeflow-images-public/katib/v1alpha3/katib-db-manager:ce89cbf
         imagePullPolicy: IfNotPresent
         livenessProbe:
           exec:

--- a/tests/stacks/generic/test_data/expected/apps_v1_deployment_katib-ui.yaml
+++ b/tests/stacks/generic/test_data/expected/apps_v1_deployment_katib-ui.yaml
@@ -37,7 +37,7 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: metadata.namespace
-        image: gcr.io/kubeflow-images-public/katib/v1alpha3/katib-ui:c3b38d8
+        image: gcr.io/kubeflow-images-public/katib/v1alpha3/katib-ui:ce89cbf
         imagePullPolicy: IfNotPresent
         name: katib-ui
         ports:

--- a/tests/stacks/generic/test_data/expected/~g_v1_configmap_katib-config.yaml
+++ b/tests/stacks/generic/test_data/expected/~g_v1_configmap_katib-config.yaml
@@ -3,13 +3,13 @@ data:
   metrics-collector-sidecar: |-
     {
       "StdOut": {
-        "image": "gcr.io/kubeflow-images-public/katib/v1alpha3/file-metrics-collector:c3b38d8"
+        "image": "gcr.io/kubeflow-images-public/katib/v1alpha3/file-metrics-collector:ce89cbf"
       },
       "File": {
-        "image": "gcr.io/kubeflow-images-public/katib/v1alpha3/file-metrics-collector:c3b38d8"
+        "image": "gcr.io/kubeflow-images-public/katib/v1alpha3/file-metrics-collector:ce89cbf"
       },
       "TensorFlowEvent": {
-        "image": "gcr.io/kubeflow-images-public/katib/v1alpha3/tfevent-metrics-collector:c3b38d8",
+        "image": "gcr.io/kubeflow-images-public/katib/v1alpha3/tfevent-metrics-collector:ce89cbf",
         "resources": {
           "limits": {
             "memory": "1Gi"
@@ -20,22 +20,22 @@ data:
   suggestion: |-
     {
       "random": {
-        "image": "gcr.io/kubeflow-images-public/katib/v1alpha3/suggestion-hyperopt:c3b38d8"
+        "image": "gcr.io/kubeflow-images-public/katib/v1alpha3/suggestion-hyperopt:ce89cbf"
       },
       "grid": {
-        "image": "gcr.io/kubeflow-images-public/katib/v1alpha3/suggestion-chocolate:c3b38d8"
+        "image": "gcr.io/kubeflow-images-public/katib/v1alpha3/suggestion-chocolate:ce89cbf"
       },
       "hyperband": {
-        "image": "gcr.io/kubeflow-images-public/katib/v1alpha3/suggestion-hyperband:c3b38d8"
+        "image": "gcr.io/kubeflow-images-public/katib/v1alpha3/suggestion-hyperband:ce89cbf"
       },
       "bayesianoptimization": {
-        "image": "gcr.io/kubeflow-images-public/katib/v1alpha3/suggestion-skopt:c3b38d8"
+        "image": "gcr.io/kubeflow-images-public/katib/v1alpha3/suggestion-skopt:ce89cbf"
       },
       "tpe": {
-        "image": "gcr.io/kubeflow-images-public/katib/v1alpha3/suggestion-hyperopt:c3b38d8"
+        "image": "gcr.io/kubeflow-images-public/katib/v1alpha3/suggestion-hyperopt:ce89cbf"
       },
       "enas": {
-        "image": "gcr.io/kubeflow-images-public/katib/v1alpha3/suggestion-enas:c3b38d8",
+        "image": "gcr.io/kubeflow-images-public/katib/v1alpha3/suggestion-enas:ce89cbf",
         "imagePullPolicy": "Always",
         "resources": {
           "limits": {
@@ -44,10 +44,10 @@ data:
         }
       },
       "cmaes": {
-        "image": "gcr.io/kubeflow-images-public/katib/v1alpha3/suggestion-goptuna:c3b38d8"
+        "image": "gcr.io/kubeflow-images-public/katib/v1alpha3/suggestion-goptuna:ce89cbf"
       },
       "darts": {
-        "image": "gcr.io/kubeflow-images-public/katib/v1alpha3/suggestion-darts:c3b38d8"
+        "image": "gcr.io/kubeflow-images-public/katib/v1alpha3/suggestion-darts:ce89cbf"
       }
     }
 kind: ConfigMap

--- a/tests/stacks/ibm/test_data/expected/apps_v1_deployment_katib-controller.yaml
+++ b/tests/stacks/ibm/test_data/expected/apps_v1_deployment_katib-controller.yaml
@@ -34,7 +34,7 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: metadata.namespace
-        image: gcr.io/kubeflow-images-public/katib/v1alpha3/katib-controller:c3b38d8
+        image: gcr.io/kubeflow-images-public/katib/v1alpha3/katib-controller:ce89cbf
         imagePullPolicy: IfNotPresent
         name: katib-controller
         ports:

--- a/tests/stacks/ibm/test_data/expected/apps_v1_deployment_katib-db-manager.yaml
+++ b/tests/stacks/ibm/test_data/expected/apps_v1_deployment_katib-db-manager.yaml
@@ -38,7 +38,7 @@ spec:
             secretKeyRef:
               key: MYSQL_ROOT_PASSWORD
               name: katib-mysql-secrets
-        image: gcr.io/kubeflow-images-public/katib/v1alpha3/katib-db-manager:c3b38d8
+        image: gcr.io/kubeflow-images-public/katib/v1alpha3/katib-db-manager:ce89cbf
         imagePullPolicy: IfNotPresent
         livenessProbe:
           exec:

--- a/tests/stacks/ibm/test_data/expected/apps_v1_deployment_katib-ui.yaml
+++ b/tests/stacks/ibm/test_data/expected/apps_v1_deployment_katib-ui.yaml
@@ -37,7 +37,7 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: metadata.namespace
-        image: gcr.io/kubeflow-images-public/katib/v1alpha3/katib-ui:c3b38d8
+        image: gcr.io/kubeflow-images-public/katib/v1alpha3/katib-ui:ce89cbf
         imagePullPolicy: IfNotPresent
         name: katib-ui
         ports:

--- a/tests/stacks/ibm/test_data/expected/~g_v1_configmap_katib-config.yaml
+++ b/tests/stacks/ibm/test_data/expected/~g_v1_configmap_katib-config.yaml
@@ -3,13 +3,13 @@ data:
   metrics-collector-sidecar: |-
     {
       "StdOut": {
-        "image": "gcr.io/kubeflow-images-public/katib/v1alpha3/file-metrics-collector:c3b38d8"
+        "image": "gcr.io/kubeflow-images-public/katib/v1alpha3/file-metrics-collector:ce89cbf"
       },
       "File": {
-        "image": "gcr.io/kubeflow-images-public/katib/v1alpha3/file-metrics-collector:c3b38d8"
+        "image": "gcr.io/kubeflow-images-public/katib/v1alpha3/file-metrics-collector:ce89cbf"
       },
       "TensorFlowEvent": {
-        "image": "gcr.io/kubeflow-images-public/katib/v1alpha3/tfevent-metrics-collector:c3b38d8",
+        "image": "gcr.io/kubeflow-images-public/katib/v1alpha3/tfevent-metrics-collector:ce89cbf",
         "resources": {
           "limits": {
             "memory": "1Gi"
@@ -20,22 +20,22 @@ data:
   suggestion: |-
     {
       "random": {
-        "image": "gcr.io/kubeflow-images-public/katib/v1alpha3/suggestion-hyperopt:c3b38d8"
+        "image": "gcr.io/kubeflow-images-public/katib/v1alpha3/suggestion-hyperopt:ce89cbf"
       },
       "grid": {
-        "image": "gcr.io/kubeflow-images-public/katib/v1alpha3/suggestion-chocolate:c3b38d8"
+        "image": "gcr.io/kubeflow-images-public/katib/v1alpha3/suggestion-chocolate:ce89cbf"
       },
       "hyperband": {
-        "image": "gcr.io/kubeflow-images-public/katib/v1alpha3/suggestion-hyperband:c3b38d8"
+        "image": "gcr.io/kubeflow-images-public/katib/v1alpha3/suggestion-hyperband:ce89cbf"
       },
       "bayesianoptimization": {
-        "image": "gcr.io/kubeflow-images-public/katib/v1alpha3/suggestion-skopt:c3b38d8"
+        "image": "gcr.io/kubeflow-images-public/katib/v1alpha3/suggestion-skopt:ce89cbf"
       },
       "tpe": {
-        "image": "gcr.io/kubeflow-images-public/katib/v1alpha3/suggestion-hyperopt:c3b38d8"
+        "image": "gcr.io/kubeflow-images-public/katib/v1alpha3/suggestion-hyperopt:ce89cbf"
       },
       "enas": {
-        "image": "gcr.io/kubeflow-images-public/katib/v1alpha3/suggestion-enas:c3b38d8",
+        "image": "gcr.io/kubeflow-images-public/katib/v1alpha3/suggestion-enas:ce89cbf",
         "imagePullPolicy": "Always",
         "resources": {
           "limits": {
@@ -44,10 +44,10 @@ data:
         }
       },
       "cmaes": {
-        "image": "gcr.io/kubeflow-images-public/katib/v1alpha3/suggestion-goptuna:c3b38d8"
+        "image": "gcr.io/kubeflow-images-public/katib/v1alpha3/suggestion-goptuna:ce89cbf"
       },
       "darts": {
-        "image": "gcr.io/kubeflow-images-public/katib/v1alpha3/suggestion-darts:c3b38d8"
+        "image": "gcr.io/kubeflow-images-public/katib/v1alpha3/suggestion-darts:ce89cbf"
       }
     }
 kind: ConfigMap

--- a/tests/tests/legacy_kustomizations/katib-controller/test_data/expected/apps_v1_deployment_katib-controller.yaml
+++ b/tests/tests/legacy_kustomizations/katib-controller/test_data/expected/apps_v1_deployment_katib-controller.yaml
@@ -46,7 +46,7 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: metadata.namespace
-        image: gcr.io/kubeflow-images-public/katib/v1alpha3/katib-controller:c3b38d8
+        image: gcr.io/kubeflow-images-public/katib/v1alpha3/katib-controller:ce89cbf
         imagePullPolicy: IfNotPresent
         name: katib-controller
         ports:

--- a/tests/tests/legacy_kustomizations/katib-controller/test_data/expected/apps_v1_deployment_katib-db-manager.yaml
+++ b/tests/tests/legacy_kustomizations/katib-controller/test_data/expected/apps_v1_deployment_katib-db-manager.yaml
@@ -50,7 +50,7 @@ spec:
             secretKeyRef:
               key: MYSQL_ROOT_PASSWORD
               name: katib-mysql-secrets
-        image: gcr.io/kubeflow-images-public/katib/v1alpha3/katib-db-manager:c3b38d8
+        image: gcr.io/kubeflow-images-public/katib/v1alpha3/katib-db-manager:ce89cbf
         imagePullPolicy: IfNotPresent
         livenessProbe:
           exec:

--- a/tests/tests/legacy_kustomizations/katib-controller/test_data/expected/apps_v1_deployment_katib-ui.yaml
+++ b/tests/tests/legacy_kustomizations/katib-controller/test_data/expected/apps_v1_deployment_katib-ui.yaml
@@ -49,7 +49,7 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: metadata.namespace
-        image: gcr.io/kubeflow-images-public/katib/v1alpha3/katib-ui:c3b38d8
+        image: gcr.io/kubeflow-images-public/katib/v1alpha3/katib-ui:ce89cbf
         imagePullPolicy: IfNotPresent
         name: katib-ui
         ports:

--- a/tests/tests/legacy_kustomizations/katib-controller/test_data/expected/~g_v1_configmap_katib-config.yaml
+++ b/tests/tests/legacy_kustomizations/katib-controller/test_data/expected/~g_v1_configmap_katib-config.yaml
@@ -3,13 +3,13 @@ data:
   metrics-collector-sidecar: |-
     {
       "StdOut": {
-        "image": "gcr.io/kubeflow-images-public/katib/v1alpha3/file-metrics-collector:c3b38d8"
+        "image": "gcr.io/kubeflow-images-public/katib/v1alpha3/file-metrics-collector:ce89cbf"
       },
       "File": {
-        "image": "gcr.io/kubeflow-images-public/katib/v1alpha3/file-metrics-collector:c3b38d8"
+        "image": "gcr.io/kubeflow-images-public/katib/v1alpha3/file-metrics-collector:ce89cbf"
       },
       "TensorFlowEvent": {
-        "image": "gcr.io/kubeflow-images-public/katib/v1alpha3/tfevent-metrics-collector:c3b38d8",
+        "image": "gcr.io/kubeflow-images-public/katib/v1alpha3/tfevent-metrics-collector:ce89cbf",
         "resources": {
           "limits": {
             "memory": "1Gi"
@@ -20,22 +20,22 @@ data:
   suggestion: |-
     {
       "random": {
-        "image": "gcr.io/kubeflow-images-public/katib/v1alpha3/suggestion-hyperopt:c3b38d8"
+        "image": "gcr.io/kubeflow-images-public/katib/v1alpha3/suggestion-hyperopt:ce89cbf"
       },
       "grid": {
-        "image": "gcr.io/kubeflow-images-public/katib/v1alpha3/suggestion-chocolate:c3b38d8"
+        "image": "gcr.io/kubeflow-images-public/katib/v1alpha3/suggestion-chocolate:ce89cbf"
       },
       "hyperband": {
-        "image": "gcr.io/kubeflow-images-public/katib/v1alpha3/suggestion-hyperband:c3b38d8"
+        "image": "gcr.io/kubeflow-images-public/katib/v1alpha3/suggestion-hyperband:ce89cbf"
       },
       "bayesianoptimization": {
-        "image": "gcr.io/kubeflow-images-public/katib/v1alpha3/suggestion-skopt:c3b38d8"
+        "image": "gcr.io/kubeflow-images-public/katib/v1alpha3/suggestion-skopt:ce89cbf"
       },
       "tpe": {
-        "image": "gcr.io/kubeflow-images-public/katib/v1alpha3/suggestion-hyperopt:c3b38d8"
+        "image": "gcr.io/kubeflow-images-public/katib/v1alpha3/suggestion-hyperopt:ce89cbf"
       },
       "enas": {
-        "image": "gcr.io/kubeflow-images-public/katib/v1alpha3/suggestion-enas:c3b38d8",
+        "image": "gcr.io/kubeflow-images-public/katib/v1alpha3/suggestion-enas:ce89cbf",
         "imagePullPolicy": "Always",
         "resources": {
           "limits": {
@@ -44,10 +44,10 @@ data:
         }
       },
       "cmaes": {
-        "image": "gcr.io/kubeflow-images-public/katib/v1alpha3/suggestion-goptuna:c3b38d8"
+        "image": "gcr.io/kubeflow-images-public/katib/v1alpha3/suggestion-goptuna:ce89cbf"
       },
       "darts": {
-        "image": "gcr.io/kubeflow-images-public/katib/v1alpha3/suggestion-darts:c3b38d8"
+        "image": "gcr.io/kubeflow-images-public/katib/v1alpha3/suggestion-darts:ce89cbf"
       }
     }
 kind: ConfigMap


### PR DESCRIPTION
I changed Katib image tag from kubeflow/katib@c3b38d8 to https://github.com/kubeflow/katib/commit/ce89cbfb9ce05e646d850ac06ac13b16764fee1c for master manifest branch.

This PR: https://github.com/kubeflow/katib/pull/1223 fixes problems with deleting extra Trials.


/assign @johnugeorge @gaocegege 
/cc @idahoakl @jlewi


**Checklist:**
- [x] Unit tests have been rebuilt: 
    1. `cd manifests/tests`
    2. `make generate-changed-only`
    3. `make test`
