### PR TITLE
update image tags

### DIFF
--- a/admission-webhook/webhook/base/kustomization.yaml
+++ b/admission-webhook/webhook/base/kustomization.yaml
@@ -15,7 +15,7 @@ namePrefix: admission-webhook-
 images:
 - name: gcr.io/kubeflow-images-public/admission-webhook
   newName: gcr.io/kubeflow-images-public/admission-webhook
-  newTag: vmaster-gaf96e4e3
+  newTag: vmaster-ge5452b6f
 namespace: kubeflow
 configMapGenerator:
 - envs:

--- a/common/centraldashboard/base/kustomization.yaml
+++ b/common/centraldashboard/base/kustomization.yaml
@@ -17,7 +17,7 @@ commonLabels:
 images:
 - name: gcr.io/kubeflow-images-public/centraldashboard
   newName: gcr.io/kubeflow-images-public/centraldashboard
-  newTag: vmaster-gf39279c0
+  newTag: vmaster-g8097cfeb
 configMapGenerator:
 - envs:
   - params.env

--- a/common/centraldashboard/base_v3/kustomization.yaml
+++ b/common/centraldashboard/base_v3/kustomization.yaml
@@ -3,7 +3,7 @@ kind: Kustomization
 images:
 - name: gcr.io/kubeflow-images-public/centraldashboard
   newName: gcr.io/kubeflow-images-public/centraldashboard
-  newTag: vmaster-gd601b2d0
+  newTag: vmaster-g8097cfeb
 resources:
 - ../base/clusterrole-binding.yaml
 - ../base/clusterrole.yaml

--- a/jupyter/jupyter-web-app/base_v3/kustomization.yaml
+++ b/jupyter/jupyter-web-app/base_v3/kustomization.yaml
@@ -29,7 +29,7 @@ namespace: kubeflow
 images:
 - name: gcr.io/kubeflow-images-public/jupyter-web-app
   newName: gcr.io/kubeflow-images-public/jupyter-web-app
-  newTag: vmaster-gd9be4b9e
+  newTag: vmaster-g845af298
 resources:
 - ../base/cluster-role-binding.yaml
 - ../base/cluster-role.yaml

--- a/jupyter/notebook-controller/base_v3/kustomization.yaml
+++ b/jupyter/notebook-controller/base_v3/kustomization.yaml
@@ -12,7 +12,7 @@ configMapGenerator:
 images:
 - name: gcr.io/kubeflow-images-public/notebook-controller
   newName: gcr.io/kubeflow-images-public/notebook-controller
-  newTag: vmaster-gf39279c0
+  newTag: vmaster-g6eb007d0
 kind: Kustomization
 namePrefix: notebook-controller-
 namespace: kubeflow

--- a/profiles/base_v3/kustomization.yaml
+++ b/profiles/base_v3/kustomization.yaml
@@ -6,10 +6,10 @@ commonLabels:
 images:
 - name: gcr.io/kubeflow-images-public/kfam
   newName: gcr.io/kubeflow-images-public/kfam
-  newTag: vmaster-gf3e09203
+  newTag: vmaster-g9f3bfd00
 - name: gcr.io/kubeflow-images-public/profile-controller
   newName: gcr.io/kubeflow-images-public/profile-controller
-  newTag: vmaster-g34aa47c2
+  newTag: vmaster-ga49f658f
 resources:
 - ../base/cluster-role-binding.yaml
 - ../base/crd.yaml

--- a/tests/stacks/aws/application/jupyter-web-app/test_data/expected/apps_v1_deployment_jupyter-web-app-deployment.yaml
+++ b/tests/stacks/aws/application/jupyter-web-app/test_data/expected/apps_v1_deployment_jupyter-web-app-deployment.yaml
@@ -32,7 +32,7 @@ spec:
             configMapKeyRef:
               key: userid-prefix
               name: kubeflow-config
-        image: gcr.io/kubeflow-images-public/jupyter-web-app:vmaster-gd9be4b9e
+        image: gcr.io/kubeflow-images-public/jupyter-web-app:vmaster-g845af298
         name: jupyter-web-app
         ports:
         - containerPort: 5000

--- a/tests/stacks/aws/test_data/expected/apps_v1_deployment_admission-webhook-deployment.yaml
+++ b/tests/stacks/aws/test_data/expected/apps_v1_deployment_admission-webhook-deployment.yaml
@@ -29,7 +29,7 @@ spec:
       - args:
         - --tlsCertFile=/etc/webhook/certs/tls.crt
         - --tlsKeyFile=/etc/webhook/certs/tls.key
-        image: gcr.io/kubeflow-images-public/admission-webhook:vmaster-gaf96e4e3
+        image: gcr.io/kubeflow-images-public/admission-webhook:vmaster-ge5452b6f
         name: admission-webhook
         volumeMounts:
         - mountPath: /etc/webhook/certs

--- a/tests/stacks/aws/test_data/expected/apps_v1_deployment_centraldashboard.yaml
+++ b/tests/stacks/aws/test_data/expected/apps_v1_deployment_centraldashboard.yaml
@@ -35,7 +35,7 @@ spec:
             configMapKeyRef:
               key: userid-prefix
               name: kubeflow-config
-        image: gcr.io/kubeflow-images-public/centraldashboard:vmaster-gd601b2d0
+        image: gcr.io/kubeflow-images-public/centraldashboard:vmaster-g8097cfeb
         imagePullPolicy: IfNotPresent
         livenessProbe:
           httpGet:

--- a/tests/stacks/aws/test_data/expected/apps_v1_deployment_jupyter-web-app-deployment.yaml
+++ b/tests/stacks/aws/test_data/expected/apps_v1_deployment_jupyter-web-app-deployment.yaml
@@ -32,7 +32,7 @@ spec:
             configMapKeyRef:
               key: userid-prefix
               name: kubeflow-config
-        image: gcr.io/kubeflow-images-public/jupyter-web-app:vmaster-gd9be4b9e
+        image: gcr.io/kubeflow-images-public/jupyter-web-app:vmaster-g845af298
         name: jupyter-web-app
         ports:
         - containerPort: 5000

--- a/tests/stacks/aws/test_data/expected/apps_v1_deployment_notebook-controller-deployment.yaml
+++ b/tests/stacks/aws/test_data/expected/apps_v1_deployment_notebook-controller-deployment.yaml
@@ -39,7 +39,7 @@ spec:
             configMapKeyRef:
               key: ISTIO_GATEWAY
               name: notebook-controller-notebook-controller-config-h4d668t5tb
-        image: gcr.io/kubeflow-images-public/notebook-controller:vmaster-gf39279c0
+        image: gcr.io/kubeflow-images-public/notebook-controller:vmaster-g6eb007d0
         imagePullPolicy: Always
         livenessProbe:
           httpGet:

--- a/tests/stacks/aws/test_data/expected/apps_v1_deployment_profiles-deployment.yaml
+++ b/tests/stacks/aws/test_data/expected/apps_v1_deployment_profiles-deployment.yaml
@@ -43,7 +43,7 @@ spec:
             configMapKeyRef:
               key: gcp-sa
               name: profiles-profiles-config-4mgcmtgk6t
-        image: gcr.io/kubeflow-images-public/profile-controller:vmaster-g34aa47c2
+        image: gcr.io/kubeflow-images-public/profile-controller:vmaster-ga49f658f
         imagePullPolicy: Always
         livenessProbe:
           httpGet:
@@ -81,7 +81,7 @@ spec:
             configMapKeyRef:
               key: admin
               name: profiles-profiles-config-4mgcmtgk6t
-        image: gcr.io/kubeflow-images-public/kfam:vmaster-gf3e09203
+        image: gcr.io/kubeflow-images-public/kfam:vmaster-g9f3bfd00
         imagePullPolicy: Always
         livenessProbe:
           httpGet:

--- a/tests/stacks/azure/test_data/expected/apps_v1_deployment_admission-webhook-deployment.yaml
+++ b/tests/stacks/azure/test_data/expected/apps_v1_deployment_admission-webhook-deployment.yaml
@@ -29,7 +29,7 @@ spec:
       - args:
         - --tlsCertFile=/etc/webhook/certs/tls.crt
         - --tlsKeyFile=/etc/webhook/certs/tls.key
-        image: gcr.io/kubeflow-images-public/admission-webhook:vmaster-gaf96e4e3
+        image: gcr.io/kubeflow-images-public/admission-webhook:vmaster-ge5452b6f
         name: admission-webhook
         volumeMounts:
         - mountPath: /etc/webhook/certs

--- a/tests/stacks/azure/test_data/expected/apps_v1_deployment_centraldashboard.yaml
+++ b/tests/stacks/azure/test_data/expected/apps_v1_deployment_centraldashboard.yaml
@@ -35,7 +35,7 @@ spec:
             configMapKeyRef:
               key: userid-prefix
               name: kubeflow-config-bk4bc7m928
-        image: gcr.io/kubeflow-images-public/centraldashboard:vmaster-gd601b2d0
+        image: gcr.io/kubeflow-images-public/centraldashboard:vmaster-g8097cfeb
         imagePullPolicy: IfNotPresent
         livenessProbe:
           httpGet:

--- a/tests/stacks/azure/test_data/expected/apps_v1_deployment_notebook-controller-deployment.yaml
+++ b/tests/stacks/azure/test_data/expected/apps_v1_deployment_notebook-controller-deployment.yaml
@@ -39,7 +39,7 @@ spec:
             configMapKeyRef:
               key: ISTIO_GATEWAY
               name: notebook-controller-notebook-controller-config-h4d668t5tb
-        image: gcr.io/kubeflow-images-public/notebook-controller:vmaster-gf39279c0
+        image: gcr.io/kubeflow-images-public/notebook-controller:vmaster-g6eb007d0
         imagePullPolicy: Always
         livenessProbe:
           httpGet:

--- a/tests/stacks/azure/test_data/expected/apps_v1_deployment_profiles-deployment.yaml
+++ b/tests/stacks/azure/test_data/expected/apps_v1_deployment_profiles-deployment.yaml
@@ -43,7 +43,7 @@ spec:
             configMapKeyRef:
               key: gcp-sa
               name: profiles-profiles-config-4mgcmtgk6t
-        image: gcr.io/kubeflow-images-public/profile-controller:vmaster-g34aa47c2
+        image: gcr.io/kubeflow-images-public/profile-controller:vmaster-ga49f658f
         imagePullPolicy: Always
         livenessProbe:
           httpGet:
@@ -81,7 +81,7 @@ spec:
             configMapKeyRef:
               key: admin
               name: profiles-profiles-config-4mgcmtgk6t
-        image: gcr.io/kubeflow-images-public/kfam:vmaster-gf3e09203
+        image: gcr.io/kubeflow-images-public/kfam:vmaster-g9f3bfd00
         imagePullPolicy: Always
         livenessProbe:
           httpGet:

--- a/tests/stacks/examples/alice/test_data/expected/apps_v1_deployment_admission-webhook-deployment.yaml
+++ b/tests/stacks/examples/alice/test_data/expected/apps_v1_deployment_admission-webhook-deployment.yaml
@@ -29,7 +29,7 @@ spec:
       - args:
         - --tlsCertFile=/etc/webhook/certs/tls.crt
         - --tlsKeyFile=/etc/webhook/certs/tls.key
-        image: gcr.io/kubeflow-images-public/admission-webhook:vmaster-gaf96e4e3
+        image: gcr.io/kubeflow-images-public/admission-webhook:vmaster-ge5452b6f
         name: admission-webhook
         volumeMounts:
         - mountPath: /etc/webhook/certs

--- a/tests/stacks/examples/alice/test_data/expected/apps_v1_deployment_centraldashboard.yaml
+++ b/tests/stacks/examples/alice/test_data/expected/apps_v1_deployment_centraldashboard.yaml
@@ -35,7 +35,7 @@ spec:
             configMapKeyRef:
               key: userid-prefix
               name: kubeflow-config-bmh8k74f52
-        image: gcr.io/kubeflow-images-public/centraldashboard:vmaster-gd601b2d0
+        image: gcr.io/kubeflow-images-public/centraldashboard:vmaster-g8097cfeb
         imagePullPolicy: IfNotPresent
         livenessProbe:
           httpGet:

--- a/tests/stacks/examples/alice/test_data/expected/apps_v1_deployment_jupyter-web-app-deployment.yaml
+++ b/tests/stacks/examples/alice/test_data/expected/apps_v1_deployment_jupyter-web-app-deployment.yaml
@@ -32,7 +32,7 @@ spec:
             configMapKeyRef:
               key: userid-prefix
               name: kubeflow-config-bmh8k74f52
-        image: gcr.io/kubeflow-images-public/jupyter-web-app:vmaster-gd9be4b9e
+        image: gcr.io/kubeflow-images-public/jupyter-web-app:vmaster-g845af298
         name: jupyter-web-app
         ports:
         - containerPort: 5000

--- a/tests/stacks/examples/alice/test_data/expected/apps_v1_deployment_notebook-controller-deployment.yaml
+++ b/tests/stacks/examples/alice/test_data/expected/apps_v1_deployment_notebook-controller-deployment.yaml
@@ -39,7 +39,7 @@ spec:
             configMapKeyRef:
               key: ISTIO_GATEWAY
               name: notebook-controller-notebook-controller-config-h4d668t5tb
-        image: gcr.io/kubeflow-images-public/notebook-controller:vmaster-gf39279c0
+        image: gcr.io/kubeflow-images-public/notebook-controller:vmaster-g6eb007d0
         imagePullPolicy: Always
         livenessProbe:
           httpGet:

--- a/tests/stacks/examples/alice/test_data/expected/apps_v1_deployment_profiles-deployment.yaml
+++ b/tests/stacks/examples/alice/test_data/expected/apps_v1_deployment_profiles-deployment.yaml
@@ -43,7 +43,7 @@ spec:
             configMapKeyRef:
               key: gcp-sa
               name: profiles-profiles-config-4mgcmtgk6t
-        image: gcr.io/kubeflow-images-public/profile-controller:vmaster-g34aa47c2
+        image: gcr.io/kubeflow-images-public/profile-controller:vmaster-ga49f658f
         imagePullPolicy: Always
         livenessProbe:
           httpGet:
@@ -81,7 +81,7 @@ spec:
             configMapKeyRef:
               key: admin
               name: profiles-profiles-config-4mgcmtgk6t
-        image: gcr.io/kubeflow-images-public/kfam:vmaster-gf3e09203
+        image: gcr.io/kubeflow-images-public/kfam:vmaster-g9f3bfd00
         imagePullPolicy: Always
         livenessProbe:
           httpGet:

--- a/tests/stacks/gcp/test_data/expected/apps_v1_deployment_admission-webhook-deployment.yaml
+++ b/tests/stacks/gcp/test_data/expected/apps_v1_deployment_admission-webhook-deployment.yaml
@@ -29,7 +29,7 @@ spec:
       - args:
         - --tlsCertFile=/etc/webhook/certs/tls.crt
         - --tlsKeyFile=/etc/webhook/certs/tls.key
-        image: gcr.io/kubeflow-images-public/admission-webhook:vmaster-gaf96e4e3
+        image: gcr.io/kubeflow-images-public/admission-webhook:vmaster-ge5452b6f
         name: admission-webhook
         volumeMounts:
         - mountPath: /etc/webhook/certs

--- a/tests/stacks/gcp/test_data/expected/apps_v1_deployment_centraldashboard.yaml
+++ b/tests/stacks/gcp/test_data/expected/apps_v1_deployment_centraldashboard.yaml
@@ -35,7 +35,7 @@ spec:
             configMapKeyRef:
               key: userid-prefix
               name: kubeflow-config-c644m77455
-        image: gcr.io/kubeflow-images-public/centraldashboard:vmaster-gd601b2d0
+        image: gcr.io/kubeflow-images-public/centraldashboard:vmaster-g8097cfeb
         imagePullPolicy: IfNotPresent
         livenessProbe:
           httpGet:

--- a/tests/stacks/gcp/test_data/expected/apps_v1_deployment_jupyter-web-app-deployment.yaml
+++ b/tests/stacks/gcp/test_data/expected/apps_v1_deployment_jupyter-web-app-deployment.yaml
@@ -32,7 +32,7 @@ spec:
             configMapKeyRef:
               key: userid-prefix
               name: kubeflow-config-c644m77455
-        image: gcr.io/kubeflow-images-public/jupyter-web-app:vmaster-gd9be4b9e
+        image: gcr.io/kubeflow-images-public/jupyter-web-app:vmaster-g845af298
         name: jupyter-web-app
         ports:
         - containerPort: 5000

--- a/tests/stacks/gcp/test_data/expected/apps_v1_deployment_notebook-controller-deployment.yaml
+++ b/tests/stacks/gcp/test_data/expected/apps_v1_deployment_notebook-controller-deployment.yaml
@@ -39,7 +39,7 @@ spec:
             configMapKeyRef:
               key: ISTIO_GATEWAY
               name: notebook-controller-notebook-controller-config-h4d668t5tb
-        image: gcr.io/kubeflow-images-public/notebook-controller:vmaster-gf39279c0
+        image: gcr.io/kubeflow-images-public/notebook-controller:vmaster-g6eb007d0
         imagePullPolicy: Always
         livenessProbe:
           httpGet:

--- a/tests/stacks/gcp/test_data/expected/apps_v1_deployment_profiles-deployment.yaml
+++ b/tests/stacks/gcp/test_data/expected/apps_v1_deployment_profiles-deployment.yaml
@@ -43,7 +43,7 @@ spec:
             configMapKeyRef:
               key: gcp-sa
               name: profiles-profiles-config-4mgcmtgk6t
-        image: gcr.io/kubeflow-images-public/profile-controller:vmaster-g34aa47c2
+        image: gcr.io/kubeflow-images-public/profile-controller:vmaster-ga49f658f
         imagePullPolicy: Always
         livenessProbe:
           httpGet:
@@ -81,7 +81,7 @@ spec:
             configMapKeyRef:
               key: admin
               name: profiles-profiles-config-4mgcmtgk6t
-        image: gcr.io/kubeflow-images-public/kfam:vmaster-gf3e09203
+        image: gcr.io/kubeflow-images-public/kfam:vmaster-g9f3bfd00
         imagePullPolicy: Always
         livenessProbe:
           httpGet:

--- a/tests/stacks/generic/test_data/expected/apps_v1_deployment_admission-webhook-deployment.yaml
+++ b/tests/stacks/generic/test_data/expected/apps_v1_deployment_admission-webhook-deployment.yaml
@@ -29,7 +29,7 @@ spec:
       - args:
         - --tlsCertFile=/etc/webhook/certs/tls.crt
         - --tlsKeyFile=/etc/webhook/certs/tls.key
-        image: gcr.io/kubeflow-images-public/admission-webhook:vmaster-gaf96e4e3
+        image: gcr.io/kubeflow-images-public/admission-webhook:vmaster-ge5452b6f
         name: admission-webhook
         volumeMounts:
         - mountPath: /etc/webhook/certs

--- a/tests/stacks/generic/test_data/expected/apps_v1_deployment_centraldashboard.yaml
+++ b/tests/stacks/generic/test_data/expected/apps_v1_deployment_centraldashboard.yaml
@@ -35,7 +35,7 @@ spec:
             configMapKeyRef:
               key: userid-prefix
               name: kubeflow-config-988m2m9m87
-        image: gcr.io/kubeflow-images-public/centraldashboard:vmaster-gd601b2d0
+        image: gcr.io/kubeflow-images-public/centraldashboard:vmaster-g8097cfeb
         imagePullPolicy: IfNotPresent
         livenessProbe:
           httpGet:

--- a/tests/stacks/generic/test_data/expected/apps_v1_deployment_jupyter-web-app-deployment.yaml
+++ b/tests/stacks/generic/test_data/expected/apps_v1_deployment_jupyter-web-app-deployment.yaml
@@ -32,7 +32,7 @@ spec:
             configMapKeyRef:
               key: userid-prefix
               name: kubeflow-config-988m2m9m87
-        image: gcr.io/kubeflow-images-public/jupyter-web-app:vmaster-gd9be4b9e
+        image: gcr.io/kubeflow-images-public/jupyter-web-app:vmaster-g845af298
         name: jupyter-web-app
         ports:
         - containerPort: 5000

--- a/tests/stacks/generic/test_data/expected/apps_v1_deployment_notebook-controller-deployment.yaml
+++ b/tests/stacks/generic/test_data/expected/apps_v1_deployment_notebook-controller-deployment.yaml
@@ -39,7 +39,7 @@ spec:
             configMapKeyRef:
               key: ISTIO_GATEWAY
               name: notebook-controller-notebook-controller-config-h4d668t5tb
-        image: gcr.io/kubeflow-images-public/notebook-controller:vmaster-gf39279c0
+        image: gcr.io/kubeflow-images-public/notebook-controller:vmaster-g6eb007d0
         imagePullPolicy: Always
         livenessProbe:
           httpGet:

--- a/tests/stacks/generic/test_data/expected/apps_v1_deployment_profiles-deployment.yaml
+++ b/tests/stacks/generic/test_data/expected/apps_v1_deployment_profiles-deployment.yaml
@@ -43,7 +43,7 @@ spec:
             configMapKeyRef:
               key: gcp-sa
               name: profiles-profiles-config-4mgcmtgk6t
-        image: gcr.io/kubeflow-images-public/profile-controller:vmaster-g34aa47c2
+        image: gcr.io/kubeflow-images-public/profile-controller:vmaster-ga49f658f
         imagePullPolicy: Always
         livenessProbe:
           httpGet:
@@ -81,7 +81,7 @@ spec:
             configMapKeyRef:
               key: admin
               name: profiles-profiles-config-4mgcmtgk6t
-        image: gcr.io/kubeflow-images-public/kfam:vmaster-gf3e09203
+        image: gcr.io/kubeflow-images-public/kfam:vmaster-g9f3bfd00
         imagePullPolicy: Always
         livenessProbe:
           httpGet:

--- a/tests/stacks/ibm/application/admission-webhook/test_data/expected/apps_v1_deployment_admission-webhook-deployment.yaml
+++ b/tests/stacks/ibm/application/admission-webhook/test_data/expected/apps_v1_deployment_admission-webhook-deployment.yaml
@@ -29,7 +29,7 @@ spec:
       - args:
         - --tlsCertFile=/etc/webhook/certs/tls.crt
         - --tlsKeyFile=/etc/webhook/certs/tls.key
-        image: gcr.io/kubeflow-images-public/admission-webhook:vmaster-gaf96e4e3
+        image: gcr.io/kubeflow-images-public/admission-webhook:vmaster-ge5452b6f
         name: admission-webhook
         volumeMounts:
         - mountPath: /etc/webhook/certs

--- a/tests/stacks/ibm/application/profile-control-plane/test_data/expected/apps_v1_deployment_centraldashboard.yaml
+++ b/tests/stacks/ibm/application/profile-control-plane/test_data/expected/apps_v1_deployment_centraldashboard.yaml
@@ -35,7 +35,7 @@ spec:
             configMapKeyRef:
               key: userid-prefix
               name: kubeflow-config-bk4bc7m928
-        image: gcr.io/kubeflow-images-public/centraldashboard:vmaster-gd601b2d0
+        image: gcr.io/kubeflow-images-public/centraldashboard:vmaster-g8097cfeb
         imagePullPolicy: IfNotPresent
         livenessProbe:
           httpGet:

--- a/tests/stacks/ibm/multi-user/test_data/expected/apps_v1_deployment_admission-webhook-deployment.yaml
+++ b/tests/stacks/ibm/multi-user/test_data/expected/apps_v1_deployment_admission-webhook-deployment.yaml
@@ -29,7 +29,7 @@ spec:
       - args:
         - --tlsCertFile=/etc/webhook/certs/tls.crt
         - --tlsKeyFile=/etc/webhook/certs/tls.key
-        image: gcr.io/kubeflow-images-public/admission-webhook:vmaster-gaf96e4e3
+        image: gcr.io/kubeflow-images-public/admission-webhook:vmaster-ge5452b6f
         name: admission-webhook
         volumeMounts:
         - mountPath: /etc/webhook/certs

--- a/tests/stacks/ibm/multi-user/test_data/expected/apps_v1_deployment_centraldashboard.yaml
+++ b/tests/stacks/ibm/multi-user/test_data/expected/apps_v1_deployment_centraldashboard.yaml
@@ -35,7 +35,7 @@ spec:
             configMapKeyRef:
               key: userid-prefix
               name: kubeflow-config-bk4bc7m928
-        image: gcr.io/kubeflow-images-public/centraldashboard:vmaster-gd601b2d0
+        image: gcr.io/kubeflow-images-public/centraldashboard:vmaster-g8097cfeb
         imagePullPolicy: IfNotPresent
         livenessProbe:
           httpGet:

--- a/tests/stacks/ibm/test_data/expected/apps_v1_deployment_admission-webhook-deployment.yaml
+++ b/tests/stacks/ibm/test_data/expected/apps_v1_deployment_admission-webhook-deployment.yaml
@@ -29,7 +29,7 @@ spec:
       - args:
         - --tlsCertFile=/etc/webhook/certs/tls.crt
         - --tlsKeyFile=/etc/webhook/certs/tls.key
-        image: gcr.io/kubeflow-images-public/admission-webhook:vmaster-gaf96e4e3
+        image: gcr.io/kubeflow-images-public/admission-webhook:vmaster-ge5452b6f
         name: admission-webhook
         volumeMounts:
         - mountPath: /etc/webhook/certs

--- a/tests/stacks/ibm/test_data/expected/apps_v1_deployment_centraldashboard.yaml
+++ b/tests/stacks/ibm/test_data/expected/apps_v1_deployment_centraldashboard.yaml
@@ -35,7 +35,7 @@ spec:
             configMapKeyRef:
               key: userid-prefix
               name: kubeflow-config-bk4bc7m928
-        image: gcr.io/kubeflow-images-public/centraldashboard:vmaster-gd601b2d0
+        image: gcr.io/kubeflow-images-public/centraldashboard:vmaster-g8097cfeb
         imagePullPolicy: IfNotPresent
         livenessProbe:
           httpGet:

--- a/tests/stacks/kubernetes/test_data/expected/apps_v1_deployment_admission-webhook-deployment.yaml
+++ b/tests/stacks/kubernetes/test_data/expected/apps_v1_deployment_admission-webhook-deployment.yaml
@@ -29,7 +29,7 @@ spec:
       - args:
         - --tlsCertFile=/etc/webhook/certs/tls.crt
         - --tlsKeyFile=/etc/webhook/certs/tls.key
-        image: gcr.io/kubeflow-images-public/admission-webhook:vmaster-gaf96e4e3
+        image: gcr.io/kubeflow-images-public/admission-webhook:vmaster-ge5452b6f
         name: admission-webhook
         volumeMounts:
         - mountPath: /etc/webhook/certs

--- a/tests/stacks/kubernetes/test_data/expected/apps_v1_deployment_centraldashboard.yaml
+++ b/tests/stacks/kubernetes/test_data/expected/apps_v1_deployment_centraldashboard.yaml
@@ -35,7 +35,7 @@ spec:
             configMapKeyRef:
               key: userid-prefix
               name: kubeflow-config
-        image: gcr.io/kubeflow-images-public/centraldashboard:vmaster-gd601b2d0
+        image: gcr.io/kubeflow-images-public/centraldashboard:vmaster-g8097cfeb
         imagePullPolicy: IfNotPresent
         livenessProbe:
           httpGet:

--- a/tests/stacks/kubernetes/test_data/expected/apps_v1_deployment_jupyter-web-app-deployment.yaml
+++ b/tests/stacks/kubernetes/test_data/expected/apps_v1_deployment_jupyter-web-app-deployment.yaml
@@ -32,7 +32,7 @@ spec:
             configMapKeyRef:
               key: userid-prefix
               name: kubeflow-config
-        image: gcr.io/kubeflow-images-public/jupyter-web-app:vmaster-gd9be4b9e
+        image: gcr.io/kubeflow-images-public/jupyter-web-app:vmaster-g845af298
         name: jupyter-web-app
         ports:
         - containerPort: 5000

--- a/tests/stacks/kubernetes/test_data/expected/apps_v1_deployment_notebook-controller-deployment.yaml
+++ b/tests/stacks/kubernetes/test_data/expected/apps_v1_deployment_notebook-controller-deployment.yaml
@@ -39,7 +39,7 @@ spec:
             configMapKeyRef:
               key: ISTIO_GATEWAY
               name: notebook-controller-notebook-controller-config-h4d668t5tb
-        image: gcr.io/kubeflow-images-public/notebook-controller:vmaster-gf39279c0
+        image: gcr.io/kubeflow-images-public/notebook-controller:vmaster-g6eb007d0
         imagePullPolicy: Always
         livenessProbe:
           httpGet:

--- a/tests/stacks/kubernetes/test_data/expected/apps_v1_deployment_profiles-deployment.yaml
+++ b/tests/stacks/kubernetes/test_data/expected/apps_v1_deployment_profiles-deployment.yaml
@@ -43,7 +43,7 @@ spec:
             configMapKeyRef:
               key: gcp-sa
               name: profiles-profiles-config-4mgcmtgk6t
-        image: gcr.io/kubeflow-images-public/profile-controller:vmaster-g34aa47c2
+        image: gcr.io/kubeflow-images-public/profile-controller:vmaster-ga49f658f
         imagePullPolicy: Always
         livenessProbe:
           httpGet:
@@ -81,7 +81,7 @@ spec:
             configMapKeyRef:
               key: admin
               name: profiles-profiles-config-4mgcmtgk6t
-        image: gcr.io/kubeflow-images-public/kfam:vmaster-gf3e09203
+        image: gcr.io/kubeflow-images-public/kfam:vmaster-g9f3bfd00
         imagePullPolicy: Always
         livenessProbe:
           httpGet:

--- a/tests/stacks/openshift/application/notebook-controller/test_data/expected/apps_v1_deployment_notebook-controller-deployment.yaml
+++ b/tests/stacks/openshift/application/notebook-controller/test_data/expected/apps_v1_deployment_notebook-controller-deployment.yaml
@@ -41,7 +41,7 @@ spec:
             configMapKeyRef:
               key: ISTIO_GATEWAY
               name: notebook-controller-notebook-controller-config-h4d668t5tb
-        image: gcr.io/kubeflow-images-public/notebook-controller:vmaster-gf39279c0
+        image: gcr.io/kubeflow-images-public/notebook-controller:vmaster-g6eb007d0
         imagePullPolicy: Always
         livenessProbe:
           httpGet:

--- a/tests/stacks/openshift/application/profiles/test_data/expected/apps_v1_deployment_profiles-deployment.yaml
+++ b/tests/stacks/openshift/application/profiles/test_data/expected/apps_v1_deployment_profiles-deployment.yaml
@@ -43,7 +43,7 @@ spec:
             configMapKeyRef:
               key: gcp-sa
               name: profiles-profiles-config-4mgcmtgk6t
-        image: gcr.io/kubeflow-images-public/profile-controller:vmaster-g34aa47c2
+        image: gcr.io/kubeflow-images-public/profile-controller:vmaster-ga49f658f
         imagePullPolicy: Always
         livenessProbe:
           httpGet:
@@ -81,7 +81,7 @@ spec:
             configMapKeyRef:
               key: admin
               name: profiles-profiles-config-4mgcmtgk6t
-        image: gcr.io/kubeflow-images-public/kfam:vmaster-gf3e09203
+        image: gcr.io/kubeflow-images-public/kfam:vmaster-g9f3bfd00
         imagePullPolicy: Always
         livenessProbe:
           httpGet:

--- a/tests/stacks/openshift/test_data/expected/apps_v1_deployment_centraldashboard.yaml
+++ b/tests/stacks/openshift/test_data/expected/apps_v1_deployment_centraldashboard.yaml
@@ -35,7 +35,7 @@ spec:
             configMapKeyRef:
               key: userid-prefix
               name: kubeflow-config-f5fk62kk74
-        image: gcr.io/kubeflow-images-public/centraldashboard:vmaster-gd601b2d0
+        image: gcr.io/kubeflow-images-public/centraldashboard:vmaster-g8097cfeb
         imagePullPolicy: IfNotPresent
         livenessProbe:
           httpGet:

--- a/tests/stacks/openshift/test_data/expected/apps_v1_deployment_profiles-deployment.yaml
+++ b/tests/stacks/openshift/test_data/expected/apps_v1_deployment_profiles-deployment.yaml
@@ -81,7 +81,7 @@ spec:
             configMapKeyRef:
               key: admin
               name: profiles-profiles-config-4mgcmtgk6t
-        image: gcr.io/kubeflow-images-public/kfam:vmaster-gf3e09203
+        image: gcr.io/kubeflow-images-public/kfam:vmaster-g9f3bfd00
         imagePullPolicy: Always
         livenessProbe:
           httpGet:

--- a/tests/tests/legacy_kustomizations/centraldashboard/test_data/expected/apps_v1_deployment_centraldashboard.yaml
+++ b/tests/tests/legacy_kustomizations/centraldashboard/test_data/expected/apps_v1_deployment_centraldashboard.yaml
@@ -50,7 +50,7 @@ spec:
           value: "true"
         - name: DASHBOARD_LINKS_CONFIGMAP
           value: centraldashboard-links-config
-        image: gcr.io/kubeflow-images-public/centraldashboard:vmaster-gf39279c0
+        image: gcr.io/kubeflow-images-public/centraldashboard:vmaster-g8097cfeb
         imagePullPolicy: IfNotPresent
         livenessProbe:
           httpGet:

--- a/tests/tests/legacy_kustomizations/webhook/test_data/expected/apps_v1_deployment_admission-webhook-deployment.yaml
+++ b/tests/tests/legacy_kustomizations/webhook/test_data/expected/apps_v1_deployment_admission-webhook-deployment.yaml
@@ -38,7 +38,7 @@ spec:
         kustomize.component: admission-webhook
     spec:
       containers:
-      - image: gcr.io/kubeflow-images-public/admission-webhook:vmaster-gaf96e4e3
+      - image: gcr.io/kubeflow-images-public/admission-webhook:vmaster-ge5452b6f
         name: admission-webhook
         volumeMounts:
         - mountPath: /etc/webhook/certs


### PR DESCRIPTION
**Which issue is resolved by this Pull Request:**

This resolves #1553 (for the components that belong to wg-notebook)

**Description of your changes:**

Updates the image tags for the following applications:
* admission-webhook
* centraldashboard
* jupyter-web-app
* notebook-controller
* kfam
* profile-controller

**Checklist:**
- [X] Unit tests have been rebuilt: 
    1. `cd manifests/tests`
    2. `make generate-changed-only`
    3. `make test`
