### PR TITLE
Explicitly disable container native load balancing (neg)

### DIFF
--- a/istio-1-3-1/istio-install-1-3-1/base/service.yaml
+++ b/istio-1-3-1/istio-install-1-3-1/base/service.yaml
@@ -44,6 +44,7 @@ metadata:
   name: istio-ingressgateway
   annotations:
     beta.cloud.google.com/backend-config: '{"ports": {"http2":"iap-backendconfig"}}'
+    cloud.google.com/neg: '{"ingress": false}'
   labels:
     app: istio-ingressgateway
     istio: ingressgateway

--- a/istio/iap-gateway/base/istio-ingressgateway.yaml
+++ b/istio/iap-gateway/base/istio-ingressgateway.yaml
@@ -4,6 +4,7 @@ metadata:
   name: istio-ingressgateway
   annotations:
     beta.cloud.google.com/backend-config: '{"ports": {"http2":"iap-backendconfig"}}'
+    cloud.google.com/neg: '{"ingress": false}'
   labels:
     app: istio-ingressgateway
     istio: ingressgateway

--- a/istio/istio-install/base/istio-noauth.yaml
+++ b/istio/istio-install/base/istio-noauth.yaml
@@ -14037,6 +14037,7 @@ metadata:
   name: istio-ingressgateway
   annotations:
     beta.cloud.google.com/backend-config: '{"ports": {"http2":"iap-backendconfig"}}'
+    cloud.google.com/neg: '{"ingress": false}'
   labels:
     chart: gateways
     heritage: Tiller

--- a/tests/stacks/aws/application/istio-1-3-1-stack/test_data/expected/~g_v1_service_istio-ingressgateway.yaml
+++ b/tests/stacks/aws/application/istio-1-3-1-stack/test_data/expected/~g_v1_service_istio-ingressgateway.yaml
@@ -3,6 +3,7 @@ kind: Service
 metadata:
   annotations:
     beta.cloud.google.com/backend-config: '{"ports": {"http2":"iap-backendconfig"}}'
+    cloud.google.com/neg: '{"ingress": false}'   
   labels:
     app: istio-ingressgateway
     istio: ingressgateway

--- a/tests/stacks/aws/application/istio-stack/test_data/expected/~g_v1_service_istio-ingressgateway.yaml
+++ b/tests/stacks/aws/application/istio-stack/test_data/expected/~g_v1_service_istio-ingressgateway.yaml
@@ -3,6 +3,7 @@ kind: Service
 metadata:
   annotations:
     beta.cloud.google.com/backend-config: '{"ports": {"http2":"iap-backendconfig"}}'
+    cloud.google.com/neg: '{"ingress": false}'
   labels:
     app: istio-ingressgateway
     chart: gateways

--- a/tests/stacks/ibm/application/istio-1-3-1-stack/test_data/expected/~g_v1_service_istio-ingressgateway.yaml
+++ b/tests/stacks/ibm/application/istio-1-3-1-stack/test_data/expected/~g_v1_service_istio-ingressgateway.yaml
@@ -3,6 +3,7 @@ kind: Service
 metadata:
   annotations:
     beta.cloud.google.com/backend-config: '{"ports": {"http2":"iap-backendconfig"}}'
+    cloud.google.com/neg: '{"ingress": false}'
   labels:
     app: istio-ingressgateway
     istio: ingressgateway

--- a/tests/stacks/ibm/application/istio-stack/test_data/expected/~g_v1_service_istio-ingressgateway.yaml
+++ b/tests/stacks/ibm/application/istio-stack/test_data/expected/~g_v1_service_istio-ingressgateway.yaml
@@ -3,6 +3,7 @@ kind: Service
 metadata:
   annotations:
     beta.cloud.google.com/backend-config: '{"ports": {"http2":"iap-backendconfig"}}'
+    cloud.google.com/neg: '{"ingress": false}'
   labels:
     app: istio-ingressgateway
     chart: gateways

--- a/tests/stacks/kubernetes/application/istio-1-3-1-stack/test_data/expected/~g_v1_service_istio-ingressgateway.yaml
+++ b/tests/stacks/kubernetes/application/istio-1-3-1-stack/test_data/expected/~g_v1_service_istio-ingressgateway.yaml
@@ -3,6 +3,7 @@ kind: Service
 metadata:
   annotations:
     beta.cloud.google.com/backend-config: '{"ports": {"http2":"iap-backendconfig"}}'
+    cloud.google.com/neg: '{"ingress": false}'
   labels:
     app: istio-ingressgateway
     istio: ingressgateway

--- a/tests/stacks/kubernetes/application/istio-stack/test_data/expected/~g_v1_service_istio-ingressgateway.yaml
+++ b/tests/stacks/kubernetes/application/istio-stack/test_data/expected/~g_v1_service_istio-ingressgateway.yaml
@@ -3,6 +3,7 @@ kind: Service
 metadata:
   annotations:
     beta.cloud.google.com/backend-config: '{"ports": {"http2":"iap-backendconfig"}}'
+    cloud.google.com/neg: '{"ingress": false}'
   labels:
     app: istio-ingressgateway
     chart: gateways

--- a/tests/tests/legacy_kustomizations/istio-install/test_data/expected/~g_v1_service_istio-ingressgateway.yaml
+++ b/tests/tests/legacy_kustomizations/istio-install/test_data/expected/~g_v1_service_istio-ingressgateway.yaml
@@ -3,6 +3,7 @@ kind: Service
 metadata:
   annotations:
     beta.cloud.google.com/backend-config: '{"ports": {"http2":"iap-backendconfig"}}'
+    cloud.google.com/neg: '{"ingress": false}'
   labels:
     app: istio-ingressgateway
     chart: gateways


### PR DESCRIPTION
# Problem

`envoy-ingress` backend services unhealthy when installing Kubeflow on GKE version `1.17.9-gke.1504`

# Solution

Add the `cloud.google.com/neg: '{"ingress": false}'` annotation to `istio-ingressgateway` to disable **container-native load balancing** (neg) which is enabled by default for GKE clusters >= 1.17 ( https://cloud.google.com/kubernetes-engine/docs/how-to/container-native-load-balancing#using )

https://github.com/kubeflow/gcp-blueprints/pull/141
