### PR TITLE
[Fix tests] Skip non SequenceNode yaml to work around on the old kyaml bug

### DIFF
--- a/tests/validate_resources_test.go
+++ b/tests/validate_resources_test.go
@@ -311,6 +311,10 @@ func TestCheckWebhookSelector(t *testing.T) {
 		nodes, err := reader.Read()
 
 		if err != nil {
+			if strings.Contains(err.Error(), "wrong Node Kind for") {
+				t.Logf("Skipping non SequenceNode yaml %v", path)
+				return nil
+			}
 			t.Errorf("Error unmarshaling %v; error: %v", path, err)
 		}
 


### PR DESCRIPTION
**Which issue is resolved by this Pull Request:**
Related #1567

**Description of your changes:**
Since we are still using kyaml v0.1.11 for our tests, it has some bugs when parsing non SequenceNode yaml. Although it's resolved in the newer release of kyaml, updating kyaml will dramatically change the current generated tests. Therefore, we skip all the files with `wrong Node Kind for` since we only need to check the proper kubernetes yaml.

**Checklist:**
- [x] Unit tests have been rebuilt: 
    1. `cd manifests/tests`
    2. `make generate-changed-only`
    3. `make test`
