### PR TITLE
Clean up inactive approvers

### DIFF
--- a/OWNERS
+++ b/OWNERS
@@ -1,16 +1,7 @@
 approvers:
-  - abhi-g
   - animeshsingh
-  - ashahba
   - Bobgy
-  - gabrielwen
-  - hougangliu
-  - IronPan
   - jlewi
-  - kkasravi
-  - kunmingg
-  - lluunn
-  - richardsliu
   - swiftdiaries
   - terrytangyuan
   - yanniszark


### PR DESCRIPTION
**Which issue is resolved by this Pull Request:**
Resolves #

**Description of your changes:**
Based on the discussion, https://github.com/kubeflow/manifests/pull/1443#issuecomment-668617654
we plan to clean up some inactive approvers. I check last 6 months histories and seems there're no issues or PR created by following contributors. You may still help on issue triage and PR review & approve. However, I don't have a way to check all activities in this repo. If you still working on this repo, let us know and I will remove from the list.  Keep PR for a week to make sure users are notified. 

/hold
/cc @jlewi 

@abhi-g @ashahba @gabrielwen @hougangliu @IronPan @kkasravi @lluunn 


**Checklist:**
- [x] Unit tests have been rebuilt: 
    1. `cd manifests/tests`
    2. `make generate-changed-only`
    3. `make test`
