### PR TITLE
add permissions for kubectl top pods

### DIFF
--- a/kubeflow-roles/base/cluster-roles.yaml
+++ b/kubeflow-roles/base/cluster-roles.yaml
@@ -333,3 +333,10 @@ rules:
   - get
   - list
   - watch
+- apiGroups:
+  - metrics.k8s.io
+  resources:
+  - pods
+  verbs:
+  - get
+  - list


### PR DESCRIPTION
**Description of your changes:**

This allows the usage of kubectl top pods. 

This is useful when setting resource requests when using kubeflow/pipelines. I think this will be useful to most users of kubeflow.


**Checklist:**
- [ ] Unit tests have been rebuilt: 
    1. `cd manifests/tests`
    2. `make generate-changed-only`
    3. `make test`
