### PR TITLE
Add Periodic Tests back

### DIFF
--- a/prow_config.yaml
+++ b/prow_config.yaml
@@ -12,11 +12,13 @@ workflows:
     job_types:
       - presubmit
       - postsubmit
+      - periodic
   - py_func: kubeflow.kfctl.testing.ci.kfctl_e2e_workflow.create_workflow
     name: e2e
     job_types:
       - presubmit
       - postsubmit
+      - periodic
     include_dirs:
       - admission-webhook/*
       - application/*


### PR DESCRIPTION
**Which issue is resolved by this Pull Request:**
Resolves #

**Description of your changes:**
Add Periodic tests back per discussion [here](https://github.com/kubeflow/manifests/pull/1612#issuecomment-722771015) 

**Checklist:**
- [x] Unit tests have been rebuilt: 
    1. `cd manifests/tests`
    2. `make generate-changed-only`
    3. `make test`
