### PR TITLE
Add USERID_HEADER argument in access management

### DIFF
--- a/profiles/base_v3/deployment_patch.yaml
+++ b/profiles/base_v3/deployment_patch.yaml
@@ -38,6 +38,8 @@ spec:
         - $(CLUSTER_ADMIN) 
         - -userid-prefix 
         - $(USERID_PREFIX)
+        - -userid-header
+        - $(USERID_HEADER)
         args: []
         name: kfam
         env:

--- a/tests/stacks/aws/test_data/expected/apps_v1_deployment_profiles-deployment.yaml
+++ b/tests/stacks/aws/test_data/expected/apps_v1_deployment_profiles-deployment.yaml
@@ -63,6 +63,8 @@ spec:
         - $(CLUSTER_ADMIN)
         - -userid-prefix
         - $(USERID_PREFIX)
+        - -userid-header
+        - $(USERID_HEADER)
         env:
         - name: USERID_HEADER
           valueFrom:

--- a/tests/stacks/examples/alice/test_data/expected/apps_v1_deployment_profiles-deployment.yaml
+++ b/tests/stacks/examples/alice/test_data/expected/apps_v1_deployment_profiles-deployment.yaml
@@ -63,6 +63,8 @@ spec:
         - $(CLUSTER_ADMIN)
         - -userid-prefix
         - $(USERID_PREFIX)
+        - -userid-header
+        - $(USERID_HEADER)
         env:
         - name: USERID_HEADER
           valueFrom:

--- a/tests/stacks/gcp/test_data/expected/apps_v1_deployment_profiles-deployment.yaml
+++ b/tests/stacks/gcp/test_data/expected/apps_v1_deployment_profiles-deployment.yaml
@@ -63,6 +63,8 @@ spec:
         - $(CLUSTER_ADMIN)
         - -userid-prefix
         - $(USERID_PREFIX)
+        - -userid-header
+        - $(USERID_HEADER)
         env:
         - name: USERID_HEADER
           valueFrom:

--- a/tests/stacks/generic/test_data/expected/apps_v1_deployment_profiles-deployment.yaml
+++ b/tests/stacks/generic/test_data/expected/apps_v1_deployment_profiles-deployment.yaml
@@ -63,6 +63,8 @@ spec:
         - $(CLUSTER_ADMIN)
         - -userid-prefix
         - $(USERID_PREFIX)
+        - -userid-header
+        - $(USERID_HEADER)
         env:
         - name: USERID_HEADER
           valueFrom:

--- a/tests/stacks/kubernetes/test_data/expected/apps_v1_deployment_profiles-deployment.yaml
+++ b/tests/stacks/kubernetes/test_data/expected/apps_v1_deployment_profiles-deployment.yaml
@@ -63,6 +63,8 @@ spec:
         - $(CLUSTER_ADMIN)
         - -userid-prefix
         - $(USERID_PREFIX)
+        - -userid-header
+        - $(USERID_HEADER)
         env:
         - name: USERID_HEADER
           valueFrom:


### PR DESCRIPTION
**Which issue is resolved by this Pull Request:**
Resolves https://github.com/kubeflow/kubeflow/issues/5227

**Description of your changes:**
Add `USERID_HEADER` to access management, otherwise, istio `ServiceRoleBinding` will use wrong header.
This is a regression issue bring into v1.1-branch due from v3 manifest migration

**Checklist:**
- [x] Unit tests have been rebuilt: 
    1. `cd manifests/tests`
    2. `make generate-changed-only`
    3. `make test`
