### PR TITLE
[IBM] Update notebooks and profiles image tags

### DIFF
--- a/stacks/ibm/application/jupyter-web-app/base/kustomization.yaml
+++ b/stacks/ibm/application/jupyter-web-app/base/kustomization.yaml
@@ -10,7 +10,7 @@ namespace: kubeflow
 images:
 - name: gcr.io/kubeflow-images-public/jupyter-web-app
   newName: gcr.io/kubeflow-images-public/jupyter-web-app
-  newTag: vmaster-gd9be4b9e
+  newTag: vmaster-g845af298
 resources:
 - ../../../../../jupyter/jupyter-web-app/base/cluster-role-binding.yaml
 - ../../../../../jupyter/jupyter-web-app/base/cluster-role.yaml

--- a/stacks/ibm/application/notebook-controller/base/kustomization.yaml
+++ b/stacks/ibm/application/notebook-controller/base/kustomization.yaml
@@ -17,7 +17,7 @@ configMapGenerator:
 images:
 - name: gcr.io/kubeflow-images-public/notebook-controller
   newName: gcr.io/kubeflow-images-public/notebook-controller
-  newTag: vmaster-gf39279c0
+  newTag: vmaster-g6eb007d0
 patchesStrategicMerge:
 - deployment_patch.yaml
 resources:

--- a/stacks/ibm/application/profiles/base/kustomization.yaml
+++ b/stacks/ibm/application/profiles/base/kustomization.yaml
@@ -6,10 +6,10 @@ commonLabels:
 images:
 - name: gcr.io/kubeflow-images-public/kfam
   newName: gcr.io/kubeflow-images-public/kfam
-  newTag: vmaster-gf3e09203
+  newTag: vmaster-g9f3bfd00
 - name: gcr.io/kubeflow-images-public/profile-controller
   newName: gcr.io/kubeflow-images-public/profile-controller
-  newTag: vmaster-g34aa47c2
+  newTag: vmaster-ga49f658f
 resources:
 - ../../../../../profiles/base/cluster-role-binding.yaml
 - ../../../../../profiles/base/crd.yaml

--- a/tests/stacks/ibm/application/jupyter-web-app/base/test_data/expected/apps_v1_deployment_jupyter-web-app-deployment.yaml
+++ b/tests/stacks/ibm/application/jupyter-web-app/base/test_data/expected/apps_v1_deployment_jupyter-web-app-deployment.yaml
@@ -48,7 +48,7 @@ spec:
             configMapKeyRef:
               key: userid-prefix
               name: kubeflow-config
-        image: gcr.io/kubeflow-images-public/jupyter-web-app:vmaster-gd9be4b9e
+        image: gcr.io/kubeflow-images-public/jupyter-web-app:vmaster-g845af298
         imagePullPolicy: Always
         name: jupyter-web-app
         ports:

--- a/tests/stacks/ibm/application/jupyter-web-app/test_data/expected/apps_v1_deployment_jupyter-web-app-deployment.yaml
+++ b/tests/stacks/ibm/application/jupyter-web-app/test_data/expected/apps_v1_deployment_jupyter-web-app-deployment.yaml
@@ -48,7 +48,7 @@ spec:
             configMapKeyRef:
               key: userid-prefix
               name: kubeflow-config
-        image: gcr.io/kubeflow-images-public/jupyter-web-app:vmaster-gd9be4b9e
+        image: gcr.io/kubeflow-images-public/jupyter-web-app:vmaster-g845af298
         imagePullPolicy: Always
         name: jupyter-web-app
         ports:

--- a/tests/stacks/ibm/application/notebook-controller/base/test_data/expected/apps_v1_deployment_notebook-controller-deployment.yaml
+++ b/tests/stacks/ibm/application/notebook-controller/base/test_data/expected/apps_v1_deployment_notebook-controller-deployment.yaml
@@ -39,7 +39,7 @@ spec:
             configMapKeyRef:
               key: ISTIO_GATEWAY
               name: notebook-controller-config
-        image: gcr.io/kubeflow-images-public/notebook-controller:vmaster-gf39279c0
+        image: gcr.io/kubeflow-images-public/notebook-controller:vmaster-g6eb007d0
         imagePullPolicy: Always
         livenessProbe:
           httpGet:

--- a/tests/stacks/ibm/application/notebook-controller/test_data/expected/kubeflow_apps_v1_deployment_notebook-controller-deployment.yaml
+++ b/tests/stacks/ibm/application/notebook-controller/test_data/expected/kubeflow_apps_v1_deployment_notebook-controller-deployment.yaml
@@ -39,7 +39,7 @@ spec:
             configMapKeyRef:
               key: ISTIO_GATEWAY
               name: notebook-controller-config
-        image: gcr.io/kubeflow-images-public/notebook-controller:vmaster-gf39279c0
+        image: gcr.io/kubeflow-images-public/notebook-controller:vmaster-g6eb007d0
         imagePullPolicy: Always
         livenessProbe:
           httpGet:

--- a/tests/stacks/ibm/application/notebooks/test_data/expected/apps_v1_deployment_jupyter-web-app-deployment.yaml
+++ b/tests/stacks/ibm/application/notebooks/test_data/expected/apps_v1_deployment_jupyter-web-app-deployment.yaml
@@ -48,7 +48,7 @@ spec:
             configMapKeyRef:
               key: userid-prefix
               name: kubeflow-config-bk4bc7m928
-        image: gcr.io/kubeflow-images-public/jupyter-web-app:vmaster-gd9be4b9e
+        image: gcr.io/kubeflow-images-public/jupyter-web-app:vmaster-g845af298
         imagePullPolicy: Always
         name: jupyter-web-app
         ports:

--- a/tests/stacks/ibm/application/notebooks/test_data/expected/apps_v1_deployment_notebook-controller-deployment.yaml
+++ b/tests/stacks/ibm/application/notebooks/test_data/expected/apps_v1_deployment_notebook-controller-deployment.yaml
@@ -39,7 +39,7 @@ spec:
             configMapKeyRef:
               key: ISTIO_GATEWAY
               name: notebook-controller-config
-        image: gcr.io/kubeflow-images-public/notebook-controller:vmaster-gf39279c0
+        image: gcr.io/kubeflow-images-public/notebook-controller:vmaster-g6eb007d0
         imagePullPolicy: Always
         livenessProbe:
           httpGet:

--- a/tests/stacks/ibm/application/profile-control-plane/test_data/expected/apps_v1_deployment_profiles-deployment.yaml
+++ b/tests/stacks/ibm/application/profile-control-plane/test_data/expected/apps_v1_deployment_profiles-deployment.yaml
@@ -49,7 +49,7 @@ spec:
             configMapKeyRef:
               key: gcp-sa
               name: profiles-profiles-config-h7dck95hm2
-        image: gcr.io/kubeflow-images-public/profile-controller:vmaster-g34aa47c2
+        image: gcr.io/kubeflow-images-public/profile-controller:vmaster-ga49f658f
         imagePullPolicy: Always
         livenessProbe:
           httpGet:
@@ -87,7 +87,7 @@ spec:
             configMapKeyRef:
               key: admin
               name: profiles-profiles-config-h7dck95hm2
-        image: gcr.io/kubeflow-images-public/kfam:vmaster-gf3e09203
+        image: gcr.io/kubeflow-images-public/kfam:vmaster-g9f3bfd00
         imagePullPolicy: Always
         livenessProbe:
           httpGet:

--- a/tests/stacks/ibm/application/profiles/base/test_data/expected/apps_v1_deployment_profiles-deployment.yaml
+++ b/tests/stacks/ibm/application/profiles/base/test_data/expected/apps_v1_deployment_profiles-deployment.yaml
@@ -42,7 +42,7 @@ spec:
             configMapKeyRef:
               key: gcp-sa
               name: profiles-profiles-config-4mgcmtgk6t
-        image: gcr.io/kubeflow-images-public/profile-controller:vmaster-g34aa47c2
+        image: gcr.io/kubeflow-images-public/profile-controller:vmaster-ga49f658f
         imagePullPolicy: Always
         livenessProbe:
           httpGet:
@@ -80,7 +80,7 @@ spec:
             configMapKeyRef:
               key: admin
               name: profiles-profiles-config-4mgcmtgk6t
-        image: gcr.io/kubeflow-images-public/kfam:vmaster-gf3e09203
+        image: gcr.io/kubeflow-images-public/kfam:vmaster-g9f3bfd00
         imagePullPolicy: Always
         livenessProbe:
           httpGet:

--- a/tests/stacks/ibm/application/profiles/test_data/expected/apps_v1_deployment_profiles-deployment.yaml
+++ b/tests/stacks/ibm/application/profiles/test_data/expected/apps_v1_deployment_profiles-deployment.yaml
@@ -48,7 +48,7 @@ spec:
             configMapKeyRef:
               key: gcp-sa
               name: profiles-profiles-config-4mgcmtgk6t
-        image: gcr.io/kubeflow-images-public/profile-controller:vmaster-g34aa47c2
+        image: gcr.io/kubeflow-images-public/profile-controller:vmaster-ga49f658f
         imagePullPolicy: Always
         livenessProbe:
           httpGet:
@@ -86,7 +86,7 @@ spec:
             configMapKeyRef:
               key: admin
               name: profiles-profiles-config-4mgcmtgk6t
-        image: gcr.io/kubeflow-images-public/kfam:vmaster-gf3e09203
+        image: gcr.io/kubeflow-images-public/kfam:vmaster-g9f3bfd00
         imagePullPolicy: Always
         livenessProbe:
           httpGet:

--- a/tests/stacks/ibm/multi-user/test_data/expected/apps_v1_deployment_jupyter-web-app-deployment.yaml
+++ b/tests/stacks/ibm/multi-user/test_data/expected/apps_v1_deployment_jupyter-web-app-deployment.yaml
@@ -48,7 +48,7 @@ spec:
             configMapKeyRef:
               key: userid-prefix
               name: kubeflow-config-bk4bc7m928
-        image: gcr.io/kubeflow-images-public/jupyter-web-app:vmaster-gd9be4b9e
+        image: gcr.io/kubeflow-images-public/jupyter-web-app:vmaster-g845af298
         imagePullPolicy: Always
         name: jupyter-web-app
         ports:

--- a/tests/stacks/ibm/multi-user/test_data/expected/apps_v1_deployment_notebook-controller-deployment.yaml
+++ b/tests/stacks/ibm/multi-user/test_data/expected/apps_v1_deployment_notebook-controller-deployment.yaml
@@ -39,7 +39,7 @@ spec:
             configMapKeyRef:
               key: ISTIO_GATEWAY
               name: notebook-controller-config
-        image: gcr.io/kubeflow-images-public/notebook-controller:vmaster-gf39279c0
+        image: gcr.io/kubeflow-images-public/notebook-controller:vmaster-g6eb007d0
         imagePullPolicy: Always
         livenessProbe:
           httpGet:

--- a/tests/stacks/ibm/multi-user/test_data/expected/apps_v1_deployment_profiles-deployment.yaml
+++ b/tests/stacks/ibm/multi-user/test_data/expected/apps_v1_deployment_profiles-deployment.yaml
@@ -49,7 +49,7 @@ spec:
             configMapKeyRef:
               key: gcp-sa
               name: profiles-profiles-config-h7dck95hm2
-        image: gcr.io/kubeflow-images-public/profile-controller:vmaster-g34aa47c2
+        image: gcr.io/kubeflow-images-public/profile-controller:vmaster-ga49f658f
         imagePullPolicy: Always
         livenessProbe:
           httpGet:
@@ -87,7 +87,7 @@ spec:
             configMapKeyRef:
               key: admin
               name: profiles-profiles-config-h7dck95hm2
-        image: gcr.io/kubeflow-images-public/kfam:vmaster-gf3e09203
+        image: gcr.io/kubeflow-images-public/kfam:vmaster-g9f3bfd00
         imagePullPolicy: Always
         livenessProbe:
           httpGet:

--- a/tests/stacks/ibm/test_data/expected/apps_v1_deployment_jupyter-web-app-deployment.yaml
+++ b/tests/stacks/ibm/test_data/expected/apps_v1_deployment_jupyter-web-app-deployment.yaml
@@ -48,7 +48,7 @@ spec:
             configMapKeyRef:
               key: userid-prefix
               name: kubeflow-config-bk4bc7m928
-        image: gcr.io/kubeflow-images-public/jupyter-web-app:vmaster-gd9be4b9e
+        image: gcr.io/kubeflow-images-public/jupyter-web-app:vmaster-g845af298
         imagePullPolicy: Always
         name: jupyter-web-app
         ports:

--- a/tests/stacks/ibm/test_data/expected/apps_v1_deployment_notebook-controller-deployment.yaml
+++ b/tests/stacks/ibm/test_data/expected/apps_v1_deployment_notebook-controller-deployment.yaml
@@ -39,7 +39,7 @@ spec:
             configMapKeyRef:
               key: ISTIO_GATEWAY
               name: notebook-controller-config
-        image: gcr.io/kubeflow-images-public/notebook-controller:vmaster-gf39279c0
+        image: gcr.io/kubeflow-images-public/notebook-controller:vmaster-g6eb007d0
         imagePullPolicy: Always
         livenessProbe:
           httpGet:

--- a/tests/stacks/ibm/test_data/expected/apps_v1_deployment_profiles-deployment.yaml
+++ b/tests/stacks/ibm/test_data/expected/apps_v1_deployment_profiles-deployment.yaml
@@ -49,7 +49,7 @@ spec:
             configMapKeyRef:
               key: gcp-sa
               name: profiles-profiles-config-h7dck95hm2
-        image: gcr.io/kubeflow-images-public/profile-controller:vmaster-g34aa47c2
+        image: gcr.io/kubeflow-images-public/profile-controller:vmaster-ga49f658f
         imagePullPolicy: Always
         livenessProbe:
           httpGet:
@@ -87,7 +87,7 @@ spec:
             configMapKeyRef:
               key: admin
               name: profiles-profiles-config-h7dck95hm2
-        image: gcr.io/kubeflow-images-public/kfam:vmaster-gf3e09203
+        image: gcr.io/kubeflow-images-public/kfam:vmaster-g9f3bfd00
         imagePullPolicy: Always
         livenessProbe:
           httpGet:


### PR DESCRIPTION
**Description of your changes:**
This PR updates the image tags that were listed in the IBM stack based on updates in https://github.com/kubeflow/manifests/pull/1645. 

Ideally, we get rid of the hard-coding here and use each component's `base_v3` directly, but I'm hesitant to do so based on https://github.com/kubeflow/manifests/issues/1285 . So for now, just update the relevant image tags in `stacks/ibm`.

**Checklist:**
- [x] Unit tests have been rebuilt: 
    1. `cd manifests/tests`
    2. `make generate-changed-only`
    3. `make test`
