### PR TITLE
Update Katib 0.10 image tag to 6dc1af8

### DIFF
--- a/katib/components/katib-controller/kustomization.yaml
+++ b/katib/components/katib-controller/kustomization.yaml
@@ -15,10 +15,10 @@ resources:
   - ../../katib-controller/overlays/istio/katib-ui-virtual-service.yaml
 images:
   - name: docker.io/kubeflowkatib/katib-controller
-    newTag: v1beta1-e294a90
+    newTag: v1beta1-6dc1af8
     newName: docker.io/kubeflowkatib/katib-controller
   - name: docker.io/kubeflowkatib/katib-ui
-    newTag: v1beta1-e294a90
+    newTag: v1beta1-6dc1af8
     newName: docker.io/kubeflowkatib/katib-ui
 commonLabels:
   app.kubernetes.io/component: katib

--- a/katib/components/katib-db-manager/kustomization.yaml
+++ b/katib/components/katib-db-manager/kustomization.yaml
@@ -6,7 +6,7 @@ resources:
   - ../../katib-controller/base/katib-db-manager-service.yaml
 images:
   - name: docker.io/kubeflowkatib/katib-db-manager
-    newTag: v1beta1-e294a90
+    newTag: v1beta1-6dc1af8
     newName: docker.io/kubeflowkatib/katib-db-manager
 commonLabels:
   app.kubernetes.io/component: katib

--- a/katib/katib-controller/base/katib-configmap.yaml
+++ b/katib/katib-controller/base/katib-configmap.yaml
@@ -6,13 +6,13 @@ data:
   metrics-collector-sidecar: |-
     {
       "StdOut": {
-        "image": "docker.io/kubeflowkatib/file-metrics-collector:v1beta1-e294a90"
+        "image": "docker.io/kubeflowkatib/file-metrics-collector:v1beta1-6dc1af8"
       },
       "File": {
-        "image": "docker.io/kubeflowkatib/file-metrics-collector:v1beta1-e294a90"
+        "image": "docker.io/kubeflowkatib/file-metrics-collector:v1beta1-6dc1af8"
       },
       "TensorFlowEvent": {
-        "image": "docker.io/kubeflowkatib/tfevent-metrics-collector:v1beta1-e294a90",
+        "image": "docker.io/kubeflowkatib/tfevent-metrics-collector:v1beta1-6dc1af8",
         "resources": {
           "limits": {
             "memory": "1Gi"
@@ -23,22 +23,22 @@ data:
   suggestion: |-
     {
       "random": {
-        "image": "docker.io/kubeflowkatib/suggestion-hyperopt:v1beta1-e294a90"
+        "image": "docker.io/kubeflowkatib/suggestion-hyperopt:v1beta1-6dc1af8"
       },
       "grid": {
-        "image": "docker.io/kubeflowkatib/suggestion-chocolate:v1beta1-e294a90"
+        "image": "docker.io/kubeflowkatib/suggestion-chocolate:v1beta1-6dc1af8"
       },
       "hyperband": {
-        "image": "docker.io/kubeflowkatib/suggestion-hyperband:v1beta1-e294a90"
+        "image": "docker.io/kubeflowkatib/suggestion-hyperband:v1beta1-6dc1af8"
       },
       "bayesianoptimization": {
-        "image": "docker.io/kubeflowkatib/suggestion-skopt:v1beta1-e294a90"
+        "image": "docker.io/kubeflowkatib/suggestion-skopt:v1beta1-6dc1af8"
       },
       "tpe": {
-        "image": "docker.io/kubeflowkatib/suggestion-hyperopt:v1beta1-e294a90"
+        "image": "docker.io/kubeflowkatib/suggestion-hyperopt:v1beta1-6dc1af8"
       },
       "enas": {
-        "image": "docker.io/kubeflowkatib/suggestion-enas:v1beta1-e294a90",
+        "image": "docker.io/kubeflowkatib/suggestion-enas:v1beta1-6dc1af8",
         "imagePullPolicy": "Always",
         "resources": {
           "limits": {
@@ -47,16 +47,16 @@ data:
         }
       },
       "cmaes": {
-        "image": "docker.io/kubeflowkatib/suggestion-goptuna:v1beta1-e294a90"
+        "image": "docker.io/kubeflowkatib/suggestion-goptuna:v1beta1-6dc1af8"
       },
       "darts": {
-        "image": "docker.io/kubeflowkatib/suggestion-darts:v1beta1-e294a90"
+        "image": "docker.io/kubeflowkatib/suggestion-darts:v1beta1-6dc1af8"
       }
     }
   early-stopping: |-
     {
       "medianstop": {
-        "image": "docker.io/kubeflowkatib/earlystopping-medianstop:v1beta1-e294a90",
+        "image": "docker.io/kubeflowkatib/earlystopping-medianstop:v1beta1-6dc1af8",
         "imagePullPolicy": "Always"
       }
     }

--- a/katib/katib-controller/base/kustomization.yaml
+++ b/katib/katib-controller/base/kustomization.yaml
@@ -23,13 +23,13 @@ generatorOptions:
   disableNameSuffixHash: true
 images:
   - name: docker.io/kubeflowkatib/katib-controller
-    newTag: v1beta1-e294a90
+    newTag: v1beta1-6dc1af8
     newName: docker.io/kubeflowkatib/katib-controller
   - name: docker.io/kubeflowkatib/katib-db-manager
-    newTag: v1beta1-e294a90
+    newTag: v1beta1-6dc1af8
     newName: docker.io/kubeflowkatib/katib-db-manager
   - name: docker.io/kubeflowkatib/katib-ui
-    newTag: v1beta1-e294a90
+    newTag: v1beta1-6dc1af8
     newName: docker.io/kubeflowkatib/katib-ui
   - name: mysql
     newTag: "8"

--- a/katib/katib-controller/base/trial-template-configmap.yaml
+++ b/katib/katib-controller/base/trial-template-configmap.yaml
@@ -13,7 +13,7 @@ data:
         spec:
           containers:
             - name: training-container
-              image: docker.io/kubeflowkatib/mxnet-mnist:v1beta1-e294a90
+              image: docker.io/kubeflowkatib/mxnet-mnist:v1beta1-6dc1af8
               command:
                 - "python3"
                 - "/opt/mxnet-mnist/mnist.py"
@@ -31,7 +31,7 @@ data:
         spec:
           containers:
             - name: training-container
-              image: docker.io/kubeflowkatib/enas-cnn-cifar10-cpu:v1beta1-e294a90
+              image: docker.io/kubeflowkatib/enas-cnn-cifar10-cpu:v1beta1-6dc1af8
               command:
                 - python3
                 - -u

--- a/tests/katib/installs/katib-external-db/test_data/expected/apps_v1_deployment_katib-controller.yaml
+++ b/tests/katib/installs/katib-external-db/test_data/expected/apps_v1_deployment_katib-controller.yaml
@@ -39,7 +39,7 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: metadata.namespace
-        image: docker.io/kubeflowkatib/katib-controller:v1beta1-e294a90
+        image: docker.io/kubeflowkatib/katib-controller:v1beta1-6dc1af8
         imagePullPolicy: IfNotPresent
         name: katib-controller
         ports:

--- a/tests/katib/installs/katib-external-db/test_data/expected/apps_v1_deployment_katib-db-manager.yaml
+++ b/tests/katib/installs/katib-external-db/test_data/expected/apps_v1_deployment_katib-db-manager.yaml
@@ -58,7 +58,7 @@ spec:
             secretKeyRef:
               key: KATIB_MYSQL_DB_PORT
               name: katib-mysql-secrets-kmcg6hfkfg
-        image: docker.io/kubeflowkatib/katib-db-manager:v1beta1-e294a90
+        image: docker.io/kubeflowkatib/katib-db-manager:v1beta1-6dc1af8
         imagePullPolicy: IfNotPresent
         livenessProbe:
           exec:

--- a/tests/katib/installs/katib-external-db/test_data/expected/apps_v1_deployment_katib-ui.yaml
+++ b/tests/katib/installs/katib-external-db/test_data/expected/apps_v1_deployment_katib-ui.yaml
@@ -37,7 +37,7 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: metadata.namespace
-        image: docker.io/kubeflowkatib/katib-ui:v1beta1-e294a90
+        image: docker.io/kubeflowkatib/katib-ui:v1beta1-6dc1af8
         imagePullPolicy: IfNotPresent
         name: katib-ui
         ports:

--- a/tests/katib/installs/katib-external-db/test_data/expected/~g_v1_configmap_katib-config.yaml
+++ b/tests/katib/installs/katib-external-db/test_data/expected/~g_v1_configmap_katib-config.yaml
@@ -3,20 +3,20 @@ data:
   early-stopping: |-
     {
       "medianstop": {
-        "image": "docker.io/kubeflowkatib/earlystopping-medianstop:v1beta1-e294a90",
+        "image": "docker.io/kubeflowkatib/earlystopping-medianstop:v1beta1-6dc1af8",
         "imagePullPolicy": "Always"
       }
     }
   metrics-collector-sidecar: |-
     {
       "StdOut": {
-        "image": "docker.io/kubeflowkatib/file-metrics-collector:v1beta1-e294a90"
+        "image": "docker.io/kubeflowkatib/file-metrics-collector:v1beta1-6dc1af8"
       },
       "File": {
-        "image": "docker.io/kubeflowkatib/file-metrics-collector:v1beta1-e294a90"
+        "image": "docker.io/kubeflowkatib/file-metrics-collector:v1beta1-6dc1af8"
       },
       "TensorFlowEvent": {
-        "image": "docker.io/kubeflowkatib/tfevent-metrics-collector:v1beta1-e294a90",
+        "image": "docker.io/kubeflowkatib/tfevent-metrics-collector:v1beta1-6dc1af8",
         "resources": {
           "limits": {
             "memory": "1Gi"
@@ -27,22 +27,22 @@ data:
   suggestion: |-
     {
       "random": {
-        "image": "docker.io/kubeflowkatib/suggestion-hyperopt:v1beta1-e294a90"
+        "image": "docker.io/kubeflowkatib/suggestion-hyperopt:v1beta1-6dc1af8"
       },
       "grid": {
-        "image": "docker.io/kubeflowkatib/suggestion-chocolate:v1beta1-e294a90"
+        "image": "docker.io/kubeflowkatib/suggestion-chocolate:v1beta1-6dc1af8"
       },
       "hyperband": {
-        "image": "docker.io/kubeflowkatib/suggestion-hyperband:v1beta1-e294a90"
+        "image": "docker.io/kubeflowkatib/suggestion-hyperband:v1beta1-6dc1af8"
       },
       "bayesianoptimization": {
-        "image": "docker.io/kubeflowkatib/suggestion-skopt:v1beta1-e294a90"
+        "image": "docker.io/kubeflowkatib/suggestion-skopt:v1beta1-6dc1af8"
       },
       "tpe": {
-        "image": "docker.io/kubeflowkatib/suggestion-hyperopt:v1beta1-e294a90"
+        "image": "docker.io/kubeflowkatib/suggestion-hyperopt:v1beta1-6dc1af8"
       },
       "enas": {
-        "image": "docker.io/kubeflowkatib/suggestion-enas:v1beta1-e294a90",
+        "image": "docker.io/kubeflowkatib/suggestion-enas:v1beta1-6dc1af8",
         "imagePullPolicy": "Always",
         "resources": {
           "limits": {
@@ -51,10 +51,10 @@ data:
         }
       },
       "cmaes": {
-        "image": "docker.io/kubeflowkatib/suggestion-goptuna:v1beta1-e294a90"
+        "image": "docker.io/kubeflowkatib/suggestion-goptuna:v1beta1-6dc1af8"
       },
       "darts": {
-        "image": "docker.io/kubeflowkatib/suggestion-darts:v1beta1-e294a90"
+        "image": "docker.io/kubeflowkatib/suggestion-darts:v1beta1-6dc1af8"
       }
     }
 kind: ConfigMap

--- a/tests/katib/installs/katib-external-db/test_data/expected/~g_v1_configmap_trial-template.yaml
+++ b/tests/katib/installs/katib-external-db/test_data/expected/~g_v1_configmap_trial-template.yaml
@@ -8,7 +8,7 @@ data:
         spec:
           containers:
             - name: training-container
-              image: docker.io/kubeflowkatib/mxnet-mnist:v1beta1-e294a90
+              image: docker.io/kubeflowkatib/mxnet-mnist:v1beta1-6dc1af8
               command:
                 - "python3"
                 - "/opt/mxnet-mnist/mnist.py"
@@ -25,7 +25,7 @@ data:
         spec:
           containers:
             - name: training-container
-              image: docker.io/kubeflowkatib/enas-cnn-cifar10-cpu:v1beta1-e294a90
+              image: docker.io/kubeflowkatib/enas-cnn-cifar10-cpu:v1beta1-6dc1af8
               command:
                 - python3
                 - -u

--- a/tests/katib/installs/katib-standalone-ibm/test_data/expected/apps_v1_deployment_katib-controller.yaml
+++ b/tests/katib/installs/katib-standalone-ibm/test_data/expected/apps_v1_deployment_katib-controller.yaml
@@ -39,7 +39,7 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: metadata.namespace
-        image: docker.io/kubeflowkatib/katib-controller:v1beta1-e294a90
+        image: docker.io/kubeflowkatib/katib-controller:v1beta1-6dc1af8
         imagePullPolicy: IfNotPresent
         name: katib-controller
         ports:

--- a/tests/katib/installs/katib-standalone-ibm/test_data/expected/apps_v1_deployment_katib-db-manager.yaml
+++ b/tests/katib/installs/katib-standalone-ibm/test_data/expected/apps_v1_deployment_katib-db-manager.yaml
@@ -38,7 +38,7 @@ spec:
             secretKeyRef:
               key: MYSQL_ROOT_PASSWORD
               name: katib-mysql-secrets
-        image: docker.io/kubeflowkatib/katib-db-manager:v1beta1-e294a90
+        image: docker.io/kubeflowkatib/katib-db-manager:v1beta1-6dc1af8
         imagePullPolicy: IfNotPresent
         livenessProbe:
           exec:

--- a/tests/katib/installs/katib-standalone-ibm/test_data/expected/apps_v1_deployment_katib-ui.yaml
+++ b/tests/katib/installs/katib-standalone-ibm/test_data/expected/apps_v1_deployment_katib-ui.yaml
@@ -37,7 +37,7 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: metadata.namespace
-        image: docker.io/kubeflowkatib/katib-ui:v1beta1-e294a90
+        image: docker.io/kubeflowkatib/katib-ui:v1beta1-6dc1af8
         imagePullPolicy: IfNotPresent
         name: katib-ui
         ports:

--- a/tests/katib/installs/katib-standalone-ibm/test_data/expected/~g_v1_configmap_katib-config.yaml
+++ b/tests/katib/installs/katib-standalone-ibm/test_data/expected/~g_v1_configmap_katib-config.yaml
@@ -3,20 +3,20 @@ data:
   early-stopping: |-
     {
       "medianstop": {
-        "image": "docker.io/kubeflowkatib/earlystopping-medianstop:v1beta1-e294a90",
+        "image": "docker.io/kubeflowkatib/earlystopping-medianstop:v1beta1-6dc1af8",
         "imagePullPolicy": "Always"
       }
     }
   metrics-collector-sidecar: |-
     {
       "StdOut": {
-        "image": "docker.io/kubeflowkatib/file-metrics-collector:v1beta1-e294a90"
+        "image": "docker.io/kubeflowkatib/file-metrics-collector:v1beta1-6dc1af8"
       },
       "File": {
-        "image": "docker.io/kubeflowkatib/file-metrics-collector:v1beta1-e294a90"
+        "image": "docker.io/kubeflowkatib/file-metrics-collector:v1beta1-6dc1af8"
       },
       "TensorFlowEvent": {
-        "image": "docker.io/kubeflowkatib/tfevent-metrics-collector:v1beta1-e294a90",
+        "image": "docker.io/kubeflowkatib/tfevent-metrics-collector:v1beta1-6dc1af8",
         "resources": {
           "limits": {
             "memory": "1Gi"
@@ -27,22 +27,22 @@ data:
   suggestion: |-
     {
       "random": {
-        "image": "docker.io/kubeflowkatib/suggestion-hyperopt:v1beta1-e294a90"
+        "image": "docker.io/kubeflowkatib/suggestion-hyperopt:v1beta1-6dc1af8"
       },
       "grid": {
-        "image": "docker.io/kubeflowkatib/suggestion-chocolate:v1beta1-e294a90"
+        "image": "docker.io/kubeflowkatib/suggestion-chocolate:v1beta1-6dc1af8"
       },
       "hyperband": {
-        "image": "docker.io/kubeflowkatib/suggestion-hyperband:v1beta1-e294a90"
+        "image": "docker.io/kubeflowkatib/suggestion-hyperband:v1beta1-6dc1af8"
       },
       "bayesianoptimization": {
-        "image": "docker.io/kubeflowkatib/suggestion-skopt:v1beta1-e294a90"
+        "image": "docker.io/kubeflowkatib/suggestion-skopt:v1beta1-6dc1af8"
       },
       "tpe": {
-        "image": "docker.io/kubeflowkatib/suggestion-hyperopt:v1beta1-e294a90"
+        "image": "docker.io/kubeflowkatib/suggestion-hyperopt:v1beta1-6dc1af8"
       },
       "enas": {
-        "image": "docker.io/kubeflowkatib/suggestion-enas:v1beta1-e294a90",
+        "image": "docker.io/kubeflowkatib/suggestion-enas:v1beta1-6dc1af8",
         "imagePullPolicy": "Always",
         "resources": {
           "limits": {
@@ -51,10 +51,10 @@ data:
         }
       },
       "cmaes": {
-        "image": "docker.io/kubeflowkatib/suggestion-goptuna:v1beta1-e294a90"
+        "image": "docker.io/kubeflowkatib/suggestion-goptuna:v1beta1-6dc1af8"
       },
       "darts": {
-        "image": "docker.io/kubeflowkatib/suggestion-darts:v1beta1-e294a90"
+        "image": "docker.io/kubeflowkatib/suggestion-darts:v1beta1-6dc1af8"
       }
     }
 kind: ConfigMap

--- a/tests/katib/installs/katib-standalone-ibm/test_data/expected/~g_v1_configmap_trial-template.yaml
+++ b/tests/katib/installs/katib-standalone-ibm/test_data/expected/~g_v1_configmap_trial-template.yaml
@@ -8,7 +8,7 @@ data:
         spec:
           containers:
             - name: training-container
-              image: docker.io/kubeflowkatib/mxnet-mnist:v1beta1-e294a90
+              image: docker.io/kubeflowkatib/mxnet-mnist:v1beta1-6dc1af8
               command:
                 - "python3"
                 - "/opt/mxnet-mnist/mnist.py"
@@ -25,7 +25,7 @@ data:
         spec:
           containers:
             - name: training-container
-              image: docker.io/kubeflowkatib/enas-cnn-cifar10-cpu:v1beta1-e294a90
+              image: docker.io/kubeflowkatib/enas-cnn-cifar10-cpu:v1beta1-6dc1af8
               command:
                 - python3
                 - -u

--- a/tests/katib/installs/katib-standalone/test_data/expected/apps_v1_deployment_katib-controller.yaml
+++ b/tests/katib/installs/katib-standalone/test_data/expected/apps_v1_deployment_katib-controller.yaml
@@ -39,7 +39,7 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: metadata.namespace
-        image: docker.io/kubeflowkatib/katib-controller:v1beta1-e294a90
+        image: docker.io/kubeflowkatib/katib-controller:v1beta1-6dc1af8
         imagePullPolicy: IfNotPresent
         name: katib-controller
         ports:

--- a/tests/katib/installs/katib-standalone/test_data/expected/apps_v1_deployment_katib-db-manager.yaml
+++ b/tests/katib/installs/katib-standalone/test_data/expected/apps_v1_deployment_katib-db-manager.yaml
@@ -38,7 +38,7 @@ spec:
             secretKeyRef:
               key: MYSQL_ROOT_PASSWORD
               name: katib-mysql-secrets
-        image: docker.io/kubeflowkatib/katib-db-manager:v1beta1-e294a90
+        image: docker.io/kubeflowkatib/katib-db-manager:v1beta1-6dc1af8
         imagePullPolicy: IfNotPresent
         livenessProbe:
           exec:

--- a/tests/katib/installs/katib-standalone/test_data/expected/apps_v1_deployment_katib-ui.yaml
+++ b/tests/katib/installs/katib-standalone/test_data/expected/apps_v1_deployment_katib-ui.yaml
@@ -37,7 +37,7 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: metadata.namespace
-        image: docker.io/kubeflowkatib/katib-ui:v1beta1-e294a90
+        image: docker.io/kubeflowkatib/katib-ui:v1beta1-6dc1af8
         imagePullPolicy: IfNotPresent
         name: katib-ui
         ports:

--- a/tests/katib/installs/katib-standalone/test_data/expected/~g_v1_configmap_katib-config.yaml
+++ b/tests/katib/installs/katib-standalone/test_data/expected/~g_v1_configmap_katib-config.yaml
@@ -3,20 +3,20 @@ data:
   early-stopping: |-
     {
       "medianstop": {
-        "image": "docker.io/kubeflowkatib/earlystopping-medianstop:v1beta1-e294a90",
+        "image": "docker.io/kubeflowkatib/earlystopping-medianstop:v1beta1-6dc1af8",
         "imagePullPolicy": "Always"
       }
     }
   metrics-collector-sidecar: |-
     {
       "StdOut": {
-        "image": "docker.io/kubeflowkatib/file-metrics-collector:v1beta1-e294a90"
+        "image": "docker.io/kubeflowkatib/file-metrics-collector:v1beta1-6dc1af8"
       },
       "File": {
-        "image": "docker.io/kubeflowkatib/file-metrics-collector:v1beta1-e294a90"
+        "image": "docker.io/kubeflowkatib/file-metrics-collector:v1beta1-6dc1af8"
       },
       "TensorFlowEvent": {
-        "image": "docker.io/kubeflowkatib/tfevent-metrics-collector:v1beta1-e294a90",
+        "image": "docker.io/kubeflowkatib/tfevent-metrics-collector:v1beta1-6dc1af8",
         "resources": {
           "limits": {
             "memory": "1Gi"
@@ -27,22 +27,22 @@ data:
   suggestion: |-
     {
       "random": {
-        "image": "docker.io/kubeflowkatib/suggestion-hyperopt:v1beta1-e294a90"
+        "image": "docker.io/kubeflowkatib/suggestion-hyperopt:v1beta1-6dc1af8"
       },
       "grid": {
-        "image": "docker.io/kubeflowkatib/suggestion-chocolate:v1beta1-e294a90"
+        "image": "docker.io/kubeflowkatib/suggestion-chocolate:v1beta1-6dc1af8"
       },
       "hyperband": {
-        "image": "docker.io/kubeflowkatib/suggestion-hyperband:v1beta1-e294a90"
+        "image": "docker.io/kubeflowkatib/suggestion-hyperband:v1beta1-6dc1af8"
       },
       "bayesianoptimization": {
-        "image": "docker.io/kubeflowkatib/suggestion-skopt:v1beta1-e294a90"
+        "image": "docker.io/kubeflowkatib/suggestion-skopt:v1beta1-6dc1af8"
       },
       "tpe": {
-        "image": "docker.io/kubeflowkatib/suggestion-hyperopt:v1beta1-e294a90"
+        "image": "docker.io/kubeflowkatib/suggestion-hyperopt:v1beta1-6dc1af8"
       },
       "enas": {
-        "image": "docker.io/kubeflowkatib/suggestion-enas:v1beta1-e294a90",
+        "image": "docker.io/kubeflowkatib/suggestion-enas:v1beta1-6dc1af8",
         "imagePullPolicy": "Always",
         "resources": {
           "limits": {
@@ -51,10 +51,10 @@ data:
         }
       },
       "cmaes": {
-        "image": "docker.io/kubeflowkatib/suggestion-goptuna:v1beta1-e294a90"
+        "image": "docker.io/kubeflowkatib/suggestion-goptuna:v1beta1-6dc1af8"
       },
       "darts": {
-        "image": "docker.io/kubeflowkatib/suggestion-darts:v1beta1-e294a90"
+        "image": "docker.io/kubeflowkatib/suggestion-darts:v1beta1-6dc1af8"
       }
     }
 kind: ConfigMap

--- a/tests/katib/installs/katib-standalone/test_data/expected/~g_v1_configmap_trial-template.yaml
+++ b/tests/katib/installs/katib-standalone/test_data/expected/~g_v1_configmap_trial-template.yaml
@@ -8,7 +8,7 @@ data:
         spec:
           containers:
             - name: training-container
-              image: docker.io/kubeflowkatib/mxnet-mnist:v1beta1-e294a90
+              image: docker.io/kubeflowkatib/mxnet-mnist:v1beta1-6dc1af8
               command:
                 - "python3"
                 - "/opt/mxnet-mnist/mnist.py"
@@ -25,7 +25,7 @@ data:
         spec:
           containers:
             - name: training-container
-              image: docker.io/kubeflowkatib/enas-cnn-cifar10-cpu:v1beta1-e294a90
+              image: docker.io/kubeflowkatib/enas-cnn-cifar10-cpu:v1beta1-6dc1af8
               command:
                 - python3
                 - -u

--- a/tests/stacks/aws/test_data/expected/apps_v1_deployment_katib-controller.yaml
+++ b/tests/stacks/aws/test_data/expected/apps_v1_deployment_katib-controller.yaml
@@ -39,7 +39,7 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: metadata.namespace
-        image: docker.io/kubeflowkatib/katib-controller:v1beta1-e294a90
+        image: docker.io/kubeflowkatib/katib-controller:v1beta1-6dc1af8
         imagePullPolicy: IfNotPresent
         name: katib-controller
         ports:

--- a/tests/stacks/aws/test_data/expected/apps_v1_deployment_katib-db-manager.yaml
+++ b/tests/stacks/aws/test_data/expected/apps_v1_deployment_katib-db-manager.yaml
@@ -38,7 +38,7 @@ spec:
             secretKeyRef:
               key: MYSQL_ROOT_PASSWORD
               name: katib-mysql-secrets
-        image: docker.io/kubeflowkatib/katib-db-manager:v1beta1-e294a90
+        image: docker.io/kubeflowkatib/katib-db-manager:v1beta1-6dc1af8
         imagePullPolicy: IfNotPresent
         livenessProbe:
           exec:

--- a/tests/stacks/aws/test_data/expected/apps_v1_deployment_katib-ui.yaml
+++ b/tests/stacks/aws/test_data/expected/apps_v1_deployment_katib-ui.yaml
@@ -37,7 +37,7 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: metadata.namespace
-        image: docker.io/kubeflowkatib/katib-ui:v1beta1-e294a90
+        image: docker.io/kubeflowkatib/katib-ui:v1beta1-6dc1af8
         imagePullPolicy: IfNotPresent
         name: katib-ui
         ports:

--- a/tests/stacks/aws/test_data/expected/~g_v1_configmap_katib-config.yaml
+++ b/tests/stacks/aws/test_data/expected/~g_v1_configmap_katib-config.yaml
@@ -3,20 +3,20 @@ data:
   early-stopping: |-
     {
       "medianstop": {
-        "image": "docker.io/kubeflowkatib/earlystopping-medianstop:v1beta1-e294a90",
+        "image": "docker.io/kubeflowkatib/earlystopping-medianstop:v1beta1-6dc1af8",
         "imagePullPolicy": "Always"
       }
     }
   metrics-collector-sidecar: |-
     {
       "StdOut": {
-        "image": "docker.io/kubeflowkatib/file-metrics-collector:v1beta1-e294a90"
+        "image": "docker.io/kubeflowkatib/file-metrics-collector:v1beta1-6dc1af8"
       },
       "File": {
-        "image": "docker.io/kubeflowkatib/file-metrics-collector:v1beta1-e294a90"
+        "image": "docker.io/kubeflowkatib/file-metrics-collector:v1beta1-6dc1af8"
       },
       "TensorFlowEvent": {
-        "image": "docker.io/kubeflowkatib/tfevent-metrics-collector:v1beta1-e294a90",
+        "image": "docker.io/kubeflowkatib/tfevent-metrics-collector:v1beta1-6dc1af8",
         "resources": {
           "limits": {
             "memory": "1Gi"
@@ -27,22 +27,22 @@ data:
   suggestion: |-
     {
       "random": {
-        "image": "docker.io/kubeflowkatib/suggestion-hyperopt:v1beta1-e294a90"
+        "image": "docker.io/kubeflowkatib/suggestion-hyperopt:v1beta1-6dc1af8"
       },
       "grid": {
-        "image": "docker.io/kubeflowkatib/suggestion-chocolate:v1beta1-e294a90"
+        "image": "docker.io/kubeflowkatib/suggestion-chocolate:v1beta1-6dc1af8"
       },
       "hyperband": {
-        "image": "docker.io/kubeflowkatib/suggestion-hyperband:v1beta1-e294a90"
+        "image": "docker.io/kubeflowkatib/suggestion-hyperband:v1beta1-6dc1af8"
       },
       "bayesianoptimization": {
-        "image": "docker.io/kubeflowkatib/suggestion-skopt:v1beta1-e294a90"
+        "image": "docker.io/kubeflowkatib/suggestion-skopt:v1beta1-6dc1af8"
       },
       "tpe": {
-        "image": "docker.io/kubeflowkatib/suggestion-hyperopt:v1beta1-e294a90"
+        "image": "docker.io/kubeflowkatib/suggestion-hyperopt:v1beta1-6dc1af8"
       },
       "enas": {
-        "image": "docker.io/kubeflowkatib/suggestion-enas:v1beta1-e294a90",
+        "image": "docker.io/kubeflowkatib/suggestion-enas:v1beta1-6dc1af8",
         "imagePullPolicy": "Always",
         "resources": {
           "limits": {
@@ -51,10 +51,10 @@ data:
         }
       },
       "cmaes": {
-        "image": "docker.io/kubeflowkatib/suggestion-goptuna:v1beta1-e294a90"
+        "image": "docker.io/kubeflowkatib/suggestion-goptuna:v1beta1-6dc1af8"
       },
       "darts": {
-        "image": "docker.io/kubeflowkatib/suggestion-darts:v1beta1-e294a90"
+        "image": "docker.io/kubeflowkatib/suggestion-darts:v1beta1-6dc1af8"
       }
     }
 kind: ConfigMap

--- a/tests/stacks/aws/test_data/expected/~g_v1_configmap_trial-template.yaml
+++ b/tests/stacks/aws/test_data/expected/~g_v1_configmap_trial-template.yaml
@@ -8,7 +8,7 @@ data:
         spec:
           containers:
             - name: training-container
-              image: docker.io/kubeflowkatib/mxnet-mnist:v1beta1-e294a90
+              image: docker.io/kubeflowkatib/mxnet-mnist:v1beta1-6dc1af8
               command:
                 - "python3"
                 - "/opt/mxnet-mnist/mnist.py"
@@ -25,7 +25,7 @@ data:
         spec:
           containers:
             - name: training-container
-              image: docker.io/kubeflowkatib/enas-cnn-cifar10-cpu:v1beta1-e294a90
+              image: docker.io/kubeflowkatib/enas-cnn-cifar10-cpu:v1beta1-6dc1af8
               command:
                 - python3
                 - -u

--- a/tests/stacks/examples/alice/test_data/expected/apps_v1_deployment_katib-controller.yaml
+++ b/tests/stacks/examples/alice/test_data/expected/apps_v1_deployment_katib-controller.yaml
@@ -39,7 +39,7 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: metadata.namespace
-        image: docker.io/kubeflowkatib/katib-controller:v1beta1-e294a90
+        image: docker.io/kubeflowkatib/katib-controller:v1beta1-6dc1af8
         imagePullPolicy: IfNotPresent
         name: katib-controller
         ports:

--- a/tests/stacks/examples/alice/test_data/expected/apps_v1_deployment_katib-db-manager.yaml
+++ b/tests/stacks/examples/alice/test_data/expected/apps_v1_deployment_katib-db-manager.yaml
@@ -38,7 +38,7 @@ spec:
             secretKeyRef:
               key: MYSQL_ROOT_PASSWORD
               name: katib-mysql-secrets
-        image: docker.io/kubeflowkatib/katib-db-manager:v1beta1-e294a90
+        image: docker.io/kubeflowkatib/katib-db-manager:v1beta1-6dc1af8
         imagePullPolicy: IfNotPresent
         livenessProbe:
           exec:

--- a/tests/stacks/examples/alice/test_data/expected/apps_v1_deployment_katib-ui.yaml
+++ b/tests/stacks/examples/alice/test_data/expected/apps_v1_deployment_katib-ui.yaml
@@ -37,7 +37,7 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: metadata.namespace
-        image: docker.io/kubeflowkatib/katib-ui:v1beta1-e294a90
+        image: docker.io/kubeflowkatib/katib-ui:v1beta1-6dc1af8
         imagePullPolicy: IfNotPresent
         name: katib-ui
         ports:

--- a/tests/stacks/examples/alice/test_data/expected/~g_v1_configmap_katib-config.yaml
+++ b/tests/stacks/examples/alice/test_data/expected/~g_v1_configmap_katib-config.yaml
@@ -3,20 +3,20 @@ data:
   early-stopping: |-
     {
       "medianstop": {
-        "image": "docker.io/kubeflowkatib/earlystopping-medianstop:v1beta1-e294a90",
+        "image": "docker.io/kubeflowkatib/earlystopping-medianstop:v1beta1-6dc1af8",
         "imagePullPolicy": "Always"
       }
     }
   metrics-collector-sidecar: |-
     {
       "StdOut": {
-        "image": "docker.io/kubeflowkatib/file-metrics-collector:v1beta1-e294a90"
+        "image": "docker.io/kubeflowkatib/file-metrics-collector:v1beta1-6dc1af8"
       },
       "File": {
-        "image": "docker.io/kubeflowkatib/file-metrics-collector:v1beta1-e294a90"
+        "image": "docker.io/kubeflowkatib/file-metrics-collector:v1beta1-6dc1af8"
       },
       "TensorFlowEvent": {
-        "image": "docker.io/kubeflowkatib/tfevent-metrics-collector:v1beta1-e294a90",
+        "image": "docker.io/kubeflowkatib/tfevent-metrics-collector:v1beta1-6dc1af8",
         "resources": {
           "limits": {
             "memory": "1Gi"
@@ -27,22 +27,22 @@ data:
   suggestion: |-
     {
       "random": {
-        "image": "docker.io/kubeflowkatib/suggestion-hyperopt:v1beta1-e294a90"
+        "image": "docker.io/kubeflowkatib/suggestion-hyperopt:v1beta1-6dc1af8"
       },
       "grid": {
-        "image": "docker.io/kubeflowkatib/suggestion-chocolate:v1beta1-e294a90"
+        "image": "docker.io/kubeflowkatib/suggestion-chocolate:v1beta1-6dc1af8"
       },
       "hyperband": {
-        "image": "docker.io/kubeflowkatib/suggestion-hyperband:v1beta1-e294a90"
+        "image": "docker.io/kubeflowkatib/suggestion-hyperband:v1beta1-6dc1af8"
       },
       "bayesianoptimization": {
-        "image": "docker.io/kubeflowkatib/suggestion-skopt:v1beta1-e294a90"
+        "image": "docker.io/kubeflowkatib/suggestion-skopt:v1beta1-6dc1af8"
       },
       "tpe": {
-        "image": "docker.io/kubeflowkatib/suggestion-hyperopt:v1beta1-e294a90"
+        "image": "docker.io/kubeflowkatib/suggestion-hyperopt:v1beta1-6dc1af8"
       },
       "enas": {
-        "image": "docker.io/kubeflowkatib/suggestion-enas:v1beta1-e294a90",
+        "image": "docker.io/kubeflowkatib/suggestion-enas:v1beta1-6dc1af8",
         "imagePullPolicy": "Always",
         "resources": {
           "limits": {
@@ -51,10 +51,10 @@ data:
         }
       },
       "cmaes": {
-        "image": "docker.io/kubeflowkatib/suggestion-goptuna:v1beta1-e294a90"
+        "image": "docker.io/kubeflowkatib/suggestion-goptuna:v1beta1-6dc1af8"
       },
       "darts": {
-        "image": "docker.io/kubeflowkatib/suggestion-darts:v1beta1-e294a90"
+        "image": "docker.io/kubeflowkatib/suggestion-darts:v1beta1-6dc1af8"
       }
     }
 kind: ConfigMap

--- a/tests/stacks/examples/alice/test_data/expected/~g_v1_configmap_trial-template.yaml
+++ b/tests/stacks/examples/alice/test_data/expected/~g_v1_configmap_trial-template.yaml
@@ -8,7 +8,7 @@ data:
         spec:
           containers:
             - name: training-container
-              image: docker.io/kubeflowkatib/mxnet-mnist:v1beta1-e294a90
+              image: docker.io/kubeflowkatib/mxnet-mnist:v1beta1-6dc1af8
               command:
                 - "python3"
                 - "/opt/mxnet-mnist/mnist.py"
@@ -25,7 +25,7 @@ data:
         spec:
           containers:
             - name: training-container
-              image: docker.io/kubeflowkatib/enas-cnn-cifar10-cpu:v1beta1-e294a90
+              image: docker.io/kubeflowkatib/enas-cnn-cifar10-cpu:v1beta1-6dc1af8
               command:
                 - python3
                 - -u

--- a/tests/stacks/gcp/test_data/expected/apps_v1_deployment_katib-controller.yaml
+++ b/tests/stacks/gcp/test_data/expected/apps_v1_deployment_katib-controller.yaml
@@ -39,7 +39,7 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: metadata.namespace
-        image: docker.io/kubeflowkatib/katib-controller:v1beta1-e294a90
+        image: docker.io/kubeflowkatib/katib-controller:v1beta1-6dc1af8
         imagePullPolicy: IfNotPresent
         name: katib-controller
         ports:

--- a/tests/stacks/gcp/test_data/expected/apps_v1_deployment_katib-db-manager.yaml
+++ b/tests/stacks/gcp/test_data/expected/apps_v1_deployment_katib-db-manager.yaml
@@ -38,7 +38,7 @@ spec:
             secretKeyRef:
               key: MYSQL_ROOT_PASSWORD
               name: katib-mysql-secrets
-        image: docker.io/kubeflowkatib/katib-db-manager:v1beta1-e294a90
+        image: docker.io/kubeflowkatib/katib-db-manager:v1beta1-6dc1af8
         imagePullPolicy: IfNotPresent
         livenessProbe:
           exec:

--- a/tests/stacks/gcp/test_data/expected/apps_v1_deployment_katib-ui.yaml
+++ b/tests/stacks/gcp/test_data/expected/apps_v1_deployment_katib-ui.yaml
@@ -37,7 +37,7 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: metadata.namespace
-        image: docker.io/kubeflowkatib/katib-ui:v1beta1-e294a90
+        image: docker.io/kubeflowkatib/katib-ui:v1beta1-6dc1af8
         imagePullPolicy: IfNotPresent
         name: katib-ui
         ports:

--- a/tests/stacks/gcp/test_data/expected/~g_v1_configmap_katib-config.yaml
+++ b/tests/stacks/gcp/test_data/expected/~g_v1_configmap_katib-config.yaml
@@ -3,20 +3,20 @@ data:
   early-stopping: |-
     {
       "medianstop": {
-        "image": "docker.io/kubeflowkatib/earlystopping-medianstop:v1beta1-e294a90",
+        "image": "docker.io/kubeflowkatib/earlystopping-medianstop:v1beta1-6dc1af8",
         "imagePullPolicy": "Always"
       }
     }
   metrics-collector-sidecar: |-
     {
       "StdOut": {
-        "image": "docker.io/kubeflowkatib/file-metrics-collector:v1beta1-e294a90"
+        "image": "docker.io/kubeflowkatib/file-metrics-collector:v1beta1-6dc1af8"
       },
       "File": {
-        "image": "docker.io/kubeflowkatib/file-metrics-collector:v1beta1-e294a90"
+        "image": "docker.io/kubeflowkatib/file-metrics-collector:v1beta1-6dc1af8"
       },
       "TensorFlowEvent": {
-        "image": "docker.io/kubeflowkatib/tfevent-metrics-collector:v1beta1-e294a90",
+        "image": "docker.io/kubeflowkatib/tfevent-metrics-collector:v1beta1-6dc1af8",
         "resources": {
           "limits": {
             "memory": "1Gi"
@@ -27,22 +27,22 @@ data:
   suggestion: |-
     {
       "random": {
-        "image": "docker.io/kubeflowkatib/suggestion-hyperopt:v1beta1-e294a90"
+        "image": "docker.io/kubeflowkatib/suggestion-hyperopt:v1beta1-6dc1af8"
       },
       "grid": {
-        "image": "docker.io/kubeflowkatib/suggestion-chocolate:v1beta1-e294a90"
+        "image": "docker.io/kubeflowkatib/suggestion-chocolate:v1beta1-6dc1af8"
       },
       "hyperband": {
-        "image": "docker.io/kubeflowkatib/suggestion-hyperband:v1beta1-e294a90"
+        "image": "docker.io/kubeflowkatib/suggestion-hyperband:v1beta1-6dc1af8"
       },
       "bayesianoptimization": {
-        "image": "docker.io/kubeflowkatib/suggestion-skopt:v1beta1-e294a90"
+        "image": "docker.io/kubeflowkatib/suggestion-skopt:v1beta1-6dc1af8"
       },
       "tpe": {
-        "image": "docker.io/kubeflowkatib/suggestion-hyperopt:v1beta1-e294a90"
+        "image": "docker.io/kubeflowkatib/suggestion-hyperopt:v1beta1-6dc1af8"
       },
       "enas": {
-        "image": "docker.io/kubeflowkatib/suggestion-enas:v1beta1-e294a90",
+        "image": "docker.io/kubeflowkatib/suggestion-enas:v1beta1-6dc1af8",
         "imagePullPolicy": "Always",
         "resources": {
           "limits": {
@@ -51,10 +51,10 @@ data:
         }
       },
       "cmaes": {
-        "image": "docker.io/kubeflowkatib/suggestion-goptuna:v1beta1-e294a90"
+        "image": "docker.io/kubeflowkatib/suggestion-goptuna:v1beta1-6dc1af8"
       },
       "darts": {
-        "image": "docker.io/kubeflowkatib/suggestion-darts:v1beta1-e294a90"
+        "image": "docker.io/kubeflowkatib/suggestion-darts:v1beta1-6dc1af8"
       }
     }
 kind: ConfigMap

--- a/tests/stacks/gcp/test_data/expected/~g_v1_configmap_trial-template.yaml
+++ b/tests/stacks/gcp/test_data/expected/~g_v1_configmap_trial-template.yaml
@@ -8,7 +8,7 @@ data:
         spec:
           containers:
             - name: training-container
-              image: docker.io/kubeflowkatib/mxnet-mnist:v1beta1-e294a90
+              image: docker.io/kubeflowkatib/mxnet-mnist:v1beta1-6dc1af8
               command:
                 - "python3"
                 - "/opt/mxnet-mnist/mnist.py"
@@ -25,7 +25,7 @@ data:
         spec:
           containers:
             - name: training-container
-              image: docker.io/kubeflowkatib/enas-cnn-cifar10-cpu:v1beta1-e294a90
+              image: docker.io/kubeflowkatib/enas-cnn-cifar10-cpu:v1beta1-6dc1af8
               command:
                 - python3
                 - -u

--- a/tests/stacks/generic/test_data/expected/apps_v1_deployment_katib-controller.yaml
+++ b/tests/stacks/generic/test_data/expected/apps_v1_deployment_katib-controller.yaml
@@ -39,7 +39,7 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: metadata.namespace
-        image: docker.io/kubeflowkatib/katib-controller:v1beta1-e294a90
+        image: docker.io/kubeflowkatib/katib-controller:v1beta1-6dc1af8
         imagePullPolicy: IfNotPresent
         name: katib-controller
         ports:

--- a/tests/stacks/generic/test_data/expected/apps_v1_deployment_katib-db-manager.yaml
+++ b/tests/stacks/generic/test_data/expected/apps_v1_deployment_katib-db-manager.yaml
@@ -38,7 +38,7 @@ spec:
             secretKeyRef:
               key: MYSQL_ROOT_PASSWORD
               name: katib-mysql-secrets
-        image: docker.io/kubeflowkatib/katib-db-manager:v1beta1-e294a90
+        image: docker.io/kubeflowkatib/katib-db-manager:v1beta1-6dc1af8
         imagePullPolicy: IfNotPresent
         livenessProbe:
           exec:

--- a/tests/stacks/generic/test_data/expected/apps_v1_deployment_katib-ui.yaml
+++ b/tests/stacks/generic/test_data/expected/apps_v1_deployment_katib-ui.yaml
@@ -37,7 +37,7 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: metadata.namespace
-        image: docker.io/kubeflowkatib/katib-ui:v1beta1-e294a90
+        image: docker.io/kubeflowkatib/katib-ui:v1beta1-6dc1af8
         imagePullPolicy: IfNotPresent
         name: katib-ui
         ports:

--- a/tests/stacks/generic/test_data/expected/~g_v1_configmap_katib-config.yaml
+++ b/tests/stacks/generic/test_data/expected/~g_v1_configmap_katib-config.yaml
@@ -3,20 +3,20 @@ data:
   early-stopping: |-
     {
       "medianstop": {
-        "image": "docker.io/kubeflowkatib/earlystopping-medianstop:v1beta1-e294a90",
+        "image": "docker.io/kubeflowkatib/earlystopping-medianstop:v1beta1-6dc1af8",
         "imagePullPolicy": "Always"
       }
     }
   metrics-collector-sidecar: |-
     {
       "StdOut": {
-        "image": "docker.io/kubeflowkatib/file-metrics-collector:v1beta1-e294a90"
+        "image": "docker.io/kubeflowkatib/file-metrics-collector:v1beta1-6dc1af8"
       },
       "File": {
-        "image": "docker.io/kubeflowkatib/file-metrics-collector:v1beta1-e294a90"
+        "image": "docker.io/kubeflowkatib/file-metrics-collector:v1beta1-6dc1af8"
       },
       "TensorFlowEvent": {
-        "image": "docker.io/kubeflowkatib/tfevent-metrics-collector:v1beta1-e294a90",
+        "image": "docker.io/kubeflowkatib/tfevent-metrics-collector:v1beta1-6dc1af8",
         "resources": {
           "limits": {
             "memory": "1Gi"
@@ -27,22 +27,22 @@ data:
   suggestion: |-
     {
       "random": {
-        "image": "docker.io/kubeflowkatib/suggestion-hyperopt:v1beta1-e294a90"
+        "image": "docker.io/kubeflowkatib/suggestion-hyperopt:v1beta1-6dc1af8"
       },
       "grid": {
-        "image": "docker.io/kubeflowkatib/suggestion-chocolate:v1beta1-e294a90"
+        "image": "docker.io/kubeflowkatib/suggestion-chocolate:v1beta1-6dc1af8"
       },
       "hyperband": {
-        "image": "docker.io/kubeflowkatib/suggestion-hyperband:v1beta1-e294a90"
+        "image": "docker.io/kubeflowkatib/suggestion-hyperband:v1beta1-6dc1af8"
       },
       "bayesianoptimization": {
-        "image": "docker.io/kubeflowkatib/suggestion-skopt:v1beta1-e294a90"
+        "image": "docker.io/kubeflowkatib/suggestion-skopt:v1beta1-6dc1af8"
       },
       "tpe": {
-        "image": "docker.io/kubeflowkatib/suggestion-hyperopt:v1beta1-e294a90"
+        "image": "docker.io/kubeflowkatib/suggestion-hyperopt:v1beta1-6dc1af8"
       },
       "enas": {
-        "image": "docker.io/kubeflowkatib/suggestion-enas:v1beta1-e294a90",
+        "image": "docker.io/kubeflowkatib/suggestion-enas:v1beta1-6dc1af8",
         "imagePullPolicy": "Always",
         "resources": {
           "limits": {
@@ -51,10 +51,10 @@ data:
         }
       },
       "cmaes": {
-        "image": "docker.io/kubeflowkatib/suggestion-goptuna:v1beta1-e294a90"
+        "image": "docker.io/kubeflowkatib/suggestion-goptuna:v1beta1-6dc1af8"
       },
       "darts": {
-        "image": "docker.io/kubeflowkatib/suggestion-darts:v1beta1-e294a90"
+        "image": "docker.io/kubeflowkatib/suggestion-darts:v1beta1-6dc1af8"
       }
     }
 kind: ConfigMap

--- a/tests/stacks/generic/test_data/expected/~g_v1_configmap_trial-template.yaml
+++ b/tests/stacks/generic/test_data/expected/~g_v1_configmap_trial-template.yaml
@@ -8,7 +8,7 @@ data:
         spec:
           containers:
             - name: training-container
-              image: docker.io/kubeflowkatib/mxnet-mnist:v1beta1-e294a90
+              image: docker.io/kubeflowkatib/mxnet-mnist:v1beta1-6dc1af8
               command:
                 - "python3"
                 - "/opt/mxnet-mnist/mnist.py"
@@ -25,7 +25,7 @@ data:
         spec:
           containers:
             - name: training-container
-              image: docker.io/kubeflowkatib/enas-cnn-cifar10-cpu:v1beta1-e294a90
+              image: docker.io/kubeflowkatib/enas-cnn-cifar10-cpu:v1beta1-6dc1af8
               command:
                 - python3
                 - -u

--- a/tests/stacks/ibm/application/oidc-authservice-appid/kustomize_test.go
+++ b/tests/stacks/ibm/application/oidc-authservice-appid/kustomize_test.go
@@ -1,0 +1,15 @@
+package oidc_authservice_appid
+
+import (
+	"github.com/kubeflow/manifests/tests"
+	"testing"
+)
+
+func TestKustomize(t *testing.T) {
+	testCase := &tests.KustomizeTestCase{
+		Package:  "../../../../../stacks/ibm/application/oidc-authservice-appid",
+		Expected: "test_data/expected",
+	}
+
+	tests.RunTestCase(t, testCase)
+}

--- a/tests/stacks/ibm/application/oidc-authservice-appid/test_data/expected/apps_v1_statefulset_authservice.yaml
+++ b/tests/stacks/ibm/application/oidc-authservice-appid/test_data/expected/apps_v1_statefulset_authservice.yaml
@@ -1,0 +1,83 @@
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  labels:
+    app.kubernetes.io/component: oidc-authservice
+    app.kubernetes.io/name: oidc-authservice
+  name: authservice
+  namespace: istio-system
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: authservice
+      app.kubernetes.io/component: oidc-authservice
+      app.kubernetes.io/name: oidc-authservice
+  serviceName: authservice
+  template:
+    metadata:
+      annotations:
+        sidecar.istio.io/inject: "false"
+      labels:
+        app: authservice
+        app.kubernetes.io/component: oidc-authservice
+        app.kubernetes.io/name: oidc-authservice
+    spec:
+      containers:
+      - env:
+        - name: USERID_HEADER
+          value: kubeflow-userid
+        - name: USERID_PREFIX
+          value: ""
+        - name: USERID_CLAIM
+          value: email
+        - name: OIDC_PROVIDER
+          valueFrom:
+            secretKeyRef:
+              key: oAuthServerUrl
+              name: appid-application-configuration
+        - name: OIDC_AUTH_URL
+          value: ""
+        - name: OIDC_SCOPES
+          value: profile email groups
+        - name: REDIRECT_URL
+          valueFrom:
+            secretKeyRef:
+              key: oidcRedirectUrl
+              name: appid-application-configuration
+        - name: SKIP_AUTH_URI
+          value: ""
+        - name: PORT
+          value: "8080"
+        - name: CLIENT_ID
+          valueFrom:
+            secretKeyRef:
+              key: clientId
+              name: appid-application-configuration
+        - name: CLIENT_SECRET
+          valueFrom:
+            secretKeyRef:
+              key: secret
+              name: appid-application-configuration
+        - name: STORE_PATH
+          value: /var/lib/authservice/data.db
+        image: gcr.io/arrikto/kubeflow/oidc-authservice:28c59ef
+        imagePullPolicy: Always
+        name: authservice
+        ports:
+        - containerPort: 8080
+          name: http-api
+        readinessProbe:
+          httpGet:
+            path: /
+            port: 8081
+        volumeMounts:
+        - mountPath: /var/lib/authservice
+          name: data
+      securityContext:
+        fsGroup: 111
+      serviceAccountName: oidc-authservice-service-account
+      volumes:
+      - name: data
+        persistentVolumeClaim:
+          claimName: authservice-pvc

--- a/tests/stacks/ibm/application/oidc-authservice-appid/test_data/expected/networking.istio.io_v1alpha3_envoyfilter_authn-filter.yaml
+++ b/tests/stacks/ibm/application/oidc-authservice-appid/test_data/expected/networking.istio.io_v1alpha3_envoyfilter_authn-filter.yaml
@@ -1,0 +1,36 @@
+apiVersion: networking.istio.io/v1alpha3
+kind: EnvoyFilter
+metadata:
+  labels:
+    app.kubernetes.io/component: oidc-authservice
+    app.kubernetes.io/name: oidc-authservice
+  name: authn-filter
+  namespace: istio-system
+spec:
+  filters:
+  - filterConfig:
+      httpService:
+        authorizationRequest:
+          allowedHeaders:
+            patterns:
+            - exact: cookie
+            - exact: X-Auth-Token
+        authorizationResponse:
+          allowedUpstreamHeaders:
+            patterns:
+            - exact: kubeflow-userid
+        serverUri:
+          cluster: outbound|8080||authservice.istio-system.svc.cluster.local
+          failureModeAllow: false
+          timeout: 10s
+          uri: http://authservice.istio-system.svc.cluster.local
+      statusOnError:
+        code: GatewayTimeout
+    filterName: envoy.ext_authz
+    filterType: HTTP
+    insertPosition:
+      index: FIRST
+    listenerMatch:
+      listenerType: GATEWAY
+  workloadLabels:
+    istio: ingressgateway

--- a/tests/stacks/ibm/application/oidc-authservice-appid/test_data/expected/networking.istio.io_v1alpha3_virtualservice_authservice.yaml
+++ b/tests/stacks/ibm/application/oidc-authservice-appid/test_data/expected/networking.istio.io_v1alpha3_virtualservice_authservice.yaml
@@ -1,0 +1,22 @@
+apiVersion: networking.istio.io/v1alpha3
+kind: VirtualService
+metadata:
+  labels:
+    app.kubernetes.io/component: oidc-authservice
+    app.kubernetes.io/name: oidc-authservice
+  name: authservice
+  namespace: istio-system
+spec:
+  gateways:
+  - kubeflow/kubeflow-gateway
+  hosts:
+  - '*'
+  http:
+  - match:
+    - uri:
+        prefix: /login
+    route:
+    - destination:
+        host: authservice.istio-system.svc.cluster.local
+        port:
+          number: 8080

--- a/tests/stacks/ibm/application/oidc-authservice-appid/test_data/expected/~g_v1_configmap_oidc-authservice-parameters.yaml
+++ b/tests/stacks/ibm/application/oidc-authservice-appid/test_data/expected/~g_v1_configmap_oidc-authservice-parameters.yaml
@@ -1,0 +1,20 @@
+apiVersion: v1
+data:
+  application_secret: pUBnBOY80SnXgjibTYM9ZWNzY2xreNGQok
+  client_id: ldapdexapp
+  gatewaySelector: ingressgateway
+  namespace: istio-system
+  oidc_auth_url: ""
+  oidc_provider: ""
+  oidc_redirect_uri: ""
+  skip_auth_uri: ""
+  userid-header: kubeflow-userid
+  userid-prefix: ""
+kind: ConfigMap
+metadata:
+  annotations: {}
+  labels:
+    app.kubernetes.io/component: oidc-authservice
+    app.kubernetes.io/name: oidc-authservice
+  name: oidc-authservice-parameters
+  namespace: istio-system

--- a/tests/stacks/ibm/application/oidc-authservice-appid/test_data/expected/~g_v1_persistentvolumeclaim_authservice-pvc.yaml
+++ b/tests/stacks/ibm/application/oidc-authservice-appid/test_data/expected/~g_v1_persistentvolumeclaim_authservice-pvc.yaml
@@ -1,0 +1,14 @@
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  labels:
+    app.kubernetes.io/component: oidc-authservice
+    app.kubernetes.io/name: oidc-authservice
+  name: authservice-pvc
+  namespace: istio-system
+spec:
+  accessModes:
+  - ReadWriteOnce
+  resources:
+    requests:
+      storage: 10Gi

--- a/tests/stacks/ibm/application/oidc-authservice-appid/test_data/expected/~g_v1_service_authservice.yaml
+++ b/tests/stacks/ibm/application/oidc-authservice-appid/test_data/expected/~g_v1_service_authservice.yaml
@@ -1,0 +1,19 @@
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    app.kubernetes.io/component: oidc-authservice
+    app.kubernetes.io/name: oidc-authservice
+  name: authservice
+  namespace: istio-system
+spec:
+  ports:
+  - name: http-authservice
+    port: 8080
+    targetPort: http-api
+  publishNotReadyAddresses: true
+  selector:
+    app: authservice
+    app.kubernetes.io/component: oidc-authservice
+    app.kubernetes.io/name: oidc-authservice
+  type: ClusterIP

--- a/tests/stacks/ibm/application/oidc-authservice-appid/test_data/expected/~g_v1_serviceaccount_oidc-authservice-service-account.yaml
+++ b/tests/stacks/ibm/application/oidc-authservice-appid/test_data/expected/~g_v1_serviceaccount_oidc-authservice-service-account.yaml
@@ -1,0 +1,8 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  labels:
+    app.kubernetes.io/component: oidc-authservice
+    app.kubernetes.io/name: oidc-authservice
+  name: oidc-authservice-service-account
+  namespace: istio-system

--- a/tests/stacks/ibm/components/katib/test_data/expected/apps_v1_deployment_katib-controller.yaml
+++ b/tests/stacks/ibm/components/katib/test_data/expected/apps_v1_deployment_katib-controller.yaml
@@ -39,7 +39,7 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: metadata.namespace
-        image: docker.io/kubeflowkatib/katib-controller:v1beta1-e294a90
+        image: docker.io/kubeflowkatib/katib-controller:v1beta1-6dc1af8
         imagePullPolicy: IfNotPresent
         name: katib-controller
         ports:

--- a/tests/stacks/ibm/components/katib/test_data/expected/apps_v1_deployment_katib-db-manager.yaml
+++ b/tests/stacks/ibm/components/katib/test_data/expected/apps_v1_deployment_katib-db-manager.yaml
@@ -38,7 +38,7 @@ spec:
             secretKeyRef:
               key: MYSQL_ROOT_PASSWORD
               name: katib-mysql-secrets
-        image: docker.io/kubeflowkatib/katib-db-manager:v1beta1-e294a90
+        image: docker.io/kubeflowkatib/katib-db-manager:v1beta1-6dc1af8
         imagePullPolicy: IfNotPresent
         livenessProbe:
           exec:

--- a/tests/stacks/ibm/components/katib/test_data/expected/apps_v1_deployment_katib-ui.yaml
+++ b/tests/stacks/ibm/components/katib/test_data/expected/apps_v1_deployment_katib-ui.yaml
@@ -37,7 +37,7 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: metadata.namespace
-        image: docker.io/kubeflowkatib/katib-ui:v1beta1-e294a90
+        image: docker.io/kubeflowkatib/katib-ui:v1beta1-6dc1af8
         imagePullPolicy: IfNotPresent
         name: katib-ui
         ports:

--- a/tests/stacks/ibm/components/katib/test_data/expected/~g_v1_configmap_katib-config.yaml
+++ b/tests/stacks/ibm/components/katib/test_data/expected/~g_v1_configmap_katib-config.yaml
@@ -3,20 +3,20 @@ data:
   early-stopping: |-
     {
       "medianstop": {
-        "image": "docker.io/kubeflowkatib/earlystopping-medianstop:v1beta1-e294a90",
+        "image": "docker.io/kubeflowkatib/earlystopping-medianstop:v1beta1-6dc1af8",
         "imagePullPolicy": "Always"
       }
     }
   metrics-collector-sidecar: |-
     {
       "StdOut": {
-        "image": "docker.io/kubeflowkatib/file-metrics-collector:v1beta1-e294a90"
+        "image": "docker.io/kubeflowkatib/file-metrics-collector:v1beta1-6dc1af8"
       },
       "File": {
-        "image": "docker.io/kubeflowkatib/file-metrics-collector:v1beta1-e294a90"
+        "image": "docker.io/kubeflowkatib/file-metrics-collector:v1beta1-6dc1af8"
       },
       "TensorFlowEvent": {
-        "image": "docker.io/kubeflowkatib/tfevent-metrics-collector:v1beta1-e294a90",
+        "image": "docker.io/kubeflowkatib/tfevent-metrics-collector:v1beta1-6dc1af8",
         "resources": {
           "limits": {
             "memory": "1Gi"
@@ -27,22 +27,22 @@ data:
   suggestion: |-
     {
       "random": {
-        "image": "docker.io/kubeflowkatib/suggestion-hyperopt:v1beta1-e294a90"
+        "image": "docker.io/kubeflowkatib/suggestion-hyperopt:v1beta1-6dc1af8"
       },
       "grid": {
-        "image": "docker.io/kubeflowkatib/suggestion-chocolate:v1beta1-e294a90"
+        "image": "docker.io/kubeflowkatib/suggestion-chocolate:v1beta1-6dc1af8"
       },
       "hyperband": {
-        "image": "docker.io/kubeflowkatib/suggestion-hyperband:v1beta1-e294a90"
+        "image": "docker.io/kubeflowkatib/suggestion-hyperband:v1beta1-6dc1af8"
       },
       "bayesianoptimization": {
-        "image": "docker.io/kubeflowkatib/suggestion-skopt:v1beta1-e294a90"
+        "image": "docker.io/kubeflowkatib/suggestion-skopt:v1beta1-6dc1af8"
       },
       "tpe": {
-        "image": "docker.io/kubeflowkatib/suggestion-hyperopt:v1beta1-e294a90"
+        "image": "docker.io/kubeflowkatib/suggestion-hyperopt:v1beta1-6dc1af8"
       },
       "enas": {
-        "image": "docker.io/kubeflowkatib/suggestion-enas:v1beta1-e294a90",
+        "image": "docker.io/kubeflowkatib/suggestion-enas:v1beta1-6dc1af8",
         "imagePullPolicy": "Always",
         "resources": {
           "limits": {
@@ -51,10 +51,10 @@ data:
         }
       },
       "cmaes": {
-        "image": "docker.io/kubeflowkatib/suggestion-goptuna:v1beta1-e294a90"
+        "image": "docker.io/kubeflowkatib/suggestion-goptuna:v1beta1-6dc1af8"
       },
       "darts": {
-        "image": "docker.io/kubeflowkatib/suggestion-darts:v1beta1-e294a90"
+        "image": "docker.io/kubeflowkatib/suggestion-darts:v1beta1-6dc1af8"
       }
     }
 kind: ConfigMap

--- a/tests/stacks/ibm/components/katib/test_data/expected/~g_v1_configmap_trial-template.yaml
+++ b/tests/stacks/ibm/components/katib/test_data/expected/~g_v1_configmap_trial-template.yaml
@@ -8,7 +8,7 @@ data:
         spec:
           containers:
             - name: training-container
-              image: docker.io/kubeflowkatib/mxnet-mnist:v1beta1-e294a90
+              image: docker.io/kubeflowkatib/mxnet-mnist:v1beta1-6dc1af8
               command:
                 - "python3"
                 - "/opt/mxnet-mnist/mnist.py"
@@ -25,7 +25,7 @@ data:
         spec:
           containers:
             - name: training-container
-              image: docker.io/kubeflowkatib/enas-cnn-cifar10-cpu:v1beta1-e294a90
+              image: docker.io/kubeflowkatib/enas-cnn-cifar10-cpu:v1beta1-6dc1af8
               command:
                 - python3
                 - -u

--- a/tests/stacks/ibm/multi-user/test_data/expected/apps_v1_deployment_katib-controller.yaml
+++ b/tests/stacks/ibm/multi-user/test_data/expected/apps_v1_deployment_katib-controller.yaml
@@ -39,7 +39,7 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: metadata.namespace
-        image: docker.io/kubeflowkatib/katib-controller:v1beta1-e294a90
+        image: docker.io/kubeflowkatib/katib-controller:v1beta1-6dc1af8
         imagePullPolicy: IfNotPresent
         name: katib-controller
         ports:

--- a/tests/stacks/ibm/multi-user/test_data/expected/apps_v1_deployment_katib-db-manager.yaml
+++ b/tests/stacks/ibm/multi-user/test_data/expected/apps_v1_deployment_katib-db-manager.yaml
@@ -38,7 +38,7 @@ spec:
             secretKeyRef:
               key: MYSQL_ROOT_PASSWORD
               name: katib-mysql-secrets
-        image: docker.io/kubeflowkatib/katib-db-manager:v1beta1-e294a90
+        image: docker.io/kubeflowkatib/katib-db-manager:v1beta1-6dc1af8
         imagePullPolicy: IfNotPresent
         livenessProbe:
           exec:

--- a/tests/stacks/ibm/multi-user/test_data/expected/apps_v1_deployment_katib-ui.yaml
+++ b/tests/stacks/ibm/multi-user/test_data/expected/apps_v1_deployment_katib-ui.yaml
@@ -37,7 +37,7 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: metadata.namespace
-        image: docker.io/kubeflowkatib/katib-ui:v1beta1-e294a90
+        image: docker.io/kubeflowkatib/katib-ui:v1beta1-6dc1af8
         imagePullPolicy: IfNotPresent
         name: katib-ui
         ports:

--- a/tests/stacks/ibm/multi-user/test_data/expected/~g_v1_configmap_katib-config.yaml
+++ b/tests/stacks/ibm/multi-user/test_data/expected/~g_v1_configmap_katib-config.yaml
@@ -3,20 +3,20 @@ data:
   early-stopping: |-
     {
       "medianstop": {
-        "image": "docker.io/kubeflowkatib/earlystopping-medianstop:v1beta1-e294a90",
+        "image": "docker.io/kubeflowkatib/earlystopping-medianstop:v1beta1-6dc1af8",
         "imagePullPolicy": "Always"
       }
     }
   metrics-collector-sidecar: |-
     {
       "StdOut": {
-        "image": "docker.io/kubeflowkatib/file-metrics-collector:v1beta1-e294a90"
+        "image": "docker.io/kubeflowkatib/file-metrics-collector:v1beta1-6dc1af8"
       },
       "File": {
-        "image": "docker.io/kubeflowkatib/file-metrics-collector:v1beta1-e294a90"
+        "image": "docker.io/kubeflowkatib/file-metrics-collector:v1beta1-6dc1af8"
       },
       "TensorFlowEvent": {
-        "image": "docker.io/kubeflowkatib/tfevent-metrics-collector:v1beta1-e294a90",
+        "image": "docker.io/kubeflowkatib/tfevent-metrics-collector:v1beta1-6dc1af8",
         "resources": {
           "limits": {
             "memory": "1Gi"
@@ -27,22 +27,22 @@ data:
   suggestion: |-
     {
       "random": {
-        "image": "docker.io/kubeflowkatib/suggestion-hyperopt:v1beta1-e294a90"
+        "image": "docker.io/kubeflowkatib/suggestion-hyperopt:v1beta1-6dc1af8"
       },
       "grid": {
-        "image": "docker.io/kubeflowkatib/suggestion-chocolate:v1beta1-e294a90"
+        "image": "docker.io/kubeflowkatib/suggestion-chocolate:v1beta1-6dc1af8"
       },
       "hyperband": {
-        "image": "docker.io/kubeflowkatib/suggestion-hyperband:v1beta1-e294a90"
+        "image": "docker.io/kubeflowkatib/suggestion-hyperband:v1beta1-6dc1af8"
       },
       "bayesianoptimization": {
-        "image": "docker.io/kubeflowkatib/suggestion-skopt:v1beta1-e294a90"
+        "image": "docker.io/kubeflowkatib/suggestion-skopt:v1beta1-6dc1af8"
       },
       "tpe": {
-        "image": "docker.io/kubeflowkatib/suggestion-hyperopt:v1beta1-e294a90"
+        "image": "docker.io/kubeflowkatib/suggestion-hyperopt:v1beta1-6dc1af8"
       },
       "enas": {
-        "image": "docker.io/kubeflowkatib/suggestion-enas:v1beta1-e294a90",
+        "image": "docker.io/kubeflowkatib/suggestion-enas:v1beta1-6dc1af8",
         "imagePullPolicy": "Always",
         "resources": {
           "limits": {
@@ -51,10 +51,10 @@ data:
         }
       },
       "cmaes": {
-        "image": "docker.io/kubeflowkatib/suggestion-goptuna:v1beta1-e294a90"
+        "image": "docker.io/kubeflowkatib/suggestion-goptuna:v1beta1-6dc1af8"
       },
       "darts": {
-        "image": "docker.io/kubeflowkatib/suggestion-darts:v1beta1-e294a90"
+        "image": "docker.io/kubeflowkatib/suggestion-darts:v1beta1-6dc1af8"
       }
     }
 kind: ConfigMap

--- a/tests/stacks/ibm/multi-user/test_data/expected/~g_v1_configmap_trial-template.yaml
+++ b/tests/stacks/ibm/multi-user/test_data/expected/~g_v1_configmap_trial-template.yaml
@@ -8,7 +8,7 @@ data:
         spec:
           containers:
             - name: training-container
-              image: docker.io/kubeflowkatib/mxnet-mnist:v1beta1-e294a90
+              image: docker.io/kubeflowkatib/mxnet-mnist:v1beta1-6dc1af8
               command:
                 - "python3"
                 - "/opt/mxnet-mnist/mnist.py"
@@ -25,7 +25,7 @@ data:
         spec:
           containers:
             - name: training-container
-              image: docker.io/kubeflowkatib/enas-cnn-cifar10-cpu:v1beta1-e294a90
+              image: docker.io/kubeflowkatib/enas-cnn-cifar10-cpu:v1beta1-6dc1af8
               command:
                 - python3
                 - -u

--- a/tests/stacks/ibm/test_data/expected/apps_v1_deployment_katib-controller.yaml
+++ b/tests/stacks/ibm/test_data/expected/apps_v1_deployment_katib-controller.yaml
@@ -39,7 +39,7 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: metadata.namespace
-        image: docker.io/kubeflowkatib/katib-controller:v1beta1-e294a90
+        image: docker.io/kubeflowkatib/katib-controller:v1beta1-6dc1af8
         imagePullPolicy: IfNotPresent
         name: katib-controller
         ports:

--- a/tests/stacks/ibm/test_data/expected/apps_v1_deployment_katib-db-manager.yaml
+++ b/tests/stacks/ibm/test_data/expected/apps_v1_deployment_katib-db-manager.yaml
@@ -38,7 +38,7 @@ spec:
             secretKeyRef:
               key: MYSQL_ROOT_PASSWORD
               name: katib-mysql-secrets
-        image: docker.io/kubeflowkatib/katib-db-manager:v1beta1-e294a90
+        image: docker.io/kubeflowkatib/katib-db-manager:v1beta1-6dc1af8
         imagePullPolicy: IfNotPresent
         livenessProbe:
           exec:

--- a/tests/stacks/ibm/test_data/expected/apps_v1_deployment_katib-ui.yaml
+++ b/tests/stacks/ibm/test_data/expected/apps_v1_deployment_katib-ui.yaml
@@ -37,7 +37,7 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: metadata.namespace
-        image: docker.io/kubeflowkatib/katib-ui:v1beta1-e294a90
+        image: docker.io/kubeflowkatib/katib-ui:v1beta1-6dc1af8
         imagePullPolicy: IfNotPresent
         name: katib-ui
         ports:

--- a/tests/stacks/ibm/test_data/expected/~g_v1_configmap_katib-config.yaml
+++ b/tests/stacks/ibm/test_data/expected/~g_v1_configmap_katib-config.yaml
@@ -3,20 +3,20 @@ data:
   early-stopping: |-
     {
       "medianstop": {
-        "image": "docker.io/kubeflowkatib/earlystopping-medianstop:v1beta1-e294a90",
+        "image": "docker.io/kubeflowkatib/earlystopping-medianstop:v1beta1-6dc1af8",
         "imagePullPolicy": "Always"
       }
     }
   metrics-collector-sidecar: |-
     {
       "StdOut": {
-        "image": "docker.io/kubeflowkatib/file-metrics-collector:v1beta1-e294a90"
+        "image": "docker.io/kubeflowkatib/file-metrics-collector:v1beta1-6dc1af8"
       },
       "File": {
-        "image": "docker.io/kubeflowkatib/file-metrics-collector:v1beta1-e294a90"
+        "image": "docker.io/kubeflowkatib/file-metrics-collector:v1beta1-6dc1af8"
       },
       "TensorFlowEvent": {
-        "image": "docker.io/kubeflowkatib/tfevent-metrics-collector:v1beta1-e294a90",
+        "image": "docker.io/kubeflowkatib/tfevent-metrics-collector:v1beta1-6dc1af8",
         "resources": {
           "limits": {
             "memory": "1Gi"
@@ -27,22 +27,22 @@ data:
   suggestion: |-
     {
       "random": {
-        "image": "docker.io/kubeflowkatib/suggestion-hyperopt:v1beta1-e294a90"
+        "image": "docker.io/kubeflowkatib/suggestion-hyperopt:v1beta1-6dc1af8"
       },
       "grid": {
-        "image": "docker.io/kubeflowkatib/suggestion-chocolate:v1beta1-e294a90"
+        "image": "docker.io/kubeflowkatib/suggestion-chocolate:v1beta1-6dc1af8"
       },
       "hyperband": {
-        "image": "docker.io/kubeflowkatib/suggestion-hyperband:v1beta1-e294a90"
+        "image": "docker.io/kubeflowkatib/suggestion-hyperband:v1beta1-6dc1af8"
       },
       "bayesianoptimization": {
-        "image": "docker.io/kubeflowkatib/suggestion-skopt:v1beta1-e294a90"
+        "image": "docker.io/kubeflowkatib/suggestion-skopt:v1beta1-6dc1af8"
       },
       "tpe": {
-        "image": "docker.io/kubeflowkatib/suggestion-hyperopt:v1beta1-e294a90"
+        "image": "docker.io/kubeflowkatib/suggestion-hyperopt:v1beta1-6dc1af8"
       },
       "enas": {
-        "image": "docker.io/kubeflowkatib/suggestion-enas:v1beta1-e294a90",
+        "image": "docker.io/kubeflowkatib/suggestion-enas:v1beta1-6dc1af8",
         "imagePullPolicy": "Always",
         "resources": {
           "limits": {
@@ -51,10 +51,10 @@ data:
         }
       },
       "cmaes": {
-        "image": "docker.io/kubeflowkatib/suggestion-goptuna:v1beta1-e294a90"
+        "image": "docker.io/kubeflowkatib/suggestion-goptuna:v1beta1-6dc1af8"
       },
       "darts": {
-        "image": "docker.io/kubeflowkatib/suggestion-darts:v1beta1-e294a90"
+        "image": "docker.io/kubeflowkatib/suggestion-darts:v1beta1-6dc1af8"
       }
     }
 kind: ConfigMap

--- a/tests/stacks/ibm/test_data/expected/~g_v1_configmap_trial-template.yaml
+++ b/tests/stacks/ibm/test_data/expected/~g_v1_configmap_trial-template.yaml
@@ -8,7 +8,7 @@ data:
         spec:
           containers:
             - name: training-container
-              image: docker.io/kubeflowkatib/mxnet-mnist:v1beta1-e294a90
+              image: docker.io/kubeflowkatib/mxnet-mnist:v1beta1-6dc1af8
               command:
                 - "python3"
                 - "/opt/mxnet-mnist/mnist.py"
@@ -25,7 +25,7 @@ data:
         spec:
           containers:
             - name: training-container
-              image: docker.io/kubeflowkatib/enas-cnn-cifar10-cpu:v1beta1-e294a90
+              image: docker.io/kubeflowkatib/enas-cnn-cifar10-cpu:v1beta1-6dc1af8
               command:
                 - python3
                 - -u

--- a/tests/stacks/kubernetes/test_data/expected/apps_v1_deployment_katib-controller.yaml
+++ b/tests/stacks/kubernetes/test_data/expected/apps_v1_deployment_katib-controller.yaml
@@ -39,7 +39,7 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: metadata.namespace
-        image: docker.io/kubeflowkatib/katib-controller:v1beta1-e294a90
+        image: docker.io/kubeflowkatib/katib-controller:v1beta1-6dc1af8
         imagePullPolicy: IfNotPresent
         name: katib-controller
         ports:

--- a/tests/stacks/kubernetes/test_data/expected/apps_v1_deployment_katib-db-manager.yaml
+++ b/tests/stacks/kubernetes/test_data/expected/apps_v1_deployment_katib-db-manager.yaml
@@ -38,7 +38,7 @@ spec:
             secretKeyRef:
               key: MYSQL_ROOT_PASSWORD
               name: katib-mysql-secrets
-        image: docker.io/kubeflowkatib/katib-db-manager:v1beta1-e294a90
+        image: docker.io/kubeflowkatib/katib-db-manager:v1beta1-6dc1af8
         imagePullPolicy: IfNotPresent
         livenessProbe:
           exec:

--- a/tests/stacks/kubernetes/test_data/expected/apps_v1_deployment_katib-ui.yaml
+++ b/tests/stacks/kubernetes/test_data/expected/apps_v1_deployment_katib-ui.yaml
@@ -37,7 +37,7 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: metadata.namespace
-        image: docker.io/kubeflowkatib/katib-ui:v1beta1-e294a90
+        image: docker.io/kubeflowkatib/katib-ui:v1beta1-6dc1af8
         imagePullPolicy: IfNotPresent
         name: katib-ui
         ports:

--- a/tests/stacks/kubernetes/test_data/expected/~g_v1_configmap_katib-config.yaml
+++ b/tests/stacks/kubernetes/test_data/expected/~g_v1_configmap_katib-config.yaml
@@ -3,20 +3,20 @@ data:
   early-stopping: |-
     {
       "medianstop": {
-        "image": "docker.io/kubeflowkatib/earlystopping-medianstop:v1beta1-e294a90",
+        "image": "docker.io/kubeflowkatib/earlystopping-medianstop:v1beta1-6dc1af8",
         "imagePullPolicy": "Always"
       }
     }
   metrics-collector-sidecar: |-
     {
       "StdOut": {
-        "image": "docker.io/kubeflowkatib/file-metrics-collector:v1beta1-e294a90"
+        "image": "docker.io/kubeflowkatib/file-metrics-collector:v1beta1-6dc1af8"
       },
       "File": {
-        "image": "docker.io/kubeflowkatib/file-metrics-collector:v1beta1-e294a90"
+        "image": "docker.io/kubeflowkatib/file-metrics-collector:v1beta1-6dc1af8"
       },
       "TensorFlowEvent": {
-        "image": "docker.io/kubeflowkatib/tfevent-metrics-collector:v1beta1-e294a90",
+        "image": "docker.io/kubeflowkatib/tfevent-metrics-collector:v1beta1-6dc1af8",
         "resources": {
           "limits": {
             "memory": "1Gi"
@@ -27,22 +27,22 @@ data:
   suggestion: |-
     {
       "random": {
-        "image": "docker.io/kubeflowkatib/suggestion-hyperopt:v1beta1-e294a90"
+        "image": "docker.io/kubeflowkatib/suggestion-hyperopt:v1beta1-6dc1af8"
       },
       "grid": {
-        "image": "docker.io/kubeflowkatib/suggestion-chocolate:v1beta1-e294a90"
+        "image": "docker.io/kubeflowkatib/suggestion-chocolate:v1beta1-6dc1af8"
       },
       "hyperband": {
-        "image": "docker.io/kubeflowkatib/suggestion-hyperband:v1beta1-e294a90"
+        "image": "docker.io/kubeflowkatib/suggestion-hyperband:v1beta1-6dc1af8"
       },
       "bayesianoptimization": {
-        "image": "docker.io/kubeflowkatib/suggestion-skopt:v1beta1-e294a90"
+        "image": "docker.io/kubeflowkatib/suggestion-skopt:v1beta1-6dc1af8"
       },
       "tpe": {
-        "image": "docker.io/kubeflowkatib/suggestion-hyperopt:v1beta1-e294a90"
+        "image": "docker.io/kubeflowkatib/suggestion-hyperopt:v1beta1-6dc1af8"
       },
       "enas": {
-        "image": "docker.io/kubeflowkatib/suggestion-enas:v1beta1-e294a90",
+        "image": "docker.io/kubeflowkatib/suggestion-enas:v1beta1-6dc1af8",
         "imagePullPolicy": "Always",
         "resources": {
           "limits": {
@@ -51,10 +51,10 @@ data:
         }
       },
       "cmaes": {
-        "image": "docker.io/kubeflowkatib/suggestion-goptuna:v1beta1-e294a90"
+        "image": "docker.io/kubeflowkatib/suggestion-goptuna:v1beta1-6dc1af8"
       },
       "darts": {
-        "image": "docker.io/kubeflowkatib/suggestion-darts:v1beta1-e294a90"
+        "image": "docker.io/kubeflowkatib/suggestion-darts:v1beta1-6dc1af8"
       }
     }
 kind: ConfigMap

--- a/tests/stacks/kubernetes/test_data/expected/~g_v1_configmap_trial-template.yaml
+++ b/tests/stacks/kubernetes/test_data/expected/~g_v1_configmap_trial-template.yaml
@@ -8,7 +8,7 @@ data:
         spec:
           containers:
             - name: training-container
-              image: docker.io/kubeflowkatib/mxnet-mnist:v1beta1-e294a90
+              image: docker.io/kubeflowkatib/mxnet-mnist:v1beta1-6dc1af8
               command:
                 - "python3"
                 - "/opt/mxnet-mnist/mnist.py"
@@ -25,7 +25,7 @@ data:
         spec:
           containers:
             - name: training-container
-              image: docker.io/kubeflowkatib/enas-cnn-cifar10-cpu:v1beta1-e294a90
+              image: docker.io/kubeflowkatib/enas-cnn-cifar10-cpu:v1beta1-6dc1af8
               command:
                 - python3
                 - -u

--- a/tests/tests/legacy_kustomizations/katib-controller/test_data/expected/apps_v1_deployment_katib-controller.yaml
+++ b/tests/tests/legacy_kustomizations/katib-controller/test_data/expected/apps_v1_deployment_katib-controller.yaml
@@ -51,7 +51,7 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: metadata.namespace
-        image: docker.io/kubeflowkatib/katib-controller:v1beta1-e294a90
+        image: docker.io/kubeflowkatib/katib-controller:v1beta1-6dc1af8
         imagePullPolicy: IfNotPresent
         name: katib-controller
         ports:

--- a/tests/tests/legacy_kustomizations/katib-controller/test_data/expected/apps_v1_deployment_katib-db-manager.yaml
+++ b/tests/tests/legacy_kustomizations/katib-controller/test_data/expected/apps_v1_deployment_katib-db-manager.yaml
@@ -50,7 +50,7 @@ spec:
             secretKeyRef:
               key: MYSQL_ROOT_PASSWORD
               name: katib-mysql-secrets
-        image: docker.io/kubeflowkatib/katib-db-manager:v1beta1-e294a90
+        image: docker.io/kubeflowkatib/katib-db-manager:v1beta1-6dc1af8
         imagePullPolicy: IfNotPresent
         livenessProbe:
           exec:

--- a/tests/tests/legacy_kustomizations/katib-controller/test_data/expected/apps_v1_deployment_katib-ui.yaml
+++ b/tests/tests/legacy_kustomizations/katib-controller/test_data/expected/apps_v1_deployment_katib-ui.yaml
@@ -49,7 +49,7 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: metadata.namespace
-        image: docker.io/kubeflowkatib/katib-ui:v1beta1-e294a90
+        image: docker.io/kubeflowkatib/katib-ui:v1beta1-6dc1af8
         imagePullPolicy: IfNotPresent
         name: katib-ui
         ports:

--- a/tests/tests/legacy_kustomizations/katib-controller/test_data/expected/~g_v1_configmap_katib-config.yaml
+++ b/tests/tests/legacy_kustomizations/katib-controller/test_data/expected/~g_v1_configmap_katib-config.yaml
@@ -3,20 +3,20 @@ data:
   early-stopping: |-
     {
       "medianstop": {
-        "image": "docker.io/kubeflowkatib/earlystopping-medianstop:v1beta1-e294a90",
+        "image": "docker.io/kubeflowkatib/earlystopping-medianstop:v1beta1-6dc1af8",
         "imagePullPolicy": "Always"
       }
     }
   metrics-collector-sidecar: |-
     {
       "StdOut": {
-        "image": "docker.io/kubeflowkatib/file-metrics-collector:v1beta1-e294a90"
+        "image": "docker.io/kubeflowkatib/file-metrics-collector:v1beta1-6dc1af8"
       },
       "File": {
-        "image": "docker.io/kubeflowkatib/file-metrics-collector:v1beta1-e294a90"
+        "image": "docker.io/kubeflowkatib/file-metrics-collector:v1beta1-6dc1af8"
       },
       "TensorFlowEvent": {
-        "image": "docker.io/kubeflowkatib/tfevent-metrics-collector:v1beta1-e294a90",
+        "image": "docker.io/kubeflowkatib/tfevent-metrics-collector:v1beta1-6dc1af8",
         "resources": {
           "limits": {
             "memory": "1Gi"
@@ -27,22 +27,22 @@ data:
   suggestion: |-
     {
       "random": {
-        "image": "docker.io/kubeflowkatib/suggestion-hyperopt:v1beta1-e294a90"
+        "image": "docker.io/kubeflowkatib/suggestion-hyperopt:v1beta1-6dc1af8"
       },
       "grid": {
-        "image": "docker.io/kubeflowkatib/suggestion-chocolate:v1beta1-e294a90"
+        "image": "docker.io/kubeflowkatib/suggestion-chocolate:v1beta1-6dc1af8"
       },
       "hyperband": {
-        "image": "docker.io/kubeflowkatib/suggestion-hyperband:v1beta1-e294a90"
+        "image": "docker.io/kubeflowkatib/suggestion-hyperband:v1beta1-6dc1af8"
       },
       "bayesianoptimization": {
-        "image": "docker.io/kubeflowkatib/suggestion-skopt:v1beta1-e294a90"
+        "image": "docker.io/kubeflowkatib/suggestion-skopt:v1beta1-6dc1af8"
       },
       "tpe": {
-        "image": "docker.io/kubeflowkatib/suggestion-hyperopt:v1beta1-e294a90"
+        "image": "docker.io/kubeflowkatib/suggestion-hyperopt:v1beta1-6dc1af8"
       },
       "enas": {
-        "image": "docker.io/kubeflowkatib/suggestion-enas:v1beta1-e294a90",
+        "image": "docker.io/kubeflowkatib/suggestion-enas:v1beta1-6dc1af8",
         "imagePullPolicy": "Always",
         "resources": {
           "limits": {
@@ -51,10 +51,10 @@ data:
         }
       },
       "cmaes": {
-        "image": "docker.io/kubeflowkatib/suggestion-goptuna:v1beta1-e294a90"
+        "image": "docker.io/kubeflowkatib/suggestion-goptuna:v1beta1-6dc1af8"
       },
       "darts": {
-        "image": "docker.io/kubeflowkatib/suggestion-darts:v1beta1-e294a90"
+        "image": "docker.io/kubeflowkatib/suggestion-darts:v1beta1-6dc1af8"
       }
     }
 kind: ConfigMap

--- a/tests/tests/legacy_kustomizations/katib-controller/test_data/expected/~g_v1_configmap_trial-template.yaml
+++ b/tests/tests/legacy_kustomizations/katib-controller/test_data/expected/~g_v1_configmap_trial-template.yaml
@@ -8,7 +8,7 @@ data:
         spec:
           containers:
             - name: training-container
-              image: docker.io/kubeflowkatib/mxnet-mnist:v1beta1-e294a90
+              image: docker.io/kubeflowkatib/mxnet-mnist:v1beta1-6dc1af8
               command:
                 - "python3"
                 - "/opt/mxnet-mnist/mnist.py"
@@ -25,7 +25,7 @@ data:
         spec:
           containers:
             - name: training-container
-              image: docker.io/kubeflowkatib/enas-cnn-cifar10-cpu:v1beta1-e294a90
+              image: docker.io/kubeflowkatib/enas-cnn-cifar10-cpu:v1beta1-6dc1af8
               command:
                 - python3
                 - -u


### PR DESCRIPTION
**Which issue is resolved by this Pull Request:**
Related: https://github.com/kubeflow/katib/issues/1360.

**Description of your changes:**
I updated Katib 0.10 image tag to `6dc1af8` for the PRs: https://github.com/kubeflow/katib/pull/1372, https://github.com/kubeflow/katib/pull/1375, https://github.com/kubeflow/katib/pull/1378. 

/assign @gaocegege @johnugeorge @Jeffwan 

**Checklist:**
- [x] Unit tests have been rebuilt: 
    1. `cd manifests/tests`
    2. `make generate-changed-only`
    3. `make test`
