### PR TITLE
Remove Tensorboard for AWS 1.2 Manifests

### DIFF
--- a/kfdef/kfctl_aws.v1.2.0.yaml
+++ b/kfdef/kfctl_aws.v1.2.0.yaml
@@ -94,11 +94,6 @@ spec:
         name: manifests
         path: stacks/aws/application/spartakus
     name: spartakus
-  - kustomizeConfig:
-      repoRef:
-        name: manifests
-        path: tensorboard/overlays/istio
-    name: tensorboard
   plugins:
   - kind: KfAwsPlugin
     metadata:

--- a/kfdef/kfctl_aws_cognito.v1.2.0.yaml
+++ b/kfdef/kfctl_aws_cognito.v1.2.0.yaml
@@ -77,11 +77,6 @@ spec:
   - kustomizeConfig:
       repoRef:
         name: manifests
-        path: tensorboard/overlays/istio
-    name: tensorboard
-  - kustomizeConfig:
-      repoRef:
-        name: manifests
         path: stacks/aws
     name: kubeflow-apps
   - kustomizeConfig:


### PR DESCRIPTION
**Which issue is resolved by this Pull Request:**
Resolves #

**Description of your changes:**
Found we removed tensorboard manifests in master branch previously 

https://github.com/kubeflow/manifests/pull/1459

Remove tensorboard in AWS 1.2 manifests.

**Checklist:**
- [x] Unit tests have been rebuilt: 
    1. `cd manifests/tests`
    2. `make generate-changed-only`
    3. `make test`
