### PR TITLE
Pin IBM v1.2 manifests

### DIFF
--- a/kfdef/kfctl_ibm.v1.2.0.yaml
+++ b/kfdef/kfctl_ibm.v1.2.0.yaml
@@ -26,16 +26,19 @@ spec:
         name: manifests
         path: stacks/ibm/application/add-anonymous-user-filter
     name: add-anonymous-user-filter
+  # application
   - kustomizeConfig:
       repoRef:
         name: manifests
         path: application/v3
     name: application
+  # bootstrap
   - kustomizeConfig:
       repoRef:
         name: manifests
         path: stacks/ibm/application/bootstrap
     name: bootstrap
+  # cert-manager
   - kustomizeConfig:
       repoRef:
         name: manifests
@@ -51,22 +54,76 @@ spec:
         name: manifests
         path: stacks/ibm/application/cert-manager
     name: cert-manager
-  # Install Kubeflow applications.
+  # Tekton
   - kustomizeConfig:
       repoRef:
         name: manifests
-        path: stacks/ibm
+        path: tektoncd/tektoncd-install/base
+    name: tektoncd-install
+  - kustomizeConfig:
+      repoRef:
+        name: manifests
+        path: tektoncd/tektoncd-dashboard/base
+    name: tektoncd-dashboard
+  # Kubeflow components
+  - kustomizeConfig:
+      repoRef:
+        name: manifests
+        path: stacks/ibm/application/admission-webhook
+    name: admission-webhook
+  - kustomizeConfig:
+      repoRef:
+        name: manifests
+        path: stacks/ibm/application/profile-control-plane
     name: kubeflow-apps
+  - kustomizeConfig:
+      repoRef:
+        name: manifests
+        path: stacks/ibm/application/metadata
+    name: metadata
+  - kustomizeConfig:
+      repoRef:
+        name: manifests
+        path: stacks/ibm/application/katib
+    name: katib
+  - kustomizeConfig:
+      repoRef:
+        name: manifests
+        path: stacks/ibm/application/kfp-tekton
+    name: kfp-tekton
+  # Switch the above kfp-tekton to
+  # the below applications if you want to
+  # run KFP with Argo
+  # - kustomizeConfig:
+  #     repoRef:
+  #       name: manifests
+  #       path: stacks/ibm/application/argo
+  #   name: argo
+  # - kustomizeConfig:
+  #     repoRef:
+  #       name: manifests
+  #       path: stacks/ibm/application/kfp-argo
+  #   name: kfp-argo
+  - kustomizeConfig:
+      repoRef:
+        name: manifests
+        path: stacks/ibm/application/notebooks
+    name: notebooks
+  - kustomizeConfig:
+      repoRef:
+        name: manifests
+        path: stacks/ibm/application/pytorch-job
+    name: pytorch-job
+  - kustomizeConfig:
+      repoRef:
+        name: manifests
+        path: stacks/ibm/application/tf-job
+    name: tf-job
   - kustomizeConfig:
       repoRef:
         name: manifests
         path: metacontroller/base
     name: metacontroller
-  - kustomizeConfig:
-      repoRef:
-        name: manifests
-        path: stacks/ibm/application/spark-operator
-    name: spark-operator
   - kustomizeConfig:
       repoRef:
         name: manifests
@@ -84,11 +141,17 @@ spec:
         name: manifests
         path: stacks/ibm/application/spartakus
     name: spartakus
-  - kustomizeConfig:
-      repoRef:
-        name: manifests
-        path: stacks/ibm/application/tensorboard
-    name: tensorboard
+  # Optional applications
+  # - kustomizeConfig:
+  #     repoRef:
+  #       name: manifests
+  #       path: stacks/ibm/application/seldon-core-operator
+  #   name: seldon-core-operator
+  # - kustomizeConfig:
+  #     repoRef:
+  #       name: manifests
+  #       path: stacks/ibm/application/spark-operator
+  #   name: spark-operator
   repos:
   - name: manifests
     uri: https://github.com/kubeflow/manifests/archive/v1.2-branch.tar.gz

--- a/kfdef/kfctl_ibm.v1.2.0.yaml
+++ b/kfdef/kfctl_ibm.v1.2.0.yaml
@@ -91,9 +91,9 @@ spec:
         name: manifests
         path: stacks/ibm/application/kfp-tekton
     name: kfp-tekton
-  # Switch the above kfp-tekton to
+  # Default on IBM Cloud is Kubeflow Pipelines with Tekton. Switch the above kfp-tekton to
   # the below applications if you want to
-  # run KFP with Argo
+  # run Kubeflow Pipelines with Argo
   # - kustomizeConfig:
   #     repoRef:
   #       name: manifests
@@ -141,7 +141,7 @@ spec:
         name: manifests
         path: stacks/ibm/application/spartakus
     name: spartakus
-  # Optional applications
+  # Optional applications: Uncomment the following lines if you want to run Seldon or Spark on IBM Cloud.
   # - kustomizeConfig:
   #     repoRef:
   #       name: manifests

--- a/kfdef/kfctl_ibm_multi_user.v1.2.0.yaml
+++ b/kfdef/kfctl_ibm_multi_user.v1.2.0.yaml
@@ -54,29 +54,76 @@ spec:
   - kustomizeConfig:
       repoRef:
         name: manifests
-        path: stacks/ibm/application/oidc-authservice
+        path: stacks/ibm/application/oidc-authservice-appid
     name: oidc-authservice
-  - kustomizeConfig:
-      repoRef:
-        name: manifests
-        path: stacks/ibm/application/dex-auth
-    name: dex-auth
   - kustomizeConfig:
       repoRef:
         name: manifests
         path: metacontroller/base
     name: metacontroller
-  # Install kubeflow applications.
   - kustomizeConfig:
       repoRef:
         name: manifests
-        path: stacks/ibm/multi-user
+        path: tektoncd/tektoncd-install/base
+    name: tektoncd-install
+  - kustomizeConfig:
+      repoRef:
+        name: manifests
+        path: tektoncd/tektoncd-dashboard/base
+    name: tektoncd-dashboard
+  - kustomizeConfig:
+      repoRef:
+        name: manifests
+        path: stacks/ibm/application/admission-webhook
+    name: admission-webhook
+  - kustomizeConfig:
+      repoRef:
+        name: manifests
+        path: stacks/ibm/application/profile-control-plane
     name: kubeflow-apps
   - kustomizeConfig:
       repoRef:
         name: manifests
-        path: stacks/ibm/application/spark-operator
-    name: spark-operator
+        path: stacks/ibm/application/metadata
+    name: metadata
+  - kustomizeConfig:
+      repoRef:
+        name: manifests
+        path: stacks/ibm/application/katib
+    name: katib
+  - kustomizeConfig:
+      repoRef:
+        name: manifests
+        path: stacks/ibm/application/kfp-tekton-multi-user
+    name: kfp-tekton-multi-user
+  # Switch the above kfp-tekton to
+  # the below applications if you want to
+  # run KFP with Argo
+  # - kustomizeConfig:
+  #     repoRef:
+  #       name: manifests
+  #       path: stacks/ibm/application/argo
+  #   name: argo
+  # - kustomizeConfig:
+  #     repoRef:
+  #       name: manifests
+  #       path: stacks/ibm/application/kfp-argo-multi-user
+  #   name: kfp-argo-multi-user
+  - kustomizeConfig:
+      repoRef:
+        name: manifests
+        path: stacks/ibm/application/notebooks
+    name: notebooks
+  - kustomizeConfig:
+      repoRef:
+        name: manifests
+        path: stacks/ibm/application/pytorch-job
+    name: pytorch-job
+  - kustomizeConfig:
+      repoRef:
+        name: manifests
+        path: stacks/ibm/application/tf-job
+    name: tf-job
   - kustomizeConfig:
       repoRef:
         name: manifests
@@ -92,6 +139,17 @@ spec:
         name: manifests
         path: stacks/ibm/application/spartakus
     name: spartakus
+  # Optional applications
+  # - kustomizeConfig:
+  #     repoRef:
+  #       name: manifests
+  #       path: stacks/ibm/application/seldon-core-operator
+  #   name: seldon-core-operator
+  # - kustomizeConfig:
+  #     repoRef:
+  #       name: manifests
+  #       path: stacks/ibm/application/spark-operator
+  #   name: spark-operator
   repos:
   - name: manifests
     uri: https://github.com/kubeflow/manifests/archive/v1.2-branch.tar.gz

--- a/kfdef/kfctl_ibm_multi_user.v1.2.0.yaml
+++ b/kfdef/kfctl_ibm_multi_user.v1.2.0.yaml
@@ -96,9 +96,9 @@ spec:
         name: manifests
         path: stacks/ibm/application/kfp-tekton-multi-user
     name: kfp-tekton-multi-user
-  # Switch the above kfp-tekton to
+  # Default on IBM Cloud is Kubeflow Pipelines with Tekton. Switch the above kfp-tekton to
   # the below applications if you want to
-  # run KFP with Argo
+  # run Kubeflow Pipelines with Argo
   # - kustomizeConfig:
   #     repoRef:
   #       name: manifests
@@ -139,7 +139,7 @@ spec:
         name: manifests
         path: stacks/ibm/application/spartakus
     name: spartakus
-  # Optional applications
+  # Optional applications: Uncomment the following lines if you want to run Seldon or Spark on IBM Cloud.
   # - kustomizeConfig:
   #     repoRef:
   #       name: manifests


### PR DESCRIPTION
**Which issue is resolved by this Pull Request:**
Resolves #

**Description of your changes:**
The IBM 1.2 manifests are based on 1.1 which didn't include our latest changes such as App ID and Tekton. Therefore, pin the IBM 1.2 manifests with the latest kfdef.


**Checklist:**
- [x] Unit tests have been rebuilt: 
    1. `cd manifests/tests`
    2. `make generate-changed-only`
    3. `make test`
