### PR TITLE
Pass userid-header param to kfam

### DIFF
--- a/stacks/ibm/application/profiles/base/deployment_patch.yaml
+++ b/stacks/ibm/application/profiles/base/deployment_patch.yaml
@@ -38,6 +38,8 @@ spec:
         - $(CLUSTER_ADMIN) 
         - -userid-prefix 
         - $(USERID_PREFIX)
+        - -userid-header
+        - $(USERID_HEADER)
         args: []
         name: kfam
         env:

--- a/tests/stacks/ibm/application/profiles/base/test_data/expected/apps_v1_deployment_profiles-deployment.yaml
+++ b/tests/stacks/ibm/application/profiles/base/test_data/expected/apps_v1_deployment_profiles-deployment.yaml
@@ -62,6 +62,8 @@ spec:
         - $(CLUSTER_ADMIN)
         - -userid-prefix
         - $(USERID_PREFIX)
+        - -userid-header
+        - $(USERID_HEADER)
         env:
         - name: USERID_HEADER
           valueFrom:

--- a/tests/stacks/ibm/application/profiles/test_data/expected/apps_v1_deployment_profiles-deployment.yaml
+++ b/tests/stacks/ibm/application/profiles/test_data/expected/apps_v1_deployment_profiles-deployment.yaml
@@ -68,6 +68,8 @@ spec:
         - $(CLUSTER_ADMIN)
         - -userid-prefix
         - $(USERID_PREFIX)
+        - -userid-header
+        - $(USERID_HEADER)
         env:
         - name: USERID_HEADER
           valueFrom:

--- a/tests/stacks/ibm/multi-user/test_data/expected/apps_v1_deployment_profiles-deployment.yaml
+++ b/tests/stacks/ibm/multi-user/test_data/expected/apps_v1_deployment_profiles-deployment.yaml
@@ -69,6 +69,8 @@ spec:
         - $(CLUSTER_ADMIN)
         - -userid-prefix
         - $(USERID_PREFIX)
+        - -userid-header
+        - $(USERID_HEADER)
         env:
         - name: USERID_HEADER
           valueFrom:

--- a/tests/stacks/ibm/test_data/expected/apps_v1_deployment_profiles-deployment.yaml
+++ b/tests/stacks/ibm/test_data/expected/apps_v1_deployment_profiles-deployment.yaml
@@ -69,6 +69,8 @@ spec:
         - $(CLUSTER_ADMIN)
         - -userid-prefix
         - $(USERID_PREFIX)
+        - -userid-header
+        - $(USERID_HEADER)
         env:
         - name: USERID_HEADER
           valueFrom:


### PR DESCRIPTION
Need `userid-header` param to use proper header when handling
the API calls. Default header value: `x-goog-authenticated-user-email`
would be used if this param doesn't present. It may only work on GCP.
Therefore, we do need this param to be properly passed to kfam.

**Which issue is resolved by this Pull Request:**
Resolves #

**Description of your changes:**


**Checklist:**
- [x] Unit tests have been rebuilt: 
    1. `cd manifests/tests`
    2. `make generate-changed-only`
    3. `make test`
