### PR TITLE
Add AWS v1.1.0 manifest to master branch

### DIFF
--- a/kfdef/kfctl_aws.v1.1.0.yaml
+++ b/kfdef/kfctl_aws.v1.1.0.yaml
@@ -1,0 +1,119 @@
+apiVersion: kfdef.apps.kubeflow.org/v1
+kind: KfDef
+metadata:
+  namespace: kubeflow
+spec:
+  applications:
+  - kustomizeConfig:
+      repoRef:
+        name: manifests
+        path: namespaces/base
+    name: namespaces
+  - kustomizeConfig:
+      repoRef:
+        name: manifests
+        path: application/v3
+    name: application
+  - kustomizeConfig:
+      repoRef:
+        name: manifests
+        path: stacks/aws/application/istio-1-3-1-stack
+    name: istio-stack
+  - kustomizeConfig:
+      repoRef:
+        name: manifests
+        path: stacks/aws/application/cluster-local-gateway-1-3-1
+    name: cluster-local-gateway
+  - kustomizeConfig:
+      repoRef:
+        name: manifests
+        path: istio/istio/base
+    name: istio
+  - kustomizeConfig:
+      repoRef:
+        name: manifests
+        path: stacks/aws/application/cert-manager-crds
+    name: cert-manager-crds
+  - kustomizeConfig:
+      repoRef:
+        name: manifests
+        path: stacks/aws/application/cert-manager-kube-system-resources
+    name: cert-manager-kube-system-resources
+  - kustomizeConfig:
+      repoRef:
+        name: manifests
+        path: stacks/aws/application/cert-manager
+    name: cert-manager
+  - kustomizeConfig:
+      repoRef:
+        name: manifests
+        path: metacontroller/base
+    name: metacontroller
+  - kustomizeConfig:
+      repoRef:
+        name: manifests
+        path: stacks/aws/application/oidc-authservice
+    name: oidc-authservice
+  - kustomizeConfig:
+      repoRef:
+        name: manifests
+        path: stacks/aws/application/dex-auth
+    name: dex
+  - kustomizeConfig:
+      repoRef:
+        name: manifests
+        path: admission-webhook/bootstrap/overlays/application
+    name: bootstrap
+  - kustomizeConfig:
+      repoRef:
+        name: manifests
+        path: spark/spark-operator/overlays/application
+    name: spark-operator
+  - kustomizeConfig:
+      repoRef:
+        name: manifests
+        path: stacks/aws
+    name: kubeflow-apps
+  - kustomizeConfig:
+      repoRef:
+        name: manifests
+        path: aws/istio-ingress/base_v3
+    name: istio-ingress
+  - kustomizeConfig:
+      repoRef:
+        name: manifests
+        path: knative/installs/generic
+    name: knative
+  - kustomizeConfig:
+      repoRef:
+        name: manifests
+        path: kfserving/installs/generic
+    name: kfserving
+  - kustomizeConfig:
+      repoRef:
+        name: manifests
+        path: stacks/aws/application/spartakus
+    name: spartakus
+  - kustomizeConfig:
+      repoRef:
+        name: manifests
+        path: tensorboard/overlays/istio
+    name: tensorboard
+  plugins:
+  - kind: KfAwsPlugin
+    metadata:
+      name: aws
+    spec:
+      auth:
+        basicAuth:
+          password: 12341234
+          username: admin@kubeflow.org
+      region: us-west-2
+      enablePodIamPolicy: true
+      # If you don't use IAM Role for Service Account, you can still use node instance roles.
+      #roles:
+      #- eksctl-kubeflow-aws-nodegroup-ng-a2-NodeInstanceRole-xxxxxxx
+  repos:
+  - name: manifests
+    uri: https://github.com/kubeflow/manifests/archive/v1.1-branch.tar.gz
+  version: v1.1-branch

--- a/kfdef/kfctl_aws_cognito.v1.1.0.yaml
+++ b/kfdef/kfctl_aws_cognito.v1.1.0.yaml
@@ -1,0 +1,116 @@
+apiVersion: kfdef.apps.kubeflow.org/v1
+kind: KfDef
+metadata:
+  namespace: kubeflow
+spec:
+  applications:
+  - kustomizeConfig:
+      repoRef:
+        name: manifests
+        path: namespaces/base
+    name: namespaces
+  - kustomizeConfig:
+      repoRef:
+        name: manifests
+        path: stacks/aws/application/istio-stack
+    name: istio-stack
+  - kustomizeConfig:
+      repoRef:
+        name: manifests
+        path: stacks/aws/application/cluster-local-gateway
+    name: cluster-local-gateway
+  - kustomizeConfig:
+      repoRef:
+        name: manifests
+        path: stacks/aws/application/istio
+    name: istio
+  - kustomizeConfig:
+      repoRef:
+        name: manifests
+        path: application/v3
+    name: application
+  - kustomizeConfig:
+      repoRef:
+        name: manifests
+        path: stacks/aws/application/cert-manager-crds
+    name: cert-manager-crds
+  - kustomizeConfig:
+      repoRef:
+        name: manifests
+        path: stacks/aws/application/cert-manager-kube-system-resources
+    name: cert-manager-kube-system-resources
+  - kustomizeConfig:
+      repoRef:
+        name: manifests
+        path: stacks/aws/application/cert-manager
+    name: cert-manager
+  - kustomizeConfig:
+      repoRef:
+        name: manifests
+        path: metacontroller/base
+    name: metacontroller
+  - kustomizeConfig:
+      repoRef:
+        name: manifests
+        path: admission-webhook/bootstrap/overlays/application
+    name: bootstrap
+  - kustomizeConfig:
+      repoRef:
+        name: manifests
+        path: spark/spark-operator/overlays/application
+    name: spark-operator
+  - kustomizeConfig:
+      repoRef:
+        name: manifests
+        path: knative/installs/generic
+    name: knative
+  - kustomizeConfig:
+      repoRef:
+        name: manifests
+        path: kfserving/installs/generic
+    name: kfserving
+  - kustomizeConfig:
+      repoRef:
+        name: manifests
+        path: stacks/aws/application/spartakus
+    name: spartakus
+  - kustomizeConfig:
+      repoRef:
+        name: manifests
+        path: tensorboard/overlays/istio
+    name: tensorboard
+  - kustomizeConfig:
+      repoRef:
+        name: manifests
+        path: stacks/aws
+    name: kubeflow-apps
+  - kustomizeConfig:
+      repoRef:
+        name: manifests
+        path: stacks/aws/application/istio-ingress-cognito
+    name: istio-ingress
+  - kustomizeConfig:
+      repoRef:
+        name: manifests
+        path: aws/aws-istio-authz-adaptor/base_v3
+    name: aws-istio-authz-adaptor
+  plugins:
+  - kind: KfAwsPlugin
+    metadata:
+      name: aws
+    spec:
+      auth:
+        cognito:
+          certArn: arn:aws:acm:us-west-2:xxxxx:certificate/xxxxxxxxxxxxx-xxxx
+          cognitoAppClientId: xxxxxbxxxxxx
+          cognitoUserPoolArn: arn:aws:cognito-idp:us-west-2:xxxxx:userpool/us-west-2_xxxxxx
+          cognitoUserPoolDomain: your-user-pool
+      region: us-west-2
+      enablePodIamPolicy: true
+      # If you don't use IAM Role for Service Account, you can still use node instance roles.
+      #roles:
+      #- eksctl-kubeflow-aws-nodegroup-ng-a2-NodeInstanceRole-xxxxxxx
+  repos:
+  - name: manifests
+    uri: https://github.com/kubeflow/manifests/archive/v1.1-branch.tar.gz
+  version: v1.1-branch


### PR DESCRIPTION
**Which issue is resolved by this Pull Request:**
Resolves #

**Description of your changes:**
The time we release v1.1, we just put manifest in v1.1 branch but forget to put in master. Add it back in case some user misunderstand that AWS didn't release v1.10 

**Checklist:**
- [x] Unit tests have been rebuilt: 
    1. `cd manifests/tests`
    2. `make generate-changed-only`
    3. `make test`
