### PR TITLE
Add PatrickXYS as tests folder approver

### DIFF
--- a/tests/OWNERS
+++ b/tests/OWNERS
@@ -5,3 +5,4 @@ approvers:
   - jeffwan
   - johnugeorge
   - krishnadurai
+  - PatrickXYS

--- a/tests/stacks/ibm/components/tf-job/test_data/expected/apps_v1_deployment_tf-job-operator.yaml
+++ b/tests/stacks/ibm/components/tf-job/test_data/expected/apps_v1_deployment_tf-job-operator.yaml
@@ -38,6 +38,6 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: metadata.name
-        image: gcr.io/kubeflow-images-public/tf_operator:vmaster-ga2ae7bff
+        image: gcr.io/kubeflow-images-public/tf_operator:vmaster-gda226016
         name: tf-job-operator
       serviceAccountName: tf-job-operator

--- a/tests/stacks/kubernetes/test_data/expected/apps_v1_deployment_tf-job-operator.yaml
+++ b/tests/stacks/kubernetes/test_data/expected/apps_v1_deployment_tf-job-operator.yaml
@@ -38,6 +38,6 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: metadata.name
-        image: gcr.io/kubeflow-images-public/tf_operator:vmaster-ga2ae7bff
+        image: gcr.io/kubeflow-images-public/tf_operator:vmaster-gda226016
         name: tf-job-operator
       serviceAccountName: tf-job-operator


### PR DESCRIPTION
**Which issue is resolved by this Pull Request:**
Resolves #

**Description of your changes:**
I've been continuously contributing to manifests repo and will be adding E2E test back which include manifests+kfctl.

Adding myself as tests folder approver.

Here is my contribution list:
https://github.com/kubeflow/manifests/pulls/PatrickXYS

**Checklist:**
- [x] Unit tests have been rebuilt: 
    1. `cd manifests/tests`
    2. `make generate-changed-only`
    3. `make test`
