### PR TITLE
[IBM] update manifests repo link

### DIFF
--- a/kfdef/kfctl_ibm.v1.1.0.yaml
+++ b/kfdef/kfctl_ibm.v1.1.0.yaml
@@ -91,5 +91,5 @@ spec:
     name: tensorboard
   repos:
   - name: manifests
-    uri: https://github.com/kubeflow/manifests/archive/v1.1.0.tar.gz
-  version: v1.1.0
+    uri: https://github.com/kubeflow/manifests/archive/v1.1-branch.tar.gz
+  version: v1.1-branch

--- a/kfdef/kfctl_ibm_dex_multi_user.v1.1.0.yaml
+++ b/kfdef/kfctl_ibm_dex_multi_user.v1.1.0.yaml
@@ -99,5 +99,5 @@ spec:
     name: tensorboard
   repos:
   - name: manifests
-    uri: https://github.com/kubeflow/manifests/archive/v1.1.0.tar.gz
-  version: v1.1.0
+    uri: https://github.com/kubeflow/manifests/archive/v1.1-branch.tar.gz
+  version: v1.1-branch


### PR DESCRIPTION
**Description of your changes:**

The multi-user kfdef configuration has been cherry-picked into `v1.1-branch` but not `v1.1.0` release. For now, instead of using the repo archive from `v1.1.0`, switch to use `v1.1-branch`.

**Checklist:**
- [ x ] Unit tests have been rebuilt: 
    1. `cd manifests/tests`
    2. `make generate-changed-only`
    3. `make test`
