### PR TITLE
Add a test to verify no more use of deprecated env syntax

### DIFF
--- a/aws/fluentd-cloud-watch/base_v3/kustomization.yaml
+++ b/aws/fluentd-cloud-watch/base_v3/kustomization.yaml
@@ -17,7 +17,8 @@ images:
   newTag: v1.7.3-debian-cloudwatch-1.0
 configMapGenerator:
 - name: fluentd-cloud-watch-parameters
-  env: params.env
+  envs: 
+  - params.env
 vars:
 - name: CLUSTER_NAME
   objref:

--- a/prow_config.yaml
+++ b/prow_config.yaml
@@ -12,7 +12,7 @@ workflows:
     job_types:
       - presubmit
       - postsubmit
-      - periodic
+      - periodic  
   - py_func: kubeflow.kfctl.testing.ci.kfctl_e2e_workflow.create_workflow
     name: e2e
     job_types:

--- a/tests/go.mod
+++ b/tests/go.mod
@@ -3,7 +3,6 @@ module github.com/kubeflow/manifests/tests
 go 1.13
 
 require (
-	github.com/PuerkitoBio/purell v1.1.1 // indirect
 	github.com/ghodss/yaml v1.0.1-0.20190212211648-25d852aebe32
 	github.com/gogo/protobuf v1.2.2-0.20190730201129-28a6bbf47e48 // indirect
 	github.com/golang/protobuf v1.3.2 // indirect


### PR DESCRIPTION
* Fix one remaining use in fluentd

* Fix #538
