### PR TITLE
fix commonLabels

### DIFF
--- a/common/centraldashboard/base_v3/kustomization.yaml
+++ b/common/centraldashboard/base_v3/kustomization.yaml
@@ -1,5 +1,8 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
+commonLabels:
+  app: centraldashboard
+  kustomize.component: centraldashboard
 images:
 - name: gcr.io/kubeflow-images-public/centraldashboard
   newName: gcr.io/kubeflow-images-public/centraldashboard

--- a/jupyter/jupyter-web-app/base_v3/kustomization.yaml
+++ b/jupyter/jupyter-web-app/base_v3/kustomization.yaml
@@ -12,20 +12,12 @@
 # break the existing KFDef files. So we want to make the stacks work 
 # and then replace it.
 apiVersion: kustomize.config.k8s.io/v1beta1
-commonLabels:
-  app.kubernetes.io/component: jupyter-web-app
-  app.kubernetes.io/instance: jupyter-web-app-v1.0.0
-  app.kubernetes.io/managed-by: kfctl
-  app.kubernetes.io/name: jupyter-web-app
-  app.kubernetes.io/part-of: kubeflow
-  app.kubernetes.io/version: v1.0.0
 kind: Kustomization
 namePrefix: jupyter-web-app-
 namespace: kubeflow
 commonLabels:
   app: jupyter-web-app
   kustomize.component: jupyter-web-app
-namespace: kubeflow
 images:
 - name: gcr.io/kubeflow-images-public/jupyter-web-app
   newName: gcr.io/kubeflow-images-public/jupyter-web-app

--- a/jupyter/notebook-controller/base_v3/kustomization.yaml
+++ b/jupyter/notebook-controller/base_v3/kustomization.yaml
@@ -1,8 +1,6 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 commonLabels:
   app: notebook-controller
-  app.kubernetes.io/component: notebook-controller
-  app.kubernetes.io/name: notebook-controller
   kustomize.component: notebook-controller
 configMapGenerator:
 - literals:

--- a/tests/stacks/aws/test_data/expected/apiextensions.k8s.io_v1beta1_customresourcedefinition_notebooks.kubeflow.org.yaml
+++ b/tests/stacks/aws/test_data/expected/apiextensions.k8s.io_v1beta1_customresourcedefinition_notebooks.kubeflow.org.yaml
@@ -3,8 +3,6 @@ kind: CustomResourceDefinition
 metadata:
   labels:
     app: notebook-controller
-    app.kubernetes.io/component: notebook-controller
-    app.kubernetes.io/name: notebook-controller
     kustomize.component: notebook-controller
   name: notebooks.kubeflow.org
 spec:

--- a/tests/stacks/aws/test_data/expected/app.k8s.io_v1beta1_application_notebook-controller-notebook-controller.yaml
+++ b/tests/stacks/aws/test_data/expected/app.k8s.io_v1beta1_application_notebook-controller-notebook-controller.yaml
@@ -3,8 +3,6 @@ kind: Application
 metadata:
   labels:
     app: notebook-controller
-    app.kubernetes.io/component: notebook-controller
-    app.kubernetes.io/name: notebook-controller
     kustomize.component: notebook-controller
   name: notebook-controller-notebook-controller
   namespace: kubeflow

--- a/tests/stacks/aws/test_data/expected/apps_v1_deployment_centraldashboard.yaml
+++ b/tests/stacks/aws/test_data/expected/apps_v1_deployment_centraldashboard.yaml
@@ -5,6 +5,7 @@ metadata:
     app: centraldashboard
     app.kubernetes.io/component: centraldashboard
     app.kubernetes.io/name: centraldashboard
+    kustomize.component: centraldashboard
   name: centraldashboard
   namespace: kubeflow
 spec:
@@ -14,6 +15,7 @@ spec:
       app: centraldashboard
       app.kubernetes.io/component: centraldashboard
       app.kubernetes.io/name: centraldashboard
+      kustomize.component: centraldashboard
   template:
     metadata:
       annotations:
@@ -22,6 +24,7 @@ spec:
         app: centraldashboard
         app.kubernetes.io/component: centraldashboard
         app.kubernetes.io/name: centraldashboard
+        kustomize.component: centraldashboard
     spec:
       containers:
       - env:

--- a/tests/stacks/aws/test_data/expected/apps_v1_deployment_notebook-controller-deployment.yaml
+++ b/tests/stacks/aws/test_data/expected/apps_v1_deployment_notebook-controller-deployment.yaml
@@ -3,8 +3,6 @@ kind: Deployment
 metadata:
   labels:
     app: notebook-controller
-    app.kubernetes.io/component: notebook-controller
-    app.kubernetes.io/name: notebook-controller
     kustomize.component: notebook-controller
   name: notebook-controller-deployment
   namespace: kubeflow
@@ -12,8 +10,6 @@ spec:
   selector:
     matchLabels:
       app: notebook-controller
-      app.kubernetes.io/component: notebook-controller
-      app.kubernetes.io/name: notebook-controller
       kustomize.component: notebook-controller
   template:
     metadata:
@@ -21,8 +17,6 @@ spec:
         sidecar.istio.io/inject: "false"
       labels:
         app: notebook-controller
-        app.kubernetes.io/component: notebook-controller
-        app.kubernetes.io/name: notebook-controller
         kustomize.component: notebook-controller
     spec:
       containers:

--- a/tests/stacks/aws/test_data/expected/rbac.authorization.k8s.io_v1_clusterrole_centraldashboard.yaml
+++ b/tests/stacks/aws/test_data/expected/rbac.authorization.k8s.io_v1_clusterrole_centraldashboard.yaml
@@ -5,6 +5,7 @@ metadata:
     app: centraldashboard
     app.kubernetes.io/component: centraldashboard
     app.kubernetes.io/name: centraldashboard
+    kustomize.component: centraldashboard
   name: centraldashboard
 rules:
 - apiGroups:

--- a/tests/stacks/aws/test_data/expected/rbac.authorization.k8s.io_v1_clusterrole_notebook-controller-kubeflow-notebooks-admin.yaml
+++ b/tests/stacks/aws/test_data/expected/rbac.authorization.k8s.io_v1_clusterrole_notebook-controller-kubeflow-notebooks-admin.yaml
@@ -7,8 +7,6 @@ kind: ClusterRole
 metadata:
   labels:
     app: notebook-controller
-    app.kubernetes.io/component: notebook-controller
-    app.kubernetes.io/name: notebook-controller
     kustomize.component: notebook-controller
     rbac.authorization.kubeflow.org/aggregate-to-kubeflow-admin: "true"
   name: notebook-controller-kubeflow-notebooks-admin

--- a/tests/stacks/aws/test_data/expected/rbac.authorization.k8s.io_v1_clusterrole_notebook-controller-kubeflow-notebooks-edit.yaml
+++ b/tests/stacks/aws/test_data/expected/rbac.authorization.k8s.io_v1_clusterrole_notebook-controller-kubeflow-notebooks-edit.yaml
@@ -3,8 +3,6 @@ kind: ClusterRole
 metadata:
   labels:
     app: notebook-controller
-    app.kubernetes.io/component: notebook-controller
-    app.kubernetes.io/name: notebook-controller
     kustomize.component: notebook-controller
     rbac.authorization.kubeflow.org/aggregate-to-kubeflow-edit: "true"
     rbac.authorization.kubeflow.org/aggregate-to-kubeflow-notebooks-admin: "true"

--- a/tests/stacks/aws/test_data/expected/rbac.authorization.k8s.io_v1_clusterrole_notebook-controller-kubeflow-notebooks-view.yaml
+++ b/tests/stacks/aws/test_data/expected/rbac.authorization.k8s.io_v1_clusterrole_notebook-controller-kubeflow-notebooks-view.yaml
@@ -3,8 +3,6 @@ kind: ClusterRole
 metadata:
   labels:
     app: notebook-controller
-    app.kubernetes.io/component: notebook-controller
-    app.kubernetes.io/name: notebook-controller
     kustomize.component: notebook-controller
     rbac.authorization.kubeflow.org/aggregate-to-kubeflow-view: "true"
   name: notebook-controller-kubeflow-notebooks-view

--- a/tests/stacks/aws/test_data/expected/rbac.authorization.k8s.io_v1_clusterrole_notebook-controller-role.yaml
+++ b/tests/stacks/aws/test_data/expected/rbac.authorization.k8s.io_v1_clusterrole_notebook-controller-role.yaml
@@ -3,8 +3,6 @@ kind: ClusterRole
 metadata:
   labels:
     app: notebook-controller
-    app.kubernetes.io/component: notebook-controller
-    app.kubernetes.io/name: notebook-controller
     kustomize.component: notebook-controller
   name: notebook-controller-role
 rules:

--- a/tests/stacks/aws/test_data/expected/rbac.authorization.k8s.io_v1_clusterrolebinding_centraldashboard.yaml
+++ b/tests/stacks/aws/test_data/expected/rbac.authorization.k8s.io_v1_clusterrolebinding_centraldashboard.yaml
@@ -5,6 +5,7 @@ metadata:
     app: centraldashboard
     app.kubernetes.io/component: centraldashboard
     app.kubernetes.io/name: centraldashboard
+    kustomize.component: centraldashboard
   name: centraldashboard
 roleRef:
   apiGroup: rbac.authorization.k8s.io

--- a/tests/stacks/aws/test_data/expected/rbac.authorization.k8s.io_v1_clusterrolebinding_notebook-controller-role-binding.yaml
+++ b/tests/stacks/aws/test_data/expected/rbac.authorization.k8s.io_v1_clusterrolebinding_notebook-controller-role-binding.yaml
@@ -3,8 +3,6 @@ kind: ClusterRoleBinding
 metadata:
   labels:
     app: notebook-controller
-    app.kubernetes.io/component: notebook-controller
-    app.kubernetes.io/name: notebook-controller
     kustomize.component: notebook-controller
   name: notebook-controller-role-binding
 roleRef:

--- a/tests/stacks/aws/test_data/expected/rbac.authorization.k8s.io_v1_role_centraldashboard.yaml
+++ b/tests/stacks/aws/test_data/expected/rbac.authorization.k8s.io_v1_role_centraldashboard.yaml
@@ -5,6 +5,7 @@ metadata:
     app: centraldashboard
     app.kubernetes.io/component: centraldashboard
     app.kubernetes.io/name: centraldashboard
+    kustomize.component: centraldashboard
   name: centraldashboard
   namespace: kubeflow
 rules:

--- a/tests/stacks/aws/test_data/expected/rbac.authorization.k8s.io_v1_rolebinding_centraldashboard.yaml
+++ b/tests/stacks/aws/test_data/expected/rbac.authorization.k8s.io_v1_rolebinding_centraldashboard.yaml
@@ -5,6 +5,7 @@ metadata:
     app: centraldashboard
     app.kubernetes.io/component: centraldashboard
     app.kubernetes.io/name: centraldashboard
+    kustomize.component: centraldashboard
   name: centraldashboard
   namespace: kubeflow
 roleRef:

--- a/tests/stacks/aws/test_data/expected/~g_v1_configmap_notebook-controller-notebook-controller-config-h4d668t5tb.yaml
+++ b/tests/stacks/aws/test_data/expected/~g_v1_configmap_notebook-controller-notebook-controller-config-h4d668t5tb.yaml
@@ -6,8 +6,6 @@ kind: ConfigMap
 metadata:
   labels:
     app: notebook-controller
-    app.kubernetes.io/component: notebook-controller
-    app.kubernetes.io/name: notebook-controller
     kustomize.component: notebook-controller
   name: notebook-controller-notebook-controller-config-h4d668t5tb
   namespace: kubeflow

--- a/tests/stacks/aws/test_data/expected/~g_v1_service_centraldashboard.yaml
+++ b/tests/stacks/aws/test_data/expected/~g_v1_service_centraldashboard.yaml
@@ -14,6 +14,7 @@ metadata:
     app: centraldashboard
     app.kubernetes.io/component: centraldashboard
     app.kubernetes.io/name: centraldashboard
+    kustomize.component: centraldashboard
   name: centraldashboard
   namespace: kubeflow
 spec:
@@ -25,5 +26,6 @@ spec:
     app: centraldashboard
     app.kubernetes.io/component: centraldashboard
     app.kubernetes.io/name: centraldashboard
+    kustomize.component: centraldashboard
   sessionAffinity: None
   type: ClusterIP

--- a/tests/stacks/aws/test_data/expected/~g_v1_service_notebook-controller-service.yaml
+++ b/tests/stacks/aws/test_data/expected/~g_v1_service_notebook-controller-service.yaml
@@ -3,8 +3,6 @@ kind: Service
 metadata:
   labels:
     app: notebook-controller
-    app.kubernetes.io/component: notebook-controller
-    app.kubernetes.io/name: notebook-controller
     kustomize.component: notebook-controller
   name: notebook-controller-service
   namespace: kubeflow
@@ -13,6 +11,4 @@ spec:
   - port: 443
   selector:
     app: notebook-controller
-    app.kubernetes.io/component: notebook-controller
-    app.kubernetes.io/name: notebook-controller
     kustomize.component: notebook-controller

--- a/tests/stacks/aws/test_data/expected/~g_v1_serviceaccount_centraldashboard.yaml
+++ b/tests/stacks/aws/test_data/expected/~g_v1_serviceaccount_centraldashboard.yaml
@@ -2,7 +2,9 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   labels:
+    app: centraldashboard
     app.kubernetes.io/component: centraldashboard
     app.kubernetes.io/name: centraldashboard
+    kustomize.component: centraldashboard
   name: centraldashboard
   namespace: kubeflow

--- a/tests/stacks/aws/test_data/expected/~g_v1_serviceaccount_notebook-controller-service-account.yaml
+++ b/tests/stacks/aws/test_data/expected/~g_v1_serviceaccount_notebook-controller-service-account.yaml
@@ -3,8 +3,6 @@ kind: ServiceAccount
 metadata:
   labels:
     app: notebook-controller
-    app.kubernetes.io/component: notebook-controller
-    app.kubernetes.io/name: notebook-controller
     kustomize.component: notebook-controller
   name: notebook-controller-service-account
   namespace: kubeflow

--- a/tests/stacks/azure/test_data/expected/apiextensions.k8s.io_v1beta1_customresourcedefinition_notebooks.kubeflow.org.yaml
+++ b/tests/stacks/azure/test_data/expected/apiextensions.k8s.io_v1beta1_customresourcedefinition_notebooks.kubeflow.org.yaml
@@ -3,8 +3,6 @@ kind: CustomResourceDefinition
 metadata:
   labels:
     app: notebook-controller
-    app.kubernetes.io/component: notebook-controller
-    app.kubernetes.io/name: notebook-controller
     kustomize.component: notebook-controller
   name: notebooks.kubeflow.org
 spec:

--- a/tests/stacks/azure/test_data/expected/app.k8s.io_v1beta1_application_notebook-controller-notebook-controller.yaml
+++ b/tests/stacks/azure/test_data/expected/app.k8s.io_v1beta1_application_notebook-controller-notebook-controller.yaml
@@ -3,8 +3,6 @@ kind: Application
 metadata:
   labels:
     app: notebook-controller
-    app.kubernetes.io/component: notebook-controller
-    app.kubernetes.io/name: notebook-controller
     kustomize.component: notebook-controller
   name: notebook-controller-notebook-controller
   namespace: kubeflow

--- a/tests/stacks/azure/test_data/expected/apps_v1_deployment_centraldashboard.yaml
+++ b/tests/stacks/azure/test_data/expected/apps_v1_deployment_centraldashboard.yaml
@@ -5,6 +5,7 @@ metadata:
     app: centraldashboard
     app.kubernetes.io/component: centraldashboard
     app.kubernetes.io/name: centraldashboard
+    kustomize.component: centraldashboard
   name: centraldashboard
   namespace: kubeflow
 spec:
@@ -14,6 +15,7 @@ spec:
       app: centraldashboard
       app.kubernetes.io/component: centraldashboard
       app.kubernetes.io/name: centraldashboard
+      kustomize.component: centraldashboard
   template:
     metadata:
       annotations:
@@ -22,6 +24,7 @@ spec:
         app: centraldashboard
         app.kubernetes.io/component: centraldashboard
         app.kubernetes.io/name: centraldashboard
+        kustomize.component: centraldashboard
     spec:
       containers:
       - env:

--- a/tests/stacks/azure/test_data/expected/apps_v1_deployment_notebook-controller-deployment.yaml
+++ b/tests/stacks/azure/test_data/expected/apps_v1_deployment_notebook-controller-deployment.yaml
@@ -3,8 +3,6 @@ kind: Deployment
 metadata:
   labels:
     app: notebook-controller
-    app.kubernetes.io/component: notebook-controller
-    app.kubernetes.io/name: notebook-controller
     kustomize.component: notebook-controller
   name: notebook-controller-deployment
   namespace: kubeflow
@@ -12,8 +10,6 @@ spec:
   selector:
     matchLabels:
       app: notebook-controller
-      app.kubernetes.io/component: notebook-controller
-      app.kubernetes.io/name: notebook-controller
       kustomize.component: notebook-controller
   template:
     metadata:
@@ -21,8 +17,6 @@ spec:
         sidecar.istio.io/inject: "false"
       labels:
         app: notebook-controller
-        app.kubernetes.io/component: notebook-controller
-        app.kubernetes.io/name: notebook-controller
         kustomize.component: notebook-controller
     spec:
       containers:

--- a/tests/stacks/azure/test_data/expected/rbac.authorization.k8s.io_v1_clusterrole_centraldashboard.yaml
+++ b/tests/stacks/azure/test_data/expected/rbac.authorization.k8s.io_v1_clusterrole_centraldashboard.yaml
@@ -5,6 +5,7 @@ metadata:
     app: centraldashboard
     app.kubernetes.io/component: centraldashboard
     app.kubernetes.io/name: centraldashboard
+    kustomize.component: centraldashboard
   name: centraldashboard
 rules:
 - apiGroups:

--- a/tests/stacks/azure/test_data/expected/rbac.authorization.k8s.io_v1_clusterrole_notebook-controller-kubeflow-notebooks-admin.yaml
+++ b/tests/stacks/azure/test_data/expected/rbac.authorization.k8s.io_v1_clusterrole_notebook-controller-kubeflow-notebooks-admin.yaml
@@ -7,8 +7,6 @@ kind: ClusterRole
 metadata:
   labels:
     app: notebook-controller
-    app.kubernetes.io/component: notebook-controller
-    app.kubernetes.io/name: notebook-controller
     kustomize.component: notebook-controller
     rbac.authorization.kubeflow.org/aggregate-to-kubeflow-admin: "true"
   name: notebook-controller-kubeflow-notebooks-admin

--- a/tests/stacks/azure/test_data/expected/rbac.authorization.k8s.io_v1_clusterrole_notebook-controller-kubeflow-notebooks-edit.yaml
+++ b/tests/stacks/azure/test_data/expected/rbac.authorization.k8s.io_v1_clusterrole_notebook-controller-kubeflow-notebooks-edit.yaml
@@ -3,8 +3,6 @@ kind: ClusterRole
 metadata:
   labels:
     app: notebook-controller
-    app.kubernetes.io/component: notebook-controller
-    app.kubernetes.io/name: notebook-controller
     kustomize.component: notebook-controller
     rbac.authorization.kubeflow.org/aggregate-to-kubeflow-edit: "true"
     rbac.authorization.kubeflow.org/aggregate-to-kubeflow-notebooks-admin: "true"

--- a/tests/stacks/azure/test_data/expected/rbac.authorization.k8s.io_v1_clusterrole_notebook-controller-kubeflow-notebooks-view.yaml
+++ b/tests/stacks/azure/test_data/expected/rbac.authorization.k8s.io_v1_clusterrole_notebook-controller-kubeflow-notebooks-view.yaml
@@ -3,8 +3,6 @@ kind: ClusterRole
 metadata:
   labels:
     app: notebook-controller
-    app.kubernetes.io/component: notebook-controller
-    app.kubernetes.io/name: notebook-controller
     kustomize.component: notebook-controller
     rbac.authorization.kubeflow.org/aggregate-to-kubeflow-view: "true"
   name: notebook-controller-kubeflow-notebooks-view

--- a/tests/stacks/azure/test_data/expected/rbac.authorization.k8s.io_v1_clusterrole_notebook-controller-role.yaml
+++ b/tests/stacks/azure/test_data/expected/rbac.authorization.k8s.io_v1_clusterrole_notebook-controller-role.yaml
@@ -3,8 +3,6 @@ kind: ClusterRole
 metadata:
   labels:
     app: notebook-controller
-    app.kubernetes.io/component: notebook-controller
-    app.kubernetes.io/name: notebook-controller
     kustomize.component: notebook-controller
   name: notebook-controller-role
 rules:

--- a/tests/stacks/azure/test_data/expected/rbac.authorization.k8s.io_v1_clusterrolebinding_centraldashboard.yaml
+++ b/tests/stacks/azure/test_data/expected/rbac.authorization.k8s.io_v1_clusterrolebinding_centraldashboard.yaml
@@ -5,6 +5,7 @@ metadata:
     app: centraldashboard
     app.kubernetes.io/component: centraldashboard
     app.kubernetes.io/name: centraldashboard
+    kustomize.component: centraldashboard
   name: centraldashboard
 roleRef:
   apiGroup: rbac.authorization.k8s.io

--- a/tests/stacks/azure/test_data/expected/rbac.authorization.k8s.io_v1_clusterrolebinding_notebook-controller-role-binding.yaml
+++ b/tests/stacks/azure/test_data/expected/rbac.authorization.k8s.io_v1_clusterrolebinding_notebook-controller-role-binding.yaml
@@ -3,8 +3,6 @@ kind: ClusterRoleBinding
 metadata:
   labels:
     app: notebook-controller
-    app.kubernetes.io/component: notebook-controller
-    app.kubernetes.io/name: notebook-controller
     kustomize.component: notebook-controller
   name: notebook-controller-role-binding
 roleRef:

--- a/tests/stacks/azure/test_data/expected/rbac.authorization.k8s.io_v1_role_centraldashboard.yaml
+++ b/tests/stacks/azure/test_data/expected/rbac.authorization.k8s.io_v1_role_centraldashboard.yaml
@@ -5,6 +5,7 @@ metadata:
     app: centraldashboard
     app.kubernetes.io/component: centraldashboard
     app.kubernetes.io/name: centraldashboard
+    kustomize.component: centraldashboard
   name: centraldashboard
   namespace: kubeflow
 rules:

--- a/tests/stacks/azure/test_data/expected/rbac.authorization.k8s.io_v1_rolebinding_centraldashboard.yaml
+++ b/tests/stacks/azure/test_data/expected/rbac.authorization.k8s.io_v1_rolebinding_centraldashboard.yaml
@@ -5,6 +5,7 @@ metadata:
     app: centraldashboard
     app.kubernetes.io/component: centraldashboard
     app.kubernetes.io/name: centraldashboard
+    kustomize.component: centraldashboard
   name: centraldashboard
   namespace: kubeflow
 roleRef:

--- a/tests/stacks/azure/test_data/expected/~g_v1_configmap_notebook-controller-notebook-controller-config-h4d668t5tb.yaml
+++ b/tests/stacks/azure/test_data/expected/~g_v1_configmap_notebook-controller-notebook-controller-config-h4d668t5tb.yaml
@@ -6,8 +6,6 @@ kind: ConfigMap
 metadata:
   labels:
     app: notebook-controller
-    app.kubernetes.io/component: notebook-controller
-    app.kubernetes.io/name: notebook-controller
     kustomize.component: notebook-controller
   name: notebook-controller-notebook-controller-config-h4d668t5tb
   namespace: kubeflow

--- a/tests/stacks/azure/test_data/expected/~g_v1_service_centraldashboard.yaml
+++ b/tests/stacks/azure/test_data/expected/~g_v1_service_centraldashboard.yaml
@@ -14,6 +14,7 @@ metadata:
     app: centraldashboard
     app.kubernetes.io/component: centraldashboard
     app.kubernetes.io/name: centraldashboard
+    kustomize.component: centraldashboard
   name: centraldashboard
   namespace: kubeflow
 spec:
@@ -25,5 +26,6 @@ spec:
     app: centraldashboard
     app.kubernetes.io/component: centraldashboard
     app.kubernetes.io/name: centraldashboard
+    kustomize.component: centraldashboard
   sessionAffinity: None
   type: ClusterIP

--- a/tests/stacks/azure/test_data/expected/~g_v1_service_notebook-controller-service.yaml
+++ b/tests/stacks/azure/test_data/expected/~g_v1_service_notebook-controller-service.yaml
@@ -3,8 +3,6 @@ kind: Service
 metadata:
   labels:
     app: notebook-controller
-    app.kubernetes.io/component: notebook-controller
-    app.kubernetes.io/name: notebook-controller
     kustomize.component: notebook-controller
   name: notebook-controller-service
   namespace: kubeflow
@@ -13,6 +11,4 @@ spec:
   - port: 443
   selector:
     app: notebook-controller
-    app.kubernetes.io/component: notebook-controller
-    app.kubernetes.io/name: notebook-controller
     kustomize.component: notebook-controller

--- a/tests/stacks/azure/test_data/expected/~g_v1_serviceaccount_centraldashboard.yaml
+++ b/tests/stacks/azure/test_data/expected/~g_v1_serviceaccount_centraldashboard.yaml
@@ -2,7 +2,9 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   labels:
+    app: centraldashboard
     app.kubernetes.io/component: centraldashboard
     app.kubernetes.io/name: centraldashboard
+    kustomize.component: centraldashboard
   name: centraldashboard
   namespace: kubeflow

--- a/tests/stacks/azure/test_data/expected/~g_v1_serviceaccount_notebook-controller-service-account.yaml
+++ b/tests/stacks/azure/test_data/expected/~g_v1_serviceaccount_notebook-controller-service-account.yaml
@@ -3,8 +3,6 @@ kind: ServiceAccount
 metadata:
   labels:
     app: notebook-controller
-    app.kubernetes.io/component: notebook-controller
-    app.kubernetes.io/name: notebook-controller
     kustomize.component: notebook-controller
   name: notebook-controller-service-account
   namespace: kubeflow

--- a/tests/stacks/examples/alice/test_data/expected/apiextensions.k8s.io_v1beta1_customresourcedefinition_notebooks.kubeflow.org.yaml
+++ b/tests/stacks/examples/alice/test_data/expected/apiextensions.k8s.io_v1beta1_customresourcedefinition_notebooks.kubeflow.org.yaml
@@ -3,8 +3,6 @@ kind: CustomResourceDefinition
 metadata:
   labels:
     app: notebook-controller
-    app.kubernetes.io/component: notebook-controller
-    app.kubernetes.io/name: notebook-controller
     kustomize.component: notebook-controller
   name: notebooks.kubeflow.org
 spec:

--- a/tests/stacks/examples/alice/test_data/expected/app.k8s.io_v1beta1_application_notebook-controller-notebook-controller.yaml
+++ b/tests/stacks/examples/alice/test_data/expected/app.k8s.io_v1beta1_application_notebook-controller-notebook-controller.yaml
@@ -3,8 +3,6 @@ kind: Application
 metadata:
   labels:
     app: notebook-controller
-    app.kubernetes.io/component: notebook-controller
-    app.kubernetes.io/name: notebook-controller
     kustomize.component: notebook-controller
   name: notebook-controller-notebook-controller
   namespace: kubeflow

--- a/tests/stacks/examples/alice/test_data/expected/apps_v1_deployment_centraldashboard.yaml
+++ b/tests/stacks/examples/alice/test_data/expected/apps_v1_deployment_centraldashboard.yaml
@@ -5,6 +5,7 @@ metadata:
     app: centraldashboard
     app.kubernetes.io/component: centraldashboard
     app.kubernetes.io/name: centraldashboard
+    kustomize.component: centraldashboard
   name: centraldashboard
   namespace: kubeflow
 spec:
@@ -14,6 +15,7 @@ spec:
       app: centraldashboard
       app.kubernetes.io/component: centraldashboard
       app.kubernetes.io/name: centraldashboard
+      kustomize.component: centraldashboard
   template:
     metadata:
       annotations:
@@ -22,6 +24,7 @@ spec:
         app: centraldashboard
         app.kubernetes.io/component: centraldashboard
         app.kubernetes.io/name: centraldashboard
+        kustomize.component: centraldashboard
     spec:
       containers:
       - env:

--- a/tests/stacks/examples/alice/test_data/expected/apps_v1_deployment_notebook-controller-deployment.yaml
+++ b/tests/stacks/examples/alice/test_data/expected/apps_v1_deployment_notebook-controller-deployment.yaml
@@ -3,8 +3,6 @@ kind: Deployment
 metadata:
   labels:
     app: notebook-controller
-    app.kubernetes.io/component: notebook-controller
-    app.kubernetes.io/name: notebook-controller
     kustomize.component: notebook-controller
   name: notebook-controller-deployment
   namespace: kubeflow
@@ -12,8 +10,6 @@ spec:
   selector:
     matchLabels:
       app: notebook-controller
-      app.kubernetes.io/component: notebook-controller
-      app.kubernetes.io/name: notebook-controller
       kustomize.component: notebook-controller
   template:
     metadata:
@@ -21,8 +17,6 @@ spec:
         sidecar.istio.io/inject: "false"
       labels:
         app: notebook-controller
-        app.kubernetes.io/component: notebook-controller
-        app.kubernetes.io/name: notebook-controller
         kustomize.component: notebook-controller
     spec:
       containers:

--- a/tests/stacks/examples/alice/test_data/expected/rbac.authorization.k8s.io_v1_clusterrole_centraldashboard.yaml
+++ b/tests/stacks/examples/alice/test_data/expected/rbac.authorization.k8s.io_v1_clusterrole_centraldashboard.yaml
@@ -5,6 +5,7 @@ metadata:
     app: centraldashboard
     app.kubernetes.io/component: centraldashboard
     app.kubernetes.io/name: centraldashboard
+    kustomize.component: centraldashboard
   name: centraldashboard
 rules:
 - apiGroups:

--- a/tests/stacks/examples/alice/test_data/expected/rbac.authorization.k8s.io_v1_clusterrole_notebook-controller-kubeflow-notebooks-admin.yaml
+++ b/tests/stacks/examples/alice/test_data/expected/rbac.authorization.k8s.io_v1_clusterrole_notebook-controller-kubeflow-notebooks-admin.yaml
@@ -7,8 +7,6 @@ kind: ClusterRole
 metadata:
   labels:
     app: notebook-controller
-    app.kubernetes.io/component: notebook-controller
-    app.kubernetes.io/name: notebook-controller
     kustomize.component: notebook-controller
     rbac.authorization.kubeflow.org/aggregate-to-kubeflow-admin: "true"
   name: notebook-controller-kubeflow-notebooks-admin

--- a/tests/stacks/examples/alice/test_data/expected/rbac.authorization.k8s.io_v1_clusterrole_notebook-controller-kubeflow-notebooks-edit.yaml
+++ b/tests/stacks/examples/alice/test_data/expected/rbac.authorization.k8s.io_v1_clusterrole_notebook-controller-kubeflow-notebooks-edit.yaml
@@ -3,8 +3,6 @@ kind: ClusterRole
 metadata:
   labels:
     app: notebook-controller
-    app.kubernetes.io/component: notebook-controller
-    app.kubernetes.io/name: notebook-controller
     kustomize.component: notebook-controller
     rbac.authorization.kubeflow.org/aggregate-to-kubeflow-edit: "true"
     rbac.authorization.kubeflow.org/aggregate-to-kubeflow-notebooks-admin: "true"

--- a/tests/stacks/examples/alice/test_data/expected/rbac.authorization.k8s.io_v1_clusterrole_notebook-controller-kubeflow-notebooks-view.yaml
+++ b/tests/stacks/examples/alice/test_data/expected/rbac.authorization.k8s.io_v1_clusterrole_notebook-controller-kubeflow-notebooks-view.yaml
@@ -3,8 +3,6 @@ kind: ClusterRole
 metadata:
   labels:
     app: notebook-controller
-    app.kubernetes.io/component: notebook-controller
-    app.kubernetes.io/name: notebook-controller
     kustomize.component: notebook-controller
     rbac.authorization.kubeflow.org/aggregate-to-kubeflow-view: "true"
   name: notebook-controller-kubeflow-notebooks-view

--- a/tests/stacks/examples/alice/test_data/expected/rbac.authorization.k8s.io_v1_clusterrole_notebook-controller-role.yaml
+++ b/tests/stacks/examples/alice/test_data/expected/rbac.authorization.k8s.io_v1_clusterrole_notebook-controller-role.yaml
@@ -3,8 +3,6 @@ kind: ClusterRole
 metadata:
   labels:
     app: notebook-controller
-    app.kubernetes.io/component: notebook-controller
-    app.kubernetes.io/name: notebook-controller
     kustomize.component: notebook-controller
   name: notebook-controller-role
 rules:

--- a/tests/stacks/examples/alice/test_data/expected/rbac.authorization.k8s.io_v1_clusterrolebinding_centraldashboard.yaml
+++ b/tests/stacks/examples/alice/test_data/expected/rbac.authorization.k8s.io_v1_clusterrolebinding_centraldashboard.yaml
@@ -5,6 +5,7 @@ metadata:
     app: centraldashboard
     app.kubernetes.io/component: centraldashboard
     app.kubernetes.io/name: centraldashboard
+    kustomize.component: centraldashboard
   name: centraldashboard
 roleRef:
   apiGroup: rbac.authorization.k8s.io

--- a/tests/stacks/examples/alice/test_data/expected/rbac.authorization.k8s.io_v1_clusterrolebinding_notebook-controller-role-binding.yaml
+++ b/tests/stacks/examples/alice/test_data/expected/rbac.authorization.k8s.io_v1_clusterrolebinding_notebook-controller-role-binding.yaml
@@ -3,8 +3,6 @@ kind: ClusterRoleBinding
 metadata:
   labels:
     app: notebook-controller
-    app.kubernetes.io/component: notebook-controller
-    app.kubernetes.io/name: notebook-controller
     kustomize.component: notebook-controller
   name: notebook-controller-role-binding
 roleRef:

--- a/tests/stacks/examples/alice/test_data/expected/rbac.authorization.k8s.io_v1_role_centraldashboard.yaml
+++ b/tests/stacks/examples/alice/test_data/expected/rbac.authorization.k8s.io_v1_role_centraldashboard.yaml
@@ -5,6 +5,7 @@ metadata:
     app: centraldashboard
     app.kubernetes.io/component: centraldashboard
     app.kubernetes.io/name: centraldashboard
+    kustomize.component: centraldashboard
   name: centraldashboard
   namespace: kubeflow
 rules:

--- a/tests/stacks/examples/alice/test_data/expected/rbac.authorization.k8s.io_v1_rolebinding_centraldashboard.yaml
+++ b/tests/stacks/examples/alice/test_data/expected/rbac.authorization.k8s.io_v1_rolebinding_centraldashboard.yaml
@@ -5,6 +5,7 @@ metadata:
     app: centraldashboard
     app.kubernetes.io/component: centraldashboard
     app.kubernetes.io/name: centraldashboard
+    kustomize.component: centraldashboard
   name: centraldashboard
   namespace: kubeflow
 roleRef:

--- a/tests/stacks/examples/alice/test_data/expected/~g_v1_configmap_notebook-controller-notebook-controller-config-h4d668t5tb.yaml
+++ b/tests/stacks/examples/alice/test_data/expected/~g_v1_configmap_notebook-controller-notebook-controller-config-h4d668t5tb.yaml
@@ -6,8 +6,6 @@ kind: ConfigMap
 metadata:
   labels:
     app: notebook-controller
-    app.kubernetes.io/component: notebook-controller
-    app.kubernetes.io/name: notebook-controller
     kustomize.component: notebook-controller
   name: notebook-controller-notebook-controller-config-h4d668t5tb
   namespace: kubeflow

--- a/tests/stacks/examples/alice/test_data/expected/~g_v1_service_centraldashboard.yaml
+++ b/tests/stacks/examples/alice/test_data/expected/~g_v1_service_centraldashboard.yaml
@@ -14,6 +14,7 @@ metadata:
     app: centraldashboard
     app.kubernetes.io/component: centraldashboard
     app.kubernetes.io/name: centraldashboard
+    kustomize.component: centraldashboard
   name: centraldashboard
   namespace: kubeflow
 spec:
@@ -25,5 +26,6 @@ spec:
     app: centraldashboard
     app.kubernetes.io/component: centraldashboard
     app.kubernetes.io/name: centraldashboard
+    kustomize.component: centraldashboard
   sessionAffinity: None
   type: ClusterIP

--- a/tests/stacks/examples/alice/test_data/expected/~g_v1_service_notebook-controller-service.yaml
+++ b/tests/stacks/examples/alice/test_data/expected/~g_v1_service_notebook-controller-service.yaml
@@ -3,8 +3,6 @@ kind: Service
 metadata:
   labels:
     app: notebook-controller
-    app.kubernetes.io/component: notebook-controller
-    app.kubernetes.io/name: notebook-controller
     kustomize.component: notebook-controller
   name: notebook-controller-service
   namespace: kubeflow
@@ -13,6 +11,4 @@ spec:
   - port: 443
   selector:
     app: notebook-controller
-    app.kubernetes.io/component: notebook-controller
-    app.kubernetes.io/name: notebook-controller
     kustomize.component: notebook-controller

--- a/tests/stacks/examples/alice/test_data/expected/~g_v1_serviceaccount_centraldashboard.yaml
+++ b/tests/stacks/examples/alice/test_data/expected/~g_v1_serviceaccount_centraldashboard.yaml
@@ -2,7 +2,9 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   labels:
+    app: centraldashboard
     app.kubernetes.io/component: centraldashboard
     app.kubernetes.io/name: centraldashboard
+    kustomize.component: centraldashboard
   name: centraldashboard
   namespace: kubeflow

--- a/tests/stacks/examples/alice/test_data/expected/~g_v1_serviceaccount_notebook-controller-service-account.yaml
+++ b/tests/stacks/examples/alice/test_data/expected/~g_v1_serviceaccount_notebook-controller-service-account.yaml
@@ -3,8 +3,6 @@ kind: ServiceAccount
 metadata:
   labels:
     app: notebook-controller
-    app.kubernetes.io/component: notebook-controller
-    app.kubernetes.io/name: notebook-controller
     kustomize.component: notebook-controller
   name: notebook-controller-service-account
   namespace: kubeflow

--- a/tests/stacks/gcp/test_data/expected/apiextensions.k8s.io_v1beta1_customresourcedefinition_notebooks.kubeflow.org.yaml
+++ b/tests/stacks/gcp/test_data/expected/apiextensions.k8s.io_v1beta1_customresourcedefinition_notebooks.kubeflow.org.yaml
@@ -3,8 +3,6 @@ kind: CustomResourceDefinition
 metadata:
   labels:
     app: notebook-controller
-    app.kubernetes.io/component: notebook-controller
-    app.kubernetes.io/name: notebook-controller
     kustomize.component: notebook-controller
   name: notebooks.kubeflow.org
 spec:

--- a/tests/stacks/gcp/test_data/expected/app.k8s.io_v1beta1_application_notebook-controller-notebook-controller.yaml
+++ b/tests/stacks/gcp/test_data/expected/app.k8s.io_v1beta1_application_notebook-controller-notebook-controller.yaml
@@ -3,8 +3,6 @@ kind: Application
 metadata:
   labels:
     app: notebook-controller
-    app.kubernetes.io/component: notebook-controller
-    app.kubernetes.io/name: notebook-controller
     kustomize.component: notebook-controller
   name: notebook-controller-notebook-controller
   namespace: kubeflow

--- a/tests/stacks/gcp/test_data/expected/apps_v1_deployment_centraldashboard.yaml
+++ b/tests/stacks/gcp/test_data/expected/apps_v1_deployment_centraldashboard.yaml
@@ -5,6 +5,7 @@ metadata:
     app: centraldashboard
     app.kubernetes.io/component: centraldashboard
     app.kubernetes.io/name: centraldashboard
+    kustomize.component: centraldashboard
   name: centraldashboard
   namespace: kubeflow
 spec:
@@ -14,6 +15,7 @@ spec:
       app: centraldashboard
       app.kubernetes.io/component: centraldashboard
       app.kubernetes.io/name: centraldashboard
+      kustomize.component: centraldashboard
   template:
     metadata:
       annotations:
@@ -22,6 +24,7 @@ spec:
         app: centraldashboard
         app.kubernetes.io/component: centraldashboard
         app.kubernetes.io/name: centraldashboard
+        kustomize.component: centraldashboard
     spec:
       containers:
       - env:

--- a/tests/stacks/gcp/test_data/expected/apps_v1_deployment_notebook-controller-deployment.yaml
+++ b/tests/stacks/gcp/test_data/expected/apps_v1_deployment_notebook-controller-deployment.yaml
@@ -3,8 +3,6 @@ kind: Deployment
 metadata:
   labels:
     app: notebook-controller
-    app.kubernetes.io/component: notebook-controller
-    app.kubernetes.io/name: notebook-controller
     kustomize.component: notebook-controller
   name: notebook-controller-deployment
   namespace: kubeflow
@@ -12,8 +10,6 @@ spec:
   selector:
     matchLabels:
       app: notebook-controller
-      app.kubernetes.io/component: notebook-controller
-      app.kubernetes.io/name: notebook-controller
       kustomize.component: notebook-controller
   template:
     metadata:
@@ -21,8 +17,6 @@ spec:
         sidecar.istio.io/inject: "false"
       labels:
         app: notebook-controller
-        app.kubernetes.io/component: notebook-controller
-        app.kubernetes.io/name: notebook-controller
         kustomize.component: notebook-controller
     spec:
       containers:

--- a/tests/stacks/gcp/test_data/expected/rbac.authorization.k8s.io_v1_clusterrole_centraldashboard.yaml
+++ b/tests/stacks/gcp/test_data/expected/rbac.authorization.k8s.io_v1_clusterrole_centraldashboard.yaml
@@ -5,6 +5,7 @@ metadata:
     app: centraldashboard
     app.kubernetes.io/component: centraldashboard
     app.kubernetes.io/name: centraldashboard
+    kustomize.component: centraldashboard
   name: centraldashboard
 rules:
 - apiGroups:

--- a/tests/stacks/gcp/test_data/expected/rbac.authorization.k8s.io_v1_clusterrole_notebook-controller-kubeflow-notebooks-admin.yaml
+++ b/tests/stacks/gcp/test_data/expected/rbac.authorization.k8s.io_v1_clusterrole_notebook-controller-kubeflow-notebooks-admin.yaml
@@ -7,8 +7,6 @@ kind: ClusterRole
 metadata:
   labels:
     app: notebook-controller
-    app.kubernetes.io/component: notebook-controller
-    app.kubernetes.io/name: notebook-controller
     kustomize.component: notebook-controller
     rbac.authorization.kubeflow.org/aggregate-to-kubeflow-admin: "true"
   name: notebook-controller-kubeflow-notebooks-admin

--- a/tests/stacks/gcp/test_data/expected/rbac.authorization.k8s.io_v1_clusterrole_notebook-controller-kubeflow-notebooks-edit.yaml
+++ b/tests/stacks/gcp/test_data/expected/rbac.authorization.k8s.io_v1_clusterrole_notebook-controller-kubeflow-notebooks-edit.yaml
@@ -3,8 +3,6 @@ kind: ClusterRole
 metadata:
   labels:
     app: notebook-controller
-    app.kubernetes.io/component: notebook-controller
-    app.kubernetes.io/name: notebook-controller
     kustomize.component: notebook-controller
     rbac.authorization.kubeflow.org/aggregate-to-kubeflow-edit: "true"
     rbac.authorization.kubeflow.org/aggregate-to-kubeflow-notebooks-admin: "true"

--- a/tests/stacks/gcp/test_data/expected/rbac.authorization.k8s.io_v1_clusterrole_notebook-controller-kubeflow-notebooks-view.yaml
+++ b/tests/stacks/gcp/test_data/expected/rbac.authorization.k8s.io_v1_clusterrole_notebook-controller-kubeflow-notebooks-view.yaml
@@ -3,8 +3,6 @@ kind: ClusterRole
 metadata:
   labels:
     app: notebook-controller
-    app.kubernetes.io/component: notebook-controller
-    app.kubernetes.io/name: notebook-controller
     kustomize.component: notebook-controller
     rbac.authorization.kubeflow.org/aggregate-to-kubeflow-view: "true"
   name: notebook-controller-kubeflow-notebooks-view

--- a/tests/stacks/gcp/test_data/expected/rbac.authorization.k8s.io_v1_clusterrole_notebook-controller-role.yaml
+++ b/tests/stacks/gcp/test_data/expected/rbac.authorization.k8s.io_v1_clusterrole_notebook-controller-role.yaml
@@ -3,8 +3,6 @@ kind: ClusterRole
 metadata:
   labels:
     app: notebook-controller
-    app.kubernetes.io/component: notebook-controller
-    app.kubernetes.io/name: notebook-controller
     kustomize.component: notebook-controller
   name: notebook-controller-role
 rules:

--- a/tests/stacks/gcp/test_data/expected/rbac.authorization.k8s.io_v1_clusterrolebinding_centraldashboard.yaml
+++ b/tests/stacks/gcp/test_data/expected/rbac.authorization.k8s.io_v1_clusterrolebinding_centraldashboard.yaml
@@ -5,6 +5,7 @@ metadata:
     app: centraldashboard
     app.kubernetes.io/component: centraldashboard
     app.kubernetes.io/name: centraldashboard
+    kustomize.component: centraldashboard
   name: centraldashboard
 roleRef:
   apiGroup: rbac.authorization.k8s.io

--- a/tests/stacks/gcp/test_data/expected/rbac.authorization.k8s.io_v1_clusterrolebinding_notebook-controller-role-binding.yaml
+++ b/tests/stacks/gcp/test_data/expected/rbac.authorization.k8s.io_v1_clusterrolebinding_notebook-controller-role-binding.yaml
@@ -3,8 +3,6 @@ kind: ClusterRoleBinding
 metadata:
   labels:
     app: notebook-controller
-    app.kubernetes.io/component: notebook-controller
-    app.kubernetes.io/name: notebook-controller
     kustomize.component: notebook-controller
   name: notebook-controller-role-binding
 roleRef:

--- a/tests/stacks/gcp/test_data/expected/rbac.authorization.k8s.io_v1_role_centraldashboard.yaml
+++ b/tests/stacks/gcp/test_data/expected/rbac.authorization.k8s.io_v1_role_centraldashboard.yaml
@@ -5,6 +5,7 @@ metadata:
     app: centraldashboard
     app.kubernetes.io/component: centraldashboard
     app.kubernetes.io/name: centraldashboard
+    kustomize.component: centraldashboard
   name: centraldashboard
   namespace: kubeflow
 rules:

--- a/tests/stacks/gcp/test_data/expected/rbac.authorization.k8s.io_v1_rolebinding_centraldashboard.yaml
+++ b/tests/stacks/gcp/test_data/expected/rbac.authorization.k8s.io_v1_rolebinding_centraldashboard.yaml
@@ -5,6 +5,7 @@ metadata:
     app: centraldashboard
     app.kubernetes.io/component: centraldashboard
     app.kubernetes.io/name: centraldashboard
+    kustomize.component: centraldashboard
   name: centraldashboard
   namespace: kubeflow
 roleRef:

--- a/tests/stacks/gcp/test_data/expected/~g_v1_configmap_notebook-controller-notebook-controller-config-h4d668t5tb.yaml
+++ b/tests/stacks/gcp/test_data/expected/~g_v1_configmap_notebook-controller-notebook-controller-config-h4d668t5tb.yaml
@@ -6,8 +6,6 @@ kind: ConfigMap
 metadata:
   labels:
     app: notebook-controller
-    app.kubernetes.io/component: notebook-controller
-    app.kubernetes.io/name: notebook-controller
     kustomize.component: notebook-controller
   name: notebook-controller-notebook-controller-config-h4d668t5tb
   namespace: kubeflow

--- a/tests/stacks/gcp/test_data/expected/~g_v1_service_centraldashboard.yaml
+++ b/tests/stacks/gcp/test_data/expected/~g_v1_service_centraldashboard.yaml
@@ -14,6 +14,7 @@ metadata:
     app: centraldashboard
     app.kubernetes.io/component: centraldashboard
     app.kubernetes.io/name: centraldashboard
+    kustomize.component: centraldashboard
   name: centraldashboard
   namespace: kubeflow
 spec:
@@ -25,5 +26,6 @@ spec:
     app: centraldashboard
     app.kubernetes.io/component: centraldashboard
     app.kubernetes.io/name: centraldashboard
+    kustomize.component: centraldashboard
   sessionAffinity: None
   type: ClusterIP

--- a/tests/stacks/gcp/test_data/expected/~g_v1_service_notebook-controller-service.yaml
+++ b/tests/stacks/gcp/test_data/expected/~g_v1_service_notebook-controller-service.yaml
@@ -3,8 +3,6 @@ kind: Service
 metadata:
   labels:
     app: notebook-controller
-    app.kubernetes.io/component: notebook-controller
-    app.kubernetes.io/name: notebook-controller
     kustomize.component: notebook-controller
   name: notebook-controller-service
   namespace: kubeflow
@@ -13,6 +11,4 @@ spec:
   - port: 443
   selector:
     app: notebook-controller
-    app.kubernetes.io/component: notebook-controller
-    app.kubernetes.io/name: notebook-controller
     kustomize.component: notebook-controller

--- a/tests/stacks/gcp/test_data/expected/~g_v1_serviceaccount_centraldashboard.yaml
+++ b/tests/stacks/gcp/test_data/expected/~g_v1_serviceaccount_centraldashboard.yaml
@@ -2,7 +2,9 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   labels:
+    app: centraldashboard
     app.kubernetes.io/component: centraldashboard
     app.kubernetes.io/name: centraldashboard
+    kustomize.component: centraldashboard
   name: centraldashboard
   namespace: kubeflow

--- a/tests/stacks/gcp/test_data/expected/~g_v1_serviceaccount_notebook-controller-service-account.yaml
+++ b/tests/stacks/gcp/test_data/expected/~g_v1_serviceaccount_notebook-controller-service-account.yaml
@@ -3,8 +3,6 @@ kind: ServiceAccount
 metadata:
   labels:
     app: notebook-controller
-    app.kubernetes.io/component: notebook-controller
-    app.kubernetes.io/name: notebook-controller
     kustomize.component: notebook-controller
   name: notebook-controller-service-account
   namespace: kubeflow

--- a/tests/stacks/generic/test_data/expected/apiextensions.k8s.io_v1beta1_customresourcedefinition_notebooks.kubeflow.org.yaml
+++ b/tests/stacks/generic/test_data/expected/apiextensions.k8s.io_v1beta1_customresourcedefinition_notebooks.kubeflow.org.yaml
@@ -3,8 +3,6 @@ kind: CustomResourceDefinition
 metadata:
   labels:
     app: notebook-controller
-    app.kubernetes.io/component: notebook-controller
-    app.kubernetes.io/name: notebook-controller
     kustomize.component: notebook-controller
   name: notebooks.kubeflow.org
 spec:

--- a/tests/stacks/generic/test_data/expected/app.k8s.io_v1beta1_application_notebook-controller-notebook-controller.yaml
+++ b/tests/stacks/generic/test_data/expected/app.k8s.io_v1beta1_application_notebook-controller-notebook-controller.yaml
@@ -3,8 +3,6 @@ kind: Application
 metadata:
   labels:
     app: notebook-controller
-    app.kubernetes.io/component: notebook-controller
-    app.kubernetes.io/name: notebook-controller
     kustomize.component: notebook-controller
   name: notebook-controller-notebook-controller
   namespace: kubeflow

--- a/tests/stacks/generic/test_data/expected/apps_v1_deployment_centraldashboard.yaml
+++ b/tests/stacks/generic/test_data/expected/apps_v1_deployment_centraldashboard.yaml
@@ -5,6 +5,7 @@ metadata:
     app: centraldashboard
     app.kubernetes.io/component: centraldashboard
     app.kubernetes.io/name: centraldashboard
+    kustomize.component: centraldashboard
   name: centraldashboard
   namespace: kubeflow
 spec:
@@ -14,6 +15,7 @@ spec:
       app: centraldashboard
       app.kubernetes.io/component: centraldashboard
       app.kubernetes.io/name: centraldashboard
+      kustomize.component: centraldashboard
   template:
     metadata:
       annotations:
@@ -22,6 +24,7 @@ spec:
         app: centraldashboard
         app.kubernetes.io/component: centraldashboard
         app.kubernetes.io/name: centraldashboard
+        kustomize.component: centraldashboard
     spec:
       containers:
       - env:

--- a/tests/stacks/generic/test_data/expected/apps_v1_deployment_notebook-controller-deployment.yaml
+++ b/tests/stacks/generic/test_data/expected/apps_v1_deployment_notebook-controller-deployment.yaml
@@ -3,8 +3,6 @@ kind: Deployment
 metadata:
   labels:
     app: notebook-controller
-    app.kubernetes.io/component: notebook-controller
-    app.kubernetes.io/name: notebook-controller
     kustomize.component: notebook-controller
   name: notebook-controller-deployment
   namespace: kubeflow
@@ -12,8 +10,6 @@ spec:
   selector:
     matchLabels:
       app: notebook-controller
-      app.kubernetes.io/component: notebook-controller
-      app.kubernetes.io/name: notebook-controller
       kustomize.component: notebook-controller
   template:
     metadata:
@@ -21,8 +17,6 @@ spec:
         sidecar.istio.io/inject: "false"
       labels:
         app: notebook-controller
-        app.kubernetes.io/component: notebook-controller
-        app.kubernetes.io/name: notebook-controller
         kustomize.component: notebook-controller
     spec:
       containers:

--- a/tests/stacks/generic/test_data/expected/rbac.authorization.k8s.io_v1_clusterrole_centraldashboard.yaml
+++ b/tests/stacks/generic/test_data/expected/rbac.authorization.k8s.io_v1_clusterrole_centraldashboard.yaml
@@ -5,6 +5,7 @@ metadata:
     app: centraldashboard
     app.kubernetes.io/component: centraldashboard
     app.kubernetes.io/name: centraldashboard
+    kustomize.component: centraldashboard
   name: centraldashboard
 rules:
 - apiGroups:

--- a/tests/stacks/generic/test_data/expected/rbac.authorization.k8s.io_v1_clusterrole_notebook-controller-kubeflow-notebooks-admin.yaml
+++ b/tests/stacks/generic/test_data/expected/rbac.authorization.k8s.io_v1_clusterrole_notebook-controller-kubeflow-notebooks-admin.yaml
@@ -7,8 +7,6 @@ kind: ClusterRole
 metadata:
   labels:
     app: notebook-controller
-    app.kubernetes.io/component: notebook-controller
-    app.kubernetes.io/name: notebook-controller
     kustomize.component: notebook-controller
     rbac.authorization.kubeflow.org/aggregate-to-kubeflow-admin: "true"
   name: notebook-controller-kubeflow-notebooks-admin

--- a/tests/stacks/generic/test_data/expected/rbac.authorization.k8s.io_v1_clusterrole_notebook-controller-kubeflow-notebooks-edit.yaml
+++ b/tests/stacks/generic/test_data/expected/rbac.authorization.k8s.io_v1_clusterrole_notebook-controller-kubeflow-notebooks-edit.yaml
@@ -3,8 +3,6 @@ kind: ClusterRole
 metadata:
   labels:
     app: notebook-controller
-    app.kubernetes.io/component: notebook-controller
-    app.kubernetes.io/name: notebook-controller
     kustomize.component: notebook-controller
     rbac.authorization.kubeflow.org/aggregate-to-kubeflow-edit: "true"
     rbac.authorization.kubeflow.org/aggregate-to-kubeflow-notebooks-admin: "true"

--- a/tests/stacks/generic/test_data/expected/rbac.authorization.k8s.io_v1_clusterrole_notebook-controller-kubeflow-notebooks-view.yaml
+++ b/tests/stacks/generic/test_data/expected/rbac.authorization.k8s.io_v1_clusterrole_notebook-controller-kubeflow-notebooks-view.yaml
@@ -3,8 +3,6 @@ kind: ClusterRole
 metadata:
   labels:
     app: notebook-controller
-    app.kubernetes.io/component: notebook-controller
-    app.kubernetes.io/name: notebook-controller
     kustomize.component: notebook-controller
     rbac.authorization.kubeflow.org/aggregate-to-kubeflow-view: "true"
   name: notebook-controller-kubeflow-notebooks-view

--- a/tests/stacks/generic/test_data/expected/rbac.authorization.k8s.io_v1_clusterrole_notebook-controller-role.yaml
+++ b/tests/stacks/generic/test_data/expected/rbac.authorization.k8s.io_v1_clusterrole_notebook-controller-role.yaml
@@ -3,8 +3,6 @@ kind: ClusterRole
 metadata:
   labels:
     app: notebook-controller
-    app.kubernetes.io/component: notebook-controller
-    app.kubernetes.io/name: notebook-controller
     kustomize.component: notebook-controller
   name: notebook-controller-role
 rules:

--- a/tests/stacks/generic/test_data/expected/rbac.authorization.k8s.io_v1_clusterrolebinding_centraldashboard.yaml
+++ b/tests/stacks/generic/test_data/expected/rbac.authorization.k8s.io_v1_clusterrolebinding_centraldashboard.yaml
@@ -5,6 +5,7 @@ metadata:
     app: centraldashboard
     app.kubernetes.io/component: centraldashboard
     app.kubernetes.io/name: centraldashboard
+    kustomize.component: centraldashboard
   name: centraldashboard
 roleRef:
   apiGroup: rbac.authorization.k8s.io

--- a/tests/stacks/generic/test_data/expected/rbac.authorization.k8s.io_v1_clusterrolebinding_notebook-controller-role-binding.yaml
+++ b/tests/stacks/generic/test_data/expected/rbac.authorization.k8s.io_v1_clusterrolebinding_notebook-controller-role-binding.yaml
@@ -3,8 +3,6 @@ kind: ClusterRoleBinding
 metadata:
   labels:
     app: notebook-controller
-    app.kubernetes.io/component: notebook-controller
-    app.kubernetes.io/name: notebook-controller
     kustomize.component: notebook-controller
   name: notebook-controller-role-binding
 roleRef:

--- a/tests/stacks/generic/test_data/expected/rbac.authorization.k8s.io_v1_role_centraldashboard.yaml
+++ b/tests/stacks/generic/test_data/expected/rbac.authorization.k8s.io_v1_role_centraldashboard.yaml
@@ -5,6 +5,7 @@ metadata:
     app: centraldashboard
     app.kubernetes.io/component: centraldashboard
     app.kubernetes.io/name: centraldashboard
+    kustomize.component: centraldashboard
   name: centraldashboard
   namespace: kubeflow
 rules:

--- a/tests/stacks/generic/test_data/expected/rbac.authorization.k8s.io_v1_rolebinding_centraldashboard.yaml
+++ b/tests/stacks/generic/test_data/expected/rbac.authorization.k8s.io_v1_rolebinding_centraldashboard.yaml
@@ -5,6 +5,7 @@ metadata:
     app: centraldashboard
     app.kubernetes.io/component: centraldashboard
     app.kubernetes.io/name: centraldashboard
+    kustomize.component: centraldashboard
   name: centraldashboard
   namespace: kubeflow
 roleRef:

--- a/tests/stacks/generic/test_data/expected/~g_v1_configmap_notebook-controller-notebook-controller-config-h4d668t5tb.yaml
+++ b/tests/stacks/generic/test_data/expected/~g_v1_configmap_notebook-controller-notebook-controller-config-h4d668t5tb.yaml
@@ -6,8 +6,6 @@ kind: ConfigMap
 metadata:
   labels:
     app: notebook-controller
-    app.kubernetes.io/component: notebook-controller
-    app.kubernetes.io/name: notebook-controller
     kustomize.component: notebook-controller
   name: notebook-controller-notebook-controller-config-h4d668t5tb
   namespace: kubeflow

--- a/tests/stacks/generic/test_data/expected/~g_v1_service_centraldashboard.yaml
+++ b/tests/stacks/generic/test_data/expected/~g_v1_service_centraldashboard.yaml
@@ -14,6 +14,7 @@ metadata:
     app: centraldashboard
     app.kubernetes.io/component: centraldashboard
     app.kubernetes.io/name: centraldashboard
+    kustomize.component: centraldashboard
   name: centraldashboard
   namespace: kubeflow
 spec:
@@ -25,5 +26,6 @@ spec:
     app: centraldashboard
     app.kubernetes.io/component: centraldashboard
     app.kubernetes.io/name: centraldashboard
+    kustomize.component: centraldashboard
   sessionAffinity: None
   type: ClusterIP

--- a/tests/stacks/generic/test_data/expected/~g_v1_service_notebook-controller-service.yaml
+++ b/tests/stacks/generic/test_data/expected/~g_v1_service_notebook-controller-service.yaml
@@ -3,8 +3,6 @@ kind: Service
 metadata:
   labels:
     app: notebook-controller
-    app.kubernetes.io/component: notebook-controller
-    app.kubernetes.io/name: notebook-controller
     kustomize.component: notebook-controller
   name: notebook-controller-service
   namespace: kubeflow
@@ -13,6 +11,4 @@ spec:
   - port: 443
   selector:
     app: notebook-controller
-    app.kubernetes.io/component: notebook-controller
-    app.kubernetes.io/name: notebook-controller
     kustomize.component: notebook-controller

--- a/tests/stacks/generic/test_data/expected/~g_v1_serviceaccount_centraldashboard.yaml
+++ b/tests/stacks/generic/test_data/expected/~g_v1_serviceaccount_centraldashboard.yaml
@@ -2,7 +2,9 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   labels:
+    app: centraldashboard
     app.kubernetes.io/component: centraldashboard
     app.kubernetes.io/name: centraldashboard
+    kustomize.component: centraldashboard
   name: centraldashboard
   namespace: kubeflow

--- a/tests/stacks/generic/test_data/expected/~g_v1_serviceaccount_notebook-controller-service-account.yaml
+++ b/tests/stacks/generic/test_data/expected/~g_v1_serviceaccount_notebook-controller-service-account.yaml
@@ -3,8 +3,6 @@ kind: ServiceAccount
 metadata:
   labels:
     app: notebook-controller
-    app.kubernetes.io/component: notebook-controller
-    app.kubernetes.io/name: notebook-controller
     kustomize.component: notebook-controller
   name: notebook-controller-service-account
   namespace: kubeflow

--- a/tests/stacks/ibm/application/profile-control-plane/test_data/expected/apps_v1_deployment_centraldashboard.yaml
+++ b/tests/stacks/ibm/application/profile-control-plane/test_data/expected/apps_v1_deployment_centraldashboard.yaml
@@ -5,6 +5,7 @@ metadata:
     app: centraldashboard
     app.kubernetes.io/component: centraldashboard
     app.kubernetes.io/name: centraldashboard
+    kustomize.component: centraldashboard
   name: centraldashboard
   namespace: kubeflow
 spec:
@@ -14,6 +15,7 @@ spec:
       app: centraldashboard
       app.kubernetes.io/component: centraldashboard
       app.kubernetes.io/name: centraldashboard
+      kustomize.component: centraldashboard
   template:
     metadata:
       annotations:
@@ -22,6 +24,7 @@ spec:
         app: centraldashboard
         app.kubernetes.io/component: centraldashboard
         app.kubernetes.io/name: centraldashboard
+        kustomize.component: centraldashboard
     spec:
       containers:
       - env:

--- a/tests/stacks/ibm/application/profile-control-plane/test_data/expected/rbac.authorization.k8s.io_v1_clusterrole_centraldashboard.yaml
+++ b/tests/stacks/ibm/application/profile-control-plane/test_data/expected/rbac.authorization.k8s.io_v1_clusterrole_centraldashboard.yaml
@@ -5,6 +5,7 @@ metadata:
     app: centraldashboard
     app.kubernetes.io/component: centraldashboard
     app.kubernetes.io/name: centraldashboard
+    kustomize.component: centraldashboard
   name: centraldashboard
 rules:
 - apiGroups:

--- a/tests/stacks/ibm/application/profile-control-plane/test_data/expected/rbac.authorization.k8s.io_v1_clusterrolebinding_centraldashboard.yaml
+++ b/tests/stacks/ibm/application/profile-control-plane/test_data/expected/rbac.authorization.k8s.io_v1_clusterrolebinding_centraldashboard.yaml
@@ -5,6 +5,7 @@ metadata:
     app: centraldashboard
     app.kubernetes.io/component: centraldashboard
     app.kubernetes.io/name: centraldashboard
+    kustomize.component: centraldashboard
   name: centraldashboard
 roleRef:
   apiGroup: rbac.authorization.k8s.io

--- a/tests/stacks/ibm/application/profile-control-plane/test_data/expected/rbac.authorization.k8s.io_v1_role_centraldashboard.yaml
+++ b/tests/stacks/ibm/application/profile-control-plane/test_data/expected/rbac.authorization.k8s.io_v1_role_centraldashboard.yaml
@@ -5,6 +5,7 @@ metadata:
     app: centraldashboard
     app.kubernetes.io/component: centraldashboard
     app.kubernetes.io/name: centraldashboard
+    kustomize.component: centraldashboard
   name: centraldashboard
   namespace: kubeflow
 rules:

--- a/tests/stacks/ibm/application/profile-control-plane/test_data/expected/rbac.authorization.k8s.io_v1_rolebinding_centraldashboard.yaml
+++ b/tests/stacks/ibm/application/profile-control-plane/test_data/expected/rbac.authorization.k8s.io_v1_rolebinding_centraldashboard.yaml
@@ -5,6 +5,7 @@ metadata:
     app: centraldashboard
     app.kubernetes.io/component: centraldashboard
     app.kubernetes.io/name: centraldashboard
+    kustomize.component: centraldashboard
   name: centraldashboard
   namespace: kubeflow
 roleRef:

--- a/tests/stacks/ibm/application/profile-control-plane/test_data/expected/~g_v1_service_centraldashboard.yaml
+++ b/tests/stacks/ibm/application/profile-control-plane/test_data/expected/~g_v1_service_centraldashboard.yaml
@@ -14,6 +14,7 @@ metadata:
     app: centraldashboard
     app.kubernetes.io/component: centraldashboard
     app.kubernetes.io/name: centraldashboard
+    kustomize.component: centraldashboard
   name: centraldashboard
   namespace: kubeflow
 spec:
@@ -25,5 +26,6 @@ spec:
     app: centraldashboard
     app.kubernetes.io/component: centraldashboard
     app.kubernetes.io/name: centraldashboard
+    kustomize.component: centraldashboard
   sessionAffinity: None
   type: ClusterIP

--- a/tests/stacks/ibm/application/profile-control-plane/test_data/expected/~g_v1_serviceaccount_centraldashboard.yaml
+++ b/tests/stacks/ibm/application/profile-control-plane/test_data/expected/~g_v1_serviceaccount_centraldashboard.yaml
@@ -2,7 +2,9 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   labels:
+    app: centraldashboard
     app.kubernetes.io/component: centraldashboard
     app.kubernetes.io/name: centraldashboard
+    kustomize.component: centraldashboard
   name: centraldashboard
   namespace: kubeflow

--- a/tests/stacks/ibm/multi-user/test_data/expected/apps_v1_deployment_centraldashboard.yaml
+++ b/tests/stacks/ibm/multi-user/test_data/expected/apps_v1_deployment_centraldashboard.yaml
@@ -5,6 +5,7 @@ metadata:
     app: centraldashboard
     app.kubernetes.io/component: centraldashboard
     app.kubernetes.io/name: centraldashboard
+    kustomize.component: centraldashboard
   name: centraldashboard
   namespace: kubeflow
 spec:
@@ -14,6 +15,7 @@ spec:
       app: centraldashboard
       app.kubernetes.io/component: centraldashboard
       app.kubernetes.io/name: centraldashboard
+      kustomize.component: centraldashboard
   template:
     metadata:
       annotations:
@@ -22,6 +24,7 @@ spec:
         app: centraldashboard
         app.kubernetes.io/component: centraldashboard
         app.kubernetes.io/name: centraldashboard
+        kustomize.component: centraldashboard
     spec:
       containers:
       - env:

--- a/tests/stacks/ibm/multi-user/test_data/expected/rbac.authorization.k8s.io_v1_clusterrole_centraldashboard.yaml
+++ b/tests/stacks/ibm/multi-user/test_data/expected/rbac.authorization.k8s.io_v1_clusterrole_centraldashboard.yaml
@@ -5,6 +5,7 @@ metadata:
     app: centraldashboard
     app.kubernetes.io/component: centraldashboard
     app.kubernetes.io/name: centraldashboard
+    kustomize.component: centraldashboard
   name: centraldashboard
 rules:
 - apiGroups:

--- a/tests/stacks/ibm/multi-user/test_data/expected/rbac.authorization.k8s.io_v1_clusterrolebinding_centraldashboard.yaml
+++ b/tests/stacks/ibm/multi-user/test_data/expected/rbac.authorization.k8s.io_v1_clusterrolebinding_centraldashboard.yaml
@@ -5,6 +5,7 @@ metadata:
     app: centraldashboard
     app.kubernetes.io/component: centraldashboard
     app.kubernetes.io/name: centraldashboard
+    kustomize.component: centraldashboard
   name: centraldashboard
 roleRef:
   apiGroup: rbac.authorization.k8s.io

--- a/tests/stacks/ibm/multi-user/test_data/expected/rbac.authorization.k8s.io_v1_role_centraldashboard.yaml
+++ b/tests/stacks/ibm/multi-user/test_data/expected/rbac.authorization.k8s.io_v1_role_centraldashboard.yaml
@@ -5,6 +5,7 @@ metadata:
     app: centraldashboard
     app.kubernetes.io/component: centraldashboard
     app.kubernetes.io/name: centraldashboard
+    kustomize.component: centraldashboard
   name: centraldashboard
   namespace: kubeflow
 rules:

--- a/tests/stacks/ibm/multi-user/test_data/expected/rbac.authorization.k8s.io_v1_rolebinding_centraldashboard.yaml
+++ b/tests/stacks/ibm/multi-user/test_data/expected/rbac.authorization.k8s.io_v1_rolebinding_centraldashboard.yaml
@@ -5,6 +5,7 @@ metadata:
     app: centraldashboard
     app.kubernetes.io/component: centraldashboard
     app.kubernetes.io/name: centraldashboard
+    kustomize.component: centraldashboard
   name: centraldashboard
   namespace: kubeflow
 roleRef:

--- a/tests/stacks/ibm/multi-user/test_data/expected/~g_v1_service_centraldashboard.yaml
+++ b/tests/stacks/ibm/multi-user/test_data/expected/~g_v1_service_centraldashboard.yaml
@@ -14,6 +14,7 @@ metadata:
     app: centraldashboard
     app.kubernetes.io/component: centraldashboard
     app.kubernetes.io/name: centraldashboard
+    kustomize.component: centraldashboard
   name: centraldashboard
   namespace: kubeflow
 spec:
@@ -25,5 +26,6 @@ spec:
     app: centraldashboard
     app.kubernetes.io/component: centraldashboard
     app.kubernetes.io/name: centraldashboard
+    kustomize.component: centraldashboard
   sessionAffinity: None
   type: ClusterIP

--- a/tests/stacks/ibm/multi-user/test_data/expected/~g_v1_serviceaccount_centraldashboard.yaml
+++ b/tests/stacks/ibm/multi-user/test_data/expected/~g_v1_serviceaccount_centraldashboard.yaml
@@ -2,7 +2,9 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   labels:
+    app: centraldashboard
     app.kubernetes.io/component: centraldashboard
     app.kubernetes.io/name: centraldashboard
+    kustomize.component: centraldashboard
   name: centraldashboard
   namespace: kubeflow

--- a/tests/stacks/ibm/test_data/expected/apps_v1_deployment_centraldashboard.yaml
+++ b/tests/stacks/ibm/test_data/expected/apps_v1_deployment_centraldashboard.yaml
@@ -5,6 +5,7 @@ metadata:
     app: centraldashboard
     app.kubernetes.io/component: centraldashboard
     app.kubernetes.io/name: centraldashboard
+    kustomize.component: centraldashboard
   name: centraldashboard
   namespace: kubeflow
 spec:
@@ -14,6 +15,7 @@ spec:
       app: centraldashboard
       app.kubernetes.io/component: centraldashboard
       app.kubernetes.io/name: centraldashboard
+      kustomize.component: centraldashboard
   template:
     metadata:
       annotations:
@@ -22,6 +24,7 @@ spec:
         app: centraldashboard
         app.kubernetes.io/component: centraldashboard
         app.kubernetes.io/name: centraldashboard
+        kustomize.component: centraldashboard
     spec:
       containers:
       - env:

--- a/tests/stacks/ibm/test_data/expected/rbac.authorization.k8s.io_v1_clusterrole_centraldashboard.yaml
+++ b/tests/stacks/ibm/test_data/expected/rbac.authorization.k8s.io_v1_clusterrole_centraldashboard.yaml
@@ -5,6 +5,7 @@ metadata:
     app: centraldashboard
     app.kubernetes.io/component: centraldashboard
     app.kubernetes.io/name: centraldashboard
+    kustomize.component: centraldashboard
   name: centraldashboard
 rules:
 - apiGroups:

--- a/tests/stacks/ibm/test_data/expected/rbac.authorization.k8s.io_v1_clusterrolebinding_centraldashboard.yaml
+++ b/tests/stacks/ibm/test_data/expected/rbac.authorization.k8s.io_v1_clusterrolebinding_centraldashboard.yaml
@@ -5,6 +5,7 @@ metadata:
     app: centraldashboard
     app.kubernetes.io/component: centraldashboard
     app.kubernetes.io/name: centraldashboard
+    kustomize.component: centraldashboard
   name: centraldashboard
 roleRef:
   apiGroup: rbac.authorization.k8s.io

--- a/tests/stacks/ibm/test_data/expected/rbac.authorization.k8s.io_v1_role_centraldashboard.yaml
+++ b/tests/stacks/ibm/test_data/expected/rbac.authorization.k8s.io_v1_role_centraldashboard.yaml
@@ -5,6 +5,7 @@ metadata:
     app: centraldashboard
     app.kubernetes.io/component: centraldashboard
     app.kubernetes.io/name: centraldashboard
+    kustomize.component: centraldashboard
   name: centraldashboard
   namespace: kubeflow
 rules:

--- a/tests/stacks/ibm/test_data/expected/rbac.authorization.k8s.io_v1_rolebinding_centraldashboard.yaml
+++ b/tests/stacks/ibm/test_data/expected/rbac.authorization.k8s.io_v1_rolebinding_centraldashboard.yaml
@@ -5,6 +5,7 @@ metadata:
     app: centraldashboard
     app.kubernetes.io/component: centraldashboard
     app.kubernetes.io/name: centraldashboard
+    kustomize.component: centraldashboard
   name: centraldashboard
   namespace: kubeflow
 roleRef:

--- a/tests/stacks/ibm/test_data/expected/~g_v1_service_centraldashboard.yaml
+++ b/tests/stacks/ibm/test_data/expected/~g_v1_service_centraldashboard.yaml
@@ -14,6 +14,7 @@ metadata:
     app: centraldashboard
     app.kubernetes.io/component: centraldashboard
     app.kubernetes.io/name: centraldashboard
+    kustomize.component: centraldashboard
   name: centraldashboard
   namespace: kubeflow
 spec:
@@ -25,5 +26,6 @@ spec:
     app: centraldashboard
     app.kubernetes.io/component: centraldashboard
     app.kubernetes.io/name: centraldashboard
+    kustomize.component: centraldashboard
   sessionAffinity: None
   type: ClusterIP

--- a/tests/stacks/ibm/test_data/expected/~g_v1_serviceaccount_centraldashboard.yaml
+++ b/tests/stacks/ibm/test_data/expected/~g_v1_serviceaccount_centraldashboard.yaml
@@ -2,7 +2,9 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   labels:
+    app: centraldashboard
     app.kubernetes.io/component: centraldashboard
     app.kubernetes.io/name: centraldashboard
+    kustomize.component: centraldashboard
   name: centraldashboard
   namespace: kubeflow

--- a/tests/stacks/kubernetes/test_data/expected/apiextensions.k8s.io_v1beta1_customresourcedefinition_notebooks.kubeflow.org.yaml
+++ b/tests/stacks/kubernetes/test_data/expected/apiextensions.k8s.io_v1beta1_customresourcedefinition_notebooks.kubeflow.org.yaml
@@ -3,8 +3,6 @@ kind: CustomResourceDefinition
 metadata:
   labels:
     app: notebook-controller
-    app.kubernetes.io/component: notebook-controller
-    app.kubernetes.io/name: notebook-controller
     kustomize.component: notebook-controller
   name: notebooks.kubeflow.org
 spec:

--- a/tests/stacks/kubernetes/test_data/expected/app.k8s.io_v1beta1_application_notebook-controller-notebook-controller.yaml
+++ b/tests/stacks/kubernetes/test_data/expected/app.k8s.io_v1beta1_application_notebook-controller-notebook-controller.yaml
@@ -3,8 +3,6 @@ kind: Application
 metadata:
   labels:
     app: notebook-controller
-    app.kubernetes.io/component: notebook-controller
-    app.kubernetes.io/name: notebook-controller
     kustomize.component: notebook-controller
   name: notebook-controller-notebook-controller
   namespace: kubeflow

--- a/tests/stacks/kubernetes/test_data/expected/apps_v1_deployment_centraldashboard.yaml
+++ b/tests/stacks/kubernetes/test_data/expected/apps_v1_deployment_centraldashboard.yaml
@@ -5,6 +5,7 @@ metadata:
     app: centraldashboard
     app.kubernetes.io/component: centraldashboard
     app.kubernetes.io/name: centraldashboard
+    kustomize.component: centraldashboard
   name: centraldashboard
   namespace: kubeflow
 spec:
@@ -14,6 +15,7 @@ spec:
       app: centraldashboard
       app.kubernetes.io/component: centraldashboard
       app.kubernetes.io/name: centraldashboard
+      kustomize.component: centraldashboard
   template:
     metadata:
       annotations:
@@ -22,6 +24,7 @@ spec:
         app: centraldashboard
         app.kubernetes.io/component: centraldashboard
         app.kubernetes.io/name: centraldashboard
+        kustomize.component: centraldashboard
     spec:
       containers:
       - env:

--- a/tests/stacks/kubernetes/test_data/expected/apps_v1_deployment_notebook-controller-deployment.yaml
+++ b/tests/stacks/kubernetes/test_data/expected/apps_v1_deployment_notebook-controller-deployment.yaml
@@ -3,8 +3,6 @@ kind: Deployment
 metadata:
   labels:
     app: notebook-controller
-    app.kubernetes.io/component: notebook-controller
-    app.kubernetes.io/name: notebook-controller
     kustomize.component: notebook-controller
   name: notebook-controller-deployment
   namespace: kubeflow
@@ -12,8 +10,6 @@ spec:
   selector:
     matchLabels:
       app: notebook-controller
-      app.kubernetes.io/component: notebook-controller
-      app.kubernetes.io/name: notebook-controller
       kustomize.component: notebook-controller
   template:
     metadata:
@@ -21,8 +17,6 @@ spec:
         sidecar.istio.io/inject: "false"
       labels:
         app: notebook-controller
-        app.kubernetes.io/component: notebook-controller
-        app.kubernetes.io/name: notebook-controller
         kustomize.component: notebook-controller
     spec:
       containers:

--- a/tests/stacks/kubernetes/test_data/expected/rbac.authorization.k8s.io_v1_clusterrole_centraldashboard.yaml
+++ b/tests/stacks/kubernetes/test_data/expected/rbac.authorization.k8s.io_v1_clusterrole_centraldashboard.yaml
@@ -5,6 +5,7 @@ metadata:
     app: centraldashboard
     app.kubernetes.io/component: centraldashboard
     app.kubernetes.io/name: centraldashboard
+    kustomize.component: centraldashboard
   name: centraldashboard
 rules:
 - apiGroups:

--- a/tests/stacks/kubernetes/test_data/expected/rbac.authorization.k8s.io_v1_clusterrole_notebook-controller-kubeflow-notebooks-admin.yaml
+++ b/tests/stacks/kubernetes/test_data/expected/rbac.authorization.k8s.io_v1_clusterrole_notebook-controller-kubeflow-notebooks-admin.yaml
@@ -7,8 +7,6 @@ kind: ClusterRole
 metadata:
   labels:
     app: notebook-controller
-    app.kubernetes.io/component: notebook-controller
-    app.kubernetes.io/name: notebook-controller
     kustomize.component: notebook-controller
     rbac.authorization.kubeflow.org/aggregate-to-kubeflow-admin: "true"
   name: notebook-controller-kubeflow-notebooks-admin

--- a/tests/stacks/kubernetes/test_data/expected/rbac.authorization.k8s.io_v1_clusterrole_notebook-controller-kubeflow-notebooks-edit.yaml
+++ b/tests/stacks/kubernetes/test_data/expected/rbac.authorization.k8s.io_v1_clusterrole_notebook-controller-kubeflow-notebooks-edit.yaml
@@ -3,8 +3,6 @@ kind: ClusterRole
 metadata:
   labels:
     app: notebook-controller
-    app.kubernetes.io/component: notebook-controller
-    app.kubernetes.io/name: notebook-controller
     kustomize.component: notebook-controller
     rbac.authorization.kubeflow.org/aggregate-to-kubeflow-edit: "true"
     rbac.authorization.kubeflow.org/aggregate-to-kubeflow-notebooks-admin: "true"

--- a/tests/stacks/kubernetes/test_data/expected/rbac.authorization.k8s.io_v1_clusterrole_notebook-controller-kubeflow-notebooks-view.yaml
+++ b/tests/stacks/kubernetes/test_data/expected/rbac.authorization.k8s.io_v1_clusterrole_notebook-controller-kubeflow-notebooks-view.yaml
@@ -3,8 +3,6 @@ kind: ClusterRole
 metadata:
   labels:
     app: notebook-controller
-    app.kubernetes.io/component: notebook-controller
-    app.kubernetes.io/name: notebook-controller
     kustomize.component: notebook-controller
     rbac.authorization.kubeflow.org/aggregate-to-kubeflow-view: "true"
   name: notebook-controller-kubeflow-notebooks-view

--- a/tests/stacks/kubernetes/test_data/expected/rbac.authorization.k8s.io_v1_clusterrole_notebook-controller-role.yaml
+++ b/tests/stacks/kubernetes/test_data/expected/rbac.authorization.k8s.io_v1_clusterrole_notebook-controller-role.yaml
@@ -3,8 +3,6 @@ kind: ClusterRole
 metadata:
   labels:
     app: notebook-controller
-    app.kubernetes.io/component: notebook-controller
-    app.kubernetes.io/name: notebook-controller
     kustomize.component: notebook-controller
   name: notebook-controller-role
 rules:

--- a/tests/stacks/kubernetes/test_data/expected/rbac.authorization.k8s.io_v1_clusterrolebinding_centraldashboard.yaml
+++ b/tests/stacks/kubernetes/test_data/expected/rbac.authorization.k8s.io_v1_clusterrolebinding_centraldashboard.yaml
@@ -5,6 +5,7 @@ metadata:
     app: centraldashboard
     app.kubernetes.io/component: centraldashboard
     app.kubernetes.io/name: centraldashboard
+    kustomize.component: centraldashboard
   name: centraldashboard
 roleRef:
   apiGroup: rbac.authorization.k8s.io

--- a/tests/stacks/kubernetes/test_data/expected/rbac.authorization.k8s.io_v1_clusterrolebinding_notebook-controller-role-binding.yaml
+++ b/tests/stacks/kubernetes/test_data/expected/rbac.authorization.k8s.io_v1_clusterrolebinding_notebook-controller-role-binding.yaml
@@ -3,8 +3,6 @@ kind: ClusterRoleBinding
 metadata:
   labels:
     app: notebook-controller
-    app.kubernetes.io/component: notebook-controller
-    app.kubernetes.io/name: notebook-controller
     kustomize.component: notebook-controller
   name: notebook-controller-role-binding
 roleRef:

--- a/tests/stacks/kubernetes/test_data/expected/rbac.authorization.k8s.io_v1_role_centraldashboard.yaml
+++ b/tests/stacks/kubernetes/test_data/expected/rbac.authorization.k8s.io_v1_role_centraldashboard.yaml
@@ -5,6 +5,7 @@ metadata:
     app: centraldashboard
     app.kubernetes.io/component: centraldashboard
     app.kubernetes.io/name: centraldashboard
+    kustomize.component: centraldashboard
   name: centraldashboard
   namespace: kubeflow
 rules:

--- a/tests/stacks/kubernetes/test_data/expected/rbac.authorization.k8s.io_v1_rolebinding_centraldashboard.yaml
+++ b/tests/stacks/kubernetes/test_data/expected/rbac.authorization.k8s.io_v1_rolebinding_centraldashboard.yaml
@@ -5,6 +5,7 @@ metadata:
     app: centraldashboard
     app.kubernetes.io/component: centraldashboard
     app.kubernetes.io/name: centraldashboard
+    kustomize.component: centraldashboard
   name: centraldashboard
   namespace: kubeflow
 roleRef:

--- a/tests/stacks/kubernetes/test_data/expected/~g_v1_configmap_notebook-controller-notebook-controller-config-h4d668t5tb.yaml
+++ b/tests/stacks/kubernetes/test_data/expected/~g_v1_configmap_notebook-controller-notebook-controller-config-h4d668t5tb.yaml
@@ -6,8 +6,6 @@ kind: ConfigMap
 metadata:
   labels:
     app: notebook-controller
-    app.kubernetes.io/component: notebook-controller
-    app.kubernetes.io/name: notebook-controller
     kustomize.component: notebook-controller
   name: notebook-controller-notebook-controller-config-h4d668t5tb
   namespace: kubeflow

--- a/tests/stacks/kubernetes/test_data/expected/~g_v1_service_centraldashboard.yaml
+++ b/tests/stacks/kubernetes/test_data/expected/~g_v1_service_centraldashboard.yaml
@@ -14,6 +14,7 @@ metadata:
     app: centraldashboard
     app.kubernetes.io/component: centraldashboard
     app.kubernetes.io/name: centraldashboard
+    kustomize.component: centraldashboard
   name: centraldashboard
   namespace: kubeflow
 spec:
@@ -25,5 +26,6 @@ spec:
     app: centraldashboard
     app.kubernetes.io/component: centraldashboard
     app.kubernetes.io/name: centraldashboard
+    kustomize.component: centraldashboard
   sessionAffinity: None
   type: ClusterIP

--- a/tests/stacks/kubernetes/test_data/expected/~g_v1_service_notebook-controller-service.yaml
+++ b/tests/stacks/kubernetes/test_data/expected/~g_v1_service_notebook-controller-service.yaml
@@ -3,8 +3,6 @@ kind: Service
 metadata:
   labels:
     app: notebook-controller
-    app.kubernetes.io/component: notebook-controller
-    app.kubernetes.io/name: notebook-controller
     kustomize.component: notebook-controller
   name: notebook-controller-service
   namespace: kubeflow
@@ -13,6 +11,4 @@ spec:
   - port: 443
   selector:
     app: notebook-controller
-    app.kubernetes.io/component: notebook-controller
-    app.kubernetes.io/name: notebook-controller
     kustomize.component: notebook-controller

--- a/tests/stacks/kubernetes/test_data/expected/~g_v1_serviceaccount_centraldashboard.yaml
+++ b/tests/stacks/kubernetes/test_data/expected/~g_v1_serviceaccount_centraldashboard.yaml
@@ -2,7 +2,9 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   labels:
+    app: centraldashboard
     app.kubernetes.io/component: centraldashboard
     app.kubernetes.io/name: centraldashboard
+    kustomize.component: centraldashboard
   name: centraldashboard
   namespace: kubeflow

--- a/tests/stacks/kubernetes/test_data/expected/~g_v1_serviceaccount_notebook-controller-service-account.yaml
+++ b/tests/stacks/kubernetes/test_data/expected/~g_v1_serviceaccount_notebook-controller-service-account.yaml
@@ -3,8 +3,6 @@ kind: ServiceAccount
 metadata:
   labels:
     app: notebook-controller
-    app.kubernetes.io/component: notebook-controller
-    app.kubernetes.io/name: notebook-controller
     kustomize.component: notebook-controller
   name: notebook-controller-service-account
   namespace: kubeflow

--- a/tests/stacks/openshift/application/notebook-controller/test_data/expected/apiextensions.k8s.io_v1beta1_customresourcedefinition_notebooks.kubeflow.org.yaml
+++ b/tests/stacks/openshift/application/notebook-controller/test_data/expected/apiextensions.k8s.io_v1beta1_customresourcedefinition_notebooks.kubeflow.org.yaml
@@ -3,8 +3,6 @@ kind: CustomResourceDefinition
 metadata:
   labels:
     app: notebook-controller
-    app.kubernetes.io/component: notebook-controller
-    app.kubernetes.io/name: notebook-controller
     kustomize.component: notebook-controller
   name: notebooks.kubeflow.org
 spec:

--- a/tests/stacks/openshift/application/notebook-controller/test_data/expected/app.k8s.io_v1beta1_application_notebook-controller-notebook-controller.yaml
+++ b/tests/stacks/openshift/application/notebook-controller/test_data/expected/app.k8s.io_v1beta1_application_notebook-controller-notebook-controller.yaml
@@ -3,8 +3,6 @@ kind: Application
 metadata:
   labels:
     app: notebook-controller
-    app.kubernetes.io/component: notebook-controller
-    app.kubernetes.io/name: notebook-controller
     kustomize.component: notebook-controller
   name: notebook-controller-notebook-controller
   namespace: kubeflow

--- a/tests/stacks/openshift/application/notebook-controller/test_data/expected/apps_v1_deployment_notebook-controller-deployment.yaml
+++ b/tests/stacks/openshift/application/notebook-controller/test_data/expected/apps_v1_deployment_notebook-controller-deployment.yaml
@@ -3,8 +3,6 @@ kind: Deployment
 metadata:
   labels:
     app: notebook-controller
-    app.kubernetes.io/component: notebook-controller
-    app.kubernetes.io/name: notebook-controller
     kustomize.component: notebook-controller
   name: notebook-controller-deployment
   namespace: kubeflow
@@ -12,8 +10,6 @@ spec:
   selector:
     matchLabels:
       app: notebook-controller
-      app.kubernetes.io/component: notebook-controller
-      app.kubernetes.io/name: notebook-controller
       kustomize.component: notebook-controller
   template:
     metadata:
@@ -21,8 +17,6 @@ spec:
         sidecar.istio.io/inject: "false"
       labels:
         app: notebook-controller
-        app.kubernetes.io/component: notebook-controller
-        app.kubernetes.io/name: notebook-controller
         kustomize.component: notebook-controller
     spec:
       containers:

--- a/tests/stacks/openshift/application/notebook-controller/test_data/expected/rbac.authorization.k8s.io_v1_clusterrole_notebook-controller-kubeflow-notebooks-admin.yaml
+++ b/tests/stacks/openshift/application/notebook-controller/test_data/expected/rbac.authorization.k8s.io_v1_clusterrole_notebook-controller-kubeflow-notebooks-admin.yaml
@@ -7,8 +7,6 @@ kind: ClusterRole
 metadata:
   labels:
     app: notebook-controller
-    app.kubernetes.io/component: notebook-controller
-    app.kubernetes.io/name: notebook-controller
     kustomize.component: notebook-controller
     rbac.authorization.kubeflow.org/aggregate-to-kubeflow-admin: "true"
   name: notebook-controller-kubeflow-notebooks-admin

--- a/tests/stacks/openshift/application/notebook-controller/test_data/expected/rbac.authorization.k8s.io_v1_clusterrole_notebook-controller-kubeflow-notebooks-edit.yaml
+++ b/tests/stacks/openshift/application/notebook-controller/test_data/expected/rbac.authorization.k8s.io_v1_clusterrole_notebook-controller-kubeflow-notebooks-edit.yaml
@@ -3,8 +3,6 @@ kind: ClusterRole
 metadata:
   labels:
     app: notebook-controller
-    app.kubernetes.io/component: notebook-controller
-    app.kubernetes.io/name: notebook-controller
     kustomize.component: notebook-controller
     rbac.authorization.kubeflow.org/aggregate-to-kubeflow-edit: "true"
     rbac.authorization.kubeflow.org/aggregate-to-kubeflow-notebooks-admin: "true"

--- a/tests/stacks/openshift/application/notebook-controller/test_data/expected/rbac.authorization.k8s.io_v1_clusterrole_notebook-controller-kubeflow-notebooks-view.yaml
+++ b/tests/stacks/openshift/application/notebook-controller/test_data/expected/rbac.authorization.k8s.io_v1_clusterrole_notebook-controller-kubeflow-notebooks-view.yaml
@@ -3,8 +3,6 @@ kind: ClusterRole
 metadata:
   labels:
     app: notebook-controller
-    app.kubernetes.io/component: notebook-controller
-    app.kubernetes.io/name: notebook-controller
     kustomize.component: notebook-controller
     rbac.authorization.kubeflow.org/aggregate-to-kubeflow-view: "true"
   name: notebook-controller-kubeflow-notebooks-view

--- a/tests/stacks/openshift/application/notebook-controller/test_data/expected/rbac.authorization.k8s.io_v1_clusterrole_notebook-controller-role.yaml
+++ b/tests/stacks/openshift/application/notebook-controller/test_data/expected/rbac.authorization.k8s.io_v1_clusterrole_notebook-controller-role.yaml
@@ -3,8 +3,6 @@ kind: ClusterRole
 metadata:
   labels:
     app: notebook-controller
-    app.kubernetes.io/component: notebook-controller
-    app.kubernetes.io/name: notebook-controller
     kustomize.component: notebook-controller
   name: notebook-controller-role
 rules:

--- a/tests/stacks/openshift/application/notebook-controller/test_data/expected/rbac.authorization.k8s.io_v1_clusterrolebinding_notebook-controller-role-binding.yaml
+++ b/tests/stacks/openshift/application/notebook-controller/test_data/expected/rbac.authorization.k8s.io_v1_clusterrolebinding_notebook-controller-role-binding.yaml
@@ -3,8 +3,6 @@ kind: ClusterRoleBinding
 metadata:
   labels:
     app: notebook-controller
-    app.kubernetes.io/component: notebook-controller
-    app.kubernetes.io/name: notebook-controller
     kustomize.component: notebook-controller
   name: notebook-controller-role-binding
 roleRef:

--- a/tests/stacks/openshift/application/notebook-controller/test_data/expected/~g_v1_configmap_notebook-controller-notebook-controller-config-h4d668t5tb.yaml
+++ b/tests/stacks/openshift/application/notebook-controller/test_data/expected/~g_v1_configmap_notebook-controller-notebook-controller-config-h4d668t5tb.yaml
@@ -6,8 +6,6 @@ kind: ConfigMap
 metadata:
   labels:
     app: notebook-controller
-    app.kubernetes.io/component: notebook-controller
-    app.kubernetes.io/name: notebook-controller
     kustomize.component: notebook-controller
   name: notebook-controller-notebook-controller-config-h4d668t5tb
   namespace: kubeflow

--- a/tests/stacks/openshift/application/notebook-controller/test_data/expected/~g_v1_service_notebook-controller-service.yaml
+++ b/tests/stacks/openshift/application/notebook-controller/test_data/expected/~g_v1_service_notebook-controller-service.yaml
@@ -3,8 +3,6 @@ kind: Service
 metadata:
   labels:
     app: notebook-controller
-    app.kubernetes.io/component: notebook-controller
-    app.kubernetes.io/name: notebook-controller
     kustomize.component: notebook-controller
   name: notebook-controller-service
   namespace: kubeflow
@@ -13,6 +11,4 @@ spec:
   - port: 443
   selector:
     app: notebook-controller
-    app.kubernetes.io/component: notebook-controller
-    app.kubernetes.io/name: notebook-controller
     kustomize.component: notebook-controller

--- a/tests/stacks/openshift/application/notebook-controller/test_data/expected/~g_v1_serviceaccount_notebook-controller-service-account.yaml
+++ b/tests/stacks/openshift/application/notebook-controller/test_data/expected/~g_v1_serviceaccount_notebook-controller-service-account.yaml
@@ -3,8 +3,6 @@ kind: ServiceAccount
 metadata:
   labels:
     app: notebook-controller
-    app.kubernetes.io/component: notebook-controller
-    app.kubernetes.io/name: notebook-controller
     kustomize.component: notebook-controller
   name: notebook-controller-service-account
   namespace: kubeflow

--- a/tests/stacks/openshift/test_data/expected/apps_v1_deployment_centraldashboard.yaml
+++ b/tests/stacks/openshift/test_data/expected/apps_v1_deployment_centraldashboard.yaml
@@ -5,6 +5,7 @@ metadata:
     app: centraldashboard
     app.kubernetes.io/component: centraldashboard
     app.kubernetes.io/name: centraldashboard
+    kustomize.component: centraldashboard
   name: centraldashboard
   namespace: kubeflow
 spec:
@@ -14,6 +15,7 @@ spec:
       app: centraldashboard
       app.kubernetes.io/component: centraldashboard
       app.kubernetes.io/name: centraldashboard
+      kustomize.component: centraldashboard
   template:
     metadata:
       annotations:
@@ -22,6 +24,7 @@ spec:
         app: centraldashboard
         app.kubernetes.io/component: centraldashboard
         app.kubernetes.io/name: centraldashboard
+        kustomize.component: centraldashboard
     spec:
       containers:
       - env:

--- a/tests/stacks/openshift/test_data/expected/rbac.authorization.k8s.io_v1_clusterrole_centraldashboard.yaml
+++ b/tests/stacks/openshift/test_data/expected/rbac.authorization.k8s.io_v1_clusterrole_centraldashboard.yaml
@@ -5,6 +5,7 @@ metadata:
     app: centraldashboard
     app.kubernetes.io/component: centraldashboard
     app.kubernetes.io/name: centraldashboard
+    kustomize.component: centraldashboard
   name: centraldashboard
 rules:
 - apiGroups:

--- a/tests/stacks/openshift/test_data/expected/rbac.authorization.k8s.io_v1_clusterrolebinding_centraldashboard.yaml
+++ b/tests/stacks/openshift/test_data/expected/rbac.authorization.k8s.io_v1_clusterrolebinding_centraldashboard.yaml
@@ -5,6 +5,7 @@ metadata:
     app: centraldashboard
     app.kubernetes.io/component: centraldashboard
     app.kubernetes.io/name: centraldashboard
+    kustomize.component: centraldashboard
   name: centraldashboard
 roleRef:
   apiGroup: rbac.authorization.k8s.io

--- a/tests/stacks/openshift/test_data/expected/rbac.authorization.k8s.io_v1_role_centraldashboard.yaml
+++ b/tests/stacks/openshift/test_data/expected/rbac.authorization.k8s.io_v1_role_centraldashboard.yaml
@@ -5,6 +5,7 @@ metadata:
     app: centraldashboard
     app.kubernetes.io/component: centraldashboard
     app.kubernetes.io/name: centraldashboard
+    kustomize.component: centraldashboard
   name: centraldashboard
   namespace: kubeflow
 rules:

--- a/tests/stacks/openshift/test_data/expected/rbac.authorization.k8s.io_v1_rolebinding_centraldashboard.yaml
+++ b/tests/stacks/openshift/test_data/expected/rbac.authorization.k8s.io_v1_rolebinding_centraldashboard.yaml
@@ -5,6 +5,7 @@ metadata:
     app: centraldashboard
     app.kubernetes.io/component: centraldashboard
     app.kubernetes.io/name: centraldashboard
+    kustomize.component: centraldashboard
   name: centraldashboard
   namespace: kubeflow
 roleRef:

--- a/tests/stacks/openshift/test_data/expected/~g_v1_service_centraldashboard.yaml
+++ b/tests/stacks/openshift/test_data/expected/~g_v1_service_centraldashboard.yaml
@@ -14,6 +14,7 @@ metadata:
     app: centraldashboard
     app.kubernetes.io/component: centraldashboard
     app.kubernetes.io/name: centraldashboard
+    kustomize.component: centraldashboard
   name: centraldashboard
   namespace: kubeflow
 spec:
@@ -25,5 +26,6 @@ spec:
     app: centraldashboard
     app.kubernetes.io/component: centraldashboard
     app.kubernetes.io/name: centraldashboard
+    kustomize.component: centraldashboard
   sessionAffinity: None
   type: ClusterIP

--- a/tests/stacks/openshift/test_data/expected/~g_v1_serviceaccount_centraldashboard.yaml
+++ b/tests/stacks/openshift/test_data/expected/~g_v1_serviceaccount_centraldashboard.yaml
@@ -2,7 +2,9 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   labels:
+    app: centraldashboard
     app.kubernetes.io/component: centraldashboard
     app.kubernetes.io/name: centraldashboard
+    kustomize.component: centraldashboard
   name: centraldashboard
   namespace: kubeflow


### PR DESCRIPTION
**Description of your changes:**
Makes the following components have consistent `commonLabels` between `base` and `base_v3`:
- centraldashboard
- jupyter-web-app
- notebook-controller

**Checklist:**
- [X] Unit tests have been rebuilt: 
    1. `cd manifests/tests`
    2. `make generate-changed-only`
    3. `make test`
