### PR TITLE
Add Exit Steps for Unit Test

### DIFF
--- a/prow_config.yaml
+++ b/prow_config.yaml
@@ -13,45 +13,45 @@ workflows:
       - presubmit
       - postsubmit
       - periodic
-  - py_func: kubeflow.kfctl.testing.ci.kfctl_e2e_workflow.create_workflow
-    name: e2e
-    job_types:
-      - presubmit
-      - postsubmit
-      - periodic 
-    include_dirs:
-      - admission-webhook/*
-      - application/*
-      - argo/*
-      - aws/*
-      - cert-manager/*
-      - common/
-      - default-install/*
-      - dex-auth/*
-      - experimental/*
-      - istio-1-3-1/*
-      - istio/*
-      - jupyter/*
-      - katib/*
-      - kfdef/*
-      - kfserving/*
-      - knative/*
-      - kubebench/*
-      - kubeflow-roles/*
-      - metacontroller/*
-      - metadata/*
-      - mpi-job/*
-      - mxnet-job/*
-      - namespaces/*
-      - pipeline/*
-      - profiles/*
-      - pytorch-job/*
-      - seldon/*
-      - spark/*
-      - stacks/*
-      - tektoncd/*
-      - tf-training/*
-      - xgboost-job/*
-    kwargs:
-      build_and_apply: false
-      config_path: https://raw.githubusercontent.com/kubeflow/manifests/master/kfdef/kfctl_istio_dex.yaml
+  # - py_func: kubeflow.kfctl.testing.ci.kfctl_e2e_workflow.create_workflow
+  #   name: e2e
+  #   job_types:
+  #     - presubmit
+  #     - postsubmit
+  #     - periodic 
+  #   include_dirs:
+  #     - admission-webhook/*
+  #     - application/*
+  #     - argo/*
+  #     - aws/*
+  #     - cert-manager/*
+  #     - common/
+  #     - default-install/*
+  #     - dex-auth/*
+  #     - experimental/*
+  #     - istio-1-3-1/*
+  #     - istio/*
+  #     - jupyter/*
+  #     - katib/*
+  #     - kfdef/*
+  #     - kfserving/*
+  #     - knative/*
+  #     - kubebench/*
+  #     - kubeflow-roles/*
+  #     - metacontroller/*
+  #     - metadata/*
+  #     - mpi-job/*
+  #     - mxnet-job/*
+  #     - namespaces/*
+  #     - pipeline/*
+  #     - profiles/*
+  #     - pytorch-job/*
+  #     - seldon/*
+  #     - spark/*
+  #     - stacks/*
+  #     - tektoncd/*
+  #     - tf-training/*
+  #     - xgboost-job/*
+  #   kwargs:
+  #     build_and_apply: false
+  #     config_path: https://raw.githubusercontent.com/kubeflow/manifests/master/kfdef/kfctl_istio_dex.yaml

--- a/tests/scripts/run_with_retry.py
+++ b/tests/scripts/run_with_retry.py
@@ -1,0 +1,45 @@
+# -*- coding: utf-8 -*-
+"""
+run_with_retry runs the given binary with the given number of retries
+This is intended primary for retrying bash scripts. Ideally, we sould use
+argo's retryStrategy, but there is a bug in it's implementation:
+https://github.com/argoproj/argo/issues/885
+Example:
+  python run_with_retry --retries=5 -- bash my_flaky_script.sh
+This runs bash my_flaky_script.sh upto 5 times till it succeeds
+"""
+import argparse
+from kubeflow.testing import test_helper, util
+from retrying import retry
+
+
+def parse_args():
+  parser = argparse.ArgumentParser()
+  parser.add_argument(
+      "--retries", required=True, type=int, help="The number of retries.")
+
+  parser.add_argument('remaining_args', nargs=argparse.REMAINDER)
+  args, _ = parser.parse_known_args()
+  return args
+
+
+def run_with_retry(_):
+  """Deploy Kubeflow."""
+  args = parse_args()
+
+  @retry(stop_max_attempt_number=args.retries)
+  def run():
+    util.run(args.remaining_args[1:])
+
+  run()
+
+
+def main():
+  test_case = test_helper.TestCase(
+      name='run_with_retry', test_func=run_with_retry)
+  test_suite = test_helper.init(name='run_with_retry', test_cases=[test_case])
+  test_suite.run()
+
+
+if __name__ == "__main__":
+  main()


### PR DESCRIPTION
**Which issue is resolved by this Pull Request:**
Since current unit doesn't provide Exit Step, which upload artifacts and delete test-dir. 
![image](https://user-images.githubusercontent.com/23116624/98179112-e7fc0f80-1eb2-11eb-8add-d93d3c2f2998.png)


**Description of your changes:**
Adding Exithandler to handle onExit logic

**Checklist:**
- [x] Unit tests have been rebuilt: 
    1. `cd manifests/tests`
    2. `make generate-changed-only`
    3. `make test`

Commenting E2E test without testing E2E workflow, hold until Unit Test succeed, will add E2E test back in the PR
/hold