### PR TITLE
Add PatrickXYS as OWNER of manifests repo

### DIFF
--- a/OWNERS
+++ b/OWNERS
@@ -2,10 +2,10 @@ approvers:
   - animeshsingh
   - Bobgy
   - jlewi
+  - PatrickXYS
   - swiftdiaries
   - terrytangyuan
   - yanniszark
   - zhenghuiwang
 reviewers:
   - krishnadurai
-  - PatrickXYS


### PR DESCRIPTION
**Which issue is resolved by this Pull Request:**
Resolves #

**Description of your changes:**
I want to add myself as the OWNER of manifests repo as a leader of wg-manifests.

And here is my[ contribution list ](https://github.com/kubeflow/manifests/pulls?q=is%3Apr+author%3APatrickXYS)

**Checklist:**
- [x] Unit tests have been rebuilt: 
    1. `cd manifests/tests`
    2. `make generate-changed-only`
    3. `make test`
