### PR TITLE
Add E2E Test on Kubeflow Shared Test-infra

### DIFF
--- a/prow_config.yaml
+++ b/prow_config.yaml
@@ -13,3 +13,45 @@ workflows:
       - presubmit
       - postsubmit
       - periodic
+  - py_func: kubeflow.kfctl.testing.ci.kfctl_e2e_workflow.create_workflow
+    name: e2e
+    job_types:
+      - presubmit
+      - postsubmit
+      - periodic 
+    include_dirs:
+      - admission-webhook/*
+      - application/*
+      - argo/*
+      - aws/*
+      - cert-manager/*
+      - common/
+      - default-install/*
+      - dex-auth/*
+      - experimental/*
+      - istio-1-3-1/*
+      - istio/*
+      - jupyter/*
+      - katib/*
+      - kfdef/*
+      - kfserving/*
+      - knative/*
+      - kubebench/*
+      - kubeflow-roles/*
+      - metacontroller/*
+      - metadata/*
+      - mpi-job/*
+      - mxnet-job/*
+      - namespaces/*
+      - pipeline/*
+      - profiles/*
+      - pytorch-job/*
+      - seldon/*
+      - spark/*
+      - stacks/*
+      - tektoncd/*
+      - tf-training/*
+      - xgboost-job/*
+    kwargs:
+      build_and_apply: false
+      config_path: https://raw.githubusercontent.com/kubeflow/manifests/master/kfdef/kfctl_istio_dex.v1.1.0.yaml

--- a/prow_config.yaml
+++ b/prow_config.yaml
@@ -54,4 +54,4 @@ workflows:
       - xgboost-job/*
     kwargs:
       build_and_apply: false
-      config_path: https://raw.githubusercontent.com/kubeflow/manifests/master/kfdef/kfctl_istio_dex.v1.1.0.yaml
+      config_path: https://raw.githubusercontent.com/kubeflow/manifests/master/kfdef/kfctl_istio_dex.yaml

--- a/tests/workflows/components/workflows.libsonnet
+++ b/tests/workflows/components/workflows.libsonnet
@@ -38,7 +38,7 @@
       local srcRootDir = testDir + "/src";
       // The directory containing the kubeflow/manifests repo
       local srcDir = srcRootDir + "/kubeflow/manifests";
-      local testWorkerImage = "527798164940.dkr.ecr.us-west-2.amazonaws.com/aws-kubeflow-ci/test-worker:latest";
+      local testWorkerImage = "527798164940.dkr.ecr.us-west-2.amazonaws.com/aws-kubeflow-ci/test-worker:v1.1-branch";
       local golangImage = "golang:1.9.4-stretch";
       // TODO(jose5918) Build our own helm image
       local pythonImage = "python:3.6-jessie";

--- a/tests/workflows/components/workflows.libsonnet
+++ b/tests/workflows/components/workflows.libsonnet
@@ -16,17 +16,9 @@
 
   // default parameters.
   defaultParams:: {
-    project:: "kubeflow-ci",
-    zone:: "us-east1-d",
-    // Default registry to use.
-    //registry:: "gcr.io/" + $.defaultParams.project,
-
     // The image tag to use.
     // Defaults to a value based on the name.
     versionTag:: null,
-
-    // The name of the secret containing GCP credentials.
-    gcpCredentialsSecretName:: "kubeflow-testing-credentials",
   },
 
   parts(namespace, name, overrides):: {
@@ -46,7 +38,7 @@
       local srcRootDir = testDir + "/src";
       // The directory containing the kubeflow/manifests repo
       local srcDir = srcRootDir + "/kubeflow/manifests";
-      local testWorkerImage = "gcr.io/kubeflow-ci/test-worker-py3:e9afed1-dirty";
+      local testWorkerImage = "527798164940.dkr.ecr.us-west-2.amazonaws.com/aws-kubeflow-ci/test-worker:latest";
       local golangImage = "golang:1.9.4-stretch";
       // TODO(jose5918) Build our own helm image
       local pythonImage = "python:3.6-jessie";
@@ -67,20 +59,7 @@
       local k8sPy = srcDir;
       local kubeflowPy = srcRootDir + "/kubeflow/testing/py";
 
-      local project = params.project;
-      // GKE cluster to use
-      // We need to truncate the cluster to no more than 40 characters because
-      // cluster names can be a max of 40 characters.
-      // We expect the suffix of the cluster name to be unique salt.
-      // We prepend a z because cluster name must start with an alphanumeric character
-      // and if we cut the prefix we might end up starting with "-" or other invalid
-      // character for first character.
-      local cluster =
-        if std.length(name) > 40 then
-          "z" + std.substr(name, std.length(name) - 39, 39)
-        else
-          name;
-      local zone = params.zone;
+      local cluster = params.cluster_name;
       {
         // Build an Argo template to execute a particular command.
         // step_name: Name for the template
@@ -107,20 +86,30 @@
                 value: cluster,
               },
               {
-                name: "GCP_ZONE",
-                value: zone,
-              },
-              {
-                name: "GCP_PROJECT",
-                value: project,
-              },
-              {
                 name: "DEPLOY_NAMESPACE",
                 value: deployNamespace,
               },
               {
-                name: "GOOGLE_APPLICATION_CREDENTIALS",
-                value: "/secret/gcp-credentials/key.json",
+                name: "AWS_ACCESS_KEY_ID",
+                valueFrom: {
+                  secretKeyRef: {
+                    name: "aws-credentials",
+                    key: "AWS_ACCESS_KEY_ID",
+                  },
+                },
+              },
+              {
+                name: "AWS_SECRET_ACCESS_KEY",
+                valueFrom: {
+                  secretKeyRef: {
+                    name: "aws-credentials",
+                    key: "AWS_SECRET_ACCESS_KEY",
+                  },
+                },
+              },
+              {
+                name: "AWS_DEFAULT_REGION",
+                value: "us-west-2",
               },
               {
                 name: "GIT_TOKEN",
@@ -137,14 +126,6 @@
                 name: dataVolume,
                 mountPath: mountPath,
               },
-              {
-                name: "github-token",
-                mountPath: "/secret/github-token",
-              },
-              {
-                name: "gcp-credentials",
-                mountPath: "/secret/gcp-credentials",
-              },
             ],
           },
         },  // buildTemplate
@@ -157,17 +138,12 @@
         },
         spec: {
           entrypoint: "e2e",
+          ttlSecondsAfterFinished: 3600,
           volumes: [
             {
               name: "github-token",
               secret: {
                 secretName: "github-token",
-              },
-            },
-            {
-              name: "gcp-credentials",
-              secret: {
-                secretName: params.gcpCredentialsSecretName,
               },
             },
             {


### PR DESCRIPTION
**Which issue is resolved by this Pull Request:**
For Kubeflow 1.2 release, we have decided to move E2E test back for kfctl + manifests

Related kfctl PR: https://github.com/kubeflow/kfctl/pull/427
This PR will only be able to merge until kfctl PR merged.

**Description of your changes:**
1. Add E2E test
2. Change E2E configuration to make it compatible on Shared Test-infra

**Checklist:**
- [x] Unit tests have been rebuilt: 
    1. `cd manifests/tests`
    2. `make generate-changed-only`
    3. `make test`
