### PR TITLE
[IBM] split full stack to components to support finer grain customization used in KfDef

### DIFF
--- a/kfdef/kfctl_ibm_customstack.yaml
+++ b/kfdef/kfctl_ibm_customstack.yaml
@@ -1,0 +1,144 @@
+apiVersion: kfdef.apps.kubeflow.org/v1
+kind: KfDef
+metadata:
+  namespace: kubeflow
+spec:
+  applications:
+  # Install istio in a different namespace: istio-system
+  # Remove this application if istio is already installed
+  - kustomizeConfig:
+      repoRef:
+        name: manifests
+        path: stacks/ibm/application/istio-1-3-1-stack
+    name: istio-stack
+  - kustomizeConfig:
+      repoRef:
+        name: manifests
+        path: stacks/ibm/application/cluster-local-gateway-1-3-1
+    name: cluster-local-gateway
+  - kustomizeConfig:
+      repoRef:
+        name: manifests
+        path: stacks/ibm/application/istio
+    name: istio
+  - kustomizeConfig:
+      repoRef:
+        name: manifests
+        path: stacks/ibm/application/add-anonymous-user-filter
+    name: add-anonymous-user-filter
+  # application
+  - kustomizeConfig:
+      repoRef:
+        name: manifests
+        path: application/v3
+    name: application
+  # bootstrap
+  - kustomizeConfig:
+      repoRef:
+        name: manifests
+        path: stacks/ibm/application/bootstrap
+    name: bootstrap
+  # cert-manager
+  - kustomizeConfig:
+      repoRef:
+        name: manifests
+        path: stacks/ibm/application/cert-manager-crds
+    name: cert-manager-crds
+  - kustomizeConfig:
+      repoRef:
+        name: manifests
+        path: stacks/ibm/application/cert-manager-kube-system-resources
+    name: cert-manager-kube-system-resources
+  - kustomizeConfig:
+      repoRef:
+        name: manifests
+        path: stacks/ibm/application/cert-manager
+    name: cert-manager
+  # Kubeflow components
+  - kustomizeConfig:
+      repoRef:
+        name: manifests
+        path: stacks/ibm/base
+    name: kubeflow-apps
+  - kustomizeConfig:
+      repoRef:
+        name: manifests
+        path: stacks/ibm/components/admission-webhook
+    name: kubeflow-apps
+  - kustomizeConfig:
+      repoRef:
+        name: manifests
+        path: stacks/ibm/components/profile-control-plane
+    name: kubeflow-apps
+  - kustomizeConfig:
+      repoRef:
+        name: manifests
+        path: stacks/ibm/components/metadata
+    name: kubeflow-apps
+  - kustomizeConfig:
+      repoRef:
+        name: manifests
+        path: stacks/ibm/components/argo
+    name: kubeflow-apps
+  - kustomizeConfig:
+      repoRef:
+        name: manifests
+        path: stacks/ibm/components/katib
+    name: kubeflow-apps
+  - kustomizeConfig:
+      repoRef:
+        name: manifests
+        path: stacks/ibm/components/pipelines
+    name: kubeflow-apps
+  - kustomizeConfig:
+      repoRef:
+        name: manifests
+        path: stacks/ibm/components/notebooks
+    name: kubeflow-apps
+  - kustomizeConfig:
+      repoRef:
+        name: manifests
+        path: stacks/ibm/components/pytorch-job
+    name: kubeflow-apps
+  - kustomizeConfig:
+      repoRef:
+        name: manifests
+        path: stacks/ibm/components/tf-job
+    name: kubeflow-apps
+  - kustomizeConfig:
+      repoRef:
+        name: manifests
+        path: stacks/ibm/components/seldon-core-operator
+    name: kubeflow-apps
+  # other applications
+  - kustomizeConfig:
+      repoRef:
+        name: manifests
+        path: metacontroller/base
+    name: metacontroller
+  - kustomizeConfig:
+      repoRef:
+        name: manifests
+        path: stacks/ibm/application/spark-operator
+    name: spark-operator
+  - kustomizeConfig:
+      repoRef:
+        name: manifests
+        path: knative/installs/generic
+    name: knative
+  - kustomizeConfig:
+      repoRef:
+        name: manifests
+        path: kfserving/installs/generic
+    name: kfserving
+  # Spartakus is a separate applications so that kfctl can remove it
+  # to disable usage reporting
+  - kustomizeConfig:
+      repoRef:
+        name: manifests
+        path: stacks/ibm/application/spartakus
+    name: spartakus
+  repos:
+  - name: manifests
+    uri: https://github.com/IBM/manifests/archive/master.tar.gz
+  version: master

--- a/stacks/ibm/application/cluster-local-gateway-1-3-1/kustomization.yaml
+++ b/stacks/ibm/application/cluster-local-gateway-1-3-1/kustomization.yaml
@@ -2,4 +2,4 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 namespace: istio-system
 resources:
-- ../../../../istio-1-3-1/cluster-local-gateway-1-3-1/base
+- ../../../../istio-1-3-1/cluster-local-gateway-1-3-1/base_v3

--- a/stacks/ibm/application/cluster-local-gateway/kustomization.yaml
+++ b/stacks/ibm/application/cluster-local-gateway/kustomization.yaml
@@ -2,4 +2,4 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 namespace: istio-system
 resources:
-- ../../../../istio/cluster-local-gateway/base
+- ../../../../istio/cluster-local-gateway/base_v3

--- a/stacks/ibm/application/istio-1-3-1-stack/kustomization.yaml
+++ b/stacks/ibm/application/istio-1-3-1-stack/kustomization.yaml
@@ -3,4 +3,4 @@ kind: Kustomization
 namespace: istio-system
 resources:
 - ../../../../istio-1-3-1/istio-crds-1-3-1/base
-- ../../../../istio-1-3-1/istio-install-1-3-1/base
+- ../../../../istio-1-3-1/istio-install-1-3-1/base_v3

--- a/stacks/ibm/application/istio/kustomization.yaml
+++ b/stacks/ibm/application/istio/kustomization.yaml
@@ -2,9 +2,9 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 namespace: kubeflow
 resources:
-- ../../../../istio/istio/base
+- ../../../../istio/istio/base_v3
 configMapGenerator:
-- name: istio-parameters
+- name: istio-config
   behavior: merge
   envs:
   - params.env

--- a/stacks/ibm/application/oidc-authservice/kustomization.yaml
+++ b/stacks/ibm/application/oidc-authservice/kustomization.yaml
@@ -2,7 +2,7 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 namespace: istio-system
 resources:
-- ../../../../istio/oidc-authservice/overlays/application
+- ../../../../istio/oidc-authservice/base_v3
 images:
 - name: busybox
   newTag: "latest"
@@ -10,7 +10,7 @@ images:
 patchesStrategicMerge:
 - statefulset-patch.yaml
 configMapGenerator:
-- name: oidc-authservice-parameters
+- name: oidc-authservice-config
   behavior: merge
   literals:
   - client_id=kubeflow-oidc-authservice

--- a/stacks/ibm/application/seldon-core-operator/kustomization.yaml
+++ b/stacks/ibm/application/seldon-core-operator/kustomization.yaml
@@ -1,0 +1,5 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+namespace: kubeflow
+resources:
+- ../../../../seldon/seldon-core-operator/overlays/application

--- a/stacks/ibm/base/config/params.env
+++ b/stacks/ibm/base/config/params.env
@@ -1,0 +1,3 @@
+clusterDomain=cluster.local
+userid-header=kubeflow-userid
+userid-prefix=

--- a/stacks/ibm/base/kustomization.yaml
+++ b/stacks/ibm/base/kustomization.yaml
@@ -1,0 +1,24 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+namespace: kubeflow
+configMapGenerator:
+- name: kubeflow-config
+  envs:
+  - ./config/params.env
+vars:
+# We need to define vars at the top level otherwise we will get
+# conflicts. 
+- fieldref:
+    fieldPath: data.clusterDomain
+  name: clusterDomain
+  objref:
+    apiVersion: v1
+    kind: ConfigMap
+    name: kubeflow-config
+- fieldref:
+    fieldPath: metadata.namespace
+  name: namespace
+  objref:
+    apiVersion: v1
+    kind: ConfigMap
+    name: kubeflow-config

--- a/stacks/ibm/components/admission-webhook/kustomization.yaml
+++ b/stacks/ibm/components/admission-webhook/kustomization.yaml
@@ -1,0 +1,5 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+namespace: kubeflow
+resources:
+- ../../../../admission-webhook/webhook/v3

--- a/stacks/ibm/components/argo/kustomization.yaml
+++ b/stacks/ibm/components/argo/kustomization.yaml
@@ -1,0 +1,10 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+namespace: kubeflow
+resources:
+  - ../../../../argo/base_v3
+configMapGenerator:
+- name: workflow-controller-parameters
+  behavior: merge
+  literals:
+  - containerRuntimeExecutor=pns

--- a/stacks/ibm/components/katib/kustomization.yaml
+++ b/stacks/ibm/components/katib/kustomization.yaml
@@ -1,0 +1,13 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+namespace: kubeflow
+resources:
+  - ../../../../katib/installs/katib-standalone-ibm
+vars:
+- fieldref:
+    fieldpath: metadata.namespace
+  name: katib-ui-namespace
+  objref:
+    kind: Service
+    name: katib-ui
+    apiVersion: v1

--- a/stacks/ibm/components/metadata/kustomization.yaml
+++ b/stacks/ibm/components/metadata/kustomization.yaml
@@ -1,0 +1,5 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+namespace: kubeflow
+resources:
+  - ../../application/metadata

--- a/stacks/ibm/components/notebooks/kustomization.yaml
+++ b/stacks/ibm/components/notebooks/kustomization.yaml
@@ -1,0 +1,6 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+namespace: kubeflow
+resources:
+  - ../../application/jupyter-web-app
+  - ../../application/notebook-controller

--- a/stacks/ibm/components/pipelines/kustomization.yaml
+++ b/stacks/ibm/components/pipelines/kustomization.yaml
@@ -1,0 +1,16 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+namespace: kubeflow
+resources:
+  - ../../../../pipeline/minio/installs/ibm
+  - ../../../../pipeline/mysql/installs/ibm
+  - ../../../../pipeline/installs/generic
+configMapGenerator:
+- name: pipeline-mysql-parameters
+  behavior: merge
+  literals:
+  - mysqlPvcName=mysql-pv-claim
+- name: pipeline-minio-parameters
+  behavior: merge
+  literals:
+  - minioPvcName=minio-pv-claim

--- a/stacks/ibm/components/profile-control-plane/kustomization.yaml
+++ b/stacks/ibm/components/profile-control-plane/kustomization.yaml
@@ -1,0 +1,12 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+namespace: kubeflow
+resources:
+  - ../../../../common/centraldashboard/overlays/stacks
+  - ../../../../kubeflow-roles/base
+  - ../../application/profiles
+configMapGenerator:
+- name: profiles-config
+  behavior: merge
+  literals:
+  - admin=example@kubeflow.org

--- a/stacks/ibm/components/pytorch-job/kustomization.yaml
+++ b/stacks/ibm/components/pytorch-job/kustomization.yaml
@@ -1,0 +1,6 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+namespace: kubeflow
+resources:
+  - ../../../../pytorch-job/pytorch-job-crds/overlays/application
+  - ../../../../pytorch-job/pytorch-operator/overlays/application

--- a/stacks/ibm/components/seldon-core-operator/kustomization.yaml
+++ b/stacks/ibm/components/seldon-core-operator/kustomization.yaml
@@ -1,0 +1,5 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+namespace: kubeflow
+resources:
+- ../../../../seldon/seldon-core-operator/overlays/application

--- a/stacks/ibm/components/tf-job/kustomization.yaml
+++ b/stacks/ibm/components/tf-job/kustomization.yaml
@@ -1,0 +1,6 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+namespace: kubeflow
+resources:
+  - ../../../../tf-training/tf-job-crds/overlays/application
+  - ../../../../tf-training/tf-job-operator/overlays/application

--- a/tests/stacks/ibm/application/cluster-local-gateway-1-3-1/test_data/expected/~g_v1_configmap_cluster-local-gateway-config.yaml
+++ b/tests/stacks/ibm/application/cluster-local-gateway-1-3-1/test_data/expected/~g_v1_configmap_cluster-local-gateway-config.yaml
@@ -5,5 +5,5 @@ kind: ConfigMap
 metadata:
   labels:
     kustomize.component: cluster-local-gateway
-  name: cluster-local-gateway-parameters-tbbdb2842d
+  name: cluster-local-gateway-config
   namespace: istio-system

--- a/tests/stacks/ibm/application/cluster-local-gateway/test_data/expected/~g_v1_configmap_cluster-local-gateway-config.yaml
+++ b/tests/stacks/ibm/application/cluster-local-gateway/test_data/expected/~g_v1_configmap_cluster-local-gateway-config.yaml
@@ -5,5 +5,5 @@ kind: ConfigMap
 metadata:
   labels:
     kustomize.component: cluster-local-gateway
-  name: cluster-local-gateway-parameters-tbbdb2842d
+  name: cluster-local-gateway-config
   namespace: istio-system

--- a/tests/stacks/ibm/application/istio-1-3-1-stack/test_data/expected/~g_v1_configmap_istio-install-config.yaml
+++ b/tests/stacks/ibm/application/istio-1-3-1-stack/test_data/expected/~g_v1_configmap_istio-install-config.yaml
@@ -3,5 +3,5 @@ data:
   namespace: istio-system
 kind: ConfigMap
 metadata:
-  name: istio-install-parameters-5kmkd2f29g
+  name: istio-install-config
   namespace: istio-system

--- a/tests/stacks/ibm/application/istio/test_data/expected/~g_v1_configmap_istio-config.yaml
+++ b/tests/stacks/ibm/application/istio/test_data/expected/~g_v1_configmap_istio-config.yaml
@@ -6,5 +6,5 @@ kind: ConfigMap
 metadata:
   annotations: {}
   labels: {}
-  name: istio-parameters-t6hhgfg9k2
+  name: istio-config
   namespace: kubeflow

--- a/tests/stacks/ibm/application/oidc-authservice/test_data/expected/app.k8s.io_v1beta1_application_oidc-authservice.yaml
+++ b/tests/stacks/ibm/application/oidc-authservice/test_data/expected/app.k8s.io_v1beta1_application_oidc-authservice.yaml
@@ -1,9 +1,6 @@
 apiVersion: app.k8s.io/v1beta1
 kind: Application
 metadata:
-  labels:
-    app.kubernetes.io/component: oidc-authservice
-    app.kubernetes.io/name: oidc-authservice
   name: oidc-authservice
   namespace: istio-system
 spec:

--- a/tests/stacks/ibm/application/oidc-authservice/test_data/expected/apps_v1_statefulset_authservice.yaml
+++ b/tests/stacks/ibm/application/oidc-authservice/test_data/expected/apps_v1_statefulset_authservice.yaml
@@ -1,9 +1,6 @@
 apiVersion: apps/v1
 kind: StatefulSet
 metadata:
-  labels:
-    app.kubernetes.io/component: oidc-authservice
-    app.kubernetes.io/name: oidc-authservice
   name: authservice
   namespace: istio-system
 spec:
@@ -11,8 +8,6 @@ spec:
   selector:
     matchLabels:
       app: authservice
-      app.kubernetes.io/component: oidc-authservice
-      app.kubernetes.io/name: oidc-authservice
   serviceName: authservice
   template:
     metadata:
@@ -20,8 +15,6 @@ spec:
         sidecar.istio.io/inject: "false"
       labels:
         app: authservice
-        app.kubernetes.io/component: oidc-authservice
-        app.kubernetes.io/name: oidc-authservice
     spec:
       containers:
       - env:

--- a/tests/stacks/ibm/application/oidc-authservice/test_data/expected/networking.istio.io_v1alpha3_envoyfilter_authn-filter.yaml
+++ b/tests/stacks/ibm/application/oidc-authservice/test_data/expected/networking.istio.io_v1alpha3_envoyfilter_authn-filter.yaml
@@ -1,9 +1,6 @@
 apiVersion: networking.istio.io/v1alpha3
 kind: EnvoyFilter
 metadata:
-  labels:
-    app.kubernetes.io/component: oidc-authservice
-    app.kubernetes.io/name: oidc-authservice
   name: authn-filter
   namespace: istio-system
 spec:
@@ -33,4 +30,4 @@ spec:
     listenerMatch:
       listenerType: GATEWAY
   workloadLabels:
-    istio: ingressgateway
+    istio: $(gatewaySelector)

--- a/tests/stacks/ibm/application/oidc-authservice/test_data/expected/~g_v1_configmap_oidc-authservice-config.yaml
+++ b/tests/stacks/ibm/application/oidc-authservice/test_data/expected/~g_v1_configmap_oidc-authservice-config.yaml
@@ -13,8 +13,6 @@ data:
 kind: ConfigMap
 metadata:
   annotations: {}
-  labels:
-    app.kubernetes.io/component: oidc-authservice
-    app.kubernetes.io/name: oidc-authservice
-  name: oidc-authservice-parameters
+  labels: {}
+  name: oidc-authservice-config
   namespace: istio-system

--- a/tests/stacks/ibm/application/oidc-authservice/test_data/expected/~g_v1_persistentvolumeclaim_authservice-pvc.yaml
+++ b/tests/stacks/ibm/application/oidc-authservice/test_data/expected/~g_v1_persistentvolumeclaim_authservice-pvc.yaml
@@ -1,9 +1,6 @@
 apiVersion: v1
 kind: PersistentVolumeClaim
 metadata:
-  labels:
-    app.kubernetes.io/component: oidc-authservice
-    app.kubernetes.io/name: oidc-authservice
   name: authservice-pvc
   namespace: istio-system
 spec:

--- a/tests/stacks/ibm/application/oidc-authservice/test_data/expected/~g_v1_service_authservice.yaml
+++ b/tests/stacks/ibm/application/oidc-authservice/test_data/expected/~g_v1_service_authservice.yaml
@@ -1,9 +1,6 @@
 apiVersion: v1
 kind: Service
 metadata:
-  labels:
-    app.kubernetes.io/component: oidc-authservice
-    app.kubernetes.io/name: oidc-authservice
   name: authservice
   namespace: istio-system
 spec:
@@ -14,6 +11,4 @@ spec:
   publishNotReadyAddresses: true
   selector:
     app: authservice
-    app.kubernetes.io/component: oidc-authservice
-    app.kubernetes.io/name: oidc-authservice
   type: ClusterIP

--- a/tests/stacks/ibm/application/seldon-core-operator/kustomize_test.go
+++ b/tests/stacks/ibm/application/seldon-core-operator/kustomize_test.go
@@ -1,0 +1,15 @@
+package seldon_core_operator
+
+import (
+	"github.com/kubeflow/manifests/tests"
+	"testing"
+)
+
+func TestKustomize(t *testing.T) {
+	testCase := &tests.KustomizeTestCase{
+		Package:  "../../../../../stacks/ibm/application/seldon-core-operator",
+		Expected: "test_data/expected",
+	}
+
+	tests.RunTestCase(t, testCase)
+}

--- a/tests/stacks/ibm/application/seldon-core-operator/test_data/expected/admissionregistration.k8s.io_v1beta1_mutatingwebhookconfiguration_seldon-mutating-webhook-configuration-kubeflow.yaml
+++ b/tests/stacks/ibm/application/seldon-core-operator/test_data/expected/admissionregistration.k8s.io_v1beta1_mutatingwebhookconfiguration_seldon-mutating-webhook-configuration-kubeflow.yaml
@@ -1,0 +1,86 @@
+apiVersion: admissionregistration.k8s.io/v1beta1
+kind: MutatingWebhookConfiguration
+metadata:
+  annotations:
+    cert-manager.io/inject-ca-from: kubeflow/seldon-serving-cert
+  creationTimestamp: null
+  labels:
+    app: seldon
+    app.kubernetes.io/component: seldon
+    app.kubernetes.io/instance: seldon-core
+    app.kubernetes.io/name: seldon-core-operator
+    app.kubernetes.io/version: 1.2.1
+  name: seldon-mutating-webhook-configuration-kubeflow
+webhooks:
+- clientConfig:
+    caBundle: LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSURCVENDQWUyZ0F3SUJBZ0lSQU9CZGZ4N0xmZXVEZnJ2QXFUK0hDWDh3RFFZSktvWklodmNOQVFFTEJRQXcKSERFYU1CZ0dBMVVFQXhNUlkzVnpkRzl0TFcxbGRISnBZM010WTJFd0hoY05NakF3TnpFd01UYzFOREV4V2hjTgpNakV3TnpFd01UYzFOREV4V2pBY01Sb3dHQVlEVlFRREV4RmpkWE4wYjIwdGJXVjBjbWxqY3kxallUQ0NBU0l3CkRRWUpLb1pJaHZjTkFRRUJCUUFEZ2dFUEFEQ0NBUW9DZ2dFQkFLSEVLQ09YVW1LN2FRS1VHL0ZjbTMwSTVmVnYKTVJlc3dGbi9yb3pxR1I2Rm5HSm9zbjFiZStJY05PZkdvUERUNkJ4T2pYRXVvczRvQjFabjNXamZZL3ZaVnNCagpjSjdCWld3TzZlUmwrUEZNOUV5S0ZwTVhncnVHdjRBTlpOZ3BrejkyYURBTTV2S1RSYng0QUVCRFdjQlgxWE93CjdEdFZrOVNpY0Q5cTdMVGYzWDBYSHF1SlRiQTNmNXhJbndEMWp2ZjltMzdZanNIRnZva3ZscGR3MFpicFhjeWYKVFozYWw0SVJ5SmU3TWJDaTV4Wm9PcmZ0R1NzT2IrNnRTemVKbU5nVjM2N3ZHbnliSEJSSmlUVTBYeGJid3hEawpjazIvNnFFMXgzOWxxUlYvOWNURWk4UE1DbU9oV0dkeFQ3cTJQS1NmeVBhSm50VWVnUndXcjZIdDRVY0NBd0VBCkFhTkNNRUF3RGdZRFZSMFBBUUgvQkFRREFnS2tNQjBHQTFVZEpRUVdNQlFHQ0NzR0FRVUZCd01CQmdnckJnRUYKQlFjREFqQVBCZ05WSFJNQkFmOEVCVEFEQVFIL01BMEdDU3FHU0liM0RRRUJDd1VBQTRJQkFRQXRMcldyeGxmMgpuU2pjNEFvK3FJaHBITXZYc21nVFJXbFNKNXR0aW1tZHE0TkpwWDBMeWJQRmVoQ2RGOTUweXRvejIxMVFZbENECmVKd3k1YXY1eHA2NTdKZ0h0ckRWb1djTmxFUnNMa0JOOElaTlI2THdJdkMrbFZjYzU0RGVRWU5XbG5neSttYnMKT3FoYWlQVXVoWTRjZW9TeENlNDlYSHVnQko4VVdZUTUwcWl4Y1hmRjdzK1JQLzZuQXRhVDRrbWVkek1HckxFbwp1a3JzcXNaOWV5SHNDYmtKTW0rcHROWWtXMUhzU29ORlhHRnZYTE5GTEllZVJpa0hyRk15Tmg3dVhwQjI2cTVrCnVES2lvL0dNNitIRG5GN1p5VXVYTVEyOWhjc1VZZ2tBcVFJZGhKWnV5R281WmpjK1VNL3hyMlFwc0tYSjBmUXoKVHpvR3I0L1JzdTRBCi0tLS0tRU5EIENFUlRJRklDQVRFLS0tLS0K
+    service:
+      name: seldon-webhook-service
+      namespace: kubeflow
+      path: /mutate-machinelearning-seldon-io-v1-seldondeployment
+  failurePolicy: Fail
+  name: v1.mseldondeployment.kb.io
+  namespaceSelector:
+    matchExpressions:
+    - key: seldon.io/controller-id
+      operator: DoesNotExist
+    matchLabels:
+      serving.kubeflow.org/inferenceservice: enabled
+  rules:
+  - apiGroups:
+    - machinelearning.seldon.io
+    apiVersions:
+    - v1
+    operations:
+    - CREATE
+    - UPDATE
+    resources:
+    - seldondeployments
+- clientConfig:
+    caBundle: LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSURCVENDQWUyZ0F3SUJBZ0lSQU9CZGZ4N0xmZXVEZnJ2QXFUK0hDWDh3RFFZSktvWklodmNOQVFFTEJRQXcKSERFYU1CZ0dBMVVFQXhNUlkzVnpkRzl0TFcxbGRISnBZM010WTJFd0hoY05NakF3TnpFd01UYzFOREV4V2hjTgpNakV3TnpFd01UYzFOREV4V2pBY01Sb3dHQVlEVlFRREV4RmpkWE4wYjIwdGJXVjBjbWxqY3kxallUQ0NBU0l3CkRRWUpLb1pJaHZjTkFRRUJCUUFEZ2dFUEFEQ0NBUW9DZ2dFQkFLSEVLQ09YVW1LN2FRS1VHL0ZjbTMwSTVmVnYKTVJlc3dGbi9yb3pxR1I2Rm5HSm9zbjFiZStJY05PZkdvUERUNkJ4T2pYRXVvczRvQjFabjNXamZZL3ZaVnNCagpjSjdCWld3TzZlUmwrUEZNOUV5S0ZwTVhncnVHdjRBTlpOZ3BrejkyYURBTTV2S1RSYng0QUVCRFdjQlgxWE93CjdEdFZrOVNpY0Q5cTdMVGYzWDBYSHF1SlRiQTNmNXhJbndEMWp2ZjltMzdZanNIRnZva3ZscGR3MFpicFhjeWYKVFozYWw0SVJ5SmU3TWJDaTV4Wm9PcmZ0R1NzT2IrNnRTemVKbU5nVjM2N3ZHbnliSEJSSmlUVTBYeGJid3hEawpjazIvNnFFMXgzOWxxUlYvOWNURWk4UE1DbU9oV0dkeFQ3cTJQS1NmeVBhSm50VWVnUndXcjZIdDRVY0NBd0VBCkFhTkNNRUF3RGdZRFZSMFBBUUgvQkFRREFnS2tNQjBHQTFVZEpRUVdNQlFHQ0NzR0FRVUZCd01CQmdnckJnRUYKQlFjREFqQVBCZ05WSFJNQkFmOEVCVEFEQVFIL01BMEdDU3FHU0liM0RRRUJDd1VBQTRJQkFRQXRMcldyeGxmMgpuU2pjNEFvK3FJaHBITXZYc21nVFJXbFNKNXR0aW1tZHE0TkpwWDBMeWJQRmVoQ2RGOTUweXRvejIxMVFZbENECmVKd3k1YXY1eHA2NTdKZ0h0ckRWb1djTmxFUnNMa0JOOElaTlI2THdJdkMrbFZjYzU0RGVRWU5XbG5neSttYnMKT3FoYWlQVXVoWTRjZW9TeENlNDlYSHVnQko4VVdZUTUwcWl4Y1hmRjdzK1JQLzZuQXRhVDRrbWVkek1HckxFbwp1a3JzcXNaOWV5SHNDYmtKTW0rcHROWWtXMUhzU29ORlhHRnZYTE5GTEllZVJpa0hyRk15Tmg3dVhwQjI2cTVrCnVES2lvL0dNNitIRG5GN1p5VXVYTVEyOWhjc1VZZ2tBcVFJZGhKWnV5R281WmpjK1VNL3hyMlFwc0tYSjBmUXoKVHpvR3I0L1JzdTRBCi0tLS0tRU5EIENFUlRJRklDQVRFLS0tLS0K
+    service:
+      name: seldon-webhook-service
+      namespace: kubeflow
+      path: /mutate-machinelearning-seldon-io-v1alpha2-seldondeployment
+  failurePolicy: Fail
+  name: v1alpha2.mseldondeployment.kb.io
+  namespaceSelector:
+    matchExpressions:
+    - key: seldon.io/controller-id
+      operator: DoesNotExist
+    matchLabels:
+      serving.kubeflow.org/inferenceservice: enabled
+  rules:
+  - apiGroups:
+    - machinelearning.seldon.io
+    apiVersions:
+    - v1alpha2
+    operations:
+    - CREATE
+    - UPDATE
+    resources:
+    - seldondeployments
+- clientConfig:
+    caBundle: LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSURCVENDQWUyZ0F3SUJBZ0lSQU9CZGZ4N0xmZXVEZnJ2QXFUK0hDWDh3RFFZSktvWklodmNOQVFFTEJRQXcKSERFYU1CZ0dBMVVFQXhNUlkzVnpkRzl0TFcxbGRISnBZM010WTJFd0hoY05NakF3TnpFd01UYzFOREV4V2hjTgpNakV3TnpFd01UYzFOREV4V2pBY01Sb3dHQVlEVlFRREV4RmpkWE4wYjIwdGJXVjBjbWxqY3kxallUQ0NBU0l3CkRRWUpLb1pJaHZjTkFRRUJCUUFEZ2dFUEFEQ0NBUW9DZ2dFQkFLSEVLQ09YVW1LN2FRS1VHL0ZjbTMwSTVmVnYKTVJlc3dGbi9yb3pxR1I2Rm5HSm9zbjFiZStJY05PZkdvUERUNkJ4T2pYRXVvczRvQjFabjNXamZZL3ZaVnNCagpjSjdCWld3TzZlUmwrUEZNOUV5S0ZwTVhncnVHdjRBTlpOZ3BrejkyYURBTTV2S1RSYng0QUVCRFdjQlgxWE93CjdEdFZrOVNpY0Q5cTdMVGYzWDBYSHF1SlRiQTNmNXhJbndEMWp2ZjltMzdZanNIRnZva3ZscGR3MFpicFhjeWYKVFozYWw0SVJ5SmU3TWJDaTV4Wm9PcmZ0R1NzT2IrNnRTemVKbU5nVjM2N3ZHbnliSEJSSmlUVTBYeGJid3hEawpjazIvNnFFMXgzOWxxUlYvOWNURWk4UE1DbU9oV0dkeFQ3cTJQS1NmeVBhSm50VWVnUndXcjZIdDRVY0NBd0VBCkFhTkNNRUF3RGdZRFZSMFBBUUgvQkFRREFnS2tNQjBHQTFVZEpRUVdNQlFHQ0NzR0FRVUZCd01CQmdnckJnRUYKQlFjREFqQVBCZ05WSFJNQkFmOEVCVEFEQVFIL01BMEdDU3FHU0liM0RRRUJDd1VBQTRJQkFRQXRMcldyeGxmMgpuU2pjNEFvK3FJaHBITXZYc21nVFJXbFNKNXR0aW1tZHE0TkpwWDBMeWJQRmVoQ2RGOTUweXRvejIxMVFZbENECmVKd3k1YXY1eHA2NTdKZ0h0ckRWb1djTmxFUnNMa0JOOElaTlI2THdJdkMrbFZjYzU0RGVRWU5XbG5neSttYnMKT3FoYWlQVXVoWTRjZW9TeENlNDlYSHVnQko4VVdZUTUwcWl4Y1hmRjdzK1JQLzZuQXRhVDRrbWVkek1HckxFbwp1a3JzcXNaOWV5SHNDYmtKTW0rcHROWWtXMUhzU29ORlhHRnZYTE5GTEllZVJpa0hyRk15Tmg3dVhwQjI2cTVrCnVES2lvL0dNNitIRG5GN1p5VXVYTVEyOWhjc1VZZ2tBcVFJZGhKWnV5R281WmpjK1VNL3hyMlFwc0tYSjBmUXoKVHpvR3I0L1JzdTRBCi0tLS0tRU5EIENFUlRJRklDQVRFLS0tLS0K
+    service:
+      name: seldon-webhook-service
+      namespace: kubeflow
+      path: /mutate-machinelearning-seldon-io-v1alpha3-seldondeployment
+  failurePolicy: Fail
+  name: v1alpha3.mseldondeployment.kb.io
+  namespaceSelector:
+    matchExpressions:
+    - key: seldon.io/controller-id
+      operator: DoesNotExist
+    matchLabels:
+      serving.kubeflow.org/inferenceservice: enabled
+  rules:
+  - apiGroups:
+    - machinelearning.seldon.io
+    apiVersions:
+    - v1alpha3
+    operations:
+    - CREATE
+    - UPDATE
+    resources:
+    - seldondeployments

--- a/tests/stacks/ibm/application/seldon-core-operator/test_data/expected/admissionregistration.k8s.io_v1beta1_validatingwebhookconfiguration_seldon-validating-webhook-configuration-kubeflow.yaml
+++ b/tests/stacks/ibm/application/seldon-core-operator/test_data/expected/admissionregistration.k8s.io_v1beta1_validatingwebhookconfiguration_seldon-validating-webhook-configuration-kubeflow.yaml
@@ -1,0 +1,86 @@
+apiVersion: admissionregistration.k8s.io/v1beta1
+kind: ValidatingWebhookConfiguration
+metadata:
+  annotations:
+    cert-manager.io/inject-ca-from: kubeflow/seldon-serving-cert
+  creationTimestamp: null
+  labels:
+    app: seldon
+    app.kubernetes.io/component: seldon
+    app.kubernetes.io/instance: seldon-core
+    app.kubernetes.io/name: seldon-core-operator
+    app.kubernetes.io/version: 1.2.1
+  name: seldon-validating-webhook-configuration-kubeflow
+webhooks:
+- clientConfig:
+    caBundle: LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSURCVENDQWUyZ0F3SUJBZ0lSQU9CZGZ4N0xmZXVEZnJ2QXFUK0hDWDh3RFFZSktvWklodmNOQVFFTEJRQXcKSERFYU1CZ0dBMVVFQXhNUlkzVnpkRzl0TFcxbGRISnBZM010WTJFd0hoY05NakF3TnpFd01UYzFOREV4V2hjTgpNakV3TnpFd01UYzFOREV4V2pBY01Sb3dHQVlEVlFRREV4RmpkWE4wYjIwdGJXVjBjbWxqY3kxallUQ0NBU0l3CkRRWUpLb1pJaHZjTkFRRUJCUUFEZ2dFUEFEQ0NBUW9DZ2dFQkFLSEVLQ09YVW1LN2FRS1VHL0ZjbTMwSTVmVnYKTVJlc3dGbi9yb3pxR1I2Rm5HSm9zbjFiZStJY05PZkdvUERUNkJ4T2pYRXVvczRvQjFabjNXamZZL3ZaVnNCagpjSjdCWld3TzZlUmwrUEZNOUV5S0ZwTVhncnVHdjRBTlpOZ3BrejkyYURBTTV2S1RSYng0QUVCRFdjQlgxWE93CjdEdFZrOVNpY0Q5cTdMVGYzWDBYSHF1SlRiQTNmNXhJbndEMWp2ZjltMzdZanNIRnZva3ZscGR3MFpicFhjeWYKVFozYWw0SVJ5SmU3TWJDaTV4Wm9PcmZ0R1NzT2IrNnRTemVKbU5nVjM2N3ZHbnliSEJSSmlUVTBYeGJid3hEawpjazIvNnFFMXgzOWxxUlYvOWNURWk4UE1DbU9oV0dkeFQ3cTJQS1NmeVBhSm50VWVnUndXcjZIdDRVY0NBd0VBCkFhTkNNRUF3RGdZRFZSMFBBUUgvQkFRREFnS2tNQjBHQTFVZEpRUVdNQlFHQ0NzR0FRVUZCd01CQmdnckJnRUYKQlFjREFqQVBCZ05WSFJNQkFmOEVCVEFEQVFIL01BMEdDU3FHU0liM0RRRUJDd1VBQTRJQkFRQXRMcldyeGxmMgpuU2pjNEFvK3FJaHBITXZYc21nVFJXbFNKNXR0aW1tZHE0TkpwWDBMeWJQRmVoQ2RGOTUweXRvejIxMVFZbENECmVKd3k1YXY1eHA2NTdKZ0h0ckRWb1djTmxFUnNMa0JOOElaTlI2THdJdkMrbFZjYzU0RGVRWU5XbG5neSttYnMKT3FoYWlQVXVoWTRjZW9TeENlNDlYSHVnQko4VVdZUTUwcWl4Y1hmRjdzK1JQLzZuQXRhVDRrbWVkek1HckxFbwp1a3JzcXNaOWV5SHNDYmtKTW0rcHROWWtXMUhzU29ORlhHRnZYTE5GTEllZVJpa0hyRk15Tmg3dVhwQjI2cTVrCnVES2lvL0dNNitIRG5GN1p5VXVYTVEyOWhjc1VZZ2tBcVFJZGhKWnV5R281WmpjK1VNL3hyMlFwc0tYSjBmUXoKVHpvR3I0L1JzdTRBCi0tLS0tRU5EIENFUlRJRklDQVRFLS0tLS0K
+    service:
+      name: seldon-webhook-service
+      namespace: kubeflow
+      path: /validate-machinelearning-seldon-io-v1-seldondeployment
+  failurePolicy: Fail
+  name: v1.vseldondeployment.kb.io
+  namespaceSelector:
+    matchExpressions:
+    - key: seldon.io/controller-id
+      operator: DoesNotExist
+    matchLabels:
+      serving.kubeflow.org/inferenceservice: enabled
+  rules:
+  - apiGroups:
+    - machinelearning.seldon.io
+    apiVersions:
+    - v1
+    operations:
+    - CREATE
+    - UPDATE
+    resources:
+    - seldondeployments
+- clientConfig:
+    caBundle: LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSURCVENDQWUyZ0F3SUJBZ0lSQU9CZGZ4N0xmZXVEZnJ2QXFUK0hDWDh3RFFZSktvWklodmNOQVFFTEJRQXcKSERFYU1CZ0dBMVVFQXhNUlkzVnpkRzl0TFcxbGRISnBZM010WTJFd0hoY05NakF3TnpFd01UYzFOREV4V2hjTgpNakV3TnpFd01UYzFOREV4V2pBY01Sb3dHQVlEVlFRREV4RmpkWE4wYjIwdGJXVjBjbWxqY3kxallUQ0NBU0l3CkRRWUpLb1pJaHZjTkFRRUJCUUFEZ2dFUEFEQ0NBUW9DZ2dFQkFLSEVLQ09YVW1LN2FRS1VHL0ZjbTMwSTVmVnYKTVJlc3dGbi9yb3pxR1I2Rm5HSm9zbjFiZStJY05PZkdvUERUNkJ4T2pYRXVvczRvQjFabjNXamZZL3ZaVnNCagpjSjdCWld3TzZlUmwrUEZNOUV5S0ZwTVhncnVHdjRBTlpOZ3BrejkyYURBTTV2S1RSYng0QUVCRFdjQlgxWE93CjdEdFZrOVNpY0Q5cTdMVGYzWDBYSHF1SlRiQTNmNXhJbndEMWp2ZjltMzdZanNIRnZva3ZscGR3MFpicFhjeWYKVFozYWw0SVJ5SmU3TWJDaTV4Wm9PcmZ0R1NzT2IrNnRTemVKbU5nVjM2N3ZHbnliSEJSSmlUVTBYeGJid3hEawpjazIvNnFFMXgzOWxxUlYvOWNURWk4UE1DbU9oV0dkeFQ3cTJQS1NmeVBhSm50VWVnUndXcjZIdDRVY0NBd0VBCkFhTkNNRUF3RGdZRFZSMFBBUUgvQkFRREFnS2tNQjBHQTFVZEpRUVdNQlFHQ0NzR0FRVUZCd01CQmdnckJnRUYKQlFjREFqQVBCZ05WSFJNQkFmOEVCVEFEQVFIL01BMEdDU3FHU0liM0RRRUJDd1VBQTRJQkFRQXRMcldyeGxmMgpuU2pjNEFvK3FJaHBITXZYc21nVFJXbFNKNXR0aW1tZHE0TkpwWDBMeWJQRmVoQ2RGOTUweXRvejIxMVFZbENECmVKd3k1YXY1eHA2NTdKZ0h0ckRWb1djTmxFUnNMa0JOOElaTlI2THdJdkMrbFZjYzU0RGVRWU5XbG5neSttYnMKT3FoYWlQVXVoWTRjZW9TeENlNDlYSHVnQko4VVdZUTUwcWl4Y1hmRjdzK1JQLzZuQXRhVDRrbWVkek1HckxFbwp1a3JzcXNaOWV5SHNDYmtKTW0rcHROWWtXMUhzU29ORlhHRnZYTE5GTEllZVJpa0hyRk15Tmg3dVhwQjI2cTVrCnVES2lvL0dNNitIRG5GN1p5VXVYTVEyOWhjc1VZZ2tBcVFJZGhKWnV5R281WmpjK1VNL3hyMlFwc0tYSjBmUXoKVHpvR3I0L1JzdTRBCi0tLS0tRU5EIENFUlRJRklDQVRFLS0tLS0K
+    service:
+      name: seldon-webhook-service
+      namespace: kubeflow
+      path: /validate-machinelearning-seldon-io-v1alpha2-seldondeployment
+  failurePolicy: Fail
+  name: v1alpha2.vseldondeployment.kb.io
+  namespaceSelector:
+    matchExpressions:
+    - key: seldon.io/controller-id
+      operator: DoesNotExist
+    matchLabels:
+      serving.kubeflow.org/inferenceservice: enabled
+  rules:
+  - apiGroups:
+    - machinelearning.seldon.io
+    apiVersions:
+    - v1alpha2
+    operations:
+    - CREATE
+    - UPDATE
+    resources:
+    - seldondeployments
+- clientConfig:
+    caBundle: LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSURCVENDQWUyZ0F3SUJBZ0lSQU9CZGZ4N0xmZXVEZnJ2QXFUK0hDWDh3RFFZSktvWklodmNOQVFFTEJRQXcKSERFYU1CZ0dBMVVFQXhNUlkzVnpkRzl0TFcxbGRISnBZM010WTJFd0hoY05NakF3TnpFd01UYzFOREV4V2hjTgpNakV3TnpFd01UYzFOREV4V2pBY01Sb3dHQVlEVlFRREV4RmpkWE4wYjIwdGJXVjBjbWxqY3kxallUQ0NBU0l3CkRRWUpLb1pJaHZjTkFRRUJCUUFEZ2dFUEFEQ0NBUW9DZ2dFQkFLSEVLQ09YVW1LN2FRS1VHL0ZjbTMwSTVmVnYKTVJlc3dGbi9yb3pxR1I2Rm5HSm9zbjFiZStJY05PZkdvUERUNkJ4T2pYRXVvczRvQjFabjNXamZZL3ZaVnNCagpjSjdCWld3TzZlUmwrUEZNOUV5S0ZwTVhncnVHdjRBTlpOZ3BrejkyYURBTTV2S1RSYng0QUVCRFdjQlgxWE93CjdEdFZrOVNpY0Q5cTdMVGYzWDBYSHF1SlRiQTNmNXhJbndEMWp2ZjltMzdZanNIRnZva3ZscGR3MFpicFhjeWYKVFozYWw0SVJ5SmU3TWJDaTV4Wm9PcmZ0R1NzT2IrNnRTemVKbU5nVjM2N3ZHbnliSEJSSmlUVTBYeGJid3hEawpjazIvNnFFMXgzOWxxUlYvOWNURWk4UE1DbU9oV0dkeFQ3cTJQS1NmeVBhSm50VWVnUndXcjZIdDRVY0NBd0VBCkFhTkNNRUF3RGdZRFZSMFBBUUgvQkFRREFnS2tNQjBHQTFVZEpRUVdNQlFHQ0NzR0FRVUZCd01CQmdnckJnRUYKQlFjREFqQVBCZ05WSFJNQkFmOEVCVEFEQVFIL01BMEdDU3FHU0liM0RRRUJDd1VBQTRJQkFRQXRMcldyeGxmMgpuU2pjNEFvK3FJaHBITXZYc21nVFJXbFNKNXR0aW1tZHE0TkpwWDBMeWJQRmVoQ2RGOTUweXRvejIxMVFZbENECmVKd3k1YXY1eHA2NTdKZ0h0ckRWb1djTmxFUnNMa0JOOElaTlI2THdJdkMrbFZjYzU0RGVRWU5XbG5neSttYnMKT3FoYWlQVXVoWTRjZW9TeENlNDlYSHVnQko4VVdZUTUwcWl4Y1hmRjdzK1JQLzZuQXRhVDRrbWVkek1HckxFbwp1a3JzcXNaOWV5SHNDYmtKTW0rcHROWWtXMUhzU29ORlhHRnZYTE5GTEllZVJpa0hyRk15Tmg3dVhwQjI2cTVrCnVES2lvL0dNNitIRG5GN1p5VXVYTVEyOWhjc1VZZ2tBcVFJZGhKWnV5R281WmpjK1VNL3hyMlFwc0tYSjBmUXoKVHpvR3I0L1JzdTRBCi0tLS0tRU5EIENFUlRJRklDQVRFLS0tLS0K
+    service:
+      name: seldon-webhook-service
+      namespace: kubeflow
+      path: /validate-machinelearning-seldon-io-v1alpha3-seldondeployment
+  failurePolicy: Fail
+  name: v1alpha3.vseldondeployment.kb.io
+  namespaceSelector:
+    matchExpressions:
+    - key: seldon.io/controller-id
+      operator: DoesNotExist
+    matchLabels:
+      serving.kubeflow.org/inferenceservice: enabled
+  rules:
+  - apiGroups:
+    - machinelearning.seldon.io
+    apiVersions:
+    - v1alpha3
+    operations:
+    - CREATE
+    - UPDATE
+    resources:
+    - seldondeployments

--- a/tests/stacks/ibm/application/seldon-core-operator/test_data/expected/apiextensions.k8s.io_v1beta1_customresourcedefinition_seldondeployments.machinelearning.seldon.io.yaml
+++ b/tests/stacks/ibm/application/seldon-core-operator/test_data/expected/apiextensions.k8s.io_v1beta1_customresourcedefinition_seldondeployments.machinelearning.seldon.io.yaml
@@ -1,0 +1,6922 @@
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    cert-manager.io/inject-ca-from: kubeflow/seldon-serving-cert
+    controller-gen.kubebuilder.io/version: v0.2.5
+  creationTimestamp: null
+  labels:
+    app: seldon
+    app.kubernetes.io/component: seldon
+    app.kubernetes.io/instance: seldon-core
+    app.kubernetes.io/name: seldon-core-operator
+    app.kubernetes.io/version: 1.2.1
+  name: seldondeployments.machinelearning.seldon.io
+spec:
+  group: machinelearning.seldon.io
+  names:
+    kind: SeldonDeployment
+    listKind: SeldonDeploymentList
+    plural: seldondeployments
+    shortNames:
+    - sdep
+    singular: seldondeployment
+  scope: Namespaced
+  subresources:
+    scale:
+      specReplicasPath: .spec.replicas
+      statusReplicasPath: .status.replicas
+    status: {}
+  validation:
+    openAPIV3Schema:
+      description: SeldonDeployment is the Schema for the seldondeployments API
+      properties:
+        apiVersion:
+          description: 'APIVersion defines the versioned schema of this representation
+            of an object. Servers should convert recognized schemas to the latest
+            internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+          type: string
+        kind:
+          description: 'Kind is a string value representing the REST resource this
+            object represents. Servers may infer this from the endpoint the client
+            submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+          type: string
+        metadata:
+          type: object
+        spec:
+          description: SeldonDeploymentSpec defines the desired state of SeldonDeployment
+          properties:
+            annotations:
+              additionalProperties:
+                type: string
+              type: object
+            name:
+              description: Name is Deprecated will be removed in future
+              type: string
+            oauth_key:
+              type: string
+            oauth_secret:
+              type: string
+            predictors:
+              items:
+                properties:
+                  annotations:
+                    additionalProperties:
+                      type: string
+                    type: object
+                  componentSpecs:
+                    items:
+                      properties:
+                        hpaSpec:
+                          properties:
+                            maxReplicas:
+                              format: int32
+                              type: integer
+                            metrics:
+                              items:
+                                description: MetricSpec specifies how to scale based
+                                  on a single metric (only `type` and one other matching
+                                  field should be set at once).
+                                properties:
+                                  external:
+                                    description: external refers to a global metric
+                                      that is not associated with any Kubernetes object.
+                                      It allows autoscaling based on information coming
+                                      from components running outside of cluster (for
+                                      example length of queue in cloud messaging service,
+                                      or QPS from loadbalancer running outside of
+                                      cluster).
+                                    properties:
+                                      metricName:
+                                        description: metricName is the name of the
+                                          metric in question.
+                                        type: string
+                                      metricSelector:
+                                        description: metricSelector is used to identify
+                                          a specific time series within a given metric.
+                                        properties:
+                                          matchExpressions:
+                                            description: matchExpressions is a list
+                                              of label selector requirements. The
+                                              requirements are ANDed.
+                                            items:
+                                              description: A label selector requirement
+                                                is a selector that contains values,
+                                                a key, and an operator that relates
+                                                the key and values.
+                                              properties:
+                                                key:
+                                                  description: key is the label key
+                                                    that the selector applies to.
+                                                  type: string
+                                                operator:
+                                                  description: operator represents
+                                                    a key's relationship to a set
+                                                    of values. Valid operators are
+                                                    In, NotIn, Exists and DoesNotExist.
+                                                  type: string
+                                                values:
+                                                  description: values is an array
+                                                    of string values. If the operator
+                                                    is In or NotIn, the values array
+                                                    must be non-empty. If the operator
+                                                    is Exists or DoesNotExist, the
+                                                    values array must be empty. This
+                                                    array is replaced during a strategic
+                                                    merge patch.
+                                                  items:
+                                                    type: string
+                                                  type: array
+                                              required:
+                                              - key
+                                              - operator
+                                              type: object
+                                            type: array
+                                          matchLabels:
+                                            additionalProperties:
+                                              type: string
+                                            description: matchLabels is a map of {key,value}
+                                              pairs. A single {key,value} in the matchLabels
+                                              map is equivalent to an element of matchExpressions,
+                                              whose key field is "key", the operator
+                                              is "In", and the values array contains
+                                              only "value". The requirements are ANDed.
+                                            type: object
+                                        type: object
+                                      targetAverageValue:
+                                        anyOf:
+                                        - type: integer
+                                        - type: string
+                                        description: targetAverageValue is the target
+                                          per-pod value of global metric (as a quantity).
+                                          Mutually exclusive with TargetValue.
+                                        pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                        x-kubernetes-int-or-string: true
+                                      targetValue:
+                                        anyOf:
+                                        - type: integer
+                                        - type: string
+                                        description: targetValue is the target value
+                                          of the metric (as a quantity). Mutually
+                                          exclusive with TargetAverageValue.
+                                        pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                        x-kubernetes-int-or-string: true
+                                    required:
+                                    - metricName
+                                    type: object
+                                  object:
+                                    description: object refers to a metric describing
+                                      a single kubernetes object (for example, hits-per-second
+                                      on an Ingress object).
+                                    properties:
+                                      averageValue:
+                                        anyOf:
+                                        - type: integer
+                                        - type: string
+                                        description: averageValue is the target value
+                                          of the average of the metric across all
+                                          relevant pods (as a quantity)
+                                        pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                        x-kubernetes-int-or-string: true
+                                      metricName:
+                                        description: metricName is the name of the
+                                          metric in question.
+                                        type: string
+                                      selector:
+                                        description: selector is the string-encoded
+                                          form of a standard kubernetes label selector
+                                          for the given metric When set, it is passed
+                                          as an additional parameter to the metrics
+                                          server for more specific metrics scoping
+                                          When unset, just the metricName will be
+                                          used to gather metrics.
+                                        properties:
+                                          matchExpressions:
+                                            description: matchExpressions is a list
+                                              of label selector requirements. The
+                                              requirements are ANDed.
+                                            items:
+                                              description: A label selector requirement
+                                                is a selector that contains values,
+                                                a key, and an operator that relates
+                                                the key and values.
+                                              properties:
+                                                key:
+                                                  description: key is the label key
+                                                    that the selector applies to.
+                                                  type: string
+                                                operator:
+                                                  description: operator represents
+                                                    a key's relationship to a set
+                                                    of values. Valid operators are
+                                                    In, NotIn, Exists and DoesNotExist.
+                                                  type: string
+                                                values:
+                                                  description: values is an array
+                                                    of string values. If the operator
+                                                    is In or NotIn, the values array
+                                                    must be non-empty. If the operator
+                                                    is Exists or DoesNotExist, the
+                                                    values array must be empty. This
+                                                    array is replaced during a strategic
+                                                    merge patch.
+                                                  items:
+                                                    type: string
+                                                  type: array
+                                              required:
+                                              - key
+                                              - operator
+                                              type: object
+                                            type: array
+                                          matchLabels:
+                                            additionalProperties:
+                                              type: string
+                                            description: matchLabels is a map of {key,value}
+                                              pairs. A single {key,value} in the matchLabels
+                                              map is equivalent to an element of matchExpressions,
+                                              whose key field is "key", the operator
+                                              is "In", and the values array contains
+                                              only "value". The requirements are ANDed.
+                                            type: object
+                                        type: object
+                                      target:
+                                        description: target is the described Kubernetes
+                                          object.
+                                        properties:
+                                          apiVersion:
+                                            description: API version of the referent
+                                            type: string
+                                          kind:
+                                            description: 'Kind of the referent; More
+                                              info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds"'
+                                            type: string
+                                          name:
+                                            description: 'Name of the referent; More
+                                              info: http://kubernetes.io/docs/user-guide/identifiers#names'
+                                            type: string
+                                        required:
+                                        - kind
+                                        - name
+                                        type: object
+                                      targetValue:
+                                        anyOf:
+                                        - type: integer
+                                        - type: string
+                                        description: targetValue is the target value
+                                          of the metric (as a quantity).
+                                        pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                        x-kubernetes-int-or-string: true
+                                    required:
+                                    - metricName
+                                    - target
+                                    - targetValue
+                                    type: object
+                                  pods:
+                                    description: pods refers to a metric describing
+                                      each pod in the current scale target (for example,
+                                      transactions-processed-per-second).  The values
+                                      will be averaged together before being compared
+                                      to the target value.
+                                    properties:
+                                      metricName:
+                                        description: metricName is the name of the
+                                          metric in question
+                                        type: string
+                                      selector:
+                                        description: selector is the string-encoded
+                                          form of a standard kubernetes label selector
+                                          for the given metric When set, it is passed
+                                          as an additional parameter to the metrics
+                                          server for more specific metrics scoping
+                                          When unset, just the metricName will be
+                                          used to gather metrics.
+                                        properties:
+                                          matchExpressions:
+                                            description: matchExpressions is a list
+                                              of label selector requirements. The
+                                              requirements are ANDed.
+                                            items:
+                                              description: A label selector requirement
+                                                is a selector that contains values,
+                                                a key, and an operator that relates
+                                                the key and values.
+                                              properties:
+                                                key:
+                                                  description: key is the label key
+                                                    that the selector applies to.
+                                                  type: string
+                                                operator:
+                                                  description: operator represents
+                                                    a key's relationship to a set
+                                                    of values. Valid operators are
+                                                    In, NotIn, Exists and DoesNotExist.
+                                                  type: string
+                                                values:
+                                                  description: values is an array
+                                                    of string values. If the operator
+                                                    is In or NotIn, the values array
+                                                    must be non-empty. If the operator
+                                                    is Exists or DoesNotExist, the
+                                                    values array must be empty. This
+                                                    array is replaced during a strategic
+                                                    merge patch.
+                                                  items:
+                                                    type: string
+                                                  type: array
+                                              required:
+                                              - key
+                                              - operator
+                                              type: object
+                                            type: array
+                                          matchLabels:
+                                            additionalProperties:
+                                              type: string
+                                            description: matchLabels is a map of {key,value}
+                                              pairs. A single {key,value} in the matchLabels
+                                              map is equivalent to an element of matchExpressions,
+                                              whose key field is "key", the operator
+                                              is "In", and the values array contains
+                                              only "value". The requirements are ANDed.
+                                            type: object
+                                        type: object
+                                      targetAverageValue:
+                                        anyOf:
+                                        - type: integer
+                                        - type: string
+                                        description: targetAverageValue is the target
+                                          value of the average of the metric across
+                                          all relevant pods (as a quantity)
+                                        pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                        x-kubernetes-int-or-string: true
+                                    required:
+                                    - metricName
+                                    - targetAverageValue
+                                    type: object
+                                  resource:
+                                    description: resource refers to a resource metric
+                                      (such as those specified in requests and limits)
+                                      known to Kubernetes describing each pod in the
+                                      current scale target (e.g. CPU or memory). Such
+                                      metrics are built in to Kubernetes, and have
+                                      special scaling options on top of those available
+                                      to normal per-pod metrics using the "pods" source.
+                                    properties:
+                                      name:
+                                        description: name is the name of the resource
+                                          in question.
+                                        type: string
+                                      targetAverageUtilization:
+                                        description: targetAverageUtilization is the
+                                          target value of the average of the resource
+                                          metric across all relevant pods, represented
+                                          as a percentage of the requested value of
+                                          the resource for the pods.
+                                        format: int32
+                                        type: integer
+                                      targetAverageValue:
+                                        anyOf:
+                                        - type: integer
+                                        - type: string
+                                        description: targetAverageValue is the target
+                                          value of the average of the resource metric
+                                          across all relevant pods, as a raw value
+                                          (instead of as a percentage of the request),
+                                          similar to the "pods" metric source type.
+                                        pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                        x-kubernetes-int-or-string: true
+                                    required:
+                                    - name
+                                    type: object
+                                  type:
+                                    description: type is the type of metric source.  It
+                                      should be one of "Object", "Pods" or "Resource",
+                                      each mapping to a matching field in the object.
+                                    type: string
+                                required:
+                                - type
+                                type: object
+                              type: array
+                            minReplicas:
+                              format: int32
+                              type: integer
+                          required:
+                          - maxReplicas
+                          type: object
+                        metadata:
+                          type: object
+                        replicas:
+                          format: int32
+                          type: integer
+                        spec:
+                          description: PodSpec is a description of a pod.
+                          properties:
+                            activeDeadlineSeconds:
+                              description: Optional duration in seconds the pod may
+                                be active on the node relative to StartTime before
+                                the system will actively try to mark it failed and
+                                kill associated containers. Value must be a positive
+                                integer.
+                              format: int64
+                              type: integer
+                            affinity:
+                              description: If specified, the pod's scheduling constraints
+                              properties:
+                                nodeAffinity:
+                                  description: Describes node affinity scheduling
+                                    rules for the pod.
+                                  properties:
+                                    preferredDuringSchedulingIgnoredDuringExecution:
+                                      description: The scheduler will prefer to schedule
+                                        pods to nodes that satisfy the affinity expressions
+                                        specified by this field, but it may choose
+                                        a node that violates one or more of the expressions.
+                                        The node that is most preferred is the one
+                                        with the greatest sum of weights, i.e. for
+                                        each node that meets all of the scheduling
+                                        requirements (resource request, requiredDuringScheduling
+                                        affinity expressions, etc.), compute a sum
+                                        by iterating through the elements of this
+                                        field and adding "weight" to the sum if the
+                                        node matches the corresponding matchExpressions;
+                                        the node(s) with the highest sum are the most
+                                        preferred.
+                                      items:
+                                        description: An empty preferred scheduling
+                                          term matches all objects with implicit weight
+                                          0 (i.e. it's a no-op). A null preferred
+                                          scheduling term matches no objects (i.e.
+                                          is also a no-op).
+                                        properties:
+                                          preference:
+                                            description: A node selector term, associated
+                                              with the corresponding weight.
+                                            properties:
+                                              matchExpressions:
+                                                description: A list of node selector
+                                                  requirements by node's labels.
+                                                items:
+                                                  description: A node selector requirement
+                                                    is a selector that contains values,
+                                                    a key, and an operator that relates
+                                                    the key and values.
+                                                  properties:
+                                                    key:
+                                                      description: The label key that
+                                                        the selector applies to.
+                                                      type: string
+                                                    operator:
+                                                      description: Represents a key's
+                                                        relationship to a set of values.
+                                                        Valid operators are In, NotIn,
+                                                        Exists, DoesNotExist. Gt,
+                                                        and Lt.
+                                                      type: string
+                                                    values:
+                                                      description: An array of string
+                                                        values. If the operator is
+                                                        In or NotIn, the values array
+                                                        must be non-empty. If the
+                                                        operator is Exists or DoesNotExist,
+                                                        the values array must be empty.
+                                                        If the operator is Gt or Lt,
+                                                        the values array must have
+                                                        a single element, which will
+                                                        be interpreted as an integer.
+                                                        This array is replaced during
+                                                        a strategic merge patch.
+                                                      items:
+                                                        type: string
+                                                      type: array
+                                                  required:
+                                                  - key
+                                                  - operator
+                                                  type: object
+                                                type: array
+                                              matchFields:
+                                                description: A list of node selector
+                                                  requirements by node's fields.
+                                                items:
+                                                  description: A node selector requirement
+                                                    is a selector that contains values,
+                                                    a key, and an operator that relates
+                                                    the key and values.
+                                                  properties:
+                                                    key:
+                                                      description: The label key that
+                                                        the selector applies to.
+                                                      type: string
+                                                    operator:
+                                                      description: Represents a key's
+                                                        relationship to a set of values.
+                                                        Valid operators are In, NotIn,
+                                                        Exists, DoesNotExist. Gt,
+                                                        and Lt.
+                                                      type: string
+                                                    values:
+                                                      description: An array of string
+                                                        values. If the operator is
+                                                        In or NotIn, the values array
+                                                        must be non-empty. If the
+                                                        operator is Exists or DoesNotExist,
+                                                        the values array must be empty.
+                                                        If the operator is Gt or Lt,
+                                                        the values array must have
+                                                        a single element, which will
+                                                        be interpreted as an integer.
+                                                        This array is replaced during
+                                                        a strategic merge patch.
+                                                      items:
+                                                        type: string
+                                                      type: array
+                                                  required:
+                                                  - key
+                                                  - operator
+                                                  type: object
+                                                type: array
+                                            type: object
+                                          weight:
+                                            description: Weight associated with matching
+                                              the corresponding nodeSelectorTerm,
+                                              in the range 1-100.
+                                            format: int32
+                                            type: integer
+                                        required:
+                                        - preference
+                                        - weight
+                                        type: object
+                                      type: array
+                                    requiredDuringSchedulingIgnoredDuringExecution:
+                                      description: If the affinity requirements specified
+                                        by this field are not met at scheduling time,
+                                        the pod will not be scheduled onto the node.
+                                        If the affinity requirements specified by
+                                        this field cease to be met at some point during
+                                        pod execution (e.g. due to an update), the
+                                        system may or may not try to eventually evict
+                                        the pod from its node.
+                                      properties:
+                                        nodeSelectorTerms:
+                                          description: Required. A list of node selector
+                                            terms. The terms are ORed.
+                                          items:
+                                            description: A null or empty node selector
+                                              term matches no objects. The requirements
+                                              of them are ANDed. The TopologySelectorTerm
+                                              type implements a subset of the NodeSelectorTerm.
+                                            properties:
+                                              matchExpressions:
+                                                description: A list of node selector
+                                                  requirements by node's labels.
+                                                items:
+                                                  description: A node selector requirement
+                                                    is a selector that contains values,
+                                                    a key, and an operator that relates
+                                                    the key and values.
+                                                  properties:
+                                                    key:
+                                                      description: The label key that
+                                                        the selector applies to.
+                                                      type: string
+                                                    operator:
+                                                      description: Represents a key's
+                                                        relationship to a set of values.
+                                                        Valid operators are In, NotIn,
+                                                        Exists, DoesNotExist. Gt,
+                                                        and Lt.
+                                                      type: string
+                                                    values:
+                                                      description: An array of string
+                                                        values. If the operator is
+                                                        In or NotIn, the values array
+                                                        must be non-empty. If the
+                                                        operator is Exists or DoesNotExist,
+                                                        the values array must be empty.
+                                                        If the operator is Gt or Lt,
+                                                        the values array must have
+                                                        a single element, which will
+                                                        be interpreted as an integer.
+                                                        This array is replaced during
+                                                        a strategic merge patch.
+                                                      items:
+                                                        type: string
+                                                      type: array
+                                                  required:
+                                                  - key
+                                                  - operator
+                                                  type: object
+                                                type: array
+                                              matchFields:
+                                                description: A list of node selector
+                                                  requirements by node's fields.
+                                                items:
+                                                  description: A node selector requirement
+                                                    is a selector that contains values,
+                                                    a key, and an operator that relates
+                                                    the key and values.
+                                                  properties:
+                                                    key:
+                                                      description: The label key that
+                                                        the selector applies to.
+                                                      type: string
+                                                    operator:
+                                                      description: Represents a key's
+                                                        relationship to a set of values.
+                                                        Valid operators are In, NotIn,
+                                                        Exists, DoesNotExist. Gt,
+                                                        and Lt.
+                                                      type: string
+                                                    values:
+                                                      description: An array of string
+                                                        values. If the operator is
+                                                        In or NotIn, the values array
+                                                        must be non-empty. If the
+                                                        operator is Exists or DoesNotExist,
+                                                        the values array must be empty.
+                                                        If the operator is Gt or Lt,
+                                                        the values array must have
+                                                        a single element, which will
+                                                        be interpreted as an integer.
+                                                        This array is replaced during
+                                                        a strategic merge patch.
+                                                      items:
+                                                        type: string
+                                                      type: array
+                                                  required:
+                                                  - key
+                                                  - operator
+                                                  type: object
+                                                type: array
+                                            type: object
+                                          type: array
+                                      required:
+                                      - nodeSelectorTerms
+                                      type: object
+                                  type: object
+                                podAffinity:
+                                  description: Describes pod affinity scheduling rules
+                                    (e.g. co-locate this pod in the same node, zone,
+                                    etc. as some other pod(s)).
+                                  properties:
+                                    preferredDuringSchedulingIgnoredDuringExecution:
+                                      description: The scheduler will prefer to schedule
+                                        pods to nodes that satisfy the affinity expressions
+                                        specified by this field, but it may choose
+                                        a node that violates one or more of the expressions.
+                                        The node that is most preferred is the one
+                                        with the greatest sum of weights, i.e. for
+                                        each node that meets all of the scheduling
+                                        requirements (resource request, requiredDuringScheduling
+                                        affinity expressions, etc.), compute a sum
+                                        by iterating through the elements of this
+                                        field and adding "weight" to the sum if the
+                                        node has pods which matches the corresponding
+                                        podAffinityTerm; the node(s) with the highest
+                                        sum are the most preferred.
+                                      items:
+                                        description: The weights of all of the matched
+                                          WeightedPodAffinityTerm fields are added
+                                          per-node to find the most preferred node(s)
+                                        properties:
+                                          podAffinityTerm:
+                                            description: Required. A pod affinity
+                                              term, associated with the corresponding
+                                              weight.
+                                            properties:
+                                              labelSelector:
+                                                description: A label query over a
+                                                  set of resources, in this case pods.
+                                                properties:
+                                                  matchExpressions:
+                                                    description: matchExpressions
+                                                      is a list of label selector
+                                                      requirements. The requirements
+                                                      are ANDed.
+                                                    items:
+                                                      description: A label selector
+                                                        requirement is a selector
+                                                        that contains values, a key,
+                                                        and an operator that relates
+                                                        the key and values.
+                                                      properties:
+                                                        key:
+                                                          description: key is the
+                                                            label key that the selector
+                                                            applies to.
+                                                          type: string
+                                                        operator:
+                                                          description: operator represents
+                                                            a key's relationship to
+                                                            a set of values. Valid
+                                                            operators are In, NotIn,
+                                                            Exists and DoesNotExist.
+                                                          type: string
+                                                        values:
+                                                          description: values is an
+                                                            array of string values.
+                                                            If the operator is In
+                                                            or NotIn, the values array
+                                                            must be non-empty. If
+                                                            the operator is Exists
+                                                            or DoesNotExist, the values
+                                                            array must be empty. This
+                                                            array is replaced during
+                                                            a strategic merge patch.
+                                                          items:
+                                                            type: string
+                                                          type: array
+                                                      required:
+                                                      - key
+                                                      - operator
+                                                      type: object
+                                                    type: array
+                                                  matchLabels:
+                                                    additionalProperties:
+                                                      type: string
+                                                    description: matchLabels is a
+                                                      map of {key,value} pairs. A
+                                                      single {key,value} in the matchLabels
+                                                      map is equivalent to an element
+                                                      of matchExpressions, whose key
+                                                      field is "key", the operator
+                                                      is "In", and the values array
+                                                      contains only "value". The requirements
+                                                      are ANDed.
+                                                    type: object
+                                                type: object
+                                              namespaces:
+                                                description: namespaces specifies
+                                                  which namespaces the labelSelector
+                                                  applies to (matches against); null
+                                                  or empty list means "this pod's
+                                                  namespace"
+                                                items:
+                                                  type: string
+                                                type: array
+                                              topologyKey:
+                                                description: This pod should be co-located
+                                                  (affinity) or not co-located (anti-affinity)
+                                                  with the pods matching the labelSelector
+                                                  in the specified namespaces, where
+                                                  co-located is defined as running
+                                                  on a node whose value of the label
+                                                  with key topologyKey matches that
+                                                  of any node on which any of the
+                                                  selected pods is running. Empty
+                                                  topologyKey is not allowed.
+                                                type: string
+                                            required:
+                                            - topologyKey
+                                            type: object
+                                          weight:
+                                            description: weight associated with matching
+                                              the corresponding podAffinityTerm, in
+                                              the range 1-100.
+                                            format: int32
+                                            type: integer
+                                        required:
+                                        - podAffinityTerm
+                                        - weight
+                                        type: object
+                                      type: array
+                                    requiredDuringSchedulingIgnoredDuringExecution:
+                                      description: If the affinity requirements specified
+                                        by this field are not met at scheduling time,
+                                        the pod will not be scheduled onto the node.
+                                        If the affinity requirements specified by
+                                        this field cease to be met at some point during
+                                        pod execution (e.g. due to a pod label update),
+                                        the system may or may not try to eventually
+                                        evict the pod from its node. When there are
+                                        multiple elements, the lists of nodes corresponding
+                                        to each podAffinityTerm are intersected, i.e.
+                                        all terms must be satisfied.
+                                      items:
+                                        description: Defines a set of pods (namely
+                                          those matching the labelSelector relative
+                                          to the given namespace(s)) that this pod
+                                          should be co-located (affinity) or not co-located
+                                          (anti-affinity) with, where co-located is
+                                          defined as running on a node whose value
+                                          of the label with key <topologyKey> matches
+                                          that of any node on which a pod of the set
+                                          of pods is running
+                                        properties:
+                                          labelSelector:
+                                            description: A label query over a set
+                                              of resources, in this case pods.
+                                            properties:
+                                              matchExpressions:
+                                                description: matchExpressions is a
+                                                  list of label selector requirements.
+                                                  The requirements are ANDed.
+                                                items:
+                                                  description: A label selector requirement
+                                                    is a selector that contains values,
+                                                    a key, and an operator that relates
+                                                    the key and values.
+                                                  properties:
+                                                    key:
+                                                      description: key is the label
+                                                        key that the selector applies
+                                                        to.
+                                                      type: string
+                                                    operator:
+                                                      description: operator represents
+                                                        a key's relationship to a
+                                                        set of values. Valid operators
+                                                        are In, NotIn, Exists and
+                                                        DoesNotExist.
+                                                      type: string
+                                                    values:
+                                                      description: values is an array
+                                                        of string values. If the operator
+                                                        is In or NotIn, the values
+                                                        array must be non-empty. If
+                                                        the operator is Exists or
+                                                        DoesNotExist, the values array
+                                                        must be empty. This array
+                                                        is replaced during a strategic
+                                                        merge patch.
+                                                      items:
+                                                        type: string
+                                                      type: array
+                                                  required:
+                                                  - key
+                                                  - operator
+                                                  type: object
+                                                type: array
+                                              matchLabels:
+                                                additionalProperties:
+                                                  type: string
+                                                description: matchLabels is a map
+                                                  of {key,value} pairs. A single {key,value}
+                                                  in the matchLabels map is equivalent
+                                                  to an element of matchExpressions,
+                                                  whose key field is "key", the operator
+                                                  is "In", and the values array contains
+                                                  only "value". The requirements are
+                                                  ANDed.
+                                                type: object
+                                            type: object
+                                          namespaces:
+                                            description: namespaces specifies which
+                                              namespaces the labelSelector applies
+                                              to (matches against); null or empty
+                                              list means "this pod's namespace"
+                                            items:
+                                              type: string
+                                            type: array
+                                          topologyKey:
+                                            description: This pod should be co-located
+                                              (affinity) or not co-located (anti-affinity)
+                                              with the pods matching the labelSelector
+                                              in the specified namespaces, where co-located
+                                              is defined as running on a node whose
+                                              value of the label with key topologyKey
+                                              matches that of any node on which any
+                                              of the selected pods is running. Empty
+                                              topologyKey is not allowed.
+                                            type: string
+                                        required:
+                                        - topologyKey
+                                        type: object
+                                      type: array
+                                  type: object
+                                podAntiAffinity:
+                                  description: Describes pod anti-affinity scheduling
+                                    rules (e.g. avoid putting this pod in the same
+                                    node, zone, etc. as some other pod(s)).
+                                  properties:
+                                    preferredDuringSchedulingIgnoredDuringExecution:
+                                      description: The scheduler will prefer to schedule
+                                        pods to nodes that satisfy the anti-affinity
+                                        expressions specified by this field, but it
+                                        may choose a node that violates one or more
+                                        of the expressions. The node that is most
+                                        preferred is the one with the greatest sum
+                                        of weights, i.e. for each node that meets
+                                        all of the scheduling requirements (resource
+                                        request, requiredDuringScheduling anti-affinity
+                                        expressions, etc.), compute a sum by iterating
+                                        through the elements of this field and adding
+                                        "weight" to the sum if the node has pods which
+                                        matches the corresponding podAffinityTerm;
+                                        the node(s) with the highest sum are the most
+                                        preferred.
+                                      items:
+                                        description: The weights of all of the matched
+                                          WeightedPodAffinityTerm fields are added
+                                          per-node to find the most preferred node(s)
+                                        properties:
+                                          podAffinityTerm:
+                                            description: Required. A pod affinity
+                                              term, associated with the corresponding
+                                              weight.
+                                            properties:
+                                              labelSelector:
+                                                description: A label query over a
+                                                  set of resources, in this case pods.
+                                                properties:
+                                                  matchExpressions:
+                                                    description: matchExpressions
+                                                      is a list of label selector
+                                                      requirements. The requirements
+                                                      are ANDed.
+                                                    items:
+                                                      description: A label selector
+                                                        requirement is a selector
+                                                        that contains values, a key,
+                                                        and an operator that relates
+                                                        the key and values.
+                                                      properties:
+                                                        key:
+                                                          description: key is the
+                                                            label key that the selector
+                                                            applies to.
+                                                          type: string
+                                                        operator:
+                                                          description: operator represents
+                                                            a key's relationship to
+                                                            a set of values. Valid
+                                                            operators are In, NotIn,
+                                                            Exists and DoesNotExist.
+                                                          type: string
+                                                        values:
+                                                          description: values is an
+                                                            array of string values.
+                                                            If the operator is In
+                                                            or NotIn, the values array
+                                                            must be non-empty. If
+                                                            the operator is Exists
+                                                            or DoesNotExist, the values
+                                                            array must be empty. This
+                                                            array is replaced during
+                                                            a strategic merge patch.
+                                                          items:
+                                                            type: string
+                                                          type: array
+                                                      required:
+                                                      - key
+                                                      - operator
+                                                      type: object
+                                                    type: array
+                                                  matchLabels:
+                                                    additionalProperties:
+                                                      type: string
+                                                    description: matchLabels is a
+                                                      map of {key,value} pairs. A
+                                                      single {key,value} in the matchLabels
+                                                      map is equivalent to an element
+                                                      of matchExpressions, whose key
+                                                      field is "key", the operator
+                                                      is "In", and the values array
+                                                      contains only "value". The requirements
+                                                      are ANDed.
+                                                    type: object
+                                                type: object
+                                              namespaces:
+                                                description: namespaces specifies
+                                                  which namespaces the labelSelector
+                                                  applies to (matches against); null
+                                                  or empty list means "this pod's
+                                                  namespace"
+                                                items:
+                                                  type: string
+                                                type: array
+                                              topologyKey:
+                                                description: This pod should be co-located
+                                                  (affinity) or not co-located (anti-affinity)
+                                                  with the pods matching the labelSelector
+                                                  in the specified namespaces, where
+                                                  co-located is defined as running
+                                                  on a node whose value of the label
+                                                  with key topologyKey matches that
+                                                  of any node on which any of the
+                                                  selected pods is running. Empty
+                                                  topologyKey is not allowed.
+                                                type: string
+                                            required:
+                                            - topologyKey
+                                            type: object
+                                          weight:
+                                            description: weight associated with matching
+                                              the corresponding podAffinityTerm, in
+                                              the range 1-100.
+                                            format: int32
+                                            type: integer
+                                        required:
+                                        - podAffinityTerm
+                                        - weight
+                                        type: object
+                                      type: array
+                                    requiredDuringSchedulingIgnoredDuringExecution:
+                                      description: If the anti-affinity requirements
+                                        specified by this field are not met at scheduling
+                                        time, the pod will not be scheduled onto the
+                                        node. If the anti-affinity requirements specified
+                                        by this field cease to be met at some point
+                                        during pod execution (e.g. due to a pod label
+                                        update), the system may or may not try to
+                                        eventually evict the pod from its node. When
+                                        there are multiple elements, the lists of
+                                        nodes corresponding to each podAffinityTerm
+                                        are intersected, i.e. all terms must be satisfied.
+                                      items:
+                                        description: Defines a set of pods (namely
+                                          those matching the labelSelector relative
+                                          to the given namespace(s)) that this pod
+                                          should be co-located (affinity) or not co-located
+                                          (anti-affinity) with, where co-located is
+                                          defined as running on a node whose value
+                                          of the label with key <topologyKey> matches
+                                          that of any node on which a pod of the set
+                                          of pods is running
+                                        properties:
+                                          labelSelector:
+                                            description: A label query over a set
+                                              of resources, in this case pods.
+                                            properties:
+                                              matchExpressions:
+                                                description: matchExpressions is a
+                                                  list of label selector requirements.
+                                                  The requirements are ANDed.
+                                                items:
+                                                  description: A label selector requirement
+                                                    is a selector that contains values,
+                                                    a key, and an operator that relates
+                                                    the key and values.
+                                                  properties:
+                                                    key:
+                                                      description: key is the label
+                                                        key that the selector applies
+                                                        to.
+                                                      type: string
+                                                    operator:
+                                                      description: operator represents
+                                                        a key's relationship to a
+                                                        set of values. Valid operators
+                                                        are In, NotIn, Exists and
+                                                        DoesNotExist.
+                                                      type: string
+                                                    values:
+                                                      description: values is an array
+                                                        of string values. If the operator
+                                                        is In or NotIn, the values
+                                                        array must be non-empty. If
+                                                        the operator is Exists or
+                                                        DoesNotExist, the values array
+                                                        must be empty. This array
+                                                        is replaced during a strategic
+                                                        merge patch.
+                                                      items:
+                                                        type: string
+                                                      type: array
+                                                  required:
+                                                  - key
+                                                  - operator
+                                                  type: object
+                                                type: array
+                                              matchLabels:
+                                                additionalProperties:
+                                                  type: string
+                                                description: matchLabels is a map
+                                                  of {key,value} pairs. A single {key,value}
+                                                  in the matchLabels map is equivalent
+                                                  to an element of matchExpressions,
+                                                  whose key field is "key", the operator
+                                                  is "In", and the values array contains
+                                                  only "value". The requirements are
+                                                  ANDed.
+                                                type: object
+                                            type: object
+                                          namespaces:
+                                            description: namespaces specifies which
+                                              namespaces the labelSelector applies
+                                              to (matches against); null or empty
+                                              list means "this pod's namespace"
+                                            items:
+                                              type: string
+                                            type: array
+                                          topologyKey:
+                                            description: This pod should be co-located
+                                              (affinity) or not co-located (anti-affinity)
+                                              with the pods matching the labelSelector
+                                              in the specified namespaces, where co-located
+                                              is defined as running on a node whose
+                                              value of the label with key topologyKey
+                                              matches that of any node on which any
+                                              of the selected pods is running. Empty
+                                              topologyKey is not allowed.
+                                            type: string
+                                        required:
+                                        - topologyKey
+                                        type: object
+                                      type: array
+                                  type: object
+                              type: object
+                            automountServiceAccountToken:
+                              description: AutomountServiceAccountToken indicates
+                                whether a service account token should be automatically
+                                mounted.
+                              type: boolean
+                            containers:
+                              description: List of containers belonging to the pod.
+                                Containers cannot currently be added or removed. There
+                                must be at least one container in a Pod. Cannot be
+                                updated.
+                              items:
+                                description: A single application container that you
+                                  want to run within a pod.
+                                properties:
+                                  args:
+                                    description: 'Arguments to the entrypoint. The
+                                      docker image''s CMD is used if this is not provided.
+                                      Variable references $(VAR_NAME) are expanded
+                                      using the container''s environment. If a variable
+                                      cannot be resolved, the reference in the input
+                                      string will be unchanged. The $(VAR_NAME) syntax
+                                      can be escaped with a double $$, ie: $$(VAR_NAME).
+                                      Escaped references will never be expanded, regardless
+                                      of whether the variable exists or not. Cannot
+                                      be updated. More info: https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell'
+                                    items:
+                                      type: string
+                                    type: array
+                                  command:
+                                    description: 'Entrypoint array. Not executed within
+                                      a shell. The docker image''s ENTRYPOINT is used
+                                      if this is not provided. Variable references
+                                      $(VAR_NAME) are expanded using the container''s
+                                      environment. If a variable cannot be resolved,
+                                      the reference in the input string will be unchanged.
+                                      The $(VAR_NAME) syntax can be escaped with a
+                                      double $$, ie: $$(VAR_NAME). Escaped references
+                                      will never be expanded, regardless of whether
+                                      the variable exists or not. Cannot be updated.
+                                      More info: https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell'
+                                    items:
+                                      type: string
+                                    type: array
+                                  env:
+                                    description: List of environment variables to
+                                      set in the container. Cannot be updated.
+                                    items:
+                                      description: EnvVar represents an environment
+                                        variable present in a Container.
+                                      properties:
+                                        name:
+                                          description: Name of the environment variable.
+                                            Must be a C_IDENTIFIER.
+                                          type: string
+                                        value:
+                                          description: 'Variable references $(VAR_NAME)
+                                            are expanded using the previous defined
+                                            environment variables in the container
+                                            and any service environment variables.
+                                            If a variable cannot be resolved, the
+                                            reference in the input string will be
+                                            unchanged. The $(VAR_NAME) syntax can
+                                            be escaped with a double $$, ie: $$(VAR_NAME).
+                                            Escaped references will never be expanded,
+                                            regardless of whether the variable exists
+                                            or not. Defaults to "".'
+                                          type: string
+                                        valueFrom:
+                                          description: Source for the environment
+                                            variable's value. Cannot be used if value
+                                            is not empty.
+                                          properties:
+                                            configMapKeyRef:
+                                              description: Selects a key of a ConfigMap.
+                                              properties:
+                                                key:
+                                                  description: The key to select.
+                                                  type: string
+                                                name:
+                                                  description: 'Name of the referent.
+                                                    More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                                    TODO: Add other useful fields.
+                                                    apiVersion, kind, uid?'
+                                                  type: string
+                                                optional:
+                                                  description: Specify whether the
+                                                    ConfigMap or its key must be defined
+                                                  type: boolean
+                                              required:
+                                              - key
+                                              type: object
+                                            fieldRef:
+                                              description: 'Selects a field of the
+                                                pod: supports metadata.name, metadata.namespace,
+                                                metadata.labels, metadata.annotations,
+                                                spec.nodeName, spec.serviceAccountName,
+                                                status.hostIP, status.podIP, status.podIPs.'
+                                              properties:
+                                                apiVersion:
+                                                  description: Version of the schema
+                                                    the FieldPath is written in terms
+                                                    of, defaults to "v1".
+                                                  type: string
+                                                fieldPath:
+                                                  description: Path of the field to
+                                                    select in the specified API version.
+                                                  type: string
+                                              required:
+                                              - fieldPath
+                                              type: object
+                                            resourceFieldRef:
+                                              description: 'Selects a resource of
+                                                the container: only resources limits
+                                                and requests (limits.cpu, limits.memory,
+                                                limits.ephemeral-storage, requests.cpu,
+                                                requests.memory and requests.ephemeral-storage)
+                                                are currently supported.'
+                                              properties:
+                                                containerName:
+                                                  description: 'Container name: required
+                                                    for volumes, optional for env
+                                                    vars'
+                                                  type: string
+                                                divisor:
+                                                  anyOf:
+                                                  - type: integer
+                                                  - type: string
+                                                  description: Specifies the output
+                                                    format of the exposed resources,
+                                                    defaults to "1"
+                                                  pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                                  x-kubernetes-int-or-string: true
+                                                resource:
+                                                  description: 'Required: resource
+                                                    to select'
+                                                  type: string
+                                              required:
+                                              - resource
+                                              type: object
+                                            secretKeyRef:
+                                              description: Selects a key of a secret
+                                                in the pod's namespace
+                                              properties:
+                                                key:
+                                                  description: The key of the secret
+                                                    to select from.  Must be a valid
+                                                    secret key.
+                                                  type: string
+                                                name:
+                                                  description: 'Name of the referent.
+                                                    More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                                    TODO: Add other useful fields.
+                                                    apiVersion, kind, uid?'
+                                                  type: string
+                                                optional:
+                                                  description: Specify whether the
+                                                    Secret or its key must be defined
+                                                  type: boolean
+                                              required:
+                                              - key
+                                              type: object
+                                          type: object
+                                      required:
+                                      - name
+                                      type: object
+                                    type: array
+                                  envFrom:
+                                    description: List of sources to populate environment
+                                      variables in the container. The keys defined
+                                      within a source must be a C_IDENTIFIER. All
+                                      invalid keys will be reported as an event when
+                                      the container is starting. When a key exists
+                                      in multiple sources, the value associated with
+                                      the last source will take precedence. Values
+                                      defined by an Env with a duplicate key will
+                                      take precedence. Cannot be updated.
+                                    items:
+                                      description: EnvFromSource represents the source
+                                        of a set of ConfigMaps
+                                      properties:
+                                        configMapRef:
+                                          description: The ConfigMap to select from
+                                          properties:
+                                            name:
+                                              description: 'Name of the referent.
+                                                More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                                TODO: Add other useful fields. apiVersion,
+                                                kind, uid?'
+                                              type: string
+                                            optional:
+                                              description: Specify whether the ConfigMap
+                                                must be defined
+                                              type: boolean
+                                          type: object
+                                        prefix:
+                                          description: An optional identifier to prepend
+                                            to each key in the ConfigMap. Must be
+                                            a C_IDENTIFIER.
+                                          type: string
+                                        secretRef:
+                                          description: The Secret to select from
+                                          properties:
+                                            name:
+                                              description: 'Name of the referent.
+                                                More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                                TODO: Add other useful fields. apiVersion,
+                                                kind, uid?'
+                                              type: string
+                                            optional:
+                                              description: Specify whether the Secret
+                                                must be defined
+                                              type: boolean
+                                          type: object
+                                      type: object
+                                    type: array
+                                  image:
+                                    description: 'Docker image name. More info: https://kubernetes.io/docs/concepts/containers/images
+                                      This field is optional to allow higher level
+                                      config management to default or override container
+                                      images in workload controllers like Deployments
+                                      and StatefulSets.'
+                                    type: string
+                                  imagePullPolicy:
+                                    description: 'Image pull policy. One of Always,
+                                      Never, IfNotPresent. Defaults to Always if :latest
+                                      tag is specified, or IfNotPresent otherwise.
+                                      Cannot be updated. More info: https://kubernetes.io/docs/concepts/containers/images#updating-images'
+                                    type: string
+                                  lifecycle:
+                                    description: Actions that the management system
+                                      should take in response to container lifecycle
+                                      events. Cannot be updated.
+                                    properties:
+                                      postStart:
+                                        description: 'PostStart is called immediately
+                                          after a container is created. If the handler
+                                          fails, the container is terminated and restarted
+                                          according to its restart policy. Other management
+                                          of the container blocks until the hook completes.
+                                          More info: https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/#container-hooks'
+                                        properties:
+                                          exec:
+                                            description: One and only one of the following
+                                              should be specified. Exec specifies
+                                              the action to take.
+                                            properties:
+                                              command:
+                                                description: Command is the command
+                                                  line to execute inside the container,
+                                                  the working directory for the command  is
+                                                  root ('/') in the container's filesystem.
+                                                  The command is simply exec'd, it
+                                                  is not run inside a shell, so traditional
+                                                  shell instructions ('|', etc) won't
+                                                  work. To use a shell, you need to
+                                                  explicitly call out to that shell.
+                                                  Exit status of 0 is treated as live/healthy
+                                                  and non-zero is unhealthy.
+                                                items:
+                                                  type: string
+                                                type: array
+                                            type: object
+                                          httpGet:
+                                            description: HTTPGet specifies the http
+                                              request to perform.
+                                            properties:
+                                              host:
+                                                description: Host name to connect
+                                                  to, defaults to the pod IP. You
+                                                  probably want to set "Host" in httpHeaders
+                                                  instead.
+                                                type: string
+                                              httpHeaders:
+                                                description: Custom headers to set
+                                                  in the request. HTTP allows repeated
+                                                  headers.
+                                                items:
+                                                  description: HTTPHeader describes
+                                                    a custom header to be used in
+                                                    HTTP probes
+                                                  properties:
+                                                    name:
+                                                      description: The header field
+                                                        name
+                                                      type: string
+                                                    value:
+                                                      description: The header field
+                                                        value
+                                                      type: string
+                                                  required:
+                                                  - name
+                                                  - value
+                                                  type: object
+                                                type: array
+                                              path:
+                                                description: Path to access on the
+                                                  HTTP server.
+                                                type: string
+                                              port:
+                                                description: Name or number of the
+                                                  port to access on the container.
+                                                  Number must be in the range 1 to
+                                                  65535. Name must be an IANA_SVC_NAME.
+                                                x-kubernetes-int-or-string: true
+                                              scheme:
+                                                description: Scheme to use for connecting
+                                                  to the host. Defaults to HTTP.
+                                                type: string
+                                            required:
+                                            - port
+                                            type: object
+                                          tcpSocket:
+                                            description: 'TCPSocket specifies an action
+                                              involving a TCP port. TCP hooks not
+                                              yet supported TODO: implement a realistic
+                                              TCP lifecycle hook'
+                                            properties:
+                                              host:
+                                                description: 'Optional: Host name
+                                                  to connect to, defaults to the pod
+                                                  IP.'
+                                                type: string
+                                              port:
+                                                description: Number or name of the
+                                                  port to access on the container.
+                                                  Number must be in the range 1 to
+                                                  65535. Name must be an IANA_SVC_NAME.
+                                                x-kubernetes-int-or-string: true
+                                            required:
+                                            - port
+                                            type: object
+                                        type: object
+                                      preStop:
+                                        description: 'PreStop is called immediately
+                                          before a container is terminated due to
+                                          an API request or management event such
+                                          as liveness/startup probe failure, preemption,
+                                          resource contention, etc. The handler is
+                                          not called if the container crashes or exits.
+                                          The reason for termination is passed to
+                                          the handler. The Pod''s termination grace
+                                          period countdown begins before the PreStop
+                                          hooked is executed. Regardless of the outcome
+                                          of the handler, the container will eventually
+                                          terminate within the Pod''s termination
+                                          grace period. Other management of the container
+                                          blocks until the hook completes or until
+                                          the termination grace period is reached.
+                                          More info: https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/#container-hooks'
+                                        properties:
+                                          exec:
+                                            description: One and only one of the following
+                                              should be specified. Exec specifies
+                                              the action to take.
+                                            properties:
+                                              command:
+                                                description: Command is the command
+                                                  line to execute inside the container,
+                                                  the working directory for the command  is
+                                                  root ('/') in the container's filesystem.
+                                                  The command is simply exec'd, it
+                                                  is not run inside a shell, so traditional
+                                                  shell instructions ('|', etc) won't
+                                                  work. To use a shell, you need to
+                                                  explicitly call out to that shell.
+                                                  Exit status of 0 is treated as live/healthy
+                                                  and non-zero is unhealthy.
+                                                items:
+                                                  type: string
+                                                type: array
+                                            type: object
+                                          httpGet:
+                                            description: HTTPGet specifies the http
+                                              request to perform.
+                                            properties:
+                                              host:
+                                                description: Host name to connect
+                                                  to, defaults to the pod IP. You
+                                                  probably want to set "Host" in httpHeaders
+                                                  instead.
+                                                type: string
+                                              httpHeaders:
+                                                description: Custom headers to set
+                                                  in the request. HTTP allows repeated
+                                                  headers.
+                                                items:
+                                                  description: HTTPHeader describes
+                                                    a custom header to be used in
+                                                    HTTP probes
+                                                  properties:
+                                                    name:
+                                                      description: The header field
+                                                        name
+                                                      type: string
+                                                    value:
+                                                      description: The header field
+                                                        value
+                                                      type: string
+                                                  required:
+                                                  - name
+                                                  - value
+                                                  type: object
+                                                type: array
+                                              path:
+                                                description: Path to access on the
+                                                  HTTP server.
+                                                type: string
+                                              port:
+                                                description: Name or number of the
+                                                  port to access on the container.
+                                                  Number must be in the range 1 to
+                                                  65535. Name must be an IANA_SVC_NAME.
+                                                x-kubernetes-int-or-string: true
+                                              scheme:
+                                                description: Scheme to use for connecting
+                                                  to the host. Defaults to HTTP.
+                                                type: string
+                                            required:
+                                            - port
+                                            type: object
+                                          tcpSocket:
+                                            description: 'TCPSocket specifies an action
+                                              involving a TCP port. TCP hooks not
+                                              yet supported TODO: implement a realistic
+                                              TCP lifecycle hook'
+                                            properties:
+                                              host:
+                                                description: 'Optional: Host name
+                                                  to connect to, defaults to the pod
+                                                  IP.'
+                                                type: string
+                                              port:
+                                                description: Number or name of the
+                                                  port to access on the container.
+                                                  Number must be in the range 1 to
+                                                  65535. Name must be an IANA_SVC_NAME.
+                                                x-kubernetes-int-or-string: true
+                                            required:
+                                            - port
+                                            type: object
+                                        type: object
+                                    type: object
+                                  livenessProbe:
+                                    description: 'Periodic probe of container liveness.
+                                      Container will be restarted if the probe fails.
+                                      Cannot be updated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                                    properties:
+                                      exec:
+                                        description: One and only one of the following
+                                          should be specified. Exec specifies the
+                                          action to take.
+                                        properties:
+                                          command:
+                                            description: Command is the command line
+                                              to execute inside the container, the
+                                              working directory for the command  is
+                                              root ('/') in the container's filesystem.
+                                              The command is simply exec'd, it is
+                                              not run inside a shell, so traditional
+                                              shell instructions ('|', etc) won't
+                                              work. To use a shell, you need to explicitly
+                                              call out to that shell. Exit status
+                                              of 0 is treated as live/healthy and
+                                              non-zero is unhealthy.
+                                            items:
+                                              type: string
+                                            type: array
+                                        type: object
+                                      failureThreshold:
+                                        description: Minimum consecutive failures
+                                          for the probe to be considered failed after
+                                          having succeeded. Defaults to 3. Minimum
+                                          value is 1.
+                                        format: int32
+                                        type: integer
+                                      httpGet:
+                                        description: HTTPGet specifies the http request
+                                          to perform.
+                                        properties:
+                                          host:
+                                            description: Host name to connect to,
+                                              defaults to the pod IP. You probably
+                                              want to set "Host" in httpHeaders instead.
+                                            type: string
+                                          httpHeaders:
+                                            description: Custom headers to set in
+                                              the request. HTTP allows repeated headers.
+                                            items:
+                                              description: HTTPHeader describes a
+                                                custom header to be used in HTTP probes
+                                              properties:
+                                                name:
+                                                  description: The header field name
+                                                  type: string
+                                                value:
+                                                  description: The header field value
+                                                  type: string
+                                              required:
+                                              - name
+                                              - value
+                                              type: object
+                                            type: array
+                                          path:
+                                            description: Path to access on the HTTP
+                                              server.
+                                            type: string
+                                          port:
+                                            description: Name or number of the port
+                                              to access on the container. Number must
+                                              be in the range 1 to 65535. Name must
+                                              be an IANA_SVC_NAME.
+                                            x-kubernetes-int-or-string: true
+                                          scheme:
+                                            description: Scheme to use for connecting
+                                              to the host. Defaults to HTTP.
+                                            type: string
+                                        required:
+                                        - port
+                                        type: object
+                                      initialDelaySeconds:
+                                        description: 'Number of seconds after the
+                                          container has started before liveness probes
+                                          are initiated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                                        format: int32
+                                        type: integer
+                                      periodSeconds:
+                                        description: How often (in seconds) to perform
+                                          the probe. Default to 10 seconds. Minimum
+                                          value is 1.
+                                        format: int32
+                                        type: integer
+                                      successThreshold:
+                                        description: Minimum consecutive successes
+                                          for the probe to be considered successful
+                                          after having failed. Defaults to 1. Must
+                                          be 1 for liveness and startup. Minimum value
+                                          is 1.
+                                        format: int32
+                                        type: integer
+                                      tcpSocket:
+                                        description: 'TCPSocket specifies an action
+                                          involving a TCP port. TCP hooks not yet
+                                          supported TODO: implement a realistic TCP
+                                          lifecycle hook'
+                                        properties:
+                                          host:
+                                            description: 'Optional: Host name to connect
+                                              to, defaults to the pod IP.'
+                                            type: string
+                                          port:
+                                            description: Number or name of the port
+                                              to access on the container. Number must
+                                              be in the range 1 to 65535. Name must
+                                              be an IANA_SVC_NAME.
+                                            x-kubernetes-int-or-string: true
+                                        required:
+                                        - port
+                                        type: object
+                                      timeoutSeconds:
+                                        description: 'Number of seconds after which
+                                          the probe times out. Defaults to 1 second.
+                                          Minimum value is 1. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                                        format: int32
+                                        type: integer
+                                    type: object
+                                  name:
+                                    description: Name of the container specified as
+                                      a DNS_LABEL. Each container in a pod must have
+                                      a unique name (DNS_LABEL). Cannot be updated.
+                                    type: string
+                                  ports:
+                                    description: List of ports to expose from the
+                                      container. Exposing a port here gives the system
+                                      additional information about the network connections
+                                      a container uses, but is primarily informational.
+                                      Not specifying a port here DOES NOT prevent
+                                      that port from being exposed. Any port which
+                                      is listening on the default "0.0.0.0" address
+                                      inside a container will be accessible from the
+                                      network. Cannot be updated.
+                                    items:
+                                      description: ContainerPort represents a network
+                                        port in a single container.
+                                      properties:
+                                        containerPort:
+                                          description: Number of port to expose on
+                                            the pod's IP address. This must be a valid
+                                            port number, 0 < x < 65536.
+                                          format: int32
+                                          type: integer
+                                        hostIP:
+                                          description: What host IP to bind the external
+                                            port to.
+                                          type: string
+                                        hostPort:
+                                          description: Number of port to expose on
+                                            the host. If specified, this must be a
+                                            valid port number, 0 < x < 65536. If HostNetwork
+                                            is specified, this must match ContainerPort.
+                                            Most containers do not need this.
+                                          format: int32
+                                          type: integer
+                                        name:
+                                          description: If specified, this must be
+                                            an IANA_SVC_NAME and unique within the
+                                            pod. Each named port in a pod must have
+                                            a unique name. Name for the port that
+                                            can be referred to by services.
+                                          type: string
+                                        protocol:
+                                          description: Protocol for port. Must be
+                                            UDP, TCP, or SCTP. Defaults to "TCP".
+                                          type: string
+                                      required:
+                                      - containerPort
+                                      type: object
+                                    type: array
+                                    x-kubernetes-list-map-keys:
+                                    - containerPort
+                                    - protocol
+                                    x-kubernetes-list-type: map
+                                  readinessProbe:
+                                    description: 'Periodic probe of container service
+                                      readiness. Container will be removed from service
+                                      endpoints if the probe fails. Cannot be updated.
+                                      More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                                    properties:
+                                      exec:
+                                        description: One and only one of the following
+                                          should be specified. Exec specifies the
+                                          action to take.
+                                        properties:
+                                          command:
+                                            description: Command is the command line
+                                              to execute inside the container, the
+                                              working directory for the command  is
+                                              root ('/') in the container's filesystem.
+                                              The command is simply exec'd, it is
+                                              not run inside a shell, so traditional
+                                              shell instructions ('|', etc) won't
+                                              work. To use a shell, you need to explicitly
+                                              call out to that shell. Exit status
+                                              of 0 is treated as live/healthy and
+                                              non-zero is unhealthy.
+                                            items:
+                                              type: string
+                                            type: array
+                                        type: object
+                                      failureThreshold:
+                                        description: Minimum consecutive failures
+                                          for the probe to be considered failed after
+                                          having succeeded. Defaults to 3. Minimum
+                                          value is 1.
+                                        format: int32
+                                        type: integer
+                                      httpGet:
+                                        description: HTTPGet specifies the http request
+                                          to perform.
+                                        properties:
+                                          host:
+                                            description: Host name to connect to,
+                                              defaults to the pod IP. You probably
+                                              want to set "Host" in httpHeaders instead.
+                                            type: string
+                                          httpHeaders:
+                                            description: Custom headers to set in
+                                              the request. HTTP allows repeated headers.
+                                            items:
+                                              description: HTTPHeader describes a
+                                                custom header to be used in HTTP probes
+                                              properties:
+                                                name:
+                                                  description: The header field name
+                                                  type: string
+                                                value:
+                                                  description: The header field value
+                                                  type: string
+                                              required:
+                                              - name
+                                              - value
+                                              type: object
+                                            type: array
+                                          path:
+                                            description: Path to access on the HTTP
+                                              server.
+                                            type: string
+                                          port:
+                                            description: Name or number of the port
+                                              to access on the container. Number must
+                                              be in the range 1 to 65535. Name must
+                                              be an IANA_SVC_NAME.
+                                            x-kubernetes-int-or-string: true
+                                          scheme:
+                                            description: Scheme to use for connecting
+                                              to the host. Defaults to HTTP.
+                                            type: string
+                                        required:
+                                        - port
+                                        type: object
+                                      initialDelaySeconds:
+                                        description: 'Number of seconds after the
+                                          container has started before liveness probes
+                                          are initiated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                                        format: int32
+                                        type: integer
+                                      periodSeconds:
+                                        description: How often (in seconds) to perform
+                                          the probe. Default to 10 seconds. Minimum
+                                          value is 1.
+                                        format: int32
+                                        type: integer
+                                      successThreshold:
+                                        description: Minimum consecutive successes
+                                          for the probe to be considered successful
+                                          after having failed. Defaults to 1. Must
+                                          be 1 for liveness and startup. Minimum value
+                                          is 1.
+                                        format: int32
+                                        type: integer
+                                      tcpSocket:
+                                        description: 'TCPSocket specifies an action
+                                          involving a TCP port. TCP hooks not yet
+                                          supported TODO: implement a realistic TCP
+                                          lifecycle hook'
+                                        properties:
+                                          host:
+                                            description: 'Optional: Host name to connect
+                                              to, defaults to the pod IP.'
+                                            type: string
+                                          port:
+                                            description: Number or name of the port
+                                              to access on the container. Number must
+                                              be in the range 1 to 65535. Name must
+                                              be an IANA_SVC_NAME.
+                                            x-kubernetes-int-or-string: true
+                                        required:
+                                        - port
+                                        type: object
+                                      timeoutSeconds:
+                                        description: 'Number of seconds after which
+                                          the probe times out. Defaults to 1 second.
+                                          Minimum value is 1. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                                        format: int32
+                                        type: integer
+                                    type: object
+                                  resources:
+                                    description: 'Compute Resources required by this
+                                      container. Cannot be updated. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
+                                    properties:
+                                      limits:
+                                        additionalProperties:
+                                          anyOf:
+                                          - type: integer
+                                          - type: string
+                                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                          x-kubernetes-int-or-string: true
+                                        description: 'Limits describes the maximum
+                                          amount of compute resources allowed. More
+                                          info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
+                                        type: object
+                                      requests:
+                                        additionalProperties:
+                                          anyOf:
+                                          - type: integer
+                                          - type: string
+                                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                          x-kubernetes-int-or-string: true
+                                        description: 'Requests describes the minimum
+                                          amount of compute resources required. If
+                                          Requests is omitted for a container, it
+                                          defaults to Limits if that is explicitly
+                                          specified, otherwise to an implementation-defined
+                                          value. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
+                                        type: object
+                                    type: object
+                                  securityContext:
+                                    description: 'Security options the pod should
+                                      run with. More info: https://kubernetes.io/docs/concepts/policy/security-context/
+                                      More info: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/'
+                                    properties:
+                                      allowPrivilegeEscalation:
+                                        description: 'AllowPrivilegeEscalation controls
+                                          whether a process can gain more privileges
+                                          than its parent process. This bool directly
+                                          controls if the no_new_privs flag will be
+                                          set on the container process. AllowPrivilegeEscalation
+                                          is true always when the container is: 1)
+                                          run as Privileged 2) has CAP_SYS_ADMIN'
+                                        type: boolean
+                                      capabilities:
+                                        description: The capabilities to add/drop
+                                          when running containers. Defaults to the
+                                          default set of capabilities granted by the
+                                          container runtime.
+                                        properties:
+                                          add:
+                                            description: Added capabilities
+                                            items:
+                                              description: Capability represent POSIX
+                                                capabilities type
+                                              type: string
+                                            type: array
+                                          drop:
+                                            description: Removed capabilities
+                                            items:
+                                              description: Capability represent POSIX
+                                                capabilities type
+                                              type: string
+                                            type: array
+                                        type: object
+                                      privileged:
+                                        description: Run container in privileged mode.
+                                          Processes in privileged containers are essentially
+                                          equivalent to root on the host. Defaults
+                                          to false.
+                                        type: boolean
+                                      procMount:
+                                        description: procMount denotes the type of
+                                          proc mount to use for the containers. The
+                                          default is DefaultProcMount which uses the
+                                          container runtime defaults for readonly
+                                          paths and masked paths. This requires the
+                                          ProcMountType feature flag to be enabled.
+                                        type: string
+                                      readOnlyRootFilesystem:
+                                        description: Whether this container has a
+                                          read-only root filesystem. Default is false.
+                                        type: boolean
+                                      runAsGroup:
+                                        description: The GID to run the entrypoint
+                                          of the container process. Uses runtime default
+                                          if unset. May also be set in PodSecurityContext.  If
+                                          set in both SecurityContext and PodSecurityContext,
+                                          the value specified in SecurityContext takes
+                                          precedence.
+                                        format: int64
+                                        type: integer
+                                      runAsNonRoot:
+                                        description: Indicates that the container
+                                          must run as a non-root user. If true, the
+                                          Kubelet will validate the image at runtime
+                                          to ensure that it does not run as UID 0
+                                          (root) and fail to start the container if
+                                          it does. If unset or false, no such validation
+                                          will be performed. May also be set in PodSecurityContext.  If
+                                          set in both SecurityContext and PodSecurityContext,
+                                          the value specified in SecurityContext takes
+                                          precedence.
+                                        type: boolean
+                                      runAsUser:
+                                        description: The UID to run the entrypoint
+                                          of the container process. Defaults to user
+                                          specified in image metadata if unspecified.
+                                          May also be set in PodSecurityContext.  If
+                                          set in both SecurityContext and PodSecurityContext,
+                                          the value specified in SecurityContext takes
+                                          precedence.
+                                        format: int64
+                                        type: integer
+                                      seLinuxOptions:
+                                        description: The SELinux context to be applied
+                                          to the container. If unspecified, the container
+                                          runtime will allocate a random SELinux context
+                                          for each container.  May also be set in
+                                          PodSecurityContext.  If set in both SecurityContext
+                                          and PodSecurityContext, the value specified
+                                          in SecurityContext takes precedence.
+                                        properties:
+                                          level:
+                                            description: Level is SELinux level label
+                                              that applies to the container.
+                                            type: string
+                                          role:
+                                            description: Role is a SELinux role label
+                                              that applies to the container.
+                                            type: string
+                                          type:
+                                            description: Type is a SELinux type label
+                                              that applies to the container.
+                                            type: string
+                                          user:
+                                            description: User is a SELinux user label
+                                              that applies to the container.
+                                            type: string
+                                        type: object
+                                      windowsOptions:
+                                        description: The Windows specific settings
+                                          applied to all containers. If unspecified,
+                                          the options from the PodSecurityContext
+                                          will be used. If set in both SecurityContext
+                                          and PodSecurityContext, the value specified
+                                          in SecurityContext takes precedence.
+                                        properties:
+                                          gmsaCredentialSpec:
+                                            description: GMSACredentialSpec is where
+                                              the GMSA admission webhook (https://github.com/kubernetes-sigs/windows-gmsa)
+                                              inlines the contents of the GMSA credential
+                                              spec named by the GMSACredentialSpecName
+                                              field. This field is alpha-level and
+                                              is only honored by servers that enable
+                                              the WindowsGMSA feature flag.
+                                            type: string
+                                          gmsaCredentialSpecName:
+                                            description: GMSACredentialSpecName is
+                                              the name of the GMSA credential spec
+                                              to use. This field is alpha-level and
+                                              is only honored by servers that enable
+                                              the WindowsGMSA feature flag.
+                                            type: string
+                                          runAsUserName:
+                                            description: The UserName in Windows to
+                                              run the entrypoint of the container
+                                              process. Defaults to the user specified
+                                              in image metadata if unspecified. May
+                                              also be set in PodSecurityContext. If
+                                              set in both SecurityContext and PodSecurityContext,
+                                              the value specified in SecurityContext
+                                              takes precedence. This field is beta-level
+                                              and may be disabled with the WindowsRunAsUserName
+                                              feature flag.
+                                            type: string
+                                        type: object
+                                    type: object
+                                  startupProbe:
+                                    description: 'StartupProbe indicates that the
+                                      Pod has successfully initialized. If specified,
+                                      no other probes are executed until this completes
+                                      successfully. If this probe fails, the Pod will
+                                      be restarted, just as if the livenessProbe failed.
+                                      This can be used to provide different probe
+                                      parameters at the beginning of a Pod''s lifecycle,
+                                      when it might take a long time to load data
+                                      or warm a cache, than during steady-state operation.
+                                      This cannot be updated. This is an alpha feature
+                                      enabled by the StartupProbe feature flag. More
+                                      info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                                    properties:
+                                      exec:
+                                        description: One and only one of the following
+                                          should be specified. Exec specifies the
+                                          action to take.
+                                        properties:
+                                          command:
+                                            description: Command is the command line
+                                              to execute inside the container, the
+                                              working directory for the command  is
+                                              root ('/') in the container's filesystem.
+                                              The command is simply exec'd, it is
+                                              not run inside a shell, so traditional
+                                              shell instructions ('|', etc) won't
+                                              work. To use a shell, you need to explicitly
+                                              call out to that shell. Exit status
+                                              of 0 is treated as live/healthy and
+                                              non-zero is unhealthy.
+                                            items:
+                                              type: string
+                                            type: array
+                                        type: object
+                                      failureThreshold:
+                                        description: Minimum consecutive failures
+                                          for the probe to be considered failed after
+                                          having succeeded. Defaults to 3. Minimum
+                                          value is 1.
+                                        format: int32
+                                        type: integer
+                                      httpGet:
+                                        description: HTTPGet specifies the http request
+                                          to perform.
+                                        properties:
+                                          host:
+                                            description: Host name to connect to,
+                                              defaults to the pod IP. You probably
+                                              want to set "Host" in httpHeaders instead.
+                                            type: string
+                                          httpHeaders:
+                                            description: Custom headers to set in
+                                              the request. HTTP allows repeated headers.
+                                            items:
+                                              description: HTTPHeader describes a
+                                                custom header to be used in HTTP probes
+                                              properties:
+                                                name:
+                                                  description: The header field name
+                                                  type: string
+                                                value:
+                                                  description: The header field value
+                                                  type: string
+                                              required:
+                                              - name
+                                              - value
+                                              type: object
+                                            type: array
+                                          path:
+                                            description: Path to access on the HTTP
+                                              server.
+                                            type: string
+                                          port:
+                                            anyOf:
+                                            - type: integer
+                                            - type: string
+                                            description: Name or number of the port
+                                              to access on the container. Number must
+                                              be in the range 1 to 65535. Name must
+                                              be an IANA_SVC_NAME.
+                                            x-kubernetes-int-or-string: true
+                                          scheme:
+                                            description: Scheme to use for connecting
+                                              to the host. Defaults to HTTP.
+                                            type: string
+                                        required:
+                                        - port
+                                        type: object
+                                      initialDelaySeconds:
+                                        description: 'Number of seconds after the
+                                          container has started before liveness probes
+                                          are initiated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                                        format: int32
+                                        type: integer
+                                      periodSeconds:
+                                        description: How often (in seconds) to perform
+                                          the probe. Default to 10 seconds. Minimum
+                                          value is 1.
+                                        format: int32
+                                        type: integer
+                                      successThreshold:
+                                        description: Minimum consecutive successes
+                                          for the probe to be considered successful
+                                          after having failed. Defaults to 1. Must
+                                          be 1 for liveness and startup. Minimum value
+                                          is 1.
+                                        format: int32
+                                        type: integer
+                                      tcpSocket:
+                                        description: 'TCPSocket specifies an action
+                                          involving a TCP port. TCP hooks not yet
+                                          supported TODO: implement a realistic TCP
+                                          lifecycle hook'
+                                        properties:
+                                          host:
+                                            description: 'Optional: Host name to connect
+                                              to, defaults to the pod IP.'
+                                            type: string
+                                          port:
+                                            anyOf:
+                                            - type: integer
+                                            - type: string
+                                            description: Number or name of the port
+                                              to access on the container. Number must
+                                              be in the range 1 to 65535. Name must
+                                              be an IANA_SVC_NAME.
+                                            x-kubernetes-int-or-string: true
+                                        required:
+                                        - port
+                                        type: object
+                                      timeoutSeconds:
+                                        description: 'Number of seconds after which
+                                          the probe times out. Defaults to 1 second.
+                                          Minimum value is 1. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                                        format: int32
+                                        type: integer
+                                    type: object
+                                  stdin:
+                                    description: Whether this container should allocate
+                                      a buffer for stdin in the container runtime.
+                                      If this is not set, reads from stdin in the
+                                      container will always result in EOF. Default
+                                      is false.
+                                    type: boolean
+                                  stdinOnce:
+                                    description: Whether the container runtime should
+                                      close the stdin channel after it has been opened
+                                      by a single attach. When stdin is true the stdin
+                                      stream will remain open across multiple attach
+                                      sessions. If stdinOnce is set to true, stdin
+                                      is opened on container start, is empty until
+                                      the first client attaches to stdin, and then
+                                      remains open and accepts data until the client
+                                      disconnects, at which time stdin is closed and
+                                      remains closed until the container is restarted.
+                                      If this flag is false, a container processes
+                                      that reads from stdin will never receive an
+                                      EOF. Default is false
+                                    type: boolean
+                                  terminationMessagePath:
+                                    description: 'Optional: Path at which the file
+                                      to which the container''s termination message
+                                      will be written is mounted into the container''s
+                                      filesystem. Message written is intended to be
+                                      brief final status, such as an assertion failure
+                                      message. Will be truncated by the node if greater
+                                      than 4096 bytes. The total message length across
+                                      all containers will be limited to 12kb. Defaults
+                                      to /dev/termination-log. Cannot be updated.'
+                                    type: string
+                                  terminationMessagePolicy:
+                                    description: Indicate how the termination message
+                                      should be populated. File will use the contents
+                                      of terminationMessagePath to populate the container
+                                      status message on both success and failure.
+                                      FallbackToLogsOnError will use the last chunk
+                                      of container log output if the termination message
+                                      file is empty and the container exited with
+                                      an error. The log output is limited to 2048
+                                      bytes or 80 lines, whichever is smaller. Defaults
+                                      to File. Cannot be updated.
+                                    type: string
+                                  tty:
+                                    description: Whether this container should allocate
+                                      a TTY for itself, also requires 'stdin' to be
+                                      true. Default is false.
+                                    type: boolean
+                                  volumeDevices:
+                                    description: volumeDevices is the list of block
+                                      devices to be used by the container. This is
+                                      a beta feature.
+                                    items:
+                                      description: volumeDevice describes a mapping
+                                        of a raw block device within a container.
+                                      properties:
+                                        devicePath:
+                                          description: devicePath is the path inside
+                                            of the container that the device will
+                                            be mapped to.
+                                          type: string
+                                        name:
+                                          description: name must match the name of
+                                            a persistentVolumeClaim in the pod
+                                          type: string
+                                      required:
+                                      - devicePath
+                                      - name
+                                      type: object
+                                    type: array
+                                  volumeMounts:
+                                    description: Pod volumes to mount into the container's
+                                      filesystem. Cannot be updated.
+                                    items:
+                                      description: VolumeMount describes a mounting
+                                        of a Volume within a container.
+                                      properties:
+                                        mountPath:
+                                          description: Path within the container at
+                                            which the volume should be mounted.  Must
+                                            not contain ':'.
+                                          type: string
+                                        mountPropagation:
+                                          description: mountPropagation determines
+                                            how mounts are propagated from the host
+                                            to container and the other way around.
+                                            When not set, MountPropagationNone is
+                                            used. This field is beta in 1.10.
+                                          type: string
+                                        name:
+                                          description: This must match the Name of
+                                            a Volume.
+                                          type: string
+                                        readOnly:
+                                          description: Mounted read-only if true,
+                                            read-write otherwise (false or unspecified).
+                                            Defaults to false.
+                                          type: boolean
+                                        subPath:
+                                          description: Path within the volume from
+                                            which the container's volume should be
+                                            mounted. Defaults to "" (volume's root).
+                                          type: string
+                                        subPathExpr:
+                                          description: Expanded path within the volume
+                                            from which the container's volume should
+                                            be mounted. Behaves similarly to SubPath
+                                            but environment variable references $(VAR_NAME)
+                                            are expanded using the container's environment.
+                                            Defaults to "" (volume's root). SubPathExpr
+                                            and SubPath are mutually exclusive.
+                                          type: string
+                                      required:
+                                      - mountPath
+                                      - name
+                                      type: object
+                                    type: array
+                                  workingDir:
+                                    description: Container's working directory. If
+                                      not specified, the container runtime's default
+                                      will be used, which might be configured in the
+                                      container image. Cannot be updated.
+                                    type: string
+                                required:
+                                - name
+                                type: object
+                              type: array
+                            dnsConfig:
+                              description: Specifies the DNS parameters of a pod.
+                                Parameters specified here will be merged to the generated
+                                DNS configuration based on DNSPolicy.
+                              properties:
+                                nameservers:
+                                  description: A list of DNS name server IP addresses.
+                                    This will be appended to the base nameservers
+                                    generated from DNSPolicy. Duplicated nameservers
+                                    will be removed.
+                                  items:
+                                    type: string
+                                  type: array
+                                options:
+                                  description: A list of DNS resolver options. This
+                                    will be merged with the base options generated
+                                    from DNSPolicy. Duplicated entries will be removed.
+                                    Resolution options given in Options will override
+                                    those that appear in the base DNSPolicy.
+                                  items:
+                                    description: PodDNSConfigOption defines DNS resolver
+                                      options of a pod.
+                                    properties:
+                                      name:
+                                        description: Required.
+                                        type: string
+                                      value:
+                                        type: string
+                                    type: object
+                                  type: array
+                                searches:
+                                  description: A list of DNS search domains for host-name
+                                    lookup. This will be appended to the base search
+                                    paths generated from DNSPolicy. Duplicated search
+                                    paths will be removed.
+                                  items:
+                                    type: string
+                                  type: array
+                              type: object
+                            dnsPolicy:
+                              description: Set DNS policy for the pod. Defaults to
+                                "ClusterFirst". Valid values are 'ClusterFirstWithHostNet',
+                                'ClusterFirst', 'Default' or 'None'. DNS parameters
+                                given in DNSConfig will be merged with the policy
+                                selected with DNSPolicy. To have DNS options set along
+                                with hostNetwork, you have to specify DNS policy explicitly
+                                to 'ClusterFirstWithHostNet'.
+                              type: string
+                            enableServiceLinks:
+                              description: 'EnableServiceLinks indicates whether information
+                                about services should be injected into pod''s environment
+                                variables, matching the syntax of Docker links. Optional:
+                                Defaults to true.'
+                              type: boolean
+                            ephemeralContainers:
+                              description: List of ephemeral containers run in this
+                                pod. Ephemeral containers may be run in an existing
+                                pod to perform user-initiated actions such as debugging.
+                                This list cannot be specified when creating a pod,
+                                and it cannot be modified by updating the pod spec.
+                                In order to add an ephemeral container to an existing
+                                pod, use the pod's ephemeralcontainers subresource.
+                                This field is alpha-level and is only honored by servers
+                                that enable the EphemeralContainers feature.
+                              items:
+                                description: An EphemeralContainer is a container
+                                  that may be added temporarily to an existing pod
+                                  for user-initiated activities such as debugging.
+                                  Ephemeral containers have no resource or scheduling
+                                  guarantees, and they will not be restarted when
+                                  they exit or when a pod is removed or restarted.
+                                  If an ephemeral container causes a pod to exceed
+                                  its resource allocation, the pod may be evicted.
+                                  Ephemeral containers may not be added by directly
+                                  updating the pod spec. They must be added via the
+                                  pod's ephemeralcontainers subresource, and they
+                                  will appear in the pod spec once added. This is
+                                  an alpha feature enabled by the EphemeralContainers
+                                  feature flag.
+                                properties:
+                                  args:
+                                    description: 'Arguments to the entrypoint. The
+                                      docker image''s CMD is used if this is not provided.
+                                      Variable references $(VAR_NAME) are expanded
+                                      using the container''s environment. If a variable
+                                      cannot be resolved, the reference in the input
+                                      string will be unchanged. The $(VAR_NAME) syntax
+                                      can be escaped with a double $$, ie: $$(VAR_NAME).
+                                      Escaped references will never be expanded, regardless
+                                      of whether the variable exists or not. Cannot
+                                      be updated. More info: https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell'
+                                    items:
+                                      type: string
+                                    type: array
+                                  command:
+                                    description: 'Entrypoint array. Not executed within
+                                      a shell. The docker image''s ENTRYPOINT is used
+                                      if this is not provided. Variable references
+                                      $(VAR_NAME) are expanded using the container''s
+                                      environment. If a variable cannot be resolved,
+                                      the reference in the input string will be unchanged.
+                                      The $(VAR_NAME) syntax can be escaped with a
+                                      double $$, ie: $$(VAR_NAME). Escaped references
+                                      will never be expanded, regardless of whether
+                                      the variable exists or not. Cannot be updated.
+                                      More info: https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell'
+                                    items:
+                                      type: string
+                                    type: array
+                                  env:
+                                    description: List of environment variables to
+                                      set in the container. Cannot be updated.
+                                    items:
+                                      description: EnvVar represents an environment
+                                        variable present in a Container.
+                                      properties:
+                                        name:
+                                          description: Name of the environment variable.
+                                            Must be a C_IDENTIFIER.
+                                          type: string
+                                        value:
+                                          description: 'Variable references $(VAR_NAME)
+                                            are expanded using the previous defined
+                                            environment variables in the container
+                                            and any service environment variables.
+                                            If a variable cannot be resolved, the
+                                            reference in the input string will be
+                                            unchanged. The $(VAR_NAME) syntax can
+                                            be escaped with a double $$, ie: $$(VAR_NAME).
+                                            Escaped references will never be expanded,
+                                            regardless of whether the variable exists
+                                            or not. Defaults to "".'
+                                          type: string
+                                        valueFrom:
+                                          description: Source for the environment
+                                            variable's value. Cannot be used if value
+                                            is not empty.
+                                          properties:
+                                            configMapKeyRef:
+                                              description: Selects a key of a ConfigMap.
+                                              properties:
+                                                key:
+                                                  description: The key to select.
+                                                  type: string
+                                                name:
+                                                  description: 'Name of the referent.
+                                                    More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                                    TODO: Add other useful fields.
+                                                    apiVersion, kind, uid?'
+                                                  type: string
+                                                optional:
+                                                  description: Specify whether the
+                                                    ConfigMap or its key must be defined
+                                                  type: boolean
+                                              required:
+                                              - key
+                                              type: object
+                                            fieldRef:
+                                              description: 'Selects a field of the
+                                                pod: supports metadata.name, metadata.namespace,
+                                                metadata.labels, metadata.annotations,
+                                                spec.nodeName, spec.serviceAccountName,
+                                                status.hostIP, status.podIP, status.podIPs.'
+                                              properties:
+                                                apiVersion:
+                                                  description: Version of the schema
+                                                    the FieldPath is written in terms
+                                                    of, defaults to "v1".
+                                                  type: string
+                                                fieldPath:
+                                                  description: Path of the field to
+                                                    select in the specified API version.
+                                                  type: string
+                                              required:
+                                              - fieldPath
+                                              type: object
+                                            resourceFieldRef:
+                                              description: 'Selects a resource of
+                                                the container: only resources limits
+                                                and requests (limits.cpu, limits.memory,
+                                                limits.ephemeral-storage, requests.cpu,
+                                                requests.memory and requests.ephemeral-storage)
+                                                are currently supported.'
+                                              properties:
+                                                containerName:
+                                                  description: 'Container name: required
+                                                    for volumes, optional for env
+                                                    vars'
+                                                  type: string
+                                                divisor:
+                                                  anyOf:
+                                                  - type: integer
+                                                  - type: string
+                                                  description: Specifies the output
+                                                    format of the exposed resources,
+                                                    defaults to "1"
+                                                  pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                                  x-kubernetes-int-or-string: true
+                                                resource:
+                                                  description: 'Required: resource
+                                                    to select'
+                                                  type: string
+                                              required:
+                                              - resource
+                                              type: object
+                                            secretKeyRef:
+                                              description: Selects a key of a secret
+                                                in the pod's namespace
+                                              properties:
+                                                key:
+                                                  description: The key of the secret
+                                                    to select from.  Must be a valid
+                                                    secret key.
+                                                  type: string
+                                                name:
+                                                  description: 'Name of the referent.
+                                                    More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                                    TODO: Add other useful fields.
+                                                    apiVersion, kind, uid?'
+                                                  type: string
+                                                optional:
+                                                  description: Specify whether the
+                                                    Secret or its key must be defined
+                                                  type: boolean
+                                              required:
+                                              - key
+                                              type: object
+                                          type: object
+                                      required:
+                                      - name
+                                      type: object
+                                    type: array
+                                  envFrom:
+                                    description: List of sources to populate environment
+                                      variables in the container. The keys defined
+                                      within a source must be a C_IDENTIFIER. All
+                                      invalid keys will be reported as an event when
+                                      the container is starting. When a key exists
+                                      in multiple sources, the value associated with
+                                      the last source will take precedence. Values
+                                      defined by an Env with a duplicate key will
+                                      take precedence. Cannot be updated.
+                                    items:
+                                      description: EnvFromSource represents the source
+                                        of a set of ConfigMaps
+                                      properties:
+                                        configMapRef:
+                                          description: The ConfigMap to select from
+                                          properties:
+                                            name:
+                                              description: 'Name of the referent.
+                                                More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                                TODO: Add other useful fields. apiVersion,
+                                                kind, uid?'
+                                              type: string
+                                            optional:
+                                              description: Specify whether the ConfigMap
+                                                must be defined
+                                              type: boolean
+                                          type: object
+                                        prefix:
+                                          description: An optional identifier to prepend
+                                            to each key in the ConfigMap. Must be
+                                            a C_IDENTIFIER.
+                                          type: string
+                                        secretRef:
+                                          description: The Secret to select from
+                                          properties:
+                                            name:
+                                              description: 'Name of the referent.
+                                                More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                                TODO: Add other useful fields. apiVersion,
+                                                kind, uid?'
+                                              type: string
+                                            optional:
+                                              description: Specify whether the Secret
+                                                must be defined
+                                              type: boolean
+                                          type: object
+                                      type: object
+                                    type: array
+                                  image:
+                                    description: 'Docker image name. More info: https://kubernetes.io/docs/concepts/containers/images'
+                                    type: string
+                                  imagePullPolicy:
+                                    description: 'Image pull policy. One of Always,
+                                      Never, IfNotPresent. Defaults to Always if :latest
+                                      tag is specified, or IfNotPresent otherwise.
+                                      Cannot be updated. More info: https://kubernetes.io/docs/concepts/containers/images#updating-images'
+                                    type: string
+                                  lifecycle:
+                                    description: Lifecycle is not allowed for ephemeral
+                                      containers.
+                                    properties:
+                                      postStart:
+                                        description: 'PostStart is called immediately
+                                          after a container is created. If the handler
+                                          fails, the container is terminated and restarted
+                                          according to its restart policy. Other management
+                                          of the container blocks until the hook completes.
+                                          More info: https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/#container-hooks'
+                                        properties:
+                                          exec:
+                                            description: One and only one of the following
+                                              should be specified. Exec specifies
+                                              the action to take.
+                                            properties:
+                                              command:
+                                                description: Command is the command
+                                                  line to execute inside the container,
+                                                  the working directory for the command  is
+                                                  root ('/') in the container's filesystem.
+                                                  The command is simply exec'd, it
+                                                  is not run inside a shell, so traditional
+                                                  shell instructions ('|', etc) won't
+                                                  work. To use a shell, you need to
+                                                  explicitly call out to that shell.
+                                                  Exit status of 0 is treated as live/healthy
+                                                  and non-zero is unhealthy.
+                                                items:
+                                                  type: string
+                                                type: array
+                                            type: object
+                                          httpGet:
+                                            description: HTTPGet specifies the http
+                                              request to perform.
+                                            properties:
+                                              host:
+                                                description: Host name to connect
+                                                  to, defaults to the pod IP. You
+                                                  probably want to set "Host" in httpHeaders
+                                                  instead.
+                                                type: string
+                                              httpHeaders:
+                                                description: Custom headers to set
+                                                  in the request. HTTP allows repeated
+                                                  headers.
+                                                items:
+                                                  description: HTTPHeader describes
+                                                    a custom header to be used in
+                                                    HTTP probes
+                                                  properties:
+                                                    name:
+                                                      description: The header field
+                                                        name
+                                                      type: string
+                                                    value:
+                                                      description: The header field
+                                                        value
+                                                      type: string
+                                                  required:
+                                                  - name
+                                                  - value
+                                                  type: object
+                                                type: array
+                                              path:
+                                                description: Path to access on the
+                                                  HTTP server.
+                                                type: string
+                                              port:
+                                                anyOf:
+                                                - type: integer
+                                                - type: string
+                                                description: Name or number of the
+                                                  port to access on the container.
+                                                  Number must be in the range 1 to
+                                                  65535. Name must be an IANA_SVC_NAME.
+                                                x-kubernetes-int-or-string: true
+                                              scheme:
+                                                description: Scheme to use for connecting
+                                                  to the host. Defaults to HTTP.
+                                                type: string
+                                            required:
+                                            - port
+                                            type: object
+                                          tcpSocket:
+                                            description: 'TCPSocket specifies an action
+                                              involving a TCP port. TCP hooks not
+                                              yet supported TODO: implement a realistic
+                                              TCP lifecycle hook'
+                                            properties:
+                                              host:
+                                                description: 'Optional: Host name
+                                                  to connect to, defaults to the pod
+                                                  IP.'
+                                                type: string
+                                              port:
+                                                anyOf:
+                                                - type: integer
+                                                - type: string
+                                                description: Number or name of the
+                                                  port to access on the container.
+                                                  Number must be in the range 1 to
+                                                  65535. Name must be an IANA_SVC_NAME.
+                                                x-kubernetes-int-or-string: true
+                                            required:
+                                            - port
+                                            type: object
+                                        type: object
+                                      preStop:
+                                        description: 'PreStop is called immediately
+                                          before a container is terminated due to
+                                          an API request or management event such
+                                          as liveness/startup probe failure, preemption,
+                                          resource contention, etc. The handler is
+                                          not called if the container crashes or exits.
+                                          The reason for termination is passed to
+                                          the handler. The Pod''s termination grace
+                                          period countdown begins before the PreStop
+                                          hooked is executed. Regardless of the outcome
+                                          of the handler, the container will eventually
+                                          terminate within the Pod''s termination
+                                          grace period. Other management of the container
+                                          blocks until the hook completes or until
+                                          the termination grace period is reached.
+                                          More info: https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/#container-hooks'
+                                        properties:
+                                          exec:
+                                            description: One and only one of the following
+                                              should be specified. Exec specifies
+                                              the action to take.
+                                            properties:
+                                              command:
+                                                description: Command is the command
+                                                  line to execute inside the container,
+                                                  the working directory for the command  is
+                                                  root ('/') in the container's filesystem.
+                                                  The command is simply exec'd, it
+                                                  is not run inside a shell, so traditional
+                                                  shell instructions ('|', etc) won't
+                                                  work. To use a shell, you need to
+                                                  explicitly call out to that shell.
+                                                  Exit status of 0 is treated as live/healthy
+                                                  and non-zero is unhealthy.
+                                                items:
+                                                  type: string
+                                                type: array
+                                            type: object
+                                          httpGet:
+                                            description: HTTPGet specifies the http
+                                              request to perform.
+                                            properties:
+                                              host:
+                                                description: Host name to connect
+                                                  to, defaults to the pod IP. You
+                                                  probably want to set "Host" in httpHeaders
+                                                  instead.
+                                                type: string
+                                              httpHeaders:
+                                                description: Custom headers to set
+                                                  in the request. HTTP allows repeated
+                                                  headers.
+                                                items:
+                                                  description: HTTPHeader describes
+                                                    a custom header to be used in
+                                                    HTTP probes
+                                                  properties:
+                                                    name:
+                                                      description: The header field
+                                                        name
+                                                      type: string
+                                                    value:
+                                                      description: The header field
+                                                        value
+                                                      type: string
+                                                  required:
+                                                  - name
+                                                  - value
+                                                  type: object
+                                                type: array
+                                              path:
+                                                description: Path to access on the
+                                                  HTTP server.
+                                                type: string
+                                              port:
+                                                anyOf:
+                                                - type: integer
+                                                - type: string
+                                                description: Name or number of the
+                                                  port to access on the container.
+                                                  Number must be in the range 1 to
+                                                  65535. Name must be an IANA_SVC_NAME.
+                                                x-kubernetes-int-or-string: true
+                                              scheme:
+                                                description: Scheme to use for connecting
+                                                  to the host. Defaults to HTTP.
+                                                type: string
+                                            required:
+                                            - port
+                                            type: object
+                                          tcpSocket:
+                                            description: 'TCPSocket specifies an action
+                                              involving a TCP port. TCP hooks not
+                                              yet supported TODO: implement a realistic
+                                              TCP lifecycle hook'
+                                            properties:
+                                              host:
+                                                description: 'Optional: Host name
+                                                  to connect to, defaults to the pod
+                                                  IP.'
+                                                type: string
+                                              port:
+                                                anyOf:
+                                                - type: integer
+                                                - type: string
+                                                description: Number or name of the
+                                                  port to access on the container.
+                                                  Number must be in the range 1 to
+                                                  65535. Name must be an IANA_SVC_NAME.
+                                                x-kubernetes-int-or-string: true
+                                            required:
+                                            - port
+                                            type: object
+                                        type: object
+                                    type: object
+                                  livenessProbe:
+                                    description: Probes are not allowed for ephemeral
+                                      containers.
+                                    properties:
+                                      exec:
+                                        description: One and only one of the following
+                                          should be specified. Exec specifies the
+                                          action to take.
+                                        properties:
+                                          command:
+                                            description: Command is the command line
+                                              to execute inside the container, the
+                                              working directory for the command  is
+                                              root ('/') in the container's filesystem.
+                                              The command is simply exec'd, it is
+                                              not run inside a shell, so traditional
+                                              shell instructions ('|', etc) won't
+                                              work. To use a shell, you need to explicitly
+                                              call out to that shell. Exit status
+                                              of 0 is treated as live/healthy and
+                                              non-zero is unhealthy.
+                                            items:
+                                              type: string
+                                            type: array
+                                        type: object
+                                      failureThreshold:
+                                        description: Minimum consecutive failures
+                                          for the probe to be considered failed after
+                                          having succeeded. Defaults to 3. Minimum
+                                          value is 1.
+                                        format: int32
+                                        type: integer
+                                      httpGet:
+                                        description: HTTPGet specifies the http request
+                                          to perform.
+                                        properties:
+                                          host:
+                                            description: Host name to connect to,
+                                              defaults to the pod IP. You probably
+                                              want to set "Host" in httpHeaders instead.
+                                            type: string
+                                          httpHeaders:
+                                            description: Custom headers to set in
+                                              the request. HTTP allows repeated headers.
+                                            items:
+                                              description: HTTPHeader describes a
+                                                custom header to be used in HTTP probes
+                                              properties:
+                                                name:
+                                                  description: The header field name
+                                                  type: string
+                                                value:
+                                                  description: The header field value
+                                                  type: string
+                                              required:
+                                              - name
+                                              - value
+                                              type: object
+                                            type: array
+                                          path:
+                                            description: Path to access on the HTTP
+                                              server.
+                                            type: string
+                                          port:
+                                            anyOf:
+                                            - type: integer
+                                            - type: string
+                                            description: Name or number of the port
+                                              to access on the container. Number must
+                                              be in the range 1 to 65535. Name must
+                                              be an IANA_SVC_NAME.
+                                            x-kubernetes-int-or-string: true
+                                          scheme:
+                                            description: Scheme to use for connecting
+                                              to the host. Defaults to HTTP.
+                                            type: string
+                                        required:
+                                        - port
+                                        type: object
+                                      initialDelaySeconds:
+                                        description: 'Number of seconds after the
+                                          container has started before liveness probes
+                                          are initiated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                                        format: int32
+                                        type: integer
+                                      periodSeconds:
+                                        description: How often (in seconds) to perform
+                                          the probe. Default to 10 seconds. Minimum
+                                          value is 1.
+                                        format: int32
+                                        type: integer
+                                      successThreshold:
+                                        description: Minimum consecutive successes
+                                          for the probe to be considered successful
+                                          after having failed. Defaults to 1. Must
+                                          be 1 for liveness and startup. Minimum value
+                                          is 1.
+                                        format: int32
+                                        type: integer
+                                      tcpSocket:
+                                        description: 'TCPSocket specifies an action
+                                          involving a TCP port. TCP hooks not yet
+                                          supported TODO: implement a realistic TCP
+                                          lifecycle hook'
+                                        properties:
+                                          host:
+                                            description: 'Optional: Host name to connect
+                                              to, defaults to the pod IP.'
+                                            type: string
+                                          port:
+                                            anyOf:
+                                            - type: integer
+                                            - type: string
+                                            description: Number or name of the port
+                                              to access on the container. Number must
+                                              be in the range 1 to 65535. Name must
+                                              be an IANA_SVC_NAME.
+                                            x-kubernetes-int-or-string: true
+                                        required:
+                                        - port
+                                        type: object
+                                      timeoutSeconds:
+                                        description: 'Number of seconds after which
+                                          the probe times out. Defaults to 1 second.
+                                          Minimum value is 1. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                                        format: int32
+                                        type: integer
+                                    type: object
+                                  name:
+                                    description: Name of the ephemeral container specified
+                                      as a DNS_LABEL. This name must be unique among
+                                      all containers, init containers and ephemeral
+                                      containers.
+                                    type: string
+                                  ports:
+                                    description: Ports are not allowed for ephemeral
+                                      containers.
+                                    items:
+                                      description: ContainerPort represents a network
+                                        port in a single container.
+                                      properties:
+                                        containerPort:
+                                          description: Number of port to expose on
+                                            the pod's IP address. This must be a valid
+                                            port number, 0 < x < 65536.
+                                          format: int32
+                                          type: integer
+                                        hostIP:
+                                          description: What host IP to bind the external
+                                            port to.
+                                          type: string
+                                        hostPort:
+                                          description: Number of port to expose on
+                                            the host. If specified, this must be a
+                                            valid port number, 0 < x < 65536. If HostNetwork
+                                            is specified, this must match ContainerPort.
+                                            Most containers do not need this.
+                                          format: int32
+                                          type: integer
+                                        name:
+                                          description: If specified, this must be
+                                            an IANA_SVC_NAME and unique within the
+                                            pod. Each named port in a pod must have
+                                            a unique name. Name for the port that
+                                            can be referred to by services.
+                                          type: string
+                                        protocol:
+                                          description: Protocol for port. Must be
+                                            UDP, TCP, or SCTP. Defaults to "TCP".
+                                          type: string
+                                      required:
+                                      - containerPort
+                                      type: object
+                                    type: array
+                                  readinessProbe:
+                                    description: Probes are not allowed for ephemeral
+                                      containers.
+                                    properties:
+                                      exec:
+                                        description: One and only one of the following
+                                          should be specified. Exec specifies the
+                                          action to take.
+                                        properties:
+                                          command:
+                                            description: Command is the command line
+                                              to execute inside the container, the
+                                              working directory for the command  is
+                                              root ('/') in the container's filesystem.
+                                              The command is simply exec'd, it is
+                                              not run inside a shell, so traditional
+                                              shell instructions ('|', etc) won't
+                                              work. To use a shell, you need to explicitly
+                                              call out to that shell. Exit status
+                                              of 0 is treated as live/healthy and
+                                              non-zero is unhealthy.
+                                            items:
+                                              type: string
+                                            type: array
+                                        type: object
+                                      failureThreshold:
+                                        description: Minimum consecutive failures
+                                          for the probe to be considered failed after
+                                          having succeeded. Defaults to 3. Minimum
+                                          value is 1.
+                                        format: int32
+                                        type: integer
+                                      httpGet:
+                                        description: HTTPGet specifies the http request
+                                          to perform.
+                                        properties:
+                                          host:
+                                            description: Host name to connect to,
+                                              defaults to the pod IP. You probably
+                                              want to set "Host" in httpHeaders instead.
+                                            type: string
+                                          httpHeaders:
+                                            description: Custom headers to set in
+                                              the request. HTTP allows repeated headers.
+                                            items:
+                                              description: HTTPHeader describes a
+                                                custom header to be used in HTTP probes
+                                              properties:
+                                                name:
+                                                  description: The header field name
+                                                  type: string
+                                                value:
+                                                  description: The header field value
+                                                  type: string
+                                              required:
+                                              - name
+                                              - value
+                                              type: object
+                                            type: array
+                                          path:
+                                            description: Path to access on the HTTP
+                                              server.
+                                            type: string
+                                          port:
+                                            anyOf:
+                                            - type: integer
+                                            - type: string
+                                            description: Name or number of the port
+                                              to access on the container. Number must
+                                              be in the range 1 to 65535. Name must
+                                              be an IANA_SVC_NAME.
+                                            x-kubernetes-int-or-string: true
+                                          scheme:
+                                            description: Scheme to use for connecting
+                                              to the host. Defaults to HTTP.
+                                            type: string
+                                        required:
+                                        - port
+                                        type: object
+                                      initialDelaySeconds:
+                                        description: 'Number of seconds after the
+                                          container has started before liveness probes
+                                          are initiated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                                        format: int32
+                                        type: integer
+                                      periodSeconds:
+                                        description: How often (in seconds) to perform
+                                          the probe. Default to 10 seconds. Minimum
+                                          value is 1.
+                                        format: int32
+                                        type: integer
+                                      successThreshold:
+                                        description: Minimum consecutive successes
+                                          for the probe to be considered successful
+                                          after having failed. Defaults to 1. Must
+                                          be 1 for liveness and startup. Minimum value
+                                          is 1.
+                                        format: int32
+                                        type: integer
+                                      tcpSocket:
+                                        description: 'TCPSocket specifies an action
+                                          involving a TCP port. TCP hooks not yet
+                                          supported TODO: implement a realistic TCP
+                                          lifecycle hook'
+                                        properties:
+                                          host:
+                                            description: 'Optional: Host name to connect
+                                              to, defaults to the pod IP.'
+                                            type: string
+                                          port:
+                                            anyOf:
+                                            - type: integer
+                                            - type: string
+                                            description: Number or name of the port
+                                              to access on the container. Number must
+                                              be in the range 1 to 65535. Name must
+                                              be an IANA_SVC_NAME.
+                                            x-kubernetes-int-or-string: true
+                                        required:
+                                        - port
+                                        type: object
+                                      timeoutSeconds:
+                                        description: 'Number of seconds after which
+                                          the probe times out. Defaults to 1 second.
+                                          Minimum value is 1. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                                        format: int32
+                                        type: integer
+                                    type: object
+                                  resources:
+                                    description: Resources are not allowed for ephemeral
+                                      containers. Ephemeral containers use spare resources
+                                      already allocated to the pod.
+                                    properties:
+                                      limits:
+                                        additionalProperties:
+                                          anyOf:
+                                          - type: integer
+                                          - type: string
+                                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                          x-kubernetes-int-or-string: true
+                                        description: 'Limits describes the maximum
+                                          amount of compute resources allowed. More
+                                          info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
+                                        type: object
+                                      requests:
+                                        additionalProperties:
+                                          anyOf:
+                                          - type: integer
+                                          - type: string
+                                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                          x-kubernetes-int-or-string: true
+                                        description: 'Requests describes the minimum
+                                          amount of compute resources required. If
+                                          Requests is omitted for a container, it
+                                          defaults to Limits if that is explicitly
+                                          specified, otherwise to an implementation-defined
+                                          value. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
+                                        type: object
+                                    type: object
+                                  securityContext:
+                                    description: SecurityContext is not allowed for
+                                      ephemeral containers.
+                                    properties:
+                                      allowPrivilegeEscalation:
+                                        description: 'AllowPrivilegeEscalation controls
+                                          whether a process can gain more privileges
+                                          than its parent process. This bool directly
+                                          controls if the no_new_privs flag will be
+                                          set on the container process. AllowPrivilegeEscalation
+                                          is true always when the container is: 1)
+                                          run as Privileged 2) has CAP_SYS_ADMIN'
+                                        type: boolean
+                                      capabilities:
+                                        description: The capabilities to add/drop
+                                          when running containers. Defaults to the
+                                          default set of capabilities granted by the
+                                          container runtime.
+                                        properties:
+                                          add:
+                                            description: Added capabilities
+                                            items:
+                                              description: Capability represent POSIX
+                                                capabilities type
+                                              type: string
+                                            type: array
+                                          drop:
+                                            description: Removed capabilities
+                                            items:
+                                              description: Capability represent POSIX
+                                                capabilities type
+                                              type: string
+                                            type: array
+                                        type: object
+                                      privileged:
+                                        description: Run container in privileged mode.
+                                          Processes in privileged containers are essentially
+                                          equivalent to root on the host. Defaults
+                                          to false.
+                                        type: boolean
+                                      procMount:
+                                        description: procMount denotes the type of
+                                          proc mount to use for the containers. The
+                                          default is DefaultProcMount which uses the
+                                          container runtime defaults for readonly
+                                          paths and masked paths. This requires the
+                                          ProcMountType feature flag to be enabled.
+                                        type: string
+                                      readOnlyRootFilesystem:
+                                        description: Whether this container has a
+                                          read-only root filesystem. Default is false.
+                                        type: boolean
+                                      runAsGroup:
+                                        description: The GID to run the entrypoint
+                                          of the container process. Uses runtime default
+                                          if unset. May also be set in PodSecurityContext.  If
+                                          set in both SecurityContext and PodSecurityContext,
+                                          the value specified in SecurityContext takes
+                                          precedence.
+                                        format: int64
+                                        type: integer
+                                      runAsNonRoot:
+                                        description: Indicates that the container
+                                          must run as a non-root user. If true, the
+                                          Kubelet will validate the image at runtime
+                                          to ensure that it does not run as UID 0
+                                          (root) and fail to start the container if
+                                          it does. If unset or false, no such validation
+                                          will be performed. May also be set in PodSecurityContext.  If
+                                          set in both SecurityContext and PodSecurityContext,
+                                          the value specified in SecurityContext takes
+                                          precedence.
+                                        type: boolean
+                                      runAsUser:
+                                        description: The UID to run the entrypoint
+                                          of the container process. Defaults to user
+                                          specified in image metadata if unspecified.
+                                          May also be set in PodSecurityContext.  If
+                                          set in both SecurityContext and PodSecurityContext,
+                                          the value specified in SecurityContext takes
+                                          precedence.
+                                        format: int64
+                                        type: integer
+                                      seLinuxOptions:
+                                        description: The SELinux context to be applied
+                                          to the container. If unspecified, the container
+                                          runtime will allocate a random SELinux context
+                                          for each container.  May also be set in
+                                          PodSecurityContext.  If set in both SecurityContext
+                                          and PodSecurityContext, the value specified
+                                          in SecurityContext takes precedence.
+                                        properties:
+                                          level:
+                                            description: Level is SELinux level label
+                                              that applies to the container.
+                                            type: string
+                                          role:
+                                            description: Role is a SELinux role label
+                                              that applies to the container.
+                                            type: string
+                                          type:
+                                            description: Type is a SELinux type label
+                                              that applies to the container.
+                                            type: string
+                                          user:
+                                            description: User is a SELinux user label
+                                              that applies to the container.
+                                            type: string
+                                        type: object
+                                      windowsOptions:
+                                        description: The Windows specific settings
+                                          applied to all containers. If unspecified,
+                                          the options from the PodSecurityContext
+                                          will be used. If set in both SecurityContext
+                                          and PodSecurityContext, the value specified
+                                          in SecurityContext takes precedence.
+                                        properties:
+                                          gmsaCredentialSpec:
+                                            description: GMSACredentialSpec is where
+                                              the GMSA admission webhook (https://github.com/kubernetes-sigs/windows-gmsa)
+                                              inlines the contents of the GMSA credential
+                                              spec named by the GMSACredentialSpecName
+                                              field. This field is alpha-level and
+                                              is only honored by servers that enable
+                                              the WindowsGMSA feature flag.
+                                            type: string
+                                          gmsaCredentialSpecName:
+                                            description: GMSACredentialSpecName is
+                                              the name of the GMSA credential spec
+                                              to use. This field is alpha-level and
+                                              is only honored by servers that enable
+                                              the WindowsGMSA feature flag.
+                                            type: string
+                                          runAsUserName:
+                                            description: The UserName in Windows to
+                                              run the entrypoint of the container
+                                              process. Defaults to the user specified
+                                              in image metadata if unspecified. May
+                                              also be set in PodSecurityContext. If
+                                              set in both SecurityContext and PodSecurityContext,
+                                              the value specified in SecurityContext
+                                              takes precedence. This field is beta-level
+                                              and may be disabled with the WindowsRunAsUserName
+                                              feature flag.
+                                            type: string
+                                        type: object
+                                    type: object
+                                  startupProbe:
+                                    description: Probes are not allowed for ephemeral
+                                      containers.
+                                    properties:
+                                      exec:
+                                        description: One and only one of the following
+                                          should be specified. Exec specifies the
+                                          action to take.
+                                        properties:
+                                          command:
+                                            description: Command is the command line
+                                              to execute inside the container, the
+                                              working directory for the command  is
+                                              root ('/') in the container's filesystem.
+                                              The command is simply exec'd, it is
+                                              not run inside a shell, so traditional
+                                              shell instructions ('|', etc) won't
+                                              work. To use a shell, you need to explicitly
+                                              call out to that shell. Exit status
+                                              of 0 is treated as live/healthy and
+                                              non-zero is unhealthy.
+                                            items:
+                                              type: string
+                                            type: array
+                                        type: object
+                                      failureThreshold:
+                                        description: Minimum consecutive failures
+                                          for the probe to be considered failed after
+                                          having succeeded. Defaults to 3. Minimum
+                                          value is 1.
+                                        format: int32
+                                        type: integer
+                                      httpGet:
+                                        description: HTTPGet specifies the http request
+                                          to perform.
+                                        properties:
+                                          host:
+                                            description: Host name to connect to,
+                                              defaults to the pod IP. You probably
+                                              want to set "Host" in httpHeaders instead.
+                                            type: string
+                                          httpHeaders:
+                                            description: Custom headers to set in
+                                              the request. HTTP allows repeated headers.
+                                            items:
+                                              description: HTTPHeader describes a
+                                                custom header to be used in HTTP probes
+                                              properties:
+                                                name:
+                                                  description: The header field name
+                                                  type: string
+                                                value:
+                                                  description: The header field value
+                                                  type: string
+                                              required:
+                                              - name
+                                              - value
+                                              type: object
+                                            type: array
+                                          path:
+                                            description: Path to access on the HTTP
+                                              server.
+                                            type: string
+                                          port:
+                                            anyOf:
+                                            - type: integer
+                                            - type: string
+                                            description: Name or number of the port
+                                              to access on the container. Number must
+                                              be in the range 1 to 65535. Name must
+                                              be an IANA_SVC_NAME.
+                                            x-kubernetes-int-or-string: true
+                                          scheme:
+                                            description: Scheme to use for connecting
+                                              to the host. Defaults to HTTP.
+                                            type: string
+                                        required:
+                                        - port
+                                        type: object
+                                      initialDelaySeconds:
+                                        description: 'Number of seconds after the
+                                          container has started before liveness probes
+                                          are initiated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                                        format: int32
+                                        type: integer
+                                      periodSeconds:
+                                        description: How often (in seconds) to perform
+                                          the probe. Default to 10 seconds. Minimum
+                                          value is 1.
+                                        format: int32
+                                        type: integer
+                                      successThreshold:
+                                        description: Minimum consecutive successes
+                                          for the probe to be considered successful
+                                          after having failed. Defaults to 1. Must
+                                          be 1 for liveness and startup. Minimum value
+                                          is 1.
+                                        format: int32
+                                        type: integer
+                                      tcpSocket:
+                                        description: 'TCPSocket specifies an action
+                                          involving a TCP port. TCP hooks not yet
+                                          supported TODO: implement a realistic TCP
+                                          lifecycle hook'
+                                        properties:
+                                          host:
+                                            description: 'Optional: Host name to connect
+                                              to, defaults to the pod IP.'
+                                            type: string
+                                          port:
+                                            anyOf:
+                                            - type: integer
+                                            - type: string
+                                            description: Number or name of the port
+                                              to access on the container. Number must
+                                              be in the range 1 to 65535. Name must
+                                              be an IANA_SVC_NAME.
+                                            x-kubernetes-int-or-string: true
+                                        required:
+                                        - port
+                                        type: object
+                                      timeoutSeconds:
+                                        description: 'Number of seconds after which
+                                          the probe times out. Defaults to 1 second.
+                                          Minimum value is 1. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                                        format: int32
+                                        type: integer
+                                    type: object
+                                  stdin:
+                                    description: Whether this container should allocate
+                                      a buffer for stdin in the container runtime.
+                                      If this is not set, reads from stdin in the
+                                      container will always result in EOF. Default
+                                      is false.
+                                    type: boolean
+                                  stdinOnce:
+                                    description: Whether the container runtime should
+                                      close the stdin channel after it has been opened
+                                      by a single attach. When stdin is true the stdin
+                                      stream will remain open across multiple attach
+                                      sessions. If stdinOnce is set to true, stdin
+                                      is opened on container start, is empty until
+                                      the first client attaches to stdin, and then
+                                      remains open and accepts data until the client
+                                      disconnects, at which time stdin is closed and
+                                      remains closed until the container is restarted.
+                                      If this flag is false, a container processes
+                                      that reads from stdin will never receive an
+                                      EOF. Default is false
+                                    type: boolean
+                                  targetContainerName:
+                                    description: If set, the name of the container
+                                      from PodSpec that this ephemeral container targets.
+                                      The ephemeral container will be run in the namespaces
+                                      (IPC, PID, etc) of this container. If not set
+                                      then the ephemeral container is run in whatever
+                                      namespaces are shared for the pod. Note that
+                                      the container runtime must support this feature.
+                                    type: string
+                                  terminationMessagePath:
+                                    description: 'Optional: Path at which the file
+                                      to which the container''s termination message
+                                      will be written is mounted into the container''s
+                                      filesystem. Message written is intended to be
+                                      brief final status, such as an assertion failure
+                                      message. Will be truncated by the node if greater
+                                      than 4096 bytes. The total message length across
+                                      all containers will be limited to 12kb. Defaults
+                                      to /dev/termination-log. Cannot be updated.'
+                                    type: string
+                                  terminationMessagePolicy:
+                                    description: Indicate how the termination message
+                                      should be populated. File will use the contents
+                                      of terminationMessagePath to populate the container
+                                      status message on both success and failure.
+                                      FallbackToLogsOnError will use the last chunk
+                                      of container log output if the termination message
+                                      file is empty and the container exited with
+                                      an error. The log output is limited to 2048
+                                      bytes or 80 lines, whichever is smaller. Defaults
+                                      to File. Cannot be updated.
+                                    type: string
+                                  tty:
+                                    description: Whether this container should allocate
+                                      a TTY for itself, also requires 'stdin' to be
+                                      true. Default is false.
+                                    type: boolean
+                                  volumeDevices:
+                                    description: volumeDevices is the list of block
+                                      devices to be used by the container. This is
+                                      a beta feature.
+                                    items:
+                                      description: volumeDevice describes a mapping
+                                        of a raw block device within a container.
+                                      properties:
+                                        devicePath:
+                                          description: devicePath is the path inside
+                                            of the container that the device will
+                                            be mapped to.
+                                          type: string
+                                        name:
+                                          description: name must match the name of
+                                            a persistentVolumeClaim in the pod
+                                          type: string
+                                      required:
+                                      - devicePath
+                                      - name
+                                      type: object
+                                    type: array
+                                  volumeMounts:
+                                    description: Pod volumes to mount into the container's
+                                      filesystem. Cannot be updated.
+                                    items:
+                                      description: VolumeMount describes a mounting
+                                        of a Volume within a container.
+                                      properties:
+                                        mountPath:
+                                          description: Path within the container at
+                                            which the volume should be mounted.  Must
+                                            not contain ':'.
+                                          type: string
+                                        mountPropagation:
+                                          description: mountPropagation determines
+                                            how mounts are propagated from the host
+                                            to container and the other way around.
+                                            When not set, MountPropagationNone is
+                                            used. This field is beta in 1.10.
+                                          type: string
+                                        name:
+                                          description: This must match the Name of
+                                            a Volume.
+                                          type: string
+                                        readOnly:
+                                          description: Mounted read-only if true,
+                                            read-write otherwise (false or unspecified).
+                                            Defaults to false.
+                                          type: boolean
+                                        subPath:
+                                          description: Path within the volume from
+                                            which the container's volume should be
+                                            mounted. Defaults to "" (volume's root).
+                                          type: string
+                                        subPathExpr:
+                                          description: Expanded path within the volume
+                                            from which the container's volume should
+                                            be mounted. Behaves similarly to SubPath
+                                            but environment variable references $(VAR_NAME)
+                                            are expanded using the container's environment.
+                                            Defaults to "" (volume's root). SubPathExpr
+                                            and SubPath are mutually exclusive.
+                                          type: string
+                                      required:
+                                      - mountPath
+                                      - name
+                                      type: object
+                                    type: array
+                                  workingDir:
+                                    description: Container's working directory. If
+                                      not specified, the container runtime's default
+                                      will be used, which might be configured in the
+                                      container image. Cannot be updated.
+                                    type: string
+                                required:
+                                - name
+                                type: object
+                              type: array
+                            hostAliases:
+                              description: HostAliases is an optional list of hosts
+                                and IPs that will be injected into the pod's hosts
+                                file if specified. This is only valid for non-hostNetwork
+                                pods.
+                              items:
+                                description: HostAlias holds the mapping between IP
+                                  and hostnames that will be injected as an entry
+                                  in the pod's hosts file.
+                                properties:
+                                  hostnames:
+                                    description: Hostnames for the above IP address.
+                                    items:
+                                      type: string
+                                    type: array
+                                  ip:
+                                    description: IP address of the host file entry.
+                                    type: string
+                                type: object
+                              type: array
+                            hostIPC:
+                              description: 'Use the host''s ipc namespace. Optional:
+                                Default to false.'
+                              type: boolean
+                            hostNetwork:
+                              description: Host networking requested for this pod.
+                                Use the host's network namespace. If this option is
+                                set, the ports that will be used must be specified.
+                                Default to false.
+                              type: boolean
+                            hostPID:
+                              description: 'Use the host''s pid namespace. Optional:
+                                Default to false.'
+                              type: boolean
+                            hostname:
+                              description: Specifies the hostname of the Pod If not
+                                specified, the pod's hostname will be set to a system-defined
+                                value.
+                              type: string
+                            imagePullSecrets:
+                              description: 'ImagePullSecrets is an optional list of
+                                references to secrets in the same namespace to use
+                                for pulling any of the images used by this PodSpec.
+                                If specified, these secrets will be passed to individual
+                                puller implementations for them to use. For example,
+                                in the case of docker, only DockerConfig type secrets
+                                are honored. More info: https://kubernetes.io/docs/concepts/containers/images#specifying-imagepullsecrets-on-a-pod'
+                              items:
+                                description: LocalObjectReference contains enough
+                                  information to let you locate the referenced object
+                                  inside the same namespace.
+                                properties:
+                                  name:
+                                    description: 'Name of the referent. More info:
+                                      https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                      TODO: Add other useful fields. apiVersion, kind,
+                                      uid?'
+                                    type: string
+                                type: object
+                              type: array
+                            initContainers:
+                              description: 'List of initialization containers belonging
+                                to the pod. Init containers are executed in order
+                                prior to containers being started. If any init container
+                                fails, the pod is considered to have failed and is
+                                handled according to its restartPolicy. The name for
+                                an init container or normal container must be unique
+                                among all containers. Init containers may not have
+                                Lifecycle actions, Readiness probes, Liveness probes,
+                                or Startup probes. The resourceRequirements of an
+                                init container are taken into account during scheduling
+                                by finding the highest request/limit for each resource
+                                type, and then using the max of of that value or the
+                                sum of the normal containers. Limits are applied to
+                                init containers in a similar fashion. Init containers
+                                cannot currently be added or removed. Cannot be updated.
+                                More info: https://kubernetes.io/docs/concepts/workloads/pods/init-containers/'
+                              items:
+                                description: A single application container that you
+                                  want to run within a pod.
+                                properties:
+                                  args:
+                                    description: 'Arguments to the entrypoint. The
+                                      docker image''s CMD is used if this is not provided.
+                                      Variable references $(VAR_NAME) are expanded
+                                      using the container''s environment. If a variable
+                                      cannot be resolved, the reference in the input
+                                      string will be unchanged. The $(VAR_NAME) syntax
+                                      can be escaped with a double $$, ie: $$(VAR_NAME).
+                                      Escaped references will never be expanded, regardless
+                                      of whether the variable exists or not. Cannot
+                                      be updated. More info: https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell'
+                                    items:
+                                      type: string
+                                    type: array
+                                  command:
+                                    description: 'Entrypoint array. Not executed within
+                                      a shell. The docker image''s ENTRYPOINT is used
+                                      if this is not provided. Variable references
+                                      $(VAR_NAME) are expanded using the container''s
+                                      environment. If a variable cannot be resolved,
+                                      the reference in the input string will be unchanged.
+                                      The $(VAR_NAME) syntax can be escaped with a
+                                      double $$, ie: $$(VAR_NAME). Escaped references
+                                      will never be expanded, regardless of whether
+                                      the variable exists or not. Cannot be updated.
+                                      More info: https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell'
+                                    items:
+                                      type: string
+                                    type: array
+                                  env:
+                                    description: List of environment variables to
+                                      set in the container. Cannot be updated.
+                                    items:
+                                      description: EnvVar represents an environment
+                                        variable present in a Container.
+                                      properties:
+                                        name:
+                                          description: Name of the environment variable.
+                                            Must be a C_IDENTIFIER.
+                                          type: string
+                                        value:
+                                          description: 'Variable references $(VAR_NAME)
+                                            are expanded using the previous defined
+                                            environment variables in the container
+                                            and any service environment variables.
+                                            If a variable cannot be resolved, the
+                                            reference in the input string will be
+                                            unchanged. The $(VAR_NAME) syntax can
+                                            be escaped with a double $$, ie: $$(VAR_NAME).
+                                            Escaped references will never be expanded,
+                                            regardless of whether the variable exists
+                                            or not. Defaults to "".'
+                                          type: string
+                                        valueFrom:
+                                          description: Source for the environment
+                                            variable's value. Cannot be used if value
+                                            is not empty.
+                                          properties:
+                                            configMapKeyRef:
+                                              description: Selects a key of a ConfigMap.
+                                              properties:
+                                                key:
+                                                  description: The key to select.
+                                                  type: string
+                                                name:
+                                                  description: 'Name of the referent.
+                                                    More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                                    TODO: Add other useful fields.
+                                                    apiVersion, kind, uid?'
+                                                  type: string
+                                                optional:
+                                                  description: Specify whether the
+                                                    ConfigMap or its key must be defined
+                                                  type: boolean
+                                              required:
+                                              - key
+                                              type: object
+                                            fieldRef:
+                                              description: 'Selects a field of the
+                                                pod: supports metadata.name, metadata.namespace,
+                                                metadata.labels, metadata.annotations,
+                                                spec.nodeName, spec.serviceAccountName,
+                                                status.hostIP, status.podIP, status.podIPs.'
+                                              properties:
+                                                apiVersion:
+                                                  description: Version of the schema
+                                                    the FieldPath is written in terms
+                                                    of, defaults to "v1".
+                                                  type: string
+                                                fieldPath:
+                                                  description: Path of the field to
+                                                    select in the specified API version.
+                                                  type: string
+                                              required:
+                                              - fieldPath
+                                              type: object
+                                            resourceFieldRef:
+                                              description: 'Selects a resource of
+                                                the container: only resources limits
+                                                and requests (limits.cpu, limits.memory,
+                                                limits.ephemeral-storage, requests.cpu,
+                                                requests.memory and requests.ephemeral-storage)
+                                                are currently supported.'
+                                              properties:
+                                                containerName:
+                                                  description: 'Container name: required
+                                                    for volumes, optional for env
+                                                    vars'
+                                                  type: string
+                                                divisor:
+                                                  anyOf:
+                                                  - type: integer
+                                                  - type: string
+                                                  description: Specifies the output
+                                                    format of the exposed resources,
+                                                    defaults to "1"
+                                                  pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                                  x-kubernetes-int-or-string: true
+                                                resource:
+                                                  description: 'Required: resource
+                                                    to select'
+                                                  type: string
+                                              required:
+                                              - resource
+                                              type: object
+                                            secretKeyRef:
+                                              description: Selects a key of a secret
+                                                in the pod's namespace
+                                              properties:
+                                                key:
+                                                  description: The key of the secret
+                                                    to select from.  Must be a valid
+                                                    secret key.
+                                                  type: string
+                                                name:
+                                                  description: 'Name of the referent.
+                                                    More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                                    TODO: Add other useful fields.
+                                                    apiVersion, kind, uid?'
+                                                  type: string
+                                                optional:
+                                                  description: Specify whether the
+                                                    Secret or its key must be defined
+                                                  type: boolean
+                                              required:
+                                              - key
+                                              type: object
+                                          type: object
+                                      required:
+                                      - name
+                                      type: object
+                                    type: array
+                                  envFrom:
+                                    description: List of sources to populate environment
+                                      variables in the container. The keys defined
+                                      within a source must be a C_IDENTIFIER. All
+                                      invalid keys will be reported as an event when
+                                      the container is starting. When a key exists
+                                      in multiple sources, the value associated with
+                                      the last source will take precedence. Values
+                                      defined by an Env with a duplicate key will
+                                      take precedence. Cannot be updated.
+                                    items:
+                                      description: EnvFromSource represents the source
+                                        of a set of ConfigMaps
+                                      properties:
+                                        configMapRef:
+                                          description: The ConfigMap to select from
+                                          properties:
+                                            name:
+                                              description: 'Name of the referent.
+                                                More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                                TODO: Add other useful fields. apiVersion,
+                                                kind, uid?'
+                                              type: string
+                                            optional:
+                                              description: Specify whether the ConfigMap
+                                                must be defined
+                                              type: boolean
+                                          type: object
+                                        prefix:
+                                          description: An optional identifier to prepend
+                                            to each key in the ConfigMap. Must be
+                                            a C_IDENTIFIER.
+                                          type: string
+                                        secretRef:
+                                          description: The Secret to select from
+                                          properties:
+                                            name:
+                                              description: 'Name of the referent.
+                                                More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                                TODO: Add other useful fields. apiVersion,
+                                                kind, uid?'
+                                              type: string
+                                            optional:
+                                              description: Specify whether the Secret
+                                                must be defined
+                                              type: boolean
+                                          type: object
+                                      type: object
+                                    type: array
+                                  image:
+                                    description: 'Docker image name. More info: https://kubernetes.io/docs/concepts/containers/images
+                                      This field is optional to allow higher level
+                                      config management to default or override container
+                                      images in workload controllers like Deployments
+                                      and StatefulSets.'
+                                    type: string
+                                  imagePullPolicy:
+                                    description: 'Image pull policy. One of Always,
+                                      Never, IfNotPresent. Defaults to Always if :latest
+                                      tag is specified, or IfNotPresent otherwise.
+                                      Cannot be updated. More info: https://kubernetes.io/docs/concepts/containers/images#updating-images'
+                                    type: string
+                                  lifecycle:
+                                    description: Actions that the management system
+                                      should take in response to container lifecycle
+                                      events. Cannot be updated.
+                                    properties:
+                                      postStart:
+                                        description: 'PostStart is called immediately
+                                          after a container is created. If the handler
+                                          fails, the container is terminated and restarted
+                                          according to its restart policy. Other management
+                                          of the container blocks until the hook completes.
+                                          More info: https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/#container-hooks'
+                                        properties:
+                                          exec:
+                                            description: One and only one of the following
+                                              should be specified. Exec specifies
+                                              the action to take.
+                                            properties:
+                                              command:
+                                                description: Command is the command
+                                                  line to execute inside the container,
+                                                  the working directory for the command  is
+                                                  root ('/') in the container's filesystem.
+                                                  The command is simply exec'd, it
+                                                  is not run inside a shell, so traditional
+                                                  shell instructions ('|', etc) won't
+                                                  work. To use a shell, you need to
+                                                  explicitly call out to that shell.
+                                                  Exit status of 0 is treated as live/healthy
+                                                  and non-zero is unhealthy.
+                                                items:
+                                                  type: string
+                                                type: array
+                                            type: object
+                                          httpGet:
+                                            description: HTTPGet specifies the http
+                                              request to perform.
+                                            properties:
+                                              host:
+                                                description: Host name to connect
+                                                  to, defaults to the pod IP. You
+                                                  probably want to set "Host" in httpHeaders
+                                                  instead.
+                                                type: string
+                                              httpHeaders:
+                                                description: Custom headers to set
+                                                  in the request. HTTP allows repeated
+                                                  headers.
+                                                items:
+                                                  description: HTTPHeader describes
+                                                    a custom header to be used in
+                                                    HTTP probes
+                                                  properties:
+                                                    name:
+                                                      description: The header field
+                                                        name
+                                                      type: string
+                                                    value:
+                                                      description: The header field
+                                                        value
+                                                      type: string
+                                                  required:
+                                                  - name
+                                                  - value
+                                                  type: object
+                                                type: array
+                                              path:
+                                                description: Path to access on the
+                                                  HTTP server.
+                                                type: string
+                                              port:
+                                                description: Name or number of the
+                                                  port to access on the container.
+                                                  Number must be in the range 1 to
+                                                  65535. Name must be an IANA_SVC_NAME.
+                                                x-kubernetes-int-or-string: true
+                                              scheme:
+                                                description: Scheme to use for connecting
+                                                  to the host. Defaults to HTTP.
+                                                type: string
+                                            required:
+                                            - port
+                                            type: object
+                                          tcpSocket:
+                                            description: 'TCPSocket specifies an action
+                                              involving a TCP port. TCP hooks not
+                                              yet supported TODO: implement a realistic
+                                              TCP lifecycle hook'
+                                            properties:
+                                              host:
+                                                description: 'Optional: Host name
+                                                  to connect to, defaults to the pod
+                                                  IP.'
+                                                type: string
+                                              port:
+                                                description: Number or name of the
+                                                  port to access on the container.
+                                                  Number must be in the range 1 to
+                                                  65535. Name must be an IANA_SVC_NAME.
+                                                x-kubernetes-int-or-string: true
+                                            required:
+                                            - port
+                                            type: object
+                                        type: object
+                                      preStop:
+                                        description: 'PreStop is called immediately
+                                          before a container is terminated due to
+                                          an API request or management event such
+                                          as liveness/startup probe failure, preemption,
+                                          resource contention, etc. The handler is
+                                          not called if the container crashes or exits.
+                                          The reason for termination is passed to
+                                          the handler. The Pod''s termination grace
+                                          period countdown begins before the PreStop
+                                          hooked is executed. Regardless of the outcome
+                                          of the handler, the container will eventually
+                                          terminate within the Pod''s termination
+                                          grace period. Other management of the container
+                                          blocks until the hook completes or until
+                                          the termination grace period is reached.
+                                          More info: https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/#container-hooks'
+                                        properties:
+                                          exec:
+                                            description: One and only one of the following
+                                              should be specified. Exec specifies
+                                              the action to take.
+                                            properties:
+                                              command:
+                                                description: Command is the command
+                                                  line to execute inside the container,
+                                                  the working directory for the command  is
+                                                  root ('/') in the container's filesystem.
+                                                  The command is simply exec'd, it
+                                                  is not run inside a shell, so traditional
+                                                  shell instructions ('|', etc) won't
+                                                  work. To use a shell, you need to
+                                                  explicitly call out to that shell.
+                                                  Exit status of 0 is treated as live/healthy
+                                                  and non-zero is unhealthy.
+                                                items:
+                                                  type: string
+                                                type: array
+                                            type: object
+                                          httpGet:
+                                            description: HTTPGet specifies the http
+                                              request to perform.
+                                            properties:
+                                              host:
+                                                description: Host name to connect
+                                                  to, defaults to the pod IP. You
+                                                  probably want to set "Host" in httpHeaders
+                                                  instead.
+                                                type: string
+                                              httpHeaders:
+                                                description: Custom headers to set
+                                                  in the request. HTTP allows repeated
+                                                  headers.
+                                                items:
+                                                  description: HTTPHeader describes
+                                                    a custom header to be used in
+                                                    HTTP probes
+                                                  properties:
+                                                    name:
+                                                      description: The header field
+                                                        name
+                                                      type: string
+                                                    value:
+                                                      description: The header field
+                                                        value
+                                                      type: string
+                                                  required:
+                                                  - name
+                                                  - value
+                                                  type: object
+                                                type: array
+                                              path:
+                                                description: Path to access on the
+                                                  HTTP server.
+                                                type: string
+                                              port:
+                                                description: Name or number of the
+                                                  port to access on the container.
+                                                  Number must be in the range 1 to
+                                                  65535. Name must be an IANA_SVC_NAME.
+                                                x-kubernetes-int-or-string: true
+                                              scheme:
+                                                description: Scheme to use for connecting
+                                                  to the host. Defaults to HTTP.
+                                                type: string
+                                            required:
+                                            - port
+                                            type: object
+                                          tcpSocket:
+                                            description: 'TCPSocket specifies an action
+                                              involving a TCP port. TCP hooks not
+                                              yet supported TODO: implement a realistic
+                                              TCP lifecycle hook'
+                                            properties:
+                                              host:
+                                                description: 'Optional: Host name
+                                                  to connect to, defaults to the pod
+                                                  IP.'
+                                                type: string
+                                              port:
+                                                description: Number or name of the
+                                                  port to access on the container.
+                                                  Number must be in the range 1 to
+                                                  65535. Name must be an IANA_SVC_NAME.
+                                                x-kubernetes-int-or-string: true
+                                            required:
+                                            - port
+                                            type: object
+                                        type: object
+                                    type: object
+                                  livenessProbe:
+                                    description: 'Periodic probe of container liveness.
+                                      Container will be restarted if the probe fails.
+                                      Cannot be updated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                                    properties:
+                                      exec:
+                                        description: One and only one of the following
+                                          should be specified. Exec specifies the
+                                          action to take.
+                                        properties:
+                                          command:
+                                            description: Command is the command line
+                                              to execute inside the container, the
+                                              working directory for the command  is
+                                              root ('/') in the container's filesystem.
+                                              The command is simply exec'd, it is
+                                              not run inside a shell, so traditional
+                                              shell instructions ('|', etc) won't
+                                              work. To use a shell, you need to explicitly
+                                              call out to that shell. Exit status
+                                              of 0 is treated as live/healthy and
+                                              non-zero is unhealthy.
+                                            items:
+                                              type: string
+                                            type: array
+                                        type: object
+                                      failureThreshold:
+                                        description: Minimum consecutive failures
+                                          for the probe to be considered failed after
+                                          having succeeded. Defaults to 3. Minimum
+                                          value is 1.
+                                        format: int32
+                                        type: integer
+                                      httpGet:
+                                        description: HTTPGet specifies the http request
+                                          to perform.
+                                        properties:
+                                          host:
+                                            description: Host name to connect to,
+                                              defaults to the pod IP. You probably
+                                              want to set "Host" in httpHeaders instead.
+                                            type: string
+                                          httpHeaders:
+                                            description: Custom headers to set in
+                                              the request. HTTP allows repeated headers.
+                                            items:
+                                              description: HTTPHeader describes a
+                                                custom header to be used in HTTP probes
+                                              properties:
+                                                name:
+                                                  description: The header field name
+                                                  type: string
+                                                value:
+                                                  description: The header field value
+                                                  type: string
+                                              required:
+                                              - name
+                                              - value
+                                              type: object
+                                            type: array
+                                          path:
+                                            description: Path to access on the HTTP
+                                              server.
+                                            type: string
+                                          port:
+                                            description: Name or number of the port
+                                              to access on the container. Number must
+                                              be in the range 1 to 65535. Name must
+                                              be an IANA_SVC_NAME.
+                                            x-kubernetes-int-or-string: true
+                                          scheme:
+                                            description: Scheme to use for connecting
+                                              to the host. Defaults to HTTP.
+                                            type: string
+                                        required:
+                                        - port
+                                        type: object
+                                      initialDelaySeconds:
+                                        description: 'Number of seconds after the
+                                          container has started before liveness probes
+                                          are initiated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                                        format: int32
+                                        type: integer
+                                      periodSeconds:
+                                        description: How often (in seconds) to perform
+                                          the probe. Default to 10 seconds. Minimum
+                                          value is 1.
+                                        format: int32
+                                        type: integer
+                                      successThreshold:
+                                        description: Minimum consecutive successes
+                                          for the probe to be considered successful
+                                          after having failed. Defaults to 1. Must
+                                          be 1 for liveness and startup. Minimum value
+                                          is 1.
+                                        format: int32
+                                        type: integer
+                                      tcpSocket:
+                                        description: 'TCPSocket specifies an action
+                                          involving a TCP port. TCP hooks not yet
+                                          supported TODO: implement a realistic TCP
+                                          lifecycle hook'
+                                        properties:
+                                          host:
+                                            description: 'Optional: Host name to connect
+                                              to, defaults to the pod IP.'
+                                            type: string
+                                          port:
+                                            description: Number or name of the port
+                                              to access on the container. Number must
+                                              be in the range 1 to 65535. Name must
+                                              be an IANA_SVC_NAME.
+                                            x-kubernetes-int-or-string: true
+                                        required:
+                                        - port
+                                        type: object
+                                      timeoutSeconds:
+                                        description: 'Number of seconds after which
+                                          the probe times out. Defaults to 1 second.
+                                          Minimum value is 1. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                                        format: int32
+                                        type: integer
+                                    type: object
+                                  name:
+                                    description: Name of the container specified as
+                                      a DNS_LABEL. Each container in a pod must have
+                                      a unique name (DNS_LABEL). Cannot be updated.
+                                    type: string
+                                  ports:
+                                    description: List of ports to expose from the
+                                      container. Exposing a port here gives the system
+                                      additional information about the network connections
+                                      a container uses, but is primarily informational.
+                                      Not specifying a port here DOES NOT prevent
+                                      that port from being exposed. Any port which
+                                      is listening on the default "0.0.0.0" address
+                                      inside a container will be accessible from the
+                                      network. Cannot be updated.
+                                    items:
+                                      description: ContainerPort represents a network
+                                        port in a single container.
+                                      properties:
+                                        containerPort:
+                                          description: Number of port to expose on
+                                            the pod's IP address. This must be a valid
+                                            port number, 0 < x < 65536.
+                                          format: int32
+                                          type: integer
+                                        hostIP:
+                                          description: What host IP to bind the external
+                                            port to.
+                                          type: string
+                                        hostPort:
+                                          description: Number of port to expose on
+                                            the host. If specified, this must be a
+                                            valid port number, 0 < x < 65536. If HostNetwork
+                                            is specified, this must match ContainerPort.
+                                            Most containers do not need this.
+                                          format: int32
+                                          type: integer
+                                        name:
+                                          description: If specified, this must be
+                                            an IANA_SVC_NAME and unique within the
+                                            pod. Each named port in a pod must have
+                                            a unique name. Name for the port that
+                                            can be referred to by services.
+                                          type: string
+                                        protocol:
+                                          description: Protocol for port. Must be
+                                            UDP, TCP, or SCTP. Defaults to "TCP".
+                                          type: string
+                                      required:
+                                      - containerPort
+                                      type: object
+                                    type: array
+                                    x-kubernetes-list-map-keys:
+                                    - containerPort
+                                    - protocol
+                                    x-kubernetes-list-type: map
+                                  readinessProbe:
+                                    description: 'Periodic probe of container service
+                                      readiness. Container will be removed from service
+                                      endpoints if the probe fails. Cannot be updated.
+                                      More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                                    properties:
+                                      exec:
+                                        description: One and only one of the following
+                                          should be specified. Exec specifies the
+                                          action to take.
+                                        properties:
+                                          command:
+                                            description: Command is the command line
+                                              to execute inside the container, the
+                                              working directory for the command  is
+                                              root ('/') in the container's filesystem.
+                                              The command is simply exec'd, it is
+                                              not run inside a shell, so traditional
+                                              shell instructions ('|', etc) won't
+                                              work. To use a shell, you need to explicitly
+                                              call out to that shell. Exit status
+                                              of 0 is treated as live/healthy and
+                                              non-zero is unhealthy.
+                                            items:
+                                              type: string
+                                            type: array
+                                        type: object
+                                      failureThreshold:
+                                        description: Minimum consecutive failures
+                                          for the probe to be considered failed after
+                                          having succeeded. Defaults to 3. Minimum
+                                          value is 1.
+                                        format: int32
+                                        type: integer
+                                      httpGet:
+                                        description: HTTPGet specifies the http request
+                                          to perform.
+                                        properties:
+                                          host:
+                                            description: Host name to connect to,
+                                              defaults to the pod IP. You probably
+                                              want to set "Host" in httpHeaders instead.
+                                            type: string
+                                          httpHeaders:
+                                            description: Custom headers to set in
+                                              the request. HTTP allows repeated headers.
+                                            items:
+                                              description: HTTPHeader describes a
+                                                custom header to be used in HTTP probes
+                                              properties:
+                                                name:
+                                                  description: The header field name
+                                                  type: string
+                                                value:
+                                                  description: The header field value
+                                                  type: string
+                                              required:
+                                              - name
+                                              - value
+                                              type: object
+                                            type: array
+                                          path:
+                                            description: Path to access on the HTTP
+                                              server.
+                                            type: string
+                                          port:
+                                            description: Name or number of the port
+                                              to access on the container. Number must
+                                              be in the range 1 to 65535. Name must
+                                              be an IANA_SVC_NAME.
+                                            x-kubernetes-int-or-string: true
+                                          scheme:
+                                            description: Scheme to use for connecting
+                                              to the host. Defaults to HTTP.
+                                            type: string
+                                        required:
+                                        - port
+                                        type: object
+                                      initialDelaySeconds:
+                                        description: 'Number of seconds after the
+                                          container has started before liveness probes
+                                          are initiated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                                        format: int32
+                                        type: integer
+                                      periodSeconds:
+                                        description: How often (in seconds) to perform
+                                          the probe. Default to 10 seconds. Minimum
+                                          value is 1.
+                                        format: int32
+                                        type: integer
+                                      successThreshold:
+                                        description: Minimum consecutive successes
+                                          for the probe to be considered successful
+                                          after having failed. Defaults to 1. Must
+                                          be 1 for liveness and startup. Minimum value
+                                          is 1.
+                                        format: int32
+                                        type: integer
+                                      tcpSocket:
+                                        description: 'TCPSocket specifies an action
+                                          involving a TCP port. TCP hooks not yet
+                                          supported TODO: implement a realistic TCP
+                                          lifecycle hook'
+                                        properties:
+                                          host:
+                                            description: 'Optional: Host name to connect
+                                              to, defaults to the pod IP.'
+                                            type: string
+                                          port:
+                                            description: Number or name of the port
+                                              to access on the container. Number must
+                                              be in the range 1 to 65535. Name must
+                                              be an IANA_SVC_NAME.
+                                            x-kubernetes-int-or-string: true
+                                        required:
+                                        - port
+                                        type: object
+                                      timeoutSeconds:
+                                        description: 'Number of seconds after which
+                                          the probe times out. Defaults to 1 second.
+                                          Minimum value is 1. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                                        format: int32
+                                        type: integer
+                                    type: object
+                                  resources:
+                                    description: 'Compute Resources required by this
+                                      container. Cannot be updated. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
+                                    properties:
+                                      limits:
+                                        additionalProperties:
+                                          anyOf:
+                                          - type: integer
+                                          - type: string
+                                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                          x-kubernetes-int-or-string: true
+                                        description: 'Limits describes the maximum
+                                          amount of compute resources allowed. More
+                                          info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
+                                        type: object
+                                      requests:
+                                        additionalProperties:
+                                          anyOf:
+                                          - type: integer
+                                          - type: string
+                                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                          x-kubernetes-int-or-string: true
+                                        description: 'Requests describes the minimum
+                                          amount of compute resources required. If
+                                          Requests is omitted for a container, it
+                                          defaults to Limits if that is explicitly
+                                          specified, otherwise to an implementation-defined
+                                          value. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
+                                        type: object
+                                    type: object
+                                  securityContext:
+                                    description: 'Security options the pod should
+                                      run with. More info: https://kubernetes.io/docs/concepts/policy/security-context/
+                                      More info: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/'
+                                    properties:
+                                      allowPrivilegeEscalation:
+                                        description: 'AllowPrivilegeEscalation controls
+                                          whether a process can gain more privileges
+                                          than its parent process. This bool directly
+                                          controls if the no_new_privs flag will be
+                                          set on the container process. AllowPrivilegeEscalation
+                                          is true always when the container is: 1)
+                                          run as Privileged 2) has CAP_SYS_ADMIN'
+                                        type: boolean
+                                      capabilities:
+                                        description: The capabilities to add/drop
+                                          when running containers. Defaults to the
+                                          default set of capabilities granted by the
+                                          container runtime.
+                                        properties:
+                                          add:
+                                            description: Added capabilities
+                                            items:
+                                              description: Capability represent POSIX
+                                                capabilities type
+                                              type: string
+                                            type: array
+                                          drop:
+                                            description: Removed capabilities
+                                            items:
+                                              description: Capability represent POSIX
+                                                capabilities type
+                                              type: string
+                                            type: array
+                                        type: object
+                                      privileged:
+                                        description: Run container in privileged mode.
+                                          Processes in privileged containers are essentially
+                                          equivalent to root on the host. Defaults
+                                          to false.
+                                        type: boolean
+                                      procMount:
+                                        description: procMount denotes the type of
+                                          proc mount to use for the containers. The
+                                          default is DefaultProcMount which uses the
+                                          container runtime defaults for readonly
+                                          paths and masked paths. This requires the
+                                          ProcMountType feature flag to be enabled.
+                                        type: string
+                                      readOnlyRootFilesystem:
+                                        description: Whether this container has a
+                                          read-only root filesystem. Default is false.
+                                        type: boolean
+                                      runAsGroup:
+                                        description: The GID to run the entrypoint
+                                          of the container process. Uses runtime default
+                                          if unset. May also be set in PodSecurityContext.  If
+                                          set in both SecurityContext and PodSecurityContext,
+                                          the value specified in SecurityContext takes
+                                          precedence.
+                                        format: int64
+                                        type: integer
+                                      runAsNonRoot:
+                                        description: Indicates that the container
+                                          must run as a non-root user. If true, the
+                                          Kubelet will validate the image at runtime
+                                          to ensure that it does not run as UID 0
+                                          (root) and fail to start the container if
+                                          it does. If unset or false, no such validation
+                                          will be performed. May also be set in PodSecurityContext.  If
+                                          set in both SecurityContext and PodSecurityContext,
+                                          the value specified in SecurityContext takes
+                                          precedence.
+                                        type: boolean
+                                      runAsUser:
+                                        description: The UID to run the entrypoint
+                                          of the container process. Defaults to user
+                                          specified in image metadata if unspecified.
+                                          May also be set in PodSecurityContext.  If
+                                          set in both SecurityContext and PodSecurityContext,
+                                          the value specified in SecurityContext takes
+                                          precedence.
+                                        format: int64
+                                        type: integer
+                                      seLinuxOptions:
+                                        description: The SELinux context to be applied
+                                          to the container. If unspecified, the container
+                                          runtime will allocate a random SELinux context
+                                          for each container.  May also be set in
+                                          PodSecurityContext.  If set in both SecurityContext
+                                          and PodSecurityContext, the value specified
+                                          in SecurityContext takes precedence.
+                                        properties:
+                                          level:
+                                            description: Level is SELinux level label
+                                              that applies to the container.
+                                            type: string
+                                          role:
+                                            description: Role is a SELinux role label
+                                              that applies to the container.
+                                            type: string
+                                          type:
+                                            description: Type is a SELinux type label
+                                              that applies to the container.
+                                            type: string
+                                          user:
+                                            description: User is a SELinux user label
+                                              that applies to the container.
+                                            type: string
+                                        type: object
+                                      windowsOptions:
+                                        description: The Windows specific settings
+                                          applied to all containers. If unspecified,
+                                          the options from the PodSecurityContext
+                                          will be used. If set in both SecurityContext
+                                          and PodSecurityContext, the value specified
+                                          in SecurityContext takes precedence.
+                                        properties:
+                                          gmsaCredentialSpec:
+                                            description: GMSACredentialSpec is where
+                                              the GMSA admission webhook (https://github.com/kubernetes-sigs/windows-gmsa)
+                                              inlines the contents of the GMSA credential
+                                              spec named by the GMSACredentialSpecName
+                                              field. This field is alpha-level and
+                                              is only honored by servers that enable
+                                              the WindowsGMSA feature flag.
+                                            type: string
+                                          gmsaCredentialSpecName:
+                                            description: GMSACredentialSpecName is
+                                              the name of the GMSA credential spec
+                                              to use. This field is alpha-level and
+                                              is only honored by servers that enable
+                                              the WindowsGMSA feature flag.
+                                            type: string
+                                          runAsUserName:
+                                            description: The UserName in Windows to
+                                              run the entrypoint of the container
+                                              process. Defaults to the user specified
+                                              in image metadata if unspecified. May
+                                              also be set in PodSecurityContext. If
+                                              set in both SecurityContext and PodSecurityContext,
+                                              the value specified in SecurityContext
+                                              takes precedence. This field is beta-level
+                                              and may be disabled with the WindowsRunAsUserName
+                                              feature flag.
+                                            type: string
+                                        type: object
+                                    type: object
+                                  startupProbe:
+                                    description: 'StartupProbe indicates that the
+                                      Pod has successfully initialized. If specified,
+                                      no other probes are executed until this completes
+                                      successfully. If this probe fails, the Pod will
+                                      be restarted, just as if the livenessProbe failed.
+                                      This can be used to provide different probe
+                                      parameters at the beginning of a Pod''s lifecycle,
+                                      when it might take a long time to load data
+                                      or warm a cache, than during steady-state operation.
+                                      This cannot be updated. This is an alpha feature
+                                      enabled by the StartupProbe feature flag. More
+                                      info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                                    properties:
+                                      exec:
+                                        description: One and only one of the following
+                                          should be specified. Exec specifies the
+                                          action to take.
+                                        properties:
+                                          command:
+                                            description: Command is the command line
+                                              to execute inside the container, the
+                                              working directory for the command  is
+                                              root ('/') in the container's filesystem.
+                                              The command is simply exec'd, it is
+                                              not run inside a shell, so traditional
+                                              shell instructions ('|', etc) won't
+                                              work. To use a shell, you need to explicitly
+                                              call out to that shell. Exit status
+                                              of 0 is treated as live/healthy and
+                                              non-zero is unhealthy.
+                                            items:
+                                              type: string
+                                            type: array
+                                        type: object
+                                      failureThreshold:
+                                        description: Minimum consecutive failures
+                                          for the probe to be considered failed after
+                                          having succeeded. Defaults to 3. Minimum
+                                          value is 1.
+                                        format: int32
+                                        type: integer
+                                      httpGet:
+                                        description: HTTPGet specifies the http request
+                                          to perform.
+                                        properties:
+                                          host:
+                                            description: Host name to connect to,
+                                              defaults to the pod IP. You probably
+                                              want to set "Host" in httpHeaders instead.
+                                            type: string
+                                          httpHeaders:
+                                            description: Custom headers to set in
+                                              the request. HTTP allows repeated headers.
+                                            items:
+                                              description: HTTPHeader describes a
+                                                custom header to be used in HTTP probes
+                                              properties:
+                                                name:
+                                                  description: The header field name
+                                                  type: string
+                                                value:
+                                                  description: The header field value
+                                                  type: string
+                                              required:
+                                              - name
+                                              - value
+                                              type: object
+                                            type: array
+                                          path:
+                                            description: Path to access on the HTTP
+                                              server.
+                                            type: string
+                                          port:
+                                            anyOf:
+                                            - type: integer
+                                            - type: string
+                                            description: Name or number of the port
+                                              to access on the container. Number must
+                                              be in the range 1 to 65535. Name must
+                                              be an IANA_SVC_NAME.
+                                            x-kubernetes-int-or-string: true
+                                          scheme:
+                                            description: Scheme to use for connecting
+                                              to the host. Defaults to HTTP.
+                                            type: string
+                                        required:
+                                        - port
+                                        type: object
+                                      initialDelaySeconds:
+                                        description: 'Number of seconds after the
+                                          container has started before liveness probes
+                                          are initiated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                                        format: int32
+                                        type: integer
+                                      periodSeconds:
+                                        description: How often (in seconds) to perform
+                                          the probe. Default to 10 seconds. Minimum
+                                          value is 1.
+                                        format: int32
+                                        type: integer
+                                      successThreshold:
+                                        description: Minimum consecutive successes
+                                          for the probe to be considered successful
+                                          after having failed. Defaults to 1. Must
+                                          be 1 for liveness and startup. Minimum value
+                                          is 1.
+                                        format: int32
+                                        type: integer
+                                      tcpSocket:
+                                        description: 'TCPSocket specifies an action
+                                          involving a TCP port. TCP hooks not yet
+                                          supported TODO: implement a realistic TCP
+                                          lifecycle hook'
+                                        properties:
+                                          host:
+                                            description: 'Optional: Host name to connect
+                                              to, defaults to the pod IP.'
+                                            type: string
+                                          port:
+                                            anyOf:
+                                            - type: integer
+                                            - type: string
+                                            description: Number or name of the port
+                                              to access on the container. Number must
+                                              be in the range 1 to 65535. Name must
+                                              be an IANA_SVC_NAME.
+                                            x-kubernetes-int-or-string: true
+                                        required:
+                                        - port
+                                        type: object
+                                      timeoutSeconds:
+                                        description: 'Number of seconds after which
+                                          the probe times out. Defaults to 1 second.
+                                          Minimum value is 1. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                                        format: int32
+                                        type: integer
+                                    type: object
+                                  stdin:
+                                    description: Whether this container should allocate
+                                      a buffer for stdin in the container runtime.
+                                      If this is not set, reads from stdin in the
+                                      container will always result in EOF. Default
+                                      is false.
+                                    type: boolean
+                                  stdinOnce:
+                                    description: Whether the container runtime should
+                                      close the stdin channel after it has been opened
+                                      by a single attach. When stdin is true the stdin
+                                      stream will remain open across multiple attach
+                                      sessions. If stdinOnce is set to true, stdin
+                                      is opened on container start, is empty until
+                                      the first client attaches to stdin, and then
+                                      remains open and accepts data until the client
+                                      disconnects, at which time stdin is closed and
+                                      remains closed until the container is restarted.
+                                      If this flag is false, a container processes
+                                      that reads from stdin will never receive an
+                                      EOF. Default is false
+                                    type: boolean
+                                  terminationMessagePath:
+                                    description: 'Optional: Path at which the file
+                                      to which the container''s termination message
+                                      will be written is mounted into the container''s
+                                      filesystem. Message written is intended to be
+                                      brief final status, such as an assertion failure
+                                      message. Will be truncated by the node if greater
+                                      than 4096 bytes. The total message length across
+                                      all containers will be limited to 12kb. Defaults
+                                      to /dev/termination-log. Cannot be updated.'
+                                    type: string
+                                  terminationMessagePolicy:
+                                    description: Indicate how the termination message
+                                      should be populated. File will use the contents
+                                      of terminationMessagePath to populate the container
+                                      status message on both success and failure.
+                                      FallbackToLogsOnError will use the last chunk
+                                      of container log output if the termination message
+                                      file is empty and the container exited with
+                                      an error. The log output is limited to 2048
+                                      bytes or 80 lines, whichever is smaller. Defaults
+                                      to File. Cannot be updated.
+                                    type: string
+                                  tty:
+                                    description: Whether this container should allocate
+                                      a TTY for itself, also requires 'stdin' to be
+                                      true. Default is false.
+                                    type: boolean
+                                  volumeDevices:
+                                    description: volumeDevices is the list of block
+                                      devices to be used by the container. This is
+                                      a beta feature.
+                                    items:
+                                      description: volumeDevice describes a mapping
+                                        of a raw block device within a container.
+                                      properties:
+                                        devicePath:
+                                          description: devicePath is the path inside
+                                            of the container that the device will
+                                            be mapped to.
+                                          type: string
+                                        name:
+                                          description: name must match the name of
+                                            a persistentVolumeClaim in the pod
+                                          type: string
+                                      required:
+                                      - devicePath
+                                      - name
+                                      type: object
+                                    type: array
+                                  volumeMounts:
+                                    description: Pod volumes to mount into the container's
+                                      filesystem. Cannot be updated.
+                                    items:
+                                      description: VolumeMount describes a mounting
+                                        of a Volume within a container.
+                                      properties:
+                                        mountPath:
+                                          description: Path within the container at
+                                            which the volume should be mounted.  Must
+                                            not contain ':'.
+                                          type: string
+                                        mountPropagation:
+                                          description: mountPropagation determines
+                                            how mounts are propagated from the host
+                                            to container and the other way around.
+                                            When not set, MountPropagationNone is
+                                            used. This field is beta in 1.10.
+                                          type: string
+                                        name:
+                                          description: This must match the Name of
+                                            a Volume.
+                                          type: string
+                                        readOnly:
+                                          description: Mounted read-only if true,
+                                            read-write otherwise (false or unspecified).
+                                            Defaults to false.
+                                          type: boolean
+                                        subPath:
+                                          description: Path within the volume from
+                                            which the container's volume should be
+                                            mounted. Defaults to "" (volume's root).
+                                          type: string
+                                        subPathExpr:
+                                          description: Expanded path within the volume
+                                            from which the container's volume should
+                                            be mounted. Behaves similarly to SubPath
+                                            but environment variable references $(VAR_NAME)
+                                            are expanded using the container's environment.
+                                            Defaults to "" (volume's root). SubPathExpr
+                                            and SubPath are mutually exclusive.
+                                          type: string
+                                      required:
+                                      - mountPath
+                                      - name
+                                      type: object
+                                    type: array
+                                  workingDir:
+                                    description: Container's working directory. If
+                                      not specified, the container runtime's default
+                                      will be used, which might be configured in the
+                                      container image. Cannot be updated.
+                                    type: string
+                                required:
+                                - name
+                                type: object
+                              type: array
+                            nodeName:
+                              description: NodeName is a request to schedule this
+                                pod onto a specific node. If it is non-empty, the
+                                scheduler simply schedules this pod onto that node,
+                                assuming that it fits resource requirements.
+                              type: string
+                            nodeSelector:
+                              additionalProperties:
+                                type: string
+                              description: 'NodeSelector is a selector which must
+                                be true for the pod to fit on a node. Selector which
+                                must match a node''s labels for the pod to be scheduled
+                                on that node. More info: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/'
+                              type: object
+                            overhead:
+                              additionalProperties:
+                                anyOf:
+                                - type: integer
+                                - type: string
+                                pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                x-kubernetes-int-or-string: true
+                              description: 'Overhead represents the resource overhead
+                                associated with running a pod for a given RuntimeClass.
+                                This field will be autopopulated at admission time
+                                by the RuntimeClass admission controller. If the RuntimeClass
+                                admission controller is enabled, overhead must not
+                                be set in Pod create requests. The RuntimeClass admission
+                                controller will reject Pod create requests which have
+                                the overhead already set. If RuntimeClass is configured
+                                and selected in the PodSpec, Overhead will be set
+                                to the value defined in the corresponding RuntimeClass,
+                                otherwise it will remain unset and treated as zero.
+                                More info: https://git.k8s.io/enhancements/keps/sig-node/20190226-pod-overhead.md
+                                This field is alpha-level as of Kubernetes v1.16,
+                                and is only honored by servers that enable the PodOverhead
+                                feature.'
+                              type: object
+                            preemptionPolicy:
+                              description: PreemptionPolicy is the Policy for preempting
+                                pods with lower priority. One of Never, PreemptLowerPriority.
+                                Defaults to PreemptLowerPriority if unset. This field
+                                is alpha-level and is only honored by servers that
+                                enable the NonPreemptingPriority feature.
+                              type: string
+                            priority:
+                              description: The priority value. Various system components
+                                use this field to find the priority of the pod. When
+                                Priority Admission Controller is enabled, it prevents
+                                users from setting this field. The admission controller
+                                populates this field from PriorityClassName. The higher
+                                the value, the higher the priority.
+                              format: int32
+                              type: integer
+                            priorityClassName:
+                              description: If specified, indicates the pod's priority.
+                                "system-node-critical" and "system-cluster-critical"
+                                are two special keywords which indicate the highest
+                                priorities with the former being the highest priority.
+                                Any other name must be defined by creating a PriorityClass
+                                object with that name. If not specified, the pod priority
+                                will be default or zero if there is no default.
+                              type: string
+                            readinessGates:
+                              description: 'If specified, all readiness gates will
+                                be evaluated for pod readiness. A pod is ready when
+                                all its containers are ready AND all conditions specified
+                                in the readiness gates have status equal to "True"
+                                More info: https://git.k8s.io/enhancements/keps/sig-network/0007-pod-ready%2B%2B.md'
+                              items:
+                                description: PodReadinessGate contains the reference
+                                  to a pod condition
+                                properties:
+                                  conditionType:
+                                    description: ConditionType refers to a condition
+                                      in the pod's condition list with matching type.
+                                    type: string
+                                required:
+                                - conditionType
+                                type: object
+                              type: array
+                            restartPolicy:
+                              description: 'Restart policy for all containers within
+                                the pod. One of Always, OnFailure, Never. Default
+                                to Always. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle/#restart-policy'
+                              type: string
+                            runtimeClassName:
+                              description: 'RuntimeClassName refers to a RuntimeClass
+                                object in the node.k8s.io group, which should be used
+                                to run this pod.  If no RuntimeClass resource matches
+                                the named class, the pod will not be run. If unset
+                                or empty, the "legacy" RuntimeClass will be used,
+                                which is an implicit class with an empty definition
+                                that uses the default runtime handler. More info:
+                                https://git.k8s.io/enhancements/keps/sig-node/runtime-class.md
+                                This is a beta feature as of Kubernetes v1.14.'
+                              type: string
+                            schedulerName:
+                              description: If specified, the pod will be dispatched
+                                by specified scheduler. If not specified, the pod
+                                will be dispatched by default scheduler.
+                              type: string
+                            securityContext:
+                              description: 'SecurityContext holds pod-level security
+                                attributes and common container settings. Optional:
+                                Defaults to empty.  See type description for default
+                                values of each field.'
+                              properties:
+                                fsGroup:
+                                  description: "A special supplemental group that
+                                    applies to all containers in a pod. Some volume
+                                    types allow the Kubelet to change the ownership
+                                    of that volume to be owned by the pod: \n 1. The
+                                    owning GID will be the FSGroup 2. The setgid bit
+                                    is set (new files created in the volume will be
+                                    owned by FSGroup) 3. The permission bits are OR'd
+                                    with rw-rw---- \n If unset, the Kubelet will not
+                                    modify the ownership and permissions of any volume."
+                                  format: int64
+                                  type: integer
+                                runAsGroup:
+                                  description: The GID to run the entrypoint of the
+                                    container process. Uses runtime default if unset.
+                                    May also be set in SecurityContext.  If set in
+                                    both SecurityContext and PodSecurityContext, the
+                                    value specified in SecurityContext takes precedence
+                                    for that container.
+                                  format: int64
+                                  type: integer
+                                runAsNonRoot:
+                                  description: Indicates that the container must run
+                                    as a non-root user. If true, the Kubelet will
+                                    validate the image at runtime to ensure that it
+                                    does not run as UID 0 (root) and fail to start
+                                    the container if it does. If unset or false, no
+                                    such validation will be performed. May also be
+                                    set in SecurityContext.  If set in both SecurityContext
+                                    and PodSecurityContext, the value specified in
+                                    SecurityContext takes precedence.
+                                  type: boolean
+                                runAsUser:
+                                  description: The UID to run the entrypoint of the
+                                    container process. Defaults to user specified
+                                    in image metadata if unspecified. May also be
+                                    set in SecurityContext.  If set in both SecurityContext
+                                    and PodSecurityContext, the value specified in
+                                    SecurityContext takes precedence for that container.
+                                  format: int64
+                                  type: integer
+                                seLinuxOptions:
+                                  description: The SELinux context to be applied to
+                                    all containers. If unspecified, the container
+                                    runtime will allocate a random SELinux context
+                                    for each container.  May also be set in SecurityContext.  If
+                                    set in both SecurityContext and PodSecurityContext,
+                                    the value specified in SecurityContext takes precedence
+                                    for that container.
+                                  properties:
+                                    level:
+                                      description: Level is SELinux level label that
+                                        applies to the container.
+                                      type: string
+                                    role:
+                                      description: Role is a SELinux role label that
+                                        applies to the container.
+                                      type: string
+                                    type:
+                                      description: Type is a SELinux type label that
+                                        applies to the container.
+                                      type: string
+                                    user:
+                                      description: User is a SELinux user label that
+                                        applies to the container.
+                                      type: string
+                                  type: object
+                                supplementalGroups:
+                                  description: A list of groups applied to the first
+                                    process run in each container, in addition to
+                                    the container's primary GID.  If unspecified,
+                                    no groups will be added to any container.
+                                  items:
+                                    format: int64
+                                    type: integer
+                                  type: array
+                                sysctls:
+                                  description: Sysctls hold a list of namespaced sysctls
+                                    used for the pod. Pods with unsupported sysctls
+                                    (by the container runtime) might fail to launch.
+                                  items:
+                                    description: Sysctl defines a kernel parameter
+                                      to be set
+                                    properties:
+                                      name:
+                                        description: Name of a property to set
+                                        type: string
+                                      value:
+                                        description: Value of a property to set
+                                        type: string
+                                    required:
+                                    - name
+                                    - value
+                                    type: object
+                                  type: array
+                                windowsOptions:
+                                  description: The Windows specific settings applied
+                                    to all containers. If unspecified, the options
+                                    within a container's SecurityContext will be used.
+                                    If set in both SecurityContext and PodSecurityContext,
+                                    the value specified in SecurityContext takes precedence.
+                                  properties:
+                                    gmsaCredentialSpec:
+                                      description: GMSACredentialSpec is where the
+                                        GMSA admission webhook (https://github.com/kubernetes-sigs/windows-gmsa)
+                                        inlines the contents of the GMSA credential
+                                        spec named by the GMSACredentialSpecName field.
+                                        This field is alpha-level and is only honored
+                                        by servers that enable the WindowsGMSA feature
+                                        flag.
+                                      type: string
+                                    gmsaCredentialSpecName:
+                                      description: GMSACredentialSpecName is the name
+                                        of the GMSA credential spec to use. This field
+                                        is alpha-level and is only honored by servers
+                                        that enable the WindowsGMSA feature flag.
+                                      type: string
+                                    runAsUserName:
+                                      description: The UserName in Windows to run
+                                        the entrypoint of the container process. Defaults
+                                        to the user specified in image metadata if
+                                        unspecified. May also be set in PodSecurityContext.
+                                        If set in both SecurityContext and PodSecurityContext,
+                                        the value specified in SecurityContext takes
+                                        precedence. This field is beta-level and may
+                                        be disabled with the WindowsRunAsUserName
+                                        feature flag.
+                                      type: string
+                                  type: object
+                              type: object
+                            serviceAccount:
+                              description: 'DeprecatedServiceAccount is a depreciated
+                                alias for ServiceAccountName. Deprecated: Use serviceAccountName
+                                instead.'
+                              type: string
+                            serviceAccountName:
+                              description: 'ServiceAccountName is the name of the
+                                ServiceAccount to use to run this pod. More info:
+                                https://kubernetes.io/docs/tasks/configure-pod-container/configure-service-account/'
+                              type: string
+                            shareProcessNamespace:
+                              description: 'Share a single process namespace between
+                                all of the containers in a pod. When this is set containers
+                                will be able to view and signal processes from other
+                                containers in the same pod, and the first process
+                                in each container will not be assigned PID 1. HostPID
+                                and ShareProcessNamespace cannot both be set. Optional:
+                                Default to false.'
+                              type: boolean
+                            subdomain:
+                              description: If specified, the fully qualified Pod hostname
+                                will be "<hostname>.<subdomain>.<pod namespace>.svc.<cluster
+                                domain>". If not specified, the pod will not have
+                                a domainname at all.
+                              type: string
+                            terminationGracePeriodSeconds:
+                              description: Optional duration in seconds the pod needs
+                                to terminate gracefully. May be decreased in delete
+                                request. Value must be non-negative integer. The value
+                                zero indicates delete immediately. If this value is
+                                nil, the default grace period will be used instead.
+                                The grace period is the duration in seconds after
+                                the processes running in the pod are sent a termination
+                                signal and the time when the processes are forcibly
+                                halted with a kill signal. Set this value longer than
+                                the expected cleanup time for your process. Defaults
+                                to 30 seconds.
+                              format: int64
+                              type: integer
+                            tolerations:
+                              description: If specified, the pod's tolerations.
+                              items:
+                                description: The pod this Toleration is attached to
+                                  tolerates any taint that matches the triple <key,value,effect>
+                                  using the matching operator <operator>.
+                                properties:
+                                  effect:
+                                    description: Effect indicates the taint effect
+                                      to match. Empty means match all taint effects.
+                                      When specified, allowed values are NoSchedule,
+                                      PreferNoSchedule and NoExecute.
+                                    type: string
+                                  key:
+                                    description: Key is the taint key that the toleration
+                                      applies to. Empty means match all taint keys.
+                                      If the key is empty, operator must be Exists;
+                                      this combination means to match all values and
+                                      all keys.
+                                    type: string
+                                  operator:
+                                    description: Operator represents a key's relationship
+                                      to the value. Valid operators are Exists and
+                                      Equal. Defaults to Equal. Exists is equivalent
+                                      to wildcard for value, so that a pod can tolerate
+                                      all taints of a particular category.
+                                    type: string
+                                  tolerationSeconds:
+                                    description: TolerationSeconds represents the
+                                      period of time the toleration (which must be
+                                      of effect NoExecute, otherwise this field is
+                                      ignored) tolerates the taint. By default, it
+                                      is not set, which means tolerate the taint forever
+                                      (do not evict). Zero and negative values will
+                                      be treated as 0 (evict immediately) by the system.
+                                    format: int64
+                                    type: integer
+                                  value:
+                                    description: Value is the taint value the toleration
+                                      matches to. If the operator is Exists, the value
+                                      should be empty, otherwise just a regular string.
+                                    type: string
+                                type: object
+                              type: array
+                            topologySpreadConstraints:
+                              description: TopologySpreadConstraints describes how
+                                a group of pods ought to spread across topology domains.
+                                Scheduler will schedule pods in a way which abides
+                                by the constraints. This field is alpha-level and
+                                is only honored by clusters that enables the EvenPodsSpread
+                                feature. All topologySpreadConstraints are ANDed.
+                              items:
+                                description: TopologySpreadConstraint specifies how
+                                  to spread matching pods among the given topology.
+                                properties:
+                                  labelSelector:
+                                    description: LabelSelector is used to find matching
+                                      pods. Pods that match this label selector are
+                                      counted to determine the number of pods in their
+                                      corresponding topology domain.
+                                    properties:
+                                      matchExpressions:
+                                        description: matchExpressions is a list of
+                                          label selector requirements. The requirements
+                                          are ANDed.
+                                        items:
+                                          description: A label selector requirement
+                                            is a selector that contains values, a
+                                            key, and an operator that relates the
+                                            key and values.
+                                          properties:
+                                            key:
+                                              description: key is the label key that
+                                                the selector applies to.
+                                              type: string
+                                            operator:
+                                              description: operator represents a key's
+                                                relationship to a set of values. Valid
+                                                operators are In, NotIn, Exists and
+                                                DoesNotExist.
+                                              type: string
+                                            values:
+                                              description: values is an array of string
+                                                values. If the operator is In or NotIn,
+                                                the values array must be non-empty.
+                                                If the operator is Exists or DoesNotExist,
+                                                the values array must be empty. This
+                                                array is replaced during a strategic
+                                                merge patch.
+                                              items:
+                                                type: string
+                                              type: array
+                                          required:
+                                          - key
+                                          - operator
+                                          type: object
+                                        type: array
+                                      matchLabels:
+                                        additionalProperties:
+                                          type: string
+                                        description: matchLabels is a map of {key,value}
+                                          pairs. A single {key,value} in the matchLabels
+                                          map is equivalent to an element of matchExpressions,
+                                          whose key field is "key", the operator is
+                                          "In", and the values array contains only
+                                          "value". The requirements are ANDed.
+                                        type: object
+                                    type: object
+                                  maxSkew:
+                                    description: 'MaxSkew describes the degree to
+                                      which pods may be unevenly distributed. It''s
+                                      the maximum permitted difference between the
+                                      number of matching pods in any two topology
+                                      domains of a given topology type. For example,
+                                      in a 3-zone cluster, MaxSkew is set to 1, and
+                                      pods with the same labelSelector spread as 1/1/0:
+                                      | zone1 | zone2 | zone3 | |   P   |   P   |       |
+                                      - if MaxSkew is 1, incoming pod can only be
+                                      scheduled to zone3 to become 1/1/1; scheduling
+                                      it onto zone1(zone2) would make the ActualSkew(2-0)
+                                      on zone1(zone2) violate MaxSkew(1). - if MaxSkew
+                                      is 2, incoming pod can be scheduled onto any
+                                      zone. It''s a required field. Default value
+                                      is 1 and 0 is not allowed.'
+                                    format: int32
+                                    type: integer
+                                  topologyKey:
+                                    description: TopologyKey is the key of node labels.
+                                      Nodes that have a label with this key and identical
+                                      values are considered to be in the same topology.
+                                      We consider each <key, value> as a "bucket",
+                                      and try to put balanced number of pods into
+                                      each bucket. It's a required field.
+                                    type: string
+                                  whenUnsatisfiable:
+                                    description: 'WhenUnsatisfiable indicates how
+                                      to deal with a pod if it doesn''t satisfy the
+                                      spread constraint. - DoNotSchedule (default)
+                                      tells the scheduler not to schedule it - ScheduleAnyway
+                                      tells the scheduler to still schedule it It''s
+                                      considered as "Unsatisfiable" if and only if
+                                      placing incoming pod on any topology violates
+                                      "MaxSkew". For example, in a 3-zone cluster,
+                                      MaxSkew is set to 1, and pods with the same
+                                      labelSelector spread as 3/1/1: | zone1 | zone2
+                                      | zone3 | | P P P |   P   |   P   | If WhenUnsatisfiable
+                                      is set to DoNotSchedule, incoming pod can only
+                                      be scheduled to zone2(zone3) to become 3/2/1(3/1/2)
+                                      as ActualSkew(2-1) on zone2(zone3) satisfies
+                                      MaxSkew(1). In other words, the cluster can
+                                      still be imbalanced, but scheduler won''t make
+                                      it *more* imbalanced. It''s a required field.'
+                                    type: string
+                                required:
+                                - maxSkew
+                                - topologyKey
+                                - whenUnsatisfiable
+                                type: object
+                              type: array
+                              x-kubernetes-list-map-keys:
+                              - topologyKey
+                              - whenUnsatisfiable
+                              x-kubernetes-list-type: map
+                            volumes:
+                              description: 'List of volumes that can be mounted by
+                                containers belonging to the pod. More info: https://kubernetes.io/docs/concepts/storage/volumes'
+                              items:
+                                type: object
+                              type: array
+                          required:
+                          - containers
+                          type: object
+                      type: object
+                    type: array
+                  engineResources:
+                    description: ResourceRequirements describes the compute resource
+                      requirements.
+                    properties:
+                      limits:
+                        additionalProperties:
+                          anyOf:
+                          - type: integer
+                          - type: string
+                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                          x-kubernetes-int-or-string: true
+                        description: 'Limits describes the maximum amount of compute
+                          resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
+                        type: object
+                      requests:
+                        additionalProperties:
+                          anyOf:
+                          - type: integer
+                          - type: string
+                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                          x-kubernetes-int-or-string: true
+                        description: 'Requests describes the minimum amount of compute
+                          resources required. If Requests is omitted for a container,
+                          it defaults to Limits if that is explicitly specified, otherwise
+                          to an implementation-defined value. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
+                        type: object
+                    type: object
+                  explainer:
+                    properties:
+                      config:
+                        additionalProperties:
+                          type: string
+                        type: object
+                      containerSpec:
+                        description: A single application container that you want
+                          to run within a pod.
+                        properties:
+                          args:
+                            description: 'Arguments to the entrypoint. The docker
+                              image''s CMD is used if this is not provided. Variable
+                              references $(VAR_NAME) are expanded using the container''s
+                              environment. If a variable cannot be resolved, the reference
+                              in the input string will be unchanged. The $(VAR_NAME)
+                              syntax can be escaped with a double $$, ie: $$(VAR_NAME).
+                              Escaped references will never be expanded, regardless
+                              of whether the variable exists or not. Cannot be updated.
+                              More info: https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell'
+                            items:
+                              type: string
+                            type: array
+                          command:
+                            description: 'Entrypoint array. Not executed within a
+                              shell. The docker image''s ENTRYPOINT is used if this
+                              is not provided. Variable references $(VAR_NAME) are
+                              expanded using the container''s environment. If a variable
+                              cannot be resolved, the reference in the input string
+                              will be unchanged. The $(VAR_NAME) syntax can be escaped
+                              with a double $$, ie: $$(VAR_NAME). Escaped references
+                              will never be expanded, regardless of whether the variable
+                              exists or not. Cannot be updated. More info: https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell'
+                            items:
+                              type: string
+                            type: array
+                          env:
+                            description: List of environment variables to set in the
+                              container. Cannot be updated.
+                            items:
+                              description: EnvVar represents an environment variable
+                                present in a Container.
+                              properties:
+                                name:
+                                  description: Name of the environment variable. Must
+                                    be a C_IDENTIFIER.
+                                  type: string
+                                value:
+                                  description: 'Variable references $(VAR_NAME) are
+                                    expanded using the previous defined environment
+                                    variables in the container and any service environment
+                                    variables. If a variable cannot be resolved, the
+                                    reference in the input string will be unchanged.
+                                    The $(VAR_NAME) syntax can be escaped with a double
+                                    $$, ie: $$(VAR_NAME). Escaped references will
+                                    never be expanded, regardless of whether the variable
+                                    exists or not. Defaults to "".'
+                                  type: string
+                                valueFrom:
+                                  description: Source for the environment variable's
+                                    value. Cannot be used if value is not empty.
+                                  properties:
+                                    configMapKeyRef:
+                                      description: Selects a key of a ConfigMap.
+                                      properties:
+                                        key:
+                                          description: The key to select.
+                                          type: string
+                                        name:
+                                          description: 'Name of the referent. More
+                                            info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                            TODO: Add other useful fields. apiVersion,
+                                            kind, uid?'
+                                          type: string
+                                        optional:
+                                          description: Specify whether the ConfigMap
+                                            or its key must be defined
+                                          type: boolean
+                                      required:
+                                      - key
+                                      type: object
+                                    fieldRef:
+                                      description: 'Selects a field of the pod: supports
+                                        metadata.name, metadata.namespace, metadata.labels,
+                                        metadata.annotations, spec.nodeName, spec.serviceAccountName,
+                                        status.hostIP, status.podIP, status.podIPs.'
+                                      properties:
+                                        apiVersion:
+                                          description: Version of the schema the FieldPath
+                                            is written in terms of, defaults to "v1".
+                                          type: string
+                                        fieldPath:
+                                          description: Path of the field to select
+                                            in the specified API version.
+                                          type: string
+                                      required:
+                                      - fieldPath
+                                      type: object
+                                    resourceFieldRef:
+                                      description: 'Selects a resource of the container:
+                                        only resources limits and requests (limits.cpu,
+                                        limits.memory, limits.ephemeral-storage, requests.cpu,
+                                        requests.memory and requests.ephemeral-storage)
+                                        are currently supported.'
+                                      properties:
+                                        containerName:
+                                          description: 'Container name: required for
+                                            volumes, optional for env vars'
+                                          type: string
+                                        divisor:
+                                          anyOf:
+                                          - type: integer
+                                          - type: string
+                                          description: Specifies the output format
+                                            of the exposed resources, defaults to
+                                            "1"
+                                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                          x-kubernetes-int-or-string: true
+                                        resource:
+                                          description: 'Required: resource to select'
+                                          type: string
+                                      required:
+                                      - resource
+                                      type: object
+                                    secretKeyRef:
+                                      description: Selects a key of a secret in the
+                                        pod's namespace
+                                      properties:
+                                        key:
+                                          description: The key of the secret to select
+                                            from.  Must be a valid secret key.
+                                          type: string
+                                        name:
+                                          description: 'Name of the referent. More
+                                            info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                            TODO: Add other useful fields. apiVersion,
+                                            kind, uid?'
+                                          type: string
+                                        optional:
+                                          description: Specify whether the Secret
+                                            or its key must be defined
+                                          type: boolean
+                                      required:
+                                      - key
+                                      type: object
+                                  type: object
+                              required:
+                              - name
+                              type: object
+                            type: array
+                          envFrom:
+                            description: List of sources to populate environment variables
+                              in the container. The keys defined within a source must
+                              be a C_IDENTIFIER. All invalid keys will be reported
+                              as an event when the container is starting. When a key
+                              exists in multiple sources, the value associated with
+                              the last source will take precedence. Values defined
+                              by an Env with a duplicate key will take precedence.
+                              Cannot be updated.
+                            items:
+                              description: EnvFromSource represents the source of
+                                a set of ConfigMaps
+                              properties:
+                                configMapRef:
+                                  description: The ConfigMap to select from
+                                  properties:
+                                    name:
+                                      description: 'Name of the referent. More info:
+                                        https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                        TODO: Add other useful fields. apiVersion,
+                                        kind, uid?'
+                                      type: string
+                                    optional:
+                                      description: Specify whether the ConfigMap must
+                                        be defined
+                                      type: boolean
+                                  type: object
+                                prefix:
+                                  description: An optional identifier to prepend to
+                                    each key in the ConfigMap. Must be a C_IDENTIFIER.
+                                  type: string
+                                secretRef:
+                                  description: The Secret to select from
+                                  properties:
+                                    name:
+                                      description: 'Name of the referent. More info:
+                                        https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                        TODO: Add other useful fields. apiVersion,
+                                        kind, uid?'
+                                      type: string
+                                    optional:
+                                      description: Specify whether the Secret must
+                                        be defined
+                                      type: boolean
+                                  type: object
+                              type: object
+                            type: array
+                          image:
+                            description: 'Docker image name. More info: https://kubernetes.io/docs/concepts/containers/images
+                              This field is optional to allow higher level config
+                              management to default or override container images in
+                              workload controllers like Deployments and StatefulSets.'
+                            type: string
+                          imagePullPolicy:
+                            description: 'Image pull policy. One of Always, Never,
+                              IfNotPresent. Defaults to Always if :latest tag is specified,
+                              or IfNotPresent otherwise. Cannot be updated. More info:
+                              https://kubernetes.io/docs/concepts/containers/images#updating-images'
+                            type: string
+                          lifecycle:
+                            description: Actions that the management system should
+                              take in response to container lifecycle events. Cannot
+                              be updated.
+                            properties:
+                              postStart:
+                                description: 'PostStart is called immediately after
+                                  a container is created. If the handler fails, the
+                                  container is terminated and restarted according
+                                  to its restart policy. Other management of the container
+                                  blocks until the hook completes. More info: https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/#container-hooks'
+                                properties:
+                                  exec:
+                                    description: One and only one of the following
+                                      should be specified. Exec specifies the action
+                                      to take.
+                                    properties:
+                                      command:
+                                        description: Command is the command line to
+                                          execute inside the container, the working
+                                          directory for the command  is root ('/')
+                                          in the container's filesystem. The command
+                                          is simply exec'd, it is not run inside a
+                                          shell, so traditional shell instructions
+                                          ('|', etc) won't work. To use a shell, you
+                                          need to explicitly call out to that shell.
+                                          Exit status of 0 is treated as live/healthy
+                                          and non-zero is unhealthy.
+                                        items:
+                                          type: string
+                                        type: array
+                                    type: object
+                                  httpGet:
+                                    description: HTTPGet specifies the http request
+                                      to perform.
+                                    properties:
+                                      host:
+                                        description: Host name to connect to, defaults
+                                          to the pod IP. You probably want to set
+                                          "Host" in httpHeaders instead.
+                                        type: string
+                                      httpHeaders:
+                                        description: Custom headers to set in the
+                                          request. HTTP allows repeated headers.
+                                        items:
+                                          description: HTTPHeader describes a custom
+                                            header to be used in HTTP probes
+                                          properties:
+                                            name:
+                                              description: The header field name
+                                              type: string
+                                            value:
+                                              description: The header field value
+                                              type: string
+                                          required:
+                                          - name
+                                          - value
+                                          type: object
+                                        type: array
+                                      path:
+                                        description: Path to access on the HTTP server.
+                                        type: string
+                                      port:
+                                        description: Name or number of the port to
+                                          access on the container. Number must be
+                                          in the range 1 to 65535. Name must be an
+                                          IANA_SVC_NAME.
+                                        x-kubernetes-int-or-string: true
+                                      scheme:
+                                        description: Scheme to use for connecting
+                                          to the host. Defaults to HTTP.
+                                        type: string
+                                    required:
+                                    - port
+                                    type: object
+                                  tcpSocket:
+                                    description: 'TCPSocket specifies an action involving
+                                      a TCP port. TCP hooks not yet supported TODO:
+                                      implement a realistic TCP lifecycle hook'
+                                    properties:
+                                      host:
+                                        description: 'Optional: Host name to connect
+                                          to, defaults to the pod IP.'
+                                        type: string
+                                      port:
+                                        description: Number or name of the port to
+                                          access on the container. Number must be
+                                          in the range 1 to 65535. Name must be an
+                                          IANA_SVC_NAME.
+                                        x-kubernetes-int-or-string: true
+                                    required:
+                                    - port
+                                    type: object
+                                type: object
+                              preStop:
+                                description: 'PreStop is called immediately before
+                                  a container is terminated due to an API request
+                                  or management event such as liveness/startup probe
+                                  failure, preemption, resource contention, etc. The
+                                  handler is not called if the container crashes or
+                                  exits. The reason for termination is passed to the
+                                  handler. The Pod''s termination grace period countdown
+                                  begins before the PreStop hooked is executed. Regardless
+                                  of the outcome of the handler, the container will
+                                  eventually terminate within the Pod''s termination
+                                  grace period. Other management of the container
+                                  blocks until the hook completes or until the termination
+                                  grace period is reached. More info: https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/#container-hooks'
+                                properties:
+                                  exec:
+                                    description: One and only one of the following
+                                      should be specified. Exec specifies the action
+                                      to take.
+                                    properties:
+                                      command:
+                                        description: Command is the command line to
+                                          execute inside the container, the working
+                                          directory for the command  is root ('/')
+                                          in the container's filesystem. The command
+                                          is simply exec'd, it is not run inside a
+                                          shell, so traditional shell instructions
+                                          ('|', etc) won't work. To use a shell, you
+                                          need to explicitly call out to that shell.
+                                          Exit status of 0 is treated as live/healthy
+                                          and non-zero is unhealthy.
+                                        items:
+                                          type: string
+                                        type: array
+                                    type: object
+                                  httpGet:
+                                    description: HTTPGet specifies the http request
+                                      to perform.
+                                    properties:
+                                      host:
+                                        description: Host name to connect to, defaults
+                                          to the pod IP. You probably want to set
+                                          "Host" in httpHeaders instead.
+                                        type: string
+                                      httpHeaders:
+                                        description: Custom headers to set in the
+                                          request. HTTP allows repeated headers.
+                                        items:
+                                          description: HTTPHeader describes a custom
+                                            header to be used in HTTP probes
+                                          properties:
+                                            name:
+                                              description: The header field name
+                                              type: string
+                                            value:
+                                              description: The header field value
+                                              type: string
+                                          required:
+                                          - name
+                                          - value
+                                          type: object
+                                        type: array
+                                      path:
+                                        description: Path to access on the HTTP server.
+                                        type: string
+                                      port:
+                                        description: Name or number of the port to
+                                          access on the container. Number must be
+                                          in the range 1 to 65535. Name must be an
+                                          IANA_SVC_NAME.
+                                        x-kubernetes-int-or-string: true
+                                      scheme:
+                                        description: Scheme to use for connecting
+                                          to the host. Defaults to HTTP.
+                                        type: string
+                                    required:
+                                    - port
+                                    type: object
+                                  tcpSocket:
+                                    description: 'TCPSocket specifies an action involving
+                                      a TCP port. TCP hooks not yet supported TODO:
+                                      implement a realistic TCP lifecycle hook'
+                                    properties:
+                                      host:
+                                        description: 'Optional: Host name to connect
+                                          to, defaults to the pod IP.'
+                                        type: string
+                                      port:
+                                        description: Number or name of the port to
+                                          access on the container. Number must be
+                                          in the range 1 to 65535. Name must be an
+                                          IANA_SVC_NAME.
+                                        x-kubernetes-int-or-string: true
+                                    required:
+                                    - port
+                                    type: object
+                                type: object
+                            type: object
+                          livenessProbe:
+                            description: 'Periodic probe of container liveness. Container
+                              will be restarted if the probe fails. Cannot be updated.
+                              More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                            properties:
+                              exec:
+                                description: One and only one of the following should
+                                  be specified. Exec specifies the action to take.
+                                properties:
+                                  command:
+                                    description: Command is the command line to execute
+                                      inside the container, the working directory
+                                      for the command  is root ('/') in the container's
+                                      filesystem. The command is simply exec'd, it
+                                      is not run inside a shell, so traditional shell
+                                      instructions ('|', etc) won't work. To use a
+                                      shell, you need to explicitly call out to that
+                                      shell. Exit status of 0 is treated as live/healthy
+                                      and non-zero is unhealthy.
+                                    items:
+                                      type: string
+                                    type: array
+                                type: object
+                              failureThreshold:
+                                description: Minimum consecutive failures for the
+                                  probe to be considered failed after having succeeded.
+                                  Defaults to 3. Minimum value is 1.
+                                format: int32
+                                type: integer
+                              httpGet:
+                                description: HTTPGet specifies the http request to
+                                  perform.
+                                properties:
+                                  host:
+                                    description: Host name to connect to, defaults
+                                      to the pod IP. You probably want to set "Host"
+                                      in httpHeaders instead.
+                                    type: string
+                                  httpHeaders:
+                                    description: Custom headers to set in the request.
+                                      HTTP allows repeated headers.
+                                    items:
+                                      description: HTTPHeader describes a custom header
+                                        to be used in HTTP probes
+                                      properties:
+                                        name:
+                                          description: The header field name
+                                          type: string
+                                        value:
+                                          description: The header field value
+                                          type: string
+                                      required:
+                                      - name
+                                      - value
+                                      type: object
+                                    type: array
+                                  path:
+                                    description: Path to access on the HTTP server.
+                                    type: string
+                                  port:
+                                    description: Name or number of the port to access
+                                      on the container. Number must be in the range
+                                      1 to 65535. Name must be an IANA_SVC_NAME.
+                                    x-kubernetes-int-or-string: true
+                                  scheme:
+                                    description: Scheme to use for connecting to the
+                                      host. Defaults to HTTP.
+                                    type: string
+                                required:
+                                - port
+                                type: object
+                              initialDelaySeconds:
+                                description: 'Number of seconds after the container
+                                  has started before liveness probes are initiated.
+                                  More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                                format: int32
+                                type: integer
+                              periodSeconds:
+                                description: How often (in seconds) to perform the
+                                  probe. Default to 10 seconds. Minimum value is 1.
+                                format: int32
+                                type: integer
+                              successThreshold:
+                                description: Minimum consecutive successes for the
+                                  probe to be considered successful after having failed.
+                                  Defaults to 1. Must be 1 for liveness and startup.
+                                  Minimum value is 1.
+                                format: int32
+                                type: integer
+                              tcpSocket:
+                                description: 'TCPSocket specifies an action involving
+                                  a TCP port. TCP hooks not yet supported TODO: implement
+                                  a realistic TCP lifecycle hook'
+                                properties:
+                                  host:
+                                    description: 'Optional: Host name to connect to,
+                                      defaults to the pod IP.'
+                                    type: string
+                                  port:
+                                    description: Number or name of the port to access
+                                      on the container. Number must be in the range
+                                      1 to 65535. Name must be an IANA_SVC_NAME.
+                                    x-kubernetes-int-or-string: true
+                                required:
+                                - port
+                                type: object
+                              timeoutSeconds:
+                                description: 'Number of seconds after which the probe
+                                  times out. Defaults to 1 second. Minimum value is
+                                  1. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                                format: int32
+                                type: integer
+                            type: object
+                          name:
+                            description: Name of the container specified as a DNS_LABEL.
+                              Each container in a pod must have a unique name (DNS_LABEL).
+                              Cannot be updated.
+                            type: string
+                          ports:
+                            description: List of ports to expose from the container.
+                              Exposing a port here gives the system additional information
+                              about the network connections a container uses, but
+                              is primarily informational. Not specifying a port here
+                              DOES NOT prevent that port from being exposed. Any port
+                              which is listening on the default "0.0.0.0" address
+                              inside a container will be accessible from the network.
+                              Cannot be updated.
+                            items:
+                              description: ContainerPort represents a network port
+                                in a single container.
+                              properties:
+                                containerPort:
+                                  description: Number of port to expose on the pod's
+                                    IP address. This must be a valid port number,
+                                    0 < x < 65536.
+                                  format: int32
+                                  type: integer
+                                hostIP:
+                                  description: What host IP to bind the external port
+                                    to.
+                                  type: string
+                                hostPort:
+                                  description: Number of port to expose on the host.
+                                    If specified, this must be a valid port number,
+                                    0 < x < 65536. If HostNetwork is specified, this
+                                    must match ContainerPort. Most containers do not
+                                    need this.
+                                  format: int32
+                                  type: integer
+                                name:
+                                  description: If specified, this must be an IANA_SVC_NAME
+                                    and unique within the pod. Each named port in
+                                    a pod must have a unique name. Name for the port
+                                    that can be referred to by services.
+                                  type: string
+                                protocol:
+                                  description: Protocol for port. Must be UDP, TCP,
+                                    or SCTP. Defaults to "TCP".
+                                  type: string
+                              required:
+                              - containerPort
+                              type: object
+                            type: array
+                            x-kubernetes-list-map-keys:
+                            - containerPort
+                            - protocol
+                            x-kubernetes-list-type: map
+                          readinessProbe:
+                            description: 'Periodic probe of container service readiness.
+                              Container will be removed from service endpoints if
+                              the probe fails. Cannot be updated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                            properties:
+                              exec:
+                                description: One and only one of the following should
+                                  be specified. Exec specifies the action to take.
+                                properties:
+                                  command:
+                                    description: Command is the command line to execute
+                                      inside the container, the working directory
+                                      for the command  is root ('/') in the container's
+                                      filesystem. The command is simply exec'd, it
+                                      is not run inside a shell, so traditional shell
+                                      instructions ('|', etc) won't work. To use a
+                                      shell, you need to explicitly call out to that
+                                      shell. Exit status of 0 is treated as live/healthy
+                                      and non-zero is unhealthy.
+                                    items:
+                                      type: string
+                                    type: array
+                                type: object
+                              failureThreshold:
+                                description: Minimum consecutive failures for the
+                                  probe to be considered failed after having succeeded.
+                                  Defaults to 3. Minimum value is 1.
+                                format: int32
+                                type: integer
+                              httpGet:
+                                description: HTTPGet specifies the http request to
+                                  perform.
+                                properties:
+                                  host:
+                                    description: Host name to connect to, defaults
+                                      to the pod IP. You probably want to set "Host"
+                                      in httpHeaders instead.
+                                    type: string
+                                  httpHeaders:
+                                    description: Custom headers to set in the request.
+                                      HTTP allows repeated headers.
+                                    items:
+                                      description: HTTPHeader describes a custom header
+                                        to be used in HTTP probes
+                                      properties:
+                                        name:
+                                          description: The header field name
+                                          type: string
+                                        value:
+                                          description: The header field value
+                                          type: string
+                                      required:
+                                      - name
+                                      - value
+                                      type: object
+                                    type: array
+                                  path:
+                                    description: Path to access on the HTTP server.
+                                    type: string
+                                  port:
+                                    description: Name or number of the port to access
+                                      on the container. Number must be in the range
+                                      1 to 65535. Name must be an IANA_SVC_NAME.
+                                    x-kubernetes-int-or-string: true
+                                  scheme:
+                                    description: Scheme to use for connecting to the
+                                      host. Defaults to HTTP.
+                                    type: string
+                                required:
+                                - port
+                                type: object
+                              initialDelaySeconds:
+                                description: 'Number of seconds after the container
+                                  has started before liveness probes are initiated.
+                                  More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                                format: int32
+                                type: integer
+                              periodSeconds:
+                                description: How often (in seconds) to perform the
+                                  probe. Default to 10 seconds. Minimum value is 1.
+                                format: int32
+                                type: integer
+                              successThreshold:
+                                description: Minimum consecutive successes for the
+                                  probe to be considered successful after having failed.
+                                  Defaults to 1. Must be 1 for liveness and startup.
+                                  Minimum value is 1.
+                                format: int32
+                                type: integer
+                              tcpSocket:
+                                description: 'TCPSocket specifies an action involving
+                                  a TCP port. TCP hooks not yet supported TODO: implement
+                                  a realistic TCP lifecycle hook'
+                                properties:
+                                  host:
+                                    description: 'Optional: Host name to connect to,
+                                      defaults to the pod IP.'
+                                    type: string
+                                  port:
+                                    description: Number or name of the port to access
+                                      on the container. Number must be in the range
+                                      1 to 65535. Name must be an IANA_SVC_NAME.
+                                    x-kubernetes-int-or-string: true
+                                required:
+                                - port
+                                type: object
+                              timeoutSeconds:
+                                description: 'Number of seconds after which the probe
+                                  times out. Defaults to 1 second. Minimum value is
+                                  1. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                                format: int32
+                                type: integer
+                            type: object
+                          resources:
+                            description: 'Compute Resources required by this container.
+                              Cannot be updated. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
+                            properties:
+                              limits:
+                                additionalProperties:
+                                  anyOf:
+                                  - type: integer
+                                  - type: string
+                                  pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                  x-kubernetes-int-or-string: true
+                                description: 'Limits describes the maximum amount
+                                  of compute resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
+                                type: object
+                              requests:
+                                additionalProperties:
+                                  anyOf:
+                                  - type: integer
+                                  - type: string
+                                  pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                  x-kubernetes-int-or-string: true
+                                description: 'Requests describes the minimum amount
+                                  of compute resources required. If Requests is omitted
+                                  for a container, it defaults to Limits if that is
+                                  explicitly specified, otherwise to an implementation-defined
+                                  value. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
+                                type: object
+                            type: object
+                          securityContext:
+                            description: 'Security options the pod should run with.
+                              More info: https://kubernetes.io/docs/concepts/policy/security-context/
+                              More info: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/'
+                            properties:
+                              allowPrivilegeEscalation:
+                                description: 'AllowPrivilegeEscalation controls whether
+                                  a process can gain more privileges than its parent
+                                  process. This bool directly controls if the no_new_privs
+                                  flag will be set on the container process. AllowPrivilegeEscalation
+                                  is true always when the container is: 1) run as
+                                  Privileged 2) has CAP_SYS_ADMIN'
+                                type: boolean
+                              capabilities:
+                                description: The capabilities to add/drop when running
+                                  containers. Defaults to the default set of capabilities
+                                  granted by the container runtime.
+                                properties:
+                                  add:
+                                    description: Added capabilities
+                                    items:
+                                      description: Capability represent POSIX capabilities
+                                        type
+                                      type: string
+                                    type: array
+                                  drop:
+                                    description: Removed capabilities
+                                    items:
+                                      description: Capability represent POSIX capabilities
+                                        type
+                                      type: string
+                                    type: array
+                                type: object
+                              privileged:
+                                description: Run container in privileged mode. Processes
+                                  in privileged containers are essentially equivalent
+                                  to root on the host. Defaults to false.
+                                type: boolean
+                              procMount:
+                                description: procMount denotes the type of proc mount
+                                  to use for the containers. The default is DefaultProcMount
+                                  which uses the container runtime defaults for readonly
+                                  paths and masked paths. This requires the ProcMountType
+                                  feature flag to be enabled.
+                                type: string
+                              readOnlyRootFilesystem:
+                                description: Whether this container has a read-only
+                                  root filesystem. Default is false.
+                                type: boolean
+                              runAsGroup:
+                                description: The GID to run the entrypoint of the
+                                  container process. Uses runtime default if unset.
+                                  May also be set in PodSecurityContext.  If set in
+                                  both SecurityContext and PodSecurityContext, the
+                                  value specified in SecurityContext takes precedence.
+                                format: int64
+                                type: integer
+                              runAsNonRoot:
+                                description: Indicates that the container must run
+                                  as a non-root user. If true, the Kubelet will validate
+                                  the image at runtime to ensure that it does not
+                                  run as UID 0 (root) and fail to start the container
+                                  if it does. If unset or false, no such validation
+                                  will be performed. May also be set in PodSecurityContext.  If
+                                  set in both SecurityContext and PodSecurityContext,
+                                  the value specified in SecurityContext takes precedence.
+                                type: boolean
+                              runAsUser:
+                                description: The UID to run the entrypoint of the
+                                  container process. Defaults to user specified in
+                                  image metadata if unspecified. May also be set in
+                                  PodSecurityContext.  If set in both SecurityContext
+                                  and PodSecurityContext, the value specified in SecurityContext
+                                  takes precedence.
+                                format: int64
+                                type: integer
+                              seLinuxOptions:
+                                description: The SELinux context to be applied to
+                                  the container. If unspecified, the container runtime
+                                  will allocate a random SELinux context for each
+                                  container.  May also be set in PodSecurityContext.  If
+                                  set in both SecurityContext and PodSecurityContext,
+                                  the value specified in SecurityContext takes precedence.
+                                properties:
+                                  level:
+                                    description: Level is SELinux level label that
+                                      applies to the container.
+                                    type: string
+                                  role:
+                                    description: Role is a SELinux role label that
+                                      applies to the container.
+                                    type: string
+                                  type:
+                                    description: Type is a SELinux type label that
+                                      applies to the container.
+                                    type: string
+                                  user:
+                                    description: User is a SELinux user label that
+                                      applies to the container.
+                                    type: string
+                                type: object
+                              windowsOptions:
+                                description: The Windows specific settings applied
+                                  to all containers. If unspecified, the options from
+                                  the PodSecurityContext will be used. If set in both
+                                  SecurityContext and PodSecurityContext, the value
+                                  specified in SecurityContext takes precedence.
+                                properties:
+                                  gmsaCredentialSpec:
+                                    description: GMSACredentialSpec is where the GMSA
+                                      admission webhook (https://github.com/kubernetes-sigs/windows-gmsa)
+                                      inlines the contents of the GMSA credential
+                                      spec named by the GMSACredentialSpecName field.
+                                      This field is alpha-level and is only honored
+                                      by servers that enable the WindowsGMSA feature
+                                      flag.
+                                    type: string
+                                  gmsaCredentialSpecName:
+                                    description: GMSACredentialSpecName is the name
+                                      of the GMSA credential spec to use. This field
+                                      is alpha-level and is only honored by servers
+                                      that enable the WindowsGMSA feature flag.
+                                    type: string
+                                  runAsUserName:
+                                    description: The UserName in Windows to run the
+                                      entrypoint of the container process. Defaults
+                                      to the user specified in image metadata if unspecified.
+                                      May also be set in PodSecurityContext. If set
+                                      in both SecurityContext and PodSecurityContext,
+                                      the value specified in SecurityContext takes
+                                      precedence. This field is beta-level and may
+                                      be disabled with the WindowsRunAsUserName feature
+                                      flag.
+                                    type: string
+                                type: object
+                            type: object
+                          startupProbe:
+                            description: 'StartupProbe indicates that the Pod has
+                              successfully initialized. If specified, no other probes
+                              are executed until this completes successfully. If this
+                              probe fails, the Pod will be restarted, just as if the
+                              livenessProbe failed. This can be used to provide different
+                              probe parameters at the beginning of a Pod''s lifecycle,
+                              when it might take a long time to load data or warm
+                              a cache, than during steady-state operation. This cannot
+                              be updated. This is an alpha feature enabled by the
+                              StartupProbe feature flag. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                            properties:
+                              exec:
+                                description: One and only one of the following should
+                                  be specified. Exec specifies the action to take.
+                                properties:
+                                  command:
+                                    description: Command is the command line to execute
+                                      inside the container, the working directory
+                                      for the command  is root ('/') in the container's
+                                      filesystem. The command is simply exec'd, it
+                                      is not run inside a shell, so traditional shell
+                                      instructions ('|', etc) won't work. To use a
+                                      shell, you need to explicitly call out to that
+                                      shell. Exit status of 0 is treated as live/healthy
+                                      and non-zero is unhealthy.
+                                    items:
+                                      type: string
+                                    type: array
+                                type: object
+                              failureThreshold:
+                                description: Minimum consecutive failures for the
+                                  probe to be considered failed after having succeeded.
+                                  Defaults to 3. Minimum value is 1.
+                                format: int32
+                                type: integer
+                              httpGet:
+                                description: HTTPGet specifies the http request to
+                                  perform.
+                                properties:
+                                  host:
+                                    description: Host name to connect to, defaults
+                                      to the pod IP. You probably want to set "Host"
+                                      in httpHeaders instead.
+                                    type: string
+                                  httpHeaders:
+                                    description: Custom headers to set in the request.
+                                      HTTP allows repeated headers.
+                                    items:
+                                      description: HTTPHeader describes a custom header
+                                        to be used in HTTP probes
+                                      properties:
+                                        name:
+                                          description: The header field name
+                                          type: string
+                                        value:
+                                          description: The header field value
+                                          type: string
+                                      required:
+                                      - name
+                                      - value
+                                      type: object
+                                    type: array
+                                  path:
+                                    description: Path to access on the HTTP server.
+                                    type: string
+                                  port:
+                                    anyOf:
+                                    - type: integer
+                                    - type: string
+                                    description: Name or number of the port to access
+                                      on the container. Number must be in the range
+                                      1 to 65535. Name must be an IANA_SVC_NAME.
+                                    x-kubernetes-int-or-string: true
+                                  scheme:
+                                    description: Scheme to use for connecting to the
+                                      host. Defaults to HTTP.
+                                    type: string
+                                required:
+                                - port
+                                type: object
+                              initialDelaySeconds:
+                                description: 'Number of seconds after the container
+                                  has started before liveness probes are initiated.
+                                  More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                                format: int32
+                                type: integer
+                              periodSeconds:
+                                description: How often (in seconds) to perform the
+                                  probe. Default to 10 seconds. Minimum value is 1.
+                                format: int32
+                                type: integer
+                              successThreshold:
+                                description: Minimum consecutive successes for the
+                                  probe to be considered successful after having failed.
+                                  Defaults to 1. Must be 1 for liveness and startup.
+                                  Minimum value is 1.
+                                format: int32
+                                type: integer
+                              tcpSocket:
+                                description: 'TCPSocket specifies an action involving
+                                  a TCP port. TCP hooks not yet supported TODO: implement
+                                  a realistic TCP lifecycle hook'
+                                properties:
+                                  host:
+                                    description: 'Optional: Host name to connect to,
+                                      defaults to the pod IP.'
+                                    type: string
+                                  port:
+                                    anyOf:
+                                    - type: integer
+                                    - type: string
+                                    description: Number or name of the port to access
+                                      on the container. Number must be in the range
+                                      1 to 65535. Name must be an IANA_SVC_NAME.
+                                    x-kubernetes-int-or-string: true
+                                required:
+                                - port
+                                type: object
+                              timeoutSeconds:
+                                description: 'Number of seconds after which the probe
+                                  times out. Defaults to 1 second. Minimum value is
+                                  1. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                                format: int32
+                                type: integer
+                            type: object
+                          stdin:
+                            description: Whether this container should allocate a
+                              buffer for stdin in the container runtime. If this is
+                              not set, reads from stdin in the container will always
+                              result in EOF. Default is false.
+                            type: boolean
+                          stdinOnce:
+                            description: Whether the container runtime should close
+                              the stdin channel after it has been opened by a single
+                              attach. When stdin is true the stdin stream will remain
+                              open across multiple attach sessions. If stdinOnce is
+                              set to true, stdin is opened on container start, is
+                              empty until the first client attaches to stdin, and
+                              then remains open and accepts data until the client
+                              disconnects, at which time stdin is closed and remains
+                              closed until the container is restarted. If this flag
+                              is false, a container processes that reads from stdin
+                              will never receive an EOF. Default is false
+                            type: boolean
+                          terminationMessagePath:
+                            description: 'Optional: Path at which the file to which
+                              the container''s termination message will be written
+                              is mounted into the container''s filesystem. Message
+                              written is intended to be brief final status, such as
+                              an assertion failure message. Will be truncated by the
+                              node if greater than 4096 bytes. The total message length
+                              across all containers will be limited to 12kb. Defaults
+                              to /dev/termination-log. Cannot be updated.'
+                            type: string
+                          terminationMessagePolicy:
+                            description: Indicate how the termination message should
+                              be populated. File will use the contents of terminationMessagePath
+                              to populate the container status message on both success
+                              and failure. FallbackToLogsOnError will use the last
+                              chunk of container log output if the termination message
+                              file is empty and the container exited with an error.
+                              The log output is limited to 2048 bytes or 80 lines,
+                              whichever is smaller. Defaults to File. Cannot be updated.
+                            type: string
+                          tty:
+                            description: Whether this container should allocate a
+                              TTY for itself, also requires 'stdin' to be true. Default
+                              is false.
+                            type: boolean
+                          volumeDevices:
+                            description: volumeDevices is the list of block devices
+                              to be used by the container. This is a beta feature.
+                            items:
+                              description: volumeDevice describes a mapping of a raw
+                                block device within a container.
+                              properties:
+                                devicePath:
+                                  description: devicePath is the path inside of the
+                                    container that the device will be mapped to.
+                                  type: string
+                                name:
+                                  description: name must match the name of a persistentVolumeClaim
+                                    in the pod
+                                  type: string
+                              required:
+                              - devicePath
+                              - name
+                              type: object
+                            type: array
+                          volumeMounts:
+                            description: Pod volumes to mount into the container's
+                              filesystem. Cannot be updated.
+                            items:
+                              description: VolumeMount describes a mounting of a Volume
+                                within a container.
+                              properties:
+                                mountPath:
+                                  description: Path within the container at which
+                                    the volume should be mounted.  Must not contain
+                                    ':'.
+                                  type: string
+                                mountPropagation:
+                                  description: mountPropagation determines how mounts
+                                    are propagated from the host to container and
+                                    the other way around. When not set, MountPropagationNone
+                                    is used. This field is beta in 1.10.
+                                  type: string
+                                name:
+                                  description: This must match the Name of a Volume.
+                                  type: string
+                                readOnly:
+                                  description: Mounted read-only if true, read-write
+                                    otherwise (false or unspecified). Defaults to
+                                    false.
+                                  type: boolean
+                                subPath:
+                                  description: Path within the volume from which the
+                                    container's volume should be mounted. Defaults
+                                    to "" (volume's root).
+                                  type: string
+                                subPathExpr:
+                                  description: Expanded path within the volume from
+                                    which the container's volume should be mounted.
+                                    Behaves similarly to SubPath but environment variable
+                                    references $(VAR_NAME) are expanded using the
+                                    container's environment. Defaults to "" (volume's
+                                    root). SubPathExpr and SubPath are mutually exclusive.
+                                  type: string
+                              required:
+                              - mountPath
+                              - name
+                              type: object
+                            type: array
+                          workingDir:
+                            description: Container's working directory. If not specified,
+                              the container runtime's default will be used, which
+                              might be configured in the container image. Cannot be
+                              updated.
+                            type: string
+                        required:
+                        - name
+                        type: object
+                      endpoint:
+                        properties:
+                          service_host:
+                            type: string
+                          service_port:
+                            format: int32
+                            type: integer
+                          type:
+                            type: string
+                        type: object
+                      envSecretRefName:
+                        type: string
+                      modelUri:
+                        type: string
+                      serviceAccountName:
+                        type: string
+                      type:
+                        type: string
+                    type: object
+                  graph:
+                    properties:
+                      children:
+                        items:
+                          properties:
+                            children:
+                              items:
+                                properties:
+                                  children:
+                                    items:
+                                      properties:
+                                        children:
+                                          items:
+                                            properties:
+                                              endpoint:
+                                                properties:
+                                                  service_host:
+                                                    type: string
+                                                  service_port:
+                                                    format: int32
+                                                    type: integer
+                                                  type:
+                                                    type: string
+                                                type: object
+                                              envSecretRefName:
+                                                type: string
+                                              implementation:
+                                                type: string
+                                              logger:
+                                                description: Request/response  payload
+                                                  logging. v2alpha1 feature that is
+                                                  added to v1 for backwards compatibility
+                                                  while v1 is the storage version.
+                                                properties:
+                                                  mode:
+                                                    description: What payloads to
+                                                      log
+                                                    type: string
+                                                  url:
+                                                    description: URL to send request
+                                                      logging CloudEvents
+                                                    type: string
+                                                type: object
+                                              methods:
+                                                items:
+                                                  type: string
+                                                type: array
+                                              modelUri:
+                                                type: string
+                                              name:
+                                                type: string
+                                              parameters:
+                                                items:
+                                                  properties:
+                                                    name:
+                                                      type: string
+                                                    type:
+                                                      type: string
+                                                    value:
+                                                      type: string
+                                                  type: object
+                                                type: array
+                                              serviceAccountName:
+                                                type: string
+                                              type:
+                                                type: string
+                                            type: object
+                                          type: array
+                                        endpoint:
+                                          properties:
+                                            service_host:
+                                              type: string
+                                            service_port:
+                                              format: int32
+                                              type: integer
+                                            type:
+                                              type: string
+                                          type: object
+                                        envSecretRefName:
+                                          type: string
+                                        implementation:
+                                          type: string
+                                        logger:
+                                          description: Request/response  payload logging.
+                                            v2alpha1 feature that is added to v1 for
+                                            backwards compatibility while v1 is the
+                                            storage version.
+                                          properties:
+                                            mode:
+                                              description: What payloads to log
+                                              type: string
+                                            url:
+                                              description: URL to send request logging
+                                                CloudEvents
+                                              type: string
+                                          type: object
+                                        methods:
+                                          items:
+                                            type: string
+                                          type: array
+                                        modelUri:
+                                          type: string
+                                        name:
+                                          type: string
+                                        parameters:
+                                          items:
+                                            properties:
+                                              name:
+                                                type: string
+                                              type:
+                                                type: string
+                                              value:
+                                                type: string
+                                            type: object
+                                          type: array
+                                        serviceAccountName:
+                                          type: string
+                                        type:
+                                          type: string
+                                      type: object
+                                    type: array
+                                  endpoint:
+                                    properties:
+                                      service_host:
+                                        type: string
+                                      service_port:
+                                        format: int32
+                                        type: integer
+                                      type:
+                                        type: string
+                                    type: object
+                                  envSecretRefName:
+                                    type: string
+                                  implementation:
+                                    type: string
+                                  logger:
+                                    description: Request/response  payload logging.
+                                      v2alpha1 feature that is added to v1 for backwards
+                                      compatibility while v1 is the storage version.
+                                    properties:
+                                      mode:
+                                        description: What payloads to log
+                                        type: string
+                                      url:
+                                        description: URL to send request logging CloudEvents
+                                        type: string
+                                    type: object
+                                  methods:
+                                    items:
+                                      type: string
+                                    type: array
+                                  modelUri:
+                                    type: string
+                                  name:
+                                    type: string
+                                  parameters:
+                                    items:
+                                      properties:
+                                        name:
+                                          type: string
+                                        type:
+                                          type: string
+                                        value:
+                                          type: string
+                                      type: object
+                                    type: array
+                                  serviceAccountName:
+                                    type: string
+                                  type:
+                                    type: string
+                                type: object
+                              type: array
+                            endpoint:
+                              properties:
+                                service_host:
+                                  type: string
+                                service_port:
+                                  format: int32
+                                  type: integer
+                                type:
+                                  type: string
+                              type: object
+                            envSecretRefName:
+                              type: string
+                            implementation:
+                              type: string
+                            logger:
+                              description: Request/response  payload logging. v2alpha1
+                                feature that is added to v1 for backwards compatibility
+                                while v1 is the storage version.
+                              properties:
+                                mode:
+                                  description: What payloads to log
+                                  type: string
+                                url:
+                                  description: URL to send request logging CloudEvents
+                                  type: string
+                              type: object
+                            methods:
+                              items:
+                                type: string
+                              type: array
+                            modelUri:
+                              type: string
+                            name:
+                              type: string
+                            parameters:
+                              items:
+                                properties:
+                                  name:
+                                    type: string
+                                  type:
+                                    type: string
+                                  value:
+                                    type: string
+                                type: object
+                              type: array
+                            serviceAccountName:
+                              type: string
+                            type:
+                              type: string
+                          type: object
+                        type: array
+                      endpoint:
+                        properties:
+                          service_host:
+                            type: string
+                          service_port:
+                            format: int32
+                            type: integer
+                          type:
+                            type: string
+                        type: object
+                      envSecretRefName:
+                        type: string
+                      implementation:
+                        type: string
+                      logger:
+                        description: Request/response  payload logging. v2alpha1 feature
+                          that is added to v1 for backwards compatibility while v1
+                          is the storage version.
+                        properties:
+                          mode:
+                            description: What payloads to log
+                            type: string
+                          url:
+                            description: URL to send request logging CloudEvents
+                            type: string
+                        type: object
+                      methods:
+                        items:
+                          type: string
+                        type: array
+                      modelUri:
+                        type: string
+                      name:
+                        type: string
+                      parameters:
+                        items:
+                          properties:
+                            name:
+                              type: string
+                            type:
+                              type: string
+                            value:
+                              type: string
+                          required:
+                          - name
+                          - type
+                          - value
+                          type: object
+                        type: array
+                      serviceAccountName:
+                        type: string
+                      type:
+                        type: string
+                    required:
+                    - name
+                    type: object
+                  labels:
+                    additionalProperties:
+                      type: string
+                    type: object
+                  name:
+                    type: string
+                  replicas:
+                    format: int32
+                    type: integer
+                  shadow:
+                    type: boolean
+                  svcOrchSpec:
+                    properties:
+                      env:
+                        items:
+                          description: EnvVar represents an environment variable present
+                            in a Container.
+                          properties:
+                            name:
+                              description: Name of the environment variable. Must
+                                be a C_IDENTIFIER.
+                              type: string
+                            value:
+                              description: 'Variable references $(VAR_NAME) are expanded
+                                using the previous defined environment variables in
+                                the container and any service environment variables.
+                                If a variable cannot be resolved, the reference in
+                                the input string will be unchanged. The $(VAR_NAME)
+                                syntax can be escaped with a double $$, ie: $$(VAR_NAME).
+                                Escaped references will never be expanded, regardless
+                                of whether the variable exists or not. Defaults to
+                                "".'
+                              type: string
+                            valueFrom:
+                              description: Source for the environment variable's value.
+                                Cannot be used if value is not empty.
+                              properties:
+                                configMapKeyRef:
+                                  description: Selects a key of a ConfigMap.
+                                  properties:
+                                    key:
+                                      description: The key to select.
+                                      type: string
+                                    name:
+                                      description: 'Name of the referent. More info:
+                                        https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                        TODO: Add other useful fields. apiVersion,
+                                        kind, uid?'
+                                      type: string
+                                    optional:
+                                      description: Specify whether the ConfigMap or
+                                        its key must be defined
+                                      type: boolean
+                                  required:
+                                  - key
+                                  type: object
+                                fieldRef:
+                                  description: 'Selects a field of the pod: supports
+                                    metadata.name, metadata.namespace, metadata.labels,
+                                    metadata.annotations, spec.nodeName, spec.serviceAccountName,
+                                    status.hostIP, status.podIP, status.podIPs.'
+                                  properties:
+                                    apiVersion:
+                                      description: Version of the schema the FieldPath
+                                        is written in terms of, defaults to "v1".
+                                      type: string
+                                    fieldPath:
+                                      description: Path of the field to select in
+                                        the specified API version.
+                                      type: string
+                                  required:
+                                  - fieldPath
+                                  type: object
+                                resourceFieldRef:
+                                  description: 'Selects a resource of the container:
+                                    only resources limits and requests (limits.cpu,
+                                    limits.memory, limits.ephemeral-storage, requests.cpu,
+                                    requests.memory and requests.ephemeral-storage)
+                                    are currently supported.'
+                                  properties:
+                                    containerName:
+                                      description: 'Container name: required for volumes,
+                                        optional for env vars'
+                                      type: string
+                                    divisor:
+                                      anyOf:
+                                      - type: integer
+                                      - type: string
+                                      description: Specifies the output format of
+                                        the exposed resources, defaults to "1"
+                                      pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                      x-kubernetes-int-or-string: true
+                                    resource:
+                                      description: 'Required: resource to select'
+                                      type: string
+                                  required:
+                                  - resource
+                                  type: object
+                                secretKeyRef:
+                                  description: Selects a key of a secret in the pod's
+                                    namespace
+                                  properties:
+                                    key:
+                                      description: The key of the secret to select
+                                        from.  Must be a valid secret key.
+                                      type: string
+                                    name:
+                                      description: 'Name of the referent. More info:
+                                        https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                        TODO: Add other useful fields. apiVersion,
+                                        kind, uid?'
+                                      type: string
+                                    optional:
+                                      description: Specify whether the Secret or its
+                                        key must be defined
+                                      type: boolean
+                                  required:
+                                  - key
+                                  type: object
+                              type: object
+                          required:
+                          - name
+                          type: object
+                        type: array
+                      replicas:
+                        format: int32
+                        type: integer
+                      resources:
+                        description: ResourceRequirements describes the compute resource
+                          requirements.
+                        properties:
+                          limits:
+                            additionalProperties:
+                              anyOf:
+                              - type: integer
+                              - type: string
+                              pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                              x-kubernetes-int-or-string: true
+                            description: 'Limits describes the maximum amount of compute
+                              resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
+                            type: object
+                          requests:
+                            additionalProperties:
+                              anyOf:
+                              - type: integer
+                              - type: string
+                              pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                              x-kubernetes-int-or-string: true
+                            description: 'Requests describes the minimum amount of
+                              compute resources required. If Requests is omitted for
+                              a container, it defaults to Limits if that is explicitly
+                              specified, otherwise to an implementation-defined value.
+                              More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
+                            type: object
+                        type: object
+                    type: object
+                  traffic:
+                    format: int32
+                    type: integer
+                required:
+                - graph
+                - name
+                type: object
+              type: array
+            protocol:
+              type: string
+            replicas:
+              format: int32
+              type: integer
+            transport:
+              type: string
+          required:
+          - predictors
+          type: object
+        status:
+          description: SeldonDeploymentStatus defines the observed state of SeldonDeployment
+          properties:
+            address:
+              description: 'Addressable placeholder until duckv1 issue is fixed:    https://github.com/kubernetes-sigs/controller-tools/issues/391'
+              properties:
+                url:
+                  type: string
+              type: object
+            deploymentStatus:
+              additionalProperties:
+                properties:
+                  availableReplicas:
+                    format: int32
+                    type: integer
+                  description:
+                    type: string
+                  explainerFor:
+                    type: string
+                  name:
+                    type: string
+                  replicas:
+                    format: int32
+                    type: integer
+                  status:
+                    type: string
+                type: object
+              type: object
+            description:
+              type: string
+            replicas:
+              format: int32
+              type: integer
+            serviceStatus:
+              additionalProperties:
+                properties:
+                  explainerFor:
+                    type: string
+                  grpcEndpoint:
+                    type: string
+                  httpEndpoint:
+                    type: string
+                  svcName:
+                    type: string
+                type: object
+              type: object
+            state:
+              type: string
+          type: object
+      type: object
+  version: v1
+  versions:
+  - name: v1
+    served: true
+    storage: true
+  - name: v1alpha2
+    served: true
+    storage: false
+  - name: v1alpha3
+    served: true
+    storage: false

--- a/tests/stacks/ibm/application/seldon-core-operator/test_data/expected/app.k8s.io_v1beta1_application_seldon-core-operator.yaml
+++ b/tests/stacks/ibm/application/seldon-core-operator/test_data/expected/app.k8s.io_v1beta1_application_seldon-core-operator.yaml
@@ -1,0 +1,46 @@
+apiVersion: app.k8s.io/v1beta1
+kind: Application
+metadata:
+  labels:
+    app.kubernetes.io/component: seldon
+    app.kubernetes.io/name: seldon-core-operator
+  name: seldon-core-operator
+  namespace: kubeflow
+spec:
+  addOwnerRef: true
+  componentKinds:
+  - group: apps/v1
+    kind: StatefulSet
+  - group: v1
+    kind: Service
+  - group: apps/v1
+    kind: Deployment
+  - group: v1
+    kind: Secret
+  - group: v1
+    kind: ConfigMap
+  descriptor:
+    description: Seldon allows users to create ML Inference Graphs to deploy their
+      models and serve predictions
+    keywords:
+    - seldon
+    - inference
+    links:
+    - description: Docs
+      url: https://docs.seldon.io/projects/seldon-core/en/v1.1.0/
+    maintainers:
+    - email: dev@seldon.io
+      name: Seldon
+    owners:
+    - email: dev@seldon.io
+      name: Seldon
+    type: seldon-core-operator
+    version: v1
+  selector:
+    matchLabels:
+      app.kubernetes.io/component: seldon
+      app.kubernetes.io/instance: seldon-1.2.1
+      app.kubernetes.io/managed-by: kfctl
+      app.kubernetes.io/name: seldon
+      app.kubernetes.io/part-of: kubeflow
+      app.kubernetes.io/version: 1.2.1

--- a/tests/stacks/ibm/application/seldon-core-operator/test_data/expected/apps_v1_deployment_seldon-controller-manager.yaml
+++ b/tests/stacks/ibm/application/seldon-core-operator/test_data/expected/apps_v1_deployment_seldon-controller-manager.yaml
@@ -1,0 +1,160 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  labels:
+    app: seldon
+    app.kubernetes.io/component: seldon
+    app.kubernetes.io/instance: seldon-core
+    app.kubernetes.io/name: seldon-core-operator
+    app.kubernetes.io/version: 1.2.1
+    control-plane: seldon-controller-manager
+  name: seldon-controller-manager
+  namespace: kubeflow
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: seldon
+      app.kubernetes.io/component: seldon
+      app.kubernetes.io/instance: seldon1
+      app.kubernetes.io/name: seldon-core-operator
+      app.kubernetes.io/version: v0.5
+      control-plane: seldon-controller-manager
+  template:
+    metadata:
+      annotations:
+        prometheus.io/scrape: "true"
+        sidecar.istio.io/inject: "false"
+      labels:
+        app: seldon
+        app.kubernetes.io/component: seldon
+        app.kubernetes.io/instance: seldon1
+        app.kubernetes.io/name: seldon-core-operator
+        app.kubernetes.io/version: v0.5
+        control-plane: seldon-controller-manager
+    spec:
+      containers:
+      - args:
+        - --enable-leader-election
+        - --webhook-port=443
+        - --create-resources=$(MANAGER_CREATE_RESOURCES)
+        - ""
+        command:
+        - /manager
+        env:
+        - name: WATCH_NAMESPACE
+          value: ""
+        - name: RELATED_IMAGE_EXECUTOR
+          value: ""
+        - name: RELATED_IMAGE_ENGINE
+          value: ""
+        - name: RELATED_IMAGE_STORAGE_INITIALIZER
+          value: ""
+        - name: RELATED_IMAGE_SKLEARNSERVER_REST
+          value: ""
+        - name: RELATED_IMAGE_SKLEARNSERVER_GRPC
+          value: ""
+        - name: RELATED_IMAGE_XGBOOSTSERVER_REST
+          value: ""
+        - name: RELATED_IMAGE_XGBOOSTSERVER_GRPC
+          value: ""
+        - name: RELATED_IMAGE_MLFLOWSERVER_REST
+          value: ""
+        - name: RELATED_IMAGE_MLFLOWSERVER_GRPC
+          value: ""
+        - name: RELATED_IMAGE_TFPROXY_REST
+          value: ""
+        - name: RELATED_IMAGE_TFPROXY_GRPC
+          value: ""
+        - name: RELATED_IMAGE_TENSORFLOW
+          value: ""
+        - name: RELATED_IMAGE_EXPLAINER
+          value: ""
+        - name: MANAGER_CREATE_RESOURCES
+          value: "false"
+        - name: POD_NAMESPACE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace
+        - name: CONTROLLER_ID
+          value: ""
+        - name: AMBASSADOR_ENABLED
+          value: "true"
+        - name: AMBASSADOR_SINGLE_NAMESPACE
+          value: "false"
+        - name: ENGINE_CONTAINER_IMAGE_AND_VERSION
+          value: docker.io/seldonio/engine:1.2.1
+        - name: ENGINE_CONTAINER_IMAGE_PULL_POLICY
+          value: IfNotPresent
+        - name: ENGINE_CONTAINER_SERVICE_ACCOUNT_NAME
+          value: default
+        - name: ENGINE_CONTAINER_USER
+          value: "8888"
+        - name: ENGINE_LOG_MESSAGES_EXTERNALLY
+          value: "false"
+        - name: PREDICTIVE_UNIT_SERVICE_PORT
+          value: "9000"
+        - name: PREDICTIVE_UNIT_DEFAULT_ENV_SECRET_REF_NAME
+          value: ""
+        - name: PREDICTIVE_UNIT_METRICS_PORT_NAME
+          value: metrics
+        - name: ENGINE_SERVER_GRPC_PORT
+          value: "5001"
+        - name: ENGINE_SERVER_PORT
+          value: "8000"
+        - name: ENGINE_PROMETHEUS_PATH
+          value: /prometheus
+        - name: ISTIO_ENABLED
+          value: "true"
+        - name: ISTIO_GATEWAY
+          value: kubeflow/kubeflow-gateway
+        - name: ISTIO_TLS_MODE
+          value: ""
+        - name: USE_EXECUTOR
+          value: "true"
+        - name: EXECUTOR_CONTAINER_IMAGE_AND_VERSION
+          value: docker.io/seldonio/seldon-core-executor:1.2.1
+        - name: EXECUTOR_CONTAINER_IMAGE_PULL_POLICY
+          value: IfNotPresent
+        - name: EXECUTOR_PROMETHEUS_PATH
+          value: /prometheus
+        - name: EXECUTOR_SERVER_PORT
+          value: "8000"
+        - name: EXECUTOR_CONTAINER_USER
+          value: "8888"
+        - name: EXECUTOR_CONTAINER_SERVICE_ACCOUNT_NAME
+          value: default
+        - name: EXECUTOR_SERVER_METRICS_PORT_NAME
+          value: metrics
+        - name: EXECUTOR_REQUEST_LOGGER_DEFAULT_ENDPOINT
+          value: http://default-broker
+        - name: DEFAULT_USER_ID
+          value: "8888"
+        image: docker.io/seldonio/seldon-core-operator:1.2.1
+        imagePullPolicy: IfNotPresent
+        name: manager
+        ports:
+        - containerPort: 443
+          name: webhook-server
+          protocol: TCP
+        - containerPort: 8080
+          name: metrics
+          protocol: TCP
+        resources:
+          limits:
+            cpu: 500m
+            memory: 300Mi
+          requests:
+            cpu: 100m
+            memory: 200Mi
+        volumeMounts:
+        - mountPath: /tmp/k8s-webhook-server/serving-certs
+          name: cert
+          readOnly: true
+      serviceAccountName: seldon-manager
+      terminationGracePeriodSeconds: 10
+      volumes:
+      - name: cert
+        secret:
+          defaultMode: 420
+          secretName: seldon-webhook-server-cert

--- a/tests/stacks/ibm/application/seldon-core-operator/test_data/expected/cert-manager.io_v1alpha2_certificate_seldon-serving-cert.yaml
+++ b/tests/stacks/ibm/application/seldon-core-operator/test_data/expected/cert-manager.io_v1alpha2_certificate_seldon-serving-cert.yaml
@@ -1,0 +1,20 @@
+apiVersion: cert-manager.io/v1alpha2
+kind: Certificate
+metadata:
+  labels:
+    app: seldon
+    app.kubernetes.io/component: seldon
+    app.kubernetes.io/instance: seldon-core
+    app.kubernetes.io/name: seldon-core-operator
+    app.kubernetes.io/version: 1.2.1
+  name: seldon-serving-cert
+  namespace: kubeflow
+spec:
+  commonName: seldon-webhook-service.kubeflow.svc
+  dnsNames:
+  - seldon-webhook-service.kubeflow.svc.cluster.local
+  - seldon-webhook-service.kubeflow.svc
+  issuerRef:
+    kind: Issuer
+    name: seldon-selfsigned-issuer
+  secretName: seldon-webhook-server-cert

--- a/tests/stacks/ibm/application/seldon-core-operator/test_data/expected/cert-manager.io_v1alpha2_issuer_seldon-selfsigned-issuer.yaml
+++ b/tests/stacks/ibm/application/seldon-core-operator/test_data/expected/cert-manager.io_v1alpha2_issuer_seldon-selfsigned-issuer.yaml
@@ -1,0 +1,13 @@
+apiVersion: cert-manager.io/v1alpha2
+kind: Issuer
+metadata:
+  labels:
+    app: seldon
+    app.kubernetes.io/component: seldon
+    app.kubernetes.io/instance: seldon-core
+    app.kubernetes.io/name: seldon-core-operator
+    app.kubernetes.io/version: 1.2.1
+  name: seldon-selfsigned-issuer
+  namespace: kubeflow
+spec:
+  selfSigned: {}

--- a/tests/stacks/ibm/application/seldon-core-operator/test_data/expected/rbac.authorization.k8s.io_v1_clusterrole_seldon-manager-role-kubeflow.yaml
+++ b/tests/stacks/ibm/application/seldon-core-operator/test_data/expected/rbac.authorization.k8s.io_v1_clusterrole_seldon-manager-role-kubeflow.yaml
@@ -1,0 +1,175 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  creationTimestamp: null
+  labels:
+    app: seldon
+    app.kubernetes.io/component: seldon
+    app.kubernetes.io/instance: seldon-core
+    app.kubernetes.io/name: seldon-core-operator
+    app.kubernetes.io/version: 1.2.1
+  name: seldon-manager-role-kubeflow
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - events
+  verbs:
+  - create
+  - patch
+- apiGroups:
+  - ""
+  resources:
+  - namespaces
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - services
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - apps
+  resources:
+  - deployments
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - apps
+  resources:
+  - deployments/status
+  verbs:
+  - get
+  - patch
+  - update
+- apiGroups:
+  - autoscaling
+  resources:
+  - horizontalpodautoscalers
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - autoscaling
+  resources:
+  - horizontalpodautoscalers/status
+  verbs:
+  - get
+  - patch
+  - update
+- apiGroups:
+  - machinelearning.seldon.io
+  resources:
+  - seldondeployments
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - machinelearning.seldon.io
+  resources:
+  - seldondeployments/finalizers
+  verbs:
+  - get
+  - patch
+  - update
+- apiGroups:
+  - machinelearning.seldon.io
+  resources:
+  - seldondeployments/status
+  verbs:
+  - get
+  - patch
+  - update
+- apiGroups:
+  - networking.istio.io
+  resources:
+  - destinationrules
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - networking.istio.io
+  resources:
+  - destinationrules/status
+  verbs:
+  - get
+  - patch
+  - update
+- apiGroups:
+  - networking.istio.io
+  resources:
+  - virtualservices
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - networking.istio.io
+  resources:
+  - virtualservices/status
+  verbs:
+  - get
+  - patch
+  - update
+- apiGroups:
+  - v1
+  resources:
+  - namespaces
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - v1
+  resources:
+  - services
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - v1
+  resources:
+  - services/status
+  verbs:
+  - get
+  - patch
+  - update

--- a/tests/stacks/ibm/application/seldon-core-operator/test_data/expected/rbac.authorization.k8s.io_v1_clusterrole_seldon-manager-sas-role-kubeflow.yaml
+++ b/tests/stacks/ibm/application/seldon-core-operator/test_data/expected/rbac.authorization.k8s.io_v1_clusterrole_seldon-manager-sas-role-kubeflow.yaml
@@ -1,0 +1,36 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  creationTimestamp: null
+  labels:
+    app: seldon
+    app.kubernetes.io/component: seldon
+    app.kubernetes.io/instance: seldon-core
+    app.kubernetes.io/name: seldon-core-operator
+    app.kubernetes.io/version: 1.2.1
+  name: seldon-manager-sas-role-kubeflow
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - secrets
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - configmaps
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - serviceaccounts
+  verbs:
+  - get
+  - list
+  - watch

--- a/tests/stacks/ibm/application/seldon-core-operator/test_data/expected/rbac.authorization.k8s.io_v1_clusterrolebinding_seldon-manager-rolebinding-kubeflow.yaml
+++ b/tests/stacks/ibm/application/seldon-core-operator/test_data/expected/rbac.authorization.k8s.io_v1_clusterrolebinding_seldon-manager-rolebinding-kubeflow.yaml
@@ -1,0 +1,18 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  labels:
+    app: seldon
+    app.kubernetes.io/component: seldon
+    app.kubernetes.io/instance: seldon-core
+    app.kubernetes.io/name: seldon-core-operator
+    app.kubernetes.io/version: 1.2.1
+  name: seldon-manager-rolebinding-kubeflow
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: seldon-manager-role-kubeflow
+subjects:
+- kind: ServiceAccount
+  name: seldon-manager
+  namespace: kubeflow

--- a/tests/stacks/ibm/application/seldon-core-operator/test_data/expected/rbac.authorization.k8s.io_v1_clusterrolebinding_seldon-manager-sas-rolebinding-kubeflow.yaml
+++ b/tests/stacks/ibm/application/seldon-core-operator/test_data/expected/rbac.authorization.k8s.io_v1_clusterrolebinding_seldon-manager-sas-rolebinding-kubeflow.yaml
@@ -1,0 +1,18 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  labels:
+    app: seldon
+    app.kubernetes.io/component: seldon
+    app.kubernetes.io/instance: seldon-core
+    app.kubernetes.io/name: seldon-core-operator
+    app.kubernetes.io/version: 1.2.1
+  name: seldon-manager-sas-rolebinding-kubeflow
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: seldon-manager-sas-role-kubeflow
+subjects:
+- kind: ServiceAccount
+  name: seldon-manager
+  namespace: kubeflow

--- a/tests/stacks/ibm/application/seldon-core-operator/test_data/expected/rbac.authorization.k8s.io_v1_role_seldon-leader-election-role.yaml
+++ b/tests/stacks/ibm/application/seldon-core-operator/test_data/expected/rbac.authorization.k8s.io_v1_role_seldon-leader-election-role.yaml
@@ -1,0 +1,38 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  labels:
+    app: seldon
+    app.kubernetes.io/component: seldon
+    app.kubernetes.io/instance: seldon-core
+    app.kubernetes.io/name: seldon-core-operator
+    app.kubernetes.io/version: 1.2.1
+  name: seldon-leader-election-role
+  namespace: kubeflow
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - configmaps
+  verbs:
+  - get
+  - list
+  - watch
+  - create
+  - update
+  - patch
+  - delete
+- apiGroups:
+  - ""
+  resources:
+  - configmaps/status
+  verbs:
+  - get
+  - update
+  - patch
+- apiGroups:
+  - ""
+  resources:
+  - events
+  verbs:
+  - create

--- a/tests/stacks/ibm/application/seldon-core-operator/test_data/expected/rbac.authorization.k8s.io_v1_rolebinding_seldon-leader-election-rolebinding.yaml
+++ b/tests/stacks/ibm/application/seldon-core-operator/test_data/expected/rbac.authorization.k8s.io_v1_rolebinding_seldon-leader-election-rolebinding.yaml
@@ -1,0 +1,19 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  labels:
+    app: seldon
+    app.kubernetes.io/component: seldon
+    app.kubernetes.io/instance: seldon-core
+    app.kubernetes.io/name: seldon-core-operator
+    app.kubernetes.io/version: 1.2.1
+  name: seldon-leader-election-rolebinding
+  namespace: kubeflow
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: seldon-leader-election-role
+subjects:
+- kind: ServiceAccount
+  name: seldon-manager
+  namespace: kubeflow

--- a/tests/stacks/ibm/application/seldon-core-operator/test_data/expected/~g_v1_configmap_seldon-config.yaml
+++ b/tests/stacks/ibm/application/seldon-core-operator/test_data/expected/~g_v1_configmap_seldon-config.yaml
@@ -1,0 +1,17 @@
+apiVersion: v1
+data:
+  credentials: '{"gcs":{"gcsCredentialFileName":"gcloud-application-credentials.json"},"s3":{"s3AccessKeyIDName":"awsAccessKeyID","s3SecretAccessKeyName":"awsSecretAccessKey"}}'
+  explainer: '{"image":"seldonio/alibiexplainer:1.2.1"}'
+  predictor_servers: '{"MLFLOW_SERVER":{"grpc":{"defaultImageVersion":"1.2.1","image":"seldonio/mlflowserver_grpc"},"rest":{"defaultImageVersion":"1.2.1","image":"seldonio/mlflowserver_rest"}},"SKLEARN_SERVER":{"grpc":{"defaultImageVersion":"1.2.1","image":"seldonio/sklearnserver_grpc"},"rest":{"defaultImageVersion":"1.2.1","image":"seldonio/sklearnserver_rest"}},"TENSORFLOW_SERVER":{"grpc":{"defaultImageVersion":"1.2.1","image":"seldonio/tfserving-proxy_grpc"},"rest":{"defaultImageVersion":"1.2.1","image":"seldonio/tfserving-proxy_rest"},"tensorflow":true,"tfImage":"tensorflow/serving:2.1.0"},"XGBOOST_SERVER":{"grpc":{"defaultImageVersion":"1.2.1","image":"seldonio/xgboostserver_grpc"},"rest":{"defaultImageVersion":"1.2.1","image":"seldonio/xgboostserver_rest"}}}'
+  storageInitializer: '{"cpuLimit":"1","cpuRequest":"100m","image":"gcr.io/kfserving/storage-initializer:0.2.2","memoryLimit":"1Gi","memoryRequest":"100Mi"}'
+kind: ConfigMap
+metadata:
+  labels:
+    app: seldon
+    app.kubernetes.io/component: seldon
+    app.kubernetes.io/instance: seldon-core
+    app.kubernetes.io/name: seldon-core-operator
+    app.kubernetes.io/version: 1.2.1
+    control-plane: seldon-controller-manager
+  name: seldon-config
+  namespace: kubeflow

--- a/tests/stacks/ibm/application/seldon-core-operator/test_data/expected/~g_v1_service_seldon-webhook-service.yaml
+++ b/tests/stacks/ibm/application/seldon-core-operator/test_data/expected/~g_v1_service_seldon-webhook-service.yaml
@@ -1,0 +1,22 @@
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    app: seldon
+    app.kubernetes.io/component: seldon
+    app.kubernetes.io/instance: seldon-core
+    app.kubernetes.io/name: seldon-core-operator
+    app.kubernetes.io/version: 1.2.1
+  name: seldon-webhook-service
+  namespace: kubeflow
+spec:
+  ports:
+  - port: 443
+    targetPort: 443
+  selector:
+    app: seldon
+    app.kubernetes.io/component: seldon
+    app.kubernetes.io/instance: seldon1
+    app.kubernetes.io/name: seldon-core-operator
+    app.kubernetes.io/version: v0.5
+    control-plane: seldon-controller-manager

--- a/tests/stacks/ibm/application/seldon-core-operator/test_data/expected/~g_v1_serviceaccount_seldon-manager.yaml
+++ b/tests/stacks/ibm/application/seldon-core-operator/test_data/expected/~g_v1_serviceaccount_seldon-manager.yaml
@@ -1,0 +1,11 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  labels:
+    app: seldon
+    app.kubernetes.io/component: seldon
+    app.kubernetes.io/instance: seldon-core
+    app.kubernetes.io/name: seldon-core-operator
+    app.kubernetes.io/version: 1.2.1
+  name: seldon-manager
+  namespace: kubeflow

--- a/tests/stacks/ibm/base/kustomize_test.go
+++ b/tests/stacks/ibm/base/kustomize_test.go
@@ -1,0 +1,15 @@
+package base
+
+import (
+	"github.com/kubeflow/manifests/tests"
+	"testing"
+)
+
+func TestKustomize(t *testing.T) {
+	testCase := &tests.KustomizeTestCase{
+		Package:  "../../../../stacks/ibm/base",
+		Expected: "test_data/expected",
+	}
+
+	tests.RunTestCase(t, testCase)
+}

--- a/tests/stacks/ibm/base/test_data/expected/~g_v1_configmap_kubeflow-config-d7dttg89h2.yaml
+++ b/tests/stacks/ibm/base/test_data/expected/~g_v1_configmap_kubeflow-config-d7dttg89h2.yaml
@@ -1,0 +1,9 @@
+apiVersion: v1
+data:
+  clusterDomain: cluster.local
+  userid-header: kubeflow-userid
+  userid-prefix: ""
+kind: ConfigMap
+metadata:
+  name: kubeflow-config-d7dttg89h2
+  namespace: kubeflow

--- a/tests/stacks/ibm/components/admission-webhook/kustomize_test.go
+++ b/tests/stacks/ibm/components/admission-webhook/kustomize_test.go
@@ -1,0 +1,15 @@
+package admission_webhook
+
+import (
+	"github.com/kubeflow/manifests/tests"
+	"testing"
+)
+
+func TestKustomize(t *testing.T) {
+	testCase := &tests.KustomizeTestCase{
+		Package:  "../../../../../stacks/ibm/components/admission-webhook",
+		Expected: "test_data/expected",
+	}
+
+	tests.RunTestCase(t, testCase)
+}

--- a/tests/stacks/ibm/components/admission-webhook/test_data/expected/admissionregistration.k8s.io_v1beta1_mutatingwebhookconfiguration_admission-webhook-mutating-webhook-configuration.yaml
+++ b/tests/stacks/ibm/components/admission-webhook/test_data/expected/admissionregistration.k8s.io_v1beta1_mutatingwebhookconfiguration_admission-webhook-mutating-webhook-configuration.yaml
@@ -1,0 +1,31 @@
+apiVersion: admissionregistration.k8s.io/v1beta1
+kind: MutatingWebhookConfiguration
+metadata:
+  annotations:
+    cert-manager.io/inject-ca-from: kubeflow/admission-webhook-cert
+  labels:
+    app: admission-webhook
+    app.kubernetes.io/component: poddefaults
+    app.kubernetes.io/name: poddefaults
+    kustomize.component: admission-webhook
+  name: admission-webhook-mutating-webhook-configuration
+webhooks:
+- clientConfig:
+    caBundle: ""
+    service:
+      name: admission-webhook-service
+      namespace: kubeflow
+      path: /apply-poddefault
+  name: admission-webhook-deployment.kubeflow.org
+  namespaceSelector:
+    matchLabels:
+      app.kubernetes.io/part-of: kubeflow-profile
+  rules:
+  - apiGroups:
+    - ""
+    apiVersions:
+    - v1
+    operations:
+    - CREATE
+    resources:
+    - pods

--- a/tests/stacks/ibm/components/admission-webhook/test_data/expected/apiextensions.k8s.io_v1beta1_customresourcedefinition_poddefaults.kubeflow.org.yaml
+++ b/tests/stacks/ibm/components/admission-webhook/test_data/expected/apiextensions.k8s.io_v1beta1_customresourcedefinition_poddefaults.kubeflow.org.yaml
@@ -1,0 +1,56 @@
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  labels:
+    app: admission-webhook
+    app.kubernetes.io/component: poddefaults
+    app.kubernetes.io/name: poddefaults
+    kustomize.component: admission-webhook
+  name: poddefaults.kubeflow.org
+spec:
+  group: kubeflow.org
+  names:
+    kind: PodDefault
+    plural: poddefaults
+    singular: poddefault
+  scope: Namespaced
+  validation:
+    openAPIV3Schema:
+      properties:
+        apiVersion:
+          type: string
+        kind:
+          type: string
+        metadata:
+          type: object
+        spec:
+          properties:
+            desc:
+              type: string
+            env:
+              items:
+                type: object
+              type: array
+            envFrom:
+              items:
+                type: object
+              type: array
+            selector:
+              type: object
+            serviceAccountName:
+              type: string
+            volumeMounts:
+              items:
+                type: object
+              type: array
+            volumes:
+              items:
+                type: object
+              type: array
+          required:
+          - selector
+          type: object
+        status:
+          type: object
+      type: object
+  version: v1alpha1

--- a/tests/stacks/ibm/components/admission-webhook/test_data/expected/app.k8s.io_v1beta1_application_webhook.yaml
+++ b/tests/stacks/ibm/components/admission-webhook/test_data/expected/app.k8s.io_v1beta1_application_webhook.yaml
@@ -1,0 +1,39 @@
+apiVersion: app.k8s.io/v1beta1
+kind: Application
+metadata:
+  labels:
+    app.kubernetes.io/component: poddefaults
+    app.kubernetes.io/name: poddefaults
+  name: webhook
+  namespace: kubeflow
+spec:
+  addOwnerRef: true
+  componentKinds:
+  - group: core
+    kind: ConfigMap
+  - group: apps
+    kind: StatefulSet
+  - group: core
+    kind: Service
+  - group: core
+    kind: ServiceAccount
+  descriptor:
+    description: injects volume, volume mounts, env vars into PodDefault
+    keywords:
+    - admission-webhook
+    - kubeflow
+    links:
+    - description: About
+      url: https://github.com/kubeflow/kubeflow/tree/master/components/admission-webhook
+    maintainers: []
+    owners: []
+    type: bootstrap
+    version: v1beta1
+  selector:
+    matchLabels:
+      app.kubernetes.io/component: bootstrap
+      app.kubernetes.io/instance: webhook-v1.0.0
+      app.kubernetes.io/managed-by: kfctl
+      app.kubernetes.io/name: webhook
+      app.kubernetes.io/part-of: webhook
+      app.kubernetes.io/version: v1.0.0

--- a/tests/stacks/ibm/components/admission-webhook/test_data/expected/apps_v1_deployment_admission-webhook-deployment.yaml
+++ b/tests/stacks/ibm/components/admission-webhook/test_data/expected/apps_v1_deployment_admission-webhook-deployment.yaml
@@ -1,0 +1,42 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  labels:
+    app: admission-webhook
+    app.kubernetes.io/component: poddefaults
+    app.kubernetes.io/name: poddefaults
+    kustomize.component: admission-webhook
+  name: admission-webhook-deployment
+  namespace: kubeflow
+spec:
+  selector:
+    matchLabels:
+      app: admission-webhook
+      app.kubernetes.io/component: poddefaults
+      app.kubernetes.io/name: poddefaults
+      kustomize.component: admission-webhook
+  template:
+    metadata:
+      annotations:
+        sidecar.istio.io/inject: "false"
+      labels:
+        app: admission-webhook
+        app.kubernetes.io/component: poddefaults
+        app.kubernetes.io/name: poddefaults
+        kustomize.component: admission-webhook
+    spec:
+      containers:
+      - args:
+        - --tlsCertFile=/etc/webhook/certs/tls.crt
+        - --tlsKeyFile=/etc/webhook/certs/tls.key
+        image: gcr.io/kubeflow-images-public/admission-webhook:vmaster-gaf96e4e3
+        name: admission-webhook
+        volumeMounts:
+        - mountPath: /etc/webhook/certs
+          name: webhook-cert
+          readOnly: true
+      serviceAccountName: admission-webhook-service-account
+      volumes:
+      - name: webhook-cert
+        secret:
+          secretName: webhook-certs

--- a/tests/stacks/ibm/components/admission-webhook/test_data/expected/cert-manager.io_v1alpha2_certificate_admission-webhook-cert.yaml
+++ b/tests/stacks/ibm/components/admission-webhook/test_data/expected/cert-manager.io_v1alpha2_certificate_admission-webhook-cert.yaml
@@ -1,0 +1,18 @@
+apiVersion: cert-manager.io/v1alpha2
+kind: Certificate
+metadata:
+  labels:
+    app.kubernetes.io/component: poddefaults
+    app.kubernetes.io/name: poddefaults
+  name: admission-webhook-cert
+  namespace: kubeflow
+spec:
+  commonName: admission-webhook-service.kubeflow.svc
+  dnsNames:
+  - admission-webhook-service.kubeflow.svc
+  - admission-webhook-service.kubeflow.svc.cluster.local
+  isCA: true
+  issuerRef:
+    kind: ClusterIssuer
+    name: kubeflow-self-signing-issuer
+  secretName: webhook-certs

--- a/tests/stacks/ibm/components/admission-webhook/test_data/expected/rbac.authorization.k8s.io_v1_clusterrole_admission-webhook-cluster-role.yaml
+++ b/tests/stacks/ibm/components/admission-webhook/test_data/expected/rbac.authorization.k8s.io_v1_clusterrole_admission-webhook-cluster-role.yaml
@@ -1,0 +1,22 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  labels:
+    app: admission-webhook
+    app.kubernetes.io/component: poddefaults
+    app.kubernetes.io/name: poddefaults
+    kustomize.component: admission-webhook
+  name: admission-webhook-cluster-role
+rules:
+- apiGroups:
+  - kubeflow.org
+  resources:
+  - poddefaults
+  verbs:
+  - get
+  - watch
+  - list
+  - update
+  - create
+  - patch
+  - delete

--- a/tests/stacks/ibm/components/admission-webhook/test_data/expected/rbac.authorization.k8s.io_v1_clusterrole_admission-webhook-kubeflow-poddefaults-admin.yaml
+++ b/tests/stacks/ibm/components/admission-webhook/test_data/expected/rbac.authorization.k8s.io_v1_clusterrole_admission-webhook-kubeflow-poddefaults-admin.yaml
@@ -1,0 +1,15 @@
+aggregationRule:
+  clusterRoleSelectors:
+  - matchLabels:
+      rbac.authorization.kubeflow.org/aggregate-to-kubeflow-poddefaults-admin: "true"
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  labels:
+    app: admission-webhook
+    app.kubernetes.io/component: poddefaults
+    app.kubernetes.io/name: poddefaults
+    kustomize.component: admission-webhook
+    rbac.authorization.kubeflow.org/aggregate-to-kubeflow-admin: "true"
+  name: admission-webhook-kubeflow-poddefaults-admin
+rules: []

--- a/tests/stacks/ibm/components/admission-webhook/test_data/expected/rbac.authorization.k8s.io_v1_clusterrole_admission-webhook-kubeflow-poddefaults-edit.yaml
+++ b/tests/stacks/ibm/components/admission-webhook/test_data/expected/rbac.authorization.k8s.io_v1_clusterrole_admission-webhook-kubeflow-poddefaults-edit.yaml
@@ -1,0 +1,15 @@
+aggregationRule:
+  clusterRoleSelectors:
+  - matchLabels:
+      rbac.authorization.kubeflow.org/aggregate-to-kubeflow-poddefaults-edit: "true"
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  labels:
+    app: admission-webhook
+    app.kubernetes.io/component: poddefaults
+    app.kubernetes.io/name: poddefaults
+    kustomize.component: admission-webhook
+    rbac.authorization.kubeflow.org/aggregate-to-kubeflow-edit: "true"
+  name: admission-webhook-kubeflow-poddefaults-edit
+rules: []

--- a/tests/stacks/ibm/components/admission-webhook/test_data/expected/rbac.authorization.k8s.io_v1_clusterrole_admission-webhook-kubeflow-poddefaults-view.yaml
+++ b/tests/stacks/ibm/components/admission-webhook/test_data/expected/rbac.authorization.k8s.io_v1_clusterrole_admission-webhook-kubeflow-poddefaults-view.yaml
@@ -1,0 +1,21 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  labels:
+    app: admission-webhook
+    app.kubernetes.io/component: poddefaults
+    app.kubernetes.io/name: poddefaults
+    kustomize.component: admission-webhook
+    rbac.authorization.kubeflow.org/aggregate-to-kubeflow-poddefaults-admin: "true"
+    rbac.authorization.kubeflow.org/aggregate-to-kubeflow-poddefaults-edit: "true"
+    rbac.authorization.kubeflow.org/aggregate-to-kubeflow-view: "true"
+  name: admission-webhook-kubeflow-poddefaults-view
+rules:
+- apiGroups:
+  - kubeflow.org
+  resources:
+  - poddefaults
+  verbs:
+  - get
+  - list
+  - watch

--- a/tests/stacks/ibm/components/admission-webhook/test_data/expected/rbac.authorization.k8s.io_v1_clusterrolebinding_admission-webhook-cluster-role-binding.yaml
+++ b/tests/stacks/ibm/components/admission-webhook/test_data/expected/rbac.authorization.k8s.io_v1_clusterrolebinding_admission-webhook-cluster-role-binding.yaml
@@ -1,0 +1,17 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  labels:
+    app: admission-webhook
+    app.kubernetes.io/component: poddefaults
+    app.kubernetes.io/name: poddefaults
+    kustomize.component: admission-webhook
+  name: admission-webhook-cluster-role-binding
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: admission-webhook-cluster-role
+subjects:
+- kind: ServiceAccount
+  name: admission-webhook-service-account
+  namespace: kubeflow

--- a/tests/stacks/ibm/components/admission-webhook/test_data/expected/~g_v1_configmap_admission-webhook-admission-webhook-parameters.yaml
+++ b/tests/stacks/ibm/components/admission-webhook/test_data/expected/~g_v1_configmap_admission-webhook-admission-webhook-parameters.yaml
@@ -1,0 +1,14 @@
+apiVersion: v1
+data:
+  issuer: kubeflow-self-signing-issuer
+  namespace: kubeflow
+kind: ConfigMap
+metadata:
+  annotations: {}
+  labels:
+    app: admission-webhook
+    app.kubernetes.io/component: poddefaults
+    app.kubernetes.io/name: poddefaults
+    kustomize.component: admission-webhook
+  name: admission-webhook-admission-webhook-parameters
+  namespace: kubeflow

--- a/tests/stacks/ibm/components/admission-webhook/test_data/expected/~g_v1_service_admission-webhook-service.yaml
+++ b/tests/stacks/ibm/components/admission-webhook/test_data/expected/~g_v1_service_admission-webhook-service.yaml
@@ -1,0 +1,19 @@
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    app: admission-webhook
+    app.kubernetes.io/component: poddefaults
+    app.kubernetes.io/name: poddefaults
+    kustomize.component: admission-webhook
+  name: admission-webhook-service
+  namespace: kubeflow
+spec:
+  ports:
+  - port: 443
+    targetPort: 443
+  selector:
+    app: admission-webhook
+    app.kubernetes.io/component: poddefaults
+    app.kubernetes.io/name: poddefaults
+    kustomize.component: admission-webhook

--- a/tests/stacks/ibm/components/admission-webhook/test_data/expected/~g_v1_serviceaccount_admission-webhook-service-account.yaml
+++ b/tests/stacks/ibm/components/admission-webhook/test_data/expected/~g_v1_serviceaccount_admission-webhook-service-account.yaml
@@ -1,0 +1,10 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  labels:
+    app: admission-webhook
+    app.kubernetes.io/component: poddefaults
+    app.kubernetes.io/name: poddefaults
+    kustomize.component: admission-webhook
+  name: admission-webhook-service-account
+  namespace: kubeflow

--- a/tests/stacks/ibm/components/argo/kustomize_test.go
+++ b/tests/stacks/ibm/components/argo/kustomize_test.go
@@ -1,0 +1,15 @@
+package argo
+
+import (
+	"github.com/kubeflow/manifests/tests"
+	"testing"
+)
+
+func TestKustomize(t *testing.T) {
+	testCase := &tests.KustomizeTestCase{
+		Package:  "../../../../../stacks/ibm/components/argo",
+		Expected: "test_data/expected",
+	}
+
+	tests.RunTestCase(t, testCase)
+}

--- a/tests/stacks/ibm/components/argo/test_data/expected/apiextensions.k8s.io_v1beta1_customresourcedefinition_workflows.argoproj.io.yaml
+++ b/tests/stacks/ibm/components/argo/test_data/expected/apiextensions.k8s.io_v1beta1_customresourcedefinition_workflows.argoproj.io.yaml
@@ -1,0 +1,19 @@
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  labels:
+    app.kubernetes.io/component: argo
+    app.kubernetes.io/name: argo
+    kustomize.component: argo
+  name: workflows.argoproj.io
+spec:
+  group: argoproj.io
+  names:
+    kind: Workflow
+    listKind: WorkflowList
+    plural: workflows
+    shortNames:
+    - wf
+    singular: workflow
+  scope: Namespaced
+  version: v1alpha1

--- a/tests/stacks/ibm/components/argo/test_data/expected/app.k8s.io_v1beta1_application_argo.yaml
+++ b/tests/stacks/ibm/components/argo/test_data/expected/app.k8s.io_v1beta1_application_argo.yaml
@@ -1,0 +1,39 @@
+apiVersion: app.k8s.io/v1beta1
+kind: Application
+metadata:
+  labels:
+    app.kubernetes.io/component: argo
+    app.kubernetes.io/name: argo
+    kustomize.component: argo
+  name: argo
+  namespace: kubeflow
+spec:
+  addOwnerRef: true
+  componentKinds:
+  - group: core
+    kind: ConfigMap
+  - group: apps
+    kind: Deployment
+  - group: core
+    kind: ServiceAccount
+  - group: core
+    kind: Service
+  - group: networking.istio.io
+    kind: VirtualService
+  descriptor:
+    description: Argo Workflows is an open source container-native workflow engine
+      for orchestrating parallel jobs on Kubernetes
+    keywords:
+    - argo
+    - kubeflow
+    links:
+    - description: About
+      url: https://github.com/argoproj/argo
+    maintainers: []
+    owners: []
+    type: argo
+    version: v1beta1
+  selector:
+    matchLabels:
+      app.kubernetes.io/component: argo
+      app.kubernetes.io/name: argo

--- a/tests/stacks/ibm/components/argo/test_data/expected/apps_v1_deployment_argo-ui.yaml
+++ b/tests/stacks/ibm/components/argo/test_data/expected/apps_v1_deployment_argo-ui.yaml
@@ -1,0 +1,66 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  labels:
+    app: argo-ui
+    app.kubernetes.io/component: argo
+    app.kubernetes.io/name: argo
+    kustomize.component: argo
+  name: argo-ui
+  namespace: kubeflow
+spec:
+  progressDeadlineSeconds: 600
+  replicas: 1
+  revisionHistoryLimit: 10
+  selector:
+    matchLabels:
+      app: argo-ui
+      app.kubernetes.io/component: argo
+      app.kubernetes.io/name: argo
+      kustomize.component: argo
+  strategy:
+    rollingUpdate:
+      maxSurge: 25%
+      maxUnavailable: 25%
+    type: RollingUpdate
+  template:
+    metadata:
+      annotations:
+        sidecar.istio.io/inject: "false"
+      creationTimestamp: null
+      labels:
+        app: argo-ui
+        app.kubernetes.io/component: argo
+        app.kubernetes.io/name: argo
+        kustomize.component: argo
+    spec:
+      containers:
+      - env:
+        - name: ARGO_NAMESPACE
+          valueFrom:
+            fieldRef:
+              apiVersion: v1
+              fieldPath: metadata.namespace
+        - name: IN_CLUSTER
+          value: "true"
+        - name: ENABLE_WEB_CONSOLE
+          value: "false"
+        - name: BASE_HREF
+          value: /argo/
+        image: argoproj/argoui:v2.3.0
+        imagePullPolicy: IfNotPresent
+        name: argo-ui
+        readinessProbe:
+          httpGet:
+            path: /
+            port: 8001
+        resources: {}
+        terminationMessagePath: /dev/termination-log
+        terminationMessagePolicy: File
+      dnsPolicy: ClusterFirst
+      restartPolicy: Always
+      schedulerName: default-scheduler
+      securityContext: {}
+      serviceAccount: argo-ui
+      serviceAccountName: argo-ui
+      terminationGracePeriodSeconds: 30

--- a/tests/stacks/ibm/components/argo/test_data/expected/apps_v1_deployment_workflow-controller.yaml
+++ b/tests/stacks/ibm/components/argo/test_data/expected/apps_v1_deployment_workflow-controller.yaml
@@ -1,0 +1,61 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  labels:
+    app: workflow-controller
+    app.kubernetes.io/component: argo
+    app.kubernetes.io/name: argo
+    kustomize.component: argo
+  name: workflow-controller
+  namespace: kubeflow
+spec:
+  progressDeadlineSeconds: 600
+  replicas: 1
+  revisionHistoryLimit: 10
+  selector:
+    matchLabels:
+      app: workflow-controller
+      app.kubernetes.io/component: argo
+      app.kubernetes.io/name: argo
+      kustomize.component: argo
+  strategy:
+    rollingUpdate:
+      maxSurge: 25%
+      maxUnavailable: 25%
+    type: RollingUpdate
+  template:
+    metadata:
+      annotations:
+        sidecar.istio.io/inject: "false"
+      creationTimestamp: null
+      labels:
+        app: workflow-controller
+        app.kubernetes.io/component: argo
+        app.kubernetes.io/name: argo
+        kustomize.component: argo
+    spec:
+      containers:
+      - args:
+        - --configmap
+        - workflow-controller-configmap
+        command:
+        - workflow-controller
+        env:
+        - name: ARGO_NAMESPACE
+          valueFrom:
+            fieldRef:
+              apiVersion: v1
+              fieldPath: metadata.namespace
+        image: argoproj/workflow-controller:v2.3.0
+        imagePullPolicy: IfNotPresent
+        name: workflow-controller
+        resources: {}
+        terminationMessagePath: /dev/termination-log
+        terminationMessagePolicy: File
+      dnsPolicy: ClusterFirst
+      restartPolicy: Always
+      schedulerName: default-scheduler
+      securityContext: {}
+      serviceAccount: argo
+      serviceAccountName: argo
+      terminationGracePeriodSeconds: 30

--- a/tests/stacks/ibm/components/argo/test_data/expected/networking.istio.io_v1alpha3_virtualservice_argo-ui.yaml
+++ b/tests/stacks/ibm/components/argo/test_data/expected/networking.istio.io_v1alpha3_virtualservice_argo-ui.yaml
@@ -1,0 +1,25 @@
+apiVersion: networking.istio.io/v1alpha3
+kind: VirtualService
+metadata:
+  labels:
+    app.kubernetes.io/component: argo
+    app.kubernetes.io/name: argo
+    kustomize.component: argo
+  name: argo-ui
+  namespace: kubeflow
+spec:
+  gateways:
+  - kubeflow-gateway
+  hosts:
+  - '*'
+  http:
+  - match:
+    - uri:
+        prefix: /argo/
+    rewrite:
+      uri: /
+    route:
+    - destination:
+        host: argo-ui.$(namespace).svc.$(clusterDomain)
+        port:
+          number: 80

--- a/tests/stacks/ibm/components/argo/test_data/expected/rbac.authorization.k8s.io_v1beta1_clusterrole_argo-ui.yaml
+++ b/tests/stacks/ibm/components/argo/test_data/expected/rbac.authorization.k8s.io_v1beta1_clusterrole_argo-ui.yaml
@@ -1,0 +1,35 @@
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: ClusterRole
+metadata:
+  labels:
+    app: argo
+    app.kubernetes.io/component: argo
+    app.kubernetes.io/name: argo
+    kustomize.component: argo
+  name: argo-ui
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - pods
+  - pods/exec
+  - pods/log
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - secrets
+  verbs:
+  - get
+- apiGroups:
+  - argoproj.io
+  resources:
+  - workflows
+  - workflows/finalizers
+  verbs:
+  - get
+  - list
+  - watch

--- a/tests/stacks/ibm/components/argo/test_data/expected/rbac.authorization.k8s.io_v1beta1_clusterrole_argo.yaml
+++ b/tests/stacks/ibm/components/argo/test_data/expected/rbac.authorization.k8s.io_v1beta1_clusterrole_argo.yaml
@@ -1,0 +1,54 @@
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: ClusterRole
+metadata:
+  labels:
+    app: argo
+    app.kubernetes.io/component: argo
+    app.kubernetes.io/name: argo
+    kustomize.component: argo
+  name: argo
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - pods
+  - pods/exec
+  verbs:
+  - create
+  - get
+  - list
+  - watch
+  - update
+  - patch
+- apiGroups:
+  - ""
+  resources:
+  - configmaps
+  verbs:
+  - get
+  - watch
+  - list
+- apiGroups:
+  - ""
+  resources:
+  - persistentvolumeclaims
+  verbs:
+  - create
+  - delete
+- apiGroups:
+  - argoproj.io
+  resources:
+  - workflows
+  - workflows/finalizers
+  verbs:
+  - get
+  - list
+  - watch
+  - update
+  - patch
+- apiGroups:
+  - sparkoperator.k8s.io
+  resources:
+  - sparkapplications
+  verbs:
+  - '*'

--- a/tests/stacks/ibm/components/argo/test_data/expected/rbac.authorization.k8s.io_v1beta1_clusterrolebinding_argo-ui.yaml
+++ b/tests/stacks/ibm/components/argo/test_data/expected/rbac.authorization.k8s.io_v1beta1_clusterrolebinding_argo-ui.yaml
@@ -1,0 +1,17 @@
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: ClusterRoleBinding
+metadata:
+  labels:
+    app: argo-ui
+    app.kubernetes.io/component: argo
+    app.kubernetes.io/name: argo
+    kustomize.component: argo
+  name: argo-ui
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: argo-ui
+subjects:
+- kind: ServiceAccount
+  name: argo-ui
+  namespace: kubeflow

--- a/tests/stacks/ibm/components/argo/test_data/expected/rbac.authorization.k8s.io_v1beta1_clusterrolebinding_argo.yaml
+++ b/tests/stacks/ibm/components/argo/test_data/expected/rbac.authorization.k8s.io_v1beta1_clusterrolebinding_argo.yaml
@@ -1,0 +1,17 @@
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: ClusterRoleBinding
+metadata:
+  labels:
+    app: argo
+    app.kubernetes.io/component: argo
+    app.kubernetes.io/name: argo
+    kustomize.component: argo
+  name: argo
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: argo
+subjects:
+- kind: ServiceAccount
+  name: argo
+  namespace: kubeflow

--- a/tests/stacks/ibm/components/argo/test_data/expected/~g_v1_configmap_workflow-controller-configmap.yaml
+++ b/tests/stacks/ibm/components/argo/test_data/expected/~g_v1_configmap_workflow-controller-configmap.yaml
@@ -1,0 +1,32 @@
+apiVersion: v1
+data:
+  config: |
+    {
+    executorImage: argoproj/argoexec:v2.3.0,
+    containerRuntimeExecutor: pns,
+    artifactRepository:
+    {
+        s3: {
+            bucket: mlpipeline,
+            keyPrefix: artifacts,
+            endpoint: minio-service.kubeflow:9000,
+            insecure: true,
+            accessKeySecret: {
+                name: mlpipeline-minio-artifact,
+                key: accesskey
+            },
+            secretKeySecret: {
+                name: mlpipeline-minio-artifact,
+                key: secretkey
+            }
+        }
+    }
+    }
+kind: ConfigMap
+metadata:
+  labels:
+    app.kubernetes.io/component: argo
+    app.kubernetes.io/name: argo
+    kustomize.component: argo
+  name: workflow-controller-configmap
+  namespace: kubeflow

--- a/tests/stacks/ibm/components/argo/test_data/expected/~g_v1_configmap_workflow-controller-parameters.yaml
+++ b/tests/stacks/ibm/components/argo/test_data/expected/~g_v1_configmap_workflow-controller-parameters.yaml
@@ -1,0 +1,23 @@
+apiVersion: v1
+data:
+  artifactRepositoryAccessKeySecretKey: accesskey
+  artifactRepositoryAccessKeySecretName: mlpipeline-minio-artifact
+  artifactRepositoryBucket: mlpipeline
+  artifactRepositoryEndpoint: minio-service.kubeflow:9000
+  artifactRepositoryInsecure: "true"
+  artifactRepositoryKeyPrefix: artifacts
+  artifactRepositorySecretKeySecretKey: secretkey
+  artifactRepositorySecretKeySecretName: mlpipeline-minio-artifact
+  clusterDomain: cluster.local
+  containerRuntimeExecutor: pns
+  executorImage: argoproj/argoexec:v2.3.0
+  namespace: ""
+kind: ConfigMap
+metadata:
+  annotations: {}
+  labels:
+    app.kubernetes.io/component: argo
+    app.kubernetes.io/name: argo
+    kustomize.component: argo
+  name: workflow-controller-parameters
+  namespace: kubeflow

--- a/tests/stacks/ibm/components/argo/test_data/expected/~g_v1_service_argo-ui.yaml
+++ b/tests/stacks/ibm/components/argo/test_data/expected/~g_v1_service_argo-ui.yaml
@@ -1,0 +1,21 @@
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    app: argo-ui
+    app.kubernetes.io/component: argo
+    app.kubernetes.io/name: argo
+    kustomize.component: argo
+  name: argo-ui
+  namespace: kubeflow
+spec:
+  ports:
+  - port: 80
+    targetPort: 8001
+  selector:
+    app: argo-ui
+    app.kubernetes.io/component: argo
+    app.kubernetes.io/name: argo
+    kustomize.component: argo
+  sessionAffinity: None
+  type: NodePort

--- a/tests/stacks/ibm/components/argo/test_data/expected/~g_v1_serviceaccount_argo-ui.yaml
+++ b/tests/stacks/ibm/components/argo/test_data/expected/~g_v1_serviceaccount_argo-ui.yaml
@@ -1,0 +1,9 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  labels:
+    app.kubernetes.io/component: argo
+    app.kubernetes.io/name: argo
+    kustomize.component: argo
+  name: argo-ui
+  namespace: kubeflow

--- a/tests/stacks/ibm/components/argo/test_data/expected/~g_v1_serviceaccount_argo.yaml
+++ b/tests/stacks/ibm/components/argo/test_data/expected/~g_v1_serviceaccount_argo.yaml
@@ -1,0 +1,9 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  labels:
+    app.kubernetes.io/component: argo
+    app.kubernetes.io/name: argo
+    kustomize.component: argo
+  name: argo
+  namespace: kubeflow

--- a/tests/stacks/ibm/components/katib/kustomize_test.go
+++ b/tests/stacks/ibm/components/katib/kustomize_test.go
@@ -1,0 +1,15 @@
+package katib
+
+import (
+	"github.com/kubeflow/manifests/tests"
+	"testing"
+)
+
+func TestKustomize(t *testing.T) {
+	testCase := &tests.KustomizeTestCase{
+		Package:  "../../../../../stacks/ibm/components/katib",
+		Expected: "test_data/expected",
+	}
+
+	tests.RunTestCase(t, testCase)
+}

--- a/tests/stacks/ibm/components/katib/test_data/expected/apiextensions.k8s.io_v1beta1_customresourcedefinition_experiments.kubeflow.org.yaml
+++ b/tests/stacks/ibm/components/katib/test_data/expected/apiextensions.k8s.io_v1beta1_customresourcedefinition_experiments.kubeflow.org.yaml
@@ -1,0 +1,28 @@
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  labels:
+    app.kubernetes.io/component: katib
+    app.kubernetes.io/name: katib-crds
+  name: experiments.kubeflow.org
+spec:
+  additionalPrinterColumns:
+  - JSONPath: .status.conditions[-1:].type
+    name: Status
+    type: string
+  - JSONPath: .metadata.creationTimestamp
+    name: Age
+    type: date
+  group: kubeflow.org
+  names:
+    categories:
+    - all
+    - kubeflow
+    - katib
+    kind: Experiment
+    plural: experiments
+    singular: experiment
+  scope: Namespaced
+  subresources:
+    status: {}
+  version: v1alpha3

--- a/tests/stacks/ibm/components/katib/test_data/expected/apiextensions.k8s.io_v1beta1_customresourcedefinition_suggestions.kubeflow.org.yaml
+++ b/tests/stacks/ibm/components/katib/test_data/expected/apiextensions.k8s.io_v1beta1_customresourcedefinition_suggestions.kubeflow.org.yaml
@@ -1,0 +1,37 @@
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  labels:
+    app.kubernetes.io/component: katib
+    app.kubernetes.io/name: katib-crds
+  name: suggestions.kubeflow.org
+spec:
+  additionalPrinterColumns:
+  - JSONPath: .status.conditions[-1:].type
+    name: Type
+    type: string
+  - JSONPath: .status.conditions[-1:].status
+    name: Status
+    type: string
+  - JSONPath: .spec.requests
+    name: Requested
+    type: string
+  - JSONPath: .status.suggestionCount
+    name: Assigned
+    type: string
+  - JSONPath: .metadata.creationTimestamp
+    name: Age
+    type: date
+  group: kubeflow.org
+  names:
+    categories:
+    - all
+    - kubeflow
+    - katib
+    kind: Suggestion
+    plural: suggestions
+    singular: suggestion
+  scope: Namespaced
+  subresources:
+    status: {}
+  version: v1alpha3

--- a/tests/stacks/ibm/components/katib/test_data/expected/apiextensions.k8s.io_v1beta1_customresourcedefinition_trials.kubeflow.org.yaml
+++ b/tests/stacks/ibm/components/katib/test_data/expected/apiextensions.k8s.io_v1beta1_customresourcedefinition_trials.kubeflow.org.yaml
@@ -1,0 +1,31 @@
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  labels:
+    app.kubernetes.io/component: katib
+    app.kubernetes.io/name: katib-crds
+  name: trials.kubeflow.org
+spec:
+  additionalPrinterColumns:
+  - JSONPath: .status.conditions[-1:].type
+    name: Type
+    type: string
+  - JSONPath: .status.conditions[-1:].status
+    name: Status
+    type: string
+  - JSONPath: .metadata.creationTimestamp
+    name: Age
+    type: date
+  group: kubeflow.org
+  names:
+    categories:
+    - all
+    - kubeflow
+    - katib
+    kind: Trial
+    plural: trials
+    singular: trial
+  scope: Namespaced
+  subresources:
+    status: {}
+  version: v1alpha3

--- a/tests/stacks/ibm/components/katib/test_data/expected/app.k8s.io_v1beta1_application_katib-controller.yaml
+++ b/tests/stacks/ibm/components/katib/test_data/expected/app.k8s.io_v1beta1_application_katib-controller.yaml
@@ -1,0 +1,70 @@
+apiVersion: app.k8s.io/v1beta1
+kind: Application
+metadata:
+  labels:
+    app.kubernetes.io/component: katib
+    app.kubernetes.io/name: katib-controller
+  name: katib-controller
+  namespace: kubeflow
+spec:
+  addOwnerRef: true
+  componentKinds:
+  - group: core
+    kind: Service
+  - group: apps
+    kind: Deployment
+  - group: core
+    kind: Secret
+  - group: core
+    kind: ServiceAccount
+  - group: kubeflow.org
+    kind: Experiment
+  - group: kubeflow.org
+    kind: Suggestion
+  - group: kubeflow.org
+    kind: Trial
+  descriptor:
+    description: Katib is a service for hyperparameter tuning and neural architecture
+      search.
+    keywords:
+    - katib
+    - katib-controller
+    - hyperparameter tuning
+    links:
+    - description: About
+      url: https://github.com/kubeflow/katib
+    maintainers:
+    - email: gaoce@caicloud.io
+      name: Ce Gao
+    - email: johnugeo@cisco.com
+      name: Johnu George
+    - email: liuhougang6@126.com
+      name: Hougang Liu
+    - email: ricliu@google.com
+      name: Richard Liu
+    - email: yuji.oshima0x3fd@gmail.com
+      name: YujiOshima
+    - email: andrey.velichkevich@gmail.com
+      name: Andrey Velichkevich
+    owners:
+    - email: gaoce@caicloud.io
+      name: Ce Gao
+    - email: johnugeo@cisco.com
+      name: Johnu George
+    - email: liuhougang6@126.com
+      name: Hougang Liu
+    - email: ricliu@google.com
+      name: Richard Liu
+    - email: yuji.oshima0x3fd@gmail.com
+      name: YujiOshima
+    - email: andrey.velichkevich@gmail.com
+      name: Andrey Velichkevich
+    type: katib
+    version: v1alpha3
+  selector:
+    matchLabels:
+      app.kubernetes.io/component: katib
+      app.kubernetes.io/instance: katib-controller
+      app.kubernetes.io/managed-by: kfctl
+      app.kubernetes.io/name: katib-controller
+      app.kubernetes.io/part-of: kubeflow

--- a/tests/stacks/ibm/components/katib/test_data/expected/app.k8s.io_v1beta1_application_katib-crds.yaml
+++ b/tests/stacks/ibm/components/katib/test_data/expected/app.k8s.io_v1beta1_application_katib-crds.yaml
@@ -1,0 +1,68 @@
+apiVersion: app.k8s.io/v1beta1
+kind: Application
+metadata:
+  labels:
+    app.kubernetes.io/component: katib
+    app.kubernetes.io/name: katib-crds
+  name: katib-crds
+  namespace: kubeflow
+spec:
+  addOwnerRef: true
+  componentKinds:
+  - group: core
+    kind: Service
+  - group: apps
+    kind: Deployment
+  - group: core
+    kind: ServiceAccount
+  - group: kubeflow.org
+    kind: Experiment
+  - group: kubeflow.org
+    kind: Suggestion
+  - group: kubeflow.org
+    kind: Trial
+  descriptor:
+    description: Katib is a service for hyperparameter tuning and neural architecture
+      search.
+    keywords:
+    - katib
+    - katib-controller
+    - hyperparameter tuning
+    links:
+    - description: About
+      url: https://github.com/kubeflow/katib
+    maintainers:
+    - email: gaoce@caicloud.io
+      name: Ce Gao
+    - email: johnugeo@cisco.com
+      name: Johnu George
+    - email: liuhougang6@126.com
+      name: Hougang Liu
+    - email: ricliu@google.com
+      name: Richard Liu
+    - email: yuji.oshima0x3fd@gmail.com
+      name: YujiOshima
+    - email: andrey.velichkevich@gmail.com
+      name: Andrey Velichkevich
+    owners:
+    - email: gaoce@caicloud.io
+      name: Ce Gao
+    - email: johnugeo@cisco.com
+      name: Johnu George
+    - email: liuhougang6@126.com
+      name: Hougang Liu
+    - email: ricliu@google.com
+      name: Richard Liu
+    - email: yuji.oshima0x3fd@gmail.com
+      name: YujiOshima
+    - email: andrey.velichkevich@gmail.com
+      name: Andrey Velichkevich
+    type: katib
+    version: v1alpha3
+  selector:
+    matchLabels:
+      app.kubernetes.io/component: katib
+      app.kubernetes.io/instance: katib-crds
+      app.kubernetes.io/managed-by: kfctl
+      app.kubernetes.io/name: katib-crds
+      app.kubernetes.io/part-of: kubeflow

--- a/tests/stacks/ibm/components/katib/test_data/expected/apps_v1_deployment_katib-controller.yaml
+++ b/tests/stacks/ibm/components/katib/test_data/expected/apps_v1_deployment_katib-controller.yaml
@@ -1,0 +1,56 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  labels:
+    app: katib-controller
+    app.kubernetes.io/component: katib
+    app.kubernetes.io/name: katib-controller
+  name: katib-controller
+  namespace: kubeflow
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: katib-controller
+      app.kubernetes.io/component: katib
+      app.kubernetes.io/name: katib-controller
+  template:
+    metadata:
+      annotations:
+        prometheus.io/scrape: "true"
+        sidecar.istio.io/inject: "false"
+      labels:
+        app: katib-controller
+        app.kubernetes.io/component: katib
+        app.kubernetes.io/name: katib-controller
+    spec:
+      containers:
+      - args:
+        - --webhook-port=8443
+        command:
+        - ./katib-controller
+        env:
+        - name: KATIB_CORE_NAMESPACE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace
+        image: gcr.io/kubeflow-images-public/katib/v1alpha3/katib-controller:ce89cbf
+        imagePullPolicy: IfNotPresent
+        name: katib-controller
+        ports:
+        - containerPort: 8443
+          name: webhook
+          protocol: TCP
+        - containerPort: 8080
+          name: metrics
+          protocol: TCP
+        volumeMounts:
+        - mountPath: /tmp/cert
+          name: cert
+          readOnly: true
+      serviceAccountName: katib-controller
+      volumes:
+      - name: cert
+        secret:
+          defaultMode: 420
+          secretName: katib-controller

--- a/tests/stacks/ibm/components/katib/test_data/expected/apps_v1_deployment_katib-db-manager.yaml
+++ b/tests/stacks/ibm/components/katib/test_data/expected/apps_v1_deployment_katib-db-manager.yaml
@@ -1,0 +1,60 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  labels:
+    app: katib
+    app.kubernetes.io/component: katib
+    app.kubernetes.io/name: katib-controller
+    component: db-manager
+  name: katib-db-manager
+  namespace: kubeflow
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: katib
+      app.kubernetes.io/component: katib
+      app.kubernetes.io/name: katib-controller
+      component: db-manager
+  template:
+    metadata:
+      annotations:
+        sidecar.istio.io/inject: "false"
+      labels:
+        app: katib
+        app.kubernetes.io/component: katib
+        app.kubernetes.io/name: katib-controller
+        component: db-manager
+      name: katib-db-manager
+    spec:
+      containers:
+      - command:
+        - ./katib-db-manager
+        env:
+        - name: DB_NAME
+          value: mysql
+        - name: DB_PASSWORD
+          valueFrom:
+            secretKeyRef:
+              key: MYSQL_ROOT_PASSWORD
+              name: katib-mysql-secrets
+        image: gcr.io/kubeflow-images-public/katib/v1alpha3/katib-db-manager:ce89cbf
+        imagePullPolicy: IfNotPresent
+        livenessProbe:
+          exec:
+            command:
+            - /bin/grpc_health_probe
+            - -addr=:6789
+          failureThreshold: 5
+          initialDelaySeconds: 10
+          periodSeconds: 60
+        name: katib-db-manager
+        ports:
+        - containerPort: 6789
+          name: api
+        readinessProbe:
+          exec:
+            command:
+            - /bin/grpc_health_probe
+            - -addr=:6789
+          initialDelaySeconds: 5

--- a/tests/stacks/ibm/components/katib/test_data/expected/apps_v1_deployment_katib-mysql.yaml
+++ b/tests/stacks/ibm/components/katib/test_data/expected/apps_v1_deployment_katib-mysql.yaml
@@ -1,0 +1,65 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  labels:
+    app: katib
+    app.kubernetes.io/component: katib
+    app.kubernetes.io/name: katib-controller
+    component: mysql
+  name: katib-mysql
+  namespace: kubeflow
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: katib
+      app.kubernetes.io/component: katib
+      app.kubernetes.io/name: katib-controller
+      component: mysql
+  template:
+    metadata:
+      annotations:
+        sidecar.istio.io/inject: "false"
+      labels:
+        app: katib
+        app.kubernetes.io/component: katib
+        app.kubernetes.io/name: katib-controller
+        component: mysql
+      name: katib-mysql
+    spec:
+      containers:
+      - args:
+        - --datadir
+        - /var/lib/mysql/datadir
+        env:
+        - name: MYSQL_ROOT_PASSWORD
+          valueFrom:
+            secretKeyRef:
+              key: MYSQL_ROOT_PASSWORD
+              name: katib-mysql-secrets
+        - name: MYSQL_ALLOW_EMPTY_PASSWORD
+          value: "true"
+        - name: MYSQL_DATABASE
+          value: katib
+        image: mysql:5.6
+        name: katib-mysql
+        ports:
+        - containerPort: 3306
+          name: dbapi
+        readinessProbe:
+          exec:
+            command:
+            - /bin/bash
+            - -c
+            - mysql -D ${MYSQL_DATABASE} -u root -p${MYSQL_ROOT_PASSWORD} -e 'SELECT
+              1'
+          initialDelaySeconds: 5
+          periodSeconds: 10
+          timeoutSeconds: 1
+        volumeMounts:
+        - mountPath: /var/lib/mysql
+          name: katib-mysql
+      volumes:
+      - name: katib-mysql
+        persistentVolumeClaim:
+          claimName: katib-mysql

--- a/tests/stacks/ibm/components/katib/test_data/expected/apps_v1_deployment_katib-ui.yaml
+++ b/tests/stacks/ibm/components/katib/test_data/expected/apps_v1_deployment_katib-ui.yaml
@@ -1,0 +1,46 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  labels:
+    app: katib
+    app.kubernetes.io/component: katib
+    app.kubernetes.io/name: katib-controller
+    component: ui
+  name: katib-ui
+  namespace: kubeflow
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: katib
+      app.kubernetes.io/component: katib
+      app.kubernetes.io/name: katib-controller
+      component: ui
+  template:
+    metadata:
+      annotations:
+        sidecar.istio.io/inject: "false"
+      labels:
+        app: katib
+        app.kubernetes.io/component: katib
+        app.kubernetes.io/name: katib-controller
+        component: ui
+      name: katib-ui
+    spec:
+      containers:
+      - args:
+        - --port=8080
+        command:
+        - ./katib-ui
+        env:
+        - name: KATIB_CORE_NAMESPACE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace
+        image: gcr.io/kubeflow-images-public/katib/v1alpha3/katib-ui:ce89cbf
+        imagePullPolicy: IfNotPresent
+        name: katib-ui
+        ports:
+        - containerPort: 8080
+          name: ui
+      serviceAccountName: katib-ui

--- a/tests/stacks/ibm/components/katib/test_data/expected/networking.istio.io_v1alpha3_virtualservice_katib-ui.yaml
+++ b/tests/stacks/ibm/components/katib/test_data/expected/networking.istio.io_v1alpha3_virtualservice_katib-ui.yaml
@@ -1,0 +1,24 @@
+apiVersion: networking.istio.io/v1alpha3
+kind: VirtualService
+metadata:
+  labels:
+    app.kubernetes.io/component: katib
+    app.kubernetes.io/name: katib-controller
+  name: katib-ui
+  namespace: kubeflow
+spec:
+  gateways:
+  - kubeflow-gateway
+  hosts:
+  - '*'
+  http:
+  - match:
+    - uri:
+        prefix: /katib/
+    rewrite:
+      uri: /katib/
+    route:
+    - destination:
+        host: katib-ui.kubeflow.svc.$(clusterDomain)
+        port:
+          number: 80

--- a/tests/stacks/ibm/components/katib/test_data/expected/rbac.authorization.k8s.io_v1_clusterrole_katib-controller.yaml
+++ b/tests/stacks/ibm/components/katib/test_data/expected/rbac.authorization.k8s.io_v1_clusterrole_katib-controller.yaml
@@ -1,0 +1,75 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  labels:
+    app.kubernetes.io/component: katib
+    app.kubernetes.io/name: katib-controller
+  name: katib-controller
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - configmaps
+  - serviceaccounts
+  - services
+  - secrets
+  - events
+  - namespaces
+  verbs:
+  - '*'
+- apiGroups:
+  - ""
+  resources:
+  - pods
+  - pods/log
+  - pods/status
+  verbs:
+  - '*'
+- apiGroups:
+  - apps
+  resources:
+  - deployments
+  verbs:
+  - '*'
+- apiGroups:
+  - batch
+  resources:
+  - jobs
+  - cronjobs
+  verbs:
+  - '*'
+- apiGroups:
+  - apiextensions.k8s.io
+  resources:
+  - customresourcedefinitions
+  verbs:
+  - create
+  - get
+- apiGroups:
+  - admissionregistration.k8s.io
+  resources:
+  - validatingwebhookconfigurations
+  - mutatingwebhookconfigurations
+  verbs:
+  - '*'
+- apiGroups:
+  - kubeflow.org
+  resources:
+  - experiments
+  - experiments/status
+  - experiments/finalizers
+  - trials
+  - trials/status
+  - trials/finalizers
+  - suggestions
+  - suggestions/status
+  - suggestions/finalizers
+  verbs:
+  - '*'
+- apiGroups:
+  - kubeflow.org
+  resources:
+  - tfjobs
+  - pytorchjobs
+  verbs:
+  - '*'

--- a/tests/stacks/ibm/components/katib/test_data/expected/rbac.authorization.k8s.io_v1_clusterrole_katib-ui.yaml
+++ b/tests/stacks/ibm/components/katib/test_data/expected/rbac.authorization.k8s.io_v1_clusterrole_katib-ui.yaml
@@ -1,0 +1,23 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  labels:
+    app.kubernetes.io/component: katib
+    app.kubernetes.io/name: katib-controller
+  name: katib-ui
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - configmaps
+  - namespaces
+  verbs:
+  - '*'
+- apiGroups:
+  - kubeflow.org
+  resources:
+  - experiments
+  - trials
+  - suggestions
+  verbs:
+  - '*'

--- a/tests/stacks/ibm/components/katib/test_data/expected/rbac.authorization.k8s.io_v1_clusterrole_kubeflow-katib-admin.yaml
+++ b/tests/stacks/ibm/components/katib/test_data/expected/rbac.authorization.k8s.io_v1_clusterrole_kubeflow-katib-admin.yaml
@@ -1,0 +1,13 @@
+aggregationRule:
+  clusterRoleSelectors:
+  - matchLabels:
+      rbac.authorization.kubeflow.org/aggregate-to-kubeflow-katib-admin: "true"
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  labels:
+    app.kubernetes.io/component: katib
+    app.kubernetes.io/name: katib-controller
+    rbac.authorization.kubeflow.org/aggregate-to-kubeflow-admin: "true"
+  name: kubeflow-katib-admin
+rules: []

--- a/tests/stacks/ibm/components/katib/test_data/expected/rbac.authorization.k8s.io_v1_clusterrole_kubeflow-katib-edit.yaml
+++ b/tests/stacks/ibm/components/katib/test_data/expected/rbac.authorization.k8s.io_v1_clusterrole_kubeflow-katib-edit.yaml
@@ -1,0 +1,25 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  labels:
+    app.kubernetes.io/component: katib
+    app.kubernetes.io/name: katib-controller
+    rbac.authorization.kubeflow.org/aggregate-to-kubeflow-edit: "true"
+    rbac.authorization.kubeflow.org/aggregate-to-kubeflow-katib-admin: "true"
+  name: kubeflow-katib-edit
+rules:
+- apiGroups:
+  - kubeflow.org
+  resources:
+  - experiments
+  - trials
+  - suggestions
+  verbs:
+  - get
+  - list
+  - watch
+  - create
+  - delete
+  - deletecollection
+  - patch
+  - update

--- a/tests/stacks/ibm/components/katib/test_data/expected/rbac.authorization.k8s.io_v1_clusterrole_kubeflow-katib-view.yaml
+++ b/tests/stacks/ibm/components/katib/test_data/expected/rbac.authorization.k8s.io_v1_clusterrole_kubeflow-katib-view.yaml
@@ -1,0 +1,19 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  labels:
+    app.kubernetes.io/component: katib
+    app.kubernetes.io/name: katib-controller
+    rbac.authorization.kubeflow.org/aggregate-to-kubeflow-view: "true"
+  name: kubeflow-katib-view
+rules:
+- apiGroups:
+  - kubeflow.org
+  resources:
+  - experiments
+  - trials
+  - suggestions
+  verbs:
+  - get
+  - list
+  - watch

--- a/tests/stacks/ibm/components/katib/test_data/expected/rbac.authorization.k8s.io_v1_clusterrolebinding_katib-controller.yaml
+++ b/tests/stacks/ibm/components/katib/test_data/expected/rbac.authorization.k8s.io_v1_clusterrolebinding_katib-controller.yaml
@@ -1,0 +1,15 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  labels:
+    app.kubernetes.io/component: katib
+    app.kubernetes.io/name: katib-controller
+  name: katib-controller
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: katib-controller
+subjects:
+- kind: ServiceAccount
+  name: katib-controller
+  namespace: kubeflow

--- a/tests/stacks/ibm/components/katib/test_data/expected/rbac.authorization.k8s.io_v1_clusterrolebinding_katib-ui.yaml
+++ b/tests/stacks/ibm/components/katib/test_data/expected/rbac.authorization.k8s.io_v1_clusterrolebinding_katib-ui.yaml
@@ -1,0 +1,15 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  labels:
+    app.kubernetes.io/component: katib
+    app.kubernetes.io/name: katib-controller
+  name: katib-ui
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: katib-ui
+subjects:
+- kind: ServiceAccount
+  name: katib-ui
+  namespace: kubeflow

--- a/tests/stacks/ibm/components/katib/test_data/expected/~g_v1_configmap_katib-config.yaml
+++ b/tests/stacks/ibm/components/katib/test_data/expected/~g_v1_configmap_katib-config.yaml
@@ -1,0 +1,59 @@
+apiVersion: v1
+data:
+  metrics-collector-sidecar: |-
+    {
+      "StdOut": {
+        "image": "gcr.io/kubeflow-images-public/katib/v1alpha3/file-metrics-collector:ce89cbf"
+      },
+      "File": {
+        "image": "gcr.io/kubeflow-images-public/katib/v1alpha3/file-metrics-collector:ce89cbf"
+      },
+      "TensorFlowEvent": {
+        "image": "gcr.io/kubeflow-images-public/katib/v1alpha3/tfevent-metrics-collector:ce89cbf",
+        "resources": {
+          "limits": {
+            "memory": "1Gi"
+          }
+        }
+      }
+    }
+  suggestion: |-
+    {
+      "random": {
+        "image": "gcr.io/kubeflow-images-public/katib/v1alpha3/suggestion-hyperopt:ce89cbf"
+      },
+      "grid": {
+        "image": "gcr.io/kubeflow-images-public/katib/v1alpha3/suggestion-chocolate:ce89cbf"
+      },
+      "hyperband": {
+        "image": "gcr.io/kubeflow-images-public/katib/v1alpha3/suggestion-hyperband:ce89cbf"
+      },
+      "bayesianoptimization": {
+        "image": "gcr.io/kubeflow-images-public/katib/v1alpha3/suggestion-skopt:ce89cbf"
+      },
+      "tpe": {
+        "image": "gcr.io/kubeflow-images-public/katib/v1alpha3/suggestion-hyperopt:ce89cbf"
+      },
+      "enas": {
+        "image": "gcr.io/kubeflow-images-public/katib/v1alpha3/suggestion-enas:ce89cbf",
+        "imagePullPolicy": "Always",
+        "resources": {
+          "limits": {
+            "memory": "200Mi"
+          }
+        }
+      },
+      "cmaes": {
+        "image": "gcr.io/kubeflow-images-public/katib/v1alpha3/suggestion-goptuna:ce89cbf"
+      },
+      "darts": {
+        "image": "gcr.io/kubeflow-images-public/katib/v1alpha3/suggestion-darts:ce89cbf"
+      }
+    }
+kind: ConfigMap
+metadata:
+  labels:
+    app.kubernetes.io/component: katib
+    app.kubernetes.io/name: katib-controller
+  name: katib-config
+  namespace: kubeflow

--- a/tests/stacks/ibm/components/katib/test_data/expected/~g_v1_configmap_trial-template-labeled.yaml
+++ b/tests/stacks/ibm/components/katib/test_data/expected/~g_v1_configmap_trial-template-labeled.yaml
@@ -1,0 +1,97 @@
+apiVersion: v1
+data:
+  defaultTrialTemplate.yaml: |-
+    apiVersion: batch/v1
+    kind: Job
+    metadata:
+      name: {{.Trial}}
+      namespace: {{.NameSpace}}
+    spec:
+      template:
+        spec:
+          containers:
+          - name: {{.Trial}}
+            image: docker.io/kubeflowkatib/mxnet-mnist
+            command:
+            - "python3"
+            - "/opt/mxnet-mnist/mnist.py"
+            - "--batch-size=64"
+            {{- with .HyperParameters}}
+            {{- range .}}
+            - "{{.Name}}={{.Value}}"
+            {{- end}}
+            {{- end}}
+          restartPolicy: Never
+  enasCPUTemplate: |-
+    apiVersion: batch/v1
+    kind: Job
+    metadata:
+      name: {{.Trial}}
+      namespace: {{.NameSpace}}
+    spec:
+      template:
+        spec:
+          containers:
+          - name: {{.Trial}}
+            image: docker.io/kubeflowkatib/enas-cnn-cifar10-cpu
+            command:
+            - "python3.5"
+            - "-u"
+            - "RunTrial.py"
+            {{- with .HyperParameters}}
+            {{- range .}}
+            - "--{{.Name}}=\"{{.Value}}\""
+            {{- end}}
+            {{- end}}
+            - "--num_epochs=1"
+          restartPolicy: Never
+  pytorchJobTemplate: |-
+    apiVersion: "kubeflow.org/v1"
+    kind: PyTorchJob
+    metadata:
+      name: {{.Trial}}
+      namespace: {{.NameSpace}}
+    spec:
+     pytorchReplicaSpecs:
+      Master:
+        replicas: 1
+        restartPolicy: OnFailure
+        template:
+          spec:
+            containers:
+              - name: pytorch
+                image: gcr.io/kubeflow-ci/pytorch-dist-mnist-test:v1.0
+                imagePullPolicy: Always
+                command:
+                  - "python"
+                  - "/var/mnist.py"
+                  {{- with .HyperParameters}}
+                  {{- range .}}
+                  - "{{.Name}}={{.Value}}"
+                  {{- end}}
+                  {{- end}}
+      Worker:
+        replicas: 2
+        restartPolicy: OnFailure
+        template:
+          spec:
+            containers:
+              - name: pytorch
+                image: gcr.io/kubeflow-ci/pytorch-dist-mnist-test:v1.0
+                imagePullPolicy: Always
+                command:
+                  - "python"
+                  - "/var/mnist.py"
+                  {{- with .HyperParameters}}
+                  {{- range .}}
+                  - "{{.Name}}={{.Value}}"
+                  {{- end}}
+                  {{- end}}
+kind: ConfigMap
+metadata:
+  labels:
+    app: katib-trial-templates
+    app.kubernetes.io/component: katib
+    app.kubernetes.io/name: katib-controller
+  name: trial-template-labeled
+  namespace: kubeflow

--- a/tests/stacks/ibm/components/katib/test_data/expected/~g_v1_configmap_trial-template.yaml
+++ b/tests/stacks/ibm/components/katib/test_data/expected/~g_v1_configmap_trial-template.yaml
@@ -1,0 +1,31 @@
+apiVersion: v1
+data:
+  defaultTrialTemplate.yaml: |-
+    apiVersion: batch/v1
+    kind: Job
+    metadata:
+      name: {{.Trial}}
+      namespace: {{.NameSpace}}
+    spec:
+      template:
+        spec:
+          containers:
+          - name: {{.Trial}}
+            image: docker.io/kubeflowkatib/mxnet-mnist
+            command:
+            - "python3"
+            - "/opt/mxnet-mnist/mnist.py"
+            - "--batch-size=64"
+            {{- with .HyperParameters}}
+            {{- range .}}
+            - "{{.Name}}={{.Value}}"
+            {{- end}}
+            {{- end}}
+          restartPolicy: Never
+kind: ConfigMap
+metadata:
+  labels:
+    app.kubernetes.io/component: katib
+    app.kubernetes.io/name: katib-controller
+  name: trial-template
+  namespace: kubeflow

--- a/tests/stacks/ibm/components/katib/test_data/expected/~g_v1_persistentvolumeclaim_katib-mysql.yaml
+++ b/tests/stacks/ibm/components/katib/test_data/expected/~g_v1_persistentvolumeclaim_katib-mysql.yaml
@@ -1,0 +1,14 @@
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  labels:
+    app.kubernetes.io/component: katib
+    app.kubernetes.io/name: katib-controller
+  name: katib-mysql
+  namespace: kubeflow
+spec:
+  accessModes:
+  - ReadWriteOnce
+  resources:
+    requests:
+      storage: 10Gi

--- a/tests/stacks/ibm/components/katib/test_data/expected/~g_v1_secret_katib-controller.yaml
+++ b/tests/stacks/ibm/components/katib/test_data/expected/~g_v1_secret_katib-controller.yaml
@@ -1,0 +1,8 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  labels:
+    app.kubernetes.io/component: katib
+    app.kubernetes.io/name: katib-controller
+  name: katib-controller
+  namespace: kubeflow

--- a/tests/stacks/ibm/components/katib/test_data/expected/~g_v1_secret_katib-mysql-secrets.yaml
+++ b/tests/stacks/ibm/components/katib/test_data/expected/~g_v1_secret_katib-mysql-secrets.yaml
@@ -1,0 +1,11 @@
+apiVersion: v1
+data:
+  MYSQL_ROOT_PASSWORD: dGVzdA==
+kind: Secret
+metadata:
+  labels:
+    app.kubernetes.io/component: katib
+    app.kubernetes.io/name: katib-controller
+  name: katib-mysql-secrets
+  namespace: kubeflow
+type: Opaque

--- a/tests/stacks/ibm/components/katib/test_data/expected/~g_v1_service_katib-controller.yaml
+++ b/tests/stacks/ibm/components/katib/test_data/expected/~g_v1_service_katib-controller.yaml
@@ -1,0 +1,25 @@
+apiVersion: v1
+kind: Service
+metadata:
+  annotations:
+    prometheus.io/port: "8080"
+    prometheus.io/scheme: http
+    prometheus.io/scrape: "true"
+  labels:
+    app.kubernetes.io/component: katib
+    app.kubernetes.io/name: katib-controller
+  name: katib-controller
+  namespace: kubeflow
+spec:
+  ports:
+  - name: webhook
+    port: 443
+    protocol: TCP
+    targetPort: 8443
+  - name: metrics
+    port: 8080
+    targetPort: 8080
+  selector:
+    app: katib-controller
+    app.kubernetes.io/component: katib
+    app.kubernetes.io/name: katib-controller

--- a/tests/stacks/ibm/components/katib/test_data/expected/~g_v1_service_katib-db-manager.yaml
+++ b/tests/stacks/ibm/components/katib/test_data/expected/~g_v1_service_katib-db-manager.yaml
@@ -1,0 +1,21 @@
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    app: katib
+    app.kubernetes.io/component: katib
+    app.kubernetes.io/name: katib-controller
+    component: db-manager
+  name: katib-db-manager
+  namespace: kubeflow
+spec:
+  ports:
+  - name: api
+    port: 6789
+    protocol: TCP
+  selector:
+    app: katib
+    app.kubernetes.io/component: katib
+    app.kubernetes.io/name: katib-controller
+    component: db-manager
+  type: ClusterIP

--- a/tests/stacks/ibm/components/katib/test_data/expected/~g_v1_service_katib-mysql.yaml
+++ b/tests/stacks/ibm/components/katib/test_data/expected/~g_v1_service_katib-mysql.yaml
@@ -1,0 +1,21 @@
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    app: katib
+    app.kubernetes.io/component: katib
+    app.kubernetes.io/name: katib-controller
+    component: mysql
+  name: katib-mysql
+  namespace: kubeflow
+spec:
+  ports:
+  - name: dbapi
+    port: 3306
+    protocol: TCP
+  selector:
+    app: katib
+    app.kubernetes.io/component: katib
+    app.kubernetes.io/name: katib-controller
+    component: mysql
+  type: ClusterIP

--- a/tests/stacks/ibm/components/katib/test_data/expected/~g_v1_service_katib-ui.yaml
+++ b/tests/stacks/ibm/components/katib/test_data/expected/~g_v1_service_katib-ui.yaml
@@ -1,0 +1,22 @@
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    app: katib
+    app.kubernetes.io/component: katib
+    app.kubernetes.io/name: katib-controller
+    component: ui
+  name: katib-ui
+  namespace: kubeflow
+spec:
+  ports:
+  - name: ui
+    port: 80
+    protocol: TCP
+    targetPort: 8080
+  selector:
+    app: katib
+    app.kubernetes.io/component: katib
+    app.kubernetes.io/name: katib-controller
+    component: ui
+  type: ClusterIP

--- a/tests/stacks/ibm/components/katib/test_data/expected/~g_v1_serviceaccount_katib-controller.yaml
+++ b/tests/stacks/ibm/components/katib/test_data/expected/~g_v1_serviceaccount_katib-controller.yaml
@@ -1,0 +1,8 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  labels:
+    app.kubernetes.io/component: katib
+    app.kubernetes.io/name: katib-controller
+  name: katib-controller
+  namespace: kubeflow

--- a/tests/stacks/ibm/components/katib/test_data/expected/~g_v1_serviceaccount_katib-ui.yaml
+++ b/tests/stacks/ibm/components/katib/test_data/expected/~g_v1_serviceaccount_katib-ui.yaml
@@ -1,0 +1,8 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  labels:
+    app.kubernetes.io/component: katib
+    app.kubernetes.io/name: katib-controller
+  name: katib-ui
+  namespace: kubeflow

--- a/tests/stacks/ibm/components/metadata/kustomize_test.go
+++ b/tests/stacks/ibm/components/metadata/kustomize_test.go
@@ -1,0 +1,15 @@
+package metadata
+
+import (
+	"github.com/kubeflow/manifests/tests"
+	"testing"
+)
+
+func TestKustomize(t *testing.T) {
+	testCase := &tests.KustomizeTestCase{
+		Package:  "../../../../../stacks/ibm/components/metadata",
+		Expected: "test_data/expected",
+	}
+
+	tests.RunTestCase(t, testCase)
+}

--- a/tests/stacks/ibm/components/metadata/test_data/expected/app.k8s.io_v1beta1_application_metadata.yaml
+++ b/tests/stacks/ibm/components/metadata/test_data/expected/app.k8s.io_v1beta1_application_metadata.yaml
@@ -1,0 +1,45 @@
+apiVersion: app.k8s.io/v1beta1
+kind: Application
+metadata:
+  labels:
+    app.kubernetes.io/component: metadata
+    app.kubernetes.io/name: metadata
+    kustomize.component: metadata
+  name: metadata
+  namespace: kubeflow
+spec:
+  addOwnerRef: true
+  componentKinds:
+  - group: core
+    kind: Service
+  - group: apps
+    kind: Deployment
+  - group: core
+    kind: ConfigMap
+  - group: core
+    kind: ServiceAccount
+  descriptor:
+    description: Tracking and managing metadata of machine learning workflows in Kubeflow.
+    keywords:
+    - metadata
+    links:
+    - description: Docs
+      url: https://www.kubeflow.org/docs/components/misc/metadata/
+    maintainers:
+    - email: zhenghui@google.com
+      name: Zhenghui Wang
+    owners:
+    - email: ajaygopinathan@google.com
+      name: Ajay Gopinathan
+    - email: zhenghui@google.com
+      name: Zhenghui Wang
+    type: metadata
+    version: alpha
+  selector:
+    matchLabels:
+      app.kubernetes.io/component: metadata
+      app.kubernetes.io/instance: metadata-0.2.1
+      app.kubernetes.io/managed-by: kfctl
+      app.kubernetes.io/name: metadata
+      app.kubernetes.io/part-of: kubeflow
+      app.kubernetes.io/version: 0.2.1

--- a/tests/stacks/ibm/components/metadata/test_data/expected/apps_v1_deployment_metadata-db.yaml
+++ b/tests/stacks/ibm/components/metadata/test_data/expected/apps_v1_deployment_metadata-db.yaml
@@ -1,0 +1,59 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  labels:
+    app.kubernetes.io/component: metadata
+    app.kubernetes.io/name: metadata
+    component: db
+    kustomize.component: metadata
+  name: metadata-db
+  namespace: kubeflow
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/component: metadata
+      app.kubernetes.io/name: metadata
+      component: db
+      kustomize.component: metadata
+  template:
+    metadata:
+      annotations:
+        sidecar.istio.io/inject: "false"
+      labels:
+        app.kubernetes.io/component: metadata
+        app.kubernetes.io/name: metadata
+        component: db
+        kustomize.component: metadata
+      name: db
+    spec:
+      containers:
+      - args:
+        - --datadir
+        - /var/lib/mysql/datadir
+        envFrom:
+        - configMapRef:
+            name: metadata-db-parameters
+        - secretRef:
+            name: metadata-db-secrets
+        image: mysql:5.6
+        name: db-container
+        ports:
+        - containerPort: 3306
+          name: dbapi
+        readinessProbe:
+          exec:
+            command:
+            - /bin/bash
+            - -c
+            - mysql -D $$MYSQL_DATABASE -p$$MYSQL_ROOT_PASSWORD -e 'SELECT 1'
+          initialDelaySeconds: 5
+          periodSeconds: 2
+          timeoutSeconds: 1
+        volumeMounts:
+        - mountPath: /var/lib/mysql
+          name: metadata-mysql
+      volumes:
+      - name: metadata-mysql
+        persistentVolumeClaim:
+          claimName: metadata-mysql

--- a/tests/stacks/ibm/components/metadata/test_data/expected/apps_v1_deployment_metadata-deployment.yaml
+++ b/tests/stacks/ibm/components/metadata/test_data/expected/apps_v1_deployment_metadata-deployment.yaml
@@ -1,0 +1,67 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  labels:
+    app.kubernetes.io/component: metadata
+    app.kubernetes.io/name: metadata
+    component: server
+    kustomize.component: metadata
+  name: metadata-deployment
+  namespace: kubeflow
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/component: metadata
+      app.kubernetes.io/name: metadata
+      component: server
+      kustomize.component: metadata
+  template:
+    metadata:
+      annotations:
+        sidecar.istio.io/inject: "false"
+      labels:
+        app.kubernetes.io/component: metadata
+        app.kubernetes.io/name: metadata
+        component: server
+        kustomize.component: metadata
+    spec:
+      containers:
+      - command:
+        - ./server/server
+        - --http_port=8080
+        - --mysql_service_host=metadata-db
+        - --mysql_service_port=$(MYSQL_PORT)
+        - --mysql_service_user=$(MYSQL_USER_NAME)
+        - --mysql_service_password=$(MYSQL_ROOT_PASSWORD)
+        - --mlmd_db_name=$(MYSQL_DATABASE)
+        envFrom:
+        - configMapRef:
+            name: metadata-db-parameters
+        - secretRef:
+            name: metadata-db-secrets
+        image: gcr.io/kubeflow-images-public/metadata:v0.1.11
+        livenessProbe:
+          httpGet:
+            httpHeaders:
+            - name: ContentType
+              value: application/json
+            path: /api/v1alpha1/artifact_types
+            port: backendapi
+          initialDelaySeconds: 3
+          periodSeconds: 5
+          timeoutSeconds: 2
+        name: container
+        ports:
+        - containerPort: 8080
+          name: backendapi
+        readinessProbe:
+          httpGet:
+            httpHeaders:
+            - name: ContentType
+              value: application/json
+            path: /api/v1alpha1/artifact_types
+            port: backendapi
+          initialDelaySeconds: 3
+          periodSeconds: 5
+          timeoutSeconds: 2

--- a/tests/stacks/ibm/components/metadata/test_data/expected/apps_v1_deployment_metadata-envoy-deployment.yaml
+++ b/tests/stacks/ibm/components/metadata/test_data/expected/apps_v1_deployment_metadata-envoy-deployment.yaml
@@ -1,0 +1,36 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  labels:
+    app.kubernetes.io/component: metadata
+    app.kubernetes.io/name: metadata
+    component: envoy
+    kustomize.component: metadata
+  name: metadata-envoy-deployment
+  namespace: kubeflow
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/component: metadata
+      app.kubernetes.io/name: metadata
+      component: envoy
+      kustomize.component: metadata
+  template:
+    metadata:
+      annotations:
+        sidecar.istio.io/inject: "false"
+      labels:
+        app.kubernetes.io/component: metadata
+        app.kubernetes.io/name: metadata
+        component: envoy
+        kustomize.component: metadata
+    spec:
+      containers:
+      - image: gcr.io/ml-pipeline/envoy:metadata-grpc
+        name: container
+        ports:
+        - containerPort: 9090
+          name: md-envoy
+        - containerPort: 9901
+          name: envoy-admin

--- a/tests/stacks/ibm/components/metadata/test_data/expected/apps_v1_deployment_metadata-grpc-deployment.yaml
+++ b/tests/stacks/ibm/components/metadata/test_data/expected/apps_v1_deployment_metadata-grpc-deployment.yaml
@@ -1,0 +1,50 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  labels:
+    app.kubernetes.io/component: metadata
+    app.kubernetes.io/name: metadata
+    component: grpc-server
+    kustomize.component: metadata
+  name: metadata-grpc-deployment
+  namespace: kubeflow
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/component: metadata
+      app.kubernetes.io/name: metadata
+      component: grpc-server
+      kustomize.component: metadata
+  template:
+    metadata:
+      annotations:
+        sidecar.istio.io/inject: "false"
+      labels:
+        app.kubernetes.io/component: metadata
+        app.kubernetes.io/name: metadata
+        component: grpc-server
+        kustomize.component: metadata
+    spec:
+      containers:
+      - args:
+        - --grpc_port=$(METADATA_GRPC_SERVICE_PORT)
+        - --mysql_config_host=metadata-db
+        - --mysql_config_database=$(MYSQL_DATABASE)
+        - --mysql_config_port=$(MYSQL_PORT)
+        - --mysql_config_user=$(MYSQL_USER_NAME)
+        - --mysql_config_password=$(MYSQL_ROOT_PASSWORD)
+        command:
+        - /bin/metadata_store_server
+        envFrom:
+        - configMapRef:
+            name: metadata-db-parameters
+        - secretRef:
+            name: metadata-db-secrets
+        - configMapRef:
+            name: metadata-grpc-configmap
+        image: gcr.io/tfx-oss-public/ml_metadata_store_server:v0.21.1
+        name: container
+        ports:
+        - containerPort: 8080
+          name: grpc-backendapi

--- a/tests/stacks/ibm/components/metadata/test_data/expected/apps_v1_deployment_metadata-ui.yaml
+++ b/tests/stacks/ibm/components/metadata/test_data/expected/apps_v1_deployment_metadata-ui.yaml
@@ -1,0 +1,35 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  labels:
+    app: metadata-ui
+    app.kubernetes.io/component: metadata
+    app.kubernetes.io/name: metadata
+    kustomize.component: metadata
+  name: metadata-ui
+  namespace: kubeflow
+spec:
+  selector:
+    matchLabels:
+      app: metadata-ui
+      app.kubernetes.io/component: metadata
+      app.kubernetes.io/name: metadata
+      kustomize.component: metadata
+  template:
+    metadata:
+      annotations:
+        sidecar.istio.io/inject: "false"
+      labels:
+        app: metadata-ui
+        app.kubernetes.io/component: metadata
+        app.kubernetes.io/name: metadata
+        kustomize.component: metadata
+      name: ui
+    spec:
+      containers:
+      - image: gcr.io/kubeflow-images-public/metadata-frontend:v0.1.8
+        imagePullPolicy: IfNotPresent
+        name: metadata-ui
+        ports:
+        - containerPort: 3000
+      serviceAccountName: metadata-ui

--- a/tests/stacks/ibm/components/metadata/test_data/expected/networking.istio.io_v1alpha3_virtualservice_metadata-grpc.yaml
+++ b/tests/stacks/ibm/components/metadata/test_data/expected/networking.istio.io_v1alpha3_virtualservice_metadata-grpc.yaml
@@ -1,0 +1,26 @@
+apiVersion: networking.istio.io/v1alpha3
+kind: VirtualService
+metadata:
+  labels:
+    app.kubernetes.io/component: metadata
+    app.kubernetes.io/name: metadata
+    kustomize.component: metadata
+  name: metadata-grpc
+  namespace: kubeflow
+spec:
+  gateways:
+  - kubeflow-gateway
+  hosts:
+  - '*'
+  http:
+  - match:
+    - uri:
+        prefix: /ml_metadata
+    rewrite:
+      uri: /ml_metadata
+    route:
+    - destination:
+        host: metadata-envoy-service.kubeflow.svc.cluster.local
+        port:
+          number: 9090
+    timeout: 300s

--- a/tests/stacks/ibm/components/metadata/test_data/expected/networking.istio.io_v1alpha3_virtualservice_metadata-ui.yaml
+++ b/tests/stacks/ibm/components/metadata/test_data/expected/networking.istio.io_v1alpha3_virtualservice_metadata-ui.yaml
@@ -1,0 +1,26 @@
+apiVersion: networking.istio.io/v1alpha3
+kind: VirtualService
+metadata:
+  labels:
+    app.kubernetes.io/component: metadata
+    app.kubernetes.io/name: metadata
+    kustomize.component: metadata
+  name: metadata-ui
+  namespace: kubeflow
+spec:
+  gateways:
+  - kubeflow-gateway
+  hosts:
+  - '*'
+  http:
+  - match:
+    - uri:
+        prefix: /metadata
+    rewrite:
+      uri: /metadata
+    route:
+    - destination:
+        host: metadata-ui.kubeflow.svc.cluster.local
+        port:
+          number: 80
+    timeout: 300s

--- a/tests/stacks/ibm/components/metadata/test_data/expected/rbac.authorization.k8s.io_v1beta1_role_metadata-ui.yaml
+++ b/tests/stacks/ibm/components/metadata/test_data/expected/rbac.authorization.k8s.io_v1beta1_role_metadata-ui.yaml
@@ -1,0 +1,30 @@
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: Role
+metadata:
+  labels:
+    app: metadata-ui
+    app.kubernetes.io/component: metadata
+    app.kubernetes.io/name: metadata
+    kustomize.component: metadata
+  name: metadata-ui
+  namespace: kubeflow
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - pods
+  - pods/log
+  verbs:
+  - create
+  - get
+  - list
+- apiGroups:
+  - kubeflow.org
+  resources:
+  - viewers
+  verbs:
+  - create
+  - get
+  - list
+  - watch
+  - delete

--- a/tests/stacks/ibm/components/metadata/test_data/expected/rbac.authorization.k8s.io_v1beta1_rolebinding_metadata-ui.yaml
+++ b/tests/stacks/ibm/components/metadata/test_data/expected/rbac.authorization.k8s.io_v1beta1_rolebinding_metadata-ui.yaml
@@ -1,0 +1,18 @@
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: RoleBinding
+metadata:
+  labels:
+    app: metadata-ui
+    app.kubernetes.io/component: metadata
+    app.kubernetes.io/name: metadata
+    kustomize.component: metadata
+  name: metadata-ui
+  namespace: kubeflow
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: metadata-ui
+subjects:
+- kind: ServiceAccount
+  name: ui
+  namespace: kubeflow

--- a/tests/stacks/ibm/components/metadata/test_data/expected/~g_v1_configmap_metadata-db-parameters.yaml
+++ b/tests/stacks/ibm/components/metadata/test_data/expected/~g_v1_configmap_metadata-db-parameters.yaml
@@ -1,0 +1,13 @@
+apiVersion: v1
+data:
+  MYSQL_ALLOW_EMPTY_PASSWORD: "true"
+  MYSQL_DATABASE: metadb
+  MYSQL_PORT: "3306"
+kind: ConfigMap
+metadata:
+  labels:
+    app.kubernetes.io/component: metadata
+    app.kubernetes.io/name: metadata
+    kustomize.component: metadata
+  name: metadata-db-parameters
+  namespace: kubeflow

--- a/tests/stacks/ibm/components/metadata/test_data/expected/~g_v1_configmap_metadata-grpc-configmap.yaml
+++ b/tests/stacks/ibm/components/metadata/test_data/expected/~g_v1_configmap_metadata-grpc-configmap.yaml
@@ -1,0 +1,12 @@
+apiVersion: v1
+data:
+  METADATA_GRPC_SERVICE_HOST: metadata-grpc-service
+  METADATA_GRPC_SERVICE_PORT: "8080"
+kind: ConfigMap
+metadata:
+  labels:
+    app.kubernetes.io/component: metadata
+    app.kubernetes.io/name: metadata
+    kustomize.component: metadata
+  name: metadata-grpc-configmap
+  namespace: kubeflow

--- a/tests/stacks/ibm/components/metadata/test_data/expected/~g_v1_configmap_metadata-ui-parameters.yaml
+++ b/tests/stacks/ibm/components/metadata/test_data/expected/~g_v1_configmap_metadata-ui-parameters.yaml
@@ -1,0 +1,11 @@
+apiVersion: v1
+data:
+  uiClusterDomain: cluster.local
+kind: ConfigMap
+metadata:
+  labels:
+    app.kubernetes.io/component: metadata
+    app.kubernetes.io/name: metadata
+    kustomize.component: metadata
+  name: metadata-ui-parameters
+  namespace: kubeflow

--- a/tests/stacks/ibm/components/metadata/test_data/expected/~g_v1_persistentvolumeclaim_metadata-mysql.yaml
+++ b/tests/stacks/ibm/components/metadata/test_data/expected/~g_v1_persistentvolumeclaim_metadata-mysql.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  labels:
+    app.kubernetes.io/component: metadata
+    app.kubernetes.io/name: metadata
+    kustomize.component: metadata
+  name: metadata-mysql
+  namespace: kubeflow
+spec:
+  accessModes:
+  - ReadWriteOnce
+  resources:
+    requests:
+      storage: 10Gi

--- a/tests/stacks/ibm/components/metadata/test_data/expected/~g_v1_secret_metadata-db-secrets.yaml
+++ b/tests/stacks/ibm/components/metadata/test_data/expected/~g_v1_secret_metadata-db-secrets.yaml
@@ -1,0 +1,13 @@
+apiVersion: v1
+data:
+  MYSQL_ROOT_PASSWORD: dGVzdA==
+  MYSQL_USER_NAME: cm9vdA==
+kind: Secret
+metadata:
+  labels:
+    app.kubernetes.io/component: metadata
+    app.kubernetes.io/name: metadata
+    kustomize.component: metadata
+  name: metadata-db-secrets
+  namespace: kubeflow
+type: Opaque

--- a/tests/stacks/ibm/components/metadata/test_data/expected/~g_v1_service_metadata-db.yaml
+++ b/tests/stacks/ibm/components/metadata/test_data/expected/~g_v1_service_metadata-db.yaml
@@ -1,0 +1,21 @@
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    app.kubernetes.io/component: metadata
+    app.kubernetes.io/name: metadata
+    component: db
+    kustomize.component: metadata
+  name: metadata-db
+  namespace: kubeflow
+spec:
+  ports:
+  - name: dbapi
+    port: 3306
+    protocol: TCP
+  selector:
+    app.kubernetes.io/component: metadata
+    app.kubernetes.io/name: metadata
+    component: db
+    kustomize.component: metadata
+  type: ClusterIP

--- a/tests/stacks/ibm/components/metadata/test_data/expected/~g_v1_service_metadata-envoy-service.yaml
+++ b/tests/stacks/ibm/components/metadata/test_data/expected/~g_v1_service_metadata-envoy-service.yaml
@@ -1,0 +1,21 @@
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    app: metadata
+    app.kubernetes.io/component: metadata
+    app.kubernetes.io/name: metadata
+    kustomize.component: metadata
+  name: metadata-envoy-service
+  namespace: kubeflow
+spec:
+  ports:
+  - name: md-envoy
+    port: 9090
+    protocol: TCP
+  selector:
+    app.kubernetes.io/component: metadata
+    app.kubernetes.io/name: metadata
+    component: envoy
+    kustomize.component: metadata
+  type: ClusterIP

--- a/tests/stacks/ibm/components/metadata/test_data/expected/~g_v1_service_metadata-grpc-service.yaml
+++ b/tests/stacks/ibm/components/metadata/test_data/expected/~g_v1_service_metadata-grpc-service.yaml
@@ -1,0 +1,21 @@
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    app: grpc-metadata
+    app.kubernetes.io/component: metadata
+    app.kubernetes.io/name: metadata
+    kustomize.component: metadata
+  name: metadata-grpc-service
+  namespace: kubeflow
+spec:
+  ports:
+  - name: grpc-backendapi
+    port: 8080
+    protocol: TCP
+  selector:
+    app.kubernetes.io/component: metadata
+    app.kubernetes.io/name: metadata
+    component: grpc-server
+    kustomize.component: metadata
+  type: ClusterIP

--- a/tests/stacks/ibm/components/metadata/test_data/expected/~g_v1_service_metadata-service.yaml
+++ b/tests/stacks/ibm/components/metadata/test_data/expected/~g_v1_service_metadata-service.yaml
@@ -1,0 +1,21 @@
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    app: metadata
+    app.kubernetes.io/component: metadata
+    app.kubernetes.io/name: metadata
+    kustomize.component: metadata
+  name: metadata-service
+  namespace: kubeflow
+spec:
+  ports:
+  - name: backendapi
+    port: 8080
+    protocol: TCP
+  selector:
+    app.kubernetes.io/component: metadata
+    app.kubernetes.io/name: metadata
+    component: server
+    kustomize.component: metadata
+  type: ClusterIP

--- a/tests/stacks/ibm/components/metadata/test_data/expected/~g_v1_service_metadata-ui.yaml
+++ b/tests/stacks/ibm/components/metadata/test_data/expected/~g_v1_service_metadata-ui.yaml
@@ -1,0 +1,19 @@
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    app: metadata-ui
+    app.kubernetes.io/component: metadata
+    app.kubernetes.io/name: metadata
+    kustomize.component: metadata
+  name: metadata-ui
+  namespace: kubeflow
+spec:
+  ports:
+  - port: 80
+    targetPort: 3000
+  selector:
+    app: metadata-ui
+    app.kubernetes.io/component: metadata
+    app.kubernetes.io/name: metadata
+    kustomize.component: metadata

--- a/tests/stacks/ibm/components/metadata/test_data/expected/~g_v1_serviceaccount_metadata-ui.yaml
+++ b/tests/stacks/ibm/components/metadata/test_data/expected/~g_v1_serviceaccount_metadata-ui.yaml
@@ -1,0 +1,9 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  labels:
+    app.kubernetes.io/component: metadata
+    app.kubernetes.io/name: metadata
+    kustomize.component: metadata
+  name: metadata-ui
+  namespace: kubeflow

--- a/tests/stacks/ibm/components/notebooks/kustomize_test.go
+++ b/tests/stacks/ibm/components/notebooks/kustomize_test.go
@@ -1,0 +1,15 @@
+package notebooks
+
+import (
+	"github.com/kubeflow/manifests/tests"
+	"testing"
+)
+
+func TestKustomize(t *testing.T) {
+	testCase := &tests.KustomizeTestCase{
+		Package:  "../../../../../stacks/ibm/components/notebooks",
+		Expected: "test_data/expected",
+	}
+
+	tests.RunTestCase(t, testCase)
+}

--- a/tests/stacks/ibm/components/notebooks/test_data/expected/apiextensions.k8s.io_v1beta1_customresourcedefinition_notebooks.kubeflow.org.yaml
+++ b/tests/stacks/ibm/components/notebooks/test_data/expected/apiextensions.k8s.io_v1beta1_customresourcedefinition_notebooks.kubeflow.org.yaml
@@ -1,0 +1,96 @@
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  labels:
+    app: notebook-controller
+    app.kubernetes.io/component: notebook-controller
+    app.kubernetes.io/name: notebook-controller
+    kustomize.component: notebook-controller
+  name: notebooks.kubeflow.org
+spec:
+  group: kubeflow.org
+  names:
+    kind: Notebook
+    plural: notebooks
+    singular: notebook
+  scope: Namespaced
+  subresources:
+    status: {}
+  validation:
+    openAPIV3Schema:
+      properties:
+        apiVersion:
+          description: 'APIVersion defines the versioned schema of this representation
+            of an object. Servers should convert recognized schemas to the latest
+            internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#resources'
+          type: string
+        kind:
+          description: 'Kind is a string value representing the REST resource this
+            object represents. Servers may infer this from the endpoint the client
+            submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds'
+          type: string
+        metadata:
+          type: object
+        spec:
+          properties:
+            template:
+              description: 'INSERT ADDITIONAL SPEC FIELDS - desired state of cluster
+                Important: Run "make" to regenerate code after modifying this file'
+              properties:
+                spec:
+                  properties:
+                    containers:
+                      items:
+                        properties:
+                          resources:
+                            properties:
+                              limits:
+                                properties:
+                                  cpu:
+                                    pattern: ^([+-]?[0-9.]+)([eEinumkKMGTP]*[-+]?[0-9]*)$
+                                    type: string
+                                  memory:
+                                    pattern: ^([+-]?[0-9.]+)([eEinumkKMGTP]*[-+]?[0-9]*)$
+                                    type: string
+                                type: object
+                              requests:
+                                properties:
+                                  cpu:
+                                    pattern: ^([+-]?[0-9.]+)([eEinumkKMGTP]*[-+]?[0-9]*)$
+                                    type: string
+                                  memory:
+                                    pattern: ^([+-]?[0-9.]+)([eEinumkKMGTP]*[-+]?[0-9]*)$
+                                    type: string
+                                type: object
+                            type: object
+                        type: object
+                      type: array
+                  type: object
+              type: object
+          type: object
+        status:
+          properties:
+            conditions:
+              description: Conditions is an array of current conditions
+              items:
+                properties:
+                  type:
+                    description: Type of the confition/
+                    type: string
+                required:
+                - type
+                type: object
+              type: array
+          required:
+          - conditions
+          type: object
+  versions:
+  - name: v1alpha1
+    served: true
+    storage: false
+  - name: v1beta1
+    served: true
+    storage: true
+  - name: v1
+    served: true
+    storage: false

--- a/tests/stacks/ibm/components/notebooks/test_data/expected/app.k8s.io_v1beta1_application_jupyter-web-app.yaml
+++ b/tests/stacks/ibm/components/notebooks/test_data/expected/app.k8s.io_v1beta1_application_jupyter-web-app.yaml
@@ -1,0 +1,53 @@
+apiVersion: app.k8s.io/v1beta1
+kind: Application
+metadata:
+  labels:
+    app.kubernetes.io/component: jupyter-web-app
+    app.kubernetes.io/name: jupyter-web-app
+  name: jupyter-web-app
+  namespace: kubeflow
+spec:
+  addOwnerRef: true
+  componentKinds:
+  - group: core
+    kind: ConfigMap
+  - group: apps
+    kind: Deployment
+  - group: rbac.authorization.k8s.io
+    kind: RoleBinding
+  - group: rbac.authorization.k8s.io
+    kind: Role
+  - group: core
+    kind: ServiceAccount
+  - group: core
+    kind: Service
+  - group: networking.istio.io
+    kind: VirtualService
+  descriptor:
+    description: Provides a UI which allows the user to create/conect/delete jupyter
+      notebooks.
+    keywords:
+    - jupyterhub
+    - jupyter ui
+    - notebooks
+    links:
+    - description: About
+      url: https://github.com/kubeflow/kubeflow/tree/master/components/jupyter-web-app
+    - description: Docs
+      url: https://www.kubeflow.org/docs/notebooks
+    maintainers:
+    - email: kimwnasptd@arrikto.com
+      name: Kimonas Sotirchos
+    owners:
+    - email: kimwnasptd@arrikto.com
+      name: Kimonas Sotirchos
+    type: jupyter-web-app
+    version: v1beta1
+  selector:
+    matchLabels:
+      app.kubernetes.io/component: jupyter-web-app
+      app.kubernetes.io/instance: jupyter-web-app-v0.7.0
+      app.kubernetes.io/managed-by: kfctl
+      app.kubernetes.io/name: jupyter-web-app
+      app.kubernetes.io/part-of: kubeflow
+      app.kubernetes.io/version: v0.7.0

--- a/tests/stacks/ibm/components/notebooks/test_data/expected/app.k8s.io_v1beta1_application_notebook-controller.yaml
+++ b/tests/stacks/ibm/components/notebooks/test_data/expected/app.k8s.io_v1beta1_application_notebook-controller.yaml
@@ -1,0 +1,44 @@
+apiVersion: app.k8s.io/v1beta1
+kind: Application
+metadata:
+  labels:
+    app.kubernetes.io/component: notebook-controller
+    app.kubernetes.io/name: notebook-controller
+  name: notebook-controller
+  namespace: kubeflow
+spec:
+  addOwnerRef: true
+  componentKinds:
+  - group: core
+    kind: Service
+  - group: apps
+    kind: Deployment
+  - group: core
+    kind: ServiceAccount
+  descriptor:
+    description: Notebooks controller allows users to create a custom resource \"Notebook\"
+      (jupyter notebook).
+    keywords:
+    - jupyter
+    - notebook
+    - notebook-controller
+    - jupyterhub
+    links:
+    - description: About
+      url: https://github.com/kubeflow/kubeflow/tree/master/components/notebook-controller
+    maintainers:
+    - email: lunkai@google.com
+      name: Lun-kai Hsu
+    owners:
+    - email: lunkai@gogle.com
+      name: Lun-kai Hsu
+    type: notebook-controller
+    version: v1beta1
+  selector:
+    matchLabels:
+      app.kubernetes.io/component: notebook-controller
+      app.kubernetes.io/instance: notebook-controller-v1.0.0
+      app.kubernetes.io/managed-by: kfctl
+      app.kubernetes.io/name: notebook-controller
+      app.kubernetes.io/part-of: kubeflow
+      app.kubernetes.io/version: v1.0.0

--- a/tests/stacks/ibm/components/notebooks/test_data/expected/apps_v1_deployment_jupyter-web-app-deployment.yaml
+++ b/tests/stacks/ibm/components/notebooks/test_data/expected/apps_v1_deployment_jupyter-web-app-deployment.yaml
@@ -1,0 +1,63 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  labels:
+    app: jupyter-web-app
+    app.kubernetes.io/component: jupyter-web-app
+    app.kubernetes.io/name: jupyter-web-app
+    kustomize.component: jupyter-web-app
+  name: jupyter-web-app-deployment
+  namespace: kubeflow
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: jupyter-web-app
+      app.kubernetes.io/component: jupyter-web-app
+      app.kubernetes.io/name: jupyter-web-app
+      kustomize.component: jupyter-web-app
+  template:
+    metadata:
+      annotations:
+        sidecar.istio.io/inject: "false"
+      labels:
+        app: jupyter-web-app
+        app.kubernetes.io/component: jupyter-web-app
+        app.kubernetes.io/name: jupyter-web-app
+        kustomize.component: jupyter-web-app
+    spec:
+      containers:
+      - env:
+        - name: ROK_SECRET_NAME
+          valueFrom:
+            configMapKeyRef:
+              key: ROK_SECRET_NAME
+              name: jupyter-web-app-parameters
+        - name: UI
+          valueFrom:
+            configMapKeyRef:
+              key: UI
+              name: jupyter-web-app-parameters
+        - name: USERID_HEADER
+          valueFrom:
+            configMapKeyRef:
+              key: userid-header
+              name: kubeflow-config
+        - name: USERID_PREFIX
+          valueFrom:
+            configMapKeyRef:
+              key: userid-prefix
+              name: kubeflow-config
+        image: gcr.io/kubeflow-images-public/jupyter-web-app:vmaster-gd9be4b9e
+        imagePullPolicy: Always
+        name: jupyter-web-app
+        ports:
+        - containerPort: 5000
+        volumeMounts:
+        - mountPath: /etc/config
+          name: config-volume
+      serviceAccountName: jupyter-web-app-service-account
+      volumes:
+      - configMap:
+          name: jupyter-web-app-jupyter-web-app-config
+        name: config-volume

--- a/tests/stacks/ibm/components/notebooks/test_data/expected/apps_v1_deployment_notebook-controller-deployment.yaml
+++ b/tests/stacks/ibm/components/notebooks/test_data/expected/apps_v1_deployment_notebook-controller-deployment.yaml
@@ -1,0 +1,51 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  labels:
+    app: notebook-controller
+    app.kubernetes.io/component: notebook-controller
+    app.kubernetes.io/name: notebook-controller
+    kustomize.component: notebook-controller
+  name: notebook-controller-deployment
+  namespace: kubeflow
+spec:
+  selector:
+    matchLabels:
+      app: notebook-controller
+      app.kubernetes.io/component: notebook-controller
+      app.kubernetes.io/name: notebook-controller
+      kustomize.component: notebook-controller
+  template:
+    metadata:
+      annotations:
+        sidecar.istio.io/inject: "false"
+      labels:
+        app: notebook-controller
+        app.kubernetes.io/component: notebook-controller
+        app.kubernetes.io/name: notebook-controller
+        kustomize.component: notebook-controller
+    spec:
+      containers:
+      - command:
+        - /manager
+        env:
+        - name: USE_ISTIO
+          valueFrom:
+            configMapKeyRef:
+              key: USE_ISTIO
+              name: notebook-controller-config
+        - name: ISTIO_GATEWAY
+          valueFrom:
+            configMapKeyRef:
+              key: ISTIO_GATEWAY
+              name: notebook-controller-config
+        image: gcr.io/kubeflow-images-public/notebook-controller:vmaster-gf39279c0
+        imagePullPolicy: Always
+        livenessProbe:
+          httpGet:
+            path: /metrics
+            port: 8080
+          initialDelaySeconds: 30
+          periodSeconds: 30
+        name: manager
+      serviceAccountName: notebook-controller-service-account

--- a/tests/stacks/ibm/components/notebooks/test_data/expected/networking.istio.io_v1alpha3_virtualservice_jupyter-web-app.yaml
+++ b/tests/stacks/ibm/components/notebooks/test_data/expected/networking.istio.io_v1alpha3_virtualservice_jupyter-web-app.yaml
@@ -1,0 +1,25 @@
+apiVersion: networking.istio.io/v1alpha3
+kind: VirtualService
+metadata:
+  name: jupyter-web-app
+  namespace: kubeflow
+spec:
+  gateways:
+  - kubeflow-gateway
+  hosts:
+  - '*'
+  http:
+  - headers:
+      request:
+        add:
+          x-forwarded-prefix: /jupyter
+    match:
+    - uri:
+        prefix: /jupyter/
+    rewrite:
+      uri: /
+    route:
+    - destination:
+        host: jupyter-web-app-service.$(namespace).svc.$(clusterDomain)
+        port:
+          number: 80

--- a/tests/stacks/ibm/components/notebooks/test_data/expected/rbac.authorization.k8s.io_v1_clusterrole_jupyter-web-app-cluster-role.yaml
+++ b/tests/stacks/ibm/components/notebooks/test_data/expected/rbac.authorization.k8s.io_v1_clusterrole_jupyter-web-app-cluster-role.yaml
@@ -1,0 +1,59 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  labels:
+    app: jupyter-web-app
+    app.kubernetes.io/component: jupyter-web-app
+    app.kubernetes.io/name: jupyter-web-app
+    kustomize.component: jupyter-web-app
+  name: jupyter-web-app-cluster-role
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - namespaces
+  verbs:
+  - get
+  - list
+  - create
+  - delete
+- apiGroups:
+  - authorization.k8s.io
+  resources:
+  - subjectaccessreviews
+  verbs:
+  - create
+- apiGroups:
+  - kubeflow.org
+  resources:
+  - notebooks
+  - notebooks/finalizers
+  - poddefaults
+  verbs:
+  - get
+  - list
+  - create
+  - delete
+- apiGroups:
+  - ""
+  resources:
+  - persistentvolumeclaims
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+- apiGroups:
+  - ""
+  resources:
+  - events
+  verbs:
+  - list
+- apiGroups:
+  - storage.k8s.io
+  resources:
+  - storageclasses
+  verbs:
+  - get
+  - list
+  - watch

--- a/tests/stacks/ibm/components/notebooks/test_data/expected/rbac.authorization.k8s.io_v1_clusterrole_jupyter-web-app-kubeflow-notebook-ui-admin.yaml
+++ b/tests/stacks/ibm/components/notebooks/test_data/expected/rbac.authorization.k8s.io_v1_clusterrole_jupyter-web-app-kubeflow-notebook-ui-admin.yaml
@@ -1,0 +1,11 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  labels:
+    app: jupyter-web-app
+    app.kubernetes.io/component: jupyter-web-app
+    app.kubernetes.io/name: jupyter-web-app
+    kustomize.component: jupyter-web-app
+    rbac.authorization.kubeflow.org/aggregate-to-kubeflow-admin: "true"
+  name: jupyter-web-app-kubeflow-notebook-ui-admin
+rules: []

--- a/tests/stacks/ibm/components/notebooks/test_data/expected/rbac.authorization.k8s.io_v1_clusterrole_jupyter-web-app-kubeflow-notebook-ui-edit.yaml
+++ b/tests/stacks/ibm/components/notebooks/test_data/expected/rbac.authorization.k8s.io_v1_clusterrole_jupyter-web-app-kubeflow-notebook-ui-edit.yaml
@@ -1,0 +1,22 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  labels:
+    app: jupyter-web-app
+    app.kubernetes.io/component: jupyter-web-app
+    app.kubernetes.io/name: jupyter-web-app
+    kustomize.component: jupyter-web-app
+    rbac.authorization.kubeflow.org/aggregate-to-kubeflow-edit: "true"
+  name: jupyter-web-app-kubeflow-notebook-ui-edit
+rules:
+- apiGroups:
+  - kubeflow.org
+  resources:
+  - notebooks
+  - notebooks/finalizers
+  - poddefaults
+  verbs:
+  - get
+  - list
+  - create
+  - delete

--- a/tests/stacks/ibm/components/notebooks/test_data/expected/rbac.authorization.k8s.io_v1_clusterrole_jupyter-web-app-kubeflow-notebook-ui-view.yaml
+++ b/tests/stacks/ibm/components/notebooks/test_data/expected/rbac.authorization.k8s.io_v1_clusterrole_jupyter-web-app-kubeflow-notebook-ui-view.yaml
@@ -1,0 +1,28 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  labels:
+    app: jupyter-web-app
+    app.kubernetes.io/component: jupyter-web-app
+    app.kubernetes.io/name: jupyter-web-app
+    kustomize.component: jupyter-web-app
+    rbac.authorization.kubeflow.org/aggregate-to-kubeflow-view: "true"
+  name: jupyter-web-app-kubeflow-notebook-ui-view
+rules:
+- apiGroups:
+  - kubeflow.org
+  resources:
+  - notebooks
+  - notebooks/finalizers
+  - poddefaults
+  verbs:
+  - get
+  - list
+- apiGroups:
+  - storage.k8s.io
+  resources:
+  - storageclasses
+  verbs:
+  - get
+  - list
+  - watch

--- a/tests/stacks/ibm/components/notebooks/test_data/expected/rbac.authorization.k8s.io_v1_clusterrole_notebook-controller-kubeflow-notebooks-admin.yaml
+++ b/tests/stacks/ibm/components/notebooks/test_data/expected/rbac.authorization.k8s.io_v1_clusterrole_notebook-controller-kubeflow-notebooks-admin.yaml
@@ -1,0 +1,15 @@
+aggregationRule:
+  clusterRoleSelectors:
+  - matchLabels:
+      rbac.authorization.kubeflow.org/aggregate-to-kubeflow-notebooks-admin: "true"
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  labels:
+    app: notebook-controller
+    app.kubernetes.io/component: notebook-controller
+    app.kubernetes.io/name: notebook-controller
+    kustomize.component: notebook-controller
+    rbac.authorization.kubeflow.org/aggregate-to-kubeflow-admin: "true"
+  name: notebook-controller-kubeflow-notebooks-admin
+rules: []

--- a/tests/stacks/ibm/components/notebooks/test_data/expected/rbac.authorization.k8s.io_v1_clusterrole_notebook-controller-kubeflow-notebooks-edit.yaml
+++ b/tests/stacks/ibm/components/notebooks/test_data/expected/rbac.authorization.k8s.io_v1_clusterrole_notebook-controller-kubeflow-notebooks-edit.yaml
@@ -1,0 +1,26 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  labels:
+    app: notebook-controller
+    app.kubernetes.io/component: notebook-controller
+    app.kubernetes.io/name: notebook-controller
+    kustomize.component: notebook-controller
+    rbac.authorization.kubeflow.org/aggregate-to-kubeflow-edit: "true"
+    rbac.authorization.kubeflow.org/aggregate-to-kubeflow-notebooks-admin: "true"
+  name: notebook-controller-kubeflow-notebooks-edit
+rules:
+- apiGroups:
+  - kubeflow.org
+  resources:
+  - notebooks
+  - notebooks/status
+  verbs:
+  - get
+  - list
+  - watch
+  - create
+  - delete
+  - deletecollection
+  - patch
+  - update

--- a/tests/stacks/ibm/components/notebooks/test_data/expected/rbac.authorization.k8s.io_v1_clusterrole_notebook-controller-kubeflow-notebooks-view.yaml
+++ b/tests/stacks/ibm/components/notebooks/test_data/expected/rbac.authorization.k8s.io_v1_clusterrole_notebook-controller-kubeflow-notebooks-view.yaml
@@ -1,0 +1,20 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  labels:
+    app: notebook-controller
+    app.kubernetes.io/component: notebook-controller
+    app.kubernetes.io/name: notebook-controller
+    kustomize.component: notebook-controller
+    rbac.authorization.kubeflow.org/aggregate-to-kubeflow-view: "true"
+  name: notebook-controller-kubeflow-notebooks-view
+rules:
+- apiGroups:
+  - kubeflow.org
+  resources:
+  - notebooks
+  - notebooks/status
+  verbs:
+  - get
+  - list
+  - watch

--- a/tests/stacks/ibm/components/notebooks/test_data/expected/rbac.authorization.k8s.io_v1_clusterrole_notebook-controller-role.yaml
+++ b/tests/stacks/ibm/components/notebooks/test_data/expected/rbac.authorization.k8s.io_v1_clusterrole_notebook-controller-role.yaml
@@ -1,0 +1,54 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  labels:
+    app: notebook-controller
+    app.kubernetes.io/component: notebook-controller
+    app.kubernetes.io/name: notebook-controller
+    kustomize.component: notebook-controller
+  name: notebook-controller-role
+rules:
+- apiGroups:
+  - apps
+  resources:
+  - statefulsets
+  - deployments
+  verbs:
+  - '*'
+- apiGroups:
+  - ""
+  resources:
+  - pods
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - services
+  verbs:
+  - '*'
+- apiGroups:
+  - ""
+  resources:
+  - events
+  verbs:
+  - get
+  - list
+  - watch
+  - create
+- apiGroups:
+  - kubeflow.org
+  resources:
+  - notebooks
+  - notebooks/status
+  - notebooks/finalizers
+  verbs:
+  - '*'
+- apiGroups:
+  - networking.istio.io
+  resources:
+  - virtualservices
+  verbs:
+  - '*'

--- a/tests/stacks/ibm/components/notebooks/test_data/expected/rbac.authorization.k8s.io_v1_clusterrolebinding_jupyter-web-app-cluster-role-binding.yaml
+++ b/tests/stacks/ibm/components/notebooks/test_data/expected/rbac.authorization.k8s.io_v1_clusterrolebinding_jupyter-web-app-cluster-role-binding.yaml
@@ -1,0 +1,17 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  labels:
+    app: jupyter-web-app
+    app.kubernetes.io/component: jupyter-web-app
+    app.kubernetes.io/name: jupyter-web-app
+    kustomize.component: jupyter-web-app
+  name: jupyter-web-app-cluster-role-binding
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: jupyter-web-app-cluster-role
+subjects:
+- kind: ServiceAccount
+  name: jupyter-web-app-service-account
+  namespace: kubeflow

--- a/tests/stacks/ibm/components/notebooks/test_data/expected/rbac.authorization.k8s.io_v1_clusterrolebinding_notebook-controller-role-binding.yaml
+++ b/tests/stacks/ibm/components/notebooks/test_data/expected/rbac.authorization.k8s.io_v1_clusterrolebinding_notebook-controller-role-binding.yaml
@@ -1,0 +1,17 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  labels:
+    app: notebook-controller
+    app.kubernetes.io/component: notebook-controller
+    app.kubernetes.io/name: notebook-controller
+    kustomize.component: notebook-controller
+  name: notebook-controller-role-binding
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: notebook-controller-role
+subjects:
+- kind: ServiceAccount
+  name: notebook-controller-service-account
+  namespace: kubeflow

--- a/tests/stacks/ibm/components/notebooks/test_data/expected/rbac.authorization.k8s.io_v1beta1_role_jupyter-web-app-jupyter-notebook-role.yaml
+++ b/tests/stacks/ibm/components/notebooks/test_data/expected/rbac.authorization.k8s.io_v1beta1_role_jupyter-web-app-jupyter-notebook-role.yaml
@@ -1,0 +1,41 @@
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: Role
+metadata:
+  labels:
+    app: jupyter-web-app
+    app.kubernetes.io/component: jupyter-web-app
+    app.kubernetes.io/name: jupyter-web-app
+    kustomize.component: jupyter-web-app
+  name: jupyter-web-app-jupyter-notebook-role
+  namespace: kubeflow
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - pods
+  - pods/log
+  - secrets
+  - services
+  verbs:
+  - '*'
+- apiGroups:
+  - ""
+  - apps
+  - extensions
+  resources:
+  - deployments
+  - replicasets
+  verbs:
+  - '*'
+- apiGroups:
+  - kubeflow.org
+  resources:
+  - '*'
+  verbs:
+  - '*'
+- apiGroups:
+  - batch
+  resources:
+  - jobs
+  verbs:
+  - '*'

--- a/tests/stacks/ibm/components/notebooks/test_data/expected/rbac.authorization.k8s.io_v1beta1_rolebinding_jupyter-web-app-jupyter-notebook-role-binding.yaml
+++ b/tests/stacks/ibm/components/notebooks/test_data/expected/rbac.authorization.k8s.io_v1beta1_rolebinding_jupyter-web-app-jupyter-notebook-role-binding.yaml
@@ -1,0 +1,17 @@
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: RoleBinding
+metadata:
+  labels:
+    app: jupyter-web-app
+    app.kubernetes.io/component: jupyter-web-app
+    app.kubernetes.io/name: jupyter-web-app
+    kustomize.component: jupyter-web-app
+  name: jupyter-web-app-jupyter-notebook-role-binding
+  namespace: kubeflow
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: jupyter-web-app-jupyter-notebook-role
+subjects:
+- kind: ServiceAccount
+  name: jupyter-notebook

--- a/tests/stacks/ibm/components/notebooks/test_data/expected/~g_v1_configmap_jupyter-web-app-jupyter-web-app-config.yaml
+++ b/tests/stacks/ibm/components/notebooks/test_data/expected/~g_v1_configmap_jupyter-web-app-jupyter-web-app-config.yaml
@@ -1,0 +1,140 @@
+apiVersion: v1
+data:
+  spawner_ui_config.yaml: |-
+    # Configuration file for the Jupyter UI.
+    #
+    # Each Jupyter UI option is configured by two keys: 'value' and 'readOnly'
+    # - The 'value' key contains the default value
+    # - The 'readOnly' key determines if the option will be available to users
+    #
+    # If the 'readOnly' key is present and set to 'true', the respective option
+    # will be disabled for users and only set by the admin. Also when a
+    # Notebook is POSTED to the API if a necessary field is not present then
+    # the value from the config will be used.
+    #
+    # If the 'readOnly' key is missing (defaults to 'false'), the respective option
+    # will be available for users to edit.
+    #
+    # Note that some values can be templated. Such values are the names of the
+    # Volumes as well as their StorageClass
+    spawnerFormDefaults:
+      image:
+        # The container Image for the user's Jupyter Notebook
+        # If readonly, this value must be a member of the list below
+        value: gcr.io/kubeflow-images-public/tensorflow-1.15.2-notebook-cpu:1.0.0
+        # The list of available standard container Images
+        options:
+          - gcr.io/kubeflow-images-public/tensorflow-1.15.2-notebook-cpu:1.0.0
+          - gcr.io/kubeflow-images-public/tensorflow-1.15.2-notebook-gpu:1.0.0
+          - gcr.io/kubeflow-images-public/tensorflow-2.1.0-notebook-cpu:1.0.0
+          - gcr.io/kubeflow-images-public/tensorflow-2.1.0-notebook-gpu:1.0.0
+        # By default, custom container Images are allowed
+        # Uncomment the following line to only enable standard container Images
+        readOnly: false
+      cpu:
+        # CPU for user's Notebook
+        value: '0.5'
+        readOnly: false
+      memory:
+        # Memory for user's Notebook
+        value: 1.0Gi
+        readOnly: false
+      workspaceVolume:
+        # Workspace Volume to be attached to user's Notebook
+        # Each Workspace Volume is declared with the following attributes:
+        # Type, Name, Size, MountPath and Access Mode
+        value:
+          type:
+            # The Type of the Workspace Volume
+            # Supported values: 'New', 'Existing'
+            value: New
+          name:
+            # The Name of the Workspace Volume
+            # Note that this is a templated value. Special values:
+            # {notebook-name}: Replaced with the name of the Notebook. The frontend
+            #                  will replace this value as the user types the name
+            value: 'workspace-{notebook-name}'
+          size:
+            # The Size of the Workspace Volume (in Gi)
+            value: '10Gi'
+          mountPath:
+            # The Path that the Workspace Volume will be mounted
+            value: /home/jovyan
+          accessModes:
+            # The Access Mode of the Workspace Volume
+            # Supported values: 'ReadWriteOnce', 'ReadWriteMany', 'ReadOnlyMany'
+            value: ReadWriteOnce
+          class:
+            # The StrageClass the PVC will use if type is New. Special values are:
+            # {none}: default StorageClass
+            # {empty}: empty string ""
+            value: '{none}'
+        readOnly: false
+      dataVolumes:
+        # List of additional Data Volumes to be attached to the user's Notebook
+        value: []
+        # Each Data Volume is declared with the following attributes:
+        # Type, Name, Size, MountPath and Access Mode
+        #
+        # For example, a list with 2 Data Volumes:
+        # value:
+        #   - value:
+        #       type:
+        #         value: New
+        #       name:
+        #         value: '{notebook-name}-vol-1'
+        #       size:
+        #         value: '10Gi'
+        #       class:
+        #         value: standard
+        #       mountPath:
+        #         value: /home/jovyan/vol-1
+        #       accessModes:
+        #         value: ReadWriteOnce
+        #       class:
+        #         value: {none}
+        #   - value:
+        #       type:
+        #         value: New
+        #       name:
+        #         value: '{notebook-name}-vol-2'
+        #       size:
+        #         value: '10Gi'
+        #       mountPath:
+        #         value: /home/jovyan/vol-2
+        #       accessModes:
+        #         value: ReadWriteMany
+        #       class:
+        #         value: {none}
+        readOnly: false
+      gpus:
+        # Number of GPUs to be assigned to the Notebook Container
+        value:
+          # values: "none", "1", "2", "4", "8"
+          num: "none"
+          # Determines what the UI will show and send to the backend
+          vendors:
+            - limitsKey: "nvidia.com/gpu"
+              uiName: "NVIDIA"
+          # Values: "" or a `limits-key` from the vendors list
+          vendor: ""
+        readOnly: false
+      shm:
+        value: true
+        readOnly: false
+      configurations:
+        # List of labels to be selected, these are the labels from PodDefaults
+        # value:
+        #   - add-gcp-secret
+        #   - default-editor
+        value: []
+        readOnly: false
+kind: ConfigMap
+metadata:
+  labels:
+    app: jupyter-web-app
+    app.kubernetes.io/component: jupyter-web-app
+    app.kubernetes.io/name: jupyter-web-app
+    kustomize.component: jupyter-web-app
+  name: jupyter-web-app-jupyter-web-app-config
+  namespace: kubeflow

--- a/tests/stacks/ibm/components/notebooks/test_data/expected/~g_v1_configmap_jupyter-web-app-parameters.yaml
+++ b/tests/stacks/ibm/components/notebooks/test_data/expected/~g_v1_configmap_jupyter-web-app-parameters.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+data:
+  ROK_SECRET_NAME: secret-rok-{username}
+  UI: default
+  policy: Always
+  prefix: jupyter
+kind: ConfigMap
+metadata:
+  labels:
+    app: jupyter-web-app
+    app.kubernetes.io/component: jupyter-web-app
+    app.kubernetes.io/name: jupyter-web-app
+    kustomize.component: jupyter-web-app
+  name: jupyter-web-app-parameters
+  namespace: kubeflow

--- a/tests/stacks/ibm/components/notebooks/test_data/expected/~g_v1_configmap_notebook-controller-config.yaml
+++ b/tests/stacks/ibm/components/notebooks/test_data/expected/~g_v1_configmap_notebook-controller-config.yaml
@@ -1,0 +1,13 @@
+apiVersion: v1
+data:
+  ISTIO_GATEWAY: kubeflow/kubeflow-gateway
+  USE_ISTIO: "true"
+kind: ConfigMap
+metadata:
+  labels:
+    app: notebook-controller
+    app.kubernetes.io/component: notebook-controller
+    app.kubernetes.io/name: notebook-controller
+    kustomize.component: notebook-controller
+  name: notebook-controller-config
+  namespace: kubeflow

--- a/tests/stacks/ibm/components/notebooks/test_data/expected/~g_v1_service_jupyter-web-app-service.yaml
+++ b/tests/stacks/ibm/components/notebooks/test_data/expected/~g_v1_service_jupyter-web-app-service.yaml
@@ -1,0 +1,33 @@
+apiVersion: v1
+kind: Service
+metadata:
+  annotations:
+    getambassador.io/config: |-
+      ---
+      apiVersion: ambassador/v0
+      kind:  Mapping
+      name: webapp_mapping
+      prefix: /jupyter/
+      service: jupyter-web-app-service.$(namespace)
+      add_request_headers:
+        x-forwarded-prefix: /jupyter
+  labels:
+    app: jupyter-web-app
+    app.kubernetes.io/component: jupyter-web-app
+    app.kubernetes.io/name: jupyter-web-app
+    kustomize.component: jupyter-web-app
+    run: jupyter-web-app
+  name: jupyter-web-app-service
+  namespace: kubeflow
+spec:
+  ports:
+  - name: http
+    port: 80
+    protocol: TCP
+    targetPort: 5000
+  selector:
+    app: jupyter-web-app
+    app.kubernetes.io/component: jupyter-web-app
+    app.kubernetes.io/name: jupyter-web-app
+    kustomize.component: jupyter-web-app
+  type: ClusterIP

--- a/tests/stacks/ibm/components/notebooks/test_data/expected/~g_v1_service_notebook-controller-service.yaml
+++ b/tests/stacks/ibm/components/notebooks/test_data/expected/~g_v1_service_notebook-controller-service.yaml
@@ -1,0 +1,18 @@
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    app: notebook-controller
+    app.kubernetes.io/component: notebook-controller
+    app.kubernetes.io/name: notebook-controller
+    kustomize.component: notebook-controller
+  name: notebook-controller-service
+  namespace: kubeflow
+spec:
+  ports:
+  - port: 443
+  selector:
+    app: notebook-controller
+    app.kubernetes.io/component: notebook-controller
+    app.kubernetes.io/name: notebook-controller
+    kustomize.component: notebook-controller

--- a/tests/stacks/ibm/components/notebooks/test_data/expected/~g_v1_serviceaccount_jupyter-web-app-service-account.yaml
+++ b/tests/stacks/ibm/components/notebooks/test_data/expected/~g_v1_serviceaccount_jupyter-web-app-service-account.yaml
@@ -1,0 +1,10 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  labels:
+    app: jupyter-web-app
+    app.kubernetes.io/component: jupyter-web-app
+    app.kubernetes.io/name: jupyter-web-app
+    kustomize.component: jupyter-web-app
+  name: jupyter-web-app-service-account
+  namespace: kubeflow

--- a/tests/stacks/ibm/components/notebooks/test_data/expected/~g_v1_serviceaccount_notebook-controller-service-account.yaml
+++ b/tests/stacks/ibm/components/notebooks/test_data/expected/~g_v1_serviceaccount_notebook-controller-service-account.yaml
@@ -1,0 +1,10 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  labels:
+    app: notebook-controller
+    app.kubernetes.io/component: notebook-controller
+    app.kubernetes.io/name: notebook-controller
+    kustomize.component: notebook-controller
+  name: notebook-controller-service-account
+  namespace: kubeflow

--- a/tests/stacks/ibm/components/pipelines/kustomize_test.go
+++ b/tests/stacks/ibm/components/pipelines/kustomize_test.go
@@ -1,0 +1,15 @@
+package pipelines
+
+import (
+	"github.com/kubeflow/manifests/tests"
+	"testing"
+)
+
+func TestKustomize(t *testing.T) {
+	testCase := &tests.KustomizeTestCase{
+		Package:  "../../../../../stacks/ibm/components/pipelines",
+		Expected: "test_data/expected",
+	}
+
+	tests.RunTestCase(t, testCase)
+}

--- a/tests/stacks/ibm/components/pipelines/test_data/expected/apiextensions.k8s.io_v1beta1_customresourcedefinition_scheduledworkflows.kubeflow.org.yaml
+++ b/tests/stacks/ibm/components/pipelines/test_data/expected/apiextensions.k8s.io_v1beta1_customresourcedefinition_scheduledworkflows.kubeflow.org.yaml
@@ -1,0 +1,21 @@
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  labels:
+    app.kubernetes.io/component: ml-pipeline
+    app.kubernetes.io/name: kubeflow-pipelines
+  name: scheduledworkflows.kubeflow.org
+spec:
+  group: kubeflow.org
+  names:
+    kind: ScheduledWorkflow
+    listKind: ScheduledWorkflowList
+    plural: scheduledworkflows
+    shortNames:
+    - swf
+    singular: scheduledworkflow
+  scope: Namespaced
+  versions:
+  - name: v1beta1
+    served: true
+    storage: true

--- a/tests/stacks/ibm/components/pipelines/test_data/expected/apiextensions.k8s.io_v1beta1_customresourcedefinition_viewers.kubeflow.org.yaml
+++ b/tests/stacks/ibm/components/pipelines/test_data/expected/apiextensions.k8s.io_v1beta1_customresourcedefinition_viewers.kubeflow.org.yaml
@@ -1,0 +1,21 @@
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  labels:
+    app.kubernetes.io/component: ml-pipeline
+    app.kubernetes.io/name: kubeflow-pipelines
+  name: viewers.kubeflow.org
+spec:
+  group: kubeflow.org
+  names:
+    kind: Viewer
+    listKind: ViewerList
+    plural: viewers
+    shortNames:
+    - vi
+    singular: viewer
+  scope: Namespaced
+  versions:
+  - name: v1beta1
+    served: true
+    storage: true

--- a/tests/stacks/ibm/components/pipelines/test_data/expected/app.k8s.io_v1beta1_application_kubeflow-pipelines.yaml
+++ b/tests/stacks/ibm/components/pipelines/test_data/expected/app.k8s.io_v1beta1_application_kubeflow-pipelines.yaml
@@ -1,0 +1,44 @@
+apiVersion: app.k8s.io/v1beta1
+kind: Application
+metadata:
+  annotations:
+    kubernetes-engine.cloud.google.com/icon: data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAADMAAAAyCAYAAADx/eOPAAALuUlEQVRogd2afWxd9XnHP99bK4pS3yhiGUIRiiJUVVVqbq8ppdR20ibqpuIMtDRkUYERp29J57gMZVuxsrZiK7oZXVv5re1AiOuoG+N1DMkuytprsGPEVMouxqQZJVHEWIdQlGVxZlmZdb/747zcc869jpMO+seOdPz7nd/L83tev89zzjX8Bq795Rq9o17zXp+Tey+Ijkyboela29DRWkhffyT733pH/Z3este9F2cC6N0kNjxtjD+FdRD8UF9X7u97y7UbQFPAivC0BdllS381slun3s3z3xVhhqeds90tqR/oMB7u68z19ZZra0E/l1if3WOziPx3skrDPTr+bvDxfxImEIJbgX6gGBJ7EfHJX/ySReDHwO9KYAenyWCMFKw21GSeslwa2Z17+TcuzPBRr7B8m6Df5oOJqdPAR/u6cm/2lmv3At+IT3GiXZqbcaxSLsfRoTsvn7XL2jE87ZXGnwf+VGiDY86ETM1wU1+XjvSW/RlgTJADQ2QaCZKWcX1/aDIcjE8i3SdzZLjn0lm8pJXD02417BM+gLmq2Rqjr/d16Vu95dp6wc8Ra5O8NrPIcoZCvIR1H+KZkd2qLcfnRYUZOuorJO+3uQt0RerolGYZR7r5+C9ZATwPviGyQprd6Liszy3bnwVKwGMjPbnFyxJmeNpX2T4gaR/QmmSpyYZTho/2depMb9k/kNh3KawuJ1bWauHzUcyXRpZAv5Zmg7aHBLcmNN9ECAFeAO3s69KZ3nLtDuF9dnBs0IT9JO24rbPb0JfP2syCZpFfE5q1mRWcvlgMNcwMTRq9z/+OWXdx4AGjvX1deqC37DbwPwOrMgsufol5mWMWs1ivEbjTrOCtLNNb+udygqsNbUBtopR/NkuuwTJ6Hxsw67KSuvH5MPDA/nJttfGTdUFCMUlp/ALwOtIs9muBxpnFnBzuSQf21oP/BbXclVvumWuTaDN8WNBm2GizJkxPM0CDMA2WGZ72bbb/Njue2TRj9Il/PcG87SeBz4ZTNaSTsmctHcO8SqDp14d7dCFLZ2v/3OpQ023Ah4n65kohvETUCdcsfmuilD+bpNdgGZvOODuHqYGIVGCec9g7+7o031v2jaBTiD0ysxbHRnZrPktzyz1zK7f0z10nh5pWwLRhvZro1KqznVJhNB8UyDeSsU4zAOiIXV1OuEqQ2AR79nflXgcY6dGLwIvR8q39cy1b+uc2Emo6dI824BpMSxz8iVhy4m/2WiYHdV5UmOHp2mpwm52ESCdwRn+9v0tPAWzpn9sAFAQbMdc60PaHsFZEWd9uxk4z8G3seykECfObTEd2KmuZG4CWyLXkYLMwtiYt+hMsTUdAEZQzjs9apv66SHJRk73ZjBQ+iRu29s+1VEr5OImmXs4MHUahVoLWgK23wbv6OrU4OulcuHYehWsVHhpXwpE2FNRayTszX2cwDpQEzTB+QvrJHCXUaigk+c++aXZiE98YmUVgV19X7u3ypH/fgfUA5h2usY2jNjmWoGVn50nvC9T2NviA5OPBGPW91OlG+0Xa1WJhhqadk3WjpKCilQIQFP19XZocnfIHgIeFWyNh6goXyX6gdNWfU8aJ5tNjEheAHZVS/ruGj0s8k6VPhh6ms6kwgoLl1aGuCEuSpwXfHZ2qrTJ+HHkNCpOjmbdFcEcGUIhUSj/H65rPO6j+766U8i/QXV0z8cqJc4btwF8AtWgtMb1wj+j41Df/s1EYQwdEDiqM3hDes9quGY3IKoYOvCrU7HlCoZtEWapPkzEpsU8uq8b36a6uBqaBv5l45URLpZT/pmGH8LnkvlAdAOt1oeXqRsuYTjlEMJiXvWN/Z+5szfqioKcOKo7qr/nAEesKiOyv2A/q88rOx8+8bPhK5dUTAA8jbUT6MuKnbKteNVHKP23xCeD1LC0F2TWOmzoAKEiWxmC+sr8rN1OerF2HGaqXFcZhDWaYj11S4ZxcXxVqyKqPZOeNTwM7Jkr5BeDPQJ8NFQaoC/gZ26rXT5TyxxAfRx6P94d0gU0pYYama+tsbwix/AHM4fKUrwAeB68kRJ5AZsWWieGTjLipsVCgrKCwKHF7pZQ/RXf104j76i4ZMmquxkzRXb2zUsqfxdxsfCiA70hRjZbpCDHmJcRdeZPDHkVck0Ul5PeHZ81DgHxKtglXaHCxVN9fr5TyR9hW3QA8Amqp5526SyKtBEbZVv1eZeZkbqKU7xfsFJwPqRW29s+11oUxnUhnkHf2dWoB+R5Jv5dNaGHh1wog8d/ZAI+0GgVpFPTp4AfJT2Hup7u6EvMk0tpkboutEz0HMPzHyD+mu3pFpZR/Aug0Pgm0RLkvFzLWYfjDvs7cqfKUt2LuXTLhue5mdWhVDJdEzxDDcRKawceN9lRePVkDfgBcR/LKVqNpz/s08DO6q4VKKT8j8zHgJ1HyzA1P11YZjfV1arw85auBR4RalDB5lEjDKi0CgPPphKZ0QiNRwUQeg88B2ydKreew9yH1NCxe/r4GaZpt1Vsrh/JnDDcBLwPkbLVgf6s86RXYj4KvtJKJM8KsGLkSlsmUL6mSg1RJY1xD7KmU8sfprnYgBqJsGVsiEfupsca7FfMo26p/OfHKiVqllB8HyPV16VxfV66G/G1QBwY5xvCgTT7X3/MTaBbFVr0fJvqw2ASZ+yul/FN0V68CHsesiDl3UopM3CwhDZDD/Dnwj3S/sjoYAMqTtc1YX02jVqYOiuuqsAKIkqZCfFIz/IrfFY8gDrKt2gI8irSuwQezyTeNaOl+6qYb+fpYGKEXJE9GSTObK5ItrheaLHE5/XRKcHul+kYN8x2kzWlLNNuVtUqibzKW5CBjxUoszO7NWrS1E/xWvMeJjck2WQHEKJeMD+qH4gWCSvg00m3AVxv5TMRKsp9Cs0Q/Ka/1BOZQNBSXMz2b9Q5oO9JCKgkqg2aKofl8uvTPeE1w3t5KKf8y26pFxINhLRa5R9JV6huT/aZuFu7Ds+A9jBdj+VIvZz2b9BL2Xi5yJQEgUFqinI9SZBDx358o5Q/HiRGtquOEmxJu6DcbC/afQWxnvHg+Odrwm2bP5txh5OEYjOM3vaiu8qqHJw1mPmK/Xs7HJf0LRncDMF5cAL6NWUxDrX/duwbczljxjSzvTX+gtXU3MBlrRCltrsxBTgorACKrRGf5bczOiVLrhUL74B2F9oHVjBd/iLwTWEhr+CIWaLYumDjIWLHha+aSwvRs1iJmJ9Kb9ZJRETS3ACsMC8i1ZNwgXZDYWTmU/1WhfeAW8Cjo+UL7wDrGik8jfid0kYz/Z2ODepv+GPIY+FAznpcUJhAo9w5mh81CFtEsWieCTzwXkogmfKBSyh8ttA98EDPqoPouYqYLxYEPMVY8itmEeTM+KEaqZhVAkiPPIL6QDPhLFiYQSC9J7M3mGlF/24zWSvwIM1xoH2gF/sFiTcSPxQakqUJxsIPx4jGCr0AzCUYTbROJ7DPAdsbSAX9ZwgDs3qTDiMGUOxF/1DgfekLVsPf0sw8DPARsDNwy8iYBXov4p0L7wC2MF99CfBJ4rqmbJbO/qYE+x1jx5HK8Xtp/aFgHDM/FX+RM9FFjHjjj4NV3HvlPsP4g+SqQgm6zCuvJQnHgi4wVz2JuAj8RnLGEVaCf8Y8cuRQ2L0mYEBB2Gb8ZHKD4NQBx+0Qpf7LQPrAVVGqiiWTpCcEn4QcLxcF7C7+aXMDahT1YX5IS5DHE/ZfC4yULEwr0DtIOWwuuvwZ8rVLKP1soDqzHPGJoyRao9b4SXiQQ30A8eO1/PJ8D7gK+BtQSJcQM8AXGlg747LUkmi91lad8J3CuZ5OeBii0D64ET2FdH1N0omWJvgLPkvwM8LmZf7lrnm3VO4CHsM4DH2P8I8vGSfK67P9q8v9wWPAcQLH4PbBHbK6Pq+3M9+Ml+6FL2dyC+WmhOLiWseKPMDeDd12uIPBrWCZ5Xds++AHsAwGlBKnoB5747c2J+aSJEuvRL8CDv/2Zz+cqh/LL/gPD//vrfwFjcI5oX6jDBwAAAABJRU5ErkJggg==
+  labels:
+    app.kubernetes.io/component: ml-pipeline
+    app.kubernetes.io/name: kubeflow-pipelines
+  name: kubeflow-pipelines
+  namespace: kubeflow
+spec:
+  addOwnerRef: true
+  componentKinds:
+  - group: v1
+    kind: ServiceAccount
+  - group: rbac.authorization.k8s.io/v1
+    kind: Role
+  - group: rbac.authorization.k8s.io/v1
+    kind: RoleBinding
+  - group: v1
+    kind: Service
+  - group: v1
+    kind: PersistentVolumeClaim
+  - group: v1
+    kind: ConfigMap
+  - group: v1
+    kind: Secret
+  - group: apps/v1
+    kind: Deployment
+  - group: networking.istio.io/v1alpha3
+    kind: VirtualService
+  descriptor:
+    description: Reusable end-to-end ML workflow
+    links:
+    - description: Kubeflow Pipelines Documentation
+      url: https://www.kubeflow.org/docs/pipelines/
+    maintainers:
+    - name: Kubeflow Pipelines
+      url: https://github.com/kubeflow/pipelines
+    type: Kubeflow Pipelines
+    version: 1.0.0
+  selector:
+    matchLabels:
+      app.kubernetes.io/application: kubeflow-pipelines

--- a/tests/stacks/ibm/components/pipelines/test_data/expected/app.k8s.io_v1beta1_application_minio.yaml
+++ b/tests/stacks/ibm/components/pipelines/test_data/expected/app.k8s.io_v1beta1_application_minio.yaml
@@ -1,0 +1,31 @@
+apiVersion: app.k8s.io/v1beta1
+kind: Application
+metadata:
+  labels:
+    app.kubernetes.io/component: minio
+    app.kubernetes.io/name: minio
+  name: minio
+  namespace: kubeflow
+spec:
+  addOwnerRef: true
+  componentKinds:
+  - group: core
+    kind: ConfigMap
+  - group: apps
+    kind: Deployment
+  descriptor:
+    description: ""
+    keywords:
+    - minio
+    - kubeflow
+    links:
+    - description: About
+      url: ""
+    maintainers: []
+    owners: []
+    type: minio
+    version: v1beta1
+  selector:
+    matchLabels:
+      app.kubernetes.io/component: minio
+      app.kubernetes.io/name: minio

--- a/tests/stacks/ibm/components/pipelines/test_data/expected/app.k8s.io_v1beta1_application_mysql.yaml
+++ b/tests/stacks/ibm/components/pipelines/test_data/expected/app.k8s.io_v1beta1_application_mysql.yaml
@@ -1,0 +1,32 @@
+apiVersion: app.k8s.io/v1beta1
+kind: Application
+metadata:
+  labels:
+    app: mysql
+    app.kubernetes.io/component: mysql
+    app.kubernetes.io/name: mysql
+  name: mysql
+  namespace: kubeflow
+spec:
+  addOwnerRef: true
+  componentKinds:
+  - group: core
+    kind: ConfigMap
+  - group: apps
+    kind: Deployment
+  descriptor:
+    description: ""
+    keywords:
+    - mysql
+    - kubeflow
+    links:
+    - description: About
+      url: ""
+    maintainers: []
+    owners: []
+    type: mysql
+    version: v1beta1
+  selector:
+    matchLabels:
+      app.kubernetes.io/component: mysql
+      app.kubernetes.io/name: mysql

--- a/tests/stacks/ibm/components/pipelines/test_data/expected/apps_v1_deployment_cache-deployer-deployment.yaml
+++ b/tests/stacks/ibm/components/pipelines/test_data/expected/apps_v1_deployment_cache-deployer-deployment.yaml
@@ -1,0 +1,36 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  labels:
+    app: cache-deployer
+    app.kubernetes.io/component: ml-pipeline
+    app.kubernetes.io/name: kubeflow-pipelines
+  name: cache-deployer-deployment
+  namespace: kubeflow
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: cache-deployer
+      app.kubernetes.io/component: ml-pipeline
+      app.kubernetes.io/name: kubeflow-pipelines
+  strategy:
+    type: Recreate
+  template:
+    metadata:
+      labels:
+        app: cache-deployer
+        app.kubernetes.io/component: ml-pipeline
+        app.kubernetes.io/name: kubeflow-pipelines
+    spec:
+      containers:
+      - env:
+        - name: NAMESPACE_TO_WATCH
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace
+        image: gcr.io/ml-pipeline/cache-deployer:1.0.0
+        imagePullPolicy: Always
+        name: main
+      restartPolicy: Always
+      serviceAccountName: kubeflow-pipelines-cache-deployer-sa

--- a/tests/stacks/ibm/components/pipelines/test_data/expected/apps_v1_deployment_cache-server.yaml
+++ b/tests/stacks/ibm/components/pipelines/test_data/expected/apps_v1_deployment_cache-server.yaml
@@ -1,0 +1,79 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  labels:
+    app: cache-server
+    app.kubernetes.io/component: ml-pipeline
+    app.kubernetes.io/name: kubeflow-pipelines
+  name: cache-server
+  namespace: kubeflow
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: cache-server
+      app.kubernetes.io/component: ml-pipeline
+      app.kubernetes.io/name: kubeflow-pipelines
+  template:
+    metadata:
+      labels:
+        app: cache-server
+        app.kubernetes.io/component: ml-pipeline
+        app.kubernetes.io/name: kubeflow-pipelines
+    spec:
+      containers:
+      - args:
+        - --db_driver=$(DBCONFIG_DRIVER)
+        - --db_host=$(DBCONFIG_HOST_NAME)
+        - --db_port=$(DBCONFIG_PORT)
+        - --db_name=$(DBCONFIG_DB_NAME)
+        - --db_user=$(DBCONFIG_USER)
+        - --db_password=$(DBCONFIG_PASSWORD)
+        - --namespace_to_watch=$(NAMESPACE_TO_WATCH)
+        env:
+        - name: DBCONFIG_DRIVER
+          value: mysql
+        - name: DBCONFIG_DB_NAME
+          valueFrom:
+            configMapKeyRef:
+              key: cacheDb
+              name: pipeline-install-config-2829cc67f8
+        - name: DBCONFIG_HOST_NAME
+          valueFrom:
+            configMapKeyRef:
+              key: dbHost
+              name: pipeline-install-config-2829cc67f8
+        - name: DBCONFIG_PORT
+          valueFrom:
+            configMapKeyRef:
+              key: dbPort
+              name: pipeline-install-config-2829cc67f8
+        - name: DBCONFIG_USER
+          valueFrom:
+            secretKeyRef:
+              key: username
+              name: mysql-secret-fd5gktm75t
+        - name: DBCONFIG_PASSWORD
+          valueFrom:
+            secretKeyRef:
+              key: password
+              name: mysql-secret-fd5gktm75t
+        - name: NAMESPACE_TO_WATCH
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace
+        image: gcr.io/ml-pipeline/cache-server:1.0.0
+        imagePullPolicy: Always
+        name: server
+        ports:
+        - containerPort: 8443
+          name: webhook-api
+        volumeMounts:
+        - mountPath: /etc/webhook/certs
+          name: webhook-tls-certs
+          readOnly: true
+      serviceAccountName: kubeflow-pipelines-cache
+      volumes:
+      - name: webhook-tls-certs
+        secret:
+          secretName: webhook-server-tls

--- a/tests/stacks/ibm/components/pipelines/test_data/expected/apps_v1_deployment_metadata-writer.yaml
+++ b/tests/stacks/ibm/components/pipelines/test_data/expected/apps_v1_deployment_metadata-writer.yaml
@@ -1,0 +1,32 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  labels:
+    app: metadata-writer
+    app.kubernetes.io/component: ml-pipeline
+    app.kubernetes.io/name: kubeflow-pipelines
+  name: metadata-writer
+  namespace: kubeflow
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: metadata-writer
+      app.kubernetes.io/component: ml-pipeline
+      app.kubernetes.io/name: kubeflow-pipelines
+  template:
+    metadata:
+      labels:
+        app: metadata-writer
+        app.kubernetes.io/component: ml-pipeline
+        app.kubernetes.io/name: kubeflow-pipelines
+    spec:
+      containers:
+      - env:
+        - name: NAMESPACE_TO_WATCH
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace
+        image: gcr.io/ml-pipeline/metadata-writer:1.0.0
+        name: main
+      serviceAccountName: kubeflow-pipelines-metadata-writer

--- a/tests/stacks/ibm/components/pipelines/test_data/expected/apps_v1_deployment_minio.yaml
+++ b/tests/stacks/ibm/components/pipelines/test_data/expected/apps_v1_deployment_minio.yaml
@@ -1,0 +1,53 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  labels:
+    app: minio
+    app.kubernetes.io/component: minio
+    app.kubernetes.io/name: minio
+  name: minio
+  namespace: kubeflow
+spec:
+  selector:
+    matchLabels:
+      app: minio
+      app.kubernetes.io/component: minio
+      app.kubernetes.io/name: minio
+  strategy:
+    type: Recreate
+  template:
+    metadata:
+      annotations:
+        sidecar.istio.io/inject: "false"
+      labels:
+        app: minio
+        app.kubernetes.io/component: minio
+        app.kubernetes.io/name: minio
+    spec:
+      containers:
+      - args:
+        - server
+        - /data
+        env:
+        - name: MINIO_ACCESS_KEY
+          valueFrom:
+            secretKeyRef:
+              key: accesskey
+              name: mlpipeline-minio-artifact
+        - name: MINIO_SECRET_KEY
+          valueFrom:
+            secretKeyRef:
+              key: secretkey
+              name: mlpipeline-minio-artifact
+        image: gcr.io/ml-pipeline/minio:RELEASE.2019-08-14T20-37-41Z-license-compliance
+        name: minio
+        ports:
+        - containerPort: 9000
+        volumeMounts:
+        - mountPath: /data
+          name: data
+          subPath: minio
+      volumes:
+      - name: data
+        persistentVolumeClaim:
+          claimName: minio-pv-claim

--- a/tests/stacks/ibm/components/pipelines/test_data/expected/apps_v1_deployment_ml-pipeline-persistenceagent.yaml
+++ b/tests/stacks/ibm/components/pipelines/test_data/expected/apps_v1_deployment_ml-pipeline-persistenceagent.yaml
@@ -1,0 +1,32 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  labels:
+    app: ml-pipeline-persistenceagent
+    app.kubernetes.io/component: ml-pipeline
+    app.kubernetes.io/name: kubeflow-pipelines
+  name: ml-pipeline-persistenceagent
+  namespace: kubeflow
+spec:
+  selector:
+    matchLabels:
+      app: ml-pipeline-persistenceagent
+      app.kubernetes.io/component: ml-pipeline
+      app.kubernetes.io/name: kubeflow-pipelines
+  template:
+    metadata:
+      labels:
+        app: ml-pipeline-persistenceagent
+        app.kubernetes.io/component: ml-pipeline
+        app.kubernetes.io/name: kubeflow-pipelines
+    spec:
+      containers:
+      - env:
+        - name: NAMESPACE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace
+        image: gcr.io/ml-pipeline/persistenceagent:1.0.0
+        imagePullPolicy: IfNotPresent
+        name: ml-pipeline-persistenceagent
+      serviceAccountName: ml-pipeline-persistenceagent

--- a/tests/stacks/ibm/components/pipelines/test_data/expected/apps_v1_deployment_ml-pipeline-scheduledworkflow.yaml
+++ b/tests/stacks/ibm/components/pipelines/test_data/expected/apps_v1_deployment_ml-pipeline-scheduledworkflow.yaml
@@ -1,0 +1,32 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  labels:
+    app: ml-pipeline-scheduledworkflow
+    app.kubernetes.io/component: ml-pipeline
+    app.kubernetes.io/name: kubeflow-pipelines
+  name: ml-pipeline-scheduledworkflow
+  namespace: kubeflow
+spec:
+  selector:
+    matchLabels:
+      app: ml-pipeline-scheduledworkflow
+      app.kubernetes.io/component: ml-pipeline
+      app.kubernetes.io/name: kubeflow-pipelines
+  template:
+    metadata:
+      labels:
+        app: ml-pipeline-scheduledworkflow
+        app.kubernetes.io/component: ml-pipeline
+        app.kubernetes.io/name: kubeflow-pipelines
+    spec:
+      containers:
+      - env:
+        - name: NAMESPACE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace
+        image: gcr.io/ml-pipeline/scheduledworkflow:1.0.0
+        imagePullPolicy: IfNotPresent
+        name: ml-pipeline-scheduledworkflow
+      serviceAccountName: ml-pipeline-scheduledworkflow

--- a/tests/stacks/ibm/components/pipelines/test_data/expected/apps_v1_deployment_ml-pipeline-ui.yaml
+++ b/tests/stacks/ibm/components/pipelines/test_data/expected/apps_v1_deployment_ml-pipeline-ui.yaml
@@ -1,0 +1,80 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  labels:
+    app: ml-pipeline-ui
+    app.kubernetes.io/component: ml-pipeline
+    app.kubernetes.io/name: kubeflow-pipelines
+  name: ml-pipeline-ui
+  namespace: kubeflow
+spec:
+  selector:
+    matchLabels:
+      app: ml-pipeline-ui
+      app.kubernetes.io/component: ml-pipeline
+      app.kubernetes.io/name: kubeflow-pipelines
+  template:
+    metadata:
+      labels:
+        app: ml-pipeline-ui
+        app.kubernetes.io/component: ml-pipeline
+        app.kubernetes.io/name: kubeflow-pipelines
+    spec:
+      containers:
+      - env:
+        - name: VIEWER_TENSORBOARD_POD_TEMPLATE_SPEC_PATH
+          value: /etc/config/viewer-pod-template.json
+        - name: MINIO_NAMESPACE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace
+        - name: MINIO_ACCESS_KEY
+          valueFrom:
+            secretKeyRef:
+              key: accesskey
+              name: mlpipeline-minio-artifact
+        - name: MINIO_SECRET_KEY
+          valueFrom:
+            secretKeyRef:
+              key: secretkey
+              name: mlpipeline-minio-artifact
+        - name: ALLOW_CUSTOM_VISUALIZATIONS
+          value: "true"
+        image: gcr.io/ml-pipeline/frontend:1.0.0
+        imagePullPolicy: IfNotPresent
+        livenessProbe:
+          exec:
+            command:
+            - wget
+            - -q
+            - -S
+            - -O
+            - '-'
+            - http://localhost:3000/apis/v1beta1/healthz
+          initialDelaySeconds: 3
+          periodSeconds: 5
+          timeoutSeconds: 2
+        name: ml-pipeline-ui
+        ports:
+        - containerPort: 3000
+        readinessProbe:
+          exec:
+            command:
+            - wget
+            - -q
+            - -S
+            - -O
+            - '-'
+            - http://localhost:3000/apis/v1beta1/healthz
+          initialDelaySeconds: 3
+          periodSeconds: 5
+          timeoutSeconds: 2
+        volumeMounts:
+        - mountPath: /etc/config
+          name: config-volume
+          readOnly: true
+      serviceAccountName: ml-pipeline-ui
+      volumes:
+      - configMap:
+          name: ml-pipeline-ui-configmap
+        name: config-volume

--- a/tests/stacks/ibm/components/pipelines/test_data/expected/apps_v1_deployment_ml-pipeline-viewer-crd.yaml
+++ b/tests/stacks/ibm/components/pipelines/test_data/expected/apps_v1_deployment_ml-pipeline-viewer-crd.yaml
@@ -1,0 +1,34 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  labels:
+    app: ml-pipeline-viewer-crd
+    app.kubernetes.io/component: ml-pipeline
+    app.kubernetes.io/name: kubeflow-pipelines
+  name: ml-pipeline-viewer-crd
+  namespace: kubeflow
+spec:
+  selector:
+    matchLabels:
+      app: ml-pipeline-viewer-crd
+      app.kubernetes.io/component: ml-pipeline
+      app.kubernetes.io/name: kubeflow-pipelines
+  template:
+    metadata:
+      labels:
+        app: ml-pipeline-viewer-crd
+        app.kubernetes.io/component: ml-pipeline
+        app.kubernetes.io/name: kubeflow-pipelines
+    spec:
+      containers:
+      - env:
+        - name: MAX_NUM_VIEWERS
+          value: "50"
+        - name: MINIO_NAMESPACE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace
+        image: gcr.io/ml-pipeline/viewer-crd-controller:1.0.0
+        imagePullPolicy: Always
+        name: ml-pipeline-viewer-crd
+      serviceAccountName: ml-pipeline-viewer-crd-service-account

--- a/tests/stacks/ibm/components/pipelines/test_data/expected/apps_v1_deployment_ml-pipeline-visualizationserver.yaml
+++ b/tests/stacks/ibm/components/pipelines/test_data/expected/apps_v1_deployment_ml-pipeline-visualizationserver.yaml
@@ -1,0 +1,54 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  labels:
+    app: ml-pipeline-visualizationserver
+    app.kubernetes.io/component: ml-pipeline
+    app.kubernetes.io/name: kubeflow-pipelines
+  name: ml-pipeline-visualizationserver
+  namespace: kubeflow
+spec:
+  selector:
+    matchLabels:
+      app: ml-pipeline-visualizationserver
+      app.kubernetes.io/component: ml-pipeline
+      app.kubernetes.io/name: kubeflow-pipelines
+  template:
+    metadata:
+      labels:
+        app: ml-pipeline-visualizationserver
+        app.kubernetes.io/component: ml-pipeline
+        app.kubernetes.io/name: kubeflow-pipelines
+    spec:
+      containers:
+      - image: gcr.io/ml-pipeline/visualization-server:1.0.0
+        imagePullPolicy: IfNotPresent
+        livenessProbe:
+          exec:
+            command:
+            - wget
+            - -q
+            - -S
+            - -O
+            - '-'
+            - http://localhost:8888/
+          initialDelaySeconds: 3
+          periodSeconds: 5
+          timeoutSeconds: 2
+        name: ml-pipeline-visualizationserver
+        ports:
+        - containerPort: 8888
+          name: http
+        readinessProbe:
+          exec:
+            command:
+            - wget
+            - -q
+            - -S
+            - -O
+            - '-'
+            - http://localhost:8888/
+          initialDelaySeconds: 3
+          periodSeconds: 5
+          timeoutSeconds: 2
+      serviceAccountName: ml-pipeline-visualizationserver

--- a/tests/stacks/ibm/components/pipelines/test_data/expected/apps_v1_deployment_ml-pipeline.yaml
+++ b/tests/stacks/ibm/components/pipelines/test_data/expected/apps_v1_deployment_ml-pipeline.yaml
@@ -1,0 +1,103 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  labels:
+    app: ml-pipeline
+    app.kubernetes.io/component: ml-pipeline
+    app.kubernetes.io/name: kubeflow-pipelines
+  name: ml-pipeline
+  namespace: kubeflow
+spec:
+  selector:
+    matchLabels:
+      app: ml-pipeline
+      app.kubernetes.io/component: ml-pipeline
+      app.kubernetes.io/name: kubeflow-pipelines
+  template:
+    metadata:
+      labels:
+        app: ml-pipeline
+        app.kubernetes.io/component: ml-pipeline
+        app.kubernetes.io/name: kubeflow-pipelines
+    spec:
+      containers:
+      - env:
+        - name: POD_NAMESPACE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace
+        - name: OBJECTSTORECONFIG_SECURE
+          value: "false"
+        - name: OBJECTSTORECONFIG_BUCKETNAME
+          valueFrom:
+            configMapKeyRef:
+              key: bucketName
+              name: pipeline-install-config-2829cc67f8
+        - name: DBCONFIG_USER
+          valueFrom:
+            secretKeyRef:
+              key: username
+              name: mysql-secret-fd5gktm75t
+        - name: DBCONFIG_PASSWORD
+          valueFrom:
+            secretKeyRef:
+              key: password
+              name: mysql-secret-fd5gktm75t
+        - name: DBCONFIG_DBNAME
+          valueFrom:
+            configMapKeyRef:
+              key: pipelineDb
+              name: pipeline-install-config-2829cc67f8
+        - name: DBCONFIG_HOST
+          valueFrom:
+            configMapKeyRef:
+              key: dbHost
+              name: pipeline-install-config-2829cc67f8
+        - name: DBCONFIG_PORT
+          valueFrom:
+            configMapKeyRef:
+              key: dbPort
+              name: pipeline-install-config-2829cc67f8
+        - name: OBJECTSTORECONFIG_ACCESSKEY
+          valueFrom:
+            secretKeyRef:
+              key: accesskey
+              name: mlpipeline-minio-artifact
+        - name: OBJECTSTORECONFIG_SECRETACCESSKEY
+          valueFrom:
+            secretKeyRef:
+              key: secretkey
+              name: mlpipeline-minio-artifact
+        image: gcr.io/ml-pipeline/api-server:1.0.0
+        imagePullPolicy: IfNotPresent
+        livenessProbe:
+          exec:
+            command:
+            - wget
+            - -q
+            - -S
+            - -O
+            - '-'
+            - http://localhost:8888/apis/v1beta1/healthz
+          initialDelaySeconds: 3
+          periodSeconds: 5
+          timeoutSeconds: 2
+        name: ml-pipeline-api-server
+        ports:
+        - containerPort: 8888
+          name: http
+        - containerPort: 8887
+          name: grpc
+        readinessProbe:
+          exec:
+            command:
+            - wget
+            - -q
+            - -S
+            - -O
+            - '-'
+            - http://localhost:8888/apis/v1beta1/healthz
+          initialDelaySeconds: 3
+          periodSeconds: 5
+          timeoutSeconds: 2
+      serviceAccountName: ml-pipeline

--- a/tests/stacks/ibm/components/pipelines/test_data/expected/apps_v1_deployment_mysql.yaml
+++ b/tests/stacks/ibm/components/pipelines/test_data/expected/apps_v1_deployment_mysql.yaml
@@ -1,0 +1,40 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  labels:
+    app: mysql
+    app.kubernetes.io/component: mysql
+    app.kubernetes.io/name: mysql
+  name: mysql
+  namespace: kubeflow
+spec:
+  selector:
+    matchLabels:
+      app: mysql
+      app.kubernetes.io/component: mysql
+      app.kubernetes.io/name: mysql
+  strategy:
+    type: Recreate
+  template:
+    metadata:
+      labels:
+        app: mysql
+        app.kubernetes.io/component: mysql
+        app.kubernetes.io/name: mysql
+    spec:
+      containers:
+      - env:
+        - name: MYSQL_ALLOW_EMPTY_PASSWORD
+          value: "true"
+        image: gcr.io/ml-pipeline/mysql:5.6
+        name: mysql
+        ports:
+        - containerPort: 3306
+          name: mysql
+        volumeMounts:
+        - mountPath: /var/lib/mysql
+          name: mysql-persistent-storage
+      volumes:
+      - name: mysql-persistent-storage
+        persistentVolumeClaim:
+          claimName: mysql-pv-claim

--- a/tests/stacks/ibm/components/pipelines/test_data/expected/networking.istio.io_v1alpha3_virtualservice_ml-pipeline-ui.yaml
+++ b/tests/stacks/ibm/components/pipelines/test_data/expected/networking.istio.io_v1alpha3_virtualservice_ml-pipeline-ui.yaml
@@ -1,0 +1,25 @@
+apiVersion: networking.istio.io/v1alpha3
+kind: VirtualService
+metadata:
+  labels:
+    app.kubernetes.io/component: ml-pipeline
+    app.kubernetes.io/name: kubeflow-pipelines
+  name: ml-pipeline-ui
+  namespace: kubeflow
+spec:
+  gateways:
+  - kubeflow-gateway
+  hosts:
+  - '*'
+  http:
+  - match:
+    - uri:
+        prefix: /pipeline
+    rewrite:
+      uri: /pipeline
+    route:
+    - destination:
+        host: ml-pipeline-ui.kubeflow.svc.$(clusterDomain)
+        port:
+          number: 80
+    timeout: 300s

--- a/tests/stacks/ibm/components/pipelines/test_data/expected/rbac.authorization.k8s.io_v1_clusterrole_kubeflow-pipelines-cache-deployer-clusterrole.yaml
+++ b/tests/stacks/ibm/components/pipelines/test_data/expected/rbac.authorization.k8s.io_v1_clusterrole_kubeflow-pipelines-cache-deployer-clusterrole.yaml
@@ -1,0 +1,26 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  labels:
+    app: kubeflow-pipelines-cache-deployer-clusterrole
+    app.kubernetes.io/component: ml-pipeline
+    app.kubernetes.io/name: kubeflow-pipelines
+  name: kubeflow-pipelines-cache-deployer-clusterrole
+rules:
+- apiGroups:
+  - certificates.k8s.io
+  resources:
+  - certificatesigningrequests
+  - certificatesigningrequests/approval
+  verbs:
+  - create
+  - delete
+  - get
+  - update
+- apiGroups:
+  - admissionregistration.k8s.io
+  resources:
+  - mutatingwebhookconfigurations
+  verbs:
+  - create
+  - get

--- a/tests/stacks/ibm/components/pipelines/test_data/expected/rbac.authorization.k8s.io_v1_clusterrolebinding_kubeflow-pipelines-cache-deployer-clusterrolebinding.yaml
+++ b/tests/stacks/ibm/components/pipelines/test_data/expected/rbac.authorization.k8s.io_v1_clusterrolebinding_kubeflow-pipelines-cache-deployer-clusterrolebinding.yaml
@@ -1,0 +1,15 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  labels:
+    app.kubernetes.io/component: ml-pipeline
+    app.kubernetes.io/name: kubeflow-pipelines
+  name: kubeflow-pipelines-cache-deployer-clusterrolebinding
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: kubeflow-pipelines-cache-deployer-clusterrole
+subjects:
+- kind: ServiceAccount
+  name: kubeflow-pipelines-cache-deployer-sa
+  namespace: kubeflow

--- a/tests/stacks/ibm/components/pipelines/test_data/expected/rbac.authorization.k8s.io_v1_role_kubeflow-pipelines-cache-deployer-role.yaml
+++ b/tests/stacks/ibm/components/pipelines/test_data/expected/rbac.authorization.k8s.io_v1_role_kubeflow-pipelines-cache-deployer-role.yaml
@@ -1,0 +1,18 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  labels:
+    app: kubeflow-pipelines-cache-deployer-role
+    app.kubernetes.io/component: ml-pipeline
+    app.kubernetes.io/name: kubeflow-pipelines
+  name: kubeflow-pipelines-cache-deployer-role
+  namespace: kubeflow
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - secrets
+  verbs:
+  - create
+  - get
+  - patch

--- a/tests/stacks/ibm/components/pipelines/test_data/expected/rbac.authorization.k8s.io_v1_role_kubeflow-pipelines-cache-role.yaml
+++ b/tests/stacks/ibm/components/pipelines/test_data/expected/rbac.authorization.k8s.io_v1_role_kubeflow-pipelines-cache-role.yaml
@@ -1,0 +1,36 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  labels:
+    app: kubeflow-pipelines-cache-role
+    app.kubernetes.io/component: ml-pipeline
+    app.kubernetes.io/name: kubeflow-pipelines
+  name: kubeflow-pipelines-cache-role
+  namespace: kubeflow
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - pods
+  verbs:
+  - get
+  - list
+  - watch
+  - update
+  - patch
+- apiGroups:
+  - ""
+  resources:
+  - configmaps
+  verbs:
+  - get
+- apiGroups:
+  - argoproj.io
+  resources:
+  - workflows
+  verbs:
+  - get
+  - list
+  - watch
+  - update
+  - patch

--- a/tests/stacks/ibm/components/pipelines/test_data/expected/rbac.authorization.k8s.io_v1_role_kubeflow-pipelines-metadata-writer-role.yaml
+++ b/tests/stacks/ibm/components/pipelines/test_data/expected/rbac.authorization.k8s.io_v1_role_kubeflow-pipelines-metadata-writer-role.yaml
@@ -1,0 +1,36 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  labels:
+    app: kubeflow-pipelines-metadata-writer-role
+    app.kubernetes.io/component: ml-pipeline
+    app.kubernetes.io/name: kubeflow-pipelines
+  name: kubeflow-pipelines-metadata-writer-role
+  namespace: kubeflow
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - pods
+  verbs:
+  - get
+  - list
+  - watch
+  - update
+  - patch
+- apiGroups:
+  - ""
+  resources:
+  - configmaps
+  verbs:
+  - get
+- apiGroups:
+  - argoproj.io
+  resources:
+  - workflows
+  verbs:
+  - get
+  - list
+  - watch
+  - update
+  - patch

--- a/tests/stacks/ibm/components/pipelines/test_data/expected/rbac.authorization.k8s.io_v1_role_ml-pipeline-persistenceagent-role.yaml
+++ b/tests/stacks/ibm/components/pipelines/test_data/expected/rbac.authorization.k8s.io_v1_role_ml-pipeline-persistenceagent-role.yaml
@@ -1,0 +1,25 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  labels:
+    app.kubernetes.io/component: ml-pipeline
+    app.kubernetes.io/name: kubeflow-pipelines
+  name: ml-pipeline-persistenceagent-role
+  namespace: kubeflow
+rules:
+- apiGroups:
+  - argoproj.io
+  resources:
+  - workflows
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - kubeflow.org
+  resources:
+  - scheduledworkflows
+  verbs:
+  - get
+  - list
+  - watch

--- a/tests/stacks/ibm/components/pipelines/test_data/expected/rbac.authorization.k8s.io_v1_role_ml-pipeline-scheduledworkflow-role.yaml
+++ b/tests/stacks/ibm/components/pipelines/test_data/expected/rbac.authorization.k8s.io_v1_role_ml-pipeline-scheduledworkflow-role.yaml
@@ -1,0 +1,41 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  labels:
+    app: ml-pipeline-scheduledworkflow-role
+    app.kubernetes.io/component: ml-pipeline
+    app.kubernetes.io/name: kubeflow-pipelines
+  name: ml-pipeline-scheduledworkflow-role
+  namespace: kubeflow
+rules:
+- apiGroups:
+  - argoproj.io
+  resources:
+  - workflows
+  verbs:
+  - create
+  - get
+  - list
+  - watch
+  - update
+  - patch
+  - delete
+- apiGroups:
+  - kubeflow.org
+  resources:
+  - scheduledworkflows
+  verbs:
+  - create
+  - get
+  - list
+  - watch
+  - update
+  - patch
+  - delete
+- apiGroups:
+  - ""
+  resources:
+  - events
+  verbs:
+  - create
+  - patch

--- a/tests/stacks/ibm/components/pipelines/test_data/expected/rbac.authorization.k8s.io_v1_role_ml-pipeline-ui.yaml
+++ b/tests/stacks/ibm/components/pipelines/test_data/expected/rbac.authorization.k8s.io_v1_role_ml-pipeline-ui.yaml
@@ -1,0 +1,47 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  labels:
+    app: ml-pipeline-ui
+    app.kubernetes.io/component: ml-pipeline
+    app.kubernetes.io/name: kubeflow-pipelines
+  name: ml-pipeline-ui
+  namespace: kubeflow
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - pods
+  - pods/log
+  verbs:
+  - get
+- apiGroups:
+  - ""
+  resources:
+  - events
+  verbs:
+  - list
+- apiGroups:
+  - ""
+  resources:
+  - secrets
+  verbs:
+  - get
+  - list
+- apiGroups:
+  - kubeflow.org
+  resources:
+  - viewers
+  verbs:
+  - create
+  - get
+  - list
+  - watch
+  - delete
+- apiGroups:
+  - argoproj.io
+  resources:
+  - workflows
+  verbs:
+  - get
+  - list

--- a/tests/stacks/ibm/components/pipelines/test_data/expected/rbac.authorization.k8s.io_v1_role_ml-pipeline-viewer-controller-role.yaml
+++ b/tests/stacks/ibm/components/pipelines/test_data/expected/rbac.authorization.k8s.io_v1_role_ml-pipeline-viewer-controller-role.yaml
@@ -1,0 +1,34 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  labels:
+    app.kubernetes.io/component: ml-pipeline
+    app.kubernetes.io/name: kubeflow-pipelines
+  name: ml-pipeline-viewer-controller-role
+  namespace: kubeflow
+rules:
+- apiGroups:
+  - '*'
+  resources:
+  - deployments
+  - services
+  verbs:
+  - create
+  - get
+  - list
+  - watch
+  - update
+  - patch
+  - delete
+- apiGroups:
+  - kubeflow.org
+  resources:
+  - viewers
+  verbs:
+  - create
+  - get
+  - list
+  - watch
+  - update
+  - patch
+  - delete

--- a/tests/stacks/ibm/components/pipelines/test_data/expected/rbac.authorization.k8s.io_v1_role_ml-pipeline.yaml
+++ b/tests/stacks/ibm/components/pipelines/test_data/expected/rbac.authorization.k8s.io_v1_role_ml-pipeline.yaml
@@ -1,0 +1,41 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  labels:
+    app: ml-pipeline
+    app.kubernetes.io/component: ml-pipeline
+    app.kubernetes.io/name: kubeflow-pipelines
+  name: ml-pipeline
+  namespace: kubeflow
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - pods
+  verbs:
+  - get
+  - list
+  - delete
+- apiGroups:
+  - argoproj.io
+  resources:
+  - workflows
+  verbs:
+  - create
+  - get
+  - list
+  - watch
+  - update
+  - patch
+  - delete
+- apiGroups:
+  - kubeflow.org
+  resources:
+  - scheduledworkflows
+  verbs:
+  - create
+  - get
+  - list
+  - update
+  - patch
+  - delete

--- a/tests/stacks/ibm/components/pipelines/test_data/expected/rbac.authorization.k8s.io_v1_role_pipeline-runner.yaml
+++ b/tests/stacks/ibm/components/pipelines/test_data/expected/rbac.authorization.k8s.io_v1_role_pipeline-runner.yaml
@@ -1,0 +1,84 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  labels:
+    app.kubernetes.io/component: ml-pipeline
+    app.kubernetes.io/name: kubeflow-pipelines
+  name: pipeline-runner
+  namespace: kubeflow
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - secrets
+  verbs:
+  - get
+- apiGroups:
+  - ""
+  resources:
+  - configmaps
+  verbs:
+  - get
+  - watch
+  - list
+- apiGroups:
+  - ""
+  resources:
+  - persistentvolumes
+  - persistentvolumeclaims
+  verbs:
+  - '*'
+- apiGroups:
+  - snapshot.storage.k8s.io
+  resources:
+  - volumesnapshots
+  verbs:
+  - create
+  - delete
+  - get
+- apiGroups:
+  - argoproj.io
+  resources:
+  - workflows
+  verbs:
+  - get
+  - list
+  - watch
+  - update
+  - patch
+- apiGroups:
+  - ""
+  resources:
+  - pods
+  - pods/exec
+  - pods/log
+  - services
+  verbs:
+  - '*'
+- apiGroups:
+  - ""
+  - apps
+  - extensions
+  resources:
+  - deployments
+  - replicasets
+  verbs:
+  - '*'
+- apiGroups:
+  - kubeflow.org
+  resources:
+  - '*'
+  verbs:
+  - '*'
+- apiGroups:
+  - batch
+  resources:
+  - jobs
+  verbs:
+  - '*'
+- apiGroups:
+  - machinelearning.seldon.io
+  resources:
+  - seldondeployments
+  verbs:
+  - '*'

--- a/tests/stacks/ibm/components/pipelines/test_data/expected/rbac.authorization.k8s.io_v1_rolebinding_kubeflow-pipelines-cache-binding.yaml
+++ b/tests/stacks/ibm/components/pipelines/test_data/expected/rbac.authorization.k8s.io_v1_rolebinding_kubeflow-pipelines-cache-binding.yaml
@@ -1,0 +1,16 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  labels:
+    app.kubernetes.io/component: ml-pipeline
+    app.kubernetes.io/name: kubeflow-pipelines
+  name: kubeflow-pipelines-cache-binding
+  namespace: kubeflow
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: kubeflow-pipelines-cache-role
+subjects:
+- kind: ServiceAccount
+  name: kubeflow-pipelines-cache
+  namespace: kubeflow

--- a/tests/stacks/ibm/components/pipelines/test_data/expected/rbac.authorization.k8s.io_v1_rolebinding_kubeflow-pipelines-cache-deployer-rolebinding.yaml
+++ b/tests/stacks/ibm/components/pipelines/test_data/expected/rbac.authorization.k8s.io_v1_rolebinding_kubeflow-pipelines-cache-deployer-rolebinding.yaml
@@ -1,0 +1,16 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  labels:
+    app.kubernetes.io/component: ml-pipeline
+    app.kubernetes.io/name: kubeflow-pipelines
+  name: kubeflow-pipelines-cache-deployer-rolebinding
+  namespace: kubeflow
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: kubeflow-pipelines-cache-deployer-role
+subjects:
+- kind: ServiceAccount
+  name: kubeflow-pipelines-cache-deployer-sa
+  namespace: kubeflow

--- a/tests/stacks/ibm/components/pipelines/test_data/expected/rbac.authorization.k8s.io_v1_rolebinding_kubeflow-pipelines-metadata-writer-binding.yaml
+++ b/tests/stacks/ibm/components/pipelines/test_data/expected/rbac.authorization.k8s.io_v1_rolebinding_kubeflow-pipelines-metadata-writer-binding.yaml
@@ -1,0 +1,16 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  labels:
+    app.kubernetes.io/component: ml-pipeline
+    app.kubernetes.io/name: kubeflow-pipelines
+  name: kubeflow-pipelines-metadata-writer-binding
+  namespace: kubeflow
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: kubeflow-pipelines-metadata-writer-role
+subjects:
+- kind: ServiceAccount
+  name: kubeflow-pipelines-metadata-writer
+  namespace: kubeflow

--- a/tests/stacks/ibm/components/pipelines/test_data/expected/rbac.authorization.k8s.io_v1_rolebinding_ml-pipeline-persistenceagent-binding.yaml
+++ b/tests/stacks/ibm/components/pipelines/test_data/expected/rbac.authorization.k8s.io_v1_rolebinding_ml-pipeline-persistenceagent-binding.yaml
@@ -1,0 +1,16 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  labels:
+    app.kubernetes.io/component: ml-pipeline
+    app.kubernetes.io/name: kubeflow-pipelines
+  name: ml-pipeline-persistenceagent-binding
+  namespace: kubeflow
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: ml-pipeline-persistenceagent-role
+subjects:
+- kind: ServiceAccount
+  name: ml-pipeline-persistenceagent
+  namespace: kubeflow

--- a/tests/stacks/ibm/components/pipelines/test_data/expected/rbac.authorization.k8s.io_v1_rolebinding_ml-pipeline-scheduledworkflow-binding.yaml
+++ b/tests/stacks/ibm/components/pipelines/test_data/expected/rbac.authorization.k8s.io_v1_rolebinding_ml-pipeline-scheduledworkflow-binding.yaml
@@ -1,0 +1,16 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  labels:
+    app.kubernetes.io/component: ml-pipeline
+    app.kubernetes.io/name: kubeflow-pipelines
+  name: ml-pipeline-scheduledworkflow-binding
+  namespace: kubeflow
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: ml-pipeline-scheduledworkflow-role
+subjects:
+- kind: ServiceAccount
+  name: ml-pipeline-scheduledworkflow
+  namespace: kubeflow

--- a/tests/stacks/ibm/components/pipelines/test_data/expected/rbac.authorization.k8s.io_v1_rolebinding_ml-pipeline-ui.yaml
+++ b/tests/stacks/ibm/components/pipelines/test_data/expected/rbac.authorization.k8s.io_v1_rolebinding_ml-pipeline-ui.yaml
@@ -1,0 +1,17 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  labels:
+    app: ml-pipeline-ui
+    app.kubernetes.io/component: ml-pipeline
+    app.kubernetes.io/name: kubeflow-pipelines
+  name: ml-pipeline-ui
+  namespace: kubeflow
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: ml-pipeline-ui
+subjects:
+- kind: ServiceAccount
+  name: ml-pipeline-ui
+  namespace: kubeflow

--- a/tests/stacks/ibm/components/pipelines/test_data/expected/rbac.authorization.k8s.io_v1_rolebinding_ml-pipeline-viewer-crd-binding.yaml
+++ b/tests/stacks/ibm/components/pipelines/test_data/expected/rbac.authorization.k8s.io_v1_rolebinding_ml-pipeline-viewer-crd-binding.yaml
@@ -1,0 +1,16 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  labels:
+    app.kubernetes.io/component: ml-pipeline
+    app.kubernetes.io/name: kubeflow-pipelines
+  name: ml-pipeline-viewer-crd-binding
+  namespace: kubeflow
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: ml-pipeline-viewer-controller-role
+subjects:
+- kind: ServiceAccount
+  name: ml-pipeline-viewer-crd-service-account
+  namespace: kubeflow

--- a/tests/stacks/ibm/components/pipelines/test_data/expected/rbac.authorization.k8s.io_v1_rolebinding_ml-pipeline.yaml
+++ b/tests/stacks/ibm/components/pipelines/test_data/expected/rbac.authorization.k8s.io_v1_rolebinding_ml-pipeline.yaml
@@ -1,0 +1,17 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  labels:
+    app: ml-pipeline
+    app.kubernetes.io/component: ml-pipeline
+    app.kubernetes.io/name: kubeflow-pipelines
+  name: ml-pipeline
+  namespace: kubeflow
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: ml-pipeline
+subjects:
+- kind: ServiceAccount
+  name: ml-pipeline
+  namespace: kubeflow

--- a/tests/stacks/ibm/components/pipelines/test_data/expected/rbac.authorization.k8s.io_v1_rolebinding_pipeline-runner-binding.yaml
+++ b/tests/stacks/ibm/components/pipelines/test_data/expected/rbac.authorization.k8s.io_v1_rolebinding_pipeline-runner-binding.yaml
@@ -1,0 +1,16 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  labels:
+    app.kubernetes.io/component: ml-pipeline
+    app.kubernetes.io/name: kubeflow-pipelines
+  name: pipeline-runner-binding
+  namespace: kubeflow
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: pipeline-runner
+subjects:
+- kind: ServiceAccount
+  name: pipeline-runner
+  namespace: kubeflow

--- a/tests/stacks/ibm/components/pipelines/test_data/expected/~g_v1_configmap_ml-pipeline-ui-configmap.yaml
+++ b/tests/stacks/ibm/components/pipelines/test_data/expected/~g_v1_configmap_ml-pipeline-ui-configmap.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+data:
+  viewer-pod-template.json: |-
+    {
+        "spec": {
+            "serviceAccountName": "kubeflow-pipelines-viewer"
+        }
+    }
+kind: ConfigMap
+metadata:
+  labels:
+    app.kubernetes.io/component: ml-pipeline
+    app.kubernetes.io/name: kubeflow-pipelines
+  name: ml-pipeline-ui-configmap
+  namespace: kubeflow

--- a/tests/stacks/ibm/components/pipelines/test_data/expected/~g_v1_configmap_pipeline-install-config-2829cc67f8.yaml
+++ b/tests/stacks/ibm/components/pipelines/test_data/expected/~g_v1_configmap_pipeline-install-config-2829cc67f8.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+data:
+  bucketName: mlpipeline
+  cacheDb: cachedb
+  dbHost: mysql
+  dbPort: "3306"
+  mlmdDb: metadb
+  pipelineDb: mlpipeline
+kind: ConfigMap
+metadata:
+  labels:
+    app.kubernetes.io/component: ml-pipeline
+    app.kubernetes.io/name: kubeflow-pipelines
+  name: pipeline-install-config-2829cc67f8
+  namespace: kubeflow

--- a/tests/stacks/ibm/components/pipelines/test_data/expected/~g_v1_configmap_pipeline-minio-parameters.yaml
+++ b/tests/stacks/ibm/components/pipelines/test_data/expected/~g_v1_configmap_pipeline-minio-parameters.yaml
@@ -1,0 +1,11 @@
+apiVersion: v1
+data:
+  minioPvcName: minio-pv-claim
+kind: ConfigMap
+metadata:
+  annotations: {}
+  labels:
+    app.kubernetes.io/component: minio
+    app.kubernetes.io/name: minio
+  name: pipeline-minio-parameters
+  namespace: kubeflow

--- a/tests/stacks/ibm/components/pipelines/test_data/expected/~g_v1_configmap_pipeline-mysql-parameters.yaml
+++ b/tests/stacks/ibm/components/pipelines/test_data/expected/~g_v1_configmap_pipeline-mysql-parameters.yaml
@@ -1,0 +1,12 @@
+apiVersion: v1
+data:
+  mysqlPvcName: mysql-pv-claim
+kind: ConfigMap
+metadata:
+  annotations: {}
+  labels:
+    app: mysql
+    app.kubernetes.io/component: mysql
+    app.kubernetes.io/name: mysql
+  name: pipeline-mysql-parameters
+  namespace: kubeflow

--- a/tests/stacks/ibm/components/pipelines/test_data/expected/~g_v1_configmap_pipeline-upstream-install-config-c958fm776d.yaml
+++ b/tests/stacks/ibm/components/pipelines/test_data/expected/~g_v1_configmap_pipeline-upstream-install-config-c958fm776d.yaml
@@ -1,0 +1,17 @@
+apiVersion: v1
+data:
+  appName: pipeline
+  appVersion: 1.0.0
+  bucketName: mlpipeline
+  cacheDb: cachedb
+  dbHost: mysql
+  dbPort: "3306"
+  mlmdDb: metadb
+  pipelineDb: mlpipeline
+kind: ConfigMap
+metadata:
+  labels:
+    app.kubernetes.io/component: ml-pipeline
+    app.kubernetes.io/name: kubeflow-pipelines
+  name: pipeline-upstream-install-config-c958fm776d
+  namespace: kubeflow

--- a/tests/stacks/ibm/components/pipelines/test_data/expected/~g_v1_persistentvolumeclaim_minio-pv-claim.yaml
+++ b/tests/stacks/ibm/components/pipelines/test_data/expected/~g_v1_persistentvolumeclaim_minio-pv-claim.yaml
@@ -1,0 +1,14 @@
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  labels:
+    app.kubernetes.io/component: minio
+    app.kubernetes.io/name: minio
+  name: minio-pv-claim
+  namespace: kubeflow
+spec:
+  accessModes:
+  - ReadWriteOnce
+  resources:
+    requests:
+      storage: 20Gi

--- a/tests/stacks/ibm/components/pipelines/test_data/expected/~g_v1_persistentvolumeclaim_minio-pvc.yaml
+++ b/tests/stacks/ibm/components/pipelines/test_data/expected/~g_v1_persistentvolumeclaim_minio-pvc.yaml
@@ -1,0 +1,14 @@
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  labels:
+    app.kubernetes.io/component: minio
+    app.kubernetes.io/name: minio
+  name: minio-pvc
+  namespace: kubeflow
+spec:
+  accessModes:
+  - ReadWriteOnce
+  resources:
+    requests:
+      storage: 20Gi

--- a/tests/stacks/ibm/components/pipelines/test_data/expected/~g_v1_persistentvolumeclaim_mysql-pv-claim.yaml
+++ b/tests/stacks/ibm/components/pipelines/test_data/expected/~g_v1_persistentvolumeclaim_mysql-pv-claim.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  labels:
+    app: mysql
+    app.kubernetes.io/component: mysql
+    app.kubernetes.io/name: mysql
+  name: mysql-pv-claim
+  namespace: kubeflow
+spec:
+  accessModes:
+  - ReadWriteOnce
+  resources:
+    requests:
+      storage: 20Gi

--- a/tests/stacks/ibm/components/pipelines/test_data/expected/~g_v1_secret_mlpipeline-minio-artifact.yaml
+++ b/tests/stacks/ibm/components/pipelines/test_data/expected/~g_v1_secret_mlpipeline-minio-artifact.yaml
@@ -1,0 +1,12 @@
+apiVersion: v1
+data:
+  accesskey: bWluaW8=
+  secretkey: bWluaW8xMjM=
+kind: Secret
+metadata:
+  labels:
+    app.kubernetes.io/component: minio
+    app.kubernetes.io/name: minio
+  name: mlpipeline-minio-artifact
+  namespace: kubeflow
+type: Opaque

--- a/tests/stacks/ibm/components/pipelines/test_data/expected/~g_v1_secret_mysql-secret-fd5gktm75t.yaml
+++ b/tests/stacks/ibm/components/pipelines/test_data/expected/~g_v1_secret_mysql-secret-fd5gktm75t.yaml
@@ -1,0 +1,12 @@
+apiVersion: v1
+data:
+  password: ""
+  username: cm9vdA==
+kind: Secret
+metadata:
+  labels:
+    app.kubernetes.io/component: ml-pipeline
+    app.kubernetes.io/name: kubeflow-pipelines
+  name: mysql-secret-fd5gktm75t
+  namespace: kubeflow
+type: Opaque

--- a/tests/stacks/ibm/components/pipelines/test_data/expected/~g_v1_service_cache-server.yaml
+++ b/tests/stacks/ibm/components/pipelines/test_data/expected/~g_v1_service_cache-server.yaml
@@ -1,0 +1,16 @@
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    app.kubernetes.io/component: ml-pipeline
+    app.kubernetes.io/name: kubeflow-pipelines
+  name: cache-server
+  namespace: kubeflow
+spec:
+  ports:
+  - port: 443
+    targetPort: webhook-api
+  selector:
+    app: cache-server
+    app.kubernetes.io/component: ml-pipeline
+    app.kubernetes.io/name: kubeflow-pipelines

--- a/tests/stacks/ibm/components/pipelines/test_data/expected/~g_v1_service_minio-service.yaml
+++ b/tests/stacks/ibm/components/pipelines/test_data/expected/~g_v1_service_minio-service.yaml
@@ -1,0 +1,18 @@
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    app.kubernetes.io/component: minio
+    app.kubernetes.io/name: minio
+  name: minio-service
+  namespace: kubeflow
+spec:
+  ports:
+  - name: http
+    port: 9000
+    protocol: TCP
+    targetPort: 9000
+  selector:
+    app: minio
+    app.kubernetes.io/component: minio
+    app.kubernetes.io/name: minio

--- a/tests/stacks/ibm/components/pipelines/test_data/expected/~g_v1_service_ml-pipeline-ui.yaml
+++ b/tests/stacks/ibm/components/pipelines/test_data/expected/~g_v1_service_ml-pipeline-ui.yaml
@@ -1,0 +1,19 @@
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    app: ml-pipeline-ui
+    app.kubernetes.io/component: ml-pipeline
+    app.kubernetes.io/name: kubeflow-pipelines
+  name: ml-pipeline-ui
+  namespace: kubeflow
+spec:
+  ports:
+  - name: http
+    port: 80
+    protocol: TCP
+    targetPort: 3000
+  selector:
+    app: ml-pipeline-ui
+    app.kubernetes.io/component: ml-pipeline
+    app.kubernetes.io/name: kubeflow-pipelines

--- a/tests/stacks/ibm/components/pipelines/test_data/expected/~g_v1_service_ml-pipeline-visualizationserver.yaml
+++ b/tests/stacks/ibm/components/pipelines/test_data/expected/~g_v1_service_ml-pipeline-visualizationserver.yaml
@@ -1,0 +1,18 @@
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    app.kubernetes.io/component: ml-pipeline
+    app.kubernetes.io/name: kubeflow-pipelines
+  name: ml-pipeline-visualizationserver
+  namespace: kubeflow
+spec:
+  ports:
+  - name: http
+    port: 8888
+    protocol: TCP
+    targetPort: 8888
+  selector:
+    app: ml-pipeline-visualizationserver
+    app.kubernetes.io/component: ml-pipeline
+    app.kubernetes.io/name: kubeflow-pipelines

--- a/tests/stacks/ibm/components/pipelines/test_data/expected/~g_v1_service_ml-pipeline.yaml
+++ b/tests/stacks/ibm/components/pipelines/test_data/expected/~g_v1_service_ml-pipeline.yaml
@@ -1,0 +1,22 @@
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    app.kubernetes.io/component: ml-pipeline
+    app.kubernetes.io/name: kubeflow-pipelines
+  name: ml-pipeline
+  namespace: kubeflow
+spec:
+  ports:
+  - name: http
+    port: 8888
+    protocol: TCP
+    targetPort: 8888
+  - name: grpc
+    port: 8887
+    protocol: TCP
+    targetPort: 8887
+  selector:
+    app: ml-pipeline
+    app.kubernetes.io/component: ml-pipeline
+    app.kubernetes.io/name: kubeflow-pipelines

--- a/tests/stacks/ibm/components/pipelines/test_data/expected/~g_v1_service_mysql.yaml
+++ b/tests/stacks/ibm/components/pipelines/test_data/expected/~g_v1_service_mysql.yaml
@@ -1,0 +1,18 @@
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    app: mysql
+    app.kubernetes.io/component: mysql
+    app.kubernetes.io/name: mysql
+  name: mysql
+  namespace: kubeflow
+spec:
+  ports:
+  - port: 3306
+    protocol: TCP
+    targetPort: 3306
+  selector:
+    app: mysql
+    app.kubernetes.io/component: mysql
+    app.kubernetes.io/name: mysql

--- a/tests/stacks/ibm/components/pipelines/test_data/expected/~g_v1_serviceaccount_kubeflow-pipelines-cache-deployer-sa.yaml
+++ b/tests/stacks/ibm/components/pipelines/test_data/expected/~g_v1_serviceaccount_kubeflow-pipelines-cache-deployer-sa.yaml
@@ -1,0 +1,8 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  labels:
+    app.kubernetes.io/component: ml-pipeline
+    app.kubernetes.io/name: kubeflow-pipelines
+  name: kubeflow-pipelines-cache-deployer-sa
+  namespace: kubeflow

--- a/tests/stacks/ibm/components/pipelines/test_data/expected/~g_v1_serviceaccount_kubeflow-pipelines-cache.yaml
+++ b/tests/stacks/ibm/components/pipelines/test_data/expected/~g_v1_serviceaccount_kubeflow-pipelines-cache.yaml
@@ -1,0 +1,8 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  labels:
+    app.kubernetes.io/component: ml-pipeline
+    app.kubernetes.io/name: kubeflow-pipelines
+  name: kubeflow-pipelines-cache
+  namespace: kubeflow

--- a/tests/stacks/ibm/components/pipelines/test_data/expected/~g_v1_serviceaccount_kubeflow-pipelines-container-builder.yaml
+++ b/tests/stacks/ibm/components/pipelines/test_data/expected/~g_v1_serviceaccount_kubeflow-pipelines-container-builder.yaml
@@ -1,0 +1,8 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  labels:
+    app.kubernetes.io/component: ml-pipeline
+    app.kubernetes.io/name: kubeflow-pipelines
+  name: kubeflow-pipelines-container-builder
+  namespace: kubeflow

--- a/tests/stacks/ibm/components/pipelines/test_data/expected/~g_v1_serviceaccount_kubeflow-pipelines-metadata-writer.yaml
+++ b/tests/stacks/ibm/components/pipelines/test_data/expected/~g_v1_serviceaccount_kubeflow-pipelines-metadata-writer.yaml
@@ -1,0 +1,8 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  labels:
+    app.kubernetes.io/component: ml-pipeline
+    app.kubernetes.io/name: kubeflow-pipelines
+  name: kubeflow-pipelines-metadata-writer
+  namespace: kubeflow

--- a/tests/stacks/ibm/components/pipelines/test_data/expected/~g_v1_serviceaccount_kubeflow-pipelines-viewer.yaml
+++ b/tests/stacks/ibm/components/pipelines/test_data/expected/~g_v1_serviceaccount_kubeflow-pipelines-viewer.yaml
@@ -1,0 +1,8 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  labels:
+    app.kubernetes.io/component: ml-pipeline
+    app.kubernetes.io/name: kubeflow-pipelines
+  name: kubeflow-pipelines-viewer
+  namespace: kubeflow

--- a/tests/stacks/ibm/components/pipelines/test_data/expected/~g_v1_serviceaccount_ml-pipeline-persistenceagent.yaml
+++ b/tests/stacks/ibm/components/pipelines/test_data/expected/~g_v1_serviceaccount_ml-pipeline-persistenceagent.yaml
@@ -1,0 +1,8 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  labels:
+    app.kubernetes.io/component: ml-pipeline
+    app.kubernetes.io/name: kubeflow-pipelines
+  name: ml-pipeline-persistenceagent
+  namespace: kubeflow

--- a/tests/stacks/ibm/components/pipelines/test_data/expected/~g_v1_serviceaccount_ml-pipeline-scheduledworkflow.yaml
+++ b/tests/stacks/ibm/components/pipelines/test_data/expected/~g_v1_serviceaccount_ml-pipeline-scheduledworkflow.yaml
@@ -1,0 +1,8 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  labels:
+    app.kubernetes.io/component: ml-pipeline
+    app.kubernetes.io/name: kubeflow-pipelines
+  name: ml-pipeline-scheduledworkflow
+  namespace: kubeflow

--- a/tests/stacks/ibm/components/pipelines/test_data/expected/~g_v1_serviceaccount_ml-pipeline-ui.yaml
+++ b/tests/stacks/ibm/components/pipelines/test_data/expected/~g_v1_serviceaccount_ml-pipeline-ui.yaml
@@ -1,0 +1,8 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  labels:
+    app.kubernetes.io/component: ml-pipeline
+    app.kubernetes.io/name: kubeflow-pipelines
+  name: ml-pipeline-ui
+  namespace: kubeflow

--- a/tests/stacks/ibm/components/pipelines/test_data/expected/~g_v1_serviceaccount_ml-pipeline-viewer-crd-service-account.yaml
+++ b/tests/stacks/ibm/components/pipelines/test_data/expected/~g_v1_serviceaccount_ml-pipeline-viewer-crd-service-account.yaml
@@ -1,0 +1,8 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  labels:
+    app.kubernetes.io/component: ml-pipeline
+    app.kubernetes.io/name: kubeflow-pipelines
+  name: ml-pipeline-viewer-crd-service-account
+  namespace: kubeflow

--- a/tests/stacks/ibm/components/pipelines/test_data/expected/~g_v1_serviceaccount_ml-pipeline-visualizationserver.yaml
+++ b/tests/stacks/ibm/components/pipelines/test_data/expected/~g_v1_serviceaccount_ml-pipeline-visualizationserver.yaml
@@ -1,0 +1,8 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  labels:
+    app.kubernetes.io/component: ml-pipeline
+    app.kubernetes.io/name: kubeflow-pipelines
+  name: ml-pipeline-visualizationserver
+  namespace: kubeflow

--- a/tests/stacks/ibm/components/pipelines/test_data/expected/~g_v1_serviceaccount_ml-pipeline.yaml
+++ b/tests/stacks/ibm/components/pipelines/test_data/expected/~g_v1_serviceaccount_ml-pipeline.yaml
@@ -1,0 +1,8 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  labels:
+    app.kubernetes.io/component: ml-pipeline
+    app.kubernetes.io/name: kubeflow-pipelines
+  name: ml-pipeline
+  namespace: kubeflow

--- a/tests/stacks/ibm/components/pipelines/test_data/expected/~g_v1_serviceaccount_pipeline-runner.yaml
+++ b/tests/stacks/ibm/components/pipelines/test_data/expected/~g_v1_serviceaccount_pipeline-runner.yaml
@@ -1,0 +1,8 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  labels:
+    app.kubernetes.io/component: ml-pipeline
+    app.kubernetes.io/name: kubeflow-pipelines
+  name: pipeline-runner
+  namespace: kubeflow

--- a/tests/stacks/ibm/components/profile-control-plane/kustomize_test.go
+++ b/tests/stacks/ibm/components/profile-control-plane/kustomize_test.go
@@ -1,0 +1,15 @@
+package profile_control_plane
+
+import (
+	"github.com/kubeflow/manifests/tests"
+	"testing"
+)
+
+func TestKustomize(t *testing.T) {
+	testCase := &tests.KustomizeTestCase{
+		Package:  "../../../../../stacks/ibm/components/profile-control-plane",
+		Expected: "test_data/expected",
+	}
+
+	tests.RunTestCase(t, testCase)
+}

--- a/tests/stacks/ibm/components/profile-control-plane/test_data/expected/apiextensions.k8s.io_v1beta1_customresourcedefinition_profiles.kubeflow.org.yaml
+++ b/tests/stacks/ibm/components/profile-control-plane/test_data/expected/apiextensions.k8s.io_v1beta1_customresourcedefinition_profiles.kubeflow.org.yaml
@@ -1,0 +1,160 @@
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  creationTimestamp: null
+  labels:
+    app.kubernetes.io/component: profiles
+    app.kubernetes.io/name: profiles
+    kustomize.component: profiles
+  name: profiles.kubeflow.org
+spec:
+  conversion:
+    strategy: None
+  group: kubeflow.org
+  names:
+    kind: Profile
+    plural: profiles
+  scope: Cluster
+  subresources:
+    status: {}
+  validation:
+    openAPIV3Schema:
+      description: Profile is the Schema for the profiles API
+      properties:
+        apiVersion:
+          description: 'APIVersion defines the versioned schema of this representation
+            of an object. Servers should convert recognized schemas to the latest
+            internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#resources'
+          type: string
+        kind:
+          description: 'Kind is a string value representing the REST resource this
+            object represents. Servers may infer this from the endpoint the client
+            submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds'
+          type: string
+        metadata:
+          type: object
+        spec:
+          description: ProfileSpec defines the desired state of Profile
+          properties:
+            owner:
+              description: The profile owner
+              properties:
+                apiGroup:
+                  description: APIGroup holds the API group of the referenced subject.
+                    Defaults to "" for ServiceAccount subjects. Defaults to "rbac.authorization.k8s.io"
+                    for User and Group subjects.
+                  type: string
+                kind:
+                  description: Kind of object being referenced. Values defined by
+                    this API group are "User", "Group", and "ServiceAccount". If the
+                    Authorizer does not recognized the kind value, the Authorizer
+                    should report an error.
+                  type: string
+                name:
+                  description: Name of the object being referenced.
+                  type: string
+              required:
+              - kind
+              - name
+              type: object
+            plugins:
+              items:
+                description: Plugin is for customize actions on different platform.
+                properties:
+                  apiVersion:
+                    description: 'APIVersion defines the versioned schema of this
+                      representation of an object. Servers should convert recognized
+                      schemas to the latest internal value, and may reject unrecognized
+                      values. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#resources'
+                    type: string
+                  kind:
+                    description: 'Kind is a string value representing the REST resource
+                      this object represents. Servers may infer this from the endpoint
+                      the client submits requests to. Cannot be updated. In CamelCase.
+                      More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds'
+                    type: string
+                  spec:
+                    type: object
+                type: object
+              type: array
+            resourceQuotaSpec:
+              description: Resourcequota that will be applied to target namespace
+              properties:
+                hard:
+                  additionalProperties:
+                    type: string
+                  description: 'hard is the set of desired hard limits for each named
+                    resource. More info: https://kubernetes.io/docs/concepts/policy/resource-quotas/'
+                  type: object
+                scopeSelector:
+                  description: scopeSelector is also a collection of filters like
+                    scopes that must match each object tracked by a quota but expressed
+                    using ScopeSelectorOperator in combination with possible values.
+                    For a resource to match, both scopes AND scopeSelector (if specified
+                    in spec), must be matched.
+                  properties:
+                    matchExpressions:
+                      description: A list of scope selector requirements by scope
+                        of the resources.
+                      items:
+                        description: A scoped-resource selector requirement is a selector
+                          that contains values, a scope name, and an operator that
+                          relates the scope name and values.
+                        properties:
+                          operator:
+                            description: Represents a scope's relationship to a set
+                              of values. Valid operators are In, NotIn, Exists, DoesNotExist.
+                            type: string
+                          scopeName:
+                            description: The name of the scope that the selector applies
+                              to.
+                            type: string
+                          values:
+                            description: An array of string values. If the operator
+                              is In or NotIn, the values array must be non-empty.
+                              If the operator is Exists or DoesNotExist, the values
+                              array must be empty. This array is replaced during a
+                              strategic merge patch.
+                            items:
+                              type: string
+                            type: array
+                        required:
+                        - operator
+                        - scopeName
+                        type: object
+                      type: array
+                  type: object
+                scopes:
+                  description: A collection of filters that must match each object
+                    tracked by a quota. If not specified, the quota matches all objects.
+                  items:
+                    description: A ResourceQuotaScope defines a filter that must match
+                      each object tracked by a quota
+                    type: string
+                  type: array
+              type: object
+          type: object
+        status:
+          description: ProfileStatus defines the observed state of Profile
+          properties:
+            conditions:
+              items:
+                properties:
+                  message:
+                    type: string
+                  status:
+                    type: string
+                  type:
+                    type: string
+                type: object
+              type: array
+          type: object
+      type: object
+  version: v1
+  versions:
+  - name: v1
+    served: true
+    storage: true
+  - name: v1beta1
+    served: true
+    storage: false

--- a/tests/stacks/ibm/components/profile-control-plane/test_data/expected/app.k8s.io_v1beta1_application_centraldashboard.yaml
+++ b/tests/stacks/ibm/components/profile-control-plane/test_data/expected/app.k8s.io_v1beta1_application_centraldashboard.yaml
@@ -1,0 +1,57 @@
+apiVersion: app.k8s.io/v1beta1
+kind: Application
+metadata:
+  labels:
+    app.kubernetes.io/component: centraldashboard
+    app.kubernetes.io/name: centraldashboard
+  name: centraldashboard
+  namespace: kubeflow
+spec:
+  addOwnerRef: true
+  componentKinds:
+  - group: core
+    kind: ConfigMap
+  - group: apps
+    kind: Deployment
+  - group: rbac.authorization.k8s.io
+    kind: RoleBinding
+  - group: rbac.authorization.k8s.io
+    kind: Role
+  - group: core
+    kind: ServiceAccount
+  - group: core
+    kind: Service
+  - group: networking.istio.io
+    kind: VirtualService
+  descriptor:
+    description: Provides a Dashboard UI for kubeflow
+    keywords:
+    - centraldashboard
+    - kubeflow
+    links:
+    - description: About
+      url: https://github.com/kubeflow/kubeflow/tree/master/components/centraldashboard
+    maintainers:
+    - email: prodonjs@gmail.com
+      name: Jason Prodonovich
+    - email: apverma@google.com
+      name: Apoorv Verma
+    - email: adhita94@gmail.com
+      name: Adhita Selvaraj
+    owners:
+    - email: prodonjs@gmail.com
+      name: Jason Prodonovich
+    - email: apverma@google.com
+      name: Apoorv Verma
+    - email: adhita94@gmail.com
+      name: Adhita Selvaraj
+    type: centraldashboard
+    version: v1beta1
+  selector:
+    matchLabels:
+      app.kubernetes.io/component: centraldashboard
+      app.kubernetes.io/instance: centraldashboard-v0.7.0
+      app.kubernetes.io/managed-by: kfctl
+      app.kubernetes.io/name: centraldashboard
+      app.kubernetes.io/part-of: kubeflow
+      app.kubernetes.io/version: v0.7.0

--- a/tests/stacks/ibm/components/profile-control-plane/test_data/expected/app.k8s.io_v1beta1_application_profiles.yaml
+++ b/tests/stacks/ibm/components/profile-control-plane/test_data/expected/app.k8s.io_v1beta1_application_profiles.yaml
@@ -1,0 +1,45 @@
+apiVersion: app.k8s.io/v1beta1
+kind: Application
+metadata:
+  labels:
+    app.kubernetes.io/component: profiles
+    app.kubernetes.io/name: profiles
+  name: profiles
+  namespace: kubeflow
+spec:
+  addOwnerRef: true
+  componentKinds:
+  - group: apps
+    kind: Deployment
+  - group: core
+    kind: ServiceAccount
+  - group: core
+    kind: Service
+  - group: kubeflow.org
+    kind: Profile
+  descriptor:
+    description: ""
+    keywords:
+    - profiles
+    - kubeflow
+    links:
+    - description: profiles
+      url: https://github.com/kubeflow/kubeflow/tree/master/components/profile-controller
+    - description: kfam
+      url: https://github.com/kubeflow/kubeflow/tree/master/components/access-management
+    maintainers:
+    - email: kunming@google.com
+      name: Kunming Qu
+    owners:
+    - email: kunming@google.com
+      name: Kunming Qu
+    type: profiles
+    version: v1
+  selector:
+    matchLabels:
+      app.kubernetes.io/component: profiles
+      app.kubernetes.io/instance: profiles-v1.0.0
+      app.kubernetes.io/managed-by: kfctl
+      app.kubernetes.io/name: profiles
+      app.kubernetes.io/part-of: kubeflow
+      app.kubernetes.io/version: v1.0.0

--- a/tests/stacks/ibm/components/profile-control-plane/test_data/expected/apps_v1_deployment_centraldashboard.yaml
+++ b/tests/stacks/ibm/components/profile-control-plane/test_data/expected/apps_v1_deployment_centraldashboard.yaml
@@ -1,0 +1,50 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  labels:
+    app: centraldashboard
+    app.kubernetes.io/component: centraldashboard
+    app.kubernetes.io/name: centraldashboard
+  name: centraldashboard
+  namespace: kubeflow
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: centraldashboard
+      app.kubernetes.io/component: centraldashboard
+      app.kubernetes.io/name: centraldashboard
+  template:
+    metadata:
+      annotations:
+        sidecar.istio.io/inject: "false"
+      labels:
+        app: centraldashboard
+        app.kubernetes.io/component: centraldashboard
+        app.kubernetes.io/name: centraldashboard
+    spec:
+      containers:
+      - env:
+        - name: USERID_HEADER
+          valueFrom:
+            configMapKeyRef:
+              key: userid-header
+              name: kubeflow-config
+        - name: USERID_PREFIX
+          valueFrom:
+            configMapKeyRef:
+              key: userid-prefix
+              name: kubeflow-config
+        image: gcr.io/kubeflow-images-public/centraldashboard:vmaster-gd601b2d0
+        imagePullPolicy: IfNotPresent
+        livenessProbe:
+          httpGet:
+            path: /healthz
+            port: 8082
+          initialDelaySeconds: 30
+          periodSeconds: 30
+        name: centraldashboard
+        ports:
+        - containerPort: 8082
+          protocol: TCP
+      serviceAccountName: centraldashboard

--- a/tests/stacks/ibm/components/profile-control-plane/test_data/expected/apps_v1_deployment_profiles-deployment.yaml
+++ b/tests/stacks/ibm/components/profile-control-plane/test_data/expected/apps_v1_deployment_profiles-deployment.yaml
@@ -1,0 +1,103 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  labels:
+    app.kubernetes.io/component: profiles
+    app.kubernetes.io/name: profiles
+    kustomize.component: profiles
+  name: profiles-deployment
+  namespace: kubeflow
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/component: profiles
+      app.kubernetes.io/name: profiles
+      kustomize.component: profiles
+  template:
+    metadata:
+      annotations:
+        sidecar.istio.io/inject: "false"
+      labels:
+        app.kubernetes.io/component: profiles
+        app.kubernetes.io/name: profiles
+        kustomize.component: profiles
+    spec:
+      containers:
+      - args: []
+        command:
+        - /manager
+        - -userid-header
+        - $(USERID_HEADER)
+        - -userid-prefix
+        - $(USERID_PREFIX)
+        - -workload-identity
+        - $(WORKLOAD_IDENTITY)
+        env:
+        - name: USERID_HEADER
+          valueFrom:
+            configMapKeyRef:
+              key: userid-header
+              name: kubeflow-config
+        - name: USERID_PREFIX
+          valueFrom:
+            configMapKeyRef:
+              key: userid-prefix
+              name: kubeflow-config
+        - name: WORKLOAD_IDENTITY
+          valueFrom:
+            configMapKeyRef:
+              key: gcp-sa
+              name: profiles-profiles-config-h7dck95hm2
+        image: gcr.io/kubeflow-images-public/profile-controller:vmaster-g34aa47c2
+        imagePullPolicy: Always
+        livenessProbe:
+          httpGet:
+            path: /metrics
+            port: 8080
+          initialDelaySeconds: 30
+          periodSeconds: 30
+        name: manager
+        ports:
+        - containerPort: 8080
+          name: manager-http
+          protocol: TCP
+      - args: []
+        command:
+        - /access-management
+        - -cluster-admin
+        - $(CLUSTER_ADMIN)
+        - -userid-prefix
+        - $(USERID_PREFIX)
+        - -userid-header
+        - $(USERID_HEADER)
+        env:
+        - name: USERID_HEADER
+          valueFrom:
+            configMapKeyRef:
+              key: userid-header
+              name: kubeflow-config
+        - name: USERID_PREFIX
+          valueFrom:
+            configMapKeyRef:
+              key: userid-prefix
+              name: kubeflow-config
+        - name: CLUSTER_ADMIN
+          valueFrom:
+            configMapKeyRef:
+              key: admin
+              name: profiles-profiles-config-h7dck95hm2
+        image: gcr.io/kubeflow-images-public/kfam:vmaster-gf3e09203
+        imagePullPolicy: Always
+        livenessProbe:
+          httpGet:
+            path: /metrics
+            port: 8081
+          initialDelaySeconds: 30
+          periodSeconds: 30
+        name: kfam
+        ports:
+        - containerPort: 8081
+          name: kfam-http
+          protocol: TCP
+      serviceAccountName: profiles-controller-service-account

--- a/tests/stacks/ibm/components/profile-control-plane/test_data/expected/networking.istio.io_v1alpha3_virtualservice_centraldashboard.yaml
+++ b/tests/stacks/ibm/components/profile-control-plane/test_data/expected/networking.istio.io_v1alpha3_virtualservice_centraldashboard.yaml
@@ -1,0 +1,24 @@
+apiVersion: networking.istio.io/v1alpha3
+kind: VirtualService
+metadata:
+  labels:
+    app.kubernetes.io/component: centraldashboard
+    app.kubernetes.io/name: centraldashboard
+  name: centraldashboard
+  namespace: kubeflow
+spec:
+  gateways:
+  - kubeflow-gateway
+  hosts:
+  - '*'
+  http:
+  - match:
+    - uri:
+        prefix: /
+    rewrite:
+      uri: /
+    route:
+    - destination:
+        host: centraldashboard.$(namespace).svc.$(clusterDomain)
+        port:
+          number: 80

--- a/tests/stacks/ibm/components/profile-control-plane/test_data/expected/networking.istio.io_v1alpha3_virtualservice_kfam.yaml
+++ b/tests/stacks/ibm/components/profile-control-plane/test_data/expected/networking.istio.io_v1alpha3_virtualservice_kfam.yaml
@@ -1,0 +1,28 @@
+apiVersion: networking.istio.io/v1alpha3
+kind: VirtualService
+metadata:
+  labels:
+    app.kubernetes.io/component: profiles
+    app.kubernetes.io/name: profiles
+  name: kfam
+  namespace: kubeflow
+spec:
+  gateways:
+  - kubeflow-gateway
+  hosts:
+  - '*'
+  http:
+  - headers:
+      request:
+        add:
+          x-forwarded-prefix: /kfam
+    match:
+    - uri:
+        prefix: /kfam/
+    rewrite:
+      uri: /kfam/
+    route:
+    - destination:
+        host: profiles-kfam.$(namespace).svc.cluster.local
+        port:
+          number: 8081

--- a/tests/stacks/ibm/components/profile-control-plane/test_data/expected/rbac.authorization.k8s.io_v1_clusterrole_centraldashboard.yaml
+++ b/tests/stacks/ibm/components/profile-control-plane/test_data/expected/rbac.authorization.k8s.io_v1_clusterrole_centraldashboard.yaml
@@ -1,0 +1,19 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  labels:
+    app: centraldashboard
+    app.kubernetes.io/component: centraldashboard
+    app.kubernetes.io/name: centraldashboard
+  name: centraldashboard
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - events
+  - namespaces
+  - nodes
+  verbs:
+  - get
+  - list
+  - watch

--- a/tests/stacks/ibm/components/profile-control-plane/test_data/expected/rbac.authorization.k8s.io_v1_clusterrole_kubeflow-admin.yaml
+++ b/tests/stacks/ibm/components/profile-control-plane/test_data/expected/rbac.authorization.k8s.io_v1_clusterrole_kubeflow-admin.yaml
@@ -1,0 +1,9 @@
+aggregationRule:
+  clusterRoleSelectors:
+  - matchLabels:
+      rbac.authorization.kubeflow.org/aggregate-to-kubeflow-admin: "true"
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: kubeflow-admin
+rules: []

--- a/tests/stacks/ibm/components/profile-control-plane/test_data/expected/rbac.authorization.k8s.io_v1_clusterrole_kubeflow-edit.yaml
+++ b/tests/stacks/ibm/components/profile-control-plane/test_data/expected/rbac.authorization.k8s.io_v1_clusterrole_kubeflow-edit.yaml
@@ -1,0 +1,11 @@
+aggregationRule:
+  clusterRoleSelectors:
+  - matchLabels:
+      rbac.authorization.kubeflow.org/aggregate-to-kubeflow-edit: "true"
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  labels:
+    rbac.authorization.kubeflow.org/aggregate-to-kubeflow-admin: "true"
+  name: kubeflow-edit
+rules: []

--- a/tests/stacks/ibm/components/profile-control-plane/test_data/expected/rbac.authorization.k8s.io_v1_clusterrole_kubeflow-kubernetes-admin.yaml
+++ b/tests/stacks/ibm/components/profile-control-plane/test_data/expected/rbac.authorization.k8s.io_v1_clusterrole_kubeflow-kubernetes-admin.yaml
@@ -1,0 +1,27 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  labels:
+    rbac.authorization.kubeflow.org/aggregate-to-kubeflow-admin: "true"
+  name: kubeflow-kubernetes-admin
+rules:
+- apiGroups:
+  - authorization.k8s.io
+  resources:
+  - localsubjectaccessreviews
+  verbs:
+  - create
+- apiGroups:
+  - rbac.authorization.k8s.io
+  resources:
+  - rolebindings
+  - roles
+  verbs:
+  - create
+  - delete
+  - deletecollection
+  - get
+  - list
+  - patch
+  - update
+  - watch

--- a/tests/stacks/ibm/components/profile-control-plane/test_data/expected/rbac.authorization.k8s.io_v1_clusterrole_kubeflow-kubernetes-edit.yaml
+++ b/tests/stacks/ibm/components/profile-control-plane/test_data/expected/rbac.authorization.k8s.io_v1_clusterrole_kubeflow-kubernetes-edit.yaml
@@ -1,0 +1,135 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  labels:
+    rbac.authorization.kubeflow.org/aggregate-to-kubeflow-edit: "true"
+  name: kubeflow-kubernetes-edit
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - pods/attach
+  - pods/exec
+  - pods/portforward
+  - pods/proxy
+  - secrets
+  - services/proxy
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - serviceaccounts
+  verbs:
+  - impersonate
+- apiGroups:
+  - ""
+  resources:
+  - pods
+  - pods/attach
+  - pods/exec
+  - pods/portforward
+  - pods/proxy
+  verbs:
+  - create
+  - delete
+  - deletecollection
+  - patch
+  - update
+- apiGroups:
+  - ""
+  resources:
+  - configmaps
+  - endpoints
+  - persistentvolumeclaims
+  - replicationcontrollers
+  - replicationcontrollers/scale
+  - secrets
+  - serviceaccounts
+  - services
+  - services/proxy
+  verbs:
+  - create
+  - delete
+  - deletecollection
+  - patch
+  - update
+- apiGroups:
+  - apps
+  resources:
+  - daemonsets
+  - deployments
+  - deployments/rollback
+  - deployments/scale
+  - replicasets
+  - replicasets/scale
+  - statefulsets
+  - statefulsets/scale
+  verbs:
+  - create
+  - delete
+  - deletecollection
+  - patch
+  - update
+- apiGroups:
+  - autoscaling
+  resources:
+  - horizontalpodautoscalers
+  verbs:
+  - create
+  - delete
+  - deletecollection
+  - patch
+  - update
+- apiGroups:
+  - batch
+  resources:
+  - cronjobs
+  - jobs
+  verbs:
+  - create
+  - delete
+  - deletecollection
+  - patch
+  - update
+- apiGroups:
+  - extensions
+  resources:
+  - daemonsets
+  - deployments
+  - deployments/rollback
+  - deployments/scale
+  - ingresses
+  - networkpolicies
+  - replicasets
+  - replicasets/scale
+  - replicationcontrollers/scale
+  verbs:
+  - create
+  - delete
+  - deletecollection
+  - patch
+  - update
+- apiGroups:
+  - policy
+  resources:
+  - poddisruptionbudgets
+  verbs:
+  - create
+  - delete
+  - deletecollection
+  - patch
+  - update
+- apiGroups:
+  - networking.k8s.io
+  resources:
+  - ingresses
+  - networkpolicies
+  verbs:
+  - create
+  - delete
+  - deletecollection
+  - patch
+  - update

--- a/tests/stacks/ibm/components/profile-control-plane/test_data/expected/rbac.authorization.k8s.io_v1_clusterrole_kubeflow-kubernetes-view.yaml
+++ b/tests/stacks/ibm/components/profile-control-plane/test_data/expected/rbac.authorization.k8s.io_v1_clusterrole_kubeflow-kubernetes-view.yaml
@@ -1,0 +1,125 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  labels:
+    rbac.authorization.kubeflow.org/aggregate-to-kubeflow-view: "true"
+  name: kubeflow-kubernetes-view
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - configmaps
+  - endpoints
+  - persistentvolumeclaims
+  - persistentvolumeclaims/status
+  - pods
+  - replicationcontrollers
+  - replicationcontrollers/scale
+  - serviceaccounts
+  - services
+  - services/status
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - bindings
+  - events
+  - limitranges
+  - namespaces/status
+  - pods/log
+  - pods/status
+  - replicationcontrollers/status
+  - resourcequotas
+  - resourcequotas/status
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - namespaces
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - apps
+  resources:
+  - controllerrevisions
+  - daemonsets
+  - daemonsets/status
+  - deployments
+  - deployments/scale
+  - deployments/status
+  - replicasets
+  - replicasets/scale
+  - replicasets/status
+  - statefulsets
+  - statefulsets/scale
+  - statefulsets/status
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - autoscaling
+  resources:
+  - horizontalpodautoscalers
+  - horizontalpodautoscalers/status
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - batch
+  resources:
+  - cronjobs
+  - cronjobs/status
+  - jobs
+  - jobs/status
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - extensions
+  resources:
+  - daemonsets
+  - daemonsets/status
+  - deployments
+  - deployments/scale
+  - deployments/status
+  - ingresses
+  - ingresses/status
+  - networkpolicies
+  - replicasets
+  - replicasets/scale
+  - replicasets/status
+  - replicationcontrollers/scale
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - policy
+  resources:
+  - poddisruptionbudgets
+  - poddisruptionbudgets/status
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - networking.k8s.io
+  resources:
+  - ingresses
+  - ingresses/status
+  - networkpolicies
+  verbs:
+  - get
+  - list
+  - watch

--- a/tests/stacks/ibm/components/profile-control-plane/test_data/expected/rbac.authorization.k8s.io_v1_clusterrole_kubeflow-view.yaml
+++ b/tests/stacks/ibm/components/profile-control-plane/test_data/expected/rbac.authorization.k8s.io_v1_clusterrole_kubeflow-view.yaml
@@ -1,0 +1,11 @@
+aggregationRule:
+  clusterRoleSelectors:
+  - matchLabels:
+      rbac.authorization.kubeflow.org/aggregate-to-kubeflow-view: "true"
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  labels:
+    rbac.authorization.kubeflow.org/aggregate-to-kubeflow-edit: "true"
+  name: kubeflow-view
+rules: []

--- a/tests/stacks/ibm/components/profile-control-plane/test_data/expected/rbac.authorization.k8s.io_v1_clusterrolebinding_centraldashboard.yaml
+++ b/tests/stacks/ibm/components/profile-control-plane/test_data/expected/rbac.authorization.k8s.io_v1_clusterrolebinding_centraldashboard.yaml
@@ -1,0 +1,16 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  labels:
+    app: centraldashboard
+    app.kubernetes.io/component: centraldashboard
+    app.kubernetes.io/name: centraldashboard
+  name: centraldashboard
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: centraldashboard
+subjects:
+- kind: ServiceAccount
+  name: centraldashboard
+  namespace: kubeflow

--- a/tests/stacks/ibm/components/profile-control-plane/test_data/expected/rbac.authorization.k8s.io_v1_clusterrolebinding_profiles-cluster-role-binding.yaml
+++ b/tests/stacks/ibm/components/profile-control-plane/test_data/expected/rbac.authorization.k8s.io_v1_clusterrolebinding_profiles-cluster-role-binding.yaml
@@ -1,0 +1,16 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  labels:
+    app.kubernetes.io/component: profiles
+    app.kubernetes.io/name: profiles
+    kustomize.component: profiles
+  name: profiles-cluster-role-binding
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: cluster-admin
+subjects:
+- kind: ServiceAccount
+  name: profiles-controller-service-account
+  namespace: kubeflow

--- a/tests/stacks/ibm/components/profile-control-plane/test_data/expected/rbac.authorization.k8s.io_v1_role_centraldashboard.yaml
+++ b/tests/stacks/ibm/components/profile-control-plane/test_data/expected/rbac.authorization.k8s.io_v1_role_centraldashboard.yaml
@@ -1,0 +1,29 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  labels:
+    app: centraldashboard
+    app.kubernetes.io/component: centraldashboard
+    app.kubernetes.io/name: centraldashboard
+  name: centraldashboard
+  namespace: kubeflow
+rules:
+- apiGroups:
+  - ""
+  - app.k8s.io
+  resources:
+  - applications
+  - pods
+  - pods/exec
+  - pods/log
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - secrets
+  - configmaps
+  verbs:
+  - get

--- a/tests/stacks/ibm/components/profile-control-plane/test_data/expected/rbac.authorization.k8s.io_v1_rolebinding_centraldashboard.yaml
+++ b/tests/stacks/ibm/components/profile-control-plane/test_data/expected/rbac.authorization.k8s.io_v1_rolebinding_centraldashboard.yaml
@@ -1,0 +1,17 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  labels:
+    app: centraldashboard
+    app.kubernetes.io/component: centraldashboard
+    app.kubernetes.io/name: centraldashboard
+  name: centraldashboard
+  namespace: kubeflow
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: centraldashboard
+subjects:
+- kind: ServiceAccount
+  name: centraldashboard
+  namespace: kubeflow

--- a/tests/stacks/ibm/components/profile-control-plane/test_data/expected/~g_v1_configmap_profiles-profiles-config-h7dck95hm2.yaml
+++ b/tests/stacks/ibm/components/profile-control-plane/test_data/expected/~g_v1_configmap_profiles-profiles-config-h7dck95hm2.yaml
@@ -1,0 +1,13 @@
+apiVersion: v1
+data:
+  admin: example@kubeflow.org
+  gcp-sa: ""
+kind: ConfigMap
+metadata:
+  annotations: {}
+  labels:
+    app.kubernetes.io/component: profiles
+    app.kubernetes.io/name: profiles
+    kustomize.component: profiles
+  name: profiles-profiles-config-h7dck95hm2
+  namespace: kubeflow

--- a/tests/stacks/ibm/components/profile-control-plane/test_data/expected/~g_v1_service_centraldashboard.yaml
+++ b/tests/stacks/ibm/components/profile-control-plane/test_data/expected/~g_v1_service_centraldashboard.yaml
@@ -1,0 +1,29 @@
+apiVersion: v1
+kind: Service
+metadata:
+  annotations:
+    getambassador.io/config: |-
+      ---
+      apiVersion: ambassador/v0
+      kind:  Mapping
+      name: centralui-mapping
+      prefix: /
+      rewrite: /
+      service: centraldashboard.$(namespace)
+  labels:
+    app: centraldashboard
+    app.kubernetes.io/component: centraldashboard
+    app.kubernetes.io/name: centraldashboard
+  name: centraldashboard
+  namespace: kubeflow
+spec:
+  ports:
+  - port: 80
+    protocol: TCP
+    targetPort: 8082
+  selector:
+    app: centraldashboard
+    app.kubernetes.io/component: centraldashboard
+    app.kubernetes.io/name: centraldashboard
+  sessionAffinity: None
+  type: ClusterIP

--- a/tests/stacks/ibm/components/profile-control-plane/test_data/expected/~g_v1_service_profiles-kfam.yaml
+++ b/tests/stacks/ibm/components/profile-control-plane/test_data/expected/~g_v1_service_profiles-kfam.yaml
@@ -1,0 +1,16 @@
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    app.kubernetes.io/component: profiles
+    app.kubernetes.io/name: profiles
+    kustomize.component: profiles
+  name: profiles-kfam
+  namespace: kubeflow
+spec:
+  ports:
+  - port: 8081
+  selector:
+    app.kubernetes.io/component: profiles
+    app.kubernetes.io/name: profiles
+    kustomize.component: profiles

--- a/tests/stacks/ibm/components/profile-control-plane/test_data/expected/~g_v1_serviceaccount_centraldashboard.yaml
+++ b/tests/stacks/ibm/components/profile-control-plane/test_data/expected/~g_v1_serviceaccount_centraldashboard.yaml
@@ -1,0 +1,8 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  labels:
+    app.kubernetes.io/component: centraldashboard
+    app.kubernetes.io/name: centraldashboard
+  name: centraldashboard
+  namespace: kubeflow

--- a/tests/stacks/ibm/components/profile-control-plane/test_data/expected/~g_v1_serviceaccount_profiles-controller-service-account.yaml
+++ b/tests/stacks/ibm/components/profile-control-plane/test_data/expected/~g_v1_serviceaccount_profiles-controller-service-account.yaml
@@ -1,0 +1,9 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  labels:
+    app.kubernetes.io/component: profiles
+    app.kubernetes.io/name: profiles
+    kustomize.component: profiles
+  name: profiles-controller-service-account
+  namespace: kubeflow

--- a/tests/stacks/ibm/components/pytorch-job/kustomize_test.go
+++ b/tests/stacks/ibm/components/pytorch-job/kustomize_test.go
@@ -1,0 +1,15 @@
+package pytorch_job
+
+import (
+	"github.com/kubeflow/manifests/tests"
+	"testing"
+)
+
+func TestKustomize(t *testing.T) {
+	testCase := &tests.KustomizeTestCase{
+		Package:  "../../../../../stacks/ibm/components/pytorch-job",
+		Expected: "test_data/expected",
+	}
+
+	tests.RunTestCase(t, testCase)
+}

--- a/tests/stacks/ibm/components/pytorch-job/test_data/expected/apiextensions.k8s.io_v1beta1_customresourcedefinition_pytorchjobs.kubeflow.org.yaml
+++ b/tests/stacks/ibm/components/pytorch-job/test_data/expected/apiextensions.k8s.io_v1beta1_customresourcedefinition_pytorchjobs.kubeflow.org.yaml
@@ -1,0 +1,45 @@
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  labels:
+    app.kubernetes.io/component: pytorch
+    app.kubernetes.io/name: pytorch-job-crds
+  name: pytorchjobs.kubeflow.org
+spec:
+  additionalPrinterColumns:
+  - JSONPath: .status.conditions[-1:].type
+    name: State
+    type: string
+  - JSONPath: .metadata.creationTimestamp
+    name: Age
+    type: date
+  group: kubeflow.org
+  names:
+    kind: PyTorchJob
+    plural: pytorchjobs
+    singular: pytorchjob
+  scope: Namespaced
+  subresources:
+    status: {}
+  validation:
+    openAPIV3Schema:
+      properties:
+        spec:
+          properties:
+            pytorchReplicaSpecs:
+              properties:
+                Master:
+                  properties:
+                    replicas:
+                      maximum: 1
+                      minimum: 1
+                      type: integer
+                Worker:
+                  properties:
+                    replicas:
+                      minimum: 1
+                      type: integer
+  versions:
+  - name: v1
+    served: true
+    storage: true

--- a/tests/stacks/ibm/components/pytorch-job/test_data/expected/app.k8s.io_v1beta1_application_pytorch-job-crds.yaml
+++ b/tests/stacks/ibm/components/pytorch-job/test_data/expected/app.k8s.io_v1beta1_application_pytorch-job-crds.yaml
@@ -1,0 +1,46 @@
+apiVersion: app.k8s.io/v1beta1
+kind: Application
+metadata:
+  labels:
+    app.kubernetes.io/component: pytorch
+    app.kubernetes.io/name: pytorch-job-crds
+  name: pytorch-job-crds
+  namespace: kubeflow
+spec:
+  addOwnerRef: true
+  componentKinds:
+  - group: core
+    kind: Service
+  - group: apps
+    kind: Deployment
+  - group: core
+    kind: ServiceAccount
+  - group: kubeflow.org
+    kind: PyTorchJob
+  descriptor:
+    description: Pytorch-job-crds contains the "PyTorchJob" custom resource definition.
+    keywords:
+    - pytorchjob
+    - pytorch-operator
+    - pytorch-training
+    links:
+    - description: About
+      url: https://github.com/kubeflow/pytorch-operator
+    - description: Docs
+      url: https://www.kubeflow.org/docs/reference/pytorchjob/v1/pytorch/
+    maintainers:
+    - email: johnugeo@cisco.com
+      name: Johnu George
+    owners:
+    - email: johnugeo@cisco.com
+      name: Johnu George
+    type: pytorch-job-crds
+    version: v1
+  selector:
+    matchLabels:
+      app.kubernetes.io/component: pytorch
+      app.kubernetes.io/instance: pytorch-job-crds-v0.7.0
+      app.kubernetes.io/managed-by: kfctl
+      app.kubernetes.io/name: pytorch-job-crds
+      app.kubernetes.io/part-of: kubeflow
+      app.kubernetes.io/version: v0.7.0

--- a/tests/stacks/ibm/components/pytorch-job/test_data/expected/app.k8s.io_v1beta1_application_pytorch-operator.yaml
+++ b/tests/stacks/ibm/components/pytorch-job/test_data/expected/app.k8s.io_v1beta1_application_pytorch-operator.yaml
@@ -1,0 +1,49 @@
+apiVersion: app.k8s.io/v1beta1
+kind: Application
+metadata:
+  labels:
+    app.kubernetes.io/component: pytorch
+    app.kubernetes.io/name: pytorch-operator
+  name: pytorch-operator
+  namespace: kubeflow
+spec:
+  addOwnerRef: true
+  componentKinds:
+  - group: core
+    kind: Service
+  - group: apps
+    kind: Deployment
+  - group: core
+    kind: ConfigMap
+  - group: core
+    kind: ServiceAccount
+  - group: kubeflow.org
+    kind: PyTorchJob
+  descriptor:
+    description: Pytorch-operator allows users to create and manage the "PyTorchJob"
+      custom resource.
+    keywords:
+    - pytorchjob
+    - pytorch-operator
+    - pytorch-training
+    links:
+    - description: About
+      url: https://github.com/kubeflow/pytorch-operator
+    - description: Docs
+      url: https://www.kubeflow.org/docs/reference/pytorchjob/v1/pytorch/
+    maintainers:
+    - email: johnugeo@cisco.com
+      name: Johnu George
+    owners:
+    - email: johnugeo@cisco.com
+      name: Johnu George
+    type: pytorch-operator
+    version: v1
+  selector:
+    matchLabels:
+      app.kubernetes.io/component: pytorch
+      app.kubernetes.io/instance: pytorch-operator-v0.7.0
+      app.kubernetes.io/managed-by: kfctl
+      app.kubernetes.io/name: pytorch-operator
+      app.kubernetes.io/part-of: kubeflow
+      app.kubernetes.io/version: v0.7.0

--- a/tests/stacks/ibm/components/pytorch-job/test_data/expected/apps_v1_deployment_pytorch-operator.yaml
+++ b/tests/stacks/ibm/components/pytorch-job/test_data/expected/apps_v1_deployment_pytorch-operator.yaml
@@ -1,0 +1,45 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  labels:
+    app.kubernetes.io/component: pytorch
+    app.kubernetes.io/name: pytorch-operator
+    kustomize.component: pytorch-operator
+  name: pytorch-operator
+  namespace: kubeflow
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/component: pytorch
+      app.kubernetes.io/name: pytorch-operator
+      kustomize.component: pytorch-operator
+      name: pytorch-operator
+  template:
+    metadata:
+      annotations:
+        sidecar.istio.io/inject: "false"
+      labels:
+        app.kubernetes.io/component: pytorch
+        app.kubernetes.io/name: pytorch-operator
+        kustomize.component: pytorch-operator
+        name: pytorch-operator
+    spec:
+      containers:
+      - command:
+        - /pytorch-operator.v1
+        - --alsologtostderr
+        - -v=1
+        - --monitoring-port=8443
+        env:
+        - name: MY_POD_NAMESPACE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace
+        - name: MY_POD_NAME
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.name
+        image: gcr.io/kubeflow-images-public/pytorch-operator:vmaster-gd596e904
+        name: pytorch-operator
+      serviceAccountName: pytorch-operator

--- a/tests/stacks/ibm/components/pytorch-job/test_data/expected/rbac.authorization.k8s.io_v1_clusterrole_kubeflow-pytorchjobs-admin.yaml
+++ b/tests/stacks/ibm/components/pytorch-job/test_data/expected/rbac.authorization.k8s.io_v1_clusterrole_kubeflow-pytorchjobs-admin.yaml
@@ -1,0 +1,14 @@
+aggregationRule:
+  clusterRoleSelectors:
+  - matchLabels:
+      rbac.authorization.kubeflow.org/aggregate-to-kubeflow-pytorchjobs-admin: "true"
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  labels:
+    app.kubernetes.io/component: pytorch
+    app.kubernetes.io/name: pytorch-operator
+    kustomize.component: pytorch-operator
+    rbac.authorization.kubeflow.org/aggregate-to-kubeflow-admin: "true"
+  name: kubeflow-pytorchjobs-admin
+rules: []

--- a/tests/stacks/ibm/components/pytorch-job/test_data/expected/rbac.authorization.k8s.io_v1_clusterrole_kubeflow-pytorchjobs-edit.yaml
+++ b/tests/stacks/ibm/components/pytorch-job/test_data/expected/rbac.authorization.k8s.io_v1_clusterrole_kubeflow-pytorchjobs-edit.yaml
@@ -1,0 +1,26 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  labels:
+    app.kubernetes.io/component: pytorch
+    app.kubernetes.io/name: pytorch-operator
+    kustomize.component: pytorch-operator
+    rbac.authorization.kubeflow.org/aggregate-to-kubeflow-edit: "true"
+    rbac.authorization.kubeflow.org/aggregate-to-kubeflow-pytorchjobs-admin: "true"
+  name: kubeflow-pytorchjobs-edit
+rules:
+- apiGroups:
+  - kubeflow.org
+  resources:
+  - pytorchjobs
+  - pytorchjobs/status
+  - pytorchjobs/finalizers
+  verbs:
+  - get
+  - list
+  - watch
+  - create
+  - delete
+  - deletecollection
+  - patch
+  - update

--- a/tests/stacks/ibm/components/pytorch-job/test_data/expected/rbac.authorization.k8s.io_v1_clusterrole_kubeflow-pytorchjobs-view.yaml
+++ b/tests/stacks/ibm/components/pytorch-job/test_data/expected/rbac.authorization.k8s.io_v1_clusterrole_kubeflow-pytorchjobs-view.yaml
@@ -1,0 +1,20 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  labels:
+    app.kubernetes.io/component: pytorch
+    app.kubernetes.io/name: pytorch-operator
+    kustomize.component: pytorch-operator
+    rbac.authorization.kubeflow.org/aggregate-to-kubeflow-view: "true"
+  name: kubeflow-pytorchjobs-view
+rules:
+- apiGroups:
+  - kubeflow.org
+  resources:
+  - pytorchjobs
+  - pytorchjobs/status
+  - pytorchjobs/finalizers
+  verbs:
+  - get
+  - list
+  - watch

--- a/tests/stacks/ibm/components/pytorch-job/test_data/expected/rbac.authorization.k8s.io_v1beta1_clusterrole_pytorch-operator.yaml
+++ b/tests/stacks/ibm/components/pytorch-job/test_data/expected/rbac.authorization.k8s.io_v1beta1_clusterrole_pytorch-operator.yaml
@@ -1,0 +1,33 @@
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: ClusterRole
+metadata:
+  labels:
+    app: pytorch-operator
+    app.kubernetes.io/component: pytorch
+    app.kubernetes.io/name: pytorch-operator
+    kustomize.component: pytorch-operator
+  name: pytorch-operator
+rules:
+- apiGroups:
+  - kubeflow.org
+  resources:
+  - pytorchjobs
+  - pytorchjobs/status
+  - pytorchjobs/finalizers
+  verbs:
+  - '*'
+- apiGroups:
+  - apiextensions.k8s.io
+  resources:
+  - customresourcedefinitions
+  verbs:
+  - '*'
+- apiGroups:
+  - ""
+  resources:
+  - pods
+  - services
+  - endpoints
+  - events
+  verbs:
+  - '*'

--- a/tests/stacks/ibm/components/pytorch-job/test_data/expected/rbac.authorization.k8s.io_v1beta1_clusterrolebinding_pytorch-operator.yaml
+++ b/tests/stacks/ibm/components/pytorch-job/test_data/expected/rbac.authorization.k8s.io_v1beta1_clusterrolebinding_pytorch-operator.yaml
@@ -1,0 +1,17 @@
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: ClusterRoleBinding
+metadata:
+  labels:
+    app: pytorch-operator
+    app.kubernetes.io/component: pytorch
+    app.kubernetes.io/name: pytorch-operator
+    kustomize.component: pytorch-operator
+  name: pytorch-operator
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: pytorch-operator
+subjects:
+- kind: ServiceAccount
+  name: pytorch-operator
+  namespace: kubeflow

--- a/tests/stacks/ibm/components/pytorch-job/test_data/expected/~g_v1_service_pytorch-operator.yaml
+++ b/tests/stacks/ibm/components/pytorch-job/test_data/expected/~g_v1_service_pytorch-operator.yaml
@@ -1,0 +1,25 @@
+apiVersion: v1
+kind: Service
+metadata:
+  annotations:
+    prometheus.io/path: /metrics
+    prometheus.io/port: "8443"
+    prometheus.io/scrape: "true"
+  labels:
+    app: pytorch-operator
+    app.kubernetes.io/component: pytorch
+    app.kubernetes.io/name: pytorch-operator
+    kustomize.component: pytorch-operator
+  name: pytorch-operator
+  namespace: kubeflow
+spec:
+  ports:
+  - name: monitoring-port
+    port: 8443
+    targetPort: 8443
+  selector:
+    app.kubernetes.io/component: pytorch
+    app.kubernetes.io/name: pytorch-operator
+    kustomize.component: pytorch-operator
+    name: pytorch-operator
+  type: ClusterIP

--- a/tests/stacks/ibm/components/pytorch-job/test_data/expected/~g_v1_serviceaccount_pytorch-operator.yaml
+++ b/tests/stacks/ibm/components/pytorch-job/test_data/expected/~g_v1_serviceaccount_pytorch-operator.yaml
@@ -1,0 +1,10 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  labels:
+    app: pytorch-operator
+    app.kubernetes.io/component: pytorch
+    app.kubernetes.io/name: pytorch-operator
+    kustomize.component: pytorch-operator
+  name: pytorch-operator
+  namespace: kubeflow

--- a/tests/stacks/ibm/components/seldon-core-operator/kustomize_test.go
+++ b/tests/stacks/ibm/components/seldon-core-operator/kustomize_test.go
@@ -1,0 +1,15 @@
+package seldon_core_operator
+
+import (
+	"github.com/kubeflow/manifests/tests"
+	"testing"
+)
+
+func TestKustomize(t *testing.T) {
+	testCase := &tests.KustomizeTestCase{
+		Package:  "../../../../../stacks/ibm/components/seldon-core-operator",
+		Expected: "test_data/expected",
+	}
+
+	tests.RunTestCase(t, testCase)
+}

--- a/tests/stacks/ibm/components/seldon-core-operator/test_data/expected/admissionregistration.k8s.io_v1beta1_mutatingwebhookconfiguration_seldon-mutating-webhook-configuration-kubeflow.yaml
+++ b/tests/stacks/ibm/components/seldon-core-operator/test_data/expected/admissionregistration.k8s.io_v1beta1_mutatingwebhookconfiguration_seldon-mutating-webhook-configuration-kubeflow.yaml
@@ -1,0 +1,86 @@
+apiVersion: admissionregistration.k8s.io/v1beta1
+kind: MutatingWebhookConfiguration
+metadata:
+  annotations:
+    cert-manager.io/inject-ca-from: kubeflow/seldon-serving-cert
+  creationTimestamp: null
+  labels:
+    app: seldon
+    app.kubernetes.io/component: seldon
+    app.kubernetes.io/instance: seldon-core
+    app.kubernetes.io/name: seldon-core-operator
+    app.kubernetes.io/version: 1.2.1
+  name: seldon-mutating-webhook-configuration-kubeflow
+webhooks:
+- clientConfig:
+    caBundle: LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSURCVENDQWUyZ0F3SUJBZ0lSQU9CZGZ4N0xmZXVEZnJ2QXFUK0hDWDh3RFFZSktvWklodmNOQVFFTEJRQXcKSERFYU1CZ0dBMVVFQXhNUlkzVnpkRzl0TFcxbGRISnBZM010WTJFd0hoY05NakF3TnpFd01UYzFOREV4V2hjTgpNakV3TnpFd01UYzFOREV4V2pBY01Sb3dHQVlEVlFRREV4RmpkWE4wYjIwdGJXVjBjbWxqY3kxallUQ0NBU0l3CkRRWUpLb1pJaHZjTkFRRUJCUUFEZ2dFUEFEQ0NBUW9DZ2dFQkFLSEVLQ09YVW1LN2FRS1VHL0ZjbTMwSTVmVnYKTVJlc3dGbi9yb3pxR1I2Rm5HSm9zbjFiZStJY05PZkdvUERUNkJ4T2pYRXVvczRvQjFabjNXamZZL3ZaVnNCagpjSjdCWld3TzZlUmwrUEZNOUV5S0ZwTVhncnVHdjRBTlpOZ3BrejkyYURBTTV2S1RSYng0QUVCRFdjQlgxWE93CjdEdFZrOVNpY0Q5cTdMVGYzWDBYSHF1SlRiQTNmNXhJbndEMWp2ZjltMzdZanNIRnZva3ZscGR3MFpicFhjeWYKVFozYWw0SVJ5SmU3TWJDaTV4Wm9PcmZ0R1NzT2IrNnRTemVKbU5nVjM2N3ZHbnliSEJSSmlUVTBYeGJid3hEawpjazIvNnFFMXgzOWxxUlYvOWNURWk4UE1DbU9oV0dkeFQ3cTJQS1NmeVBhSm50VWVnUndXcjZIdDRVY0NBd0VBCkFhTkNNRUF3RGdZRFZSMFBBUUgvQkFRREFnS2tNQjBHQTFVZEpRUVdNQlFHQ0NzR0FRVUZCd01CQmdnckJnRUYKQlFjREFqQVBCZ05WSFJNQkFmOEVCVEFEQVFIL01BMEdDU3FHU0liM0RRRUJDd1VBQTRJQkFRQXRMcldyeGxmMgpuU2pjNEFvK3FJaHBITXZYc21nVFJXbFNKNXR0aW1tZHE0TkpwWDBMeWJQRmVoQ2RGOTUweXRvejIxMVFZbENECmVKd3k1YXY1eHA2NTdKZ0h0ckRWb1djTmxFUnNMa0JOOElaTlI2THdJdkMrbFZjYzU0RGVRWU5XbG5neSttYnMKT3FoYWlQVXVoWTRjZW9TeENlNDlYSHVnQko4VVdZUTUwcWl4Y1hmRjdzK1JQLzZuQXRhVDRrbWVkek1HckxFbwp1a3JzcXNaOWV5SHNDYmtKTW0rcHROWWtXMUhzU29ORlhHRnZYTE5GTEllZVJpa0hyRk15Tmg3dVhwQjI2cTVrCnVES2lvL0dNNitIRG5GN1p5VXVYTVEyOWhjc1VZZ2tBcVFJZGhKWnV5R281WmpjK1VNL3hyMlFwc0tYSjBmUXoKVHpvR3I0L1JzdTRBCi0tLS0tRU5EIENFUlRJRklDQVRFLS0tLS0K
+    service:
+      name: seldon-webhook-service
+      namespace: kubeflow
+      path: /mutate-machinelearning-seldon-io-v1-seldondeployment
+  failurePolicy: Fail
+  name: v1.mseldondeployment.kb.io
+  namespaceSelector:
+    matchExpressions:
+    - key: seldon.io/controller-id
+      operator: DoesNotExist
+    matchLabels:
+      serving.kubeflow.org/inferenceservice: enabled
+  rules:
+  - apiGroups:
+    - machinelearning.seldon.io
+    apiVersions:
+    - v1
+    operations:
+    - CREATE
+    - UPDATE
+    resources:
+    - seldondeployments
+- clientConfig:
+    caBundle: LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSURCVENDQWUyZ0F3SUJBZ0lSQU9CZGZ4N0xmZXVEZnJ2QXFUK0hDWDh3RFFZSktvWklodmNOQVFFTEJRQXcKSERFYU1CZ0dBMVVFQXhNUlkzVnpkRzl0TFcxbGRISnBZM010WTJFd0hoY05NakF3TnpFd01UYzFOREV4V2hjTgpNakV3TnpFd01UYzFOREV4V2pBY01Sb3dHQVlEVlFRREV4RmpkWE4wYjIwdGJXVjBjbWxqY3kxallUQ0NBU0l3CkRRWUpLb1pJaHZjTkFRRUJCUUFEZ2dFUEFEQ0NBUW9DZ2dFQkFLSEVLQ09YVW1LN2FRS1VHL0ZjbTMwSTVmVnYKTVJlc3dGbi9yb3pxR1I2Rm5HSm9zbjFiZStJY05PZkdvUERUNkJ4T2pYRXVvczRvQjFabjNXamZZL3ZaVnNCagpjSjdCWld3TzZlUmwrUEZNOUV5S0ZwTVhncnVHdjRBTlpOZ3BrejkyYURBTTV2S1RSYng0QUVCRFdjQlgxWE93CjdEdFZrOVNpY0Q5cTdMVGYzWDBYSHF1SlRiQTNmNXhJbndEMWp2ZjltMzdZanNIRnZva3ZscGR3MFpicFhjeWYKVFozYWw0SVJ5SmU3TWJDaTV4Wm9PcmZ0R1NzT2IrNnRTemVKbU5nVjM2N3ZHbnliSEJSSmlUVTBYeGJid3hEawpjazIvNnFFMXgzOWxxUlYvOWNURWk4UE1DbU9oV0dkeFQ3cTJQS1NmeVBhSm50VWVnUndXcjZIdDRVY0NBd0VBCkFhTkNNRUF3RGdZRFZSMFBBUUgvQkFRREFnS2tNQjBHQTFVZEpRUVdNQlFHQ0NzR0FRVUZCd01CQmdnckJnRUYKQlFjREFqQVBCZ05WSFJNQkFmOEVCVEFEQVFIL01BMEdDU3FHU0liM0RRRUJDd1VBQTRJQkFRQXRMcldyeGxmMgpuU2pjNEFvK3FJaHBITXZYc21nVFJXbFNKNXR0aW1tZHE0TkpwWDBMeWJQRmVoQ2RGOTUweXRvejIxMVFZbENECmVKd3k1YXY1eHA2NTdKZ0h0ckRWb1djTmxFUnNMa0JOOElaTlI2THdJdkMrbFZjYzU0RGVRWU5XbG5neSttYnMKT3FoYWlQVXVoWTRjZW9TeENlNDlYSHVnQko4VVdZUTUwcWl4Y1hmRjdzK1JQLzZuQXRhVDRrbWVkek1HckxFbwp1a3JzcXNaOWV5SHNDYmtKTW0rcHROWWtXMUhzU29ORlhHRnZYTE5GTEllZVJpa0hyRk15Tmg3dVhwQjI2cTVrCnVES2lvL0dNNitIRG5GN1p5VXVYTVEyOWhjc1VZZ2tBcVFJZGhKWnV5R281WmpjK1VNL3hyMlFwc0tYSjBmUXoKVHpvR3I0L1JzdTRBCi0tLS0tRU5EIENFUlRJRklDQVRFLS0tLS0K
+    service:
+      name: seldon-webhook-service
+      namespace: kubeflow
+      path: /mutate-machinelearning-seldon-io-v1alpha2-seldondeployment
+  failurePolicy: Fail
+  name: v1alpha2.mseldondeployment.kb.io
+  namespaceSelector:
+    matchExpressions:
+    - key: seldon.io/controller-id
+      operator: DoesNotExist
+    matchLabels:
+      serving.kubeflow.org/inferenceservice: enabled
+  rules:
+  - apiGroups:
+    - machinelearning.seldon.io
+    apiVersions:
+    - v1alpha2
+    operations:
+    - CREATE
+    - UPDATE
+    resources:
+    - seldondeployments
+- clientConfig:
+    caBundle: LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSURCVENDQWUyZ0F3SUJBZ0lSQU9CZGZ4N0xmZXVEZnJ2QXFUK0hDWDh3RFFZSktvWklodmNOQVFFTEJRQXcKSERFYU1CZ0dBMVVFQXhNUlkzVnpkRzl0TFcxbGRISnBZM010WTJFd0hoY05NakF3TnpFd01UYzFOREV4V2hjTgpNakV3TnpFd01UYzFOREV4V2pBY01Sb3dHQVlEVlFRREV4RmpkWE4wYjIwdGJXVjBjbWxqY3kxallUQ0NBU0l3CkRRWUpLb1pJaHZjTkFRRUJCUUFEZ2dFUEFEQ0NBUW9DZ2dFQkFLSEVLQ09YVW1LN2FRS1VHL0ZjbTMwSTVmVnYKTVJlc3dGbi9yb3pxR1I2Rm5HSm9zbjFiZStJY05PZkdvUERUNkJ4T2pYRXVvczRvQjFabjNXamZZL3ZaVnNCagpjSjdCWld3TzZlUmwrUEZNOUV5S0ZwTVhncnVHdjRBTlpOZ3BrejkyYURBTTV2S1RSYng0QUVCRFdjQlgxWE93CjdEdFZrOVNpY0Q5cTdMVGYzWDBYSHF1SlRiQTNmNXhJbndEMWp2ZjltMzdZanNIRnZva3ZscGR3MFpicFhjeWYKVFozYWw0SVJ5SmU3TWJDaTV4Wm9PcmZ0R1NzT2IrNnRTemVKbU5nVjM2N3ZHbnliSEJSSmlUVTBYeGJid3hEawpjazIvNnFFMXgzOWxxUlYvOWNURWk4UE1DbU9oV0dkeFQ3cTJQS1NmeVBhSm50VWVnUndXcjZIdDRVY0NBd0VBCkFhTkNNRUF3RGdZRFZSMFBBUUgvQkFRREFnS2tNQjBHQTFVZEpRUVdNQlFHQ0NzR0FRVUZCd01CQmdnckJnRUYKQlFjREFqQVBCZ05WSFJNQkFmOEVCVEFEQVFIL01BMEdDU3FHU0liM0RRRUJDd1VBQTRJQkFRQXRMcldyeGxmMgpuU2pjNEFvK3FJaHBITXZYc21nVFJXbFNKNXR0aW1tZHE0TkpwWDBMeWJQRmVoQ2RGOTUweXRvejIxMVFZbENECmVKd3k1YXY1eHA2NTdKZ0h0ckRWb1djTmxFUnNMa0JOOElaTlI2THdJdkMrbFZjYzU0RGVRWU5XbG5neSttYnMKT3FoYWlQVXVoWTRjZW9TeENlNDlYSHVnQko4VVdZUTUwcWl4Y1hmRjdzK1JQLzZuQXRhVDRrbWVkek1HckxFbwp1a3JzcXNaOWV5SHNDYmtKTW0rcHROWWtXMUhzU29ORlhHRnZYTE5GTEllZVJpa0hyRk15Tmg3dVhwQjI2cTVrCnVES2lvL0dNNitIRG5GN1p5VXVYTVEyOWhjc1VZZ2tBcVFJZGhKWnV5R281WmpjK1VNL3hyMlFwc0tYSjBmUXoKVHpvR3I0L1JzdTRBCi0tLS0tRU5EIENFUlRJRklDQVRFLS0tLS0K
+    service:
+      name: seldon-webhook-service
+      namespace: kubeflow
+      path: /mutate-machinelearning-seldon-io-v1alpha3-seldondeployment
+  failurePolicy: Fail
+  name: v1alpha3.mseldondeployment.kb.io
+  namespaceSelector:
+    matchExpressions:
+    - key: seldon.io/controller-id
+      operator: DoesNotExist
+    matchLabels:
+      serving.kubeflow.org/inferenceservice: enabled
+  rules:
+  - apiGroups:
+    - machinelearning.seldon.io
+    apiVersions:
+    - v1alpha3
+    operations:
+    - CREATE
+    - UPDATE
+    resources:
+    - seldondeployments

--- a/tests/stacks/ibm/components/seldon-core-operator/test_data/expected/admissionregistration.k8s.io_v1beta1_validatingwebhookconfiguration_seldon-validating-webhook-configuration-kubeflow.yaml
+++ b/tests/stacks/ibm/components/seldon-core-operator/test_data/expected/admissionregistration.k8s.io_v1beta1_validatingwebhookconfiguration_seldon-validating-webhook-configuration-kubeflow.yaml
@@ -1,0 +1,86 @@
+apiVersion: admissionregistration.k8s.io/v1beta1
+kind: ValidatingWebhookConfiguration
+metadata:
+  annotations:
+    cert-manager.io/inject-ca-from: kubeflow/seldon-serving-cert
+  creationTimestamp: null
+  labels:
+    app: seldon
+    app.kubernetes.io/component: seldon
+    app.kubernetes.io/instance: seldon-core
+    app.kubernetes.io/name: seldon-core-operator
+    app.kubernetes.io/version: 1.2.1
+  name: seldon-validating-webhook-configuration-kubeflow
+webhooks:
+- clientConfig:
+    caBundle: LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSURCVENDQWUyZ0F3SUJBZ0lSQU9CZGZ4N0xmZXVEZnJ2QXFUK0hDWDh3RFFZSktvWklodmNOQVFFTEJRQXcKSERFYU1CZ0dBMVVFQXhNUlkzVnpkRzl0TFcxbGRISnBZM010WTJFd0hoY05NakF3TnpFd01UYzFOREV4V2hjTgpNakV3TnpFd01UYzFOREV4V2pBY01Sb3dHQVlEVlFRREV4RmpkWE4wYjIwdGJXVjBjbWxqY3kxallUQ0NBU0l3CkRRWUpLb1pJaHZjTkFRRUJCUUFEZ2dFUEFEQ0NBUW9DZ2dFQkFLSEVLQ09YVW1LN2FRS1VHL0ZjbTMwSTVmVnYKTVJlc3dGbi9yb3pxR1I2Rm5HSm9zbjFiZStJY05PZkdvUERUNkJ4T2pYRXVvczRvQjFabjNXamZZL3ZaVnNCagpjSjdCWld3TzZlUmwrUEZNOUV5S0ZwTVhncnVHdjRBTlpOZ3BrejkyYURBTTV2S1RSYng0QUVCRFdjQlgxWE93CjdEdFZrOVNpY0Q5cTdMVGYzWDBYSHF1SlRiQTNmNXhJbndEMWp2ZjltMzdZanNIRnZva3ZscGR3MFpicFhjeWYKVFozYWw0SVJ5SmU3TWJDaTV4Wm9PcmZ0R1NzT2IrNnRTemVKbU5nVjM2N3ZHbnliSEJSSmlUVTBYeGJid3hEawpjazIvNnFFMXgzOWxxUlYvOWNURWk4UE1DbU9oV0dkeFQ3cTJQS1NmeVBhSm50VWVnUndXcjZIdDRVY0NBd0VBCkFhTkNNRUF3RGdZRFZSMFBBUUgvQkFRREFnS2tNQjBHQTFVZEpRUVdNQlFHQ0NzR0FRVUZCd01CQmdnckJnRUYKQlFjREFqQVBCZ05WSFJNQkFmOEVCVEFEQVFIL01BMEdDU3FHU0liM0RRRUJDd1VBQTRJQkFRQXRMcldyeGxmMgpuU2pjNEFvK3FJaHBITXZYc21nVFJXbFNKNXR0aW1tZHE0TkpwWDBMeWJQRmVoQ2RGOTUweXRvejIxMVFZbENECmVKd3k1YXY1eHA2NTdKZ0h0ckRWb1djTmxFUnNMa0JOOElaTlI2THdJdkMrbFZjYzU0RGVRWU5XbG5neSttYnMKT3FoYWlQVXVoWTRjZW9TeENlNDlYSHVnQko4VVdZUTUwcWl4Y1hmRjdzK1JQLzZuQXRhVDRrbWVkek1HckxFbwp1a3JzcXNaOWV5SHNDYmtKTW0rcHROWWtXMUhzU29ORlhHRnZYTE5GTEllZVJpa0hyRk15Tmg3dVhwQjI2cTVrCnVES2lvL0dNNitIRG5GN1p5VXVYTVEyOWhjc1VZZ2tBcVFJZGhKWnV5R281WmpjK1VNL3hyMlFwc0tYSjBmUXoKVHpvR3I0L1JzdTRBCi0tLS0tRU5EIENFUlRJRklDQVRFLS0tLS0K
+    service:
+      name: seldon-webhook-service
+      namespace: kubeflow
+      path: /validate-machinelearning-seldon-io-v1-seldondeployment
+  failurePolicy: Fail
+  name: v1.vseldondeployment.kb.io
+  namespaceSelector:
+    matchExpressions:
+    - key: seldon.io/controller-id
+      operator: DoesNotExist
+    matchLabels:
+      serving.kubeflow.org/inferenceservice: enabled
+  rules:
+  - apiGroups:
+    - machinelearning.seldon.io
+    apiVersions:
+    - v1
+    operations:
+    - CREATE
+    - UPDATE
+    resources:
+    - seldondeployments
+- clientConfig:
+    caBundle: LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSURCVENDQWUyZ0F3SUJBZ0lSQU9CZGZ4N0xmZXVEZnJ2QXFUK0hDWDh3RFFZSktvWklodmNOQVFFTEJRQXcKSERFYU1CZ0dBMVVFQXhNUlkzVnpkRzl0TFcxbGRISnBZM010WTJFd0hoY05NakF3TnpFd01UYzFOREV4V2hjTgpNakV3TnpFd01UYzFOREV4V2pBY01Sb3dHQVlEVlFRREV4RmpkWE4wYjIwdGJXVjBjbWxqY3kxallUQ0NBU0l3CkRRWUpLb1pJaHZjTkFRRUJCUUFEZ2dFUEFEQ0NBUW9DZ2dFQkFLSEVLQ09YVW1LN2FRS1VHL0ZjbTMwSTVmVnYKTVJlc3dGbi9yb3pxR1I2Rm5HSm9zbjFiZStJY05PZkdvUERUNkJ4T2pYRXVvczRvQjFabjNXamZZL3ZaVnNCagpjSjdCWld3TzZlUmwrUEZNOUV5S0ZwTVhncnVHdjRBTlpOZ3BrejkyYURBTTV2S1RSYng0QUVCRFdjQlgxWE93CjdEdFZrOVNpY0Q5cTdMVGYzWDBYSHF1SlRiQTNmNXhJbndEMWp2ZjltMzdZanNIRnZva3ZscGR3MFpicFhjeWYKVFozYWw0SVJ5SmU3TWJDaTV4Wm9PcmZ0R1NzT2IrNnRTemVKbU5nVjM2N3ZHbnliSEJSSmlUVTBYeGJid3hEawpjazIvNnFFMXgzOWxxUlYvOWNURWk4UE1DbU9oV0dkeFQ3cTJQS1NmeVBhSm50VWVnUndXcjZIdDRVY0NBd0VBCkFhTkNNRUF3RGdZRFZSMFBBUUgvQkFRREFnS2tNQjBHQTFVZEpRUVdNQlFHQ0NzR0FRVUZCd01CQmdnckJnRUYKQlFjREFqQVBCZ05WSFJNQkFmOEVCVEFEQVFIL01BMEdDU3FHU0liM0RRRUJDd1VBQTRJQkFRQXRMcldyeGxmMgpuU2pjNEFvK3FJaHBITXZYc21nVFJXbFNKNXR0aW1tZHE0TkpwWDBMeWJQRmVoQ2RGOTUweXRvejIxMVFZbENECmVKd3k1YXY1eHA2NTdKZ0h0ckRWb1djTmxFUnNMa0JOOElaTlI2THdJdkMrbFZjYzU0RGVRWU5XbG5neSttYnMKT3FoYWlQVXVoWTRjZW9TeENlNDlYSHVnQko4VVdZUTUwcWl4Y1hmRjdzK1JQLzZuQXRhVDRrbWVkek1HckxFbwp1a3JzcXNaOWV5SHNDYmtKTW0rcHROWWtXMUhzU29ORlhHRnZYTE5GTEllZVJpa0hyRk15Tmg3dVhwQjI2cTVrCnVES2lvL0dNNitIRG5GN1p5VXVYTVEyOWhjc1VZZ2tBcVFJZGhKWnV5R281WmpjK1VNL3hyMlFwc0tYSjBmUXoKVHpvR3I0L1JzdTRBCi0tLS0tRU5EIENFUlRJRklDQVRFLS0tLS0K
+    service:
+      name: seldon-webhook-service
+      namespace: kubeflow
+      path: /validate-machinelearning-seldon-io-v1alpha2-seldondeployment
+  failurePolicy: Fail
+  name: v1alpha2.vseldondeployment.kb.io
+  namespaceSelector:
+    matchExpressions:
+    - key: seldon.io/controller-id
+      operator: DoesNotExist
+    matchLabels:
+      serving.kubeflow.org/inferenceservice: enabled
+  rules:
+  - apiGroups:
+    - machinelearning.seldon.io
+    apiVersions:
+    - v1alpha2
+    operations:
+    - CREATE
+    - UPDATE
+    resources:
+    - seldondeployments
+- clientConfig:
+    caBundle: LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSURCVENDQWUyZ0F3SUJBZ0lSQU9CZGZ4N0xmZXVEZnJ2QXFUK0hDWDh3RFFZSktvWklodmNOQVFFTEJRQXcKSERFYU1CZ0dBMVVFQXhNUlkzVnpkRzl0TFcxbGRISnBZM010WTJFd0hoY05NakF3TnpFd01UYzFOREV4V2hjTgpNakV3TnpFd01UYzFOREV4V2pBY01Sb3dHQVlEVlFRREV4RmpkWE4wYjIwdGJXVjBjbWxqY3kxallUQ0NBU0l3CkRRWUpLb1pJaHZjTkFRRUJCUUFEZ2dFUEFEQ0NBUW9DZ2dFQkFLSEVLQ09YVW1LN2FRS1VHL0ZjbTMwSTVmVnYKTVJlc3dGbi9yb3pxR1I2Rm5HSm9zbjFiZStJY05PZkdvUERUNkJ4T2pYRXVvczRvQjFabjNXamZZL3ZaVnNCagpjSjdCWld3TzZlUmwrUEZNOUV5S0ZwTVhncnVHdjRBTlpOZ3BrejkyYURBTTV2S1RSYng0QUVCRFdjQlgxWE93CjdEdFZrOVNpY0Q5cTdMVGYzWDBYSHF1SlRiQTNmNXhJbndEMWp2ZjltMzdZanNIRnZva3ZscGR3MFpicFhjeWYKVFozYWw0SVJ5SmU3TWJDaTV4Wm9PcmZ0R1NzT2IrNnRTemVKbU5nVjM2N3ZHbnliSEJSSmlUVTBYeGJid3hEawpjazIvNnFFMXgzOWxxUlYvOWNURWk4UE1DbU9oV0dkeFQ3cTJQS1NmeVBhSm50VWVnUndXcjZIdDRVY0NBd0VBCkFhTkNNRUF3RGdZRFZSMFBBUUgvQkFRREFnS2tNQjBHQTFVZEpRUVdNQlFHQ0NzR0FRVUZCd01CQmdnckJnRUYKQlFjREFqQVBCZ05WSFJNQkFmOEVCVEFEQVFIL01BMEdDU3FHU0liM0RRRUJDd1VBQTRJQkFRQXRMcldyeGxmMgpuU2pjNEFvK3FJaHBITXZYc21nVFJXbFNKNXR0aW1tZHE0TkpwWDBMeWJQRmVoQ2RGOTUweXRvejIxMVFZbENECmVKd3k1YXY1eHA2NTdKZ0h0ckRWb1djTmxFUnNMa0JOOElaTlI2THdJdkMrbFZjYzU0RGVRWU5XbG5neSttYnMKT3FoYWlQVXVoWTRjZW9TeENlNDlYSHVnQko4VVdZUTUwcWl4Y1hmRjdzK1JQLzZuQXRhVDRrbWVkek1HckxFbwp1a3JzcXNaOWV5SHNDYmtKTW0rcHROWWtXMUhzU29ORlhHRnZYTE5GTEllZVJpa0hyRk15Tmg3dVhwQjI2cTVrCnVES2lvL0dNNitIRG5GN1p5VXVYTVEyOWhjc1VZZ2tBcVFJZGhKWnV5R281WmpjK1VNL3hyMlFwc0tYSjBmUXoKVHpvR3I0L1JzdTRBCi0tLS0tRU5EIENFUlRJRklDQVRFLS0tLS0K
+    service:
+      name: seldon-webhook-service
+      namespace: kubeflow
+      path: /validate-machinelearning-seldon-io-v1alpha3-seldondeployment
+  failurePolicy: Fail
+  name: v1alpha3.vseldondeployment.kb.io
+  namespaceSelector:
+    matchExpressions:
+    - key: seldon.io/controller-id
+      operator: DoesNotExist
+    matchLabels:
+      serving.kubeflow.org/inferenceservice: enabled
+  rules:
+  - apiGroups:
+    - machinelearning.seldon.io
+    apiVersions:
+    - v1alpha3
+    operations:
+    - CREATE
+    - UPDATE
+    resources:
+    - seldondeployments

--- a/tests/stacks/ibm/components/seldon-core-operator/test_data/expected/apiextensions.k8s.io_v1beta1_customresourcedefinition_seldondeployments.machinelearning.seldon.io.yaml
+++ b/tests/stacks/ibm/components/seldon-core-operator/test_data/expected/apiextensions.k8s.io_v1beta1_customresourcedefinition_seldondeployments.machinelearning.seldon.io.yaml
@@ -1,0 +1,6922 @@
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    cert-manager.io/inject-ca-from: kubeflow/seldon-serving-cert
+    controller-gen.kubebuilder.io/version: v0.2.5
+  creationTimestamp: null
+  labels:
+    app: seldon
+    app.kubernetes.io/component: seldon
+    app.kubernetes.io/instance: seldon-core
+    app.kubernetes.io/name: seldon-core-operator
+    app.kubernetes.io/version: 1.2.1
+  name: seldondeployments.machinelearning.seldon.io
+spec:
+  group: machinelearning.seldon.io
+  names:
+    kind: SeldonDeployment
+    listKind: SeldonDeploymentList
+    plural: seldondeployments
+    shortNames:
+    - sdep
+    singular: seldondeployment
+  scope: Namespaced
+  subresources:
+    scale:
+      specReplicasPath: .spec.replicas
+      statusReplicasPath: .status.replicas
+    status: {}
+  validation:
+    openAPIV3Schema:
+      description: SeldonDeployment is the Schema for the seldondeployments API
+      properties:
+        apiVersion:
+          description: 'APIVersion defines the versioned schema of this representation
+            of an object. Servers should convert recognized schemas to the latest
+            internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+          type: string
+        kind:
+          description: 'Kind is a string value representing the REST resource this
+            object represents. Servers may infer this from the endpoint the client
+            submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+          type: string
+        metadata:
+          type: object
+        spec:
+          description: SeldonDeploymentSpec defines the desired state of SeldonDeployment
+          properties:
+            annotations:
+              additionalProperties:
+                type: string
+              type: object
+            name:
+              description: Name is Deprecated will be removed in future
+              type: string
+            oauth_key:
+              type: string
+            oauth_secret:
+              type: string
+            predictors:
+              items:
+                properties:
+                  annotations:
+                    additionalProperties:
+                      type: string
+                    type: object
+                  componentSpecs:
+                    items:
+                      properties:
+                        hpaSpec:
+                          properties:
+                            maxReplicas:
+                              format: int32
+                              type: integer
+                            metrics:
+                              items:
+                                description: MetricSpec specifies how to scale based
+                                  on a single metric (only `type` and one other matching
+                                  field should be set at once).
+                                properties:
+                                  external:
+                                    description: external refers to a global metric
+                                      that is not associated with any Kubernetes object.
+                                      It allows autoscaling based on information coming
+                                      from components running outside of cluster (for
+                                      example length of queue in cloud messaging service,
+                                      or QPS from loadbalancer running outside of
+                                      cluster).
+                                    properties:
+                                      metricName:
+                                        description: metricName is the name of the
+                                          metric in question.
+                                        type: string
+                                      metricSelector:
+                                        description: metricSelector is used to identify
+                                          a specific time series within a given metric.
+                                        properties:
+                                          matchExpressions:
+                                            description: matchExpressions is a list
+                                              of label selector requirements. The
+                                              requirements are ANDed.
+                                            items:
+                                              description: A label selector requirement
+                                                is a selector that contains values,
+                                                a key, and an operator that relates
+                                                the key and values.
+                                              properties:
+                                                key:
+                                                  description: key is the label key
+                                                    that the selector applies to.
+                                                  type: string
+                                                operator:
+                                                  description: operator represents
+                                                    a key's relationship to a set
+                                                    of values. Valid operators are
+                                                    In, NotIn, Exists and DoesNotExist.
+                                                  type: string
+                                                values:
+                                                  description: values is an array
+                                                    of string values. If the operator
+                                                    is In or NotIn, the values array
+                                                    must be non-empty. If the operator
+                                                    is Exists or DoesNotExist, the
+                                                    values array must be empty. This
+                                                    array is replaced during a strategic
+                                                    merge patch.
+                                                  items:
+                                                    type: string
+                                                  type: array
+                                              required:
+                                              - key
+                                              - operator
+                                              type: object
+                                            type: array
+                                          matchLabels:
+                                            additionalProperties:
+                                              type: string
+                                            description: matchLabels is a map of {key,value}
+                                              pairs. A single {key,value} in the matchLabels
+                                              map is equivalent to an element of matchExpressions,
+                                              whose key field is "key", the operator
+                                              is "In", and the values array contains
+                                              only "value". The requirements are ANDed.
+                                            type: object
+                                        type: object
+                                      targetAverageValue:
+                                        anyOf:
+                                        - type: integer
+                                        - type: string
+                                        description: targetAverageValue is the target
+                                          per-pod value of global metric (as a quantity).
+                                          Mutually exclusive with TargetValue.
+                                        pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                        x-kubernetes-int-or-string: true
+                                      targetValue:
+                                        anyOf:
+                                        - type: integer
+                                        - type: string
+                                        description: targetValue is the target value
+                                          of the metric (as a quantity). Mutually
+                                          exclusive with TargetAverageValue.
+                                        pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                        x-kubernetes-int-or-string: true
+                                    required:
+                                    - metricName
+                                    type: object
+                                  object:
+                                    description: object refers to a metric describing
+                                      a single kubernetes object (for example, hits-per-second
+                                      on an Ingress object).
+                                    properties:
+                                      averageValue:
+                                        anyOf:
+                                        - type: integer
+                                        - type: string
+                                        description: averageValue is the target value
+                                          of the average of the metric across all
+                                          relevant pods (as a quantity)
+                                        pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                        x-kubernetes-int-or-string: true
+                                      metricName:
+                                        description: metricName is the name of the
+                                          metric in question.
+                                        type: string
+                                      selector:
+                                        description: selector is the string-encoded
+                                          form of a standard kubernetes label selector
+                                          for the given metric When set, it is passed
+                                          as an additional parameter to the metrics
+                                          server for more specific metrics scoping
+                                          When unset, just the metricName will be
+                                          used to gather metrics.
+                                        properties:
+                                          matchExpressions:
+                                            description: matchExpressions is a list
+                                              of label selector requirements. The
+                                              requirements are ANDed.
+                                            items:
+                                              description: A label selector requirement
+                                                is a selector that contains values,
+                                                a key, and an operator that relates
+                                                the key and values.
+                                              properties:
+                                                key:
+                                                  description: key is the label key
+                                                    that the selector applies to.
+                                                  type: string
+                                                operator:
+                                                  description: operator represents
+                                                    a key's relationship to a set
+                                                    of values. Valid operators are
+                                                    In, NotIn, Exists and DoesNotExist.
+                                                  type: string
+                                                values:
+                                                  description: values is an array
+                                                    of string values. If the operator
+                                                    is In or NotIn, the values array
+                                                    must be non-empty. If the operator
+                                                    is Exists or DoesNotExist, the
+                                                    values array must be empty. This
+                                                    array is replaced during a strategic
+                                                    merge patch.
+                                                  items:
+                                                    type: string
+                                                  type: array
+                                              required:
+                                              - key
+                                              - operator
+                                              type: object
+                                            type: array
+                                          matchLabels:
+                                            additionalProperties:
+                                              type: string
+                                            description: matchLabels is a map of {key,value}
+                                              pairs. A single {key,value} in the matchLabels
+                                              map is equivalent to an element of matchExpressions,
+                                              whose key field is "key", the operator
+                                              is "In", and the values array contains
+                                              only "value". The requirements are ANDed.
+                                            type: object
+                                        type: object
+                                      target:
+                                        description: target is the described Kubernetes
+                                          object.
+                                        properties:
+                                          apiVersion:
+                                            description: API version of the referent
+                                            type: string
+                                          kind:
+                                            description: 'Kind of the referent; More
+                                              info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds"'
+                                            type: string
+                                          name:
+                                            description: 'Name of the referent; More
+                                              info: http://kubernetes.io/docs/user-guide/identifiers#names'
+                                            type: string
+                                        required:
+                                        - kind
+                                        - name
+                                        type: object
+                                      targetValue:
+                                        anyOf:
+                                        - type: integer
+                                        - type: string
+                                        description: targetValue is the target value
+                                          of the metric (as a quantity).
+                                        pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                        x-kubernetes-int-or-string: true
+                                    required:
+                                    - metricName
+                                    - target
+                                    - targetValue
+                                    type: object
+                                  pods:
+                                    description: pods refers to a metric describing
+                                      each pod in the current scale target (for example,
+                                      transactions-processed-per-second).  The values
+                                      will be averaged together before being compared
+                                      to the target value.
+                                    properties:
+                                      metricName:
+                                        description: metricName is the name of the
+                                          metric in question
+                                        type: string
+                                      selector:
+                                        description: selector is the string-encoded
+                                          form of a standard kubernetes label selector
+                                          for the given metric When set, it is passed
+                                          as an additional parameter to the metrics
+                                          server for more specific metrics scoping
+                                          When unset, just the metricName will be
+                                          used to gather metrics.
+                                        properties:
+                                          matchExpressions:
+                                            description: matchExpressions is a list
+                                              of label selector requirements. The
+                                              requirements are ANDed.
+                                            items:
+                                              description: A label selector requirement
+                                                is a selector that contains values,
+                                                a key, and an operator that relates
+                                                the key and values.
+                                              properties:
+                                                key:
+                                                  description: key is the label key
+                                                    that the selector applies to.
+                                                  type: string
+                                                operator:
+                                                  description: operator represents
+                                                    a key's relationship to a set
+                                                    of values. Valid operators are
+                                                    In, NotIn, Exists and DoesNotExist.
+                                                  type: string
+                                                values:
+                                                  description: values is an array
+                                                    of string values. If the operator
+                                                    is In or NotIn, the values array
+                                                    must be non-empty. If the operator
+                                                    is Exists or DoesNotExist, the
+                                                    values array must be empty. This
+                                                    array is replaced during a strategic
+                                                    merge patch.
+                                                  items:
+                                                    type: string
+                                                  type: array
+                                              required:
+                                              - key
+                                              - operator
+                                              type: object
+                                            type: array
+                                          matchLabels:
+                                            additionalProperties:
+                                              type: string
+                                            description: matchLabels is a map of {key,value}
+                                              pairs. A single {key,value} in the matchLabels
+                                              map is equivalent to an element of matchExpressions,
+                                              whose key field is "key", the operator
+                                              is "In", and the values array contains
+                                              only "value". The requirements are ANDed.
+                                            type: object
+                                        type: object
+                                      targetAverageValue:
+                                        anyOf:
+                                        - type: integer
+                                        - type: string
+                                        description: targetAverageValue is the target
+                                          value of the average of the metric across
+                                          all relevant pods (as a quantity)
+                                        pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                        x-kubernetes-int-or-string: true
+                                    required:
+                                    - metricName
+                                    - targetAverageValue
+                                    type: object
+                                  resource:
+                                    description: resource refers to a resource metric
+                                      (such as those specified in requests and limits)
+                                      known to Kubernetes describing each pod in the
+                                      current scale target (e.g. CPU or memory). Such
+                                      metrics are built in to Kubernetes, and have
+                                      special scaling options on top of those available
+                                      to normal per-pod metrics using the "pods" source.
+                                    properties:
+                                      name:
+                                        description: name is the name of the resource
+                                          in question.
+                                        type: string
+                                      targetAverageUtilization:
+                                        description: targetAverageUtilization is the
+                                          target value of the average of the resource
+                                          metric across all relevant pods, represented
+                                          as a percentage of the requested value of
+                                          the resource for the pods.
+                                        format: int32
+                                        type: integer
+                                      targetAverageValue:
+                                        anyOf:
+                                        - type: integer
+                                        - type: string
+                                        description: targetAverageValue is the target
+                                          value of the average of the resource metric
+                                          across all relevant pods, as a raw value
+                                          (instead of as a percentage of the request),
+                                          similar to the "pods" metric source type.
+                                        pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                        x-kubernetes-int-or-string: true
+                                    required:
+                                    - name
+                                    type: object
+                                  type:
+                                    description: type is the type of metric source.  It
+                                      should be one of "Object", "Pods" or "Resource",
+                                      each mapping to a matching field in the object.
+                                    type: string
+                                required:
+                                - type
+                                type: object
+                              type: array
+                            minReplicas:
+                              format: int32
+                              type: integer
+                          required:
+                          - maxReplicas
+                          type: object
+                        metadata:
+                          type: object
+                        replicas:
+                          format: int32
+                          type: integer
+                        spec:
+                          description: PodSpec is a description of a pod.
+                          properties:
+                            activeDeadlineSeconds:
+                              description: Optional duration in seconds the pod may
+                                be active on the node relative to StartTime before
+                                the system will actively try to mark it failed and
+                                kill associated containers. Value must be a positive
+                                integer.
+                              format: int64
+                              type: integer
+                            affinity:
+                              description: If specified, the pod's scheduling constraints
+                              properties:
+                                nodeAffinity:
+                                  description: Describes node affinity scheduling
+                                    rules for the pod.
+                                  properties:
+                                    preferredDuringSchedulingIgnoredDuringExecution:
+                                      description: The scheduler will prefer to schedule
+                                        pods to nodes that satisfy the affinity expressions
+                                        specified by this field, but it may choose
+                                        a node that violates one or more of the expressions.
+                                        The node that is most preferred is the one
+                                        with the greatest sum of weights, i.e. for
+                                        each node that meets all of the scheduling
+                                        requirements (resource request, requiredDuringScheduling
+                                        affinity expressions, etc.), compute a sum
+                                        by iterating through the elements of this
+                                        field and adding "weight" to the sum if the
+                                        node matches the corresponding matchExpressions;
+                                        the node(s) with the highest sum are the most
+                                        preferred.
+                                      items:
+                                        description: An empty preferred scheduling
+                                          term matches all objects with implicit weight
+                                          0 (i.e. it's a no-op). A null preferred
+                                          scheduling term matches no objects (i.e.
+                                          is also a no-op).
+                                        properties:
+                                          preference:
+                                            description: A node selector term, associated
+                                              with the corresponding weight.
+                                            properties:
+                                              matchExpressions:
+                                                description: A list of node selector
+                                                  requirements by node's labels.
+                                                items:
+                                                  description: A node selector requirement
+                                                    is a selector that contains values,
+                                                    a key, and an operator that relates
+                                                    the key and values.
+                                                  properties:
+                                                    key:
+                                                      description: The label key that
+                                                        the selector applies to.
+                                                      type: string
+                                                    operator:
+                                                      description: Represents a key's
+                                                        relationship to a set of values.
+                                                        Valid operators are In, NotIn,
+                                                        Exists, DoesNotExist. Gt,
+                                                        and Lt.
+                                                      type: string
+                                                    values:
+                                                      description: An array of string
+                                                        values. If the operator is
+                                                        In or NotIn, the values array
+                                                        must be non-empty. If the
+                                                        operator is Exists or DoesNotExist,
+                                                        the values array must be empty.
+                                                        If the operator is Gt or Lt,
+                                                        the values array must have
+                                                        a single element, which will
+                                                        be interpreted as an integer.
+                                                        This array is replaced during
+                                                        a strategic merge patch.
+                                                      items:
+                                                        type: string
+                                                      type: array
+                                                  required:
+                                                  - key
+                                                  - operator
+                                                  type: object
+                                                type: array
+                                              matchFields:
+                                                description: A list of node selector
+                                                  requirements by node's fields.
+                                                items:
+                                                  description: A node selector requirement
+                                                    is a selector that contains values,
+                                                    a key, and an operator that relates
+                                                    the key and values.
+                                                  properties:
+                                                    key:
+                                                      description: The label key that
+                                                        the selector applies to.
+                                                      type: string
+                                                    operator:
+                                                      description: Represents a key's
+                                                        relationship to a set of values.
+                                                        Valid operators are In, NotIn,
+                                                        Exists, DoesNotExist. Gt,
+                                                        and Lt.
+                                                      type: string
+                                                    values:
+                                                      description: An array of string
+                                                        values. If the operator is
+                                                        In or NotIn, the values array
+                                                        must be non-empty. If the
+                                                        operator is Exists or DoesNotExist,
+                                                        the values array must be empty.
+                                                        If the operator is Gt or Lt,
+                                                        the values array must have
+                                                        a single element, which will
+                                                        be interpreted as an integer.
+                                                        This array is replaced during
+                                                        a strategic merge patch.
+                                                      items:
+                                                        type: string
+                                                      type: array
+                                                  required:
+                                                  - key
+                                                  - operator
+                                                  type: object
+                                                type: array
+                                            type: object
+                                          weight:
+                                            description: Weight associated with matching
+                                              the corresponding nodeSelectorTerm,
+                                              in the range 1-100.
+                                            format: int32
+                                            type: integer
+                                        required:
+                                        - preference
+                                        - weight
+                                        type: object
+                                      type: array
+                                    requiredDuringSchedulingIgnoredDuringExecution:
+                                      description: If the affinity requirements specified
+                                        by this field are not met at scheduling time,
+                                        the pod will not be scheduled onto the node.
+                                        If the affinity requirements specified by
+                                        this field cease to be met at some point during
+                                        pod execution (e.g. due to an update), the
+                                        system may or may not try to eventually evict
+                                        the pod from its node.
+                                      properties:
+                                        nodeSelectorTerms:
+                                          description: Required. A list of node selector
+                                            terms. The terms are ORed.
+                                          items:
+                                            description: A null or empty node selector
+                                              term matches no objects. The requirements
+                                              of them are ANDed. The TopologySelectorTerm
+                                              type implements a subset of the NodeSelectorTerm.
+                                            properties:
+                                              matchExpressions:
+                                                description: A list of node selector
+                                                  requirements by node's labels.
+                                                items:
+                                                  description: A node selector requirement
+                                                    is a selector that contains values,
+                                                    a key, and an operator that relates
+                                                    the key and values.
+                                                  properties:
+                                                    key:
+                                                      description: The label key that
+                                                        the selector applies to.
+                                                      type: string
+                                                    operator:
+                                                      description: Represents a key's
+                                                        relationship to a set of values.
+                                                        Valid operators are In, NotIn,
+                                                        Exists, DoesNotExist. Gt,
+                                                        and Lt.
+                                                      type: string
+                                                    values:
+                                                      description: An array of string
+                                                        values. If the operator is
+                                                        In or NotIn, the values array
+                                                        must be non-empty. If the
+                                                        operator is Exists or DoesNotExist,
+                                                        the values array must be empty.
+                                                        If the operator is Gt or Lt,
+                                                        the values array must have
+                                                        a single element, which will
+                                                        be interpreted as an integer.
+                                                        This array is replaced during
+                                                        a strategic merge patch.
+                                                      items:
+                                                        type: string
+                                                      type: array
+                                                  required:
+                                                  - key
+                                                  - operator
+                                                  type: object
+                                                type: array
+                                              matchFields:
+                                                description: A list of node selector
+                                                  requirements by node's fields.
+                                                items:
+                                                  description: A node selector requirement
+                                                    is a selector that contains values,
+                                                    a key, and an operator that relates
+                                                    the key and values.
+                                                  properties:
+                                                    key:
+                                                      description: The label key that
+                                                        the selector applies to.
+                                                      type: string
+                                                    operator:
+                                                      description: Represents a key's
+                                                        relationship to a set of values.
+                                                        Valid operators are In, NotIn,
+                                                        Exists, DoesNotExist. Gt,
+                                                        and Lt.
+                                                      type: string
+                                                    values:
+                                                      description: An array of string
+                                                        values. If the operator is
+                                                        In or NotIn, the values array
+                                                        must be non-empty. If the
+                                                        operator is Exists or DoesNotExist,
+                                                        the values array must be empty.
+                                                        If the operator is Gt or Lt,
+                                                        the values array must have
+                                                        a single element, which will
+                                                        be interpreted as an integer.
+                                                        This array is replaced during
+                                                        a strategic merge patch.
+                                                      items:
+                                                        type: string
+                                                      type: array
+                                                  required:
+                                                  - key
+                                                  - operator
+                                                  type: object
+                                                type: array
+                                            type: object
+                                          type: array
+                                      required:
+                                      - nodeSelectorTerms
+                                      type: object
+                                  type: object
+                                podAffinity:
+                                  description: Describes pod affinity scheduling rules
+                                    (e.g. co-locate this pod in the same node, zone,
+                                    etc. as some other pod(s)).
+                                  properties:
+                                    preferredDuringSchedulingIgnoredDuringExecution:
+                                      description: The scheduler will prefer to schedule
+                                        pods to nodes that satisfy the affinity expressions
+                                        specified by this field, but it may choose
+                                        a node that violates one or more of the expressions.
+                                        The node that is most preferred is the one
+                                        with the greatest sum of weights, i.e. for
+                                        each node that meets all of the scheduling
+                                        requirements (resource request, requiredDuringScheduling
+                                        affinity expressions, etc.), compute a sum
+                                        by iterating through the elements of this
+                                        field and adding "weight" to the sum if the
+                                        node has pods which matches the corresponding
+                                        podAffinityTerm; the node(s) with the highest
+                                        sum are the most preferred.
+                                      items:
+                                        description: The weights of all of the matched
+                                          WeightedPodAffinityTerm fields are added
+                                          per-node to find the most preferred node(s)
+                                        properties:
+                                          podAffinityTerm:
+                                            description: Required. A pod affinity
+                                              term, associated with the corresponding
+                                              weight.
+                                            properties:
+                                              labelSelector:
+                                                description: A label query over a
+                                                  set of resources, in this case pods.
+                                                properties:
+                                                  matchExpressions:
+                                                    description: matchExpressions
+                                                      is a list of label selector
+                                                      requirements. The requirements
+                                                      are ANDed.
+                                                    items:
+                                                      description: A label selector
+                                                        requirement is a selector
+                                                        that contains values, a key,
+                                                        and an operator that relates
+                                                        the key and values.
+                                                      properties:
+                                                        key:
+                                                          description: key is the
+                                                            label key that the selector
+                                                            applies to.
+                                                          type: string
+                                                        operator:
+                                                          description: operator represents
+                                                            a key's relationship to
+                                                            a set of values. Valid
+                                                            operators are In, NotIn,
+                                                            Exists and DoesNotExist.
+                                                          type: string
+                                                        values:
+                                                          description: values is an
+                                                            array of string values.
+                                                            If the operator is In
+                                                            or NotIn, the values array
+                                                            must be non-empty. If
+                                                            the operator is Exists
+                                                            or DoesNotExist, the values
+                                                            array must be empty. This
+                                                            array is replaced during
+                                                            a strategic merge patch.
+                                                          items:
+                                                            type: string
+                                                          type: array
+                                                      required:
+                                                      - key
+                                                      - operator
+                                                      type: object
+                                                    type: array
+                                                  matchLabels:
+                                                    additionalProperties:
+                                                      type: string
+                                                    description: matchLabels is a
+                                                      map of {key,value} pairs. A
+                                                      single {key,value} in the matchLabels
+                                                      map is equivalent to an element
+                                                      of matchExpressions, whose key
+                                                      field is "key", the operator
+                                                      is "In", and the values array
+                                                      contains only "value". The requirements
+                                                      are ANDed.
+                                                    type: object
+                                                type: object
+                                              namespaces:
+                                                description: namespaces specifies
+                                                  which namespaces the labelSelector
+                                                  applies to (matches against); null
+                                                  or empty list means "this pod's
+                                                  namespace"
+                                                items:
+                                                  type: string
+                                                type: array
+                                              topologyKey:
+                                                description: This pod should be co-located
+                                                  (affinity) or not co-located (anti-affinity)
+                                                  with the pods matching the labelSelector
+                                                  in the specified namespaces, where
+                                                  co-located is defined as running
+                                                  on a node whose value of the label
+                                                  with key topologyKey matches that
+                                                  of any node on which any of the
+                                                  selected pods is running. Empty
+                                                  topologyKey is not allowed.
+                                                type: string
+                                            required:
+                                            - topologyKey
+                                            type: object
+                                          weight:
+                                            description: weight associated with matching
+                                              the corresponding podAffinityTerm, in
+                                              the range 1-100.
+                                            format: int32
+                                            type: integer
+                                        required:
+                                        - podAffinityTerm
+                                        - weight
+                                        type: object
+                                      type: array
+                                    requiredDuringSchedulingIgnoredDuringExecution:
+                                      description: If the affinity requirements specified
+                                        by this field are not met at scheduling time,
+                                        the pod will not be scheduled onto the node.
+                                        If the affinity requirements specified by
+                                        this field cease to be met at some point during
+                                        pod execution (e.g. due to a pod label update),
+                                        the system may or may not try to eventually
+                                        evict the pod from its node. When there are
+                                        multiple elements, the lists of nodes corresponding
+                                        to each podAffinityTerm are intersected, i.e.
+                                        all terms must be satisfied.
+                                      items:
+                                        description: Defines a set of pods (namely
+                                          those matching the labelSelector relative
+                                          to the given namespace(s)) that this pod
+                                          should be co-located (affinity) or not co-located
+                                          (anti-affinity) with, where co-located is
+                                          defined as running on a node whose value
+                                          of the label with key <topologyKey> matches
+                                          that of any node on which a pod of the set
+                                          of pods is running
+                                        properties:
+                                          labelSelector:
+                                            description: A label query over a set
+                                              of resources, in this case pods.
+                                            properties:
+                                              matchExpressions:
+                                                description: matchExpressions is a
+                                                  list of label selector requirements.
+                                                  The requirements are ANDed.
+                                                items:
+                                                  description: A label selector requirement
+                                                    is a selector that contains values,
+                                                    a key, and an operator that relates
+                                                    the key and values.
+                                                  properties:
+                                                    key:
+                                                      description: key is the label
+                                                        key that the selector applies
+                                                        to.
+                                                      type: string
+                                                    operator:
+                                                      description: operator represents
+                                                        a key's relationship to a
+                                                        set of values. Valid operators
+                                                        are In, NotIn, Exists and
+                                                        DoesNotExist.
+                                                      type: string
+                                                    values:
+                                                      description: values is an array
+                                                        of string values. If the operator
+                                                        is In or NotIn, the values
+                                                        array must be non-empty. If
+                                                        the operator is Exists or
+                                                        DoesNotExist, the values array
+                                                        must be empty. This array
+                                                        is replaced during a strategic
+                                                        merge patch.
+                                                      items:
+                                                        type: string
+                                                      type: array
+                                                  required:
+                                                  - key
+                                                  - operator
+                                                  type: object
+                                                type: array
+                                              matchLabels:
+                                                additionalProperties:
+                                                  type: string
+                                                description: matchLabels is a map
+                                                  of {key,value} pairs. A single {key,value}
+                                                  in the matchLabels map is equivalent
+                                                  to an element of matchExpressions,
+                                                  whose key field is "key", the operator
+                                                  is "In", and the values array contains
+                                                  only "value". The requirements are
+                                                  ANDed.
+                                                type: object
+                                            type: object
+                                          namespaces:
+                                            description: namespaces specifies which
+                                              namespaces the labelSelector applies
+                                              to (matches against); null or empty
+                                              list means "this pod's namespace"
+                                            items:
+                                              type: string
+                                            type: array
+                                          topologyKey:
+                                            description: This pod should be co-located
+                                              (affinity) or not co-located (anti-affinity)
+                                              with the pods matching the labelSelector
+                                              in the specified namespaces, where co-located
+                                              is defined as running on a node whose
+                                              value of the label with key topologyKey
+                                              matches that of any node on which any
+                                              of the selected pods is running. Empty
+                                              topologyKey is not allowed.
+                                            type: string
+                                        required:
+                                        - topologyKey
+                                        type: object
+                                      type: array
+                                  type: object
+                                podAntiAffinity:
+                                  description: Describes pod anti-affinity scheduling
+                                    rules (e.g. avoid putting this pod in the same
+                                    node, zone, etc. as some other pod(s)).
+                                  properties:
+                                    preferredDuringSchedulingIgnoredDuringExecution:
+                                      description: The scheduler will prefer to schedule
+                                        pods to nodes that satisfy the anti-affinity
+                                        expressions specified by this field, but it
+                                        may choose a node that violates one or more
+                                        of the expressions. The node that is most
+                                        preferred is the one with the greatest sum
+                                        of weights, i.e. for each node that meets
+                                        all of the scheduling requirements (resource
+                                        request, requiredDuringScheduling anti-affinity
+                                        expressions, etc.), compute a sum by iterating
+                                        through the elements of this field and adding
+                                        "weight" to the sum if the node has pods which
+                                        matches the corresponding podAffinityTerm;
+                                        the node(s) with the highest sum are the most
+                                        preferred.
+                                      items:
+                                        description: The weights of all of the matched
+                                          WeightedPodAffinityTerm fields are added
+                                          per-node to find the most preferred node(s)
+                                        properties:
+                                          podAffinityTerm:
+                                            description: Required. A pod affinity
+                                              term, associated with the corresponding
+                                              weight.
+                                            properties:
+                                              labelSelector:
+                                                description: A label query over a
+                                                  set of resources, in this case pods.
+                                                properties:
+                                                  matchExpressions:
+                                                    description: matchExpressions
+                                                      is a list of label selector
+                                                      requirements. The requirements
+                                                      are ANDed.
+                                                    items:
+                                                      description: A label selector
+                                                        requirement is a selector
+                                                        that contains values, a key,
+                                                        and an operator that relates
+                                                        the key and values.
+                                                      properties:
+                                                        key:
+                                                          description: key is the
+                                                            label key that the selector
+                                                            applies to.
+                                                          type: string
+                                                        operator:
+                                                          description: operator represents
+                                                            a key's relationship to
+                                                            a set of values. Valid
+                                                            operators are In, NotIn,
+                                                            Exists and DoesNotExist.
+                                                          type: string
+                                                        values:
+                                                          description: values is an
+                                                            array of string values.
+                                                            If the operator is In
+                                                            or NotIn, the values array
+                                                            must be non-empty. If
+                                                            the operator is Exists
+                                                            or DoesNotExist, the values
+                                                            array must be empty. This
+                                                            array is replaced during
+                                                            a strategic merge patch.
+                                                          items:
+                                                            type: string
+                                                          type: array
+                                                      required:
+                                                      - key
+                                                      - operator
+                                                      type: object
+                                                    type: array
+                                                  matchLabels:
+                                                    additionalProperties:
+                                                      type: string
+                                                    description: matchLabels is a
+                                                      map of {key,value} pairs. A
+                                                      single {key,value} in the matchLabels
+                                                      map is equivalent to an element
+                                                      of matchExpressions, whose key
+                                                      field is "key", the operator
+                                                      is "In", and the values array
+                                                      contains only "value". The requirements
+                                                      are ANDed.
+                                                    type: object
+                                                type: object
+                                              namespaces:
+                                                description: namespaces specifies
+                                                  which namespaces the labelSelector
+                                                  applies to (matches against); null
+                                                  or empty list means "this pod's
+                                                  namespace"
+                                                items:
+                                                  type: string
+                                                type: array
+                                              topologyKey:
+                                                description: This pod should be co-located
+                                                  (affinity) or not co-located (anti-affinity)
+                                                  with the pods matching the labelSelector
+                                                  in the specified namespaces, where
+                                                  co-located is defined as running
+                                                  on a node whose value of the label
+                                                  with key topologyKey matches that
+                                                  of any node on which any of the
+                                                  selected pods is running. Empty
+                                                  topologyKey is not allowed.
+                                                type: string
+                                            required:
+                                            - topologyKey
+                                            type: object
+                                          weight:
+                                            description: weight associated with matching
+                                              the corresponding podAffinityTerm, in
+                                              the range 1-100.
+                                            format: int32
+                                            type: integer
+                                        required:
+                                        - podAffinityTerm
+                                        - weight
+                                        type: object
+                                      type: array
+                                    requiredDuringSchedulingIgnoredDuringExecution:
+                                      description: If the anti-affinity requirements
+                                        specified by this field are not met at scheduling
+                                        time, the pod will not be scheduled onto the
+                                        node. If the anti-affinity requirements specified
+                                        by this field cease to be met at some point
+                                        during pod execution (e.g. due to a pod label
+                                        update), the system may or may not try to
+                                        eventually evict the pod from its node. When
+                                        there are multiple elements, the lists of
+                                        nodes corresponding to each podAffinityTerm
+                                        are intersected, i.e. all terms must be satisfied.
+                                      items:
+                                        description: Defines a set of pods (namely
+                                          those matching the labelSelector relative
+                                          to the given namespace(s)) that this pod
+                                          should be co-located (affinity) or not co-located
+                                          (anti-affinity) with, where co-located is
+                                          defined as running on a node whose value
+                                          of the label with key <topologyKey> matches
+                                          that of any node on which a pod of the set
+                                          of pods is running
+                                        properties:
+                                          labelSelector:
+                                            description: A label query over a set
+                                              of resources, in this case pods.
+                                            properties:
+                                              matchExpressions:
+                                                description: matchExpressions is a
+                                                  list of label selector requirements.
+                                                  The requirements are ANDed.
+                                                items:
+                                                  description: A label selector requirement
+                                                    is a selector that contains values,
+                                                    a key, and an operator that relates
+                                                    the key and values.
+                                                  properties:
+                                                    key:
+                                                      description: key is the label
+                                                        key that the selector applies
+                                                        to.
+                                                      type: string
+                                                    operator:
+                                                      description: operator represents
+                                                        a key's relationship to a
+                                                        set of values. Valid operators
+                                                        are In, NotIn, Exists and
+                                                        DoesNotExist.
+                                                      type: string
+                                                    values:
+                                                      description: values is an array
+                                                        of string values. If the operator
+                                                        is In or NotIn, the values
+                                                        array must be non-empty. If
+                                                        the operator is Exists or
+                                                        DoesNotExist, the values array
+                                                        must be empty. This array
+                                                        is replaced during a strategic
+                                                        merge patch.
+                                                      items:
+                                                        type: string
+                                                      type: array
+                                                  required:
+                                                  - key
+                                                  - operator
+                                                  type: object
+                                                type: array
+                                              matchLabels:
+                                                additionalProperties:
+                                                  type: string
+                                                description: matchLabels is a map
+                                                  of {key,value} pairs. A single {key,value}
+                                                  in the matchLabels map is equivalent
+                                                  to an element of matchExpressions,
+                                                  whose key field is "key", the operator
+                                                  is "In", and the values array contains
+                                                  only "value". The requirements are
+                                                  ANDed.
+                                                type: object
+                                            type: object
+                                          namespaces:
+                                            description: namespaces specifies which
+                                              namespaces the labelSelector applies
+                                              to (matches against); null or empty
+                                              list means "this pod's namespace"
+                                            items:
+                                              type: string
+                                            type: array
+                                          topologyKey:
+                                            description: This pod should be co-located
+                                              (affinity) or not co-located (anti-affinity)
+                                              with the pods matching the labelSelector
+                                              in the specified namespaces, where co-located
+                                              is defined as running on a node whose
+                                              value of the label with key topologyKey
+                                              matches that of any node on which any
+                                              of the selected pods is running. Empty
+                                              topologyKey is not allowed.
+                                            type: string
+                                        required:
+                                        - topologyKey
+                                        type: object
+                                      type: array
+                                  type: object
+                              type: object
+                            automountServiceAccountToken:
+                              description: AutomountServiceAccountToken indicates
+                                whether a service account token should be automatically
+                                mounted.
+                              type: boolean
+                            containers:
+                              description: List of containers belonging to the pod.
+                                Containers cannot currently be added or removed. There
+                                must be at least one container in a Pod. Cannot be
+                                updated.
+                              items:
+                                description: A single application container that you
+                                  want to run within a pod.
+                                properties:
+                                  args:
+                                    description: 'Arguments to the entrypoint. The
+                                      docker image''s CMD is used if this is not provided.
+                                      Variable references $(VAR_NAME) are expanded
+                                      using the container''s environment. If a variable
+                                      cannot be resolved, the reference in the input
+                                      string will be unchanged. The $(VAR_NAME) syntax
+                                      can be escaped with a double $$, ie: $$(VAR_NAME).
+                                      Escaped references will never be expanded, regardless
+                                      of whether the variable exists or not. Cannot
+                                      be updated. More info: https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell'
+                                    items:
+                                      type: string
+                                    type: array
+                                  command:
+                                    description: 'Entrypoint array. Not executed within
+                                      a shell. The docker image''s ENTRYPOINT is used
+                                      if this is not provided. Variable references
+                                      $(VAR_NAME) are expanded using the container''s
+                                      environment. If a variable cannot be resolved,
+                                      the reference in the input string will be unchanged.
+                                      The $(VAR_NAME) syntax can be escaped with a
+                                      double $$, ie: $$(VAR_NAME). Escaped references
+                                      will never be expanded, regardless of whether
+                                      the variable exists or not. Cannot be updated.
+                                      More info: https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell'
+                                    items:
+                                      type: string
+                                    type: array
+                                  env:
+                                    description: List of environment variables to
+                                      set in the container. Cannot be updated.
+                                    items:
+                                      description: EnvVar represents an environment
+                                        variable present in a Container.
+                                      properties:
+                                        name:
+                                          description: Name of the environment variable.
+                                            Must be a C_IDENTIFIER.
+                                          type: string
+                                        value:
+                                          description: 'Variable references $(VAR_NAME)
+                                            are expanded using the previous defined
+                                            environment variables in the container
+                                            and any service environment variables.
+                                            If a variable cannot be resolved, the
+                                            reference in the input string will be
+                                            unchanged. The $(VAR_NAME) syntax can
+                                            be escaped with a double $$, ie: $$(VAR_NAME).
+                                            Escaped references will never be expanded,
+                                            regardless of whether the variable exists
+                                            or not. Defaults to "".'
+                                          type: string
+                                        valueFrom:
+                                          description: Source for the environment
+                                            variable's value. Cannot be used if value
+                                            is not empty.
+                                          properties:
+                                            configMapKeyRef:
+                                              description: Selects a key of a ConfigMap.
+                                              properties:
+                                                key:
+                                                  description: The key to select.
+                                                  type: string
+                                                name:
+                                                  description: 'Name of the referent.
+                                                    More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                                    TODO: Add other useful fields.
+                                                    apiVersion, kind, uid?'
+                                                  type: string
+                                                optional:
+                                                  description: Specify whether the
+                                                    ConfigMap or its key must be defined
+                                                  type: boolean
+                                              required:
+                                              - key
+                                              type: object
+                                            fieldRef:
+                                              description: 'Selects a field of the
+                                                pod: supports metadata.name, metadata.namespace,
+                                                metadata.labels, metadata.annotations,
+                                                spec.nodeName, spec.serviceAccountName,
+                                                status.hostIP, status.podIP, status.podIPs.'
+                                              properties:
+                                                apiVersion:
+                                                  description: Version of the schema
+                                                    the FieldPath is written in terms
+                                                    of, defaults to "v1".
+                                                  type: string
+                                                fieldPath:
+                                                  description: Path of the field to
+                                                    select in the specified API version.
+                                                  type: string
+                                              required:
+                                              - fieldPath
+                                              type: object
+                                            resourceFieldRef:
+                                              description: 'Selects a resource of
+                                                the container: only resources limits
+                                                and requests (limits.cpu, limits.memory,
+                                                limits.ephemeral-storage, requests.cpu,
+                                                requests.memory and requests.ephemeral-storage)
+                                                are currently supported.'
+                                              properties:
+                                                containerName:
+                                                  description: 'Container name: required
+                                                    for volumes, optional for env
+                                                    vars'
+                                                  type: string
+                                                divisor:
+                                                  anyOf:
+                                                  - type: integer
+                                                  - type: string
+                                                  description: Specifies the output
+                                                    format of the exposed resources,
+                                                    defaults to "1"
+                                                  pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                                  x-kubernetes-int-or-string: true
+                                                resource:
+                                                  description: 'Required: resource
+                                                    to select'
+                                                  type: string
+                                              required:
+                                              - resource
+                                              type: object
+                                            secretKeyRef:
+                                              description: Selects a key of a secret
+                                                in the pod's namespace
+                                              properties:
+                                                key:
+                                                  description: The key of the secret
+                                                    to select from.  Must be a valid
+                                                    secret key.
+                                                  type: string
+                                                name:
+                                                  description: 'Name of the referent.
+                                                    More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                                    TODO: Add other useful fields.
+                                                    apiVersion, kind, uid?'
+                                                  type: string
+                                                optional:
+                                                  description: Specify whether the
+                                                    Secret or its key must be defined
+                                                  type: boolean
+                                              required:
+                                              - key
+                                              type: object
+                                          type: object
+                                      required:
+                                      - name
+                                      type: object
+                                    type: array
+                                  envFrom:
+                                    description: List of sources to populate environment
+                                      variables in the container. The keys defined
+                                      within a source must be a C_IDENTIFIER. All
+                                      invalid keys will be reported as an event when
+                                      the container is starting. When a key exists
+                                      in multiple sources, the value associated with
+                                      the last source will take precedence. Values
+                                      defined by an Env with a duplicate key will
+                                      take precedence. Cannot be updated.
+                                    items:
+                                      description: EnvFromSource represents the source
+                                        of a set of ConfigMaps
+                                      properties:
+                                        configMapRef:
+                                          description: The ConfigMap to select from
+                                          properties:
+                                            name:
+                                              description: 'Name of the referent.
+                                                More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                                TODO: Add other useful fields. apiVersion,
+                                                kind, uid?'
+                                              type: string
+                                            optional:
+                                              description: Specify whether the ConfigMap
+                                                must be defined
+                                              type: boolean
+                                          type: object
+                                        prefix:
+                                          description: An optional identifier to prepend
+                                            to each key in the ConfigMap. Must be
+                                            a C_IDENTIFIER.
+                                          type: string
+                                        secretRef:
+                                          description: The Secret to select from
+                                          properties:
+                                            name:
+                                              description: 'Name of the referent.
+                                                More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                                TODO: Add other useful fields. apiVersion,
+                                                kind, uid?'
+                                              type: string
+                                            optional:
+                                              description: Specify whether the Secret
+                                                must be defined
+                                              type: boolean
+                                          type: object
+                                      type: object
+                                    type: array
+                                  image:
+                                    description: 'Docker image name. More info: https://kubernetes.io/docs/concepts/containers/images
+                                      This field is optional to allow higher level
+                                      config management to default or override container
+                                      images in workload controllers like Deployments
+                                      and StatefulSets.'
+                                    type: string
+                                  imagePullPolicy:
+                                    description: 'Image pull policy. One of Always,
+                                      Never, IfNotPresent. Defaults to Always if :latest
+                                      tag is specified, or IfNotPresent otherwise.
+                                      Cannot be updated. More info: https://kubernetes.io/docs/concepts/containers/images#updating-images'
+                                    type: string
+                                  lifecycle:
+                                    description: Actions that the management system
+                                      should take in response to container lifecycle
+                                      events. Cannot be updated.
+                                    properties:
+                                      postStart:
+                                        description: 'PostStart is called immediately
+                                          after a container is created. If the handler
+                                          fails, the container is terminated and restarted
+                                          according to its restart policy. Other management
+                                          of the container blocks until the hook completes.
+                                          More info: https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/#container-hooks'
+                                        properties:
+                                          exec:
+                                            description: One and only one of the following
+                                              should be specified. Exec specifies
+                                              the action to take.
+                                            properties:
+                                              command:
+                                                description: Command is the command
+                                                  line to execute inside the container,
+                                                  the working directory for the command  is
+                                                  root ('/') in the container's filesystem.
+                                                  The command is simply exec'd, it
+                                                  is not run inside a shell, so traditional
+                                                  shell instructions ('|', etc) won't
+                                                  work. To use a shell, you need to
+                                                  explicitly call out to that shell.
+                                                  Exit status of 0 is treated as live/healthy
+                                                  and non-zero is unhealthy.
+                                                items:
+                                                  type: string
+                                                type: array
+                                            type: object
+                                          httpGet:
+                                            description: HTTPGet specifies the http
+                                              request to perform.
+                                            properties:
+                                              host:
+                                                description: Host name to connect
+                                                  to, defaults to the pod IP. You
+                                                  probably want to set "Host" in httpHeaders
+                                                  instead.
+                                                type: string
+                                              httpHeaders:
+                                                description: Custom headers to set
+                                                  in the request. HTTP allows repeated
+                                                  headers.
+                                                items:
+                                                  description: HTTPHeader describes
+                                                    a custom header to be used in
+                                                    HTTP probes
+                                                  properties:
+                                                    name:
+                                                      description: The header field
+                                                        name
+                                                      type: string
+                                                    value:
+                                                      description: The header field
+                                                        value
+                                                      type: string
+                                                  required:
+                                                  - name
+                                                  - value
+                                                  type: object
+                                                type: array
+                                              path:
+                                                description: Path to access on the
+                                                  HTTP server.
+                                                type: string
+                                              port:
+                                                description: Name or number of the
+                                                  port to access on the container.
+                                                  Number must be in the range 1 to
+                                                  65535. Name must be an IANA_SVC_NAME.
+                                                x-kubernetes-int-or-string: true
+                                              scheme:
+                                                description: Scheme to use for connecting
+                                                  to the host. Defaults to HTTP.
+                                                type: string
+                                            required:
+                                            - port
+                                            type: object
+                                          tcpSocket:
+                                            description: 'TCPSocket specifies an action
+                                              involving a TCP port. TCP hooks not
+                                              yet supported TODO: implement a realistic
+                                              TCP lifecycle hook'
+                                            properties:
+                                              host:
+                                                description: 'Optional: Host name
+                                                  to connect to, defaults to the pod
+                                                  IP.'
+                                                type: string
+                                              port:
+                                                description: Number or name of the
+                                                  port to access on the container.
+                                                  Number must be in the range 1 to
+                                                  65535. Name must be an IANA_SVC_NAME.
+                                                x-kubernetes-int-or-string: true
+                                            required:
+                                            - port
+                                            type: object
+                                        type: object
+                                      preStop:
+                                        description: 'PreStop is called immediately
+                                          before a container is terminated due to
+                                          an API request or management event such
+                                          as liveness/startup probe failure, preemption,
+                                          resource contention, etc. The handler is
+                                          not called if the container crashes or exits.
+                                          The reason for termination is passed to
+                                          the handler. The Pod''s termination grace
+                                          period countdown begins before the PreStop
+                                          hooked is executed. Regardless of the outcome
+                                          of the handler, the container will eventually
+                                          terminate within the Pod''s termination
+                                          grace period. Other management of the container
+                                          blocks until the hook completes or until
+                                          the termination grace period is reached.
+                                          More info: https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/#container-hooks'
+                                        properties:
+                                          exec:
+                                            description: One and only one of the following
+                                              should be specified. Exec specifies
+                                              the action to take.
+                                            properties:
+                                              command:
+                                                description: Command is the command
+                                                  line to execute inside the container,
+                                                  the working directory for the command  is
+                                                  root ('/') in the container's filesystem.
+                                                  The command is simply exec'd, it
+                                                  is not run inside a shell, so traditional
+                                                  shell instructions ('|', etc) won't
+                                                  work. To use a shell, you need to
+                                                  explicitly call out to that shell.
+                                                  Exit status of 0 is treated as live/healthy
+                                                  and non-zero is unhealthy.
+                                                items:
+                                                  type: string
+                                                type: array
+                                            type: object
+                                          httpGet:
+                                            description: HTTPGet specifies the http
+                                              request to perform.
+                                            properties:
+                                              host:
+                                                description: Host name to connect
+                                                  to, defaults to the pod IP. You
+                                                  probably want to set "Host" in httpHeaders
+                                                  instead.
+                                                type: string
+                                              httpHeaders:
+                                                description: Custom headers to set
+                                                  in the request. HTTP allows repeated
+                                                  headers.
+                                                items:
+                                                  description: HTTPHeader describes
+                                                    a custom header to be used in
+                                                    HTTP probes
+                                                  properties:
+                                                    name:
+                                                      description: The header field
+                                                        name
+                                                      type: string
+                                                    value:
+                                                      description: The header field
+                                                        value
+                                                      type: string
+                                                  required:
+                                                  - name
+                                                  - value
+                                                  type: object
+                                                type: array
+                                              path:
+                                                description: Path to access on the
+                                                  HTTP server.
+                                                type: string
+                                              port:
+                                                description: Name or number of the
+                                                  port to access on the container.
+                                                  Number must be in the range 1 to
+                                                  65535. Name must be an IANA_SVC_NAME.
+                                                x-kubernetes-int-or-string: true
+                                              scheme:
+                                                description: Scheme to use for connecting
+                                                  to the host. Defaults to HTTP.
+                                                type: string
+                                            required:
+                                            - port
+                                            type: object
+                                          tcpSocket:
+                                            description: 'TCPSocket specifies an action
+                                              involving a TCP port. TCP hooks not
+                                              yet supported TODO: implement a realistic
+                                              TCP lifecycle hook'
+                                            properties:
+                                              host:
+                                                description: 'Optional: Host name
+                                                  to connect to, defaults to the pod
+                                                  IP.'
+                                                type: string
+                                              port:
+                                                description: Number or name of the
+                                                  port to access on the container.
+                                                  Number must be in the range 1 to
+                                                  65535. Name must be an IANA_SVC_NAME.
+                                                x-kubernetes-int-or-string: true
+                                            required:
+                                            - port
+                                            type: object
+                                        type: object
+                                    type: object
+                                  livenessProbe:
+                                    description: 'Periodic probe of container liveness.
+                                      Container will be restarted if the probe fails.
+                                      Cannot be updated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                                    properties:
+                                      exec:
+                                        description: One and only one of the following
+                                          should be specified. Exec specifies the
+                                          action to take.
+                                        properties:
+                                          command:
+                                            description: Command is the command line
+                                              to execute inside the container, the
+                                              working directory for the command  is
+                                              root ('/') in the container's filesystem.
+                                              The command is simply exec'd, it is
+                                              not run inside a shell, so traditional
+                                              shell instructions ('|', etc) won't
+                                              work. To use a shell, you need to explicitly
+                                              call out to that shell. Exit status
+                                              of 0 is treated as live/healthy and
+                                              non-zero is unhealthy.
+                                            items:
+                                              type: string
+                                            type: array
+                                        type: object
+                                      failureThreshold:
+                                        description: Minimum consecutive failures
+                                          for the probe to be considered failed after
+                                          having succeeded. Defaults to 3. Minimum
+                                          value is 1.
+                                        format: int32
+                                        type: integer
+                                      httpGet:
+                                        description: HTTPGet specifies the http request
+                                          to perform.
+                                        properties:
+                                          host:
+                                            description: Host name to connect to,
+                                              defaults to the pod IP. You probably
+                                              want to set "Host" in httpHeaders instead.
+                                            type: string
+                                          httpHeaders:
+                                            description: Custom headers to set in
+                                              the request. HTTP allows repeated headers.
+                                            items:
+                                              description: HTTPHeader describes a
+                                                custom header to be used in HTTP probes
+                                              properties:
+                                                name:
+                                                  description: The header field name
+                                                  type: string
+                                                value:
+                                                  description: The header field value
+                                                  type: string
+                                              required:
+                                              - name
+                                              - value
+                                              type: object
+                                            type: array
+                                          path:
+                                            description: Path to access on the HTTP
+                                              server.
+                                            type: string
+                                          port:
+                                            description: Name or number of the port
+                                              to access on the container. Number must
+                                              be in the range 1 to 65535. Name must
+                                              be an IANA_SVC_NAME.
+                                            x-kubernetes-int-or-string: true
+                                          scheme:
+                                            description: Scheme to use for connecting
+                                              to the host. Defaults to HTTP.
+                                            type: string
+                                        required:
+                                        - port
+                                        type: object
+                                      initialDelaySeconds:
+                                        description: 'Number of seconds after the
+                                          container has started before liveness probes
+                                          are initiated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                                        format: int32
+                                        type: integer
+                                      periodSeconds:
+                                        description: How often (in seconds) to perform
+                                          the probe. Default to 10 seconds. Minimum
+                                          value is 1.
+                                        format: int32
+                                        type: integer
+                                      successThreshold:
+                                        description: Minimum consecutive successes
+                                          for the probe to be considered successful
+                                          after having failed. Defaults to 1. Must
+                                          be 1 for liveness and startup. Minimum value
+                                          is 1.
+                                        format: int32
+                                        type: integer
+                                      tcpSocket:
+                                        description: 'TCPSocket specifies an action
+                                          involving a TCP port. TCP hooks not yet
+                                          supported TODO: implement a realistic TCP
+                                          lifecycle hook'
+                                        properties:
+                                          host:
+                                            description: 'Optional: Host name to connect
+                                              to, defaults to the pod IP.'
+                                            type: string
+                                          port:
+                                            description: Number or name of the port
+                                              to access on the container. Number must
+                                              be in the range 1 to 65535. Name must
+                                              be an IANA_SVC_NAME.
+                                            x-kubernetes-int-or-string: true
+                                        required:
+                                        - port
+                                        type: object
+                                      timeoutSeconds:
+                                        description: 'Number of seconds after which
+                                          the probe times out. Defaults to 1 second.
+                                          Minimum value is 1. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                                        format: int32
+                                        type: integer
+                                    type: object
+                                  name:
+                                    description: Name of the container specified as
+                                      a DNS_LABEL. Each container in a pod must have
+                                      a unique name (DNS_LABEL). Cannot be updated.
+                                    type: string
+                                  ports:
+                                    description: List of ports to expose from the
+                                      container. Exposing a port here gives the system
+                                      additional information about the network connections
+                                      a container uses, but is primarily informational.
+                                      Not specifying a port here DOES NOT prevent
+                                      that port from being exposed. Any port which
+                                      is listening on the default "0.0.0.0" address
+                                      inside a container will be accessible from the
+                                      network. Cannot be updated.
+                                    items:
+                                      description: ContainerPort represents a network
+                                        port in a single container.
+                                      properties:
+                                        containerPort:
+                                          description: Number of port to expose on
+                                            the pod's IP address. This must be a valid
+                                            port number, 0 < x < 65536.
+                                          format: int32
+                                          type: integer
+                                        hostIP:
+                                          description: What host IP to bind the external
+                                            port to.
+                                          type: string
+                                        hostPort:
+                                          description: Number of port to expose on
+                                            the host. If specified, this must be a
+                                            valid port number, 0 < x < 65536. If HostNetwork
+                                            is specified, this must match ContainerPort.
+                                            Most containers do not need this.
+                                          format: int32
+                                          type: integer
+                                        name:
+                                          description: If specified, this must be
+                                            an IANA_SVC_NAME and unique within the
+                                            pod. Each named port in a pod must have
+                                            a unique name. Name for the port that
+                                            can be referred to by services.
+                                          type: string
+                                        protocol:
+                                          description: Protocol for port. Must be
+                                            UDP, TCP, or SCTP. Defaults to "TCP".
+                                          type: string
+                                      required:
+                                      - containerPort
+                                      type: object
+                                    type: array
+                                    x-kubernetes-list-map-keys:
+                                    - containerPort
+                                    - protocol
+                                    x-kubernetes-list-type: map
+                                  readinessProbe:
+                                    description: 'Periodic probe of container service
+                                      readiness. Container will be removed from service
+                                      endpoints if the probe fails. Cannot be updated.
+                                      More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                                    properties:
+                                      exec:
+                                        description: One and only one of the following
+                                          should be specified. Exec specifies the
+                                          action to take.
+                                        properties:
+                                          command:
+                                            description: Command is the command line
+                                              to execute inside the container, the
+                                              working directory for the command  is
+                                              root ('/') in the container's filesystem.
+                                              The command is simply exec'd, it is
+                                              not run inside a shell, so traditional
+                                              shell instructions ('|', etc) won't
+                                              work. To use a shell, you need to explicitly
+                                              call out to that shell. Exit status
+                                              of 0 is treated as live/healthy and
+                                              non-zero is unhealthy.
+                                            items:
+                                              type: string
+                                            type: array
+                                        type: object
+                                      failureThreshold:
+                                        description: Minimum consecutive failures
+                                          for the probe to be considered failed after
+                                          having succeeded. Defaults to 3. Minimum
+                                          value is 1.
+                                        format: int32
+                                        type: integer
+                                      httpGet:
+                                        description: HTTPGet specifies the http request
+                                          to perform.
+                                        properties:
+                                          host:
+                                            description: Host name to connect to,
+                                              defaults to the pod IP. You probably
+                                              want to set "Host" in httpHeaders instead.
+                                            type: string
+                                          httpHeaders:
+                                            description: Custom headers to set in
+                                              the request. HTTP allows repeated headers.
+                                            items:
+                                              description: HTTPHeader describes a
+                                                custom header to be used in HTTP probes
+                                              properties:
+                                                name:
+                                                  description: The header field name
+                                                  type: string
+                                                value:
+                                                  description: The header field value
+                                                  type: string
+                                              required:
+                                              - name
+                                              - value
+                                              type: object
+                                            type: array
+                                          path:
+                                            description: Path to access on the HTTP
+                                              server.
+                                            type: string
+                                          port:
+                                            description: Name or number of the port
+                                              to access on the container. Number must
+                                              be in the range 1 to 65535. Name must
+                                              be an IANA_SVC_NAME.
+                                            x-kubernetes-int-or-string: true
+                                          scheme:
+                                            description: Scheme to use for connecting
+                                              to the host. Defaults to HTTP.
+                                            type: string
+                                        required:
+                                        - port
+                                        type: object
+                                      initialDelaySeconds:
+                                        description: 'Number of seconds after the
+                                          container has started before liveness probes
+                                          are initiated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                                        format: int32
+                                        type: integer
+                                      periodSeconds:
+                                        description: How often (in seconds) to perform
+                                          the probe. Default to 10 seconds. Minimum
+                                          value is 1.
+                                        format: int32
+                                        type: integer
+                                      successThreshold:
+                                        description: Minimum consecutive successes
+                                          for the probe to be considered successful
+                                          after having failed. Defaults to 1. Must
+                                          be 1 for liveness and startup. Minimum value
+                                          is 1.
+                                        format: int32
+                                        type: integer
+                                      tcpSocket:
+                                        description: 'TCPSocket specifies an action
+                                          involving a TCP port. TCP hooks not yet
+                                          supported TODO: implement a realistic TCP
+                                          lifecycle hook'
+                                        properties:
+                                          host:
+                                            description: 'Optional: Host name to connect
+                                              to, defaults to the pod IP.'
+                                            type: string
+                                          port:
+                                            description: Number or name of the port
+                                              to access on the container. Number must
+                                              be in the range 1 to 65535. Name must
+                                              be an IANA_SVC_NAME.
+                                            x-kubernetes-int-or-string: true
+                                        required:
+                                        - port
+                                        type: object
+                                      timeoutSeconds:
+                                        description: 'Number of seconds after which
+                                          the probe times out. Defaults to 1 second.
+                                          Minimum value is 1. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                                        format: int32
+                                        type: integer
+                                    type: object
+                                  resources:
+                                    description: 'Compute Resources required by this
+                                      container. Cannot be updated. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
+                                    properties:
+                                      limits:
+                                        additionalProperties:
+                                          anyOf:
+                                          - type: integer
+                                          - type: string
+                                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                          x-kubernetes-int-or-string: true
+                                        description: 'Limits describes the maximum
+                                          amount of compute resources allowed. More
+                                          info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
+                                        type: object
+                                      requests:
+                                        additionalProperties:
+                                          anyOf:
+                                          - type: integer
+                                          - type: string
+                                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                          x-kubernetes-int-or-string: true
+                                        description: 'Requests describes the minimum
+                                          amount of compute resources required. If
+                                          Requests is omitted for a container, it
+                                          defaults to Limits if that is explicitly
+                                          specified, otherwise to an implementation-defined
+                                          value. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
+                                        type: object
+                                    type: object
+                                  securityContext:
+                                    description: 'Security options the pod should
+                                      run with. More info: https://kubernetes.io/docs/concepts/policy/security-context/
+                                      More info: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/'
+                                    properties:
+                                      allowPrivilegeEscalation:
+                                        description: 'AllowPrivilegeEscalation controls
+                                          whether a process can gain more privileges
+                                          than its parent process. This bool directly
+                                          controls if the no_new_privs flag will be
+                                          set on the container process. AllowPrivilegeEscalation
+                                          is true always when the container is: 1)
+                                          run as Privileged 2) has CAP_SYS_ADMIN'
+                                        type: boolean
+                                      capabilities:
+                                        description: The capabilities to add/drop
+                                          when running containers. Defaults to the
+                                          default set of capabilities granted by the
+                                          container runtime.
+                                        properties:
+                                          add:
+                                            description: Added capabilities
+                                            items:
+                                              description: Capability represent POSIX
+                                                capabilities type
+                                              type: string
+                                            type: array
+                                          drop:
+                                            description: Removed capabilities
+                                            items:
+                                              description: Capability represent POSIX
+                                                capabilities type
+                                              type: string
+                                            type: array
+                                        type: object
+                                      privileged:
+                                        description: Run container in privileged mode.
+                                          Processes in privileged containers are essentially
+                                          equivalent to root on the host. Defaults
+                                          to false.
+                                        type: boolean
+                                      procMount:
+                                        description: procMount denotes the type of
+                                          proc mount to use for the containers. The
+                                          default is DefaultProcMount which uses the
+                                          container runtime defaults for readonly
+                                          paths and masked paths. This requires the
+                                          ProcMountType feature flag to be enabled.
+                                        type: string
+                                      readOnlyRootFilesystem:
+                                        description: Whether this container has a
+                                          read-only root filesystem. Default is false.
+                                        type: boolean
+                                      runAsGroup:
+                                        description: The GID to run the entrypoint
+                                          of the container process. Uses runtime default
+                                          if unset. May also be set in PodSecurityContext.  If
+                                          set in both SecurityContext and PodSecurityContext,
+                                          the value specified in SecurityContext takes
+                                          precedence.
+                                        format: int64
+                                        type: integer
+                                      runAsNonRoot:
+                                        description: Indicates that the container
+                                          must run as a non-root user. If true, the
+                                          Kubelet will validate the image at runtime
+                                          to ensure that it does not run as UID 0
+                                          (root) and fail to start the container if
+                                          it does. If unset or false, no such validation
+                                          will be performed. May also be set in PodSecurityContext.  If
+                                          set in both SecurityContext and PodSecurityContext,
+                                          the value specified in SecurityContext takes
+                                          precedence.
+                                        type: boolean
+                                      runAsUser:
+                                        description: The UID to run the entrypoint
+                                          of the container process. Defaults to user
+                                          specified in image metadata if unspecified.
+                                          May also be set in PodSecurityContext.  If
+                                          set in both SecurityContext and PodSecurityContext,
+                                          the value specified in SecurityContext takes
+                                          precedence.
+                                        format: int64
+                                        type: integer
+                                      seLinuxOptions:
+                                        description: The SELinux context to be applied
+                                          to the container. If unspecified, the container
+                                          runtime will allocate a random SELinux context
+                                          for each container.  May also be set in
+                                          PodSecurityContext.  If set in both SecurityContext
+                                          and PodSecurityContext, the value specified
+                                          in SecurityContext takes precedence.
+                                        properties:
+                                          level:
+                                            description: Level is SELinux level label
+                                              that applies to the container.
+                                            type: string
+                                          role:
+                                            description: Role is a SELinux role label
+                                              that applies to the container.
+                                            type: string
+                                          type:
+                                            description: Type is a SELinux type label
+                                              that applies to the container.
+                                            type: string
+                                          user:
+                                            description: User is a SELinux user label
+                                              that applies to the container.
+                                            type: string
+                                        type: object
+                                      windowsOptions:
+                                        description: The Windows specific settings
+                                          applied to all containers. If unspecified,
+                                          the options from the PodSecurityContext
+                                          will be used. If set in both SecurityContext
+                                          and PodSecurityContext, the value specified
+                                          in SecurityContext takes precedence.
+                                        properties:
+                                          gmsaCredentialSpec:
+                                            description: GMSACredentialSpec is where
+                                              the GMSA admission webhook (https://github.com/kubernetes-sigs/windows-gmsa)
+                                              inlines the contents of the GMSA credential
+                                              spec named by the GMSACredentialSpecName
+                                              field. This field is alpha-level and
+                                              is only honored by servers that enable
+                                              the WindowsGMSA feature flag.
+                                            type: string
+                                          gmsaCredentialSpecName:
+                                            description: GMSACredentialSpecName is
+                                              the name of the GMSA credential spec
+                                              to use. This field is alpha-level and
+                                              is only honored by servers that enable
+                                              the WindowsGMSA feature flag.
+                                            type: string
+                                          runAsUserName:
+                                            description: The UserName in Windows to
+                                              run the entrypoint of the container
+                                              process. Defaults to the user specified
+                                              in image metadata if unspecified. May
+                                              also be set in PodSecurityContext. If
+                                              set in both SecurityContext and PodSecurityContext,
+                                              the value specified in SecurityContext
+                                              takes precedence. This field is beta-level
+                                              and may be disabled with the WindowsRunAsUserName
+                                              feature flag.
+                                            type: string
+                                        type: object
+                                    type: object
+                                  startupProbe:
+                                    description: 'StartupProbe indicates that the
+                                      Pod has successfully initialized. If specified,
+                                      no other probes are executed until this completes
+                                      successfully. If this probe fails, the Pod will
+                                      be restarted, just as if the livenessProbe failed.
+                                      This can be used to provide different probe
+                                      parameters at the beginning of a Pod''s lifecycle,
+                                      when it might take a long time to load data
+                                      or warm a cache, than during steady-state operation.
+                                      This cannot be updated. This is an alpha feature
+                                      enabled by the StartupProbe feature flag. More
+                                      info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                                    properties:
+                                      exec:
+                                        description: One and only one of the following
+                                          should be specified. Exec specifies the
+                                          action to take.
+                                        properties:
+                                          command:
+                                            description: Command is the command line
+                                              to execute inside the container, the
+                                              working directory for the command  is
+                                              root ('/') in the container's filesystem.
+                                              The command is simply exec'd, it is
+                                              not run inside a shell, so traditional
+                                              shell instructions ('|', etc) won't
+                                              work. To use a shell, you need to explicitly
+                                              call out to that shell. Exit status
+                                              of 0 is treated as live/healthy and
+                                              non-zero is unhealthy.
+                                            items:
+                                              type: string
+                                            type: array
+                                        type: object
+                                      failureThreshold:
+                                        description: Minimum consecutive failures
+                                          for the probe to be considered failed after
+                                          having succeeded. Defaults to 3. Minimum
+                                          value is 1.
+                                        format: int32
+                                        type: integer
+                                      httpGet:
+                                        description: HTTPGet specifies the http request
+                                          to perform.
+                                        properties:
+                                          host:
+                                            description: Host name to connect to,
+                                              defaults to the pod IP. You probably
+                                              want to set "Host" in httpHeaders instead.
+                                            type: string
+                                          httpHeaders:
+                                            description: Custom headers to set in
+                                              the request. HTTP allows repeated headers.
+                                            items:
+                                              description: HTTPHeader describes a
+                                                custom header to be used in HTTP probes
+                                              properties:
+                                                name:
+                                                  description: The header field name
+                                                  type: string
+                                                value:
+                                                  description: The header field value
+                                                  type: string
+                                              required:
+                                              - name
+                                              - value
+                                              type: object
+                                            type: array
+                                          path:
+                                            description: Path to access on the HTTP
+                                              server.
+                                            type: string
+                                          port:
+                                            anyOf:
+                                            - type: integer
+                                            - type: string
+                                            description: Name or number of the port
+                                              to access on the container. Number must
+                                              be in the range 1 to 65535. Name must
+                                              be an IANA_SVC_NAME.
+                                            x-kubernetes-int-or-string: true
+                                          scheme:
+                                            description: Scheme to use for connecting
+                                              to the host. Defaults to HTTP.
+                                            type: string
+                                        required:
+                                        - port
+                                        type: object
+                                      initialDelaySeconds:
+                                        description: 'Number of seconds after the
+                                          container has started before liveness probes
+                                          are initiated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                                        format: int32
+                                        type: integer
+                                      periodSeconds:
+                                        description: How often (in seconds) to perform
+                                          the probe. Default to 10 seconds. Minimum
+                                          value is 1.
+                                        format: int32
+                                        type: integer
+                                      successThreshold:
+                                        description: Minimum consecutive successes
+                                          for the probe to be considered successful
+                                          after having failed. Defaults to 1. Must
+                                          be 1 for liveness and startup. Minimum value
+                                          is 1.
+                                        format: int32
+                                        type: integer
+                                      tcpSocket:
+                                        description: 'TCPSocket specifies an action
+                                          involving a TCP port. TCP hooks not yet
+                                          supported TODO: implement a realistic TCP
+                                          lifecycle hook'
+                                        properties:
+                                          host:
+                                            description: 'Optional: Host name to connect
+                                              to, defaults to the pod IP.'
+                                            type: string
+                                          port:
+                                            anyOf:
+                                            - type: integer
+                                            - type: string
+                                            description: Number or name of the port
+                                              to access on the container. Number must
+                                              be in the range 1 to 65535. Name must
+                                              be an IANA_SVC_NAME.
+                                            x-kubernetes-int-or-string: true
+                                        required:
+                                        - port
+                                        type: object
+                                      timeoutSeconds:
+                                        description: 'Number of seconds after which
+                                          the probe times out. Defaults to 1 second.
+                                          Minimum value is 1. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                                        format: int32
+                                        type: integer
+                                    type: object
+                                  stdin:
+                                    description: Whether this container should allocate
+                                      a buffer for stdin in the container runtime.
+                                      If this is not set, reads from stdin in the
+                                      container will always result in EOF. Default
+                                      is false.
+                                    type: boolean
+                                  stdinOnce:
+                                    description: Whether the container runtime should
+                                      close the stdin channel after it has been opened
+                                      by a single attach. When stdin is true the stdin
+                                      stream will remain open across multiple attach
+                                      sessions. If stdinOnce is set to true, stdin
+                                      is opened on container start, is empty until
+                                      the first client attaches to stdin, and then
+                                      remains open and accepts data until the client
+                                      disconnects, at which time stdin is closed and
+                                      remains closed until the container is restarted.
+                                      If this flag is false, a container processes
+                                      that reads from stdin will never receive an
+                                      EOF. Default is false
+                                    type: boolean
+                                  terminationMessagePath:
+                                    description: 'Optional: Path at which the file
+                                      to which the container''s termination message
+                                      will be written is mounted into the container''s
+                                      filesystem. Message written is intended to be
+                                      brief final status, such as an assertion failure
+                                      message. Will be truncated by the node if greater
+                                      than 4096 bytes. The total message length across
+                                      all containers will be limited to 12kb. Defaults
+                                      to /dev/termination-log. Cannot be updated.'
+                                    type: string
+                                  terminationMessagePolicy:
+                                    description: Indicate how the termination message
+                                      should be populated. File will use the contents
+                                      of terminationMessagePath to populate the container
+                                      status message on both success and failure.
+                                      FallbackToLogsOnError will use the last chunk
+                                      of container log output if the termination message
+                                      file is empty and the container exited with
+                                      an error. The log output is limited to 2048
+                                      bytes or 80 lines, whichever is smaller. Defaults
+                                      to File. Cannot be updated.
+                                    type: string
+                                  tty:
+                                    description: Whether this container should allocate
+                                      a TTY for itself, also requires 'stdin' to be
+                                      true. Default is false.
+                                    type: boolean
+                                  volumeDevices:
+                                    description: volumeDevices is the list of block
+                                      devices to be used by the container. This is
+                                      a beta feature.
+                                    items:
+                                      description: volumeDevice describes a mapping
+                                        of a raw block device within a container.
+                                      properties:
+                                        devicePath:
+                                          description: devicePath is the path inside
+                                            of the container that the device will
+                                            be mapped to.
+                                          type: string
+                                        name:
+                                          description: name must match the name of
+                                            a persistentVolumeClaim in the pod
+                                          type: string
+                                      required:
+                                      - devicePath
+                                      - name
+                                      type: object
+                                    type: array
+                                  volumeMounts:
+                                    description: Pod volumes to mount into the container's
+                                      filesystem. Cannot be updated.
+                                    items:
+                                      description: VolumeMount describes a mounting
+                                        of a Volume within a container.
+                                      properties:
+                                        mountPath:
+                                          description: Path within the container at
+                                            which the volume should be mounted.  Must
+                                            not contain ':'.
+                                          type: string
+                                        mountPropagation:
+                                          description: mountPropagation determines
+                                            how mounts are propagated from the host
+                                            to container and the other way around.
+                                            When not set, MountPropagationNone is
+                                            used. This field is beta in 1.10.
+                                          type: string
+                                        name:
+                                          description: This must match the Name of
+                                            a Volume.
+                                          type: string
+                                        readOnly:
+                                          description: Mounted read-only if true,
+                                            read-write otherwise (false or unspecified).
+                                            Defaults to false.
+                                          type: boolean
+                                        subPath:
+                                          description: Path within the volume from
+                                            which the container's volume should be
+                                            mounted. Defaults to "" (volume's root).
+                                          type: string
+                                        subPathExpr:
+                                          description: Expanded path within the volume
+                                            from which the container's volume should
+                                            be mounted. Behaves similarly to SubPath
+                                            but environment variable references $(VAR_NAME)
+                                            are expanded using the container's environment.
+                                            Defaults to "" (volume's root). SubPathExpr
+                                            and SubPath are mutually exclusive.
+                                          type: string
+                                      required:
+                                      - mountPath
+                                      - name
+                                      type: object
+                                    type: array
+                                  workingDir:
+                                    description: Container's working directory. If
+                                      not specified, the container runtime's default
+                                      will be used, which might be configured in the
+                                      container image. Cannot be updated.
+                                    type: string
+                                required:
+                                - name
+                                type: object
+                              type: array
+                            dnsConfig:
+                              description: Specifies the DNS parameters of a pod.
+                                Parameters specified here will be merged to the generated
+                                DNS configuration based on DNSPolicy.
+                              properties:
+                                nameservers:
+                                  description: A list of DNS name server IP addresses.
+                                    This will be appended to the base nameservers
+                                    generated from DNSPolicy. Duplicated nameservers
+                                    will be removed.
+                                  items:
+                                    type: string
+                                  type: array
+                                options:
+                                  description: A list of DNS resolver options. This
+                                    will be merged with the base options generated
+                                    from DNSPolicy. Duplicated entries will be removed.
+                                    Resolution options given in Options will override
+                                    those that appear in the base DNSPolicy.
+                                  items:
+                                    description: PodDNSConfigOption defines DNS resolver
+                                      options of a pod.
+                                    properties:
+                                      name:
+                                        description: Required.
+                                        type: string
+                                      value:
+                                        type: string
+                                    type: object
+                                  type: array
+                                searches:
+                                  description: A list of DNS search domains for host-name
+                                    lookup. This will be appended to the base search
+                                    paths generated from DNSPolicy. Duplicated search
+                                    paths will be removed.
+                                  items:
+                                    type: string
+                                  type: array
+                              type: object
+                            dnsPolicy:
+                              description: Set DNS policy for the pod. Defaults to
+                                "ClusterFirst". Valid values are 'ClusterFirstWithHostNet',
+                                'ClusterFirst', 'Default' or 'None'. DNS parameters
+                                given in DNSConfig will be merged with the policy
+                                selected with DNSPolicy. To have DNS options set along
+                                with hostNetwork, you have to specify DNS policy explicitly
+                                to 'ClusterFirstWithHostNet'.
+                              type: string
+                            enableServiceLinks:
+                              description: 'EnableServiceLinks indicates whether information
+                                about services should be injected into pod''s environment
+                                variables, matching the syntax of Docker links. Optional:
+                                Defaults to true.'
+                              type: boolean
+                            ephemeralContainers:
+                              description: List of ephemeral containers run in this
+                                pod. Ephemeral containers may be run in an existing
+                                pod to perform user-initiated actions such as debugging.
+                                This list cannot be specified when creating a pod,
+                                and it cannot be modified by updating the pod spec.
+                                In order to add an ephemeral container to an existing
+                                pod, use the pod's ephemeralcontainers subresource.
+                                This field is alpha-level and is only honored by servers
+                                that enable the EphemeralContainers feature.
+                              items:
+                                description: An EphemeralContainer is a container
+                                  that may be added temporarily to an existing pod
+                                  for user-initiated activities such as debugging.
+                                  Ephemeral containers have no resource or scheduling
+                                  guarantees, and they will not be restarted when
+                                  they exit or when a pod is removed or restarted.
+                                  If an ephemeral container causes a pod to exceed
+                                  its resource allocation, the pod may be evicted.
+                                  Ephemeral containers may not be added by directly
+                                  updating the pod spec. They must be added via the
+                                  pod's ephemeralcontainers subresource, and they
+                                  will appear in the pod spec once added. This is
+                                  an alpha feature enabled by the EphemeralContainers
+                                  feature flag.
+                                properties:
+                                  args:
+                                    description: 'Arguments to the entrypoint. The
+                                      docker image''s CMD is used if this is not provided.
+                                      Variable references $(VAR_NAME) are expanded
+                                      using the container''s environment. If a variable
+                                      cannot be resolved, the reference in the input
+                                      string will be unchanged. The $(VAR_NAME) syntax
+                                      can be escaped with a double $$, ie: $$(VAR_NAME).
+                                      Escaped references will never be expanded, regardless
+                                      of whether the variable exists or not. Cannot
+                                      be updated. More info: https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell'
+                                    items:
+                                      type: string
+                                    type: array
+                                  command:
+                                    description: 'Entrypoint array. Not executed within
+                                      a shell. The docker image''s ENTRYPOINT is used
+                                      if this is not provided. Variable references
+                                      $(VAR_NAME) are expanded using the container''s
+                                      environment. If a variable cannot be resolved,
+                                      the reference in the input string will be unchanged.
+                                      The $(VAR_NAME) syntax can be escaped with a
+                                      double $$, ie: $$(VAR_NAME). Escaped references
+                                      will never be expanded, regardless of whether
+                                      the variable exists or not. Cannot be updated.
+                                      More info: https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell'
+                                    items:
+                                      type: string
+                                    type: array
+                                  env:
+                                    description: List of environment variables to
+                                      set in the container. Cannot be updated.
+                                    items:
+                                      description: EnvVar represents an environment
+                                        variable present in a Container.
+                                      properties:
+                                        name:
+                                          description: Name of the environment variable.
+                                            Must be a C_IDENTIFIER.
+                                          type: string
+                                        value:
+                                          description: 'Variable references $(VAR_NAME)
+                                            are expanded using the previous defined
+                                            environment variables in the container
+                                            and any service environment variables.
+                                            If a variable cannot be resolved, the
+                                            reference in the input string will be
+                                            unchanged. The $(VAR_NAME) syntax can
+                                            be escaped with a double $$, ie: $$(VAR_NAME).
+                                            Escaped references will never be expanded,
+                                            regardless of whether the variable exists
+                                            or not. Defaults to "".'
+                                          type: string
+                                        valueFrom:
+                                          description: Source for the environment
+                                            variable's value. Cannot be used if value
+                                            is not empty.
+                                          properties:
+                                            configMapKeyRef:
+                                              description: Selects a key of a ConfigMap.
+                                              properties:
+                                                key:
+                                                  description: The key to select.
+                                                  type: string
+                                                name:
+                                                  description: 'Name of the referent.
+                                                    More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                                    TODO: Add other useful fields.
+                                                    apiVersion, kind, uid?'
+                                                  type: string
+                                                optional:
+                                                  description: Specify whether the
+                                                    ConfigMap or its key must be defined
+                                                  type: boolean
+                                              required:
+                                              - key
+                                              type: object
+                                            fieldRef:
+                                              description: 'Selects a field of the
+                                                pod: supports metadata.name, metadata.namespace,
+                                                metadata.labels, metadata.annotations,
+                                                spec.nodeName, spec.serviceAccountName,
+                                                status.hostIP, status.podIP, status.podIPs.'
+                                              properties:
+                                                apiVersion:
+                                                  description: Version of the schema
+                                                    the FieldPath is written in terms
+                                                    of, defaults to "v1".
+                                                  type: string
+                                                fieldPath:
+                                                  description: Path of the field to
+                                                    select in the specified API version.
+                                                  type: string
+                                              required:
+                                              - fieldPath
+                                              type: object
+                                            resourceFieldRef:
+                                              description: 'Selects a resource of
+                                                the container: only resources limits
+                                                and requests (limits.cpu, limits.memory,
+                                                limits.ephemeral-storage, requests.cpu,
+                                                requests.memory and requests.ephemeral-storage)
+                                                are currently supported.'
+                                              properties:
+                                                containerName:
+                                                  description: 'Container name: required
+                                                    for volumes, optional for env
+                                                    vars'
+                                                  type: string
+                                                divisor:
+                                                  anyOf:
+                                                  - type: integer
+                                                  - type: string
+                                                  description: Specifies the output
+                                                    format of the exposed resources,
+                                                    defaults to "1"
+                                                  pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                                  x-kubernetes-int-or-string: true
+                                                resource:
+                                                  description: 'Required: resource
+                                                    to select'
+                                                  type: string
+                                              required:
+                                              - resource
+                                              type: object
+                                            secretKeyRef:
+                                              description: Selects a key of a secret
+                                                in the pod's namespace
+                                              properties:
+                                                key:
+                                                  description: The key of the secret
+                                                    to select from.  Must be a valid
+                                                    secret key.
+                                                  type: string
+                                                name:
+                                                  description: 'Name of the referent.
+                                                    More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                                    TODO: Add other useful fields.
+                                                    apiVersion, kind, uid?'
+                                                  type: string
+                                                optional:
+                                                  description: Specify whether the
+                                                    Secret or its key must be defined
+                                                  type: boolean
+                                              required:
+                                              - key
+                                              type: object
+                                          type: object
+                                      required:
+                                      - name
+                                      type: object
+                                    type: array
+                                  envFrom:
+                                    description: List of sources to populate environment
+                                      variables in the container. The keys defined
+                                      within a source must be a C_IDENTIFIER. All
+                                      invalid keys will be reported as an event when
+                                      the container is starting. When a key exists
+                                      in multiple sources, the value associated with
+                                      the last source will take precedence. Values
+                                      defined by an Env with a duplicate key will
+                                      take precedence. Cannot be updated.
+                                    items:
+                                      description: EnvFromSource represents the source
+                                        of a set of ConfigMaps
+                                      properties:
+                                        configMapRef:
+                                          description: The ConfigMap to select from
+                                          properties:
+                                            name:
+                                              description: 'Name of the referent.
+                                                More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                                TODO: Add other useful fields. apiVersion,
+                                                kind, uid?'
+                                              type: string
+                                            optional:
+                                              description: Specify whether the ConfigMap
+                                                must be defined
+                                              type: boolean
+                                          type: object
+                                        prefix:
+                                          description: An optional identifier to prepend
+                                            to each key in the ConfigMap. Must be
+                                            a C_IDENTIFIER.
+                                          type: string
+                                        secretRef:
+                                          description: The Secret to select from
+                                          properties:
+                                            name:
+                                              description: 'Name of the referent.
+                                                More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                                TODO: Add other useful fields. apiVersion,
+                                                kind, uid?'
+                                              type: string
+                                            optional:
+                                              description: Specify whether the Secret
+                                                must be defined
+                                              type: boolean
+                                          type: object
+                                      type: object
+                                    type: array
+                                  image:
+                                    description: 'Docker image name. More info: https://kubernetes.io/docs/concepts/containers/images'
+                                    type: string
+                                  imagePullPolicy:
+                                    description: 'Image pull policy. One of Always,
+                                      Never, IfNotPresent. Defaults to Always if :latest
+                                      tag is specified, or IfNotPresent otherwise.
+                                      Cannot be updated. More info: https://kubernetes.io/docs/concepts/containers/images#updating-images'
+                                    type: string
+                                  lifecycle:
+                                    description: Lifecycle is not allowed for ephemeral
+                                      containers.
+                                    properties:
+                                      postStart:
+                                        description: 'PostStart is called immediately
+                                          after a container is created. If the handler
+                                          fails, the container is terminated and restarted
+                                          according to its restart policy. Other management
+                                          of the container blocks until the hook completes.
+                                          More info: https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/#container-hooks'
+                                        properties:
+                                          exec:
+                                            description: One and only one of the following
+                                              should be specified. Exec specifies
+                                              the action to take.
+                                            properties:
+                                              command:
+                                                description: Command is the command
+                                                  line to execute inside the container,
+                                                  the working directory for the command  is
+                                                  root ('/') in the container's filesystem.
+                                                  The command is simply exec'd, it
+                                                  is not run inside a shell, so traditional
+                                                  shell instructions ('|', etc) won't
+                                                  work. To use a shell, you need to
+                                                  explicitly call out to that shell.
+                                                  Exit status of 0 is treated as live/healthy
+                                                  and non-zero is unhealthy.
+                                                items:
+                                                  type: string
+                                                type: array
+                                            type: object
+                                          httpGet:
+                                            description: HTTPGet specifies the http
+                                              request to perform.
+                                            properties:
+                                              host:
+                                                description: Host name to connect
+                                                  to, defaults to the pod IP. You
+                                                  probably want to set "Host" in httpHeaders
+                                                  instead.
+                                                type: string
+                                              httpHeaders:
+                                                description: Custom headers to set
+                                                  in the request. HTTP allows repeated
+                                                  headers.
+                                                items:
+                                                  description: HTTPHeader describes
+                                                    a custom header to be used in
+                                                    HTTP probes
+                                                  properties:
+                                                    name:
+                                                      description: The header field
+                                                        name
+                                                      type: string
+                                                    value:
+                                                      description: The header field
+                                                        value
+                                                      type: string
+                                                  required:
+                                                  - name
+                                                  - value
+                                                  type: object
+                                                type: array
+                                              path:
+                                                description: Path to access on the
+                                                  HTTP server.
+                                                type: string
+                                              port:
+                                                anyOf:
+                                                - type: integer
+                                                - type: string
+                                                description: Name or number of the
+                                                  port to access on the container.
+                                                  Number must be in the range 1 to
+                                                  65535. Name must be an IANA_SVC_NAME.
+                                                x-kubernetes-int-or-string: true
+                                              scheme:
+                                                description: Scheme to use for connecting
+                                                  to the host. Defaults to HTTP.
+                                                type: string
+                                            required:
+                                            - port
+                                            type: object
+                                          tcpSocket:
+                                            description: 'TCPSocket specifies an action
+                                              involving a TCP port. TCP hooks not
+                                              yet supported TODO: implement a realistic
+                                              TCP lifecycle hook'
+                                            properties:
+                                              host:
+                                                description: 'Optional: Host name
+                                                  to connect to, defaults to the pod
+                                                  IP.'
+                                                type: string
+                                              port:
+                                                anyOf:
+                                                - type: integer
+                                                - type: string
+                                                description: Number or name of the
+                                                  port to access on the container.
+                                                  Number must be in the range 1 to
+                                                  65535. Name must be an IANA_SVC_NAME.
+                                                x-kubernetes-int-or-string: true
+                                            required:
+                                            - port
+                                            type: object
+                                        type: object
+                                      preStop:
+                                        description: 'PreStop is called immediately
+                                          before a container is terminated due to
+                                          an API request or management event such
+                                          as liveness/startup probe failure, preemption,
+                                          resource contention, etc. The handler is
+                                          not called if the container crashes or exits.
+                                          The reason for termination is passed to
+                                          the handler. The Pod''s termination grace
+                                          period countdown begins before the PreStop
+                                          hooked is executed. Regardless of the outcome
+                                          of the handler, the container will eventually
+                                          terminate within the Pod''s termination
+                                          grace period. Other management of the container
+                                          blocks until the hook completes or until
+                                          the termination grace period is reached.
+                                          More info: https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/#container-hooks'
+                                        properties:
+                                          exec:
+                                            description: One and only one of the following
+                                              should be specified. Exec specifies
+                                              the action to take.
+                                            properties:
+                                              command:
+                                                description: Command is the command
+                                                  line to execute inside the container,
+                                                  the working directory for the command  is
+                                                  root ('/') in the container's filesystem.
+                                                  The command is simply exec'd, it
+                                                  is not run inside a shell, so traditional
+                                                  shell instructions ('|', etc) won't
+                                                  work. To use a shell, you need to
+                                                  explicitly call out to that shell.
+                                                  Exit status of 0 is treated as live/healthy
+                                                  and non-zero is unhealthy.
+                                                items:
+                                                  type: string
+                                                type: array
+                                            type: object
+                                          httpGet:
+                                            description: HTTPGet specifies the http
+                                              request to perform.
+                                            properties:
+                                              host:
+                                                description: Host name to connect
+                                                  to, defaults to the pod IP. You
+                                                  probably want to set "Host" in httpHeaders
+                                                  instead.
+                                                type: string
+                                              httpHeaders:
+                                                description: Custom headers to set
+                                                  in the request. HTTP allows repeated
+                                                  headers.
+                                                items:
+                                                  description: HTTPHeader describes
+                                                    a custom header to be used in
+                                                    HTTP probes
+                                                  properties:
+                                                    name:
+                                                      description: The header field
+                                                        name
+                                                      type: string
+                                                    value:
+                                                      description: The header field
+                                                        value
+                                                      type: string
+                                                  required:
+                                                  - name
+                                                  - value
+                                                  type: object
+                                                type: array
+                                              path:
+                                                description: Path to access on the
+                                                  HTTP server.
+                                                type: string
+                                              port:
+                                                anyOf:
+                                                - type: integer
+                                                - type: string
+                                                description: Name or number of the
+                                                  port to access on the container.
+                                                  Number must be in the range 1 to
+                                                  65535. Name must be an IANA_SVC_NAME.
+                                                x-kubernetes-int-or-string: true
+                                              scheme:
+                                                description: Scheme to use for connecting
+                                                  to the host. Defaults to HTTP.
+                                                type: string
+                                            required:
+                                            - port
+                                            type: object
+                                          tcpSocket:
+                                            description: 'TCPSocket specifies an action
+                                              involving a TCP port. TCP hooks not
+                                              yet supported TODO: implement a realistic
+                                              TCP lifecycle hook'
+                                            properties:
+                                              host:
+                                                description: 'Optional: Host name
+                                                  to connect to, defaults to the pod
+                                                  IP.'
+                                                type: string
+                                              port:
+                                                anyOf:
+                                                - type: integer
+                                                - type: string
+                                                description: Number or name of the
+                                                  port to access on the container.
+                                                  Number must be in the range 1 to
+                                                  65535. Name must be an IANA_SVC_NAME.
+                                                x-kubernetes-int-or-string: true
+                                            required:
+                                            - port
+                                            type: object
+                                        type: object
+                                    type: object
+                                  livenessProbe:
+                                    description: Probes are not allowed for ephemeral
+                                      containers.
+                                    properties:
+                                      exec:
+                                        description: One and only one of the following
+                                          should be specified. Exec specifies the
+                                          action to take.
+                                        properties:
+                                          command:
+                                            description: Command is the command line
+                                              to execute inside the container, the
+                                              working directory for the command  is
+                                              root ('/') in the container's filesystem.
+                                              The command is simply exec'd, it is
+                                              not run inside a shell, so traditional
+                                              shell instructions ('|', etc) won't
+                                              work. To use a shell, you need to explicitly
+                                              call out to that shell. Exit status
+                                              of 0 is treated as live/healthy and
+                                              non-zero is unhealthy.
+                                            items:
+                                              type: string
+                                            type: array
+                                        type: object
+                                      failureThreshold:
+                                        description: Minimum consecutive failures
+                                          for the probe to be considered failed after
+                                          having succeeded. Defaults to 3. Minimum
+                                          value is 1.
+                                        format: int32
+                                        type: integer
+                                      httpGet:
+                                        description: HTTPGet specifies the http request
+                                          to perform.
+                                        properties:
+                                          host:
+                                            description: Host name to connect to,
+                                              defaults to the pod IP. You probably
+                                              want to set "Host" in httpHeaders instead.
+                                            type: string
+                                          httpHeaders:
+                                            description: Custom headers to set in
+                                              the request. HTTP allows repeated headers.
+                                            items:
+                                              description: HTTPHeader describes a
+                                                custom header to be used in HTTP probes
+                                              properties:
+                                                name:
+                                                  description: The header field name
+                                                  type: string
+                                                value:
+                                                  description: The header field value
+                                                  type: string
+                                              required:
+                                              - name
+                                              - value
+                                              type: object
+                                            type: array
+                                          path:
+                                            description: Path to access on the HTTP
+                                              server.
+                                            type: string
+                                          port:
+                                            anyOf:
+                                            - type: integer
+                                            - type: string
+                                            description: Name or number of the port
+                                              to access on the container. Number must
+                                              be in the range 1 to 65535. Name must
+                                              be an IANA_SVC_NAME.
+                                            x-kubernetes-int-or-string: true
+                                          scheme:
+                                            description: Scheme to use for connecting
+                                              to the host. Defaults to HTTP.
+                                            type: string
+                                        required:
+                                        - port
+                                        type: object
+                                      initialDelaySeconds:
+                                        description: 'Number of seconds after the
+                                          container has started before liveness probes
+                                          are initiated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                                        format: int32
+                                        type: integer
+                                      periodSeconds:
+                                        description: How often (in seconds) to perform
+                                          the probe. Default to 10 seconds. Minimum
+                                          value is 1.
+                                        format: int32
+                                        type: integer
+                                      successThreshold:
+                                        description: Minimum consecutive successes
+                                          for the probe to be considered successful
+                                          after having failed. Defaults to 1. Must
+                                          be 1 for liveness and startup. Minimum value
+                                          is 1.
+                                        format: int32
+                                        type: integer
+                                      tcpSocket:
+                                        description: 'TCPSocket specifies an action
+                                          involving a TCP port. TCP hooks not yet
+                                          supported TODO: implement a realistic TCP
+                                          lifecycle hook'
+                                        properties:
+                                          host:
+                                            description: 'Optional: Host name to connect
+                                              to, defaults to the pod IP.'
+                                            type: string
+                                          port:
+                                            anyOf:
+                                            - type: integer
+                                            - type: string
+                                            description: Number or name of the port
+                                              to access on the container. Number must
+                                              be in the range 1 to 65535. Name must
+                                              be an IANA_SVC_NAME.
+                                            x-kubernetes-int-or-string: true
+                                        required:
+                                        - port
+                                        type: object
+                                      timeoutSeconds:
+                                        description: 'Number of seconds after which
+                                          the probe times out. Defaults to 1 second.
+                                          Minimum value is 1. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                                        format: int32
+                                        type: integer
+                                    type: object
+                                  name:
+                                    description: Name of the ephemeral container specified
+                                      as a DNS_LABEL. This name must be unique among
+                                      all containers, init containers and ephemeral
+                                      containers.
+                                    type: string
+                                  ports:
+                                    description: Ports are not allowed for ephemeral
+                                      containers.
+                                    items:
+                                      description: ContainerPort represents a network
+                                        port in a single container.
+                                      properties:
+                                        containerPort:
+                                          description: Number of port to expose on
+                                            the pod's IP address. This must be a valid
+                                            port number, 0 < x < 65536.
+                                          format: int32
+                                          type: integer
+                                        hostIP:
+                                          description: What host IP to bind the external
+                                            port to.
+                                          type: string
+                                        hostPort:
+                                          description: Number of port to expose on
+                                            the host. If specified, this must be a
+                                            valid port number, 0 < x < 65536. If HostNetwork
+                                            is specified, this must match ContainerPort.
+                                            Most containers do not need this.
+                                          format: int32
+                                          type: integer
+                                        name:
+                                          description: If specified, this must be
+                                            an IANA_SVC_NAME and unique within the
+                                            pod. Each named port in a pod must have
+                                            a unique name. Name for the port that
+                                            can be referred to by services.
+                                          type: string
+                                        protocol:
+                                          description: Protocol for port. Must be
+                                            UDP, TCP, or SCTP. Defaults to "TCP".
+                                          type: string
+                                      required:
+                                      - containerPort
+                                      type: object
+                                    type: array
+                                  readinessProbe:
+                                    description: Probes are not allowed for ephemeral
+                                      containers.
+                                    properties:
+                                      exec:
+                                        description: One and only one of the following
+                                          should be specified. Exec specifies the
+                                          action to take.
+                                        properties:
+                                          command:
+                                            description: Command is the command line
+                                              to execute inside the container, the
+                                              working directory for the command  is
+                                              root ('/') in the container's filesystem.
+                                              The command is simply exec'd, it is
+                                              not run inside a shell, so traditional
+                                              shell instructions ('|', etc) won't
+                                              work. To use a shell, you need to explicitly
+                                              call out to that shell. Exit status
+                                              of 0 is treated as live/healthy and
+                                              non-zero is unhealthy.
+                                            items:
+                                              type: string
+                                            type: array
+                                        type: object
+                                      failureThreshold:
+                                        description: Minimum consecutive failures
+                                          for the probe to be considered failed after
+                                          having succeeded. Defaults to 3. Minimum
+                                          value is 1.
+                                        format: int32
+                                        type: integer
+                                      httpGet:
+                                        description: HTTPGet specifies the http request
+                                          to perform.
+                                        properties:
+                                          host:
+                                            description: Host name to connect to,
+                                              defaults to the pod IP. You probably
+                                              want to set "Host" in httpHeaders instead.
+                                            type: string
+                                          httpHeaders:
+                                            description: Custom headers to set in
+                                              the request. HTTP allows repeated headers.
+                                            items:
+                                              description: HTTPHeader describes a
+                                                custom header to be used in HTTP probes
+                                              properties:
+                                                name:
+                                                  description: The header field name
+                                                  type: string
+                                                value:
+                                                  description: The header field value
+                                                  type: string
+                                              required:
+                                              - name
+                                              - value
+                                              type: object
+                                            type: array
+                                          path:
+                                            description: Path to access on the HTTP
+                                              server.
+                                            type: string
+                                          port:
+                                            anyOf:
+                                            - type: integer
+                                            - type: string
+                                            description: Name or number of the port
+                                              to access on the container. Number must
+                                              be in the range 1 to 65535. Name must
+                                              be an IANA_SVC_NAME.
+                                            x-kubernetes-int-or-string: true
+                                          scheme:
+                                            description: Scheme to use for connecting
+                                              to the host. Defaults to HTTP.
+                                            type: string
+                                        required:
+                                        - port
+                                        type: object
+                                      initialDelaySeconds:
+                                        description: 'Number of seconds after the
+                                          container has started before liveness probes
+                                          are initiated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                                        format: int32
+                                        type: integer
+                                      periodSeconds:
+                                        description: How often (in seconds) to perform
+                                          the probe. Default to 10 seconds. Minimum
+                                          value is 1.
+                                        format: int32
+                                        type: integer
+                                      successThreshold:
+                                        description: Minimum consecutive successes
+                                          for the probe to be considered successful
+                                          after having failed. Defaults to 1. Must
+                                          be 1 for liveness and startup. Minimum value
+                                          is 1.
+                                        format: int32
+                                        type: integer
+                                      tcpSocket:
+                                        description: 'TCPSocket specifies an action
+                                          involving a TCP port. TCP hooks not yet
+                                          supported TODO: implement a realistic TCP
+                                          lifecycle hook'
+                                        properties:
+                                          host:
+                                            description: 'Optional: Host name to connect
+                                              to, defaults to the pod IP.'
+                                            type: string
+                                          port:
+                                            anyOf:
+                                            - type: integer
+                                            - type: string
+                                            description: Number or name of the port
+                                              to access on the container. Number must
+                                              be in the range 1 to 65535. Name must
+                                              be an IANA_SVC_NAME.
+                                            x-kubernetes-int-or-string: true
+                                        required:
+                                        - port
+                                        type: object
+                                      timeoutSeconds:
+                                        description: 'Number of seconds after which
+                                          the probe times out. Defaults to 1 second.
+                                          Minimum value is 1. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                                        format: int32
+                                        type: integer
+                                    type: object
+                                  resources:
+                                    description: Resources are not allowed for ephemeral
+                                      containers. Ephemeral containers use spare resources
+                                      already allocated to the pod.
+                                    properties:
+                                      limits:
+                                        additionalProperties:
+                                          anyOf:
+                                          - type: integer
+                                          - type: string
+                                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                          x-kubernetes-int-or-string: true
+                                        description: 'Limits describes the maximum
+                                          amount of compute resources allowed. More
+                                          info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
+                                        type: object
+                                      requests:
+                                        additionalProperties:
+                                          anyOf:
+                                          - type: integer
+                                          - type: string
+                                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                          x-kubernetes-int-or-string: true
+                                        description: 'Requests describes the minimum
+                                          amount of compute resources required. If
+                                          Requests is omitted for a container, it
+                                          defaults to Limits if that is explicitly
+                                          specified, otherwise to an implementation-defined
+                                          value. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
+                                        type: object
+                                    type: object
+                                  securityContext:
+                                    description: SecurityContext is not allowed for
+                                      ephemeral containers.
+                                    properties:
+                                      allowPrivilegeEscalation:
+                                        description: 'AllowPrivilegeEscalation controls
+                                          whether a process can gain more privileges
+                                          than its parent process. This bool directly
+                                          controls if the no_new_privs flag will be
+                                          set on the container process. AllowPrivilegeEscalation
+                                          is true always when the container is: 1)
+                                          run as Privileged 2) has CAP_SYS_ADMIN'
+                                        type: boolean
+                                      capabilities:
+                                        description: The capabilities to add/drop
+                                          when running containers. Defaults to the
+                                          default set of capabilities granted by the
+                                          container runtime.
+                                        properties:
+                                          add:
+                                            description: Added capabilities
+                                            items:
+                                              description: Capability represent POSIX
+                                                capabilities type
+                                              type: string
+                                            type: array
+                                          drop:
+                                            description: Removed capabilities
+                                            items:
+                                              description: Capability represent POSIX
+                                                capabilities type
+                                              type: string
+                                            type: array
+                                        type: object
+                                      privileged:
+                                        description: Run container in privileged mode.
+                                          Processes in privileged containers are essentially
+                                          equivalent to root on the host. Defaults
+                                          to false.
+                                        type: boolean
+                                      procMount:
+                                        description: procMount denotes the type of
+                                          proc mount to use for the containers. The
+                                          default is DefaultProcMount which uses the
+                                          container runtime defaults for readonly
+                                          paths and masked paths. This requires the
+                                          ProcMountType feature flag to be enabled.
+                                        type: string
+                                      readOnlyRootFilesystem:
+                                        description: Whether this container has a
+                                          read-only root filesystem. Default is false.
+                                        type: boolean
+                                      runAsGroup:
+                                        description: The GID to run the entrypoint
+                                          of the container process. Uses runtime default
+                                          if unset. May also be set in PodSecurityContext.  If
+                                          set in both SecurityContext and PodSecurityContext,
+                                          the value specified in SecurityContext takes
+                                          precedence.
+                                        format: int64
+                                        type: integer
+                                      runAsNonRoot:
+                                        description: Indicates that the container
+                                          must run as a non-root user. If true, the
+                                          Kubelet will validate the image at runtime
+                                          to ensure that it does not run as UID 0
+                                          (root) and fail to start the container if
+                                          it does. If unset or false, no such validation
+                                          will be performed. May also be set in PodSecurityContext.  If
+                                          set in both SecurityContext and PodSecurityContext,
+                                          the value specified in SecurityContext takes
+                                          precedence.
+                                        type: boolean
+                                      runAsUser:
+                                        description: The UID to run the entrypoint
+                                          of the container process. Defaults to user
+                                          specified in image metadata if unspecified.
+                                          May also be set in PodSecurityContext.  If
+                                          set in both SecurityContext and PodSecurityContext,
+                                          the value specified in SecurityContext takes
+                                          precedence.
+                                        format: int64
+                                        type: integer
+                                      seLinuxOptions:
+                                        description: The SELinux context to be applied
+                                          to the container. If unspecified, the container
+                                          runtime will allocate a random SELinux context
+                                          for each container.  May also be set in
+                                          PodSecurityContext.  If set in both SecurityContext
+                                          and PodSecurityContext, the value specified
+                                          in SecurityContext takes precedence.
+                                        properties:
+                                          level:
+                                            description: Level is SELinux level label
+                                              that applies to the container.
+                                            type: string
+                                          role:
+                                            description: Role is a SELinux role label
+                                              that applies to the container.
+                                            type: string
+                                          type:
+                                            description: Type is a SELinux type label
+                                              that applies to the container.
+                                            type: string
+                                          user:
+                                            description: User is a SELinux user label
+                                              that applies to the container.
+                                            type: string
+                                        type: object
+                                      windowsOptions:
+                                        description: The Windows specific settings
+                                          applied to all containers. If unspecified,
+                                          the options from the PodSecurityContext
+                                          will be used. If set in both SecurityContext
+                                          and PodSecurityContext, the value specified
+                                          in SecurityContext takes precedence.
+                                        properties:
+                                          gmsaCredentialSpec:
+                                            description: GMSACredentialSpec is where
+                                              the GMSA admission webhook (https://github.com/kubernetes-sigs/windows-gmsa)
+                                              inlines the contents of the GMSA credential
+                                              spec named by the GMSACredentialSpecName
+                                              field. This field is alpha-level and
+                                              is only honored by servers that enable
+                                              the WindowsGMSA feature flag.
+                                            type: string
+                                          gmsaCredentialSpecName:
+                                            description: GMSACredentialSpecName is
+                                              the name of the GMSA credential spec
+                                              to use. This field is alpha-level and
+                                              is only honored by servers that enable
+                                              the WindowsGMSA feature flag.
+                                            type: string
+                                          runAsUserName:
+                                            description: The UserName in Windows to
+                                              run the entrypoint of the container
+                                              process. Defaults to the user specified
+                                              in image metadata if unspecified. May
+                                              also be set in PodSecurityContext. If
+                                              set in both SecurityContext and PodSecurityContext,
+                                              the value specified in SecurityContext
+                                              takes precedence. This field is beta-level
+                                              and may be disabled with the WindowsRunAsUserName
+                                              feature flag.
+                                            type: string
+                                        type: object
+                                    type: object
+                                  startupProbe:
+                                    description: Probes are not allowed for ephemeral
+                                      containers.
+                                    properties:
+                                      exec:
+                                        description: One and only one of the following
+                                          should be specified. Exec specifies the
+                                          action to take.
+                                        properties:
+                                          command:
+                                            description: Command is the command line
+                                              to execute inside the container, the
+                                              working directory for the command  is
+                                              root ('/') in the container's filesystem.
+                                              The command is simply exec'd, it is
+                                              not run inside a shell, so traditional
+                                              shell instructions ('|', etc) won't
+                                              work. To use a shell, you need to explicitly
+                                              call out to that shell. Exit status
+                                              of 0 is treated as live/healthy and
+                                              non-zero is unhealthy.
+                                            items:
+                                              type: string
+                                            type: array
+                                        type: object
+                                      failureThreshold:
+                                        description: Minimum consecutive failures
+                                          for the probe to be considered failed after
+                                          having succeeded. Defaults to 3. Minimum
+                                          value is 1.
+                                        format: int32
+                                        type: integer
+                                      httpGet:
+                                        description: HTTPGet specifies the http request
+                                          to perform.
+                                        properties:
+                                          host:
+                                            description: Host name to connect to,
+                                              defaults to the pod IP. You probably
+                                              want to set "Host" in httpHeaders instead.
+                                            type: string
+                                          httpHeaders:
+                                            description: Custom headers to set in
+                                              the request. HTTP allows repeated headers.
+                                            items:
+                                              description: HTTPHeader describes a
+                                                custom header to be used in HTTP probes
+                                              properties:
+                                                name:
+                                                  description: The header field name
+                                                  type: string
+                                                value:
+                                                  description: The header field value
+                                                  type: string
+                                              required:
+                                              - name
+                                              - value
+                                              type: object
+                                            type: array
+                                          path:
+                                            description: Path to access on the HTTP
+                                              server.
+                                            type: string
+                                          port:
+                                            anyOf:
+                                            - type: integer
+                                            - type: string
+                                            description: Name or number of the port
+                                              to access on the container. Number must
+                                              be in the range 1 to 65535. Name must
+                                              be an IANA_SVC_NAME.
+                                            x-kubernetes-int-or-string: true
+                                          scheme:
+                                            description: Scheme to use for connecting
+                                              to the host. Defaults to HTTP.
+                                            type: string
+                                        required:
+                                        - port
+                                        type: object
+                                      initialDelaySeconds:
+                                        description: 'Number of seconds after the
+                                          container has started before liveness probes
+                                          are initiated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                                        format: int32
+                                        type: integer
+                                      periodSeconds:
+                                        description: How often (in seconds) to perform
+                                          the probe. Default to 10 seconds. Minimum
+                                          value is 1.
+                                        format: int32
+                                        type: integer
+                                      successThreshold:
+                                        description: Minimum consecutive successes
+                                          for the probe to be considered successful
+                                          after having failed. Defaults to 1. Must
+                                          be 1 for liveness and startup. Minimum value
+                                          is 1.
+                                        format: int32
+                                        type: integer
+                                      tcpSocket:
+                                        description: 'TCPSocket specifies an action
+                                          involving a TCP port. TCP hooks not yet
+                                          supported TODO: implement a realistic TCP
+                                          lifecycle hook'
+                                        properties:
+                                          host:
+                                            description: 'Optional: Host name to connect
+                                              to, defaults to the pod IP.'
+                                            type: string
+                                          port:
+                                            anyOf:
+                                            - type: integer
+                                            - type: string
+                                            description: Number or name of the port
+                                              to access on the container. Number must
+                                              be in the range 1 to 65535. Name must
+                                              be an IANA_SVC_NAME.
+                                            x-kubernetes-int-or-string: true
+                                        required:
+                                        - port
+                                        type: object
+                                      timeoutSeconds:
+                                        description: 'Number of seconds after which
+                                          the probe times out. Defaults to 1 second.
+                                          Minimum value is 1. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                                        format: int32
+                                        type: integer
+                                    type: object
+                                  stdin:
+                                    description: Whether this container should allocate
+                                      a buffer for stdin in the container runtime.
+                                      If this is not set, reads from stdin in the
+                                      container will always result in EOF. Default
+                                      is false.
+                                    type: boolean
+                                  stdinOnce:
+                                    description: Whether the container runtime should
+                                      close the stdin channel after it has been opened
+                                      by a single attach. When stdin is true the stdin
+                                      stream will remain open across multiple attach
+                                      sessions. If stdinOnce is set to true, stdin
+                                      is opened on container start, is empty until
+                                      the first client attaches to stdin, and then
+                                      remains open and accepts data until the client
+                                      disconnects, at which time stdin is closed and
+                                      remains closed until the container is restarted.
+                                      If this flag is false, a container processes
+                                      that reads from stdin will never receive an
+                                      EOF. Default is false
+                                    type: boolean
+                                  targetContainerName:
+                                    description: If set, the name of the container
+                                      from PodSpec that this ephemeral container targets.
+                                      The ephemeral container will be run in the namespaces
+                                      (IPC, PID, etc) of this container. If not set
+                                      then the ephemeral container is run in whatever
+                                      namespaces are shared for the pod. Note that
+                                      the container runtime must support this feature.
+                                    type: string
+                                  terminationMessagePath:
+                                    description: 'Optional: Path at which the file
+                                      to which the container''s termination message
+                                      will be written is mounted into the container''s
+                                      filesystem. Message written is intended to be
+                                      brief final status, such as an assertion failure
+                                      message. Will be truncated by the node if greater
+                                      than 4096 bytes. The total message length across
+                                      all containers will be limited to 12kb. Defaults
+                                      to /dev/termination-log. Cannot be updated.'
+                                    type: string
+                                  terminationMessagePolicy:
+                                    description: Indicate how the termination message
+                                      should be populated. File will use the contents
+                                      of terminationMessagePath to populate the container
+                                      status message on both success and failure.
+                                      FallbackToLogsOnError will use the last chunk
+                                      of container log output if the termination message
+                                      file is empty and the container exited with
+                                      an error. The log output is limited to 2048
+                                      bytes or 80 lines, whichever is smaller. Defaults
+                                      to File. Cannot be updated.
+                                    type: string
+                                  tty:
+                                    description: Whether this container should allocate
+                                      a TTY for itself, also requires 'stdin' to be
+                                      true. Default is false.
+                                    type: boolean
+                                  volumeDevices:
+                                    description: volumeDevices is the list of block
+                                      devices to be used by the container. This is
+                                      a beta feature.
+                                    items:
+                                      description: volumeDevice describes a mapping
+                                        of a raw block device within a container.
+                                      properties:
+                                        devicePath:
+                                          description: devicePath is the path inside
+                                            of the container that the device will
+                                            be mapped to.
+                                          type: string
+                                        name:
+                                          description: name must match the name of
+                                            a persistentVolumeClaim in the pod
+                                          type: string
+                                      required:
+                                      - devicePath
+                                      - name
+                                      type: object
+                                    type: array
+                                  volumeMounts:
+                                    description: Pod volumes to mount into the container's
+                                      filesystem. Cannot be updated.
+                                    items:
+                                      description: VolumeMount describes a mounting
+                                        of a Volume within a container.
+                                      properties:
+                                        mountPath:
+                                          description: Path within the container at
+                                            which the volume should be mounted.  Must
+                                            not contain ':'.
+                                          type: string
+                                        mountPropagation:
+                                          description: mountPropagation determines
+                                            how mounts are propagated from the host
+                                            to container and the other way around.
+                                            When not set, MountPropagationNone is
+                                            used. This field is beta in 1.10.
+                                          type: string
+                                        name:
+                                          description: This must match the Name of
+                                            a Volume.
+                                          type: string
+                                        readOnly:
+                                          description: Mounted read-only if true,
+                                            read-write otherwise (false or unspecified).
+                                            Defaults to false.
+                                          type: boolean
+                                        subPath:
+                                          description: Path within the volume from
+                                            which the container's volume should be
+                                            mounted. Defaults to "" (volume's root).
+                                          type: string
+                                        subPathExpr:
+                                          description: Expanded path within the volume
+                                            from which the container's volume should
+                                            be mounted. Behaves similarly to SubPath
+                                            but environment variable references $(VAR_NAME)
+                                            are expanded using the container's environment.
+                                            Defaults to "" (volume's root). SubPathExpr
+                                            and SubPath are mutually exclusive.
+                                          type: string
+                                      required:
+                                      - mountPath
+                                      - name
+                                      type: object
+                                    type: array
+                                  workingDir:
+                                    description: Container's working directory. If
+                                      not specified, the container runtime's default
+                                      will be used, which might be configured in the
+                                      container image. Cannot be updated.
+                                    type: string
+                                required:
+                                - name
+                                type: object
+                              type: array
+                            hostAliases:
+                              description: HostAliases is an optional list of hosts
+                                and IPs that will be injected into the pod's hosts
+                                file if specified. This is only valid for non-hostNetwork
+                                pods.
+                              items:
+                                description: HostAlias holds the mapping between IP
+                                  and hostnames that will be injected as an entry
+                                  in the pod's hosts file.
+                                properties:
+                                  hostnames:
+                                    description: Hostnames for the above IP address.
+                                    items:
+                                      type: string
+                                    type: array
+                                  ip:
+                                    description: IP address of the host file entry.
+                                    type: string
+                                type: object
+                              type: array
+                            hostIPC:
+                              description: 'Use the host''s ipc namespace. Optional:
+                                Default to false.'
+                              type: boolean
+                            hostNetwork:
+                              description: Host networking requested for this pod.
+                                Use the host's network namespace. If this option is
+                                set, the ports that will be used must be specified.
+                                Default to false.
+                              type: boolean
+                            hostPID:
+                              description: 'Use the host''s pid namespace. Optional:
+                                Default to false.'
+                              type: boolean
+                            hostname:
+                              description: Specifies the hostname of the Pod If not
+                                specified, the pod's hostname will be set to a system-defined
+                                value.
+                              type: string
+                            imagePullSecrets:
+                              description: 'ImagePullSecrets is an optional list of
+                                references to secrets in the same namespace to use
+                                for pulling any of the images used by this PodSpec.
+                                If specified, these secrets will be passed to individual
+                                puller implementations for them to use. For example,
+                                in the case of docker, only DockerConfig type secrets
+                                are honored. More info: https://kubernetes.io/docs/concepts/containers/images#specifying-imagepullsecrets-on-a-pod'
+                              items:
+                                description: LocalObjectReference contains enough
+                                  information to let you locate the referenced object
+                                  inside the same namespace.
+                                properties:
+                                  name:
+                                    description: 'Name of the referent. More info:
+                                      https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                      TODO: Add other useful fields. apiVersion, kind,
+                                      uid?'
+                                    type: string
+                                type: object
+                              type: array
+                            initContainers:
+                              description: 'List of initialization containers belonging
+                                to the pod. Init containers are executed in order
+                                prior to containers being started. If any init container
+                                fails, the pod is considered to have failed and is
+                                handled according to its restartPolicy. The name for
+                                an init container or normal container must be unique
+                                among all containers. Init containers may not have
+                                Lifecycle actions, Readiness probes, Liveness probes,
+                                or Startup probes. The resourceRequirements of an
+                                init container are taken into account during scheduling
+                                by finding the highest request/limit for each resource
+                                type, and then using the max of of that value or the
+                                sum of the normal containers. Limits are applied to
+                                init containers in a similar fashion. Init containers
+                                cannot currently be added or removed. Cannot be updated.
+                                More info: https://kubernetes.io/docs/concepts/workloads/pods/init-containers/'
+                              items:
+                                description: A single application container that you
+                                  want to run within a pod.
+                                properties:
+                                  args:
+                                    description: 'Arguments to the entrypoint. The
+                                      docker image''s CMD is used if this is not provided.
+                                      Variable references $(VAR_NAME) are expanded
+                                      using the container''s environment. If a variable
+                                      cannot be resolved, the reference in the input
+                                      string will be unchanged. The $(VAR_NAME) syntax
+                                      can be escaped with a double $$, ie: $$(VAR_NAME).
+                                      Escaped references will never be expanded, regardless
+                                      of whether the variable exists or not. Cannot
+                                      be updated. More info: https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell'
+                                    items:
+                                      type: string
+                                    type: array
+                                  command:
+                                    description: 'Entrypoint array. Not executed within
+                                      a shell. The docker image''s ENTRYPOINT is used
+                                      if this is not provided. Variable references
+                                      $(VAR_NAME) are expanded using the container''s
+                                      environment. If a variable cannot be resolved,
+                                      the reference in the input string will be unchanged.
+                                      The $(VAR_NAME) syntax can be escaped with a
+                                      double $$, ie: $$(VAR_NAME). Escaped references
+                                      will never be expanded, regardless of whether
+                                      the variable exists or not. Cannot be updated.
+                                      More info: https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell'
+                                    items:
+                                      type: string
+                                    type: array
+                                  env:
+                                    description: List of environment variables to
+                                      set in the container. Cannot be updated.
+                                    items:
+                                      description: EnvVar represents an environment
+                                        variable present in a Container.
+                                      properties:
+                                        name:
+                                          description: Name of the environment variable.
+                                            Must be a C_IDENTIFIER.
+                                          type: string
+                                        value:
+                                          description: 'Variable references $(VAR_NAME)
+                                            are expanded using the previous defined
+                                            environment variables in the container
+                                            and any service environment variables.
+                                            If a variable cannot be resolved, the
+                                            reference in the input string will be
+                                            unchanged. The $(VAR_NAME) syntax can
+                                            be escaped with a double $$, ie: $$(VAR_NAME).
+                                            Escaped references will never be expanded,
+                                            regardless of whether the variable exists
+                                            or not. Defaults to "".'
+                                          type: string
+                                        valueFrom:
+                                          description: Source for the environment
+                                            variable's value. Cannot be used if value
+                                            is not empty.
+                                          properties:
+                                            configMapKeyRef:
+                                              description: Selects a key of a ConfigMap.
+                                              properties:
+                                                key:
+                                                  description: The key to select.
+                                                  type: string
+                                                name:
+                                                  description: 'Name of the referent.
+                                                    More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                                    TODO: Add other useful fields.
+                                                    apiVersion, kind, uid?'
+                                                  type: string
+                                                optional:
+                                                  description: Specify whether the
+                                                    ConfigMap or its key must be defined
+                                                  type: boolean
+                                              required:
+                                              - key
+                                              type: object
+                                            fieldRef:
+                                              description: 'Selects a field of the
+                                                pod: supports metadata.name, metadata.namespace,
+                                                metadata.labels, metadata.annotations,
+                                                spec.nodeName, spec.serviceAccountName,
+                                                status.hostIP, status.podIP, status.podIPs.'
+                                              properties:
+                                                apiVersion:
+                                                  description: Version of the schema
+                                                    the FieldPath is written in terms
+                                                    of, defaults to "v1".
+                                                  type: string
+                                                fieldPath:
+                                                  description: Path of the field to
+                                                    select in the specified API version.
+                                                  type: string
+                                              required:
+                                              - fieldPath
+                                              type: object
+                                            resourceFieldRef:
+                                              description: 'Selects a resource of
+                                                the container: only resources limits
+                                                and requests (limits.cpu, limits.memory,
+                                                limits.ephemeral-storage, requests.cpu,
+                                                requests.memory and requests.ephemeral-storage)
+                                                are currently supported.'
+                                              properties:
+                                                containerName:
+                                                  description: 'Container name: required
+                                                    for volumes, optional for env
+                                                    vars'
+                                                  type: string
+                                                divisor:
+                                                  anyOf:
+                                                  - type: integer
+                                                  - type: string
+                                                  description: Specifies the output
+                                                    format of the exposed resources,
+                                                    defaults to "1"
+                                                  pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                                  x-kubernetes-int-or-string: true
+                                                resource:
+                                                  description: 'Required: resource
+                                                    to select'
+                                                  type: string
+                                              required:
+                                              - resource
+                                              type: object
+                                            secretKeyRef:
+                                              description: Selects a key of a secret
+                                                in the pod's namespace
+                                              properties:
+                                                key:
+                                                  description: The key of the secret
+                                                    to select from.  Must be a valid
+                                                    secret key.
+                                                  type: string
+                                                name:
+                                                  description: 'Name of the referent.
+                                                    More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                                    TODO: Add other useful fields.
+                                                    apiVersion, kind, uid?'
+                                                  type: string
+                                                optional:
+                                                  description: Specify whether the
+                                                    Secret or its key must be defined
+                                                  type: boolean
+                                              required:
+                                              - key
+                                              type: object
+                                          type: object
+                                      required:
+                                      - name
+                                      type: object
+                                    type: array
+                                  envFrom:
+                                    description: List of sources to populate environment
+                                      variables in the container. The keys defined
+                                      within a source must be a C_IDENTIFIER. All
+                                      invalid keys will be reported as an event when
+                                      the container is starting. When a key exists
+                                      in multiple sources, the value associated with
+                                      the last source will take precedence. Values
+                                      defined by an Env with a duplicate key will
+                                      take precedence. Cannot be updated.
+                                    items:
+                                      description: EnvFromSource represents the source
+                                        of a set of ConfigMaps
+                                      properties:
+                                        configMapRef:
+                                          description: The ConfigMap to select from
+                                          properties:
+                                            name:
+                                              description: 'Name of the referent.
+                                                More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                                TODO: Add other useful fields. apiVersion,
+                                                kind, uid?'
+                                              type: string
+                                            optional:
+                                              description: Specify whether the ConfigMap
+                                                must be defined
+                                              type: boolean
+                                          type: object
+                                        prefix:
+                                          description: An optional identifier to prepend
+                                            to each key in the ConfigMap. Must be
+                                            a C_IDENTIFIER.
+                                          type: string
+                                        secretRef:
+                                          description: The Secret to select from
+                                          properties:
+                                            name:
+                                              description: 'Name of the referent.
+                                                More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                                TODO: Add other useful fields. apiVersion,
+                                                kind, uid?'
+                                              type: string
+                                            optional:
+                                              description: Specify whether the Secret
+                                                must be defined
+                                              type: boolean
+                                          type: object
+                                      type: object
+                                    type: array
+                                  image:
+                                    description: 'Docker image name. More info: https://kubernetes.io/docs/concepts/containers/images
+                                      This field is optional to allow higher level
+                                      config management to default or override container
+                                      images in workload controllers like Deployments
+                                      and StatefulSets.'
+                                    type: string
+                                  imagePullPolicy:
+                                    description: 'Image pull policy. One of Always,
+                                      Never, IfNotPresent. Defaults to Always if :latest
+                                      tag is specified, or IfNotPresent otherwise.
+                                      Cannot be updated. More info: https://kubernetes.io/docs/concepts/containers/images#updating-images'
+                                    type: string
+                                  lifecycle:
+                                    description: Actions that the management system
+                                      should take in response to container lifecycle
+                                      events. Cannot be updated.
+                                    properties:
+                                      postStart:
+                                        description: 'PostStart is called immediately
+                                          after a container is created. If the handler
+                                          fails, the container is terminated and restarted
+                                          according to its restart policy. Other management
+                                          of the container blocks until the hook completes.
+                                          More info: https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/#container-hooks'
+                                        properties:
+                                          exec:
+                                            description: One and only one of the following
+                                              should be specified. Exec specifies
+                                              the action to take.
+                                            properties:
+                                              command:
+                                                description: Command is the command
+                                                  line to execute inside the container,
+                                                  the working directory for the command  is
+                                                  root ('/') in the container's filesystem.
+                                                  The command is simply exec'd, it
+                                                  is not run inside a shell, so traditional
+                                                  shell instructions ('|', etc) won't
+                                                  work. To use a shell, you need to
+                                                  explicitly call out to that shell.
+                                                  Exit status of 0 is treated as live/healthy
+                                                  and non-zero is unhealthy.
+                                                items:
+                                                  type: string
+                                                type: array
+                                            type: object
+                                          httpGet:
+                                            description: HTTPGet specifies the http
+                                              request to perform.
+                                            properties:
+                                              host:
+                                                description: Host name to connect
+                                                  to, defaults to the pod IP. You
+                                                  probably want to set "Host" in httpHeaders
+                                                  instead.
+                                                type: string
+                                              httpHeaders:
+                                                description: Custom headers to set
+                                                  in the request. HTTP allows repeated
+                                                  headers.
+                                                items:
+                                                  description: HTTPHeader describes
+                                                    a custom header to be used in
+                                                    HTTP probes
+                                                  properties:
+                                                    name:
+                                                      description: The header field
+                                                        name
+                                                      type: string
+                                                    value:
+                                                      description: The header field
+                                                        value
+                                                      type: string
+                                                  required:
+                                                  - name
+                                                  - value
+                                                  type: object
+                                                type: array
+                                              path:
+                                                description: Path to access on the
+                                                  HTTP server.
+                                                type: string
+                                              port:
+                                                description: Name or number of the
+                                                  port to access on the container.
+                                                  Number must be in the range 1 to
+                                                  65535. Name must be an IANA_SVC_NAME.
+                                                x-kubernetes-int-or-string: true
+                                              scheme:
+                                                description: Scheme to use for connecting
+                                                  to the host. Defaults to HTTP.
+                                                type: string
+                                            required:
+                                            - port
+                                            type: object
+                                          tcpSocket:
+                                            description: 'TCPSocket specifies an action
+                                              involving a TCP port. TCP hooks not
+                                              yet supported TODO: implement a realistic
+                                              TCP lifecycle hook'
+                                            properties:
+                                              host:
+                                                description: 'Optional: Host name
+                                                  to connect to, defaults to the pod
+                                                  IP.'
+                                                type: string
+                                              port:
+                                                description: Number or name of the
+                                                  port to access on the container.
+                                                  Number must be in the range 1 to
+                                                  65535. Name must be an IANA_SVC_NAME.
+                                                x-kubernetes-int-or-string: true
+                                            required:
+                                            - port
+                                            type: object
+                                        type: object
+                                      preStop:
+                                        description: 'PreStop is called immediately
+                                          before a container is terminated due to
+                                          an API request or management event such
+                                          as liveness/startup probe failure, preemption,
+                                          resource contention, etc. The handler is
+                                          not called if the container crashes or exits.
+                                          The reason for termination is passed to
+                                          the handler. The Pod''s termination grace
+                                          period countdown begins before the PreStop
+                                          hooked is executed. Regardless of the outcome
+                                          of the handler, the container will eventually
+                                          terminate within the Pod''s termination
+                                          grace period. Other management of the container
+                                          blocks until the hook completes or until
+                                          the termination grace period is reached.
+                                          More info: https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/#container-hooks'
+                                        properties:
+                                          exec:
+                                            description: One and only one of the following
+                                              should be specified. Exec specifies
+                                              the action to take.
+                                            properties:
+                                              command:
+                                                description: Command is the command
+                                                  line to execute inside the container,
+                                                  the working directory for the command  is
+                                                  root ('/') in the container's filesystem.
+                                                  The command is simply exec'd, it
+                                                  is not run inside a shell, so traditional
+                                                  shell instructions ('|', etc) won't
+                                                  work. To use a shell, you need to
+                                                  explicitly call out to that shell.
+                                                  Exit status of 0 is treated as live/healthy
+                                                  and non-zero is unhealthy.
+                                                items:
+                                                  type: string
+                                                type: array
+                                            type: object
+                                          httpGet:
+                                            description: HTTPGet specifies the http
+                                              request to perform.
+                                            properties:
+                                              host:
+                                                description: Host name to connect
+                                                  to, defaults to the pod IP. You
+                                                  probably want to set "Host" in httpHeaders
+                                                  instead.
+                                                type: string
+                                              httpHeaders:
+                                                description: Custom headers to set
+                                                  in the request. HTTP allows repeated
+                                                  headers.
+                                                items:
+                                                  description: HTTPHeader describes
+                                                    a custom header to be used in
+                                                    HTTP probes
+                                                  properties:
+                                                    name:
+                                                      description: The header field
+                                                        name
+                                                      type: string
+                                                    value:
+                                                      description: The header field
+                                                        value
+                                                      type: string
+                                                  required:
+                                                  - name
+                                                  - value
+                                                  type: object
+                                                type: array
+                                              path:
+                                                description: Path to access on the
+                                                  HTTP server.
+                                                type: string
+                                              port:
+                                                description: Name or number of the
+                                                  port to access on the container.
+                                                  Number must be in the range 1 to
+                                                  65535. Name must be an IANA_SVC_NAME.
+                                                x-kubernetes-int-or-string: true
+                                              scheme:
+                                                description: Scheme to use for connecting
+                                                  to the host. Defaults to HTTP.
+                                                type: string
+                                            required:
+                                            - port
+                                            type: object
+                                          tcpSocket:
+                                            description: 'TCPSocket specifies an action
+                                              involving a TCP port. TCP hooks not
+                                              yet supported TODO: implement a realistic
+                                              TCP lifecycle hook'
+                                            properties:
+                                              host:
+                                                description: 'Optional: Host name
+                                                  to connect to, defaults to the pod
+                                                  IP.'
+                                                type: string
+                                              port:
+                                                description: Number or name of the
+                                                  port to access on the container.
+                                                  Number must be in the range 1 to
+                                                  65535. Name must be an IANA_SVC_NAME.
+                                                x-kubernetes-int-or-string: true
+                                            required:
+                                            - port
+                                            type: object
+                                        type: object
+                                    type: object
+                                  livenessProbe:
+                                    description: 'Periodic probe of container liveness.
+                                      Container will be restarted if the probe fails.
+                                      Cannot be updated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                                    properties:
+                                      exec:
+                                        description: One and only one of the following
+                                          should be specified. Exec specifies the
+                                          action to take.
+                                        properties:
+                                          command:
+                                            description: Command is the command line
+                                              to execute inside the container, the
+                                              working directory for the command  is
+                                              root ('/') in the container's filesystem.
+                                              The command is simply exec'd, it is
+                                              not run inside a shell, so traditional
+                                              shell instructions ('|', etc) won't
+                                              work. To use a shell, you need to explicitly
+                                              call out to that shell. Exit status
+                                              of 0 is treated as live/healthy and
+                                              non-zero is unhealthy.
+                                            items:
+                                              type: string
+                                            type: array
+                                        type: object
+                                      failureThreshold:
+                                        description: Minimum consecutive failures
+                                          for the probe to be considered failed after
+                                          having succeeded. Defaults to 3. Minimum
+                                          value is 1.
+                                        format: int32
+                                        type: integer
+                                      httpGet:
+                                        description: HTTPGet specifies the http request
+                                          to perform.
+                                        properties:
+                                          host:
+                                            description: Host name to connect to,
+                                              defaults to the pod IP. You probably
+                                              want to set "Host" in httpHeaders instead.
+                                            type: string
+                                          httpHeaders:
+                                            description: Custom headers to set in
+                                              the request. HTTP allows repeated headers.
+                                            items:
+                                              description: HTTPHeader describes a
+                                                custom header to be used in HTTP probes
+                                              properties:
+                                                name:
+                                                  description: The header field name
+                                                  type: string
+                                                value:
+                                                  description: The header field value
+                                                  type: string
+                                              required:
+                                              - name
+                                              - value
+                                              type: object
+                                            type: array
+                                          path:
+                                            description: Path to access on the HTTP
+                                              server.
+                                            type: string
+                                          port:
+                                            description: Name or number of the port
+                                              to access on the container. Number must
+                                              be in the range 1 to 65535. Name must
+                                              be an IANA_SVC_NAME.
+                                            x-kubernetes-int-or-string: true
+                                          scheme:
+                                            description: Scheme to use for connecting
+                                              to the host. Defaults to HTTP.
+                                            type: string
+                                        required:
+                                        - port
+                                        type: object
+                                      initialDelaySeconds:
+                                        description: 'Number of seconds after the
+                                          container has started before liveness probes
+                                          are initiated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                                        format: int32
+                                        type: integer
+                                      periodSeconds:
+                                        description: How often (in seconds) to perform
+                                          the probe. Default to 10 seconds. Minimum
+                                          value is 1.
+                                        format: int32
+                                        type: integer
+                                      successThreshold:
+                                        description: Minimum consecutive successes
+                                          for the probe to be considered successful
+                                          after having failed. Defaults to 1. Must
+                                          be 1 for liveness and startup. Minimum value
+                                          is 1.
+                                        format: int32
+                                        type: integer
+                                      tcpSocket:
+                                        description: 'TCPSocket specifies an action
+                                          involving a TCP port. TCP hooks not yet
+                                          supported TODO: implement a realistic TCP
+                                          lifecycle hook'
+                                        properties:
+                                          host:
+                                            description: 'Optional: Host name to connect
+                                              to, defaults to the pod IP.'
+                                            type: string
+                                          port:
+                                            description: Number or name of the port
+                                              to access on the container. Number must
+                                              be in the range 1 to 65535. Name must
+                                              be an IANA_SVC_NAME.
+                                            x-kubernetes-int-or-string: true
+                                        required:
+                                        - port
+                                        type: object
+                                      timeoutSeconds:
+                                        description: 'Number of seconds after which
+                                          the probe times out. Defaults to 1 second.
+                                          Minimum value is 1. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                                        format: int32
+                                        type: integer
+                                    type: object
+                                  name:
+                                    description: Name of the container specified as
+                                      a DNS_LABEL. Each container in a pod must have
+                                      a unique name (DNS_LABEL). Cannot be updated.
+                                    type: string
+                                  ports:
+                                    description: List of ports to expose from the
+                                      container. Exposing a port here gives the system
+                                      additional information about the network connections
+                                      a container uses, but is primarily informational.
+                                      Not specifying a port here DOES NOT prevent
+                                      that port from being exposed. Any port which
+                                      is listening on the default "0.0.0.0" address
+                                      inside a container will be accessible from the
+                                      network. Cannot be updated.
+                                    items:
+                                      description: ContainerPort represents a network
+                                        port in a single container.
+                                      properties:
+                                        containerPort:
+                                          description: Number of port to expose on
+                                            the pod's IP address. This must be a valid
+                                            port number, 0 < x < 65536.
+                                          format: int32
+                                          type: integer
+                                        hostIP:
+                                          description: What host IP to bind the external
+                                            port to.
+                                          type: string
+                                        hostPort:
+                                          description: Number of port to expose on
+                                            the host. If specified, this must be a
+                                            valid port number, 0 < x < 65536. If HostNetwork
+                                            is specified, this must match ContainerPort.
+                                            Most containers do not need this.
+                                          format: int32
+                                          type: integer
+                                        name:
+                                          description: If specified, this must be
+                                            an IANA_SVC_NAME and unique within the
+                                            pod. Each named port in a pod must have
+                                            a unique name. Name for the port that
+                                            can be referred to by services.
+                                          type: string
+                                        protocol:
+                                          description: Protocol for port. Must be
+                                            UDP, TCP, or SCTP. Defaults to "TCP".
+                                          type: string
+                                      required:
+                                      - containerPort
+                                      type: object
+                                    type: array
+                                    x-kubernetes-list-map-keys:
+                                    - containerPort
+                                    - protocol
+                                    x-kubernetes-list-type: map
+                                  readinessProbe:
+                                    description: 'Periodic probe of container service
+                                      readiness. Container will be removed from service
+                                      endpoints if the probe fails. Cannot be updated.
+                                      More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                                    properties:
+                                      exec:
+                                        description: One and only one of the following
+                                          should be specified. Exec specifies the
+                                          action to take.
+                                        properties:
+                                          command:
+                                            description: Command is the command line
+                                              to execute inside the container, the
+                                              working directory for the command  is
+                                              root ('/') in the container's filesystem.
+                                              The command is simply exec'd, it is
+                                              not run inside a shell, so traditional
+                                              shell instructions ('|', etc) won't
+                                              work. To use a shell, you need to explicitly
+                                              call out to that shell. Exit status
+                                              of 0 is treated as live/healthy and
+                                              non-zero is unhealthy.
+                                            items:
+                                              type: string
+                                            type: array
+                                        type: object
+                                      failureThreshold:
+                                        description: Minimum consecutive failures
+                                          for the probe to be considered failed after
+                                          having succeeded. Defaults to 3. Minimum
+                                          value is 1.
+                                        format: int32
+                                        type: integer
+                                      httpGet:
+                                        description: HTTPGet specifies the http request
+                                          to perform.
+                                        properties:
+                                          host:
+                                            description: Host name to connect to,
+                                              defaults to the pod IP. You probably
+                                              want to set "Host" in httpHeaders instead.
+                                            type: string
+                                          httpHeaders:
+                                            description: Custom headers to set in
+                                              the request. HTTP allows repeated headers.
+                                            items:
+                                              description: HTTPHeader describes a
+                                                custom header to be used in HTTP probes
+                                              properties:
+                                                name:
+                                                  description: The header field name
+                                                  type: string
+                                                value:
+                                                  description: The header field value
+                                                  type: string
+                                              required:
+                                              - name
+                                              - value
+                                              type: object
+                                            type: array
+                                          path:
+                                            description: Path to access on the HTTP
+                                              server.
+                                            type: string
+                                          port:
+                                            description: Name or number of the port
+                                              to access on the container. Number must
+                                              be in the range 1 to 65535. Name must
+                                              be an IANA_SVC_NAME.
+                                            x-kubernetes-int-or-string: true
+                                          scheme:
+                                            description: Scheme to use for connecting
+                                              to the host. Defaults to HTTP.
+                                            type: string
+                                        required:
+                                        - port
+                                        type: object
+                                      initialDelaySeconds:
+                                        description: 'Number of seconds after the
+                                          container has started before liveness probes
+                                          are initiated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                                        format: int32
+                                        type: integer
+                                      periodSeconds:
+                                        description: How often (in seconds) to perform
+                                          the probe. Default to 10 seconds. Minimum
+                                          value is 1.
+                                        format: int32
+                                        type: integer
+                                      successThreshold:
+                                        description: Minimum consecutive successes
+                                          for the probe to be considered successful
+                                          after having failed. Defaults to 1. Must
+                                          be 1 for liveness and startup. Minimum value
+                                          is 1.
+                                        format: int32
+                                        type: integer
+                                      tcpSocket:
+                                        description: 'TCPSocket specifies an action
+                                          involving a TCP port. TCP hooks not yet
+                                          supported TODO: implement a realistic TCP
+                                          lifecycle hook'
+                                        properties:
+                                          host:
+                                            description: 'Optional: Host name to connect
+                                              to, defaults to the pod IP.'
+                                            type: string
+                                          port:
+                                            description: Number or name of the port
+                                              to access on the container. Number must
+                                              be in the range 1 to 65535. Name must
+                                              be an IANA_SVC_NAME.
+                                            x-kubernetes-int-or-string: true
+                                        required:
+                                        - port
+                                        type: object
+                                      timeoutSeconds:
+                                        description: 'Number of seconds after which
+                                          the probe times out. Defaults to 1 second.
+                                          Minimum value is 1. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                                        format: int32
+                                        type: integer
+                                    type: object
+                                  resources:
+                                    description: 'Compute Resources required by this
+                                      container. Cannot be updated. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
+                                    properties:
+                                      limits:
+                                        additionalProperties:
+                                          anyOf:
+                                          - type: integer
+                                          - type: string
+                                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                          x-kubernetes-int-or-string: true
+                                        description: 'Limits describes the maximum
+                                          amount of compute resources allowed. More
+                                          info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
+                                        type: object
+                                      requests:
+                                        additionalProperties:
+                                          anyOf:
+                                          - type: integer
+                                          - type: string
+                                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                          x-kubernetes-int-or-string: true
+                                        description: 'Requests describes the minimum
+                                          amount of compute resources required. If
+                                          Requests is omitted for a container, it
+                                          defaults to Limits if that is explicitly
+                                          specified, otherwise to an implementation-defined
+                                          value. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
+                                        type: object
+                                    type: object
+                                  securityContext:
+                                    description: 'Security options the pod should
+                                      run with. More info: https://kubernetes.io/docs/concepts/policy/security-context/
+                                      More info: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/'
+                                    properties:
+                                      allowPrivilegeEscalation:
+                                        description: 'AllowPrivilegeEscalation controls
+                                          whether a process can gain more privileges
+                                          than its parent process. This bool directly
+                                          controls if the no_new_privs flag will be
+                                          set on the container process. AllowPrivilegeEscalation
+                                          is true always when the container is: 1)
+                                          run as Privileged 2) has CAP_SYS_ADMIN'
+                                        type: boolean
+                                      capabilities:
+                                        description: The capabilities to add/drop
+                                          when running containers. Defaults to the
+                                          default set of capabilities granted by the
+                                          container runtime.
+                                        properties:
+                                          add:
+                                            description: Added capabilities
+                                            items:
+                                              description: Capability represent POSIX
+                                                capabilities type
+                                              type: string
+                                            type: array
+                                          drop:
+                                            description: Removed capabilities
+                                            items:
+                                              description: Capability represent POSIX
+                                                capabilities type
+                                              type: string
+                                            type: array
+                                        type: object
+                                      privileged:
+                                        description: Run container in privileged mode.
+                                          Processes in privileged containers are essentially
+                                          equivalent to root on the host. Defaults
+                                          to false.
+                                        type: boolean
+                                      procMount:
+                                        description: procMount denotes the type of
+                                          proc mount to use for the containers. The
+                                          default is DefaultProcMount which uses the
+                                          container runtime defaults for readonly
+                                          paths and masked paths. This requires the
+                                          ProcMountType feature flag to be enabled.
+                                        type: string
+                                      readOnlyRootFilesystem:
+                                        description: Whether this container has a
+                                          read-only root filesystem. Default is false.
+                                        type: boolean
+                                      runAsGroup:
+                                        description: The GID to run the entrypoint
+                                          of the container process. Uses runtime default
+                                          if unset. May also be set in PodSecurityContext.  If
+                                          set in both SecurityContext and PodSecurityContext,
+                                          the value specified in SecurityContext takes
+                                          precedence.
+                                        format: int64
+                                        type: integer
+                                      runAsNonRoot:
+                                        description: Indicates that the container
+                                          must run as a non-root user. If true, the
+                                          Kubelet will validate the image at runtime
+                                          to ensure that it does not run as UID 0
+                                          (root) and fail to start the container if
+                                          it does. If unset or false, no such validation
+                                          will be performed. May also be set in PodSecurityContext.  If
+                                          set in both SecurityContext and PodSecurityContext,
+                                          the value specified in SecurityContext takes
+                                          precedence.
+                                        type: boolean
+                                      runAsUser:
+                                        description: The UID to run the entrypoint
+                                          of the container process. Defaults to user
+                                          specified in image metadata if unspecified.
+                                          May also be set in PodSecurityContext.  If
+                                          set in both SecurityContext and PodSecurityContext,
+                                          the value specified in SecurityContext takes
+                                          precedence.
+                                        format: int64
+                                        type: integer
+                                      seLinuxOptions:
+                                        description: The SELinux context to be applied
+                                          to the container. If unspecified, the container
+                                          runtime will allocate a random SELinux context
+                                          for each container.  May also be set in
+                                          PodSecurityContext.  If set in both SecurityContext
+                                          and PodSecurityContext, the value specified
+                                          in SecurityContext takes precedence.
+                                        properties:
+                                          level:
+                                            description: Level is SELinux level label
+                                              that applies to the container.
+                                            type: string
+                                          role:
+                                            description: Role is a SELinux role label
+                                              that applies to the container.
+                                            type: string
+                                          type:
+                                            description: Type is a SELinux type label
+                                              that applies to the container.
+                                            type: string
+                                          user:
+                                            description: User is a SELinux user label
+                                              that applies to the container.
+                                            type: string
+                                        type: object
+                                      windowsOptions:
+                                        description: The Windows specific settings
+                                          applied to all containers. If unspecified,
+                                          the options from the PodSecurityContext
+                                          will be used. If set in both SecurityContext
+                                          and PodSecurityContext, the value specified
+                                          in SecurityContext takes precedence.
+                                        properties:
+                                          gmsaCredentialSpec:
+                                            description: GMSACredentialSpec is where
+                                              the GMSA admission webhook (https://github.com/kubernetes-sigs/windows-gmsa)
+                                              inlines the contents of the GMSA credential
+                                              spec named by the GMSACredentialSpecName
+                                              field. This field is alpha-level and
+                                              is only honored by servers that enable
+                                              the WindowsGMSA feature flag.
+                                            type: string
+                                          gmsaCredentialSpecName:
+                                            description: GMSACredentialSpecName is
+                                              the name of the GMSA credential spec
+                                              to use. This field is alpha-level and
+                                              is only honored by servers that enable
+                                              the WindowsGMSA feature flag.
+                                            type: string
+                                          runAsUserName:
+                                            description: The UserName in Windows to
+                                              run the entrypoint of the container
+                                              process. Defaults to the user specified
+                                              in image metadata if unspecified. May
+                                              also be set in PodSecurityContext. If
+                                              set in both SecurityContext and PodSecurityContext,
+                                              the value specified in SecurityContext
+                                              takes precedence. This field is beta-level
+                                              and may be disabled with the WindowsRunAsUserName
+                                              feature flag.
+                                            type: string
+                                        type: object
+                                    type: object
+                                  startupProbe:
+                                    description: 'StartupProbe indicates that the
+                                      Pod has successfully initialized. If specified,
+                                      no other probes are executed until this completes
+                                      successfully. If this probe fails, the Pod will
+                                      be restarted, just as if the livenessProbe failed.
+                                      This can be used to provide different probe
+                                      parameters at the beginning of a Pod''s lifecycle,
+                                      when it might take a long time to load data
+                                      or warm a cache, than during steady-state operation.
+                                      This cannot be updated. This is an alpha feature
+                                      enabled by the StartupProbe feature flag. More
+                                      info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                                    properties:
+                                      exec:
+                                        description: One and only one of the following
+                                          should be specified. Exec specifies the
+                                          action to take.
+                                        properties:
+                                          command:
+                                            description: Command is the command line
+                                              to execute inside the container, the
+                                              working directory for the command  is
+                                              root ('/') in the container's filesystem.
+                                              The command is simply exec'd, it is
+                                              not run inside a shell, so traditional
+                                              shell instructions ('|', etc) won't
+                                              work. To use a shell, you need to explicitly
+                                              call out to that shell. Exit status
+                                              of 0 is treated as live/healthy and
+                                              non-zero is unhealthy.
+                                            items:
+                                              type: string
+                                            type: array
+                                        type: object
+                                      failureThreshold:
+                                        description: Minimum consecutive failures
+                                          for the probe to be considered failed after
+                                          having succeeded. Defaults to 3. Minimum
+                                          value is 1.
+                                        format: int32
+                                        type: integer
+                                      httpGet:
+                                        description: HTTPGet specifies the http request
+                                          to perform.
+                                        properties:
+                                          host:
+                                            description: Host name to connect to,
+                                              defaults to the pod IP. You probably
+                                              want to set "Host" in httpHeaders instead.
+                                            type: string
+                                          httpHeaders:
+                                            description: Custom headers to set in
+                                              the request. HTTP allows repeated headers.
+                                            items:
+                                              description: HTTPHeader describes a
+                                                custom header to be used in HTTP probes
+                                              properties:
+                                                name:
+                                                  description: The header field name
+                                                  type: string
+                                                value:
+                                                  description: The header field value
+                                                  type: string
+                                              required:
+                                              - name
+                                              - value
+                                              type: object
+                                            type: array
+                                          path:
+                                            description: Path to access on the HTTP
+                                              server.
+                                            type: string
+                                          port:
+                                            anyOf:
+                                            - type: integer
+                                            - type: string
+                                            description: Name or number of the port
+                                              to access on the container. Number must
+                                              be in the range 1 to 65535. Name must
+                                              be an IANA_SVC_NAME.
+                                            x-kubernetes-int-or-string: true
+                                          scheme:
+                                            description: Scheme to use for connecting
+                                              to the host. Defaults to HTTP.
+                                            type: string
+                                        required:
+                                        - port
+                                        type: object
+                                      initialDelaySeconds:
+                                        description: 'Number of seconds after the
+                                          container has started before liveness probes
+                                          are initiated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                                        format: int32
+                                        type: integer
+                                      periodSeconds:
+                                        description: How often (in seconds) to perform
+                                          the probe. Default to 10 seconds. Minimum
+                                          value is 1.
+                                        format: int32
+                                        type: integer
+                                      successThreshold:
+                                        description: Minimum consecutive successes
+                                          for the probe to be considered successful
+                                          after having failed. Defaults to 1. Must
+                                          be 1 for liveness and startup. Minimum value
+                                          is 1.
+                                        format: int32
+                                        type: integer
+                                      tcpSocket:
+                                        description: 'TCPSocket specifies an action
+                                          involving a TCP port. TCP hooks not yet
+                                          supported TODO: implement a realistic TCP
+                                          lifecycle hook'
+                                        properties:
+                                          host:
+                                            description: 'Optional: Host name to connect
+                                              to, defaults to the pod IP.'
+                                            type: string
+                                          port:
+                                            anyOf:
+                                            - type: integer
+                                            - type: string
+                                            description: Number or name of the port
+                                              to access on the container. Number must
+                                              be in the range 1 to 65535. Name must
+                                              be an IANA_SVC_NAME.
+                                            x-kubernetes-int-or-string: true
+                                        required:
+                                        - port
+                                        type: object
+                                      timeoutSeconds:
+                                        description: 'Number of seconds after which
+                                          the probe times out. Defaults to 1 second.
+                                          Minimum value is 1. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                                        format: int32
+                                        type: integer
+                                    type: object
+                                  stdin:
+                                    description: Whether this container should allocate
+                                      a buffer for stdin in the container runtime.
+                                      If this is not set, reads from stdin in the
+                                      container will always result in EOF. Default
+                                      is false.
+                                    type: boolean
+                                  stdinOnce:
+                                    description: Whether the container runtime should
+                                      close the stdin channel after it has been opened
+                                      by a single attach. When stdin is true the stdin
+                                      stream will remain open across multiple attach
+                                      sessions. If stdinOnce is set to true, stdin
+                                      is opened on container start, is empty until
+                                      the first client attaches to stdin, and then
+                                      remains open and accepts data until the client
+                                      disconnects, at which time stdin is closed and
+                                      remains closed until the container is restarted.
+                                      If this flag is false, a container processes
+                                      that reads from stdin will never receive an
+                                      EOF. Default is false
+                                    type: boolean
+                                  terminationMessagePath:
+                                    description: 'Optional: Path at which the file
+                                      to which the container''s termination message
+                                      will be written is mounted into the container''s
+                                      filesystem. Message written is intended to be
+                                      brief final status, such as an assertion failure
+                                      message. Will be truncated by the node if greater
+                                      than 4096 bytes. The total message length across
+                                      all containers will be limited to 12kb. Defaults
+                                      to /dev/termination-log. Cannot be updated.'
+                                    type: string
+                                  terminationMessagePolicy:
+                                    description: Indicate how the termination message
+                                      should be populated. File will use the contents
+                                      of terminationMessagePath to populate the container
+                                      status message on both success and failure.
+                                      FallbackToLogsOnError will use the last chunk
+                                      of container log output if the termination message
+                                      file is empty and the container exited with
+                                      an error. The log output is limited to 2048
+                                      bytes or 80 lines, whichever is smaller. Defaults
+                                      to File. Cannot be updated.
+                                    type: string
+                                  tty:
+                                    description: Whether this container should allocate
+                                      a TTY for itself, also requires 'stdin' to be
+                                      true. Default is false.
+                                    type: boolean
+                                  volumeDevices:
+                                    description: volumeDevices is the list of block
+                                      devices to be used by the container. This is
+                                      a beta feature.
+                                    items:
+                                      description: volumeDevice describes a mapping
+                                        of a raw block device within a container.
+                                      properties:
+                                        devicePath:
+                                          description: devicePath is the path inside
+                                            of the container that the device will
+                                            be mapped to.
+                                          type: string
+                                        name:
+                                          description: name must match the name of
+                                            a persistentVolumeClaim in the pod
+                                          type: string
+                                      required:
+                                      - devicePath
+                                      - name
+                                      type: object
+                                    type: array
+                                  volumeMounts:
+                                    description: Pod volumes to mount into the container's
+                                      filesystem. Cannot be updated.
+                                    items:
+                                      description: VolumeMount describes a mounting
+                                        of a Volume within a container.
+                                      properties:
+                                        mountPath:
+                                          description: Path within the container at
+                                            which the volume should be mounted.  Must
+                                            not contain ':'.
+                                          type: string
+                                        mountPropagation:
+                                          description: mountPropagation determines
+                                            how mounts are propagated from the host
+                                            to container and the other way around.
+                                            When not set, MountPropagationNone is
+                                            used. This field is beta in 1.10.
+                                          type: string
+                                        name:
+                                          description: This must match the Name of
+                                            a Volume.
+                                          type: string
+                                        readOnly:
+                                          description: Mounted read-only if true,
+                                            read-write otherwise (false or unspecified).
+                                            Defaults to false.
+                                          type: boolean
+                                        subPath:
+                                          description: Path within the volume from
+                                            which the container's volume should be
+                                            mounted. Defaults to "" (volume's root).
+                                          type: string
+                                        subPathExpr:
+                                          description: Expanded path within the volume
+                                            from which the container's volume should
+                                            be mounted. Behaves similarly to SubPath
+                                            but environment variable references $(VAR_NAME)
+                                            are expanded using the container's environment.
+                                            Defaults to "" (volume's root). SubPathExpr
+                                            and SubPath are mutually exclusive.
+                                          type: string
+                                      required:
+                                      - mountPath
+                                      - name
+                                      type: object
+                                    type: array
+                                  workingDir:
+                                    description: Container's working directory. If
+                                      not specified, the container runtime's default
+                                      will be used, which might be configured in the
+                                      container image. Cannot be updated.
+                                    type: string
+                                required:
+                                - name
+                                type: object
+                              type: array
+                            nodeName:
+                              description: NodeName is a request to schedule this
+                                pod onto a specific node. If it is non-empty, the
+                                scheduler simply schedules this pod onto that node,
+                                assuming that it fits resource requirements.
+                              type: string
+                            nodeSelector:
+                              additionalProperties:
+                                type: string
+                              description: 'NodeSelector is a selector which must
+                                be true for the pod to fit on a node. Selector which
+                                must match a node''s labels for the pod to be scheduled
+                                on that node. More info: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/'
+                              type: object
+                            overhead:
+                              additionalProperties:
+                                anyOf:
+                                - type: integer
+                                - type: string
+                                pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                x-kubernetes-int-or-string: true
+                              description: 'Overhead represents the resource overhead
+                                associated with running a pod for a given RuntimeClass.
+                                This field will be autopopulated at admission time
+                                by the RuntimeClass admission controller. If the RuntimeClass
+                                admission controller is enabled, overhead must not
+                                be set in Pod create requests. The RuntimeClass admission
+                                controller will reject Pod create requests which have
+                                the overhead already set. If RuntimeClass is configured
+                                and selected in the PodSpec, Overhead will be set
+                                to the value defined in the corresponding RuntimeClass,
+                                otherwise it will remain unset and treated as zero.
+                                More info: https://git.k8s.io/enhancements/keps/sig-node/20190226-pod-overhead.md
+                                This field is alpha-level as of Kubernetes v1.16,
+                                and is only honored by servers that enable the PodOverhead
+                                feature.'
+                              type: object
+                            preemptionPolicy:
+                              description: PreemptionPolicy is the Policy for preempting
+                                pods with lower priority. One of Never, PreemptLowerPriority.
+                                Defaults to PreemptLowerPriority if unset. This field
+                                is alpha-level and is only honored by servers that
+                                enable the NonPreemptingPriority feature.
+                              type: string
+                            priority:
+                              description: The priority value. Various system components
+                                use this field to find the priority of the pod. When
+                                Priority Admission Controller is enabled, it prevents
+                                users from setting this field. The admission controller
+                                populates this field from PriorityClassName. The higher
+                                the value, the higher the priority.
+                              format: int32
+                              type: integer
+                            priorityClassName:
+                              description: If specified, indicates the pod's priority.
+                                "system-node-critical" and "system-cluster-critical"
+                                are two special keywords which indicate the highest
+                                priorities with the former being the highest priority.
+                                Any other name must be defined by creating a PriorityClass
+                                object with that name. If not specified, the pod priority
+                                will be default or zero if there is no default.
+                              type: string
+                            readinessGates:
+                              description: 'If specified, all readiness gates will
+                                be evaluated for pod readiness. A pod is ready when
+                                all its containers are ready AND all conditions specified
+                                in the readiness gates have status equal to "True"
+                                More info: https://git.k8s.io/enhancements/keps/sig-network/0007-pod-ready%2B%2B.md'
+                              items:
+                                description: PodReadinessGate contains the reference
+                                  to a pod condition
+                                properties:
+                                  conditionType:
+                                    description: ConditionType refers to a condition
+                                      in the pod's condition list with matching type.
+                                    type: string
+                                required:
+                                - conditionType
+                                type: object
+                              type: array
+                            restartPolicy:
+                              description: 'Restart policy for all containers within
+                                the pod. One of Always, OnFailure, Never. Default
+                                to Always. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle/#restart-policy'
+                              type: string
+                            runtimeClassName:
+                              description: 'RuntimeClassName refers to a RuntimeClass
+                                object in the node.k8s.io group, which should be used
+                                to run this pod.  If no RuntimeClass resource matches
+                                the named class, the pod will not be run. If unset
+                                or empty, the "legacy" RuntimeClass will be used,
+                                which is an implicit class with an empty definition
+                                that uses the default runtime handler. More info:
+                                https://git.k8s.io/enhancements/keps/sig-node/runtime-class.md
+                                This is a beta feature as of Kubernetes v1.14.'
+                              type: string
+                            schedulerName:
+                              description: If specified, the pod will be dispatched
+                                by specified scheduler. If not specified, the pod
+                                will be dispatched by default scheduler.
+                              type: string
+                            securityContext:
+                              description: 'SecurityContext holds pod-level security
+                                attributes and common container settings. Optional:
+                                Defaults to empty.  See type description for default
+                                values of each field.'
+                              properties:
+                                fsGroup:
+                                  description: "A special supplemental group that
+                                    applies to all containers in a pod. Some volume
+                                    types allow the Kubelet to change the ownership
+                                    of that volume to be owned by the pod: \n 1. The
+                                    owning GID will be the FSGroup 2. The setgid bit
+                                    is set (new files created in the volume will be
+                                    owned by FSGroup) 3. The permission bits are OR'd
+                                    with rw-rw---- \n If unset, the Kubelet will not
+                                    modify the ownership and permissions of any volume."
+                                  format: int64
+                                  type: integer
+                                runAsGroup:
+                                  description: The GID to run the entrypoint of the
+                                    container process. Uses runtime default if unset.
+                                    May also be set in SecurityContext.  If set in
+                                    both SecurityContext and PodSecurityContext, the
+                                    value specified in SecurityContext takes precedence
+                                    for that container.
+                                  format: int64
+                                  type: integer
+                                runAsNonRoot:
+                                  description: Indicates that the container must run
+                                    as a non-root user. If true, the Kubelet will
+                                    validate the image at runtime to ensure that it
+                                    does not run as UID 0 (root) and fail to start
+                                    the container if it does. If unset or false, no
+                                    such validation will be performed. May also be
+                                    set in SecurityContext.  If set in both SecurityContext
+                                    and PodSecurityContext, the value specified in
+                                    SecurityContext takes precedence.
+                                  type: boolean
+                                runAsUser:
+                                  description: The UID to run the entrypoint of the
+                                    container process. Defaults to user specified
+                                    in image metadata if unspecified. May also be
+                                    set in SecurityContext.  If set in both SecurityContext
+                                    and PodSecurityContext, the value specified in
+                                    SecurityContext takes precedence for that container.
+                                  format: int64
+                                  type: integer
+                                seLinuxOptions:
+                                  description: The SELinux context to be applied to
+                                    all containers. If unspecified, the container
+                                    runtime will allocate a random SELinux context
+                                    for each container.  May also be set in SecurityContext.  If
+                                    set in both SecurityContext and PodSecurityContext,
+                                    the value specified in SecurityContext takes precedence
+                                    for that container.
+                                  properties:
+                                    level:
+                                      description: Level is SELinux level label that
+                                        applies to the container.
+                                      type: string
+                                    role:
+                                      description: Role is a SELinux role label that
+                                        applies to the container.
+                                      type: string
+                                    type:
+                                      description: Type is a SELinux type label that
+                                        applies to the container.
+                                      type: string
+                                    user:
+                                      description: User is a SELinux user label that
+                                        applies to the container.
+                                      type: string
+                                  type: object
+                                supplementalGroups:
+                                  description: A list of groups applied to the first
+                                    process run in each container, in addition to
+                                    the container's primary GID.  If unspecified,
+                                    no groups will be added to any container.
+                                  items:
+                                    format: int64
+                                    type: integer
+                                  type: array
+                                sysctls:
+                                  description: Sysctls hold a list of namespaced sysctls
+                                    used for the pod. Pods with unsupported sysctls
+                                    (by the container runtime) might fail to launch.
+                                  items:
+                                    description: Sysctl defines a kernel parameter
+                                      to be set
+                                    properties:
+                                      name:
+                                        description: Name of a property to set
+                                        type: string
+                                      value:
+                                        description: Value of a property to set
+                                        type: string
+                                    required:
+                                    - name
+                                    - value
+                                    type: object
+                                  type: array
+                                windowsOptions:
+                                  description: The Windows specific settings applied
+                                    to all containers. If unspecified, the options
+                                    within a container's SecurityContext will be used.
+                                    If set in both SecurityContext and PodSecurityContext,
+                                    the value specified in SecurityContext takes precedence.
+                                  properties:
+                                    gmsaCredentialSpec:
+                                      description: GMSACredentialSpec is where the
+                                        GMSA admission webhook (https://github.com/kubernetes-sigs/windows-gmsa)
+                                        inlines the contents of the GMSA credential
+                                        spec named by the GMSACredentialSpecName field.
+                                        This field is alpha-level and is only honored
+                                        by servers that enable the WindowsGMSA feature
+                                        flag.
+                                      type: string
+                                    gmsaCredentialSpecName:
+                                      description: GMSACredentialSpecName is the name
+                                        of the GMSA credential spec to use. This field
+                                        is alpha-level and is only honored by servers
+                                        that enable the WindowsGMSA feature flag.
+                                      type: string
+                                    runAsUserName:
+                                      description: The UserName in Windows to run
+                                        the entrypoint of the container process. Defaults
+                                        to the user specified in image metadata if
+                                        unspecified. May also be set in PodSecurityContext.
+                                        If set in both SecurityContext and PodSecurityContext,
+                                        the value specified in SecurityContext takes
+                                        precedence. This field is beta-level and may
+                                        be disabled with the WindowsRunAsUserName
+                                        feature flag.
+                                      type: string
+                                  type: object
+                              type: object
+                            serviceAccount:
+                              description: 'DeprecatedServiceAccount is a depreciated
+                                alias for ServiceAccountName. Deprecated: Use serviceAccountName
+                                instead.'
+                              type: string
+                            serviceAccountName:
+                              description: 'ServiceAccountName is the name of the
+                                ServiceAccount to use to run this pod. More info:
+                                https://kubernetes.io/docs/tasks/configure-pod-container/configure-service-account/'
+                              type: string
+                            shareProcessNamespace:
+                              description: 'Share a single process namespace between
+                                all of the containers in a pod. When this is set containers
+                                will be able to view and signal processes from other
+                                containers in the same pod, and the first process
+                                in each container will not be assigned PID 1. HostPID
+                                and ShareProcessNamespace cannot both be set. Optional:
+                                Default to false.'
+                              type: boolean
+                            subdomain:
+                              description: If specified, the fully qualified Pod hostname
+                                will be "<hostname>.<subdomain>.<pod namespace>.svc.<cluster
+                                domain>". If not specified, the pod will not have
+                                a domainname at all.
+                              type: string
+                            terminationGracePeriodSeconds:
+                              description: Optional duration in seconds the pod needs
+                                to terminate gracefully. May be decreased in delete
+                                request. Value must be non-negative integer. The value
+                                zero indicates delete immediately. If this value is
+                                nil, the default grace period will be used instead.
+                                The grace period is the duration in seconds after
+                                the processes running in the pod are sent a termination
+                                signal and the time when the processes are forcibly
+                                halted with a kill signal. Set this value longer than
+                                the expected cleanup time for your process. Defaults
+                                to 30 seconds.
+                              format: int64
+                              type: integer
+                            tolerations:
+                              description: If specified, the pod's tolerations.
+                              items:
+                                description: The pod this Toleration is attached to
+                                  tolerates any taint that matches the triple <key,value,effect>
+                                  using the matching operator <operator>.
+                                properties:
+                                  effect:
+                                    description: Effect indicates the taint effect
+                                      to match. Empty means match all taint effects.
+                                      When specified, allowed values are NoSchedule,
+                                      PreferNoSchedule and NoExecute.
+                                    type: string
+                                  key:
+                                    description: Key is the taint key that the toleration
+                                      applies to. Empty means match all taint keys.
+                                      If the key is empty, operator must be Exists;
+                                      this combination means to match all values and
+                                      all keys.
+                                    type: string
+                                  operator:
+                                    description: Operator represents a key's relationship
+                                      to the value. Valid operators are Exists and
+                                      Equal. Defaults to Equal. Exists is equivalent
+                                      to wildcard for value, so that a pod can tolerate
+                                      all taints of a particular category.
+                                    type: string
+                                  tolerationSeconds:
+                                    description: TolerationSeconds represents the
+                                      period of time the toleration (which must be
+                                      of effect NoExecute, otherwise this field is
+                                      ignored) tolerates the taint. By default, it
+                                      is not set, which means tolerate the taint forever
+                                      (do not evict). Zero and negative values will
+                                      be treated as 0 (evict immediately) by the system.
+                                    format: int64
+                                    type: integer
+                                  value:
+                                    description: Value is the taint value the toleration
+                                      matches to. If the operator is Exists, the value
+                                      should be empty, otherwise just a regular string.
+                                    type: string
+                                type: object
+                              type: array
+                            topologySpreadConstraints:
+                              description: TopologySpreadConstraints describes how
+                                a group of pods ought to spread across topology domains.
+                                Scheduler will schedule pods in a way which abides
+                                by the constraints. This field is alpha-level and
+                                is only honored by clusters that enables the EvenPodsSpread
+                                feature. All topologySpreadConstraints are ANDed.
+                              items:
+                                description: TopologySpreadConstraint specifies how
+                                  to spread matching pods among the given topology.
+                                properties:
+                                  labelSelector:
+                                    description: LabelSelector is used to find matching
+                                      pods. Pods that match this label selector are
+                                      counted to determine the number of pods in their
+                                      corresponding topology domain.
+                                    properties:
+                                      matchExpressions:
+                                        description: matchExpressions is a list of
+                                          label selector requirements. The requirements
+                                          are ANDed.
+                                        items:
+                                          description: A label selector requirement
+                                            is a selector that contains values, a
+                                            key, and an operator that relates the
+                                            key and values.
+                                          properties:
+                                            key:
+                                              description: key is the label key that
+                                                the selector applies to.
+                                              type: string
+                                            operator:
+                                              description: operator represents a key's
+                                                relationship to a set of values. Valid
+                                                operators are In, NotIn, Exists and
+                                                DoesNotExist.
+                                              type: string
+                                            values:
+                                              description: values is an array of string
+                                                values. If the operator is In or NotIn,
+                                                the values array must be non-empty.
+                                                If the operator is Exists or DoesNotExist,
+                                                the values array must be empty. This
+                                                array is replaced during a strategic
+                                                merge patch.
+                                              items:
+                                                type: string
+                                              type: array
+                                          required:
+                                          - key
+                                          - operator
+                                          type: object
+                                        type: array
+                                      matchLabels:
+                                        additionalProperties:
+                                          type: string
+                                        description: matchLabels is a map of {key,value}
+                                          pairs. A single {key,value} in the matchLabels
+                                          map is equivalent to an element of matchExpressions,
+                                          whose key field is "key", the operator is
+                                          "In", and the values array contains only
+                                          "value". The requirements are ANDed.
+                                        type: object
+                                    type: object
+                                  maxSkew:
+                                    description: 'MaxSkew describes the degree to
+                                      which pods may be unevenly distributed. It''s
+                                      the maximum permitted difference between the
+                                      number of matching pods in any two topology
+                                      domains of a given topology type. For example,
+                                      in a 3-zone cluster, MaxSkew is set to 1, and
+                                      pods with the same labelSelector spread as 1/1/0:
+                                      | zone1 | zone2 | zone3 | |   P   |   P   |       |
+                                      - if MaxSkew is 1, incoming pod can only be
+                                      scheduled to zone3 to become 1/1/1; scheduling
+                                      it onto zone1(zone2) would make the ActualSkew(2-0)
+                                      on zone1(zone2) violate MaxSkew(1). - if MaxSkew
+                                      is 2, incoming pod can be scheduled onto any
+                                      zone. It''s a required field. Default value
+                                      is 1 and 0 is not allowed.'
+                                    format: int32
+                                    type: integer
+                                  topologyKey:
+                                    description: TopologyKey is the key of node labels.
+                                      Nodes that have a label with this key and identical
+                                      values are considered to be in the same topology.
+                                      We consider each <key, value> as a "bucket",
+                                      and try to put balanced number of pods into
+                                      each bucket. It's a required field.
+                                    type: string
+                                  whenUnsatisfiable:
+                                    description: 'WhenUnsatisfiable indicates how
+                                      to deal with a pod if it doesn''t satisfy the
+                                      spread constraint. - DoNotSchedule (default)
+                                      tells the scheduler not to schedule it - ScheduleAnyway
+                                      tells the scheduler to still schedule it It''s
+                                      considered as "Unsatisfiable" if and only if
+                                      placing incoming pod on any topology violates
+                                      "MaxSkew". For example, in a 3-zone cluster,
+                                      MaxSkew is set to 1, and pods with the same
+                                      labelSelector spread as 3/1/1: | zone1 | zone2
+                                      | zone3 | | P P P |   P   |   P   | If WhenUnsatisfiable
+                                      is set to DoNotSchedule, incoming pod can only
+                                      be scheduled to zone2(zone3) to become 3/2/1(3/1/2)
+                                      as ActualSkew(2-1) on zone2(zone3) satisfies
+                                      MaxSkew(1). In other words, the cluster can
+                                      still be imbalanced, but scheduler won''t make
+                                      it *more* imbalanced. It''s a required field.'
+                                    type: string
+                                required:
+                                - maxSkew
+                                - topologyKey
+                                - whenUnsatisfiable
+                                type: object
+                              type: array
+                              x-kubernetes-list-map-keys:
+                              - topologyKey
+                              - whenUnsatisfiable
+                              x-kubernetes-list-type: map
+                            volumes:
+                              description: 'List of volumes that can be mounted by
+                                containers belonging to the pod. More info: https://kubernetes.io/docs/concepts/storage/volumes'
+                              items:
+                                type: object
+                              type: array
+                          required:
+                          - containers
+                          type: object
+                      type: object
+                    type: array
+                  engineResources:
+                    description: ResourceRequirements describes the compute resource
+                      requirements.
+                    properties:
+                      limits:
+                        additionalProperties:
+                          anyOf:
+                          - type: integer
+                          - type: string
+                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                          x-kubernetes-int-or-string: true
+                        description: 'Limits describes the maximum amount of compute
+                          resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
+                        type: object
+                      requests:
+                        additionalProperties:
+                          anyOf:
+                          - type: integer
+                          - type: string
+                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                          x-kubernetes-int-or-string: true
+                        description: 'Requests describes the minimum amount of compute
+                          resources required. If Requests is omitted for a container,
+                          it defaults to Limits if that is explicitly specified, otherwise
+                          to an implementation-defined value. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
+                        type: object
+                    type: object
+                  explainer:
+                    properties:
+                      config:
+                        additionalProperties:
+                          type: string
+                        type: object
+                      containerSpec:
+                        description: A single application container that you want
+                          to run within a pod.
+                        properties:
+                          args:
+                            description: 'Arguments to the entrypoint. The docker
+                              image''s CMD is used if this is not provided. Variable
+                              references $(VAR_NAME) are expanded using the container''s
+                              environment. If a variable cannot be resolved, the reference
+                              in the input string will be unchanged. The $(VAR_NAME)
+                              syntax can be escaped with a double $$, ie: $$(VAR_NAME).
+                              Escaped references will never be expanded, regardless
+                              of whether the variable exists or not. Cannot be updated.
+                              More info: https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell'
+                            items:
+                              type: string
+                            type: array
+                          command:
+                            description: 'Entrypoint array. Not executed within a
+                              shell. The docker image''s ENTRYPOINT is used if this
+                              is not provided. Variable references $(VAR_NAME) are
+                              expanded using the container''s environment. If a variable
+                              cannot be resolved, the reference in the input string
+                              will be unchanged. The $(VAR_NAME) syntax can be escaped
+                              with a double $$, ie: $$(VAR_NAME). Escaped references
+                              will never be expanded, regardless of whether the variable
+                              exists or not. Cannot be updated. More info: https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell'
+                            items:
+                              type: string
+                            type: array
+                          env:
+                            description: List of environment variables to set in the
+                              container. Cannot be updated.
+                            items:
+                              description: EnvVar represents an environment variable
+                                present in a Container.
+                              properties:
+                                name:
+                                  description: Name of the environment variable. Must
+                                    be a C_IDENTIFIER.
+                                  type: string
+                                value:
+                                  description: 'Variable references $(VAR_NAME) are
+                                    expanded using the previous defined environment
+                                    variables in the container and any service environment
+                                    variables. If a variable cannot be resolved, the
+                                    reference in the input string will be unchanged.
+                                    The $(VAR_NAME) syntax can be escaped with a double
+                                    $$, ie: $$(VAR_NAME). Escaped references will
+                                    never be expanded, regardless of whether the variable
+                                    exists or not. Defaults to "".'
+                                  type: string
+                                valueFrom:
+                                  description: Source for the environment variable's
+                                    value. Cannot be used if value is not empty.
+                                  properties:
+                                    configMapKeyRef:
+                                      description: Selects a key of a ConfigMap.
+                                      properties:
+                                        key:
+                                          description: The key to select.
+                                          type: string
+                                        name:
+                                          description: 'Name of the referent. More
+                                            info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                            TODO: Add other useful fields. apiVersion,
+                                            kind, uid?'
+                                          type: string
+                                        optional:
+                                          description: Specify whether the ConfigMap
+                                            or its key must be defined
+                                          type: boolean
+                                      required:
+                                      - key
+                                      type: object
+                                    fieldRef:
+                                      description: 'Selects a field of the pod: supports
+                                        metadata.name, metadata.namespace, metadata.labels,
+                                        metadata.annotations, spec.nodeName, spec.serviceAccountName,
+                                        status.hostIP, status.podIP, status.podIPs.'
+                                      properties:
+                                        apiVersion:
+                                          description: Version of the schema the FieldPath
+                                            is written in terms of, defaults to "v1".
+                                          type: string
+                                        fieldPath:
+                                          description: Path of the field to select
+                                            in the specified API version.
+                                          type: string
+                                      required:
+                                      - fieldPath
+                                      type: object
+                                    resourceFieldRef:
+                                      description: 'Selects a resource of the container:
+                                        only resources limits and requests (limits.cpu,
+                                        limits.memory, limits.ephemeral-storage, requests.cpu,
+                                        requests.memory and requests.ephemeral-storage)
+                                        are currently supported.'
+                                      properties:
+                                        containerName:
+                                          description: 'Container name: required for
+                                            volumes, optional for env vars'
+                                          type: string
+                                        divisor:
+                                          anyOf:
+                                          - type: integer
+                                          - type: string
+                                          description: Specifies the output format
+                                            of the exposed resources, defaults to
+                                            "1"
+                                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                          x-kubernetes-int-or-string: true
+                                        resource:
+                                          description: 'Required: resource to select'
+                                          type: string
+                                      required:
+                                      - resource
+                                      type: object
+                                    secretKeyRef:
+                                      description: Selects a key of a secret in the
+                                        pod's namespace
+                                      properties:
+                                        key:
+                                          description: The key of the secret to select
+                                            from.  Must be a valid secret key.
+                                          type: string
+                                        name:
+                                          description: 'Name of the referent. More
+                                            info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                            TODO: Add other useful fields. apiVersion,
+                                            kind, uid?'
+                                          type: string
+                                        optional:
+                                          description: Specify whether the Secret
+                                            or its key must be defined
+                                          type: boolean
+                                      required:
+                                      - key
+                                      type: object
+                                  type: object
+                              required:
+                              - name
+                              type: object
+                            type: array
+                          envFrom:
+                            description: List of sources to populate environment variables
+                              in the container. The keys defined within a source must
+                              be a C_IDENTIFIER. All invalid keys will be reported
+                              as an event when the container is starting. When a key
+                              exists in multiple sources, the value associated with
+                              the last source will take precedence. Values defined
+                              by an Env with a duplicate key will take precedence.
+                              Cannot be updated.
+                            items:
+                              description: EnvFromSource represents the source of
+                                a set of ConfigMaps
+                              properties:
+                                configMapRef:
+                                  description: The ConfigMap to select from
+                                  properties:
+                                    name:
+                                      description: 'Name of the referent. More info:
+                                        https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                        TODO: Add other useful fields. apiVersion,
+                                        kind, uid?'
+                                      type: string
+                                    optional:
+                                      description: Specify whether the ConfigMap must
+                                        be defined
+                                      type: boolean
+                                  type: object
+                                prefix:
+                                  description: An optional identifier to prepend to
+                                    each key in the ConfigMap. Must be a C_IDENTIFIER.
+                                  type: string
+                                secretRef:
+                                  description: The Secret to select from
+                                  properties:
+                                    name:
+                                      description: 'Name of the referent. More info:
+                                        https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                        TODO: Add other useful fields. apiVersion,
+                                        kind, uid?'
+                                      type: string
+                                    optional:
+                                      description: Specify whether the Secret must
+                                        be defined
+                                      type: boolean
+                                  type: object
+                              type: object
+                            type: array
+                          image:
+                            description: 'Docker image name. More info: https://kubernetes.io/docs/concepts/containers/images
+                              This field is optional to allow higher level config
+                              management to default or override container images in
+                              workload controllers like Deployments and StatefulSets.'
+                            type: string
+                          imagePullPolicy:
+                            description: 'Image pull policy. One of Always, Never,
+                              IfNotPresent. Defaults to Always if :latest tag is specified,
+                              or IfNotPresent otherwise. Cannot be updated. More info:
+                              https://kubernetes.io/docs/concepts/containers/images#updating-images'
+                            type: string
+                          lifecycle:
+                            description: Actions that the management system should
+                              take in response to container lifecycle events. Cannot
+                              be updated.
+                            properties:
+                              postStart:
+                                description: 'PostStart is called immediately after
+                                  a container is created. If the handler fails, the
+                                  container is terminated and restarted according
+                                  to its restart policy. Other management of the container
+                                  blocks until the hook completes. More info: https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/#container-hooks'
+                                properties:
+                                  exec:
+                                    description: One and only one of the following
+                                      should be specified. Exec specifies the action
+                                      to take.
+                                    properties:
+                                      command:
+                                        description: Command is the command line to
+                                          execute inside the container, the working
+                                          directory for the command  is root ('/')
+                                          in the container's filesystem. The command
+                                          is simply exec'd, it is not run inside a
+                                          shell, so traditional shell instructions
+                                          ('|', etc) won't work. To use a shell, you
+                                          need to explicitly call out to that shell.
+                                          Exit status of 0 is treated as live/healthy
+                                          and non-zero is unhealthy.
+                                        items:
+                                          type: string
+                                        type: array
+                                    type: object
+                                  httpGet:
+                                    description: HTTPGet specifies the http request
+                                      to perform.
+                                    properties:
+                                      host:
+                                        description: Host name to connect to, defaults
+                                          to the pod IP. You probably want to set
+                                          "Host" in httpHeaders instead.
+                                        type: string
+                                      httpHeaders:
+                                        description: Custom headers to set in the
+                                          request. HTTP allows repeated headers.
+                                        items:
+                                          description: HTTPHeader describes a custom
+                                            header to be used in HTTP probes
+                                          properties:
+                                            name:
+                                              description: The header field name
+                                              type: string
+                                            value:
+                                              description: The header field value
+                                              type: string
+                                          required:
+                                          - name
+                                          - value
+                                          type: object
+                                        type: array
+                                      path:
+                                        description: Path to access on the HTTP server.
+                                        type: string
+                                      port:
+                                        description: Name or number of the port to
+                                          access on the container. Number must be
+                                          in the range 1 to 65535. Name must be an
+                                          IANA_SVC_NAME.
+                                        x-kubernetes-int-or-string: true
+                                      scheme:
+                                        description: Scheme to use for connecting
+                                          to the host. Defaults to HTTP.
+                                        type: string
+                                    required:
+                                    - port
+                                    type: object
+                                  tcpSocket:
+                                    description: 'TCPSocket specifies an action involving
+                                      a TCP port. TCP hooks not yet supported TODO:
+                                      implement a realistic TCP lifecycle hook'
+                                    properties:
+                                      host:
+                                        description: 'Optional: Host name to connect
+                                          to, defaults to the pod IP.'
+                                        type: string
+                                      port:
+                                        description: Number or name of the port to
+                                          access on the container. Number must be
+                                          in the range 1 to 65535. Name must be an
+                                          IANA_SVC_NAME.
+                                        x-kubernetes-int-or-string: true
+                                    required:
+                                    - port
+                                    type: object
+                                type: object
+                              preStop:
+                                description: 'PreStop is called immediately before
+                                  a container is terminated due to an API request
+                                  or management event such as liveness/startup probe
+                                  failure, preemption, resource contention, etc. The
+                                  handler is not called if the container crashes or
+                                  exits. The reason for termination is passed to the
+                                  handler. The Pod''s termination grace period countdown
+                                  begins before the PreStop hooked is executed. Regardless
+                                  of the outcome of the handler, the container will
+                                  eventually terminate within the Pod''s termination
+                                  grace period. Other management of the container
+                                  blocks until the hook completes or until the termination
+                                  grace period is reached. More info: https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/#container-hooks'
+                                properties:
+                                  exec:
+                                    description: One and only one of the following
+                                      should be specified. Exec specifies the action
+                                      to take.
+                                    properties:
+                                      command:
+                                        description: Command is the command line to
+                                          execute inside the container, the working
+                                          directory for the command  is root ('/')
+                                          in the container's filesystem. The command
+                                          is simply exec'd, it is not run inside a
+                                          shell, so traditional shell instructions
+                                          ('|', etc) won't work. To use a shell, you
+                                          need to explicitly call out to that shell.
+                                          Exit status of 0 is treated as live/healthy
+                                          and non-zero is unhealthy.
+                                        items:
+                                          type: string
+                                        type: array
+                                    type: object
+                                  httpGet:
+                                    description: HTTPGet specifies the http request
+                                      to perform.
+                                    properties:
+                                      host:
+                                        description: Host name to connect to, defaults
+                                          to the pod IP. You probably want to set
+                                          "Host" in httpHeaders instead.
+                                        type: string
+                                      httpHeaders:
+                                        description: Custom headers to set in the
+                                          request. HTTP allows repeated headers.
+                                        items:
+                                          description: HTTPHeader describes a custom
+                                            header to be used in HTTP probes
+                                          properties:
+                                            name:
+                                              description: The header field name
+                                              type: string
+                                            value:
+                                              description: The header field value
+                                              type: string
+                                          required:
+                                          - name
+                                          - value
+                                          type: object
+                                        type: array
+                                      path:
+                                        description: Path to access on the HTTP server.
+                                        type: string
+                                      port:
+                                        description: Name or number of the port to
+                                          access on the container. Number must be
+                                          in the range 1 to 65535. Name must be an
+                                          IANA_SVC_NAME.
+                                        x-kubernetes-int-or-string: true
+                                      scheme:
+                                        description: Scheme to use for connecting
+                                          to the host. Defaults to HTTP.
+                                        type: string
+                                    required:
+                                    - port
+                                    type: object
+                                  tcpSocket:
+                                    description: 'TCPSocket specifies an action involving
+                                      a TCP port. TCP hooks not yet supported TODO:
+                                      implement a realistic TCP lifecycle hook'
+                                    properties:
+                                      host:
+                                        description: 'Optional: Host name to connect
+                                          to, defaults to the pod IP.'
+                                        type: string
+                                      port:
+                                        description: Number or name of the port to
+                                          access on the container. Number must be
+                                          in the range 1 to 65535. Name must be an
+                                          IANA_SVC_NAME.
+                                        x-kubernetes-int-or-string: true
+                                    required:
+                                    - port
+                                    type: object
+                                type: object
+                            type: object
+                          livenessProbe:
+                            description: 'Periodic probe of container liveness. Container
+                              will be restarted if the probe fails. Cannot be updated.
+                              More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                            properties:
+                              exec:
+                                description: One and only one of the following should
+                                  be specified. Exec specifies the action to take.
+                                properties:
+                                  command:
+                                    description: Command is the command line to execute
+                                      inside the container, the working directory
+                                      for the command  is root ('/') in the container's
+                                      filesystem. The command is simply exec'd, it
+                                      is not run inside a shell, so traditional shell
+                                      instructions ('|', etc) won't work. To use a
+                                      shell, you need to explicitly call out to that
+                                      shell. Exit status of 0 is treated as live/healthy
+                                      and non-zero is unhealthy.
+                                    items:
+                                      type: string
+                                    type: array
+                                type: object
+                              failureThreshold:
+                                description: Minimum consecutive failures for the
+                                  probe to be considered failed after having succeeded.
+                                  Defaults to 3. Minimum value is 1.
+                                format: int32
+                                type: integer
+                              httpGet:
+                                description: HTTPGet specifies the http request to
+                                  perform.
+                                properties:
+                                  host:
+                                    description: Host name to connect to, defaults
+                                      to the pod IP. You probably want to set "Host"
+                                      in httpHeaders instead.
+                                    type: string
+                                  httpHeaders:
+                                    description: Custom headers to set in the request.
+                                      HTTP allows repeated headers.
+                                    items:
+                                      description: HTTPHeader describes a custom header
+                                        to be used in HTTP probes
+                                      properties:
+                                        name:
+                                          description: The header field name
+                                          type: string
+                                        value:
+                                          description: The header field value
+                                          type: string
+                                      required:
+                                      - name
+                                      - value
+                                      type: object
+                                    type: array
+                                  path:
+                                    description: Path to access on the HTTP server.
+                                    type: string
+                                  port:
+                                    description: Name or number of the port to access
+                                      on the container. Number must be in the range
+                                      1 to 65535. Name must be an IANA_SVC_NAME.
+                                    x-kubernetes-int-or-string: true
+                                  scheme:
+                                    description: Scheme to use for connecting to the
+                                      host. Defaults to HTTP.
+                                    type: string
+                                required:
+                                - port
+                                type: object
+                              initialDelaySeconds:
+                                description: 'Number of seconds after the container
+                                  has started before liveness probes are initiated.
+                                  More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                                format: int32
+                                type: integer
+                              periodSeconds:
+                                description: How often (in seconds) to perform the
+                                  probe. Default to 10 seconds. Minimum value is 1.
+                                format: int32
+                                type: integer
+                              successThreshold:
+                                description: Minimum consecutive successes for the
+                                  probe to be considered successful after having failed.
+                                  Defaults to 1. Must be 1 for liveness and startup.
+                                  Minimum value is 1.
+                                format: int32
+                                type: integer
+                              tcpSocket:
+                                description: 'TCPSocket specifies an action involving
+                                  a TCP port. TCP hooks not yet supported TODO: implement
+                                  a realistic TCP lifecycle hook'
+                                properties:
+                                  host:
+                                    description: 'Optional: Host name to connect to,
+                                      defaults to the pod IP.'
+                                    type: string
+                                  port:
+                                    description: Number or name of the port to access
+                                      on the container. Number must be in the range
+                                      1 to 65535. Name must be an IANA_SVC_NAME.
+                                    x-kubernetes-int-or-string: true
+                                required:
+                                - port
+                                type: object
+                              timeoutSeconds:
+                                description: 'Number of seconds after which the probe
+                                  times out. Defaults to 1 second. Minimum value is
+                                  1. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                                format: int32
+                                type: integer
+                            type: object
+                          name:
+                            description: Name of the container specified as a DNS_LABEL.
+                              Each container in a pod must have a unique name (DNS_LABEL).
+                              Cannot be updated.
+                            type: string
+                          ports:
+                            description: List of ports to expose from the container.
+                              Exposing a port here gives the system additional information
+                              about the network connections a container uses, but
+                              is primarily informational. Not specifying a port here
+                              DOES NOT prevent that port from being exposed. Any port
+                              which is listening on the default "0.0.0.0" address
+                              inside a container will be accessible from the network.
+                              Cannot be updated.
+                            items:
+                              description: ContainerPort represents a network port
+                                in a single container.
+                              properties:
+                                containerPort:
+                                  description: Number of port to expose on the pod's
+                                    IP address. This must be a valid port number,
+                                    0 < x < 65536.
+                                  format: int32
+                                  type: integer
+                                hostIP:
+                                  description: What host IP to bind the external port
+                                    to.
+                                  type: string
+                                hostPort:
+                                  description: Number of port to expose on the host.
+                                    If specified, this must be a valid port number,
+                                    0 < x < 65536. If HostNetwork is specified, this
+                                    must match ContainerPort. Most containers do not
+                                    need this.
+                                  format: int32
+                                  type: integer
+                                name:
+                                  description: If specified, this must be an IANA_SVC_NAME
+                                    and unique within the pod. Each named port in
+                                    a pod must have a unique name. Name for the port
+                                    that can be referred to by services.
+                                  type: string
+                                protocol:
+                                  description: Protocol for port. Must be UDP, TCP,
+                                    or SCTP. Defaults to "TCP".
+                                  type: string
+                              required:
+                              - containerPort
+                              type: object
+                            type: array
+                            x-kubernetes-list-map-keys:
+                            - containerPort
+                            - protocol
+                            x-kubernetes-list-type: map
+                          readinessProbe:
+                            description: 'Periodic probe of container service readiness.
+                              Container will be removed from service endpoints if
+                              the probe fails. Cannot be updated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                            properties:
+                              exec:
+                                description: One and only one of the following should
+                                  be specified. Exec specifies the action to take.
+                                properties:
+                                  command:
+                                    description: Command is the command line to execute
+                                      inside the container, the working directory
+                                      for the command  is root ('/') in the container's
+                                      filesystem. The command is simply exec'd, it
+                                      is not run inside a shell, so traditional shell
+                                      instructions ('|', etc) won't work. To use a
+                                      shell, you need to explicitly call out to that
+                                      shell. Exit status of 0 is treated as live/healthy
+                                      and non-zero is unhealthy.
+                                    items:
+                                      type: string
+                                    type: array
+                                type: object
+                              failureThreshold:
+                                description: Minimum consecutive failures for the
+                                  probe to be considered failed after having succeeded.
+                                  Defaults to 3. Minimum value is 1.
+                                format: int32
+                                type: integer
+                              httpGet:
+                                description: HTTPGet specifies the http request to
+                                  perform.
+                                properties:
+                                  host:
+                                    description: Host name to connect to, defaults
+                                      to the pod IP. You probably want to set "Host"
+                                      in httpHeaders instead.
+                                    type: string
+                                  httpHeaders:
+                                    description: Custom headers to set in the request.
+                                      HTTP allows repeated headers.
+                                    items:
+                                      description: HTTPHeader describes a custom header
+                                        to be used in HTTP probes
+                                      properties:
+                                        name:
+                                          description: The header field name
+                                          type: string
+                                        value:
+                                          description: The header field value
+                                          type: string
+                                      required:
+                                      - name
+                                      - value
+                                      type: object
+                                    type: array
+                                  path:
+                                    description: Path to access on the HTTP server.
+                                    type: string
+                                  port:
+                                    description: Name or number of the port to access
+                                      on the container. Number must be in the range
+                                      1 to 65535. Name must be an IANA_SVC_NAME.
+                                    x-kubernetes-int-or-string: true
+                                  scheme:
+                                    description: Scheme to use for connecting to the
+                                      host. Defaults to HTTP.
+                                    type: string
+                                required:
+                                - port
+                                type: object
+                              initialDelaySeconds:
+                                description: 'Number of seconds after the container
+                                  has started before liveness probes are initiated.
+                                  More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                                format: int32
+                                type: integer
+                              periodSeconds:
+                                description: How often (in seconds) to perform the
+                                  probe. Default to 10 seconds. Minimum value is 1.
+                                format: int32
+                                type: integer
+                              successThreshold:
+                                description: Minimum consecutive successes for the
+                                  probe to be considered successful after having failed.
+                                  Defaults to 1. Must be 1 for liveness and startup.
+                                  Minimum value is 1.
+                                format: int32
+                                type: integer
+                              tcpSocket:
+                                description: 'TCPSocket specifies an action involving
+                                  a TCP port. TCP hooks not yet supported TODO: implement
+                                  a realistic TCP lifecycle hook'
+                                properties:
+                                  host:
+                                    description: 'Optional: Host name to connect to,
+                                      defaults to the pod IP.'
+                                    type: string
+                                  port:
+                                    description: Number or name of the port to access
+                                      on the container. Number must be in the range
+                                      1 to 65535. Name must be an IANA_SVC_NAME.
+                                    x-kubernetes-int-or-string: true
+                                required:
+                                - port
+                                type: object
+                              timeoutSeconds:
+                                description: 'Number of seconds after which the probe
+                                  times out. Defaults to 1 second. Minimum value is
+                                  1. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                                format: int32
+                                type: integer
+                            type: object
+                          resources:
+                            description: 'Compute Resources required by this container.
+                              Cannot be updated. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
+                            properties:
+                              limits:
+                                additionalProperties:
+                                  anyOf:
+                                  - type: integer
+                                  - type: string
+                                  pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                  x-kubernetes-int-or-string: true
+                                description: 'Limits describes the maximum amount
+                                  of compute resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
+                                type: object
+                              requests:
+                                additionalProperties:
+                                  anyOf:
+                                  - type: integer
+                                  - type: string
+                                  pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                  x-kubernetes-int-or-string: true
+                                description: 'Requests describes the minimum amount
+                                  of compute resources required. If Requests is omitted
+                                  for a container, it defaults to Limits if that is
+                                  explicitly specified, otherwise to an implementation-defined
+                                  value. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
+                                type: object
+                            type: object
+                          securityContext:
+                            description: 'Security options the pod should run with.
+                              More info: https://kubernetes.io/docs/concepts/policy/security-context/
+                              More info: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/'
+                            properties:
+                              allowPrivilegeEscalation:
+                                description: 'AllowPrivilegeEscalation controls whether
+                                  a process can gain more privileges than its parent
+                                  process. This bool directly controls if the no_new_privs
+                                  flag will be set on the container process. AllowPrivilegeEscalation
+                                  is true always when the container is: 1) run as
+                                  Privileged 2) has CAP_SYS_ADMIN'
+                                type: boolean
+                              capabilities:
+                                description: The capabilities to add/drop when running
+                                  containers. Defaults to the default set of capabilities
+                                  granted by the container runtime.
+                                properties:
+                                  add:
+                                    description: Added capabilities
+                                    items:
+                                      description: Capability represent POSIX capabilities
+                                        type
+                                      type: string
+                                    type: array
+                                  drop:
+                                    description: Removed capabilities
+                                    items:
+                                      description: Capability represent POSIX capabilities
+                                        type
+                                      type: string
+                                    type: array
+                                type: object
+                              privileged:
+                                description: Run container in privileged mode. Processes
+                                  in privileged containers are essentially equivalent
+                                  to root on the host. Defaults to false.
+                                type: boolean
+                              procMount:
+                                description: procMount denotes the type of proc mount
+                                  to use for the containers. The default is DefaultProcMount
+                                  which uses the container runtime defaults for readonly
+                                  paths and masked paths. This requires the ProcMountType
+                                  feature flag to be enabled.
+                                type: string
+                              readOnlyRootFilesystem:
+                                description: Whether this container has a read-only
+                                  root filesystem. Default is false.
+                                type: boolean
+                              runAsGroup:
+                                description: The GID to run the entrypoint of the
+                                  container process. Uses runtime default if unset.
+                                  May also be set in PodSecurityContext.  If set in
+                                  both SecurityContext and PodSecurityContext, the
+                                  value specified in SecurityContext takes precedence.
+                                format: int64
+                                type: integer
+                              runAsNonRoot:
+                                description: Indicates that the container must run
+                                  as a non-root user. If true, the Kubelet will validate
+                                  the image at runtime to ensure that it does not
+                                  run as UID 0 (root) and fail to start the container
+                                  if it does. If unset or false, no such validation
+                                  will be performed. May also be set in PodSecurityContext.  If
+                                  set in both SecurityContext and PodSecurityContext,
+                                  the value specified in SecurityContext takes precedence.
+                                type: boolean
+                              runAsUser:
+                                description: The UID to run the entrypoint of the
+                                  container process. Defaults to user specified in
+                                  image metadata if unspecified. May also be set in
+                                  PodSecurityContext.  If set in both SecurityContext
+                                  and PodSecurityContext, the value specified in SecurityContext
+                                  takes precedence.
+                                format: int64
+                                type: integer
+                              seLinuxOptions:
+                                description: The SELinux context to be applied to
+                                  the container. If unspecified, the container runtime
+                                  will allocate a random SELinux context for each
+                                  container.  May also be set in PodSecurityContext.  If
+                                  set in both SecurityContext and PodSecurityContext,
+                                  the value specified in SecurityContext takes precedence.
+                                properties:
+                                  level:
+                                    description: Level is SELinux level label that
+                                      applies to the container.
+                                    type: string
+                                  role:
+                                    description: Role is a SELinux role label that
+                                      applies to the container.
+                                    type: string
+                                  type:
+                                    description: Type is a SELinux type label that
+                                      applies to the container.
+                                    type: string
+                                  user:
+                                    description: User is a SELinux user label that
+                                      applies to the container.
+                                    type: string
+                                type: object
+                              windowsOptions:
+                                description: The Windows specific settings applied
+                                  to all containers. If unspecified, the options from
+                                  the PodSecurityContext will be used. If set in both
+                                  SecurityContext and PodSecurityContext, the value
+                                  specified in SecurityContext takes precedence.
+                                properties:
+                                  gmsaCredentialSpec:
+                                    description: GMSACredentialSpec is where the GMSA
+                                      admission webhook (https://github.com/kubernetes-sigs/windows-gmsa)
+                                      inlines the contents of the GMSA credential
+                                      spec named by the GMSACredentialSpecName field.
+                                      This field is alpha-level and is only honored
+                                      by servers that enable the WindowsGMSA feature
+                                      flag.
+                                    type: string
+                                  gmsaCredentialSpecName:
+                                    description: GMSACredentialSpecName is the name
+                                      of the GMSA credential spec to use. This field
+                                      is alpha-level and is only honored by servers
+                                      that enable the WindowsGMSA feature flag.
+                                    type: string
+                                  runAsUserName:
+                                    description: The UserName in Windows to run the
+                                      entrypoint of the container process. Defaults
+                                      to the user specified in image metadata if unspecified.
+                                      May also be set in PodSecurityContext. If set
+                                      in both SecurityContext and PodSecurityContext,
+                                      the value specified in SecurityContext takes
+                                      precedence. This field is beta-level and may
+                                      be disabled with the WindowsRunAsUserName feature
+                                      flag.
+                                    type: string
+                                type: object
+                            type: object
+                          startupProbe:
+                            description: 'StartupProbe indicates that the Pod has
+                              successfully initialized. If specified, no other probes
+                              are executed until this completes successfully. If this
+                              probe fails, the Pod will be restarted, just as if the
+                              livenessProbe failed. This can be used to provide different
+                              probe parameters at the beginning of a Pod''s lifecycle,
+                              when it might take a long time to load data or warm
+                              a cache, than during steady-state operation. This cannot
+                              be updated. This is an alpha feature enabled by the
+                              StartupProbe feature flag. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                            properties:
+                              exec:
+                                description: One and only one of the following should
+                                  be specified. Exec specifies the action to take.
+                                properties:
+                                  command:
+                                    description: Command is the command line to execute
+                                      inside the container, the working directory
+                                      for the command  is root ('/') in the container's
+                                      filesystem. The command is simply exec'd, it
+                                      is not run inside a shell, so traditional shell
+                                      instructions ('|', etc) won't work. To use a
+                                      shell, you need to explicitly call out to that
+                                      shell. Exit status of 0 is treated as live/healthy
+                                      and non-zero is unhealthy.
+                                    items:
+                                      type: string
+                                    type: array
+                                type: object
+                              failureThreshold:
+                                description: Minimum consecutive failures for the
+                                  probe to be considered failed after having succeeded.
+                                  Defaults to 3. Minimum value is 1.
+                                format: int32
+                                type: integer
+                              httpGet:
+                                description: HTTPGet specifies the http request to
+                                  perform.
+                                properties:
+                                  host:
+                                    description: Host name to connect to, defaults
+                                      to the pod IP. You probably want to set "Host"
+                                      in httpHeaders instead.
+                                    type: string
+                                  httpHeaders:
+                                    description: Custom headers to set in the request.
+                                      HTTP allows repeated headers.
+                                    items:
+                                      description: HTTPHeader describes a custom header
+                                        to be used in HTTP probes
+                                      properties:
+                                        name:
+                                          description: The header field name
+                                          type: string
+                                        value:
+                                          description: The header field value
+                                          type: string
+                                      required:
+                                      - name
+                                      - value
+                                      type: object
+                                    type: array
+                                  path:
+                                    description: Path to access on the HTTP server.
+                                    type: string
+                                  port:
+                                    anyOf:
+                                    - type: integer
+                                    - type: string
+                                    description: Name or number of the port to access
+                                      on the container. Number must be in the range
+                                      1 to 65535. Name must be an IANA_SVC_NAME.
+                                    x-kubernetes-int-or-string: true
+                                  scheme:
+                                    description: Scheme to use for connecting to the
+                                      host. Defaults to HTTP.
+                                    type: string
+                                required:
+                                - port
+                                type: object
+                              initialDelaySeconds:
+                                description: 'Number of seconds after the container
+                                  has started before liveness probes are initiated.
+                                  More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                                format: int32
+                                type: integer
+                              periodSeconds:
+                                description: How often (in seconds) to perform the
+                                  probe. Default to 10 seconds. Minimum value is 1.
+                                format: int32
+                                type: integer
+                              successThreshold:
+                                description: Minimum consecutive successes for the
+                                  probe to be considered successful after having failed.
+                                  Defaults to 1. Must be 1 for liveness and startup.
+                                  Minimum value is 1.
+                                format: int32
+                                type: integer
+                              tcpSocket:
+                                description: 'TCPSocket specifies an action involving
+                                  a TCP port. TCP hooks not yet supported TODO: implement
+                                  a realistic TCP lifecycle hook'
+                                properties:
+                                  host:
+                                    description: 'Optional: Host name to connect to,
+                                      defaults to the pod IP.'
+                                    type: string
+                                  port:
+                                    anyOf:
+                                    - type: integer
+                                    - type: string
+                                    description: Number or name of the port to access
+                                      on the container. Number must be in the range
+                                      1 to 65535. Name must be an IANA_SVC_NAME.
+                                    x-kubernetes-int-or-string: true
+                                required:
+                                - port
+                                type: object
+                              timeoutSeconds:
+                                description: 'Number of seconds after which the probe
+                                  times out. Defaults to 1 second. Minimum value is
+                                  1. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                                format: int32
+                                type: integer
+                            type: object
+                          stdin:
+                            description: Whether this container should allocate a
+                              buffer for stdin in the container runtime. If this is
+                              not set, reads from stdin in the container will always
+                              result in EOF. Default is false.
+                            type: boolean
+                          stdinOnce:
+                            description: Whether the container runtime should close
+                              the stdin channel after it has been opened by a single
+                              attach. When stdin is true the stdin stream will remain
+                              open across multiple attach sessions. If stdinOnce is
+                              set to true, stdin is opened on container start, is
+                              empty until the first client attaches to stdin, and
+                              then remains open and accepts data until the client
+                              disconnects, at which time stdin is closed and remains
+                              closed until the container is restarted. If this flag
+                              is false, a container processes that reads from stdin
+                              will never receive an EOF. Default is false
+                            type: boolean
+                          terminationMessagePath:
+                            description: 'Optional: Path at which the file to which
+                              the container''s termination message will be written
+                              is mounted into the container''s filesystem. Message
+                              written is intended to be brief final status, such as
+                              an assertion failure message. Will be truncated by the
+                              node if greater than 4096 bytes. The total message length
+                              across all containers will be limited to 12kb. Defaults
+                              to /dev/termination-log. Cannot be updated.'
+                            type: string
+                          terminationMessagePolicy:
+                            description: Indicate how the termination message should
+                              be populated. File will use the contents of terminationMessagePath
+                              to populate the container status message on both success
+                              and failure. FallbackToLogsOnError will use the last
+                              chunk of container log output if the termination message
+                              file is empty and the container exited with an error.
+                              The log output is limited to 2048 bytes or 80 lines,
+                              whichever is smaller. Defaults to File. Cannot be updated.
+                            type: string
+                          tty:
+                            description: Whether this container should allocate a
+                              TTY for itself, also requires 'stdin' to be true. Default
+                              is false.
+                            type: boolean
+                          volumeDevices:
+                            description: volumeDevices is the list of block devices
+                              to be used by the container. This is a beta feature.
+                            items:
+                              description: volumeDevice describes a mapping of a raw
+                                block device within a container.
+                              properties:
+                                devicePath:
+                                  description: devicePath is the path inside of the
+                                    container that the device will be mapped to.
+                                  type: string
+                                name:
+                                  description: name must match the name of a persistentVolumeClaim
+                                    in the pod
+                                  type: string
+                              required:
+                              - devicePath
+                              - name
+                              type: object
+                            type: array
+                          volumeMounts:
+                            description: Pod volumes to mount into the container's
+                              filesystem. Cannot be updated.
+                            items:
+                              description: VolumeMount describes a mounting of a Volume
+                                within a container.
+                              properties:
+                                mountPath:
+                                  description: Path within the container at which
+                                    the volume should be mounted.  Must not contain
+                                    ':'.
+                                  type: string
+                                mountPropagation:
+                                  description: mountPropagation determines how mounts
+                                    are propagated from the host to container and
+                                    the other way around. When not set, MountPropagationNone
+                                    is used. This field is beta in 1.10.
+                                  type: string
+                                name:
+                                  description: This must match the Name of a Volume.
+                                  type: string
+                                readOnly:
+                                  description: Mounted read-only if true, read-write
+                                    otherwise (false or unspecified). Defaults to
+                                    false.
+                                  type: boolean
+                                subPath:
+                                  description: Path within the volume from which the
+                                    container's volume should be mounted. Defaults
+                                    to "" (volume's root).
+                                  type: string
+                                subPathExpr:
+                                  description: Expanded path within the volume from
+                                    which the container's volume should be mounted.
+                                    Behaves similarly to SubPath but environment variable
+                                    references $(VAR_NAME) are expanded using the
+                                    container's environment. Defaults to "" (volume's
+                                    root). SubPathExpr and SubPath are mutually exclusive.
+                                  type: string
+                              required:
+                              - mountPath
+                              - name
+                              type: object
+                            type: array
+                          workingDir:
+                            description: Container's working directory. If not specified,
+                              the container runtime's default will be used, which
+                              might be configured in the container image. Cannot be
+                              updated.
+                            type: string
+                        required:
+                        - name
+                        type: object
+                      endpoint:
+                        properties:
+                          service_host:
+                            type: string
+                          service_port:
+                            format: int32
+                            type: integer
+                          type:
+                            type: string
+                        type: object
+                      envSecretRefName:
+                        type: string
+                      modelUri:
+                        type: string
+                      serviceAccountName:
+                        type: string
+                      type:
+                        type: string
+                    type: object
+                  graph:
+                    properties:
+                      children:
+                        items:
+                          properties:
+                            children:
+                              items:
+                                properties:
+                                  children:
+                                    items:
+                                      properties:
+                                        children:
+                                          items:
+                                            properties:
+                                              endpoint:
+                                                properties:
+                                                  service_host:
+                                                    type: string
+                                                  service_port:
+                                                    format: int32
+                                                    type: integer
+                                                  type:
+                                                    type: string
+                                                type: object
+                                              envSecretRefName:
+                                                type: string
+                                              implementation:
+                                                type: string
+                                              logger:
+                                                description: Request/response  payload
+                                                  logging. v2alpha1 feature that is
+                                                  added to v1 for backwards compatibility
+                                                  while v1 is the storage version.
+                                                properties:
+                                                  mode:
+                                                    description: What payloads to
+                                                      log
+                                                    type: string
+                                                  url:
+                                                    description: URL to send request
+                                                      logging CloudEvents
+                                                    type: string
+                                                type: object
+                                              methods:
+                                                items:
+                                                  type: string
+                                                type: array
+                                              modelUri:
+                                                type: string
+                                              name:
+                                                type: string
+                                              parameters:
+                                                items:
+                                                  properties:
+                                                    name:
+                                                      type: string
+                                                    type:
+                                                      type: string
+                                                    value:
+                                                      type: string
+                                                  type: object
+                                                type: array
+                                              serviceAccountName:
+                                                type: string
+                                              type:
+                                                type: string
+                                            type: object
+                                          type: array
+                                        endpoint:
+                                          properties:
+                                            service_host:
+                                              type: string
+                                            service_port:
+                                              format: int32
+                                              type: integer
+                                            type:
+                                              type: string
+                                          type: object
+                                        envSecretRefName:
+                                          type: string
+                                        implementation:
+                                          type: string
+                                        logger:
+                                          description: Request/response  payload logging.
+                                            v2alpha1 feature that is added to v1 for
+                                            backwards compatibility while v1 is the
+                                            storage version.
+                                          properties:
+                                            mode:
+                                              description: What payloads to log
+                                              type: string
+                                            url:
+                                              description: URL to send request logging
+                                                CloudEvents
+                                              type: string
+                                          type: object
+                                        methods:
+                                          items:
+                                            type: string
+                                          type: array
+                                        modelUri:
+                                          type: string
+                                        name:
+                                          type: string
+                                        parameters:
+                                          items:
+                                            properties:
+                                              name:
+                                                type: string
+                                              type:
+                                                type: string
+                                              value:
+                                                type: string
+                                            type: object
+                                          type: array
+                                        serviceAccountName:
+                                          type: string
+                                        type:
+                                          type: string
+                                      type: object
+                                    type: array
+                                  endpoint:
+                                    properties:
+                                      service_host:
+                                        type: string
+                                      service_port:
+                                        format: int32
+                                        type: integer
+                                      type:
+                                        type: string
+                                    type: object
+                                  envSecretRefName:
+                                    type: string
+                                  implementation:
+                                    type: string
+                                  logger:
+                                    description: Request/response  payload logging.
+                                      v2alpha1 feature that is added to v1 for backwards
+                                      compatibility while v1 is the storage version.
+                                    properties:
+                                      mode:
+                                        description: What payloads to log
+                                        type: string
+                                      url:
+                                        description: URL to send request logging CloudEvents
+                                        type: string
+                                    type: object
+                                  methods:
+                                    items:
+                                      type: string
+                                    type: array
+                                  modelUri:
+                                    type: string
+                                  name:
+                                    type: string
+                                  parameters:
+                                    items:
+                                      properties:
+                                        name:
+                                          type: string
+                                        type:
+                                          type: string
+                                        value:
+                                          type: string
+                                      type: object
+                                    type: array
+                                  serviceAccountName:
+                                    type: string
+                                  type:
+                                    type: string
+                                type: object
+                              type: array
+                            endpoint:
+                              properties:
+                                service_host:
+                                  type: string
+                                service_port:
+                                  format: int32
+                                  type: integer
+                                type:
+                                  type: string
+                              type: object
+                            envSecretRefName:
+                              type: string
+                            implementation:
+                              type: string
+                            logger:
+                              description: Request/response  payload logging. v2alpha1
+                                feature that is added to v1 for backwards compatibility
+                                while v1 is the storage version.
+                              properties:
+                                mode:
+                                  description: What payloads to log
+                                  type: string
+                                url:
+                                  description: URL to send request logging CloudEvents
+                                  type: string
+                              type: object
+                            methods:
+                              items:
+                                type: string
+                              type: array
+                            modelUri:
+                              type: string
+                            name:
+                              type: string
+                            parameters:
+                              items:
+                                properties:
+                                  name:
+                                    type: string
+                                  type:
+                                    type: string
+                                  value:
+                                    type: string
+                                type: object
+                              type: array
+                            serviceAccountName:
+                              type: string
+                            type:
+                              type: string
+                          type: object
+                        type: array
+                      endpoint:
+                        properties:
+                          service_host:
+                            type: string
+                          service_port:
+                            format: int32
+                            type: integer
+                          type:
+                            type: string
+                        type: object
+                      envSecretRefName:
+                        type: string
+                      implementation:
+                        type: string
+                      logger:
+                        description: Request/response  payload logging. v2alpha1 feature
+                          that is added to v1 for backwards compatibility while v1
+                          is the storage version.
+                        properties:
+                          mode:
+                            description: What payloads to log
+                            type: string
+                          url:
+                            description: URL to send request logging CloudEvents
+                            type: string
+                        type: object
+                      methods:
+                        items:
+                          type: string
+                        type: array
+                      modelUri:
+                        type: string
+                      name:
+                        type: string
+                      parameters:
+                        items:
+                          properties:
+                            name:
+                              type: string
+                            type:
+                              type: string
+                            value:
+                              type: string
+                          required:
+                          - name
+                          - type
+                          - value
+                          type: object
+                        type: array
+                      serviceAccountName:
+                        type: string
+                      type:
+                        type: string
+                    required:
+                    - name
+                    type: object
+                  labels:
+                    additionalProperties:
+                      type: string
+                    type: object
+                  name:
+                    type: string
+                  replicas:
+                    format: int32
+                    type: integer
+                  shadow:
+                    type: boolean
+                  svcOrchSpec:
+                    properties:
+                      env:
+                        items:
+                          description: EnvVar represents an environment variable present
+                            in a Container.
+                          properties:
+                            name:
+                              description: Name of the environment variable. Must
+                                be a C_IDENTIFIER.
+                              type: string
+                            value:
+                              description: 'Variable references $(VAR_NAME) are expanded
+                                using the previous defined environment variables in
+                                the container and any service environment variables.
+                                If a variable cannot be resolved, the reference in
+                                the input string will be unchanged. The $(VAR_NAME)
+                                syntax can be escaped with a double $$, ie: $$(VAR_NAME).
+                                Escaped references will never be expanded, regardless
+                                of whether the variable exists or not. Defaults to
+                                "".'
+                              type: string
+                            valueFrom:
+                              description: Source for the environment variable's value.
+                                Cannot be used if value is not empty.
+                              properties:
+                                configMapKeyRef:
+                                  description: Selects a key of a ConfigMap.
+                                  properties:
+                                    key:
+                                      description: The key to select.
+                                      type: string
+                                    name:
+                                      description: 'Name of the referent. More info:
+                                        https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                        TODO: Add other useful fields. apiVersion,
+                                        kind, uid?'
+                                      type: string
+                                    optional:
+                                      description: Specify whether the ConfigMap or
+                                        its key must be defined
+                                      type: boolean
+                                  required:
+                                  - key
+                                  type: object
+                                fieldRef:
+                                  description: 'Selects a field of the pod: supports
+                                    metadata.name, metadata.namespace, metadata.labels,
+                                    metadata.annotations, spec.nodeName, spec.serviceAccountName,
+                                    status.hostIP, status.podIP, status.podIPs.'
+                                  properties:
+                                    apiVersion:
+                                      description: Version of the schema the FieldPath
+                                        is written in terms of, defaults to "v1".
+                                      type: string
+                                    fieldPath:
+                                      description: Path of the field to select in
+                                        the specified API version.
+                                      type: string
+                                  required:
+                                  - fieldPath
+                                  type: object
+                                resourceFieldRef:
+                                  description: 'Selects a resource of the container:
+                                    only resources limits and requests (limits.cpu,
+                                    limits.memory, limits.ephemeral-storage, requests.cpu,
+                                    requests.memory and requests.ephemeral-storage)
+                                    are currently supported.'
+                                  properties:
+                                    containerName:
+                                      description: 'Container name: required for volumes,
+                                        optional for env vars'
+                                      type: string
+                                    divisor:
+                                      anyOf:
+                                      - type: integer
+                                      - type: string
+                                      description: Specifies the output format of
+                                        the exposed resources, defaults to "1"
+                                      pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                      x-kubernetes-int-or-string: true
+                                    resource:
+                                      description: 'Required: resource to select'
+                                      type: string
+                                  required:
+                                  - resource
+                                  type: object
+                                secretKeyRef:
+                                  description: Selects a key of a secret in the pod's
+                                    namespace
+                                  properties:
+                                    key:
+                                      description: The key of the secret to select
+                                        from.  Must be a valid secret key.
+                                      type: string
+                                    name:
+                                      description: 'Name of the referent. More info:
+                                        https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                        TODO: Add other useful fields. apiVersion,
+                                        kind, uid?'
+                                      type: string
+                                    optional:
+                                      description: Specify whether the Secret or its
+                                        key must be defined
+                                      type: boolean
+                                  required:
+                                  - key
+                                  type: object
+                              type: object
+                          required:
+                          - name
+                          type: object
+                        type: array
+                      replicas:
+                        format: int32
+                        type: integer
+                      resources:
+                        description: ResourceRequirements describes the compute resource
+                          requirements.
+                        properties:
+                          limits:
+                            additionalProperties:
+                              anyOf:
+                              - type: integer
+                              - type: string
+                              pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                              x-kubernetes-int-or-string: true
+                            description: 'Limits describes the maximum amount of compute
+                              resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
+                            type: object
+                          requests:
+                            additionalProperties:
+                              anyOf:
+                              - type: integer
+                              - type: string
+                              pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                              x-kubernetes-int-or-string: true
+                            description: 'Requests describes the minimum amount of
+                              compute resources required. If Requests is omitted for
+                              a container, it defaults to Limits if that is explicitly
+                              specified, otherwise to an implementation-defined value.
+                              More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
+                            type: object
+                        type: object
+                    type: object
+                  traffic:
+                    format: int32
+                    type: integer
+                required:
+                - graph
+                - name
+                type: object
+              type: array
+            protocol:
+              type: string
+            replicas:
+              format: int32
+              type: integer
+            transport:
+              type: string
+          required:
+          - predictors
+          type: object
+        status:
+          description: SeldonDeploymentStatus defines the observed state of SeldonDeployment
+          properties:
+            address:
+              description: 'Addressable placeholder until duckv1 issue is fixed:    https://github.com/kubernetes-sigs/controller-tools/issues/391'
+              properties:
+                url:
+                  type: string
+              type: object
+            deploymentStatus:
+              additionalProperties:
+                properties:
+                  availableReplicas:
+                    format: int32
+                    type: integer
+                  description:
+                    type: string
+                  explainerFor:
+                    type: string
+                  name:
+                    type: string
+                  replicas:
+                    format: int32
+                    type: integer
+                  status:
+                    type: string
+                type: object
+              type: object
+            description:
+              type: string
+            replicas:
+              format: int32
+              type: integer
+            serviceStatus:
+              additionalProperties:
+                properties:
+                  explainerFor:
+                    type: string
+                  grpcEndpoint:
+                    type: string
+                  httpEndpoint:
+                    type: string
+                  svcName:
+                    type: string
+                type: object
+              type: object
+            state:
+              type: string
+          type: object
+      type: object
+  version: v1
+  versions:
+  - name: v1
+    served: true
+    storage: true
+  - name: v1alpha2
+    served: true
+    storage: false
+  - name: v1alpha3
+    served: true
+    storage: false

--- a/tests/stacks/ibm/components/seldon-core-operator/test_data/expected/app.k8s.io_v1beta1_application_seldon-core-operator.yaml
+++ b/tests/stacks/ibm/components/seldon-core-operator/test_data/expected/app.k8s.io_v1beta1_application_seldon-core-operator.yaml
@@ -1,0 +1,46 @@
+apiVersion: app.k8s.io/v1beta1
+kind: Application
+metadata:
+  labels:
+    app.kubernetes.io/component: seldon
+    app.kubernetes.io/name: seldon-core-operator
+  name: seldon-core-operator
+  namespace: kubeflow
+spec:
+  addOwnerRef: true
+  componentKinds:
+  - group: apps/v1
+    kind: StatefulSet
+  - group: v1
+    kind: Service
+  - group: apps/v1
+    kind: Deployment
+  - group: v1
+    kind: Secret
+  - group: v1
+    kind: ConfigMap
+  descriptor:
+    description: Seldon allows users to create ML Inference Graphs to deploy their
+      models and serve predictions
+    keywords:
+    - seldon
+    - inference
+    links:
+    - description: Docs
+      url: https://docs.seldon.io/projects/seldon-core/en/v1.1.0/
+    maintainers:
+    - email: dev@seldon.io
+      name: Seldon
+    owners:
+    - email: dev@seldon.io
+      name: Seldon
+    type: seldon-core-operator
+    version: v1
+  selector:
+    matchLabels:
+      app.kubernetes.io/component: seldon
+      app.kubernetes.io/instance: seldon-1.2.1
+      app.kubernetes.io/managed-by: kfctl
+      app.kubernetes.io/name: seldon
+      app.kubernetes.io/part-of: kubeflow
+      app.kubernetes.io/version: 1.2.1

--- a/tests/stacks/ibm/components/seldon-core-operator/test_data/expected/apps_v1_deployment_seldon-controller-manager.yaml
+++ b/tests/stacks/ibm/components/seldon-core-operator/test_data/expected/apps_v1_deployment_seldon-controller-manager.yaml
@@ -1,0 +1,160 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  labels:
+    app: seldon
+    app.kubernetes.io/component: seldon
+    app.kubernetes.io/instance: seldon-core
+    app.kubernetes.io/name: seldon-core-operator
+    app.kubernetes.io/version: 1.2.1
+    control-plane: seldon-controller-manager
+  name: seldon-controller-manager
+  namespace: kubeflow
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: seldon
+      app.kubernetes.io/component: seldon
+      app.kubernetes.io/instance: seldon1
+      app.kubernetes.io/name: seldon-core-operator
+      app.kubernetes.io/version: v0.5
+      control-plane: seldon-controller-manager
+  template:
+    metadata:
+      annotations:
+        prometheus.io/scrape: "true"
+        sidecar.istio.io/inject: "false"
+      labels:
+        app: seldon
+        app.kubernetes.io/component: seldon
+        app.kubernetes.io/instance: seldon1
+        app.kubernetes.io/name: seldon-core-operator
+        app.kubernetes.io/version: v0.5
+        control-plane: seldon-controller-manager
+    spec:
+      containers:
+      - args:
+        - --enable-leader-election
+        - --webhook-port=443
+        - --create-resources=$(MANAGER_CREATE_RESOURCES)
+        - ""
+        command:
+        - /manager
+        env:
+        - name: WATCH_NAMESPACE
+          value: ""
+        - name: RELATED_IMAGE_EXECUTOR
+          value: ""
+        - name: RELATED_IMAGE_ENGINE
+          value: ""
+        - name: RELATED_IMAGE_STORAGE_INITIALIZER
+          value: ""
+        - name: RELATED_IMAGE_SKLEARNSERVER_REST
+          value: ""
+        - name: RELATED_IMAGE_SKLEARNSERVER_GRPC
+          value: ""
+        - name: RELATED_IMAGE_XGBOOSTSERVER_REST
+          value: ""
+        - name: RELATED_IMAGE_XGBOOSTSERVER_GRPC
+          value: ""
+        - name: RELATED_IMAGE_MLFLOWSERVER_REST
+          value: ""
+        - name: RELATED_IMAGE_MLFLOWSERVER_GRPC
+          value: ""
+        - name: RELATED_IMAGE_TFPROXY_REST
+          value: ""
+        - name: RELATED_IMAGE_TFPROXY_GRPC
+          value: ""
+        - name: RELATED_IMAGE_TENSORFLOW
+          value: ""
+        - name: RELATED_IMAGE_EXPLAINER
+          value: ""
+        - name: MANAGER_CREATE_RESOURCES
+          value: "false"
+        - name: POD_NAMESPACE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace
+        - name: CONTROLLER_ID
+          value: ""
+        - name: AMBASSADOR_ENABLED
+          value: "true"
+        - name: AMBASSADOR_SINGLE_NAMESPACE
+          value: "false"
+        - name: ENGINE_CONTAINER_IMAGE_AND_VERSION
+          value: docker.io/seldonio/engine:1.2.1
+        - name: ENGINE_CONTAINER_IMAGE_PULL_POLICY
+          value: IfNotPresent
+        - name: ENGINE_CONTAINER_SERVICE_ACCOUNT_NAME
+          value: default
+        - name: ENGINE_CONTAINER_USER
+          value: "8888"
+        - name: ENGINE_LOG_MESSAGES_EXTERNALLY
+          value: "false"
+        - name: PREDICTIVE_UNIT_SERVICE_PORT
+          value: "9000"
+        - name: PREDICTIVE_UNIT_DEFAULT_ENV_SECRET_REF_NAME
+          value: ""
+        - name: PREDICTIVE_UNIT_METRICS_PORT_NAME
+          value: metrics
+        - name: ENGINE_SERVER_GRPC_PORT
+          value: "5001"
+        - name: ENGINE_SERVER_PORT
+          value: "8000"
+        - name: ENGINE_PROMETHEUS_PATH
+          value: /prometheus
+        - name: ISTIO_ENABLED
+          value: "true"
+        - name: ISTIO_GATEWAY
+          value: kubeflow/kubeflow-gateway
+        - name: ISTIO_TLS_MODE
+          value: ""
+        - name: USE_EXECUTOR
+          value: "true"
+        - name: EXECUTOR_CONTAINER_IMAGE_AND_VERSION
+          value: docker.io/seldonio/seldon-core-executor:1.2.1
+        - name: EXECUTOR_CONTAINER_IMAGE_PULL_POLICY
+          value: IfNotPresent
+        - name: EXECUTOR_PROMETHEUS_PATH
+          value: /prometheus
+        - name: EXECUTOR_SERVER_PORT
+          value: "8000"
+        - name: EXECUTOR_CONTAINER_USER
+          value: "8888"
+        - name: EXECUTOR_CONTAINER_SERVICE_ACCOUNT_NAME
+          value: default
+        - name: EXECUTOR_SERVER_METRICS_PORT_NAME
+          value: metrics
+        - name: EXECUTOR_REQUEST_LOGGER_DEFAULT_ENDPOINT
+          value: http://default-broker
+        - name: DEFAULT_USER_ID
+          value: "8888"
+        image: docker.io/seldonio/seldon-core-operator:1.2.1
+        imagePullPolicy: IfNotPresent
+        name: manager
+        ports:
+        - containerPort: 443
+          name: webhook-server
+          protocol: TCP
+        - containerPort: 8080
+          name: metrics
+          protocol: TCP
+        resources:
+          limits:
+            cpu: 500m
+            memory: 300Mi
+          requests:
+            cpu: 100m
+            memory: 200Mi
+        volumeMounts:
+        - mountPath: /tmp/k8s-webhook-server/serving-certs
+          name: cert
+          readOnly: true
+      serviceAccountName: seldon-manager
+      terminationGracePeriodSeconds: 10
+      volumes:
+      - name: cert
+        secret:
+          defaultMode: 420
+          secretName: seldon-webhook-server-cert

--- a/tests/stacks/ibm/components/seldon-core-operator/test_data/expected/cert-manager.io_v1alpha2_certificate_seldon-serving-cert.yaml
+++ b/tests/stacks/ibm/components/seldon-core-operator/test_data/expected/cert-manager.io_v1alpha2_certificate_seldon-serving-cert.yaml
@@ -1,0 +1,20 @@
+apiVersion: cert-manager.io/v1alpha2
+kind: Certificate
+metadata:
+  labels:
+    app: seldon
+    app.kubernetes.io/component: seldon
+    app.kubernetes.io/instance: seldon-core
+    app.kubernetes.io/name: seldon-core-operator
+    app.kubernetes.io/version: 1.2.1
+  name: seldon-serving-cert
+  namespace: kubeflow
+spec:
+  commonName: seldon-webhook-service.kubeflow.svc
+  dnsNames:
+  - seldon-webhook-service.kubeflow.svc.cluster.local
+  - seldon-webhook-service.kubeflow.svc
+  issuerRef:
+    kind: Issuer
+    name: seldon-selfsigned-issuer
+  secretName: seldon-webhook-server-cert

--- a/tests/stacks/ibm/components/seldon-core-operator/test_data/expected/cert-manager.io_v1alpha2_issuer_seldon-selfsigned-issuer.yaml
+++ b/tests/stacks/ibm/components/seldon-core-operator/test_data/expected/cert-manager.io_v1alpha2_issuer_seldon-selfsigned-issuer.yaml
@@ -1,0 +1,13 @@
+apiVersion: cert-manager.io/v1alpha2
+kind: Issuer
+metadata:
+  labels:
+    app: seldon
+    app.kubernetes.io/component: seldon
+    app.kubernetes.io/instance: seldon-core
+    app.kubernetes.io/name: seldon-core-operator
+    app.kubernetes.io/version: 1.2.1
+  name: seldon-selfsigned-issuer
+  namespace: kubeflow
+spec:
+  selfSigned: {}

--- a/tests/stacks/ibm/components/seldon-core-operator/test_data/expected/rbac.authorization.k8s.io_v1_clusterrole_seldon-manager-role-kubeflow.yaml
+++ b/tests/stacks/ibm/components/seldon-core-operator/test_data/expected/rbac.authorization.k8s.io_v1_clusterrole_seldon-manager-role-kubeflow.yaml
@@ -1,0 +1,175 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  creationTimestamp: null
+  labels:
+    app: seldon
+    app.kubernetes.io/component: seldon
+    app.kubernetes.io/instance: seldon-core
+    app.kubernetes.io/name: seldon-core-operator
+    app.kubernetes.io/version: 1.2.1
+  name: seldon-manager-role-kubeflow
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - events
+  verbs:
+  - create
+  - patch
+- apiGroups:
+  - ""
+  resources:
+  - namespaces
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - services
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - apps
+  resources:
+  - deployments
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - apps
+  resources:
+  - deployments/status
+  verbs:
+  - get
+  - patch
+  - update
+- apiGroups:
+  - autoscaling
+  resources:
+  - horizontalpodautoscalers
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - autoscaling
+  resources:
+  - horizontalpodautoscalers/status
+  verbs:
+  - get
+  - patch
+  - update
+- apiGroups:
+  - machinelearning.seldon.io
+  resources:
+  - seldondeployments
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - machinelearning.seldon.io
+  resources:
+  - seldondeployments/finalizers
+  verbs:
+  - get
+  - patch
+  - update
+- apiGroups:
+  - machinelearning.seldon.io
+  resources:
+  - seldondeployments/status
+  verbs:
+  - get
+  - patch
+  - update
+- apiGroups:
+  - networking.istio.io
+  resources:
+  - destinationrules
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - networking.istio.io
+  resources:
+  - destinationrules/status
+  verbs:
+  - get
+  - patch
+  - update
+- apiGroups:
+  - networking.istio.io
+  resources:
+  - virtualservices
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - networking.istio.io
+  resources:
+  - virtualservices/status
+  verbs:
+  - get
+  - patch
+  - update
+- apiGroups:
+  - v1
+  resources:
+  - namespaces
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - v1
+  resources:
+  - services
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - v1
+  resources:
+  - services/status
+  verbs:
+  - get
+  - patch
+  - update

--- a/tests/stacks/ibm/components/seldon-core-operator/test_data/expected/rbac.authorization.k8s.io_v1_clusterrole_seldon-manager-sas-role-kubeflow.yaml
+++ b/tests/stacks/ibm/components/seldon-core-operator/test_data/expected/rbac.authorization.k8s.io_v1_clusterrole_seldon-manager-sas-role-kubeflow.yaml
@@ -1,0 +1,36 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  creationTimestamp: null
+  labels:
+    app: seldon
+    app.kubernetes.io/component: seldon
+    app.kubernetes.io/instance: seldon-core
+    app.kubernetes.io/name: seldon-core-operator
+    app.kubernetes.io/version: 1.2.1
+  name: seldon-manager-sas-role-kubeflow
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - secrets
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - configmaps
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - serviceaccounts
+  verbs:
+  - get
+  - list
+  - watch

--- a/tests/stacks/ibm/components/seldon-core-operator/test_data/expected/rbac.authorization.k8s.io_v1_clusterrolebinding_seldon-manager-rolebinding-kubeflow.yaml
+++ b/tests/stacks/ibm/components/seldon-core-operator/test_data/expected/rbac.authorization.k8s.io_v1_clusterrolebinding_seldon-manager-rolebinding-kubeflow.yaml
@@ -1,0 +1,18 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  labels:
+    app: seldon
+    app.kubernetes.io/component: seldon
+    app.kubernetes.io/instance: seldon-core
+    app.kubernetes.io/name: seldon-core-operator
+    app.kubernetes.io/version: 1.2.1
+  name: seldon-manager-rolebinding-kubeflow
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: seldon-manager-role-kubeflow
+subjects:
+- kind: ServiceAccount
+  name: seldon-manager
+  namespace: kubeflow

--- a/tests/stacks/ibm/components/seldon-core-operator/test_data/expected/rbac.authorization.k8s.io_v1_clusterrolebinding_seldon-manager-sas-rolebinding-kubeflow.yaml
+++ b/tests/stacks/ibm/components/seldon-core-operator/test_data/expected/rbac.authorization.k8s.io_v1_clusterrolebinding_seldon-manager-sas-rolebinding-kubeflow.yaml
@@ -1,0 +1,18 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  labels:
+    app: seldon
+    app.kubernetes.io/component: seldon
+    app.kubernetes.io/instance: seldon-core
+    app.kubernetes.io/name: seldon-core-operator
+    app.kubernetes.io/version: 1.2.1
+  name: seldon-manager-sas-rolebinding-kubeflow
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: seldon-manager-sas-role-kubeflow
+subjects:
+- kind: ServiceAccount
+  name: seldon-manager
+  namespace: kubeflow

--- a/tests/stacks/ibm/components/seldon-core-operator/test_data/expected/rbac.authorization.k8s.io_v1_role_seldon-leader-election-role.yaml
+++ b/tests/stacks/ibm/components/seldon-core-operator/test_data/expected/rbac.authorization.k8s.io_v1_role_seldon-leader-election-role.yaml
@@ -1,0 +1,38 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  labels:
+    app: seldon
+    app.kubernetes.io/component: seldon
+    app.kubernetes.io/instance: seldon-core
+    app.kubernetes.io/name: seldon-core-operator
+    app.kubernetes.io/version: 1.2.1
+  name: seldon-leader-election-role
+  namespace: kubeflow
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - configmaps
+  verbs:
+  - get
+  - list
+  - watch
+  - create
+  - update
+  - patch
+  - delete
+- apiGroups:
+  - ""
+  resources:
+  - configmaps/status
+  verbs:
+  - get
+  - update
+  - patch
+- apiGroups:
+  - ""
+  resources:
+  - events
+  verbs:
+  - create

--- a/tests/stacks/ibm/components/seldon-core-operator/test_data/expected/rbac.authorization.k8s.io_v1_rolebinding_seldon-leader-election-rolebinding.yaml
+++ b/tests/stacks/ibm/components/seldon-core-operator/test_data/expected/rbac.authorization.k8s.io_v1_rolebinding_seldon-leader-election-rolebinding.yaml
@@ -1,0 +1,19 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  labels:
+    app: seldon
+    app.kubernetes.io/component: seldon
+    app.kubernetes.io/instance: seldon-core
+    app.kubernetes.io/name: seldon-core-operator
+    app.kubernetes.io/version: 1.2.1
+  name: seldon-leader-election-rolebinding
+  namespace: kubeflow
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: seldon-leader-election-role
+subjects:
+- kind: ServiceAccount
+  name: seldon-manager
+  namespace: kubeflow

--- a/tests/stacks/ibm/components/seldon-core-operator/test_data/expected/~g_v1_configmap_seldon-config.yaml
+++ b/tests/stacks/ibm/components/seldon-core-operator/test_data/expected/~g_v1_configmap_seldon-config.yaml
@@ -1,0 +1,17 @@
+apiVersion: v1
+data:
+  credentials: '{"gcs":{"gcsCredentialFileName":"gcloud-application-credentials.json"},"s3":{"s3AccessKeyIDName":"awsAccessKeyID","s3SecretAccessKeyName":"awsSecretAccessKey"}}'
+  explainer: '{"image":"seldonio/alibiexplainer:1.2.1"}'
+  predictor_servers: '{"MLFLOW_SERVER":{"grpc":{"defaultImageVersion":"1.2.1","image":"seldonio/mlflowserver_grpc"},"rest":{"defaultImageVersion":"1.2.1","image":"seldonio/mlflowserver_rest"}},"SKLEARN_SERVER":{"grpc":{"defaultImageVersion":"1.2.1","image":"seldonio/sklearnserver_grpc"},"rest":{"defaultImageVersion":"1.2.1","image":"seldonio/sklearnserver_rest"}},"TENSORFLOW_SERVER":{"grpc":{"defaultImageVersion":"1.2.1","image":"seldonio/tfserving-proxy_grpc"},"rest":{"defaultImageVersion":"1.2.1","image":"seldonio/tfserving-proxy_rest"},"tensorflow":true,"tfImage":"tensorflow/serving:2.1.0"},"XGBOOST_SERVER":{"grpc":{"defaultImageVersion":"1.2.1","image":"seldonio/xgboostserver_grpc"},"rest":{"defaultImageVersion":"1.2.1","image":"seldonio/xgboostserver_rest"}}}'
+  storageInitializer: '{"cpuLimit":"1","cpuRequest":"100m","image":"gcr.io/kfserving/storage-initializer:0.2.2","memoryLimit":"1Gi","memoryRequest":"100Mi"}'
+kind: ConfigMap
+metadata:
+  labels:
+    app: seldon
+    app.kubernetes.io/component: seldon
+    app.kubernetes.io/instance: seldon-core
+    app.kubernetes.io/name: seldon-core-operator
+    app.kubernetes.io/version: 1.2.1
+    control-plane: seldon-controller-manager
+  name: seldon-config
+  namespace: kubeflow

--- a/tests/stacks/ibm/components/seldon-core-operator/test_data/expected/~g_v1_service_seldon-webhook-service.yaml
+++ b/tests/stacks/ibm/components/seldon-core-operator/test_data/expected/~g_v1_service_seldon-webhook-service.yaml
@@ -1,0 +1,22 @@
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    app: seldon
+    app.kubernetes.io/component: seldon
+    app.kubernetes.io/instance: seldon-core
+    app.kubernetes.io/name: seldon-core-operator
+    app.kubernetes.io/version: 1.2.1
+  name: seldon-webhook-service
+  namespace: kubeflow
+spec:
+  ports:
+  - port: 443
+    targetPort: 443
+  selector:
+    app: seldon
+    app.kubernetes.io/component: seldon
+    app.kubernetes.io/instance: seldon1
+    app.kubernetes.io/name: seldon-core-operator
+    app.kubernetes.io/version: v0.5
+    control-plane: seldon-controller-manager

--- a/tests/stacks/ibm/components/seldon-core-operator/test_data/expected/~g_v1_serviceaccount_seldon-manager.yaml
+++ b/tests/stacks/ibm/components/seldon-core-operator/test_data/expected/~g_v1_serviceaccount_seldon-manager.yaml
@@ -1,0 +1,11 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  labels:
+    app: seldon
+    app.kubernetes.io/component: seldon
+    app.kubernetes.io/instance: seldon-core
+    app.kubernetes.io/name: seldon-core-operator
+    app.kubernetes.io/version: 1.2.1
+  name: seldon-manager
+  namespace: kubeflow

--- a/tests/stacks/ibm/components/tf-job/kustomize_test.go
+++ b/tests/stacks/ibm/components/tf-job/kustomize_test.go
@@ -1,0 +1,15 @@
+package tf_job
+
+import (
+	"github.com/kubeflow/manifests/tests"
+	"testing"
+)
+
+func TestKustomize(t *testing.T) {
+	testCase := &tests.KustomizeTestCase{
+		Package:  "../../../../../stacks/ibm/components/tf-job",
+		Expected: "test_data/expected",
+	}
+
+	tests.RunTestCase(t, testCase)
+}

--- a/tests/stacks/ibm/components/tf-job/test_data/expected/apiextensions.k8s.io_v1beta1_customresourcedefinition_tfjobs.kubeflow.org.yaml
+++ b/tests/stacks/ibm/components/tf-job/test_data/expected/apiextensions.k8s.io_v1beta1_customresourcedefinition_tfjobs.kubeflow.org.yaml
@@ -1,0 +1,50 @@
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  labels:
+    app.kubernetes.io/component: tfjob
+    app.kubernetes.io/name: tf-job-crds
+  name: tfjobs.kubeflow.org
+spec:
+  additionalPrinterColumns:
+  - JSONPath: .status.conditions[-1:].type
+    name: State
+    type: string
+  - JSONPath: .metadata.creationTimestamp
+    name: Age
+    type: date
+  group: kubeflow.org
+  names:
+    kind: TFJob
+    plural: tfjobs
+    singular: tfjob
+  scope: Namespaced
+  subresources:
+    status: {}
+  validation:
+    openAPIV3Schema:
+      properties:
+        spec:
+          properties:
+            tfReplicaSpecs:
+              properties:
+                Chief:
+                  properties:
+                    replicas:
+                      maximum: 1
+                      minimum: 1
+                      type: integer
+                PS:
+                  properties:
+                    replicas:
+                      minimum: 1
+                      type: integer
+                Worker:
+                  properties:
+                    replicas:
+                      minimum: 1
+                      type: integer
+  versions:
+  - name: v1
+    served: true
+    storage: true

--- a/tests/stacks/ibm/components/tf-job/test_data/expected/app.k8s.io_v1beta1_application_tf-job-crds.yaml
+++ b/tests/stacks/ibm/components/tf-job/test_data/expected/app.k8s.io_v1beta1_application_tf-job-crds.yaml
@@ -1,0 +1,46 @@
+apiVersion: app.k8s.io/v1beta1
+kind: Application
+metadata:
+  labels:
+    app.kubernetes.io/component: tfjob
+    app.kubernetes.io/name: tf-job-crds
+  name: tf-job-crds
+  namespace: kubeflow
+spec:
+  addOwnerRef: true
+  componentKinds:
+  - group: core
+    kind: Service
+  - group: apps
+    kind: Deployment
+  - group: core
+    kind: ServiceAccount
+  - group: kubeflow.org
+    kind: TFJob
+  descriptor:
+    description: Tf-job-crds contains the "TFJob" custom resource definition.
+    keywords:
+    - tfjob
+    - tf-operator
+    - tf-training
+    links:
+    - description: About
+      url: https://github.com/kubeflow/tf-operator
+    - description: Docs
+      url: https://www.kubeflow.org/docs/reference/tfjob/v1/tensorflow/
+    maintainers:
+    - email: ricliu@google.com
+      name: Richard Liu
+    owners:
+    - email: ricliu@google.com
+      name: Richard Liu
+    type: tf-job-crds
+    version: v1
+  selector:
+    matchLabels:
+      app.kubernetes.io/component: tfjob
+      app.kubernetes.io/instance: tf-job-crds-v0.7.0
+      app.kubernetes.io/managed-by: kfctl
+      app.kubernetes.io/name: tf-job-crds
+      app.kubernetes.io/part-of: kubeflow
+      app.kubernetes.io/version: v0.7.0

--- a/tests/stacks/ibm/components/tf-job/test_data/expected/app.k8s.io_v1beta1_application_tf-job-operator.yaml
+++ b/tests/stacks/ibm/components/tf-job/test_data/expected/app.k8s.io_v1beta1_application_tf-job-operator.yaml
@@ -1,0 +1,47 @@
+apiVersion: app.k8s.io/v1beta1
+kind: Application
+metadata:
+  labels:
+    app.kubernetes.io/component: tfjob
+    app.kubernetes.io/name: tf-job-operator
+  name: tf-job-operator
+  namespace: kubeflow
+spec:
+  addOwnerRef: true
+  componentKinds:
+  - group: core
+    kind: Service
+  - group: apps
+    kind: Deployment
+  - group: core
+    kind: ServiceAccount
+  - group: kubeflow.org
+    kind: TFJob
+  descriptor:
+    description: Tf-operator allows users to create and manage the "TFJob" custom
+      resource.
+    keywords:
+    - tfjob
+    - tf-operator
+    - tf-training
+    links:
+    - description: About
+      url: https://github.com/kubeflow/tf-operator
+    - description: Docs
+      url: https://www.kubeflow.org/docs/reference/tfjob/v1/tensorflow/
+    maintainers:
+    - email: ricliu@google.com
+      name: Richard Liu
+    owners:
+    - email: ricliu@google.com
+      name: Richard Liu
+    type: tf-job-operator
+    version: v1
+  selector:
+    matchLabels:
+      app.kubernetes.io/component: tfjob
+      app.kubernetes.io/instance: tf-job-operator-v0.7.0
+      app.kubernetes.io/managed-by: kfctl
+      app.kubernetes.io/name: tf-job-operator
+      app.kubernetes.io/part-of: kubeflow
+      app.kubernetes.io/version: v0.7.0

--- a/tests/stacks/ibm/components/tf-job/test_data/expected/apps_v1_deployment_tf-job-operator.yaml
+++ b/tests/stacks/ibm/components/tf-job/test_data/expected/apps_v1_deployment_tf-job-operator.yaml
@@ -1,0 +1,43 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  labels:
+    app.kubernetes.io/component: tfjob
+    app.kubernetes.io/name: tf-job-operator
+    kustomize.component: tf-job-operator
+  name: tf-job-operator
+  namespace: kubeflow
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/component: tfjob
+      app.kubernetes.io/name: tf-job-operator
+      kustomize.component: tf-job-operator
+  template:
+    metadata:
+      annotations:
+        sidecar.istio.io/inject: "false"
+      labels:
+        app.kubernetes.io/component: tfjob
+        app.kubernetes.io/name: tf-job-operator
+        kustomize.component: tf-job-operator
+        name: tf-job-operator
+    spec:
+      containers:
+      - args:
+        - --alsologtostderr
+        - -v=1
+        - --monitoring-port=8443
+        env:
+        - name: MY_POD_NAMESPACE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace
+        - name: MY_POD_NAME
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.name
+        image: gcr.io/kubeflow-images-public/tf_operator:vmaster-ga2ae7bff
+        name: tf-job-operator
+      serviceAccountName: tf-job-operator

--- a/tests/stacks/ibm/components/tf-job/test_data/expected/rbac.authorization.k8s.io_v1_clusterrole_kubeflow-tfjobs-admin.yaml
+++ b/tests/stacks/ibm/components/tf-job/test_data/expected/rbac.authorization.k8s.io_v1_clusterrole_kubeflow-tfjobs-admin.yaml
@@ -1,0 +1,14 @@
+aggregationRule:
+  clusterRoleSelectors:
+  - matchLabels:
+      rbac.authorization.kubeflow.org/aggregate-to-kubeflow-tfjobs-admin: "true"
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  labels:
+    app.kubernetes.io/component: tfjob
+    app.kubernetes.io/name: tf-job-operator
+    kustomize.component: tf-job-operator
+    rbac.authorization.kubeflow.org/aggregate-to-kubeflow-admin: "true"
+  name: kubeflow-tfjobs-admin
+rules: []

--- a/tests/stacks/ibm/components/tf-job/test_data/expected/rbac.authorization.k8s.io_v1_clusterrole_kubeflow-tfjobs-edit.yaml
+++ b/tests/stacks/ibm/components/tf-job/test_data/expected/rbac.authorization.k8s.io_v1_clusterrole_kubeflow-tfjobs-edit.yaml
@@ -1,0 +1,25 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  labels:
+    app.kubernetes.io/component: tfjob
+    app.kubernetes.io/name: tf-job-operator
+    kustomize.component: tf-job-operator
+    rbac.authorization.kubeflow.org/aggregate-to-kubeflow-edit: "true"
+    rbac.authorization.kubeflow.org/aggregate-to-kubeflow-tfjobs-admin: "true"
+  name: kubeflow-tfjobs-edit
+rules:
+- apiGroups:
+  - kubeflow.org
+  resources:
+  - tfjobs
+  - tfjobs/status
+  verbs:
+  - get
+  - list
+  - watch
+  - create
+  - delete
+  - deletecollection
+  - patch
+  - update

--- a/tests/stacks/ibm/components/tf-job/test_data/expected/rbac.authorization.k8s.io_v1_clusterrole_kubeflow-tfjobs-view.yaml
+++ b/tests/stacks/ibm/components/tf-job/test_data/expected/rbac.authorization.k8s.io_v1_clusterrole_kubeflow-tfjobs-view.yaml
@@ -1,0 +1,19 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  labels:
+    app.kubernetes.io/component: tfjob
+    app.kubernetes.io/name: tf-job-operator
+    kustomize.component: tf-job-operator
+    rbac.authorization.kubeflow.org/aggregate-to-kubeflow-view: "true"
+  name: kubeflow-tfjobs-view
+rules:
+- apiGroups:
+  - kubeflow.org
+  resources:
+  - tfjobs
+  - tfjobs/status
+  verbs:
+  - get
+  - list
+  - watch

--- a/tests/stacks/ibm/components/tf-job/test_data/expected/rbac.authorization.k8s.io_v1beta1_clusterrole_tf-job-operator.yaml
+++ b/tests/stacks/ibm/components/tf-job/test_data/expected/rbac.authorization.k8s.io_v1beta1_clusterrole_tf-job-operator.yaml
@@ -1,0 +1,40 @@
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: ClusterRole
+metadata:
+  labels:
+    app: tf-job-operator
+    app.kubernetes.io/component: tfjob
+    app.kubernetes.io/name: tf-job-operator
+    kustomize.component: tf-job-operator
+  name: tf-job-operator
+rules:
+- apiGroups:
+  - kubeflow.org
+  resources:
+  - tfjobs
+  - tfjobs/status
+  - tfjobs/finalizers
+  verbs:
+  - '*'
+- apiGroups:
+  - apiextensions.k8s.io
+  resources:
+  - customresourcedefinitions
+  verbs:
+  - '*'
+- apiGroups:
+  - ""
+  resources:
+  - pods
+  - services
+  - endpoints
+  - events
+  verbs:
+  - '*'
+- apiGroups:
+  - apps
+  - extensions
+  resources:
+  - deployments
+  verbs:
+  - '*'

--- a/tests/stacks/ibm/components/tf-job/test_data/expected/rbac.authorization.k8s.io_v1beta1_clusterrolebinding_tf-job-operator.yaml
+++ b/tests/stacks/ibm/components/tf-job/test_data/expected/rbac.authorization.k8s.io_v1beta1_clusterrolebinding_tf-job-operator.yaml
@@ -1,0 +1,17 @@
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: ClusterRoleBinding
+metadata:
+  labels:
+    app: tf-job-operator
+    app.kubernetes.io/component: tfjob
+    app.kubernetes.io/name: tf-job-operator
+    kustomize.component: tf-job-operator
+  name: tf-job-operator
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: tf-job-operator
+subjects:
+- kind: ServiceAccount
+  name: tf-job-operator
+  namespace: kubeflow

--- a/tests/stacks/ibm/components/tf-job/test_data/expected/~g_v1_service_tf-job-operator.yaml
+++ b/tests/stacks/ibm/components/tf-job/test_data/expected/~g_v1_service_tf-job-operator.yaml
@@ -1,0 +1,25 @@
+apiVersion: v1
+kind: Service
+metadata:
+  annotations:
+    prometheus.io/path: /metrics
+    prometheus.io/port: "8443"
+    prometheus.io/scrape: "true"
+  labels:
+    app: tf-job-operator
+    app.kubernetes.io/component: tfjob
+    app.kubernetes.io/name: tf-job-operator
+    kustomize.component: tf-job-operator
+  name: tf-job-operator
+  namespace: kubeflow
+spec:
+  ports:
+  - name: monitoring-port
+    port: 8443
+    targetPort: 8443
+  selector:
+    app.kubernetes.io/component: tfjob
+    app.kubernetes.io/name: tf-job-operator
+    kustomize.component: tf-job-operator
+    name: tf-job-operator
+  type: ClusterIP

--- a/tests/stacks/ibm/components/tf-job/test_data/expected/~g_v1_serviceaccount_tf-job-dashboard.yaml
+++ b/tests/stacks/ibm/components/tf-job/test_data/expected/~g_v1_serviceaccount_tf-job-dashboard.yaml
@@ -1,0 +1,10 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  labels:
+    app: tf-job-dashboard
+    app.kubernetes.io/component: tfjob
+    app.kubernetes.io/name: tf-job-operator
+    kustomize.component: tf-job-operator
+  name: tf-job-dashboard
+  namespace: kubeflow

--- a/tests/stacks/ibm/components/tf-job/test_data/expected/~g_v1_serviceaccount_tf-job-operator.yaml
+++ b/tests/stacks/ibm/components/tf-job/test_data/expected/~g_v1_serviceaccount_tf-job-operator.yaml
@@ -1,0 +1,10 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  labels:
+    app: tf-job-operator
+    app.kubernetes.io/component: tfjob
+    app.kubernetes.io/name: tf-job-operator
+    kustomize.component: tf-job-operator
+  name: tf-job-operator
+  namespace: kubeflow

--- a/tests/tests/legacy_kustomizations/seldon-core-operator/test_data/expected/app.k8s.io_v1beta1_application_seldon-core-operator.yaml
+++ b/tests/tests/legacy_kustomizations/seldon-core-operator/test_data/expected/app.k8s.io_v1beta1_application_seldon-core-operator.yaml
@@ -7,7 +7,7 @@ metadata:
     app.kubernetes.io/managed-by: kfctl
     app.kubernetes.io/name: seldon-core-operator
     app.kubernetes.io/part-of: kubeflow
-    app.kubernetes.io/version: 1.15
+    app.kubernetes.io/version: "1.15"
   name: seldon-core-operator
   namespace: kubeflow
 spec:


### PR DESCRIPTION
**Which issue is resolved by this Pull Request:**
Resolves #

**Description of your changes:**
This PR splits the full Kubeflow stack for IBM Cloud platform in `stacks/ibm/kustomization.yaml` to a set of components, including `control plane`, `argo`, `pipelines`, `notebooks` etc. This enables a finer grain customization of Kubeflow components when users using `KfDef` configuration file to install Kubeflow. For example, if `notebooks` is not part of the `KfDef` configuration, then the Kubeflow's notebook server component won't be installed.

A sample `KfDef` configuration file `kfctl_ibm_customstack.yaml` is provided.

**Checklist:**
- [ x ] Unit tests have been rebuilt: 
    1. `cd manifests/tests`
    2. `make generate-changed-only`
    3. `make test`
