### PR TITLE
fix mysql deployment strategy

### DIFF
--- a/katib/katib-controller/base/katib-mysql-deployment.yaml
+++ b/katib/katib-controller/base/katib-mysql-deployment.yaml
@@ -11,6 +11,8 @@ spec:
     matchLabels:
       app: katib
       component: mysql
+  strategy:
+    type: Recreate
   template:
     metadata:
       name: katib-mysql

--- a/metadata/overlays/db/metadata-db-deployment.yaml
+++ b/metadata/overlays/db/metadata-db-deployment.yaml
@@ -5,10 +5,12 @@ metadata:
   labels:
     component: db
 spec:
+  replicas: 1
   selector:
     matchLabels:
       component: db
-  replicas: 1
+  strategy:
+    type: Recreate
   template:
     metadata:
       name: db

--- a/tests/katib/installs/katib-standalone-ibm/test_data/expected/apps_v1_deployment_katib-mysql.yaml
+++ b/tests/katib/installs/katib-standalone-ibm/test_data/expected/apps_v1_deployment_katib-mysql.yaml
@@ -16,6 +16,8 @@ spec:
       app.kubernetes.io/component: katib
       app.kubernetes.io/name: katib-controller
       component: mysql
+  strategy:
+    type: Recreate
   template:
     metadata:
       annotations:

--- a/tests/katib/installs/katib-standalone/test_data/expected/apps_v1_deployment_katib-mysql.yaml
+++ b/tests/katib/installs/katib-standalone/test_data/expected/apps_v1_deployment_katib-mysql.yaml
@@ -16,6 +16,8 @@ spec:
       app.kubernetes.io/component: katib
       app.kubernetes.io/name: katib-controller
       component: mysql
+  strategy:
+    type: Recreate
   template:
     metadata:
       annotations:

--- a/tests/stacks/aws/test_data/expected/apps_v1_deployment_katib-mysql.yaml
+++ b/tests/stacks/aws/test_data/expected/apps_v1_deployment_katib-mysql.yaml
@@ -16,6 +16,8 @@ spec:
       app.kubernetes.io/component: katib
       app.kubernetes.io/name: katib-controller
       component: mysql
+  strategy:
+    type: Recreate
   template:
     metadata:
       annotations:

--- a/tests/stacks/aws/test_data/expected/apps_v1_deployment_metadata-db.yaml
+++ b/tests/stacks/aws/test_data/expected/apps_v1_deployment_metadata-db.yaml
@@ -12,6 +12,8 @@ spec:
     matchLabels:
       component: db
       kustomize.component: metadata
+  strategy:
+    type: Recreate
   template:
     metadata:
       annotations:

--- a/tests/stacks/examples/alice/test_data/expected/apps_v1_deployment_katib-mysql.yaml
+++ b/tests/stacks/examples/alice/test_data/expected/apps_v1_deployment_katib-mysql.yaml
@@ -16,6 +16,8 @@ spec:
       app.kubernetes.io/component: katib
       app.kubernetes.io/name: katib-controller
       component: mysql
+  strategy:
+    type: Recreate
   template:
     metadata:
       annotations:

--- a/tests/stacks/examples/alice/test_data/expected/apps_v1_deployment_metadata-db.yaml
+++ b/tests/stacks/examples/alice/test_data/expected/apps_v1_deployment_metadata-db.yaml
@@ -12,6 +12,8 @@ spec:
     matchLabels:
       component: db
       kustomize.component: metadata
+  strategy:
+    type: Recreate
   template:
     metadata:
       annotations:

--- a/tests/stacks/gcp/test_data/expected/apps_v1_deployment_katib-mysql.yaml
+++ b/tests/stacks/gcp/test_data/expected/apps_v1_deployment_katib-mysql.yaml
@@ -16,6 +16,8 @@ spec:
       app.kubernetes.io/component: katib
       app.kubernetes.io/name: katib-controller
       component: mysql
+  strategy:
+    type: Recreate
   template:
     metadata:
       annotations:

--- a/tests/stacks/gcp/test_data/expected/apps_v1_deployment_metadata-db.yaml
+++ b/tests/stacks/gcp/test_data/expected/apps_v1_deployment_metadata-db.yaml
@@ -12,6 +12,8 @@ spec:
     matchLabels:
       component: db
       kustomize.component: metadata
+  strategy:
+    type: Recreate
   template:
     metadata:
       annotations:

--- a/tests/stacks/generic/test_data/expected/apps_v1_deployment_katib-mysql.yaml
+++ b/tests/stacks/generic/test_data/expected/apps_v1_deployment_katib-mysql.yaml
@@ -16,6 +16,8 @@ spec:
       app.kubernetes.io/component: katib
       app.kubernetes.io/name: katib-controller
       component: mysql
+  strategy:
+    type: Recreate
   template:
     metadata:
       annotations:

--- a/tests/stacks/generic/test_data/expected/apps_v1_deployment_metadata-db.yaml
+++ b/tests/stacks/generic/test_data/expected/apps_v1_deployment_metadata-db.yaml
@@ -12,6 +12,8 @@ spec:
     matchLabels:
       component: db
       kustomize.component: metadata
+  strategy:
+    type: Recreate
   template:
     metadata:
       annotations:

--- a/tests/stacks/ibm/application/katib/test_data/expected/apps_v1_deployment_katib-mysql.yaml
+++ b/tests/stacks/ibm/application/katib/test_data/expected/apps_v1_deployment_katib-mysql.yaml
@@ -16,6 +16,8 @@ spec:
       app.kubernetes.io/component: katib
       app.kubernetes.io/name: katib-controller
       component: mysql
+  strategy:
+    type: Recreate
   template:
     metadata:
       annotations:

--- a/tests/stacks/ibm/application/metadata/test_data/expected/apps_v1_deployment_metadata-db.yaml
+++ b/tests/stacks/ibm/application/metadata/test_data/expected/apps_v1_deployment_metadata-db.yaml
@@ -16,6 +16,8 @@ spec:
       app.kubernetes.io/name: metadata
       component: db
       kustomize.component: metadata
+  strategy:
+    type: Recreate
   template:
     metadata:
       annotations:

--- a/tests/stacks/ibm/multi-user/test_data/expected/apps_v1_deployment_katib-mysql.yaml
+++ b/tests/stacks/ibm/multi-user/test_data/expected/apps_v1_deployment_katib-mysql.yaml
@@ -16,6 +16,8 @@ spec:
       app.kubernetes.io/component: katib
       app.kubernetes.io/name: katib-controller
       component: mysql
+  strategy:
+    type: Recreate
   template:
     metadata:
       annotations:

--- a/tests/stacks/ibm/multi-user/test_data/expected/apps_v1_deployment_metadata-db.yaml
+++ b/tests/stacks/ibm/multi-user/test_data/expected/apps_v1_deployment_metadata-db.yaml
@@ -16,6 +16,8 @@ spec:
       app.kubernetes.io/name: metadata
       component: db
       kustomize.component: metadata
+  strategy:
+    type: Recreate
   template:
     metadata:
       annotations:

--- a/tests/stacks/ibm/test_data/expected/apps_v1_deployment_katib-mysql.yaml
+++ b/tests/stacks/ibm/test_data/expected/apps_v1_deployment_katib-mysql.yaml
@@ -16,6 +16,8 @@ spec:
       app.kubernetes.io/component: katib
       app.kubernetes.io/name: katib-controller
       component: mysql
+  strategy:
+    type: Recreate
   template:
     metadata:
       annotations:

--- a/tests/stacks/ibm/test_data/expected/apps_v1_deployment_metadata-db.yaml
+++ b/tests/stacks/ibm/test_data/expected/apps_v1_deployment_metadata-db.yaml
@@ -16,6 +16,8 @@ spec:
       app.kubernetes.io/name: metadata
       component: db
       kustomize.component: metadata
+  strategy:
+    type: Recreate
   template:
     metadata:
       annotations:

--- a/tests/stacks/kubernetes/test_data/expected/apps_v1_deployment_katib-mysql.yaml
+++ b/tests/stacks/kubernetes/test_data/expected/apps_v1_deployment_katib-mysql.yaml
@@ -16,6 +16,8 @@ spec:
       app.kubernetes.io/component: katib
       app.kubernetes.io/name: katib-controller
       component: mysql
+  strategy:
+    type: Recreate
   template:
     metadata:
       annotations:

--- a/tests/stacks/kubernetes/test_data/expected/apps_v1_deployment_metadata-db.yaml
+++ b/tests/stacks/kubernetes/test_data/expected/apps_v1_deployment_metadata-db.yaml
@@ -12,6 +12,8 @@ spec:
     matchLabels:
       component: db
       kustomize.component: metadata
+  strategy:
+    type: Recreate
   template:
     metadata:
       annotations:

--- a/tests/stacks/openshift/application/katib/test_data/expected/apps_v1_deployment_katib-mysql.yaml
+++ b/tests/stacks/openshift/application/katib/test_data/expected/apps_v1_deployment_katib-mysql.yaml
@@ -16,6 +16,8 @@ spec:
       app.kubernetes.io/component: katib
       app.kubernetes.io/name: katib-controller
       component: mysql
+  strategy:
+    type: Recreate
   template:
     metadata:
       annotations:

--- a/tests/stacks/openshift/application/metadata/test_data/expected/apps_v1_deployment_metadata-db.yaml
+++ b/tests/stacks/openshift/application/metadata/test_data/expected/apps_v1_deployment_metadata-db.yaml
@@ -12,6 +12,8 @@ spec:
     matchLabels:
       component: db
       kustomize.component: metadata
+  strategy:
+    type: Recreate
   template:
     metadata:
       annotations:

--- a/tests/tests/legacy_kustomizations/katib-controller/test_data/expected/apps_v1_deployment_katib-mysql.yaml
+++ b/tests/tests/legacy_kustomizations/katib-controller/test_data/expected/apps_v1_deployment_katib-mysql.yaml
@@ -24,6 +24,8 @@ spec:
       app.kubernetes.io/part-of: kubeflow
       app.kubernetes.io/version: 0.8.0
       component: mysql
+  strategy:
+    type: Recreate
   template:
     metadata:
       annotations:

--- a/tests/tests/legacy_kustomizations/metadata/test_data/expected/apps_v1_deployment_metadata-db.yaml
+++ b/tests/tests/legacy_kustomizations/metadata/test_data/expected/apps_v1_deployment_metadata-db.yaml
@@ -24,6 +24,8 @@ spec:
       app.kubernetes.io/version: 0.2.1
       component: db
       kustomize.component: metadata
+  strategy:
+    type: Recreate
   template:
     metadata:
       annotations:


### PR DESCRIPTION
When trying to restart MySQL instances, they get stuck because the old container will refuse to give up the lock on the DB:
* `kubectl rollout restart deployment/katib-mysql  -n kubeflow`
* `kubectl rollout restart deployment/metadata-db  -n kubeflow`

This PR fixes that by setting the deployment strategy to `Recreate`.


**Checklist:**
- [X] Unit tests have been rebuilt: 
    1. `cd manifests/tests`
    2. `make generate-changed-only`
    3. `make test`
