### PR TITLE
disable istio-sidecar for pipelines mysql

### DIFF
--- a/pipeline/mysql/installs/generic/deployment-patch.yaml
+++ b/pipeline/mysql/installs/generic/deployment-patch.yaml
@@ -1,0 +1,9 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: mysql
+spec:
+  template:
+    metadata:
+      annotations:
+        sidecar.istio.io/inject: "false"

--- a/pipeline/mysql/installs/generic/kustomization.yaml
+++ b/pipeline/mysql/installs/generic/kustomization.yaml
@@ -7,6 +7,8 @@ commonLabels:
 resources:
 - ../../../upstream/env/platform-agnostic/mysql
 - ../../overlays/application/application.yaml
+patchesStrategicMerge:
+  - deployment-patch.yaml
 images:
 - name: gcr.io/ml-pipeline/mysql
   newTag: '5.6'

--- a/tests/stacks/aws/test_data/expected/apps_v1_deployment_mysql.yaml
+++ b/tests/stacks/aws/test_data/expected/apps_v1_deployment_mysql.yaml
@@ -17,6 +17,8 @@ spec:
     type: Recreate
   template:
     metadata:
+      annotations:
+        sidecar.istio.io/inject: "false"
       labels:
         app: mysql
         app.kubernetes.io/component: mysql

--- a/tests/stacks/generic/test_data/expected/apps_v1_deployment_mysql.yaml
+++ b/tests/stacks/generic/test_data/expected/apps_v1_deployment_mysql.yaml
@@ -17,6 +17,8 @@ spec:
     type: Recreate
   template:
     metadata:
+      annotations:
+        sidecar.istio.io/inject: "false"
       labels:
         app: mysql
         app.kubernetes.io/component: mysql

--- a/tests/stacks/ibm/multi-user/test_data/expected/apps_v1_deployment_mysql.yaml
+++ b/tests/stacks/ibm/multi-user/test_data/expected/apps_v1_deployment_mysql.yaml
@@ -17,6 +17,8 @@ spec:
     type: Recreate
   template:
     metadata:
+      annotations:
+        sidecar.istio.io/inject: "false"
       labels:
         app: mysql
         app.kubernetes.io/component: mysql

--- a/tests/stacks/ibm/test_data/expected/apps_v1_deployment_mysql.yaml
+++ b/tests/stacks/ibm/test_data/expected/apps_v1_deployment_mysql.yaml
@@ -17,6 +17,8 @@ spec:
     type: Recreate
   template:
     metadata:
+      annotations:
+        sidecar.istio.io/inject: "false"
       labels:
         app: mysql
         app.kubernetes.io/component: mysql

--- a/tests/stacks/kubernetes/test_data/expected/apps_v1_deployment_mysql.yaml
+++ b/tests/stacks/kubernetes/test_data/expected/apps_v1_deployment_mysql.yaml
@@ -17,6 +17,8 @@ spec:
     type: Recreate
   template:
     metadata:
+      annotations:
+        sidecar.istio.io/inject: "false"
       labels:
         app: mysql
         app.kubernetes.io/component: mysql


### PR DESCRIPTION
I am not 100% sure this is correct, but I believe the pipelines MySQL pod does not need an istio-sidecar.


**Checklist:**
- [X] Unit tests have been rebuilt: 
    1. `cd manifests/tests`
    2. `make generate-changed-only`
    3. `make test`
