### PR TITLE
Fix XGBoost Operator manifest issue

### DIFF
--- a/xgboost-job/xgboost-operator/base/cluster-role.yaml
+++ b/xgboost-job/xgboost-operator/base/cluster-role.yaml
@@ -17,7 +17,7 @@ rules:
   - patch
   - delete
 - apiGroups:
-  - kubeflow.org
+  - xgboostjob.kubeflow.org
   resources:
   - xgboostjobs
   - xgboostjobs/status

--- a/xgboost-job/xgboost-operator/base/crd.yaml
+++ b/xgboost-job/xgboost-operator/base/crd.yaml
@@ -1,9 +1,9 @@
 apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
 metadata:
-  name: xgboostjobs.kubeflow.org
+  name: xgboostjobs.xgboostjob.kubeflow.org
 spec:
-  group: kubeflow.org
+  group: xgboostjob.kubeflow.org
   names:
     kind: XGBoostJob
     singular: xgboostjob

--- a/xgboost-job/xgboost-operator/base/kustomization.yaml
+++ b/xgboost-job/xgboost-operator/base/kustomization.yaml
@@ -16,4 +16,4 @@ configMapGenerator:
 images:
 - name: gcr.io/kubeflow-images-public/xgboost-operator
   newName: gcr.io/kubeflow-images-public/xgboost-operator
-  newTag: vmaster-g8f8c3f96
+  newTag: v0.1.0

--- a/xgboost-job/xgboost-operator/overlays/application/application.yaml
+++ b/xgboost-job/xgboost-operator/overlays/application/application.yaml
@@ -17,7 +17,7 @@ spec:
     kind: Deployment
   - group: core
     kind: ServiceAccount
-  - group: kubeflow.org
+  - group: xgboostjob.kubeflow.org
     kind: XGBoostJob
   descriptor: 
     type: xgboostjob


### PR DESCRIPTION
**Which issue is resolved by this Pull Request:**
Resolves #https://github.com/kubeflow/xgboost-operator/issues/99

xgboost-operator now point user to use manifest in kubeflow/manifest to install operator. There's issue like code changes in xgboost-operator auto trigger images building here.  Sometimes, we might not want to update image tags for those dev changes. 

**Description of your changes:**
I add `xgboostjob` back from https://github.com/kubeflow/manifests/pull/1313/files. master xgboost-operator code changes has been changed to v1. However, the examples have not been updated yet. That's the reason I change to previous stable manifest with v1alpha1. 

Once we fully migrate to v1, we can update manifest here. 

/cc @terrytangyuan 


**Checklist:**
- [x] Unit tests have been rebuilt: 
    1. `cd manifests/tests`
    2. `make generate-changed-only`
    3. `make test`
