### PR TITLE
Pin test manifest to v1.2-branch

### DIFF
--- a/prow_config.yaml
+++ b/prow_config.yaml
@@ -54,7 +54,7 @@ workflows:
       - xgboost-job/*
     kwargs:
       build_and_apply: false
-      config_path: https://raw.githubusercontent.com/kubeflow/manifests/master/kfdef/kfctl_istio_dex.yaml
+      config_path: https://raw.githubusercontent.com/kubeflow/manifests/v1.2-branch/kfdef/kfctl_istio_dex.v1.2.0.yaml
 
   ####################################### AWS Specific Tests
   - py_func: kubeflow.kfctl.testing.ci.kfctl_e2e_workflow.create_workflow
@@ -63,5 +63,5 @@ workflows:
       - periodic
     kwargs:
       build_and_apply: false
-      config_path: https://raw.githubusercontent.com/kubeflow/manifests/master/kfdef/kfctl_aws.yaml
+      config_path: https://raw.githubusercontent.com/kubeflow/manifests/v1.2-branch/kfdef/kfctl_aws.v1.2.0.yaml
     


### PR DESCRIPTION
**Which issue is resolved by this Pull Request:**
for 1.2 release

**Description of your changes:**
Make prow periodical test against v1.2-branch

**Checklist:**
- [x] Unit tests have been rebuilt: 
    1. `cd manifests/tests`
    2. `make generate-changed-only`
    3. `make test`
