### PR TITLE
Increase unit test argo workflow TTL

### DIFF
--- a/tests/workflows/components/workflows.libsonnet
+++ b/tests/workflows/components/workflows.libsonnet
@@ -138,7 +138,7 @@
         },
         spec: {
           entrypoint: "e2e",
-          ttlSecondsAfterFinished: 3600,
+          ttlSecondsAfterFinished: 8*60*60,
           volumes: [
             {
               name: "github-token",


### PR DESCRIPTION
**Which issue is resolved by this Pull Request:**
Resolves #

**Description of your changes:**
Increase unit test TTL from 1h to 8h

**Checklist:**
- [x] Unit tests have been rebuilt: 
    1. `cd manifests/tests`
    2. `make generate-changed-only`
    3. `make test`
