### PR TITLE
cert-manager namespace needs label control-plane

### DIFF
--- a/namespaces/base/namespaces.yaml
+++ b/namespaces/base/namespaces.yaml
@@ -10,3 +10,4 @@ apiVersion: v1
 kind: Namespace
 metadata:
   name: cert-manager
+  control-plane: kubeflow

--- a/namespaces/base/namespaces.yaml
+++ b/namespaces/base/namespaces.yaml
@@ -10,4 +10,5 @@ apiVersion: v1
 kind: Namespace
 metadata:
   name: cert-manager
-  control-plane: kubeflow
+  labels:
+    control-plane: kubeflow


### PR DESCRIPTION
* cert-manager namespace needs the control-plane label to prevent
  application of kfserving webhooks.

related to: #1450
