### PR TITLE
[seldon] add protocol to required list

### DIFF
--- a/seldon/seldon-core-operator/base/resources.yaml
+++ b/seldon/seldon-core-operator/base/resources.yaml
@@ -1022,6 +1022,7 @@ spec:
                                           type: string
                                       required:
                                       - containerPort
+                                      - protocol
                                       type: object
                                     type: array
                                     x-kubernetes-list-map-keys:
@@ -1761,6 +1762,7 @@ spec:
                                           type: string
                                       required:
                                       - containerPort
+                                      - protocol
                                       type: object
                                     type: array
                                   readinessProbe:
@@ -3429,6 +3431,7 @@ spec:
                                   type: string
                               required:
                               - containerPort
+                              - protocol
                               type: object
                             type: array
                             x-kubernetes-list-map-keys:


### PR DESCRIPTION
**Description of your changes:**
I don't know deeply about kubeflow/manifests, but just faced with this message.
```
WARN[0746] Encountered error applying application kubeflow-apps:  (kubeflow.error): Code 500 with message: Apply.Run : error when creating "/tmp/kout967039652": CustomResourceDefinition.apiextensions.k8s.io "seldondeployments.machinelearning.seldon.io" is invalid: [spec.validation.openAPIV3Schema.properties[spec].properties[predictors].items.properties[componentSpecs].items.properties[spec].properties[initContainers].items.properties[ports].items.properties[protocol].default: Required value: this property is in x-kubernetes-list-map-keys, so it must have a default or be a required property, spec.validation.openAPIV3Schema.properties[spec].properties[predictors].items.properties[componentSpecs].items.properties[spec].properties[containers].items.properties[ports].items.properties[protocol].default: Required value: this property is in x-kubernetes-list-map-keys, so it must have a default or be a required property, spec.validation.openAPIV3Schema.properties[spec].properties[predictors].items.properties[explainer].properties[containerSpec].properties[ports].items.properties[protocol].default: Required value: this property is in x-kubernetes-list-map-keys, so it must have a default or be a required property]  filename="kustomize/kustomize.go:266"
```

This message says 'Add what is written in x-kubernetes-list-map-keys to required as well'.

So I just add.

kfctl version: kfctl v1.1.0-0-g9a3621e
manifests version: v1.1-branch


**Checklist:**
- [ ] Unit tests have been rebuilt: 
    1. `cd manifests/tests`
    2. `make generate-changed-only`
    3. `make test`
