### PR TITLE
Update profile controller image tag

### DIFF
--- a/profiles/base/kustomization.yaml
+++ b/profiles/base/kustomization.yaml
@@ -24,7 +24,7 @@ images:
   newTag: vmaster-g9f3bfd00
 - name: gcr.io/kubeflow-images-public/profile-controller
   newName: gcr.io/kubeflow-images-public/profile-controller
-  newTag: vmaster-ga49f658f
+  newTag: v1.1.0-ga49f658f
 vars:
 - fieldref:
     fieldPath: data.admin

--- a/profiles/base_v3/kustomization.yaml
+++ b/profiles/base_v3/kustomization.yaml
@@ -9,7 +9,7 @@ images:
   newTag: vmaster-gf3e09203
 - name: gcr.io/kubeflow-images-public/profile-controller
   newName: gcr.io/kubeflow-images-public/profile-controller
-  newTag: vmaster-g34aa47c2
+  newTag: v1.1.0-ga49f658f
 resources:
 - ../base/cluster-role-binding.yaml
 - ../base/crd.yaml

--- a/stacks/ibm/application/profiles/base/kustomization.yaml
+++ b/stacks/ibm/application/profiles/base/kustomization.yaml
@@ -9,7 +9,7 @@ images:
   newTag: vmaster-gf3e09203
 - name: gcr.io/kubeflow-images-public/profile-controller
   newName: gcr.io/kubeflow-images-public/profile-controller
-  newTag: vmaster-g34aa47c2
+  newTag: v1.1.0-ga49f658f
 resources:
 - ../../../../../profiles/base/cluster-role-binding.yaml
 - ../../../../../profiles/base/crd.yaml


### PR DESCRIPTION
Resolves kubeflow/kubeflow#5207
It resolves the namespace issue created by the old profile controller described here kubeflow/kubeflow#5207

Description of your changes:
Update to v1.1. The old image was coming from **base_v3**/kustomization.yaml in dex enabled deployment.

 https://console.cloud.google.com/gcr/images/kubeflow-images-public/GLOBAL/profile-controller@sha256:370596d3672a60e2e15c5c3c4df436190b0fb34f84aad85406d93c52f7f039b5/details?tab=info

Checklist:

    Unit tests have been rebuilt:
        cd manifests/tests
        make generate-changed-only
        make test

