### PR TITLE
Remove http from the GCP ingress and explicitly set the default backend.

### DIFF
--- a/gcp/iap-ingress/base/ingress.yaml
+++ b/gcp/iap-ingress/base/ingress.yaml
@@ -2,11 +2,14 @@ apiVersion: networking.k8s.io/v1beta1
 kind: Ingress
 metadata:
   annotations:
-    ingress.kubernetes.io/ssl-redirect: "true"
+    kubernetes.io/ingress.allow-http: "false" 
     kubernetes.io/ingress.global-static-ip-name: $(ipName)
     networking.gke.io/managed-certificates: gke-certificate
   name: envoy-ingress
 spec:
+  backend:
+    serviceName: istio-ingressgateway
+    servicePort: 80
   rules:
   - host: $(hostname)
     http:

--- a/tests/go.mod
+++ b/tests/go.mod
@@ -3,7 +3,6 @@ module github.com/kubeflow/manifests/tests
 go 1.13
 
 require (
-	github.com/PuerkitoBio/purell v1.1.1 // indirect
 	github.com/ghodss/yaml v1.0.1-0.20190212211648-25d852aebe32
 	github.com/gogo/protobuf v1.2.2-0.20190730201129-28a6bbf47e48 // indirect
 	github.com/golang/protobuf v1.3.2 // indirect

--- a/tests/stacks/kubernetes/application/add-anonymous-user-filter/kustomize_test.go
+++ b/tests/stacks/kubernetes/application/add-anonymous-user-filter/kustomize_test.go
@@ -1,9 +1,8 @@
 package add_anonymous_user_filter
 
 import (
-	"testing"
-
 	"github.com/kubeflow/manifests/tests"
+	"testing"
 )
 
 func TestKustomize(t *testing.T) {

--- a/tests/tests/legacy_kustomizations/iap-ingress/test_data/expected/networking.k8s.io_v1beta1_ingress_envoy-ingress.yaml
+++ b/tests/tests/legacy_kustomizations/iap-ingress/test_data/expected/networking.k8s.io_v1beta1_ingress_envoy-ingress.yaml
@@ -2,7 +2,7 @@ apiVersion: networking.k8s.io/v1beta1
 kind: Ingress
 metadata:
   annotations:
-    ingress.kubernetes.io/ssl-redirect: "true"
+    kubernetes.io/ingress.allow-http: "false"
     kubernetes.io/ingress.global-static-ip-name: kf-v1-0210-ip
     networking.gke.io/managed-certificates: gke-certificate
   labels:
@@ -16,6 +16,9 @@ metadata:
   name: envoy-ingress
   namespace: istio-system
 spec:
+  backend:
+    serviceName: istio-ingressgateway
+    servicePort: 80
   rules:
   - host: kf-v1-0210.endpoints.jlewi-dev.cloud.goog
     http:


### PR DESCRIPTION
* Ref https://cloud.google.com/kubernetes-engine/docs/concepts/ingress-xlb#disabling_http force all traffic from client to ingress to be https.

* Fix kubeflow/gcp-blueprints#116

* Explicitly set the default backend to the ISTIO ingress gateway.