### PR TITLE
Require protocol in seldon-core-operator resources for kubernetes 1.18 and higher

### DIFF
--- a/seldon/seldon-core-operator/base/resources.yaml
+++ b/seldon/seldon-core-operator/base/resources.yaml
@@ -1022,6 +1022,7 @@ spec:
                                           type: string
                                       required:
                                       - containerPort
+                                      - protocol
                                       type: object
                                     type: array
                                     x-kubernetes-list-map-keys:
@@ -2492,6 +2493,7 @@ spec:
                                           type: string
                                       required:
                                       - containerPort
+                                      - protocol
                                       type: object
                                     type: array
                                     x-kubernetes-list-map-keys:
@@ -3429,6 +3431,7 @@ spec:
                                   type: string
                               required:
                               - containerPort
+                              - protocol
                               type: object
                             type: array
                             x-kubernetes-list-map-keys:


### PR DESCRIPTION
**Which issue is resolved by this Pull Request:**
Resolves #1543

**Description of your changes:**
Set the `protocol` field to required to fix deployment errors on Kubernetes 1.18 and higher. Tested deployment on Charmed Kubernetes 1.19 on Ubuntu 20.04.1. 

**Checklist:**
- [ ] Unit tests have been rebuilt: 
    1. `cd manifests/tests`
    2. `make generate-changed-only`
    3. `make test`
