### PR TITLE
Enable AWS Kubeflow-Kubernetes Periodic Tests in v1.2-branch

### DIFF
--- a/prow_config.yaml
+++ b/prow_config.yaml
@@ -58,10 +58,45 @@ workflows:
 
   ####################################### AWS Specific Tests
   - py_func: kubeflow.kfctl.testing.ci.kfctl_e2e_workflow.create_workflow
-    name: aws-e2e
+    name: aws-default
     job_types:
       - periodic
     kwargs:
       build_and_apply: false
       config_path: https://raw.githubusercontent.com/kubeflow/manifests/v1.2-branch/kfdef/kfctl_aws.v1.2.0.yaml
+      
+  - py_func: kubeflow.kfctl.testing.ci.kfctl_e2e_workflow.create_workflow
+    name: aws-1-15
+    job_types:
+      - periodic
+    kwargs:
+      build_and_apply: false
+      config_path: https://raw.githubusercontent.com/kubeflow/manifests/v1.2-branch/kfdef/kfctl_aws.v1.2.0.yaml
+      eks_cluster_version: "1.15"
     
+  - py_func: kubeflow.kfctl.testing.ci.kfctl_e2e_workflow.create_workflow
+    name: aws-1-16
+    job_types:
+      - periodic
+    kwargs:
+      build_and_apply: false
+      config_path: https://raw.githubusercontent.com/kubeflow/manifests/v1.2-branch/kfdef/kfctl_aws.v1.2.0.yaml
+      eks_cluster_version: "1.16"  
+
+  - py_func: kubeflow.kfctl.testing.ci.kfctl_e2e_workflow.create_workflow
+    name: aws-1-17
+    job_types:
+      - periodic
+    kwargs:
+      build_and_apply: false
+      config_path: https://raw.githubusercontent.com/kubeflow/manifests/v1.2-branch/kfdef/kfctl_aws.v1.2.0.yaml
+      eks_cluster_version: "1.17"
+  
+  - py_func: kubeflow.kfctl.testing.ci.kfctl_e2e_workflow.create_workflow
+    name: aws-1-18
+    job_types:
+      - periodic
+    kwargs:
+      build_and_apply: false
+      config_path: https://raw.githubusercontent.com/kubeflow/manifests/v1.2-branch/kfdef/kfctl_aws.v1.2.0.yaml
+      eks_cluster_version: "1.18"


### PR DESCRIPTION
**Which issue is resolved by this Pull Request:**
Resolves #

**Description of your changes:**
This PR is to enable AWS Kubeflow-Kubernetes Periodic Tests in v1.2-branch 

**Checklist:**
- [x] Unit tests have been rebuilt: 
    1. `cd manifests/tests`
    2. `make generate-changed-only`
    3. `make test`
