### PR TITLE
Add a GitHub Action for presubmit checks

### DIFF
--- a/.github/OWNERS
+++ b/.github/OWNERS
@@ -1,0 +1,11 @@
+approvers:
+  - animeshsingh
+  - Bobgy
+  - jlewi
+  - swiftdiaries
+  - terrytangyuan
+  - yanniszark
+  - zhenghuiwang
+reviewers:
+  - krishnadurai
+  - PatrickXYS

--- a/.github/workflows/presubmits.yaml
+++ b/.github/workflows/presubmits.yaml
@@ -1,0 +1,16 @@
+name: Presubmit Tests
+on: pull_request
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+
+    - name: Step 1 - Checkout Repo
+      uses: actions/checkout@v2
+    
+    - name: Step 2 - Run unit-tests
+      run: |
+        cd tests
+        make generate-changed-only
+        make test

--- a/docs/development.md
+++ b/docs/development.md
@@ -1,0 +1,26 @@
+# Development
+
+## Presubmit checks
+
+We use a GitHub Action to run checks on every PR.
+
+```yaml
+name: Presubmit Tests
+on: pull_request
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+
+    - name: Step 1 - Checkout Repo
+      uses: actions/checkout@v2
+    
+    - name: Step 2 - Run unit-tests
+      run: |
+        cd tests
+        make generate-changed-only
+        make test
+```
+
+It's a workflow that replicates the developer workflow on a Ubuntu runner (VM) provided by GitHub.


### PR DESCRIPTION

**Which issue is resolved by this Pull Request:**
Resolves https://github.com/kubeflow/manifests/issues/1498

**Description of your changes:**
1. Add a GA presubmit workflow
2. Replicate repo root OWNERS file for the action
3. Add docs for the workflow

**Checklist:**
- [ ] Unit tests have been rebuilt: 
    1. `cd manifests/tests`
    2. `make generate-changed-only`
    3. `make test`
