### PR TITLE
Update OWNERS file with Arrikto folk

### DIFF
--- a/OWNERS
+++ b/OWNERS
@@ -1,10 +1,13 @@
 approvers:
   - animeshsingh
   - Bobgy
+  - elikatsis
   - jlewi
   - PatrickXYS
+  - StefanoFioravanzo
   - swiftdiaries
   - terrytangyuan
+  - vkoukis
   - yanniszark
   - zhenghuiwang
 reviewers:


### PR DESCRIPTION
Add Arrikto folk to the OWNERS file, as part of forming the new WG
Manifests, in order to carry out the plan specified in the charter.

/cc @PatrickXYS @jlewi @Bobgy 

Signed-off-by: Yannis Zarkadas <yanniszark@arrikto.com>
