### PR TITLE
Add AWS Periodic Tests

### DIFF
--- a/prow_config.yaml
+++ b/prow_config.yaml
@@ -12,13 +12,11 @@ workflows:
     job_types:
       - presubmit
       - postsubmit
-      - periodic  
   - py_func: kubeflow.kfctl.testing.ci.kfctl_e2e_workflow.create_workflow
     name: e2e
     job_types:
       - presubmit
       - postsubmit
-      - periodic 
     include_dirs:
       - admission-webhook/*
       - application/*
@@ -55,3 +53,13 @@ workflows:
     kwargs:
       build_and_apply: false
       config_path: https://raw.githubusercontent.com/kubeflow/manifests/master/kfdef/kfctl_istio_dex.yaml
+
+  ####################################### AWS Specific Tests
+  - py_func: kubeflow.kfctl.testing.ci.kfctl_e2e_workflow.create_workflow
+    name: aws-e2e
+    job_types:
+      - periodic
+    kwargs:
+      build_and_apply: false
+      config_path: https://raw.githubusercontent.com/kubeflow/manifests/master/kfdef/kfctl_aws.yaml
+    


### PR DESCRIPTION
**Which issue is resolved by this Pull Request:**
Resolves #

**Description of your changes:**
Add AWS Periodic Tests to test orchestration on Kubeflow AWS.

Also removes periodic tests for e2e and unit tests, since no one will check it daily and see if they succeed or fail, thus, it only consume resources without any contribution.

**Checklist:**
- [x] Unit tests have been rebuilt: 
    1. `cd manifests/tests`
    2. `make generate-changed-only`
    3. `make test`
