### PR TITLE
fix application selectors

### DIFF
--- a/admission-webhook/webhook/overlays/application/application.yaml
+++ b/admission-webhook/webhook/overlays/application/application.yaml
@@ -8,23 +8,23 @@ spec:
       # TODO(jlewi): We should probably rename the app to PodDefaults
       # as that is what the admission controller is actually doing.
       # webhook is generic and uninformative.      
+      app.kubernetes.io/component: webhook
       app.kubernetes.io/name: webhook
-      app.kubernetes.io/instance: webhook-v1.0.0
-      app.kubernetes.io/managed-by: kfctl
-      app.kubernetes.io/component: bootstrap
-      app.kubernetes.io/part-of: webhook
-      app.kubernetes.io/version: v1.0.0
   componentKinds:
-  # Do not select any cluster scoped resources
-  # as that will cause problems.
   - group: core
     kind: ConfigMap
   - group: apps
-    kind: StatefulSet
+    kind: Deployment
+  - group: rbac.authorization.k8s.io
+    kind: Role
+  - group: rbac.authorization.k8s.io
+    kind: RoleBinding
   - group: core
     kind: Service
   - group: core
     kind: ServiceAccount
+  - group: apps
+    kind: StatefulSet
   descriptor:
     type: bootstrap
     version: v1beta1

--- a/common/centraldashboard/overlays/application/application.yaml
+++ b/common/centraldashboard/overlays/application/application.yaml
@@ -5,25 +5,21 @@ metadata:
 spec:
   selector:
     matchLabels:
-      app.kubernetes.io/name: centraldashboard
-      app.kubernetes.io/instance: centraldashboard-v0.7.0
-      app.kubernetes.io/managed-by: kfctl
       app.kubernetes.io/component: centraldashboard
-      app.kubernetes.io/part-of: kubeflow
-      app.kubernetes.io/version: v0.7.0
+      app.kubernetes.io/name: centraldashboard
   componentKinds:
   - group: core
     kind: ConfigMap
   - group: apps
     kind: Deployment
   - group: rbac.authorization.k8s.io
-    kind: RoleBinding
-  - group: rbac.authorization.k8s.io
     kind: Role
-  - group: core
-    kind: ServiceAccount
+  - group: rbac.authorization.k8s.io
+    kind: RoleBinding
   - group: core
     kind: Service
+  - group: core
+    kind: ServiceAccount
   - group: networking.istio.io
     kind: VirtualService
   descriptor:

--- a/jupyter/jupyter-web-app/overlays/application/application.yaml
+++ b/jupyter/jupyter-web-app/overlays/application/application.yaml
@@ -5,25 +5,21 @@ metadata:
 spec:
   selector:
     matchLabels:
-      app.kubernetes.io/name: jupyter-web-app
-      app.kubernetes.io/instance: jupyter-web-app-v0.7.0
-      app.kubernetes.io/managed-by: kfctl
       app.kubernetes.io/component: jupyter-web-app
-      app.kubernetes.io/part-of: kubeflow
-      app.kubernetes.io/version: v0.7.0
+      app.kubernetes.io/name: jupyter-web-app
   componentKinds:
   - group: core
     kind: ConfigMap
   - group: apps
     kind: Deployment
   - group: rbac.authorization.k8s.io
-    kind: RoleBinding
-  - group: rbac.authorization.k8s.io
     kind: Role
-  - group: core
-    kind: ServiceAccount
+  - group: rbac.authorization.k8s.io
+    kind: RoleBinding
   - group: core
     kind: Service
+  - group: core
+    kind: ServiceAccount
   - group: networking.istio.io
     kind: VirtualService
   descriptor:

--- a/jupyter/notebook-controller/overlays/application/application.yaml
+++ b/jupyter/notebook-controller/overlays/application/application.yaml
@@ -5,19 +5,17 @@ metadata:
 spec:
   selector:
     matchLabels:
-      app.kubernetes.io/name: notebook-controller
-      app.kubernetes.io/instance: notebook-controller-v1.0.0
-      app.kubernetes.io/managed-by: kfctl
       app.kubernetes.io/component: notebook-controller
-      app.kubernetes.io/part-of: kubeflow
-      app.kubernetes.io/version: v1.0.0
+      app.kubernetes.io/name: notebook-controller
   componentKinds:
-    - group: core
-      kind: Service
-    - group: apps
-      kind: Deployment
-    - group: core
-      kind: ServiceAccount
+  - group: core
+    kind: ConfigMap
+  - group: apps
+    kind: Deployment
+  - group: core
+    kind: Service
+  - group: core
+    kind: ServiceAccount
   descriptor:
     type: notebook-controller
     version: v1beta1

--- a/profiles/overlays/application/application.yaml
+++ b/profiles/overlays/application/application.yaml
@@ -5,23 +5,17 @@ metadata:
 spec:
   selector:
     matchLabels:
-      app.kubernetes.io/name: profiles
-      app.kubernetes.io/instance: profiles-v1.0.0
-      app.kubernetes.io/managed-by: kfctl
       app.kubernetes.io/component: profiles
-      app.kubernetes.io/part-of: kubeflow
-      app.kubernetes.io/version: v1.0.0
+      app.kubernetes.io/name: profiles
   componentKinds:
-  # Do not select any cluster scoped resources
-  # as that will cause problems.
+  - group: core
+    kind: ConfigMap
   - group: apps
     kind: Deployment
   - group: core
-    kind: ServiceAccount
-  - group: core
     kind: Service
-  - group: kubeflow.org
-    kind: Profile
+  - group: core
+    kind: ServiceAccount
   descriptor:
     type: profiles
     version: v1

--- a/tests/stacks/aws/application/jupyter-web-app/test_data/expected/app.k8s.io_v1beta1_application_jupyter-web-app-jupyter-web-app.yaml
+++ b/tests/stacks/aws/application/jupyter-web-app/test_data/expected/app.k8s.io_v1beta1_application_jupyter-web-app-jupyter-web-app.yaml
@@ -16,13 +16,13 @@ spec:
   - group: apps
     kind: Deployment
   - group: rbac.authorization.k8s.io
-    kind: RoleBinding
-  - group: rbac.authorization.k8s.io
     kind: Role
-  - group: core
-    kind: ServiceAccount
+  - group: rbac.authorization.k8s.io
+    kind: RoleBinding
   - group: core
     kind: Service
+  - group: core
+    kind: ServiceAccount
   - group: networking.istio.io
     kind: VirtualService
   descriptor:
@@ -48,8 +48,4 @@ spec:
   selector:
     matchLabels:
       app.kubernetes.io/component: jupyter-web-app
-      app.kubernetes.io/instance: jupyter-web-app-v0.7.0
-      app.kubernetes.io/managed-by: kfctl
       app.kubernetes.io/name: jupyter-web-app
-      app.kubernetes.io/part-of: kubeflow
-      app.kubernetes.io/version: v0.7.0

--- a/tests/stacks/aws/test_data/expected/app.k8s.io_v1beta1_application_centraldashboard.yaml
+++ b/tests/stacks/aws/test_data/expected/app.k8s.io_v1beta1_application_centraldashboard.yaml
@@ -14,13 +14,13 @@ spec:
   - group: apps
     kind: Deployment
   - group: rbac.authorization.k8s.io
-    kind: RoleBinding
-  - group: rbac.authorization.k8s.io
     kind: Role
-  - group: core
-    kind: ServiceAccount
+  - group: rbac.authorization.k8s.io
+    kind: RoleBinding
   - group: core
     kind: Service
+  - group: core
+    kind: ServiceAccount
   - group: networking.istio.io
     kind: VirtualService
   descriptor:
@@ -50,8 +50,4 @@ spec:
   selector:
     matchLabels:
       app.kubernetes.io/component: centraldashboard
-      app.kubernetes.io/instance: centraldashboard-v0.7.0
-      app.kubernetes.io/managed-by: kfctl
       app.kubernetes.io/name: centraldashboard
-      app.kubernetes.io/part-of: kubeflow
-      app.kubernetes.io/version: v0.7.0

--- a/tests/stacks/aws/test_data/expected/app.k8s.io_v1beta1_application_jupyter-web-app-jupyter-web-app.yaml
+++ b/tests/stacks/aws/test_data/expected/app.k8s.io_v1beta1_application_jupyter-web-app-jupyter-web-app.yaml
@@ -16,13 +16,13 @@ spec:
   - group: apps
     kind: Deployment
   - group: rbac.authorization.k8s.io
-    kind: RoleBinding
-  - group: rbac.authorization.k8s.io
     kind: Role
-  - group: core
-    kind: ServiceAccount
+  - group: rbac.authorization.k8s.io
+    kind: RoleBinding
   - group: core
     kind: Service
+  - group: core
+    kind: ServiceAccount
   - group: networking.istio.io
     kind: VirtualService
   descriptor:
@@ -48,8 +48,4 @@ spec:
   selector:
     matchLabels:
       app.kubernetes.io/component: jupyter-web-app
-      app.kubernetes.io/instance: jupyter-web-app-v0.7.0
-      app.kubernetes.io/managed-by: kfctl
       app.kubernetes.io/name: jupyter-web-app
-      app.kubernetes.io/part-of: kubeflow
-      app.kubernetes.io/version: v0.7.0

--- a/tests/stacks/aws/test_data/expected/app.k8s.io_v1beta1_application_notebook-controller-notebook-controller.yaml
+++ b/tests/stacks/aws/test_data/expected/app.k8s.io_v1beta1_application_notebook-controller-notebook-controller.yaml
@@ -12,9 +12,11 @@ spec:
   addOwnerRef: true
   componentKinds:
   - group: core
-    kind: Service
+    kind: ConfigMap
   - group: apps
     kind: Deployment
+  - group: core
+    kind: Service
   - group: core
     kind: ServiceAccount
   descriptor:
@@ -39,8 +41,4 @@ spec:
   selector:
     matchLabels:
       app.kubernetes.io/component: notebook-controller
-      app.kubernetes.io/instance: notebook-controller-v1.0.0
-      app.kubernetes.io/managed-by: kfctl
       app.kubernetes.io/name: notebook-controller
-      app.kubernetes.io/part-of: kubeflow
-      app.kubernetes.io/version: v1.0.0

--- a/tests/stacks/aws/test_data/expected/app.k8s.io_v1beta1_application_profiles-profiles.yaml
+++ b/tests/stacks/aws/test_data/expected/app.k8s.io_v1beta1_application_profiles-profiles.yaml
@@ -8,14 +8,14 @@ metadata:
 spec:
   addOwnerRef: true
   componentKinds:
+  - group: core
+    kind: ConfigMap
   - group: apps
     kind: Deployment
   - group: core
-    kind: ServiceAccount
-  - group: core
     kind: Service
-  - group: kubeflow.org
-    kind: Profile
+  - group: core
+    kind: ServiceAccount
   descriptor:
     description: ""
     keywords:
@@ -37,8 +37,4 @@ spec:
   selector:
     matchLabels:
       app.kubernetes.io/component: profiles
-      app.kubernetes.io/instance: profiles-v1.0.0
-      app.kubernetes.io/managed-by: kfctl
       app.kubernetes.io/name: profiles
-      app.kubernetes.io/part-of: kubeflow
-      app.kubernetes.io/version: v1.0.0

--- a/tests/stacks/aws/test_data/expected/app.k8s.io_v1beta1_application_webhook.yaml
+++ b/tests/stacks/aws/test_data/expected/app.k8s.io_v1beta1_application_webhook.yaml
@@ -12,11 +12,17 @@ spec:
   - group: core
     kind: ConfigMap
   - group: apps
-    kind: StatefulSet
+    kind: Deployment
+  - group: rbac.authorization.k8s.io
+    kind: Role
+  - group: rbac.authorization.k8s.io
+    kind: RoleBinding
   - group: core
     kind: Service
   - group: core
     kind: ServiceAccount
+  - group: apps
+    kind: StatefulSet
   descriptor:
     description: injects volume, volume mounts, env vars into PodDefault
     keywords:
@@ -31,9 +37,5 @@ spec:
     version: v1beta1
   selector:
     matchLabels:
-      app.kubernetes.io/component: bootstrap
-      app.kubernetes.io/instance: webhook-v1.0.0
-      app.kubernetes.io/managed-by: kfctl
+      app.kubernetes.io/component: webhook
       app.kubernetes.io/name: webhook
-      app.kubernetes.io/part-of: webhook
-      app.kubernetes.io/version: v1.0.0

--- a/tests/stacks/azure/application/jupyter-web-app/test_data/expected/app.k8s.io_v1beta1_application_jupyter-web-app.yaml
+++ b/tests/stacks/azure/application/jupyter-web-app/test_data/expected/app.k8s.io_v1beta1_application_jupyter-web-app.yaml
@@ -14,13 +14,13 @@ spec:
   - group: apps
     kind: Deployment
   - group: rbac.authorization.k8s.io
-    kind: RoleBinding
-  - group: rbac.authorization.k8s.io
     kind: Role
-  - group: core
-    kind: ServiceAccount
+  - group: rbac.authorization.k8s.io
+    kind: RoleBinding
   - group: core
     kind: Service
+  - group: core
+    kind: ServiceAccount
   - group: networking.istio.io
     kind: VirtualService
   descriptor:
@@ -46,8 +46,4 @@ spec:
   selector:
     matchLabels:
       app.kubernetes.io/component: jupyter-web-app
-      app.kubernetes.io/instance: jupyter-web-app-v0.7.0
-      app.kubernetes.io/managed-by: kfctl
       app.kubernetes.io/name: jupyter-web-app
-      app.kubernetes.io/part-of: kubeflow
-      app.kubernetes.io/version: v0.7.0

--- a/tests/stacks/azure/test_data/expected/app.k8s.io_v1beta1_application_centraldashboard.yaml
+++ b/tests/stacks/azure/test_data/expected/app.k8s.io_v1beta1_application_centraldashboard.yaml
@@ -14,13 +14,13 @@ spec:
   - group: apps
     kind: Deployment
   - group: rbac.authorization.k8s.io
-    kind: RoleBinding
-  - group: rbac.authorization.k8s.io
     kind: Role
-  - group: core
-    kind: ServiceAccount
+  - group: rbac.authorization.k8s.io
+    kind: RoleBinding
   - group: core
     kind: Service
+  - group: core
+    kind: ServiceAccount
   - group: networking.istio.io
     kind: VirtualService
   descriptor:
@@ -50,8 +50,4 @@ spec:
   selector:
     matchLabels:
       app.kubernetes.io/component: centraldashboard
-      app.kubernetes.io/instance: centraldashboard-v0.7.0
-      app.kubernetes.io/managed-by: kfctl
       app.kubernetes.io/name: centraldashboard
-      app.kubernetes.io/part-of: kubeflow
-      app.kubernetes.io/version: v0.7.0

--- a/tests/stacks/azure/test_data/expected/app.k8s.io_v1beta1_application_jupyter-web-app.yaml
+++ b/tests/stacks/azure/test_data/expected/app.k8s.io_v1beta1_application_jupyter-web-app.yaml
@@ -14,13 +14,13 @@ spec:
   - group: apps
     kind: Deployment
   - group: rbac.authorization.k8s.io
-    kind: RoleBinding
-  - group: rbac.authorization.k8s.io
     kind: Role
-  - group: core
-    kind: ServiceAccount
+  - group: rbac.authorization.k8s.io
+    kind: RoleBinding
   - group: core
     kind: Service
+  - group: core
+    kind: ServiceAccount
   - group: networking.istio.io
     kind: VirtualService
   descriptor:
@@ -46,8 +46,4 @@ spec:
   selector:
     matchLabels:
       app.kubernetes.io/component: jupyter-web-app
-      app.kubernetes.io/instance: jupyter-web-app-v0.7.0
-      app.kubernetes.io/managed-by: kfctl
       app.kubernetes.io/name: jupyter-web-app
-      app.kubernetes.io/part-of: kubeflow
-      app.kubernetes.io/version: v0.7.0

--- a/tests/stacks/azure/test_data/expected/app.k8s.io_v1beta1_application_notebook-controller-notebook-controller.yaml
+++ b/tests/stacks/azure/test_data/expected/app.k8s.io_v1beta1_application_notebook-controller-notebook-controller.yaml
@@ -12,9 +12,11 @@ spec:
   addOwnerRef: true
   componentKinds:
   - group: core
-    kind: Service
+    kind: ConfigMap
   - group: apps
     kind: Deployment
+  - group: core
+    kind: Service
   - group: core
     kind: ServiceAccount
   descriptor:
@@ -39,8 +41,4 @@ spec:
   selector:
     matchLabels:
       app.kubernetes.io/component: notebook-controller
-      app.kubernetes.io/instance: notebook-controller-v1.0.0
-      app.kubernetes.io/managed-by: kfctl
       app.kubernetes.io/name: notebook-controller
-      app.kubernetes.io/part-of: kubeflow
-      app.kubernetes.io/version: v1.0.0

--- a/tests/stacks/azure/test_data/expected/app.k8s.io_v1beta1_application_profiles-profiles.yaml
+++ b/tests/stacks/azure/test_data/expected/app.k8s.io_v1beta1_application_profiles-profiles.yaml
@@ -8,14 +8,14 @@ metadata:
 spec:
   addOwnerRef: true
   componentKinds:
+  - group: core
+    kind: ConfigMap
   - group: apps
     kind: Deployment
   - group: core
-    kind: ServiceAccount
-  - group: core
     kind: Service
-  - group: kubeflow.org
-    kind: Profile
+  - group: core
+    kind: ServiceAccount
   descriptor:
     description: ""
     keywords:
@@ -37,8 +37,4 @@ spec:
   selector:
     matchLabels:
       app.kubernetes.io/component: profiles
-      app.kubernetes.io/instance: profiles-v1.0.0
-      app.kubernetes.io/managed-by: kfctl
       app.kubernetes.io/name: profiles
-      app.kubernetes.io/part-of: kubeflow
-      app.kubernetes.io/version: v1.0.0

--- a/tests/stacks/azure/test_data/expected/app.k8s.io_v1beta1_application_webhook.yaml
+++ b/tests/stacks/azure/test_data/expected/app.k8s.io_v1beta1_application_webhook.yaml
@@ -12,11 +12,17 @@ spec:
   - group: core
     kind: ConfigMap
   - group: apps
-    kind: StatefulSet
+    kind: Deployment
+  - group: rbac.authorization.k8s.io
+    kind: Role
+  - group: rbac.authorization.k8s.io
+    kind: RoleBinding
   - group: core
     kind: Service
   - group: core
     kind: ServiceAccount
+  - group: apps
+    kind: StatefulSet
   descriptor:
     description: injects volume, volume mounts, env vars into PodDefault
     keywords:
@@ -31,9 +37,5 @@ spec:
     version: v1beta1
   selector:
     matchLabels:
-      app.kubernetes.io/component: bootstrap
-      app.kubernetes.io/instance: webhook-v1.0.0
-      app.kubernetes.io/managed-by: kfctl
+      app.kubernetes.io/component: webhook
       app.kubernetes.io/name: webhook
-      app.kubernetes.io/part-of: webhook
-      app.kubernetes.io/version: v1.0.0

--- a/tests/stacks/examples/alice/test_data/expected/app.k8s.io_v1beta1_application_centraldashboard.yaml
+++ b/tests/stacks/examples/alice/test_data/expected/app.k8s.io_v1beta1_application_centraldashboard.yaml
@@ -14,13 +14,13 @@ spec:
   - group: apps
     kind: Deployment
   - group: rbac.authorization.k8s.io
-    kind: RoleBinding
-  - group: rbac.authorization.k8s.io
     kind: Role
-  - group: core
-    kind: ServiceAccount
+  - group: rbac.authorization.k8s.io
+    kind: RoleBinding
   - group: core
     kind: Service
+  - group: core
+    kind: ServiceAccount
   - group: networking.istio.io
     kind: VirtualService
   descriptor:
@@ -50,8 +50,4 @@ spec:
   selector:
     matchLabels:
       app.kubernetes.io/component: centraldashboard
-      app.kubernetes.io/instance: centraldashboard-v0.7.0
-      app.kubernetes.io/managed-by: kfctl
       app.kubernetes.io/name: centraldashboard
-      app.kubernetes.io/part-of: kubeflow
-      app.kubernetes.io/version: v0.7.0

--- a/tests/stacks/examples/alice/test_data/expected/app.k8s.io_v1beta1_application_jupyter-web-app-jupyter-web-app.yaml
+++ b/tests/stacks/examples/alice/test_data/expected/app.k8s.io_v1beta1_application_jupyter-web-app-jupyter-web-app.yaml
@@ -16,13 +16,13 @@ spec:
   - group: apps
     kind: Deployment
   - group: rbac.authorization.k8s.io
-    kind: RoleBinding
-  - group: rbac.authorization.k8s.io
     kind: Role
-  - group: core
-    kind: ServiceAccount
+  - group: rbac.authorization.k8s.io
+    kind: RoleBinding
   - group: core
     kind: Service
+  - group: core
+    kind: ServiceAccount
   - group: networking.istio.io
     kind: VirtualService
   descriptor:
@@ -48,8 +48,4 @@ spec:
   selector:
     matchLabels:
       app.kubernetes.io/component: jupyter-web-app
-      app.kubernetes.io/instance: jupyter-web-app-v0.7.0
-      app.kubernetes.io/managed-by: kfctl
       app.kubernetes.io/name: jupyter-web-app
-      app.kubernetes.io/part-of: kubeflow
-      app.kubernetes.io/version: v0.7.0

--- a/tests/stacks/examples/alice/test_data/expected/app.k8s.io_v1beta1_application_notebook-controller-notebook-controller.yaml
+++ b/tests/stacks/examples/alice/test_data/expected/app.k8s.io_v1beta1_application_notebook-controller-notebook-controller.yaml
@@ -12,9 +12,11 @@ spec:
   addOwnerRef: true
   componentKinds:
   - group: core
-    kind: Service
+    kind: ConfigMap
   - group: apps
     kind: Deployment
+  - group: core
+    kind: Service
   - group: core
     kind: ServiceAccount
   descriptor:
@@ -39,8 +41,4 @@ spec:
   selector:
     matchLabels:
       app.kubernetes.io/component: notebook-controller
-      app.kubernetes.io/instance: notebook-controller-v1.0.0
-      app.kubernetes.io/managed-by: kfctl
       app.kubernetes.io/name: notebook-controller
-      app.kubernetes.io/part-of: kubeflow
-      app.kubernetes.io/version: v1.0.0

--- a/tests/stacks/examples/alice/test_data/expected/app.k8s.io_v1beta1_application_profiles-profiles.yaml
+++ b/tests/stacks/examples/alice/test_data/expected/app.k8s.io_v1beta1_application_profiles-profiles.yaml
@@ -8,14 +8,14 @@ metadata:
 spec:
   addOwnerRef: true
   componentKinds:
+  - group: core
+    kind: ConfigMap
   - group: apps
     kind: Deployment
   - group: core
-    kind: ServiceAccount
-  - group: core
     kind: Service
-  - group: kubeflow.org
-    kind: Profile
+  - group: core
+    kind: ServiceAccount
   descriptor:
     description: ""
     keywords:
@@ -37,8 +37,4 @@ spec:
   selector:
     matchLabels:
       app.kubernetes.io/component: profiles
-      app.kubernetes.io/instance: profiles-v1.0.0
-      app.kubernetes.io/managed-by: kfctl
       app.kubernetes.io/name: profiles
-      app.kubernetes.io/part-of: kubeflow
-      app.kubernetes.io/version: v1.0.0

--- a/tests/stacks/examples/alice/test_data/expected/app.k8s.io_v1beta1_application_webhook.yaml
+++ b/tests/stacks/examples/alice/test_data/expected/app.k8s.io_v1beta1_application_webhook.yaml
@@ -12,11 +12,17 @@ spec:
   - group: core
     kind: ConfigMap
   - group: apps
-    kind: StatefulSet
+    kind: Deployment
+  - group: rbac.authorization.k8s.io
+    kind: Role
+  - group: rbac.authorization.k8s.io
+    kind: RoleBinding
   - group: core
     kind: Service
   - group: core
     kind: ServiceAccount
+  - group: apps
+    kind: StatefulSet
   descriptor:
     description: injects volume, volume mounts, env vars into PodDefault
     keywords:
@@ -31,9 +37,5 @@ spec:
     version: v1beta1
   selector:
     matchLabels:
-      app.kubernetes.io/component: bootstrap
-      app.kubernetes.io/instance: webhook-v1.0.0
-      app.kubernetes.io/managed-by: kfctl
+      app.kubernetes.io/component: webhook
       app.kubernetes.io/name: webhook
-      app.kubernetes.io/part-of: webhook
-      app.kubernetes.io/version: v1.0.0

--- a/tests/stacks/gcp/test_data/expected/app.k8s.io_v1beta1_application_centraldashboard.yaml
+++ b/tests/stacks/gcp/test_data/expected/app.k8s.io_v1beta1_application_centraldashboard.yaml
@@ -14,13 +14,13 @@ spec:
   - group: apps
     kind: Deployment
   - group: rbac.authorization.k8s.io
-    kind: RoleBinding
-  - group: rbac.authorization.k8s.io
     kind: Role
-  - group: core
-    kind: ServiceAccount
+  - group: rbac.authorization.k8s.io
+    kind: RoleBinding
   - group: core
     kind: Service
+  - group: core
+    kind: ServiceAccount
   - group: networking.istio.io
     kind: VirtualService
   descriptor:
@@ -50,8 +50,4 @@ spec:
   selector:
     matchLabels:
       app.kubernetes.io/component: centraldashboard
-      app.kubernetes.io/instance: centraldashboard-v0.7.0
-      app.kubernetes.io/managed-by: kfctl
       app.kubernetes.io/name: centraldashboard
-      app.kubernetes.io/part-of: kubeflow
-      app.kubernetes.io/version: v0.7.0

--- a/tests/stacks/gcp/test_data/expected/app.k8s.io_v1beta1_application_jupyter-web-app-jupyter-web-app.yaml
+++ b/tests/stacks/gcp/test_data/expected/app.k8s.io_v1beta1_application_jupyter-web-app-jupyter-web-app.yaml
@@ -16,13 +16,13 @@ spec:
   - group: apps
     kind: Deployment
   - group: rbac.authorization.k8s.io
-    kind: RoleBinding
-  - group: rbac.authorization.k8s.io
     kind: Role
-  - group: core
-    kind: ServiceAccount
+  - group: rbac.authorization.k8s.io
+    kind: RoleBinding
   - group: core
     kind: Service
+  - group: core
+    kind: ServiceAccount
   - group: networking.istio.io
     kind: VirtualService
   descriptor:
@@ -48,8 +48,4 @@ spec:
   selector:
     matchLabels:
       app.kubernetes.io/component: jupyter-web-app
-      app.kubernetes.io/instance: jupyter-web-app-v0.7.0
-      app.kubernetes.io/managed-by: kfctl
       app.kubernetes.io/name: jupyter-web-app
-      app.kubernetes.io/part-of: kubeflow
-      app.kubernetes.io/version: v0.7.0

--- a/tests/stacks/gcp/test_data/expected/app.k8s.io_v1beta1_application_notebook-controller-notebook-controller.yaml
+++ b/tests/stacks/gcp/test_data/expected/app.k8s.io_v1beta1_application_notebook-controller-notebook-controller.yaml
@@ -12,9 +12,11 @@ spec:
   addOwnerRef: true
   componentKinds:
   - group: core
-    kind: Service
+    kind: ConfigMap
   - group: apps
     kind: Deployment
+  - group: core
+    kind: Service
   - group: core
     kind: ServiceAccount
   descriptor:
@@ -39,8 +41,4 @@ spec:
   selector:
     matchLabels:
       app.kubernetes.io/component: notebook-controller
-      app.kubernetes.io/instance: notebook-controller-v1.0.0
-      app.kubernetes.io/managed-by: kfctl
       app.kubernetes.io/name: notebook-controller
-      app.kubernetes.io/part-of: kubeflow
-      app.kubernetes.io/version: v1.0.0

--- a/tests/stacks/gcp/test_data/expected/app.k8s.io_v1beta1_application_profiles-profiles.yaml
+++ b/tests/stacks/gcp/test_data/expected/app.k8s.io_v1beta1_application_profiles-profiles.yaml
@@ -8,14 +8,14 @@ metadata:
 spec:
   addOwnerRef: true
   componentKinds:
+  - group: core
+    kind: ConfigMap
   - group: apps
     kind: Deployment
   - group: core
-    kind: ServiceAccount
-  - group: core
     kind: Service
-  - group: kubeflow.org
-    kind: Profile
+  - group: core
+    kind: ServiceAccount
   descriptor:
     description: ""
     keywords:
@@ -37,8 +37,4 @@ spec:
   selector:
     matchLabels:
       app.kubernetes.io/component: profiles
-      app.kubernetes.io/instance: profiles-v1.0.0
-      app.kubernetes.io/managed-by: kfctl
       app.kubernetes.io/name: profiles
-      app.kubernetes.io/part-of: kubeflow
-      app.kubernetes.io/version: v1.0.0

--- a/tests/stacks/gcp/test_data/expected/app.k8s.io_v1beta1_application_webhook.yaml
+++ b/tests/stacks/gcp/test_data/expected/app.k8s.io_v1beta1_application_webhook.yaml
@@ -12,11 +12,17 @@ spec:
   - group: core
     kind: ConfigMap
   - group: apps
-    kind: StatefulSet
+    kind: Deployment
+  - group: rbac.authorization.k8s.io
+    kind: Role
+  - group: rbac.authorization.k8s.io
+    kind: RoleBinding
   - group: core
     kind: Service
   - group: core
     kind: ServiceAccount
+  - group: apps
+    kind: StatefulSet
   descriptor:
     description: injects volume, volume mounts, env vars into PodDefault
     keywords:
@@ -31,9 +37,5 @@ spec:
     version: v1beta1
   selector:
     matchLabels:
-      app.kubernetes.io/component: bootstrap
-      app.kubernetes.io/instance: webhook-v1.0.0
-      app.kubernetes.io/managed-by: kfctl
+      app.kubernetes.io/component: webhook
       app.kubernetes.io/name: webhook
-      app.kubernetes.io/part-of: webhook
-      app.kubernetes.io/version: v1.0.0

--- a/tests/stacks/generic/test_data/expected/app.k8s.io_v1beta1_application_centraldashboard.yaml
+++ b/tests/stacks/generic/test_data/expected/app.k8s.io_v1beta1_application_centraldashboard.yaml
@@ -14,13 +14,13 @@ spec:
   - group: apps
     kind: Deployment
   - group: rbac.authorization.k8s.io
-    kind: RoleBinding
-  - group: rbac.authorization.k8s.io
     kind: Role
-  - group: core
-    kind: ServiceAccount
+  - group: rbac.authorization.k8s.io
+    kind: RoleBinding
   - group: core
     kind: Service
+  - group: core
+    kind: ServiceAccount
   - group: networking.istio.io
     kind: VirtualService
   descriptor:
@@ -50,8 +50,4 @@ spec:
   selector:
     matchLabels:
       app.kubernetes.io/component: centraldashboard
-      app.kubernetes.io/instance: centraldashboard-v0.7.0
-      app.kubernetes.io/managed-by: kfctl
       app.kubernetes.io/name: centraldashboard
-      app.kubernetes.io/part-of: kubeflow
-      app.kubernetes.io/version: v0.7.0

--- a/tests/stacks/generic/test_data/expected/app.k8s.io_v1beta1_application_jupyter-web-app-jupyter-web-app.yaml
+++ b/tests/stacks/generic/test_data/expected/app.k8s.io_v1beta1_application_jupyter-web-app-jupyter-web-app.yaml
@@ -16,13 +16,13 @@ spec:
   - group: apps
     kind: Deployment
   - group: rbac.authorization.k8s.io
-    kind: RoleBinding
-  - group: rbac.authorization.k8s.io
     kind: Role
-  - group: core
-    kind: ServiceAccount
+  - group: rbac.authorization.k8s.io
+    kind: RoleBinding
   - group: core
     kind: Service
+  - group: core
+    kind: ServiceAccount
   - group: networking.istio.io
     kind: VirtualService
   descriptor:
@@ -48,8 +48,4 @@ spec:
   selector:
     matchLabels:
       app.kubernetes.io/component: jupyter-web-app
-      app.kubernetes.io/instance: jupyter-web-app-v0.7.0
-      app.kubernetes.io/managed-by: kfctl
       app.kubernetes.io/name: jupyter-web-app
-      app.kubernetes.io/part-of: kubeflow
-      app.kubernetes.io/version: v0.7.0

--- a/tests/stacks/generic/test_data/expected/app.k8s.io_v1beta1_application_notebook-controller-notebook-controller.yaml
+++ b/tests/stacks/generic/test_data/expected/app.k8s.io_v1beta1_application_notebook-controller-notebook-controller.yaml
@@ -12,9 +12,11 @@ spec:
   addOwnerRef: true
   componentKinds:
   - group: core
-    kind: Service
+    kind: ConfigMap
   - group: apps
     kind: Deployment
+  - group: core
+    kind: Service
   - group: core
     kind: ServiceAccount
   descriptor:
@@ -39,8 +41,4 @@ spec:
   selector:
     matchLabels:
       app.kubernetes.io/component: notebook-controller
-      app.kubernetes.io/instance: notebook-controller-v1.0.0
-      app.kubernetes.io/managed-by: kfctl
       app.kubernetes.io/name: notebook-controller
-      app.kubernetes.io/part-of: kubeflow
-      app.kubernetes.io/version: v1.0.0

--- a/tests/stacks/generic/test_data/expected/app.k8s.io_v1beta1_application_profiles-profiles.yaml
+++ b/tests/stacks/generic/test_data/expected/app.k8s.io_v1beta1_application_profiles-profiles.yaml
@@ -8,14 +8,14 @@ metadata:
 spec:
   addOwnerRef: true
   componentKinds:
+  - group: core
+    kind: ConfigMap
   - group: apps
     kind: Deployment
   - group: core
-    kind: ServiceAccount
-  - group: core
     kind: Service
-  - group: kubeflow.org
-    kind: Profile
+  - group: core
+    kind: ServiceAccount
   descriptor:
     description: ""
     keywords:
@@ -37,8 +37,4 @@ spec:
   selector:
     matchLabels:
       app.kubernetes.io/component: profiles
-      app.kubernetes.io/instance: profiles-v1.0.0
-      app.kubernetes.io/managed-by: kfctl
       app.kubernetes.io/name: profiles
-      app.kubernetes.io/part-of: kubeflow
-      app.kubernetes.io/version: v1.0.0

--- a/tests/stacks/generic/test_data/expected/app.k8s.io_v1beta1_application_webhook.yaml
+++ b/tests/stacks/generic/test_data/expected/app.k8s.io_v1beta1_application_webhook.yaml
@@ -12,11 +12,17 @@ spec:
   - group: core
     kind: ConfigMap
   - group: apps
-    kind: StatefulSet
+    kind: Deployment
+  - group: rbac.authorization.k8s.io
+    kind: Role
+  - group: rbac.authorization.k8s.io
+    kind: RoleBinding
   - group: core
     kind: Service
   - group: core
     kind: ServiceAccount
+  - group: apps
+    kind: StatefulSet
   descriptor:
     description: injects volume, volume mounts, env vars into PodDefault
     keywords:
@@ -31,9 +37,5 @@ spec:
     version: v1beta1
   selector:
     matchLabels:
-      app.kubernetes.io/component: bootstrap
-      app.kubernetes.io/instance: webhook-v1.0.0
-      app.kubernetes.io/managed-by: kfctl
+      app.kubernetes.io/component: webhook
       app.kubernetes.io/name: webhook
-      app.kubernetes.io/part-of: webhook
-      app.kubernetes.io/version: v1.0.0

--- a/tests/stacks/ibm/application/admission-webhook/test_data/expected/app.k8s.io_v1beta1_application_webhook.yaml
+++ b/tests/stacks/ibm/application/admission-webhook/test_data/expected/app.k8s.io_v1beta1_application_webhook.yaml
@@ -12,11 +12,17 @@ spec:
   - group: core
     kind: ConfigMap
   - group: apps
-    kind: StatefulSet
+    kind: Deployment
+  - group: rbac.authorization.k8s.io
+    kind: Role
+  - group: rbac.authorization.k8s.io
+    kind: RoleBinding
   - group: core
     kind: Service
   - group: core
     kind: ServiceAccount
+  - group: apps
+    kind: StatefulSet
   descriptor:
     description: injects volume, volume mounts, env vars into PodDefault
     keywords:
@@ -31,9 +37,5 @@ spec:
     version: v1beta1
   selector:
     matchLabels:
-      app.kubernetes.io/component: bootstrap
-      app.kubernetes.io/instance: webhook-v1.0.0
-      app.kubernetes.io/managed-by: kfctl
+      app.kubernetes.io/component: webhook
       app.kubernetes.io/name: webhook
-      app.kubernetes.io/part-of: webhook
-      app.kubernetes.io/version: v1.0.0

--- a/tests/stacks/ibm/application/jupyter-web-app/test_data/expected/app.k8s.io_v1beta1_application_jupyter-web-app.yaml
+++ b/tests/stacks/ibm/application/jupyter-web-app/test_data/expected/app.k8s.io_v1beta1_application_jupyter-web-app.yaml
@@ -14,13 +14,13 @@ spec:
   - group: apps
     kind: Deployment
   - group: rbac.authorization.k8s.io
-    kind: RoleBinding
-  - group: rbac.authorization.k8s.io
     kind: Role
-  - group: core
-    kind: ServiceAccount
+  - group: rbac.authorization.k8s.io
+    kind: RoleBinding
   - group: core
     kind: Service
+  - group: core
+    kind: ServiceAccount
   - group: networking.istio.io
     kind: VirtualService
   descriptor:
@@ -46,8 +46,4 @@ spec:
   selector:
     matchLabels:
       app.kubernetes.io/component: jupyter-web-app
-      app.kubernetes.io/instance: jupyter-web-app-v0.7.0
-      app.kubernetes.io/managed-by: kfctl
       app.kubernetes.io/name: jupyter-web-app
-      app.kubernetes.io/part-of: kubeflow
-      app.kubernetes.io/version: v0.7.0

--- a/tests/stacks/ibm/application/notebook-controller/test_data/expected/default_app.k8s.io_v1beta1_application_notebook-controller.yaml
+++ b/tests/stacks/ibm/application/notebook-controller/test_data/expected/default_app.k8s.io_v1beta1_application_notebook-controller.yaml
@@ -9,9 +9,11 @@ spec:
   addOwnerRef: true
   componentKinds:
   - group: core
-    kind: Service
+    kind: ConfigMap
   - group: apps
     kind: Deployment
+  - group: core
+    kind: Service
   - group: core
     kind: ServiceAccount
   descriptor:
@@ -36,8 +38,4 @@ spec:
   selector:
     matchLabels:
       app.kubernetes.io/component: notebook-controller
-      app.kubernetes.io/instance: notebook-controller-v1.0.0
-      app.kubernetes.io/managed-by: kfctl
       app.kubernetes.io/name: notebook-controller
-      app.kubernetes.io/part-of: kubeflow
-      app.kubernetes.io/version: v1.0.0

--- a/tests/stacks/ibm/application/notebooks/test_data/expected/app.k8s.io_v1beta1_application_jupyter-web-app.yaml
+++ b/tests/stacks/ibm/application/notebooks/test_data/expected/app.k8s.io_v1beta1_application_jupyter-web-app.yaml
@@ -14,13 +14,13 @@ spec:
   - group: apps
     kind: Deployment
   - group: rbac.authorization.k8s.io
-    kind: RoleBinding
-  - group: rbac.authorization.k8s.io
     kind: Role
-  - group: core
-    kind: ServiceAccount
+  - group: rbac.authorization.k8s.io
+    kind: RoleBinding
   - group: core
     kind: Service
+  - group: core
+    kind: ServiceAccount
   - group: networking.istio.io
     kind: VirtualService
   descriptor:
@@ -46,8 +46,4 @@ spec:
   selector:
     matchLabels:
       app.kubernetes.io/component: jupyter-web-app
-      app.kubernetes.io/instance: jupyter-web-app-v0.7.0
-      app.kubernetes.io/managed-by: kfctl
       app.kubernetes.io/name: jupyter-web-app
-      app.kubernetes.io/part-of: kubeflow
-      app.kubernetes.io/version: v0.7.0

--- a/tests/stacks/ibm/application/notebooks/test_data/expected/app.k8s.io_v1beta1_application_notebook-controller.yaml
+++ b/tests/stacks/ibm/application/notebooks/test_data/expected/app.k8s.io_v1beta1_application_notebook-controller.yaml
@@ -10,9 +10,11 @@ spec:
   addOwnerRef: true
   componentKinds:
   - group: core
-    kind: Service
+    kind: ConfigMap
   - group: apps
     kind: Deployment
+  - group: core
+    kind: Service
   - group: core
     kind: ServiceAccount
   descriptor:
@@ -37,8 +39,4 @@ spec:
   selector:
     matchLabels:
       app.kubernetes.io/component: notebook-controller
-      app.kubernetes.io/instance: notebook-controller-v1.0.0
-      app.kubernetes.io/managed-by: kfctl
       app.kubernetes.io/name: notebook-controller
-      app.kubernetes.io/part-of: kubeflow
-      app.kubernetes.io/version: v1.0.0

--- a/tests/stacks/ibm/application/profile-control-plane/test_data/expected/app.k8s.io_v1beta1_application_centraldashboard.yaml
+++ b/tests/stacks/ibm/application/profile-control-plane/test_data/expected/app.k8s.io_v1beta1_application_centraldashboard.yaml
@@ -14,13 +14,13 @@ spec:
   - group: apps
     kind: Deployment
   - group: rbac.authorization.k8s.io
-    kind: RoleBinding
-  - group: rbac.authorization.k8s.io
     kind: Role
-  - group: core
-    kind: ServiceAccount
+  - group: rbac.authorization.k8s.io
+    kind: RoleBinding
   - group: core
     kind: Service
+  - group: core
+    kind: ServiceAccount
   - group: networking.istio.io
     kind: VirtualService
   descriptor:
@@ -50,8 +50,4 @@ spec:
   selector:
     matchLabels:
       app.kubernetes.io/component: centraldashboard
-      app.kubernetes.io/instance: centraldashboard-v0.7.0
-      app.kubernetes.io/managed-by: kfctl
       app.kubernetes.io/name: centraldashboard
-      app.kubernetes.io/part-of: kubeflow
-      app.kubernetes.io/version: v0.7.0

--- a/tests/stacks/ibm/application/profile-control-plane/test_data/expected/app.k8s.io_v1beta1_application_profiles.yaml
+++ b/tests/stacks/ibm/application/profile-control-plane/test_data/expected/app.k8s.io_v1beta1_application_profiles.yaml
@@ -9,14 +9,14 @@ metadata:
 spec:
   addOwnerRef: true
   componentKinds:
+  - group: core
+    kind: ConfigMap
   - group: apps
     kind: Deployment
   - group: core
-    kind: ServiceAccount
-  - group: core
     kind: Service
-  - group: kubeflow.org
-    kind: Profile
+  - group: core
+    kind: ServiceAccount
   descriptor:
     description: ""
     keywords:
@@ -38,8 +38,4 @@ spec:
   selector:
     matchLabels:
       app.kubernetes.io/component: profiles
-      app.kubernetes.io/instance: profiles-v1.0.0
-      app.kubernetes.io/managed-by: kfctl
       app.kubernetes.io/name: profiles
-      app.kubernetes.io/part-of: kubeflow
-      app.kubernetes.io/version: v1.0.0

--- a/tests/stacks/ibm/application/profiles/test_data/expected/app.k8s.io_v1beta1_application_profiles.yaml
+++ b/tests/stacks/ibm/application/profiles/test_data/expected/app.k8s.io_v1beta1_application_profiles.yaml
@@ -8,14 +8,14 @@ metadata:
 spec:
   addOwnerRef: true
   componentKinds:
+  - group: core
+    kind: ConfigMap
   - group: apps
     kind: Deployment
   - group: core
-    kind: ServiceAccount
-  - group: core
     kind: Service
-  - group: kubeflow.org
-    kind: Profile
+  - group: core
+    kind: ServiceAccount
   descriptor:
     description: ""
     keywords:
@@ -37,8 +37,4 @@ spec:
   selector:
     matchLabels:
       app.kubernetes.io/component: profiles
-      app.kubernetes.io/instance: profiles-v1.0.0
-      app.kubernetes.io/managed-by: kfctl
       app.kubernetes.io/name: profiles
-      app.kubernetes.io/part-of: kubeflow
-      app.kubernetes.io/version: v1.0.0

--- a/tests/stacks/ibm/multi-user/test_data/expected/app.k8s.io_v1beta1_application_centraldashboard.yaml
+++ b/tests/stacks/ibm/multi-user/test_data/expected/app.k8s.io_v1beta1_application_centraldashboard.yaml
@@ -14,13 +14,13 @@ spec:
   - group: apps
     kind: Deployment
   - group: rbac.authorization.k8s.io
-    kind: RoleBinding
-  - group: rbac.authorization.k8s.io
     kind: Role
-  - group: core
-    kind: ServiceAccount
+  - group: rbac.authorization.k8s.io
+    kind: RoleBinding
   - group: core
     kind: Service
+  - group: core
+    kind: ServiceAccount
   - group: networking.istio.io
     kind: VirtualService
   descriptor:
@@ -50,8 +50,4 @@ spec:
   selector:
     matchLabels:
       app.kubernetes.io/component: centraldashboard
-      app.kubernetes.io/instance: centraldashboard-v0.7.0
-      app.kubernetes.io/managed-by: kfctl
       app.kubernetes.io/name: centraldashboard
-      app.kubernetes.io/part-of: kubeflow
-      app.kubernetes.io/version: v0.7.0

--- a/tests/stacks/ibm/multi-user/test_data/expected/app.k8s.io_v1beta1_application_jupyter-web-app.yaml
+++ b/tests/stacks/ibm/multi-user/test_data/expected/app.k8s.io_v1beta1_application_jupyter-web-app.yaml
@@ -14,13 +14,13 @@ spec:
   - group: apps
     kind: Deployment
   - group: rbac.authorization.k8s.io
-    kind: RoleBinding
-  - group: rbac.authorization.k8s.io
     kind: Role
-  - group: core
-    kind: ServiceAccount
+  - group: rbac.authorization.k8s.io
+    kind: RoleBinding
   - group: core
     kind: Service
+  - group: core
+    kind: ServiceAccount
   - group: networking.istio.io
     kind: VirtualService
   descriptor:
@@ -46,8 +46,4 @@ spec:
   selector:
     matchLabels:
       app.kubernetes.io/component: jupyter-web-app
-      app.kubernetes.io/instance: jupyter-web-app-v0.7.0
-      app.kubernetes.io/managed-by: kfctl
       app.kubernetes.io/name: jupyter-web-app
-      app.kubernetes.io/part-of: kubeflow
-      app.kubernetes.io/version: v0.7.0

--- a/tests/stacks/ibm/multi-user/test_data/expected/app.k8s.io_v1beta1_application_notebook-controller.yaml
+++ b/tests/stacks/ibm/multi-user/test_data/expected/app.k8s.io_v1beta1_application_notebook-controller.yaml
@@ -10,9 +10,11 @@ spec:
   addOwnerRef: true
   componentKinds:
   - group: core
-    kind: Service
+    kind: ConfigMap
   - group: apps
     kind: Deployment
+  - group: core
+    kind: Service
   - group: core
     kind: ServiceAccount
   descriptor:
@@ -37,8 +39,4 @@ spec:
   selector:
     matchLabels:
       app.kubernetes.io/component: notebook-controller
-      app.kubernetes.io/instance: notebook-controller-v1.0.0
-      app.kubernetes.io/managed-by: kfctl
       app.kubernetes.io/name: notebook-controller
-      app.kubernetes.io/part-of: kubeflow
-      app.kubernetes.io/version: v1.0.0

--- a/tests/stacks/ibm/multi-user/test_data/expected/app.k8s.io_v1beta1_application_profiles.yaml
+++ b/tests/stacks/ibm/multi-user/test_data/expected/app.k8s.io_v1beta1_application_profiles.yaml
@@ -9,14 +9,14 @@ metadata:
 spec:
   addOwnerRef: true
   componentKinds:
+  - group: core
+    kind: ConfigMap
   - group: apps
     kind: Deployment
   - group: core
-    kind: ServiceAccount
-  - group: core
     kind: Service
-  - group: kubeflow.org
-    kind: Profile
+  - group: core
+    kind: ServiceAccount
   descriptor:
     description: ""
     keywords:
@@ -38,8 +38,4 @@ spec:
   selector:
     matchLabels:
       app.kubernetes.io/component: profiles
-      app.kubernetes.io/instance: profiles-v1.0.0
-      app.kubernetes.io/managed-by: kfctl
       app.kubernetes.io/name: profiles
-      app.kubernetes.io/part-of: kubeflow
-      app.kubernetes.io/version: v1.0.0

--- a/tests/stacks/ibm/multi-user/test_data/expected/app.k8s.io_v1beta1_application_webhook.yaml
+++ b/tests/stacks/ibm/multi-user/test_data/expected/app.k8s.io_v1beta1_application_webhook.yaml
@@ -12,11 +12,17 @@ spec:
   - group: core
     kind: ConfigMap
   - group: apps
-    kind: StatefulSet
+    kind: Deployment
+  - group: rbac.authorization.k8s.io
+    kind: Role
+  - group: rbac.authorization.k8s.io
+    kind: RoleBinding
   - group: core
     kind: Service
   - group: core
     kind: ServiceAccount
+  - group: apps
+    kind: StatefulSet
   descriptor:
     description: injects volume, volume mounts, env vars into PodDefault
     keywords:
@@ -31,9 +37,5 @@ spec:
     version: v1beta1
   selector:
     matchLabels:
-      app.kubernetes.io/component: bootstrap
-      app.kubernetes.io/instance: webhook-v1.0.0
-      app.kubernetes.io/managed-by: kfctl
+      app.kubernetes.io/component: webhook
       app.kubernetes.io/name: webhook
-      app.kubernetes.io/part-of: webhook
-      app.kubernetes.io/version: v1.0.0

--- a/tests/stacks/ibm/test_data/expected/app.k8s.io_v1beta1_application_centraldashboard.yaml
+++ b/tests/stacks/ibm/test_data/expected/app.k8s.io_v1beta1_application_centraldashboard.yaml
@@ -14,13 +14,13 @@ spec:
   - group: apps
     kind: Deployment
   - group: rbac.authorization.k8s.io
-    kind: RoleBinding
-  - group: rbac.authorization.k8s.io
     kind: Role
-  - group: core
-    kind: ServiceAccount
+  - group: rbac.authorization.k8s.io
+    kind: RoleBinding
   - group: core
     kind: Service
+  - group: core
+    kind: ServiceAccount
   - group: networking.istio.io
     kind: VirtualService
   descriptor:
@@ -50,8 +50,4 @@ spec:
   selector:
     matchLabels:
       app.kubernetes.io/component: centraldashboard
-      app.kubernetes.io/instance: centraldashboard-v0.7.0
-      app.kubernetes.io/managed-by: kfctl
       app.kubernetes.io/name: centraldashboard
-      app.kubernetes.io/part-of: kubeflow
-      app.kubernetes.io/version: v0.7.0

--- a/tests/stacks/ibm/test_data/expected/app.k8s.io_v1beta1_application_jupyter-web-app.yaml
+++ b/tests/stacks/ibm/test_data/expected/app.k8s.io_v1beta1_application_jupyter-web-app.yaml
@@ -14,13 +14,13 @@ spec:
   - group: apps
     kind: Deployment
   - group: rbac.authorization.k8s.io
-    kind: RoleBinding
-  - group: rbac.authorization.k8s.io
     kind: Role
-  - group: core
-    kind: ServiceAccount
+  - group: rbac.authorization.k8s.io
+    kind: RoleBinding
   - group: core
     kind: Service
+  - group: core
+    kind: ServiceAccount
   - group: networking.istio.io
     kind: VirtualService
   descriptor:
@@ -46,8 +46,4 @@ spec:
   selector:
     matchLabels:
       app.kubernetes.io/component: jupyter-web-app
-      app.kubernetes.io/instance: jupyter-web-app-v0.7.0
-      app.kubernetes.io/managed-by: kfctl
       app.kubernetes.io/name: jupyter-web-app
-      app.kubernetes.io/part-of: kubeflow
-      app.kubernetes.io/version: v0.7.0

--- a/tests/stacks/ibm/test_data/expected/app.k8s.io_v1beta1_application_notebook-controller.yaml
+++ b/tests/stacks/ibm/test_data/expected/app.k8s.io_v1beta1_application_notebook-controller.yaml
@@ -10,9 +10,11 @@ spec:
   addOwnerRef: true
   componentKinds:
   - group: core
-    kind: Service
+    kind: ConfigMap
   - group: apps
     kind: Deployment
+  - group: core
+    kind: Service
   - group: core
     kind: ServiceAccount
   descriptor:
@@ -37,8 +39,4 @@ spec:
   selector:
     matchLabels:
       app.kubernetes.io/component: notebook-controller
-      app.kubernetes.io/instance: notebook-controller-v1.0.0
-      app.kubernetes.io/managed-by: kfctl
       app.kubernetes.io/name: notebook-controller
-      app.kubernetes.io/part-of: kubeflow
-      app.kubernetes.io/version: v1.0.0

--- a/tests/stacks/ibm/test_data/expected/app.k8s.io_v1beta1_application_profiles.yaml
+++ b/tests/stacks/ibm/test_data/expected/app.k8s.io_v1beta1_application_profiles.yaml
@@ -9,14 +9,14 @@ metadata:
 spec:
   addOwnerRef: true
   componentKinds:
+  - group: core
+    kind: ConfigMap
   - group: apps
     kind: Deployment
   - group: core
-    kind: ServiceAccount
-  - group: core
     kind: Service
-  - group: kubeflow.org
-    kind: Profile
+  - group: core
+    kind: ServiceAccount
   descriptor:
     description: ""
     keywords:
@@ -38,8 +38,4 @@ spec:
   selector:
     matchLabels:
       app.kubernetes.io/component: profiles
-      app.kubernetes.io/instance: profiles-v1.0.0
-      app.kubernetes.io/managed-by: kfctl
       app.kubernetes.io/name: profiles
-      app.kubernetes.io/part-of: kubeflow
-      app.kubernetes.io/version: v1.0.0

--- a/tests/stacks/ibm/test_data/expected/app.k8s.io_v1beta1_application_webhook.yaml
+++ b/tests/stacks/ibm/test_data/expected/app.k8s.io_v1beta1_application_webhook.yaml
@@ -12,11 +12,17 @@ spec:
   - group: core
     kind: ConfigMap
   - group: apps
-    kind: StatefulSet
+    kind: Deployment
+  - group: rbac.authorization.k8s.io
+    kind: Role
+  - group: rbac.authorization.k8s.io
+    kind: RoleBinding
   - group: core
     kind: Service
   - group: core
     kind: ServiceAccount
+  - group: apps
+    kind: StatefulSet
   descriptor:
     description: injects volume, volume mounts, env vars into PodDefault
     keywords:
@@ -31,9 +37,5 @@ spec:
     version: v1beta1
   selector:
     matchLabels:
-      app.kubernetes.io/component: bootstrap
-      app.kubernetes.io/instance: webhook-v1.0.0
-      app.kubernetes.io/managed-by: kfctl
+      app.kubernetes.io/component: webhook
       app.kubernetes.io/name: webhook
-      app.kubernetes.io/part-of: webhook
-      app.kubernetes.io/version: v1.0.0

--- a/tests/stacks/kubernetes/test_data/expected/app.k8s.io_v1beta1_application_centraldashboard.yaml
+++ b/tests/stacks/kubernetes/test_data/expected/app.k8s.io_v1beta1_application_centraldashboard.yaml
@@ -14,13 +14,13 @@ spec:
   - group: apps
     kind: Deployment
   - group: rbac.authorization.k8s.io
-    kind: RoleBinding
-  - group: rbac.authorization.k8s.io
     kind: Role
-  - group: core
-    kind: ServiceAccount
+  - group: rbac.authorization.k8s.io
+    kind: RoleBinding
   - group: core
     kind: Service
+  - group: core
+    kind: ServiceAccount
   - group: networking.istio.io
     kind: VirtualService
   descriptor:
@@ -50,8 +50,4 @@ spec:
   selector:
     matchLabels:
       app.kubernetes.io/component: centraldashboard
-      app.kubernetes.io/instance: centraldashboard-v0.7.0
-      app.kubernetes.io/managed-by: kfctl
       app.kubernetes.io/name: centraldashboard
-      app.kubernetes.io/part-of: kubeflow
-      app.kubernetes.io/version: v0.7.0

--- a/tests/stacks/kubernetes/test_data/expected/app.k8s.io_v1beta1_application_jupyter-web-app-jupyter-web-app.yaml
+++ b/tests/stacks/kubernetes/test_data/expected/app.k8s.io_v1beta1_application_jupyter-web-app-jupyter-web-app.yaml
@@ -16,13 +16,13 @@ spec:
   - group: apps
     kind: Deployment
   - group: rbac.authorization.k8s.io
-    kind: RoleBinding
-  - group: rbac.authorization.k8s.io
     kind: Role
-  - group: core
-    kind: ServiceAccount
+  - group: rbac.authorization.k8s.io
+    kind: RoleBinding
   - group: core
     kind: Service
+  - group: core
+    kind: ServiceAccount
   - group: networking.istio.io
     kind: VirtualService
   descriptor:
@@ -48,8 +48,4 @@ spec:
   selector:
     matchLabels:
       app.kubernetes.io/component: jupyter-web-app
-      app.kubernetes.io/instance: jupyter-web-app-v0.7.0
-      app.kubernetes.io/managed-by: kfctl
       app.kubernetes.io/name: jupyter-web-app
-      app.kubernetes.io/part-of: kubeflow
-      app.kubernetes.io/version: v0.7.0

--- a/tests/stacks/kubernetes/test_data/expected/app.k8s.io_v1beta1_application_notebook-controller-notebook-controller.yaml
+++ b/tests/stacks/kubernetes/test_data/expected/app.k8s.io_v1beta1_application_notebook-controller-notebook-controller.yaml
@@ -12,9 +12,11 @@ spec:
   addOwnerRef: true
   componentKinds:
   - group: core
-    kind: Service
+    kind: ConfigMap
   - group: apps
     kind: Deployment
+  - group: core
+    kind: Service
   - group: core
     kind: ServiceAccount
   descriptor:
@@ -39,8 +41,4 @@ spec:
   selector:
     matchLabels:
       app.kubernetes.io/component: notebook-controller
-      app.kubernetes.io/instance: notebook-controller-v1.0.0
-      app.kubernetes.io/managed-by: kfctl
       app.kubernetes.io/name: notebook-controller
-      app.kubernetes.io/part-of: kubeflow
-      app.kubernetes.io/version: v1.0.0

--- a/tests/stacks/kubernetes/test_data/expected/app.k8s.io_v1beta1_application_profiles-profiles.yaml
+++ b/tests/stacks/kubernetes/test_data/expected/app.k8s.io_v1beta1_application_profiles-profiles.yaml
@@ -8,14 +8,14 @@ metadata:
 spec:
   addOwnerRef: true
   componentKinds:
+  - group: core
+    kind: ConfigMap
   - group: apps
     kind: Deployment
   - group: core
-    kind: ServiceAccount
-  - group: core
     kind: Service
-  - group: kubeflow.org
-    kind: Profile
+  - group: core
+    kind: ServiceAccount
   descriptor:
     description: ""
     keywords:
@@ -37,8 +37,4 @@ spec:
   selector:
     matchLabels:
       app.kubernetes.io/component: profiles
-      app.kubernetes.io/instance: profiles-v1.0.0
-      app.kubernetes.io/managed-by: kfctl
       app.kubernetes.io/name: profiles
-      app.kubernetes.io/part-of: kubeflow
-      app.kubernetes.io/version: v1.0.0

--- a/tests/stacks/kubernetes/test_data/expected/app.k8s.io_v1beta1_application_webhook.yaml
+++ b/tests/stacks/kubernetes/test_data/expected/app.k8s.io_v1beta1_application_webhook.yaml
@@ -12,11 +12,17 @@ spec:
   - group: core
     kind: ConfigMap
   - group: apps
-    kind: StatefulSet
+    kind: Deployment
+  - group: rbac.authorization.k8s.io
+    kind: Role
+  - group: rbac.authorization.k8s.io
+    kind: RoleBinding
   - group: core
     kind: Service
   - group: core
     kind: ServiceAccount
+  - group: apps
+    kind: StatefulSet
   descriptor:
     description: injects volume, volume mounts, env vars into PodDefault
     keywords:
@@ -31,9 +37,5 @@ spec:
     version: v1beta1
   selector:
     matchLabels:
-      app.kubernetes.io/component: bootstrap
-      app.kubernetes.io/instance: webhook-v1.0.0
-      app.kubernetes.io/managed-by: kfctl
+      app.kubernetes.io/component: webhook
       app.kubernetes.io/name: webhook
-      app.kubernetes.io/part-of: webhook
-      app.kubernetes.io/version: v1.0.0

--- a/tests/stacks/openshift/application/jupyter-web-app/test_data/expected/app.k8s.io_v1beta1_application_jupyter-web-app-jupyter-web-app.yaml
+++ b/tests/stacks/openshift/application/jupyter-web-app/test_data/expected/app.k8s.io_v1beta1_application_jupyter-web-app-jupyter-web-app.yaml
@@ -16,13 +16,13 @@ spec:
   - group: apps
     kind: Deployment
   - group: rbac.authorization.k8s.io
-    kind: RoleBinding
-  - group: rbac.authorization.k8s.io
     kind: Role
-  - group: core
-    kind: ServiceAccount
+  - group: rbac.authorization.k8s.io
+    kind: RoleBinding
   - group: core
     kind: Service
+  - group: core
+    kind: ServiceAccount
   - group: networking.istio.io
     kind: VirtualService
   descriptor:
@@ -48,8 +48,4 @@ spec:
   selector:
     matchLabels:
       app.kubernetes.io/component: jupyter-web-app
-      app.kubernetes.io/instance: jupyter-web-app-v0.7.0
-      app.kubernetes.io/managed-by: kfctl
       app.kubernetes.io/name: jupyter-web-app
-      app.kubernetes.io/part-of: kubeflow
-      app.kubernetes.io/version: v0.7.0

--- a/tests/stacks/openshift/application/notebook-controller/test_data/expected/app.k8s.io_v1beta1_application_notebook-controller-notebook-controller.yaml
+++ b/tests/stacks/openshift/application/notebook-controller/test_data/expected/app.k8s.io_v1beta1_application_notebook-controller-notebook-controller.yaml
@@ -12,9 +12,11 @@ spec:
   addOwnerRef: true
   componentKinds:
   - group: core
-    kind: Service
+    kind: ConfigMap
   - group: apps
     kind: Deployment
+  - group: core
+    kind: Service
   - group: core
     kind: ServiceAccount
   descriptor:
@@ -39,8 +41,4 @@ spec:
   selector:
     matchLabels:
       app.kubernetes.io/component: notebook-controller
-      app.kubernetes.io/instance: notebook-controller-v1.0.0
-      app.kubernetes.io/managed-by: kfctl
       app.kubernetes.io/name: notebook-controller
-      app.kubernetes.io/part-of: kubeflow
-      app.kubernetes.io/version: v1.0.0

--- a/tests/stacks/openshift/application/profiles/test_data/expected/app.k8s.io_v1beta1_application_profiles-profiles.yaml
+++ b/tests/stacks/openshift/application/profiles/test_data/expected/app.k8s.io_v1beta1_application_profiles-profiles.yaml
@@ -8,14 +8,14 @@ metadata:
 spec:
   addOwnerRef: true
   componentKinds:
+  - group: core
+    kind: ConfigMap
   - group: apps
     kind: Deployment
   - group: core
-    kind: ServiceAccount
-  - group: core
     kind: Service
-  - group: kubeflow.org
-    kind: Profile
+  - group: core
+    kind: ServiceAccount
   descriptor:
     description: ""
     keywords:
@@ -37,8 +37,4 @@ spec:
   selector:
     matchLabels:
       app.kubernetes.io/component: profiles
-      app.kubernetes.io/instance: profiles-v1.0.0
-      app.kubernetes.io/managed-by: kfctl
       app.kubernetes.io/name: profiles
-      app.kubernetes.io/part-of: kubeflow
-      app.kubernetes.io/version: v1.0.0

--- a/tests/stacks/openshift/test_data/expected/app.k8s.io_v1beta1_application_centraldashboard.yaml
+++ b/tests/stacks/openshift/test_data/expected/app.k8s.io_v1beta1_application_centraldashboard.yaml
@@ -14,13 +14,13 @@ spec:
   - group: apps
     kind: Deployment
   - group: rbac.authorization.k8s.io
-    kind: RoleBinding
-  - group: rbac.authorization.k8s.io
     kind: Role
-  - group: core
-    kind: ServiceAccount
+  - group: rbac.authorization.k8s.io
+    kind: RoleBinding
   - group: core
     kind: Service
+  - group: core
+    kind: ServiceAccount
   - group: networking.istio.io
     kind: VirtualService
   descriptor:
@@ -50,8 +50,4 @@ spec:
   selector:
     matchLabels:
       app.kubernetes.io/component: centraldashboard
-      app.kubernetes.io/instance: centraldashboard-v0.7.0
-      app.kubernetes.io/managed-by: kfctl
       app.kubernetes.io/name: centraldashboard
-      app.kubernetes.io/part-of: kubeflow
-      app.kubernetes.io/version: v0.7.0

--- a/tests/stacks/openshift/test_data/expected/app.k8s.io_v1beta1_application_profiles-profiles.yaml
+++ b/tests/stacks/openshift/test_data/expected/app.k8s.io_v1beta1_application_profiles-profiles.yaml
@@ -8,14 +8,14 @@ metadata:
 spec:
   addOwnerRef: true
   componentKinds:
+  - group: core
+    kind: ConfigMap
   - group: apps
     kind: Deployment
   - group: core
-    kind: ServiceAccount
-  - group: core
     kind: Service
-  - group: kubeflow.org
-    kind: Profile
+  - group: core
+    kind: ServiceAccount
   descriptor:
     description: ""
     keywords:
@@ -37,8 +37,4 @@ spec:
   selector:
     matchLabels:
       app.kubernetes.io/component: profiles
-      app.kubernetes.io/instance: profiles-v1.0.0
-      app.kubernetes.io/managed-by: kfctl
       app.kubernetes.io/name: profiles
-      app.kubernetes.io/part-of: kubeflow
-      app.kubernetes.io/version: v1.0.0

--- a/tests/tests/legacy_kustomizations/centraldashboard/test_data/expected/app.k8s.io_v1beta1_application_centraldashboard.yaml
+++ b/tests/tests/legacy_kustomizations/centraldashboard/test_data/expected/app.k8s.io_v1beta1_application_centraldashboard.yaml
@@ -18,13 +18,13 @@ spec:
   - group: apps
     kind: Deployment
   - group: rbac.authorization.k8s.io
-    kind: RoleBinding
-  - group: rbac.authorization.k8s.io
     kind: Role
-  - group: core
-    kind: ServiceAccount
+  - group: rbac.authorization.k8s.io
+    kind: RoleBinding
   - group: core
     kind: Service
+  - group: core
+    kind: ServiceAccount
   - group: networking.istio.io
     kind: VirtualService
   descriptor:
@@ -54,8 +54,4 @@ spec:
   selector:
     matchLabels:
       app.kubernetes.io/component: centraldashboard
-      app.kubernetes.io/instance: centraldashboard-v0.7.0
-      app.kubernetes.io/managed-by: kfctl
       app.kubernetes.io/name: centraldashboard
-      app.kubernetes.io/part-of: kubeflow
-      app.kubernetes.io/version: v0.7.0

--- a/tests/tests/legacy_kustomizations/jupyter-web-app/test_data/expected/app.k8s.io_v1beta1_application_jupyter-web-app.yaml
+++ b/tests/tests/legacy_kustomizations/jupyter-web-app/test_data/expected/app.k8s.io_v1beta1_application_jupyter-web-app.yaml
@@ -18,13 +18,13 @@ spec:
   - group: apps
     kind: Deployment
   - group: rbac.authorization.k8s.io
-    kind: RoleBinding
-  - group: rbac.authorization.k8s.io
     kind: Role
-  - group: core
-    kind: ServiceAccount
+  - group: rbac.authorization.k8s.io
+    kind: RoleBinding
   - group: core
     kind: Service
+  - group: core
+    kind: ServiceAccount
   - group: networking.istio.io
     kind: VirtualService
   descriptor:
@@ -50,8 +50,4 @@ spec:
   selector:
     matchLabels:
       app.kubernetes.io/component: jupyter-web-app
-      app.kubernetes.io/instance: jupyter-web-app-v0.7.0
-      app.kubernetes.io/managed-by: kfctl
       app.kubernetes.io/name: jupyter-web-app
-      app.kubernetes.io/part-of: kubeflow
-      app.kubernetes.io/version: v0.7.0

--- a/tests/tests/legacy_kustomizations/notebook-controller/test_data/expected/app.k8s.io_v1beta1_application_notebook-controller.yaml
+++ b/tests/tests/legacy_kustomizations/notebook-controller/test_data/expected/app.k8s.io_v1beta1_application_notebook-controller.yaml
@@ -14,9 +14,11 @@ spec:
   addOwnerRef: true
   componentKinds:
   - group: core
-    kind: Service
+    kind: ConfigMap
   - group: apps
     kind: Deployment
+  - group: core
+    kind: Service
   - group: core
     kind: ServiceAccount
   descriptor:
@@ -41,8 +43,4 @@ spec:
   selector:
     matchLabels:
       app.kubernetes.io/component: notebook-controller
-      app.kubernetes.io/instance: notebook-controller-v1.0.0
-      app.kubernetes.io/managed-by: kfctl
       app.kubernetes.io/name: notebook-controller
-      app.kubernetes.io/part-of: kubeflow
-      app.kubernetes.io/version: v1.0.0

--- a/tests/tests/legacy_kustomizations/profiles/test_data/expected/app.k8s.io_v1beta1_application_profiles.yaml
+++ b/tests/tests/legacy_kustomizations/profiles/test_data/expected/app.k8s.io_v1beta1_application_profiles.yaml
@@ -13,14 +13,14 @@ metadata:
 spec:
   addOwnerRef: true
   componentKinds:
+  - group: core
+    kind: ConfigMap
   - group: apps
     kind: Deployment
   - group: core
-    kind: ServiceAccount
-  - group: core
     kind: Service
-  - group: kubeflow.org
-    kind: Profile
+  - group: core
+    kind: ServiceAccount
   descriptor:
     description: ""
     keywords:
@@ -42,8 +42,4 @@ spec:
   selector:
     matchLabels:
       app.kubernetes.io/component: profiles
-      app.kubernetes.io/instance: profiles-v1.0.0
-      app.kubernetes.io/managed-by: kfctl
       app.kubernetes.io/name: profiles
-      app.kubernetes.io/part-of: kubeflow
-      app.kubernetes.io/version: v1.0.0

--- a/tests/tests/legacy_kustomizations/webhook/test_data/expected/app.k8s.io_v1beta1_application_webhook.yaml
+++ b/tests/tests/legacy_kustomizations/webhook/test_data/expected/app.k8s.io_v1beta1_application_webhook.yaml
@@ -16,11 +16,17 @@ spec:
   - group: core
     kind: ConfigMap
   - group: apps
-    kind: StatefulSet
+    kind: Deployment
+  - group: rbac.authorization.k8s.io
+    kind: Role
+  - group: rbac.authorization.k8s.io
+    kind: RoleBinding
   - group: core
     kind: Service
   - group: core
     kind: ServiceAccount
+  - group: apps
+    kind: StatefulSet
   descriptor:
     description: injects volume, volume mounts, env vars into PodDefault
     keywords:
@@ -35,9 +41,5 @@ spec:
     version: v1beta1
   selector:
     matchLabels:
-      app.kubernetes.io/component: bootstrap
-      app.kubernetes.io/instance: webhook-v1.0.0
-      app.kubernetes.io/managed-by: kfctl
+      app.kubernetes.io/component: webhook
       app.kubernetes.io/name: webhook
-      app.kubernetes.io/part-of: webhook
-      app.kubernetes.io/version: v1.0.0


### PR DESCRIPTION
**Which issue is resolved by this Pull Request:**
Resolves #1573 (for components owned by wg-notebook)

**Description of your changes:**

Fixes the Application resource selectors for:
- `webhook` (PodDefaults)
- `centraldashboard`
- `jupyter-web-app`
- `notebook-controller`
- `profiles`

**Checklist:**
- [X] Unit tests have been rebuilt: 
    1. `cd manifests/tests`
    2. `make generate-changed-only`
    3. `make test`
