### PR TITLE
Add external db to katib

### DIFF
--- a/katib/katib-controller/overlays/external-mysql/katib-db-manager-deployment.yaml
+++ b/katib/katib-controller/overlays/external-mysql/katib-db-manager-deployment.yaml
@@ -1,0 +1,55 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: katib-db-manager
+  labels:
+    app: katib
+    component: db-manager
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: katib
+      component: db-manager
+  template:
+    metadata:
+      name: katib-db-manager
+      labels:
+        app: katib
+        component: db-manager
+      annotations:
+        sidecar.istio.io/inject: "false"
+    spec:
+      containers:
+      - name: katib-db-manager
+        image: gcr.io/kubeflow-images-public/katib/v1alpha3/katib-db-manager
+        imagePullPolicy: IfNotPresent
+        env:
+          - name : DB_NAME
+            value: "mysql"
+          - name: DB_USER
+            value: $(mysql-username)
+          - name: DB_PASSWORD
+            valueFrom:
+              secretKeyRef:
+                name: katib-db-secrets
+                key: MYSQL_PASSWORD
+          - name: KATIB_MYSQL_DB_HOST
+            value: $(mysql-host)
+          - name: KATIB_MYSQL_DB_DATABASE
+            value: $(mysql-database)
+        command:
+          - './katib-db-manager'
+        ports:
+        - name: api
+          containerPort: 6789
+        readinessProbe:
+          exec:
+            command: ["/bin/grpc_health_probe", "-addr=:6789"]
+          initialDelaySeconds: 5
+        livenessProbe:
+          exec:
+            command: ["/bin/grpc_health_probe", "-addr=:6789"]
+          initialDelaySeconds: 10
+          periodSeconds: 60
+          failureThreshold: 5

--- a/katib/katib-controller/overlays/external-mysql/kustomization.yaml
+++ b/katib/katib-controller/overlays/external-mysql/kustomization.yaml
@@ -1,0 +1,41 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+commonLabels:
+  kustomize.component: katib
+configMapGenerator:
+- name: katib-db-parameters
+  env: params.env
+secretGenerator:
+- name: katib-db-secrets
+  env: secrets.env
+
+vars:
+- name: mysql-username
+  objref:
+    kind: ConfigMap
+    name: katib-db-parameters
+    apiVersion: v1
+  fieldref:
+    fieldpath: data.mysql-username
+- name: mysql-host
+  objref:
+    kind: ConfigMap
+    name: katib-db-parameters
+    apiVersion: v1
+  fieldref:
+    fieldpath: data.mysql-host
+- name: mysql-database
+  objref:
+    kind: ConfigMap
+    name: katib-db-parameters
+    apiVersion: v1
+  fieldref:
+    fieldpath: data.mysql-database
+configurations:
+- params.yaml
+
+bases:
+- ../../base
+
+patchesStrategicMerge:
+- katib-db-manager-deployment.yaml

--- a/katib/katib-controller/overlays/external-mysql/params.env
+++ b/katib/katib-controller/overlays/external-mysql/params.env
@@ -1,0 +1,5 @@
+mysql-username=
+mysql-host=
+mysql-database=
+MYSQL_PORT=3306
+MYSQL_ALLOW_EMPTY_PASSWORD=true

--- a/katib/katib-controller/overlays/external-mysql/params.yaml
+++ b/katib/katib-controller/overlays/external-mysql/params.yaml
@@ -1,0 +1,3 @@
+varReference:
+- path: spec/template/spec/containers/env/value
+  kind: Deployment

--- a/katib/katib-controller/overlays/external-mysql/secrets.env
+++ b/katib/katib-controller/overlays/external-mysql/secrets.env
@@ -1,0 +1,1 @@
+MYSQL_PASSWORD=test


### PR DESCRIPTION
**Which issue is resolved by this Pull Request:**
An enhancement to Katib's ability to use external mysql db

**Description of your changes:**
Added kustomize code to add external db.

Example of how it can be used in kubeflow app.yaml

![image](https://user-images.githubusercontent.com/8271182/94748230-732f3600-0346-11eb-9e16-6e63e1e38af6.png)


