### PR TITLE
Automated cherry pick of #1559: Add USERID_HEADER argument in access management

### DIFF
--- a/profiles/base_v3/deployment_patch.yaml
+++ b/profiles/base_v3/deployment_patch.yaml
@@ -38,6 +38,8 @@ spec:
         - $(CLUSTER_ADMIN) 
         - -userid-prefix 
         - $(USERID_PREFIX)
+        - -userid-header
+        - $(USERID_HEADER)
         args: []
         name: kfam
         env:

--- a/tests/stacks/aws/test_data/expected/apps_v1_deployment_profiles-deployment.yaml
+++ b/tests/stacks/aws/test_data/expected/apps_v1_deployment_profiles-deployment.yaml
@@ -63,6 +63,8 @@ spec:
         - $(CLUSTER_ADMIN)
         - -userid-prefix
         - $(USERID_PREFIX)
+        - -userid-header
+        - $(USERID_HEADER)
         env:
         - name: USERID_HEADER
           valueFrom:

--- a/tests/stacks/examples/alice/test_data/expected/apps_v1_deployment_profiles-deployment.yaml
+++ b/tests/stacks/examples/alice/test_data/expected/apps_v1_deployment_profiles-deployment.yaml
@@ -63,6 +63,8 @@ spec:
         - $(CLUSTER_ADMIN)
         - -userid-prefix
         - $(USERID_PREFIX)
+        - -userid-header
+        - $(USERID_HEADER)
         env:
         - name: USERID_HEADER
           valueFrom:

--- a/tests/stacks/gcp/test_data/expected/apps_v1_deployment_profiles-deployment.yaml
+++ b/tests/stacks/gcp/test_data/expected/apps_v1_deployment_profiles-deployment.yaml
@@ -63,6 +63,8 @@ spec:
         - $(CLUSTER_ADMIN)
         - -userid-prefix
         - $(USERID_PREFIX)
+        - -userid-header
+        - $(USERID_HEADER)
         env:
         - name: USERID_HEADER
           valueFrom:

--- a/tests/stacks/generic/test_data/expected/apps_v1_deployment_profiles-deployment.yaml
+++ b/tests/stacks/generic/test_data/expected/apps_v1_deployment_profiles-deployment.yaml
@@ -63,6 +63,8 @@ spec:
         - $(CLUSTER_ADMIN)
         - -userid-prefix
         - $(USERID_PREFIX)
+        - -userid-header
+        - $(USERID_HEADER)
         env:
         - name: USERID_HEADER
           valueFrom:

--- a/tests/stacks/kubernetes/test_data/expected/apps_v1_deployment_profiles-deployment.yaml
+++ b/tests/stacks/kubernetes/test_data/expected/apps_v1_deployment_profiles-deployment.yaml
@@ -63,6 +63,8 @@ spec:
         - $(CLUSTER_ADMIN)
         - -userid-prefix
         - $(USERID_PREFIX)
+        - -userid-header
+        - $(USERID_HEADER)
         env:
         - name: USERID_HEADER
           valueFrom:


### PR DESCRIPTION
Cherry pick of #1559 on v1.1-branch.

#1559: Add USERID_HEADER argument in access management

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.