### PR TITLE
Rollout AWS Jupyter images to 1.2.0

### DIFF
--- a/stacks/aws/application/jupyter-web-app/configs/spawner_ui_config.yaml
+++ b/stacks/aws/application/jupyter-web-app/configs/spawner_ui_config.yaml
@@ -18,13 +18,13 @@ spawnerFormDefaults:
   image:
     # The container Image for the user's Jupyter Notebook
     # If readonly, this value must be a member of the list below
-    value: 527798164940.dkr.ecr.us-west-2.amazonaws.com/tensorflow-1.15.2-notebook-cpu:1.0.0
+    value: 527798164940.dkr.ecr.us-west-2.amazonaws.com/tensorflow-1.15.2-notebook-cpu:1.2.0
     # The list of available standard container Images
     options:
-      - 527798164940.dkr.ecr.us-west-2.amazonaws.com/tensorflow-1.15.2-notebook-cpu:1.1.0
-      - 527798164940.dkr.ecr.us-west-2.amazonaws.com/tensorflow-1.15.2-notebook-gpu:1.1.0
-      - 527798164940.dkr.ecr.us-west-2.amazonaws.com/tensorflow-2.1.0-notebook-cpu:1.1.0
-      - 527798164940.dkr.ecr.us-west-2.amazonaws.com/tensorflow-2.1.0-notebook-gpu:1.1.0
+      - 527798164940.dkr.ecr.us-west-2.amazonaws.com/tensorflow-1.15.2-notebook-cpu:1.2.0
+      - 527798164940.dkr.ecr.us-west-2.amazonaws.com/tensorflow-1.15.2-notebook-gpu:1.2.0
+      - 527798164940.dkr.ecr.us-west-2.amazonaws.com/tensorflow-2.1.0-notebook-cpu:1.2.0
+      - 527798164940.dkr.ecr.us-west-2.amazonaws.com/tensorflow-2.1.0-notebook-gpu:1.2.0
       - gcr.io/kubeflow-images-public/tensorflow-1.15.2-notebook-cpu:1.0.0
       - gcr.io/kubeflow-images-public/tensorflow-1.15.2-notebook-gpu:1.0.0
       - gcr.io/kubeflow-images-public/tensorflow-2.1.0-notebook-cpu:1.0.0

--- a/tests/stacks/aws/application/jupyter-web-app/test_data/expected/apps_v1_deployment_jupyter-web-app-deployment.yaml
+++ b/tests/stacks/aws/application/jupyter-web-app/test_data/expected/apps_v1_deployment_jupyter-web-app-deployment.yaml
@@ -42,5 +42,5 @@ spec:
       serviceAccountName: jupyter-web-app-service-account
       volumes:
       - configMap:
-          name: jupyter-web-app-jupyter-web-app-config-57ddmh4ht8
+          name: jupyter-web-app-jupyter-web-app-config-8fc6g84c8k
         name: config-volume

--- a/tests/stacks/aws/application/jupyter-web-app/test_data/expected/~g_v1_configmap_jupyter-web-app-jupyter-web-app-config-8fc6g84c8k.yaml
+++ b/tests/stacks/aws/application/jupyter-web-app/test_data/expected/~g_v1_configmap_jupyter-web-app-jupyter-web-app-config-8fc6g84c8k.yaml
@@ -21,13 +21,13 @@ data:
       image:
         # The container Image for the user's Jupyter Notebook
         # If readonly, this value must be a member of the list below
-        value: 527798164940.dkr.ecr.us-west-2.amazonaws.com/tensorflow-1.15.2-notebook-cpu:1.0.0
+        value: 527798164940.dkr.ecr.us-west-2.amazonaws.com/tensorflow-1.15.2-notebook-cpu:1.2.0
         # The list of available standard container Images
         options:
-          - 527798164940.dkr.ecr.us-west-2.amazonaws.com/tensorflow-1.15.2-notebook-cpu:1.1.0
-          - 527798164940.dkr.ecr.us-west-2.amazonaws.com/tensorflow-1.15.2-notebook-gpu:1.1.0
-          - 527798164940.dkr.ecr.us-west-2.amazonaws.com/tensorflow-2.1.0-notebook-cpu:1.1.0
-          - 527798164940.dkr.ecr.us-west-2.amazonaws.com/tensorflow-2.1.0-notebook-gpu:1.1.0
+          - 527798164940.dkr.ecr.us-west-2.amazonaws.com/tensorflow-1.15.2-notebook-cpu:1.2.0
+          - 527798164940.dkr.ecr.us-west-2.amazonaws.com/tensorflow-1.15.2-notebook-gpu:1.2.0
+          - 527798164940.dkr.ecr.us-west-2.amazonaws.com/tensorflow-2.1.0-notebook-cpu:1.2.0
+          - 527798164940.dkr.ecr.us-west-2.amazonaws.com/tensorflow-2.1.0-notebook-gpu:1.2.0
           - gcr.io/kubeflow-images-public/tensorflow-1.15.2-notebook-cpu:1.0.0
           - gcr.io/kubeflow-images-public/tensorflow-1.15.2-notebook-gpu:1.0.0
           - gcr.io/kubeflow-images-public/tensorflow-2.1.0-notebook-cpu:1.0.0
@@ -139,5 +139,5 @@ metadata:
   labels:
     app: jupyter-web-app
     kustomize.component: jupyter-web-app
-  name: jupyter-web-app-jupyter-web-app-config-57ddmh4ht8
+  name: jupyter-web-app-jupyter-web-app-config-8fc6g84c8k
   namespace: kubeflow

--- a/tests/stacks/aws/test_data/expected/apps_v1_deployment_jupyter-web-app-deployment.yaml
+++ b/tests/stacks/aws/test_data/expected/apps_v1_deployment_jupyter-web-app-deployment.yaml
@@ -42,5 +42,5 @@ spec:
       serviceAccountName: jupyter-web-app-service-account
       volumes:
       - configMap:
-          name: jupyter-web-app-jupyter-web-app-config-57ddmh4ht8
+          name: jupyter-web-app-jupyter-web-app-config-8fc6g84c8k
         name: config-volume

--- a/tests/stacks/aws/test_data/expected/~g_v1_configmap_jupyter-web-app-jupyter-web-app-config-8fc6g84c8k.yaml
+++ b/tests/stacks/aws/test_data/expected/~g_v1_configmap_jupyter-web-app-jupyter-web-app-config-8fc6g84c8k.yaml
@@ -21,13 +21,13 @@ data:
       image:
         # The container Image for the user's Jupyter Notebook
         # If readonly, this value must be a member of the list below
-        value: 527798164940.dkr.ecr.us-west-2.amazonaws.com/tensorflow-1.15.2-notebook-cpu:1.0.0
+        value: 527798164940.dkr.ecr.us-west-2.amazonaws.com/tensorflow-1.15.2-notebook-cpu:1.2.0
         # The list of available standard container Images
         options:
-          - 527798164940.dkr.ecr.us-west-2.amazonaws.com/tensorflow-1.15.2-notebook-cpu:1.1.0
-          - 527798164940.dkr.ecr.us-west-2.amazonaws.com/tensorflow-1.15.2-notebook-gpu:1.1.0
-          - 527798164940.dkr.ecr.us-west-2.amazonaws.com/tensorflow-2.1.0-notebook-cpu:1.1.0
-          - 527798164940.dkr.ecr.us-west-2.amazonaws.com/tensorflow-2.1.0-notebook-gpu:1.1.0
+          - 527798164940.dkr.ecr.us-west-2.amazonaws.com/tensorflow-1.15.2-notebook-cpu:1.2.0
+          - 527798164940.dkr.ecr.us-west-2.amazonaws.com/tensorflow-1.15.2-notebook-gpu:1.2.0
+          - 527798164940.dkr.ecr.us-west-2.amazonaws.com/tensorflow-2.1.0-notebook-cpu:1.2.0
+          - 527798164940.dkr.ecr.us-west-2.amazonaws.com/tensorflow-2.1.0-notebook-gpu:1.2.0
           - gcr.io/kubeflow-images-public/tensorflow-1.15.2-notebook-cpu:1.0.0
           - gcr.io/kubeflow-images-public/tensorflow-1.15.2-notebook-gpu:1.0.0
           - gcr.io/kubeflow-images-public/tensorflow-2.1.0-notebook-cpu:1.0.0
@@ -139,5 +139,5 @@ metadata:
   labels:
     app: jupyter-web-app
     kustomize.component: jupyter-web-app
-  name: jupyter-web-app-jupyter-web-app-config-57ddmh4ht8
+  name: jupyter-web-app-jupyter-web-app-config-8fc6g84c8k
   namespace: kubeflow


### PR DESCRIPTION
**Which issue is resolved by this Pull Request:**
Resolves #

**Description of your changes:**
Rollout AWS Jupyter images to 1.2.0 alongside with Kubeflow 1.2 release

**Checklist:**
- [x] Unit tests have been rebuilt: 
    1. `cd manifests/tests`
    2. `make generate-changed-only`
    3. `make test`
