### PR TITLE
Presubmit kicked off by istio_dex manifests

### DIFF
--- a/prow_config.yaml
+++ b/prow_config.yaml
@@ -33,7 +33,7 @@ workflows:
       - istio/*
       - jupyter/*
       - katib/*
-      - kfdef/*
+      - kfdef/kfctl_istio_dex*
       - kfserving/*
       - knative/*
       - kubebench/*


### PR DESCRIPTION
**Which issue is resolved by this Pull Request:**
Resolves #

**Description of your changes:**
Since cloud providers are changing kfdef/* manifests frequently, and we should only kick off E2E tests when `kfctl_istio_dex` manifests.

**Checklist:**
- [x] Unit tests have been rebuilt: 
    1. `cd manifests/tests`
    2. `make generate-changed-only`
    3. `make test`
