### PR TITLE
Automated cherry pick of #1442: Upgrade AWS jupyter images to 1.1.0

### DIFF
--- a/stacks/aws/application/jupyter-web-app/configs/spawner_ui_config.yaml
+++ b/stacks/aws/application/jupyter-web-app/configs/spawner_ui_config.yaml
@@ -21,10 +21,10 @@ spawnerFormDefaults:
     value: 527798164940.dkr.ecr.us-west-2.amazonaws.com/tensorflow-1.15.2-notebook-cpu:1.0.0
     # The list of available standard container Images
     options:
-      - 527798164940.dkr.ecr.us-west-2.amazonaws.com/tensorflow-1.15.2-notebook-cpu:1.0.0
-      - 527798164940.dkr.ecr.us-west-2.amazonaws.com/tensorflow-1.15.2-notebook-gpu:1.0.0
-      - 527798164940.dkr.ecr.us-west-2.amazonaws.com/tensorflow-2.1.0-notebook-cpu:1.0.0
-      - 527798164940.dkr.ecr.us-west-2.amazonaws.com/tensorflow-2.1.0-notebook-gpu:1.0.0
+      - 527798164940.dkr.ecr.us-west-2.amazonaws.com/tensorflow-1.15.2-notebook-cpu:1.1.0
+      - 527798164940.dkr.ecr.us-west-2.amazonaws.com/tensorflow-1.15.2-notebook-gpu:1.1.0
+      - 527798164940.dkr.ecr.us-west-2.amazonaws.com/tensorflow-2.1.0-notebook-cpu:1.1.0
+      - 527798164940.dkr.ecr.us-west-2.amazonaws.com/tensorflow-2.1.0-notebook-gpu:1.1.0
       - gcr.io/kubeflow-images-public/tensorflow-1.15.2-notebook-cpu:1.0.0
       - gcr.io/kubeflow-images-public/tensorflow-1.15.2-notebook-gpu:1.0.0
       - gcr.io/kubeflow-images-public/tensorflow-2.1.0-notebook-cpu:1.0.0

--- a/tests/stacks/aws/application/jupyter-web-app/test_data/expected/apps_v1_deployment_jupyter-web-app-deployment.yaml
+++ b/tests/stacks/aws/application/jupyter-web-app/test_data/expected/apps_v1_deployment_jupyter-web-app-deployment.yaml
@@ -42,5 +42,5 @@ spec:
       serviceAccountName: jupyter-web-app-service-account
       volumes:
       - configMap:
-          name: jupyter-web-app-jupyter-web-app-config-t6dm9hd6mm
+          name: jupyter-web-app-jupyter-web-app-config-57ddmh4ht8
         name: config-volume

--- a/tests/stacks/aws/application/jupyter-web-app/test_data/expected/~g_v1_configmap_jupyter-web-app-jupyter-web-app-config-57ddmh4ht8.yaml
+++ b/tests/stacks/aws/application/jupyter-web-app/test_data/expected/~g_v1_configmap_jupyter-web-app-jupyter-web-app-config-57ddmh4ht8.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 data:
-  spawner_ui_config.yaml: |-
+  spawner_ui_config.yaml: |
     # Configuration file for the Jupyter UI.
     #
     # Each Jupyter UI option is configured by two keys: 'value' and 'readOnly'
@@ -24,10 +24,10 @@ data:
         value: 527798164940.dkr.ecr.us-west-2.amazonaws.com/tensorflow-1.15.2-notebook-cpu:1.0.0
         # The list of available standard container Images
         options:
-          - 527798164940.dkr.ecr.us-west-2.amazonaws.com/tensorflow-1.15.2-notebook-cpu:1.0.0
-          - 527798164940.dkr.ecr.us-west-2.amazonaws.com/tensorflow-1.15.2-notebook-gpu:1.0.0
-          - 527798164940.dkr.ecr.us-west-2.amazonaws.com/tensorflow-2.1.0-notebook-cpu:1.0.0
-          - 527798164940.dkr.ecr.us-west-2.amazonaws.com/tensorflow-2.1.0-notebook-gpu:1.0.0
+          - 527798164940.dkr.ecr.us-west-2.amazonaws.com/tensorflow-1.15.2-notebook-cpu:1.1.0
+          - 527798164940.dkr.ecr.us-west-2.amazonaws.com/tensorflow-1.15.2-notebook-gpu:1.1.0
+          - 527798164940.dkr.ecr.us-west-2.amazonaws.com/tensorflow-2.1.0-notebook-cpu:1.1.0
+          - 527798164940.dkr.ecr.us-west-2.amazonaws.com/tensorflow-2.1.0-notebook-gpu:1.1.0
           - gcr.io/kubeflow-images-public/tensorflow-1.15.2-notebook-cpu:1.0.0
           - gcr.io/kubeflow-images-public/tensorflow-1.15.2-notebook-gpu:1.0.0
           - gcr.io/kubeflow-images-public/tensorflow-2.1.0-notebook-cpu:1.0.0
@@ -139,5 +139,5 @@ metadata:
   labels:
     app: jupyter-web-app
     kustomize.component: jupyter-web-app
-  name: jupyter-web-app-jupyter-web-app-config-t6dm9hd6mm
+  name: jupyter-web-app-jupyter-web-app-config-57ddmh4ht8
   namespace: kubeflow

--- a/tests/stacks/aws/test_data/expected/apps_v1_deployment_jupyter-web-app-deployment.yaml
+++ b/tests/stacks/aws/test_data/expected/apps_v1_deployment_jupyter-web-app-deployment.yaml
@@ -42,5 +42,5 @@ spec:
       serviceAccountName: jupyter-web-app-service-account
       volumes:
       - configMap:
-          name: jupyter-web-app-jupyter-web-app-config-t6dm9hd6mm
+          name: jupyter-web-app-jupyter-web-app-config-57ddmh4ht8
         name: config-volume

--- a/tests/stacks/aws/test_data/expected/~g_v1_configmap_jupyter-web-app-jupyter-web-app-config-57ddmh4ht8.yaml
+++ b/tests/stacks/aws/test_data/expected/~g_v1_configmap_jupyter-web-app-jupyter-web-app-config-57ddmh4ht8.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 data:
-  spawner_ui_config.yaml: |-
+  spawner_ui_config.yaml: |
     # Configuration file for the Jupyter UI.
     #
     # Each Jupyter UI option is configured by two keys: 'value' and 'readOnly'
@@ -24,10 +24,10 @@ data:
         value: 527798164940.dkr.ecr.us-west-2.amazonaws.com/tensorflow-1.15.2-notebook-cpu:1.0.0
         # The list of available standard container Images
         options:
-          - 527798164940.dkr.ecr.us-west-2.amazonaws.com/tensorflow-1.15.2-notebook-cpu:1.0.0
-          - 527798164940.dkr.ecr.us-west-2.amazonaws.com/tensorflow-1.15.2-notebook-gpu:1.0.0
-          - 527798164940.dkr.ecr.us-west-2.amazonaws.com/tensorflow-2.1.0-notebook-cpu:1.0.0
-          - 527798164940.dkr.ecr.us-west-2.amazonaws.com/tensorflow-2.1.0-notebook-gpu:1.0.0
+          - 527798164940.dkr.ecr.us-west-2.amazonaws.com/tensorflow-1.15.2-notebook-cpu:1.1.0
+          - 527798164940.dkr.ecr.us-west-2.amazonaws.com/tensorflow-1.15.2-notebook-gpu:1.1.0
+          - 527798164940.dkr.ecr.us-west-2.amazonaws.com/tensorflow-2.1.0-notebook-cpu:1.1.0
+          - 527798164940.dkr.ecr.us-west-2.amazonaws.com/tensorflow-2.1.0-notebook-gpu:1.1.0
           - gcr.io/kubeflow-images-public/tensorflow-1.15.2-notebook-cpu:1.0.0
           - gcr.io/kubeflow-images-public/tensorflow-1.15.2-notebook-gpu:1.0.0
           - gcr.io/kubeflow-images-public/tensorflow-2.1.0-notebook-cpu:1.0.0
@@ -139,5 +139,5 @@ metadata:
   labels:
     app: jupyter-web-app
     kustomize.component: jupyter-web-app
-  name: jupyter-web-app-jupyter-web-app-config-t6dm9hd6mm
+  name: jupyter-web-app-jupyter-web-app-config-57ddmh4ht8
   namespace: kubeflow


### PR DESCRIPTION
Cherry pick of #1442 on v1.1-branch.

#1442: Upgrade AWS jupyter images to 1.1.0

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.