### PR TITLE
Update unit test for the latest changes

### DIFF
--- a/tests/stacks/ibm/multi-user/test_data/expected/apps_v1_deployment_katib-controller.yaml
+++ b/tests/stacks/ibm/multi-user/test_data/expected/apps_v1_deployment_katib-controller.yaml
@@ -34,7 +34,7 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: metadata.namespace
-        image: gcr.io/kubeflow-images-public/katib/v1alpha3/katib-controller:c3b38d8
+        image: gcr.io/kubeflow-images-public/katib/v1alpha3/katib-controller:ce89cbf
         imagePullPolicy: IfNotPresent
         name: katib-controller
         ports:

--- a/tests/stacks/ibm/multi-user/test_data/expected/apps_v1_deployment_katib-db-manager.yaml
+++ b/tests/stacks/ibm/multi-user/test_data/expected/apps_v1_deployment_katib-db-manager.yaml
@@ -38,7 +38,7 @@ spec:
             secretKeyRef:
               key: MYSQL_ROOT_PASSWORD
               name: katib-mysql-secrets
-        image: gcr.io/kubeflow-images-public/katib/v1alpha3/katib-db-manager:c3b38d8
+        image: gcr.io/kubeflow-images-public/katib/v1alpha3/katib-db-manager:ce89cbf
         imagePullPolicy: IfNotPresent
         livenessProbe:
           exec:

--- a/tests/stacks/ibm/multi-user/test_data/expected/apps_v1_deployment_katib-ui.yaml
+++ b/tests/stacks/ibm/multi-user/test_data/expected/apps_v1_deployment_katib-ui.yaml
@@ -37,7 +37,7 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: metadata.namespace
-        image: gcr.io/kubeflow-images-public/katib/v1alpha3/katib-ui:c3b38d8
+        image: gcr.io/kubeflow-images-public/katib/v1alpha3/katib-ui:ce89cbf
         imagePullPolicy: IfNotPresent
         name: katib-ui
         ports:

--- a/tests/stacks/ibm/multi-user/test_data/expected/~g_v1_configmap_katib-config.yaml
+++ b/tests/stacks/ibm/multi-user/test_data/expected/~g_v1_configmap_katib-config.yaml
@@ -3,13 +3,13 @@ data:
   metrics-collector-sidecar: |-
     {
       "StdOut": {
-        "image": "gcr.io/kubeflow-images-public/katib/v1alpha3/file-metrics-collector:c3b38d8"
+        "image": "gcr.io/kubeflow-images-public/katib/v1alpha3/file-metrics-collector:ce89cbf"
       },
       "File": {
-        "image": "gcr.io/kubeflow-images-public/katib/v1alpha3/file-metrics-collector:c3b38d8"
+        "image": "gcr.io/kubeflow-images-public/katib/v1alpha3/file-metrics-collector:ce89cbf"
       },
       "TensorFlowEvent": {
-        "image": "gcr.io/kubeflow-images-public/katib/v1alpha3/tfevent-metrics-collector:c3b38d8",
+        "image": "gcr.io/kubeflow-images-public/katib/v1alpha3/tfevent-metrics-collector:ce89cbf",
         "resources": {
           "limits": {
             "memory": "1Gi"
@@ -20,22 +20,22 @@ data:
   suggestion: |-
     {
       "random": {
-        "image": "gcr.io/kubeflow-images-public/katib/v1alpha3/suggestion-hyperopt:c3b38d8"
+        "image": "gcr.io/kubeflow-images-public/katib/v1alpha3/suggestion-hyperopt:ce89cbf"
       },
       "grid": {
-        "image": "gcr.io/kubeflow-images-public/katib/v1alpha3/suggestion-chocolate:c3b38d8"
+        "image": "gcr.io/kubeflow-images-public/katib/v1alpha3/suggestion-chocolate:ce89cbf"
       },
       "hyperband": {
-        "image": "gcr.io/kubeflow-images-public/katib/v1alpha3/suggestion-hyperband:c3b38d8"
+        "image": "gcr.io/kubeflow-images-public/katib/v1alpha3/suggestion-hyperband:ce89cbf"
       },
       "bayesianoptimization": {
-        "image": "gcr.io/kubeflow-images-public/katib/v1alpha3/suggestion-skopt:c3b38d8"
+        "image": "gcr.io/kubeflow-images-public/katib/v1alpha3/suggestion-skopt:ce89cbf"
       },
       "tpe": {
-        "image": "gcr.io/kubeflow-images-public/katib/v1alpha3/suggestion-hyperopt:c3b38d8"
+        "image": "gcr.io/kubeflow-images-public/katib/v1alpha3/suggestion-hyperopt:ce89cbf"
       },
       "enas": {
-        "image": "gcr.io/kubeflow-images-public/katib/v1alpha3/suggestion-enas:c3b38d8",
+        "image": "gcr.io/kubeflow-images-public/katib/v1alpha3/suggestion-enas:ce89cbf",
         "imagePullPolicy": "Always",
         "resources": {
           "limits": {
@@ -44,10 +44,10 @@ data:
         }
       },
       "cmaes": {
-        "image": "gcr.io/kubeflow-images-public/katib/v1alpha3/suggestion-goptuna:c3b38d8"
+        "image": "gcr.io/kubeflow-images-public/katib/v1alpha3/suggestion-goptuna:ce89cbf"
       },
       "darts": {
-        "image": "gcr.io/kubeflow-images-public/katib/v1alpha3/suggestion-darts:c3b38d8"
+        "image": "gcr.io/kubeflow-images-public/katib/v1alpha3/suggestion-darts:ce89cbf"
       }
     }
 kind: ConfigMap


### PR DESCRIPTION
After https://github.com/kubeflow/manifests/pull/1440 was merged, some unit test was not generated and post-submit fails: https://prow.k8s.io/view/gcs/kubernetes-jenkins/logs/kubeflow_manifests/kubeflow-manifests-postsubmit/1290236501023526912/.
We had to re-generate tests after https://github.com/kubeflow/manifests/pull/1428 was merged.
This PR should fix unit-test.

/cc @johnugeorge @jlewi @adrian555 


**Checklist:**
- [x] Unit tests have been rebuilt: 
    1. `cd manifests/tests`
    2. `make generate-changed-only`
    3. `make test`
