### PR TITLE
Create a kustomize function to change the gateway of virtual services.

### DIFF
--- a/gcp/kustomize-fns/virtual_service_config.yaml
+++ b/gcp/kustomize-fns/virtual_service_config.yaml
@@ -1,20 +1,12 @@
 # Define a transform to remove namespace from cluster scoped resources
 apiVersion: v1alpha1 
-kind: RemoveNamespace
+kind: VirtualServiceTransform
 metadata:
-  name: remove-namespace
+  name: vs-config
   annotations:
     config.kubernetes.io/function: |
       container:
         image: gcr.io/kubeflow-images-public/kpt-fns:v1.1-rc.0-22-gbb803bc@sha256:23c586b7df3603bcf6610e8089acfe03956473cd4d367bbc05270bba74dc29fd
 spec:
-  clusterKinds:
-  - kind: Profile
-    group: kubeflow.org
-  - kind: ClusterIssuer
-    group: cert-manager.io
-  - kind: CompositeController
-    group: metacontroller.k8s.io
-  - kind: ClusterRbacConfig
-    group: rbac.istio.io
+  gateway: "istio-system/ingressgateway"
  


### PR DESCRIPTION
* Related to kubeflow/manifests#1169 we should be using the gateway
  in the istio-system namespace and not the gateway in the kubeflow
  namespace

* kubeflow/gcl-blueprints#22 With ACM we want to use
  istio-system/ingressgateway and stop using the kubeflow-gateway.

**Which issue is resolved by this Pull Request:**
Resolves #

**Description of your changes:**


**Checklist:**
- [ ] Unit tests have been rebuilt: 
    1. `cd manifests/tests`
    2. `make generate-changed-only`
    3. `make test`
