### PR TITLE
Enable central dashboard to use configmap and remove manifest link

### DIFF
--- a/common/centraldashboard/base/links-configmap.yaml
+++ b/common/centraldashboard/base/links-configmap.yaml
@@ -14,10 +14,6 @@ data:
         {
           "link": "/katib/",
           "text": "Katib"
-        },
-        {
-          "link": "/metadata/",
-          "text": "Artifact Store"
         }
       ],
       "externalLinks": [],
@@ -41,11 +37,6 @@ data:
           "text": "View Katib Experiments",
           "desc": "Katib",
           "link": "/katib/"
-        },
-        {
-          "text": "View Metadata Artifacts",
-          "desc": "Artifact Store",
-          "link": "/metadata/"
         }
       ],
       "documentationItems": [

--- a/common/centraldashboard/base_v3/deployment_patch.yaml
+++ b/common/centraldashboard/base_v3/deployment_patch.yaml
@@ -1,0 +1,12 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: centraldashboard
+spec:
+  template:
+    spec:
+      containers:
+      - name: centraldashboard
+        env:
+        - name: DASHBOARD_LINKS_CONFIGMAP
+          value: centraldashboard-links-config

--- a/common/centraldashboard/base_v3/kustomization.yaml
+++ b/common/centraldashboard/base_v3/kustomization.yaml
@@ -15,3 +15,6 @@ resources:
 - ../base/role.yaml
 - ../base/service-account.yaml
 - ../base/service.yaml
+- ../base/links-configmap.yaml
+patchesStrategicMerge:
+- deployment_patch.yaml

--- a/tests/stacks/aws/test_data/expected/apps_v1_deployment_centraldashboard.yaml
+++ b/tests/stacks/aws/test_data/expected/apps_v1_deployment_centraldashboard.yaml
@@ -38,6 +38,8 @@ spec:
             configMapKeyRef:
               key: userid-prefix
               name: kubeflow-config
+        - name: DASHBOARD_LINKS_CONFIGMAP
+          value: centraldashboard-links-config
         image: gcr.io/kubeflow-images-public/centraldashboard:vmaster-g8097cfeb
         imagePullPolicy: IfNotPresent
         livenessProbe:

--- a/tests/stacks/aws/test_data/expected/~g_v1_configmap_centraldashboard-links-config.yaml
+++ b/tests/stacks/aws/test_data/expected/~g_v1_configmap_centraldashboard-links-config.yaml
@@ -1,0 +1,88 @@
+apiVersion: v1
+data:
+  links: |-
+    {
+      "menuLinks": [
+        {
+          "link": "/pipeline/",
+          "text": "Pipelines"
+        },
+        {
+          "link": "/jupyter/",
+          "text": "Notebook Servers"
+        },
+        {
+          "link": "/katib/",
+          "text": "Katib"
+        }
+      ],
+      "externalLinks": [],
+      "quickLinks": [
+        {
+          "text": "Upload a pipeline",
+          "desc": "Pipelines",
+          "link": "/pipeline/"
+        },
+        {
+          "text": "View all pipeline runs",
+          "desc": "Pipelines",
+          "link": "/pipeline/#/runs"
+        },
+        {
+          "text": "Create a new Notebook server",
+          "desc": "Notebook Servers",
+          "link": "/jupyter/new?namespace=kubeflow"
+        },
+        {
+          "text": "View Katib Experiments",
+          "desc": "Katib",
+          "link": "/katib/"
+        }
+      ],
+      "documentationItems": [
+        {
+          "text": "Getting Started with Kubeflow",
+          "desc": "Get your machine-learning workflow up and running on Kubeflow",
+          "link": "https://www.kubeflow.org/docs/started/getting-started/"
+        },
+        {
+          "text": "MiniKF",
+          "desc": "A fast and easy way to deploy Kubeflow locally",
+          "link": "https://www.kubeflow.org/docs/started/getting-started-minikf/"
+        },
+        {
+          "text": "Microk8s for Kubeflow",
+          "desc": "Quickly get Kubeflow running locally on native hypervisors",
+          "link": "https://www.kubeflow.org/docs/started/getting-started-multipass/"
+        },
+        {
+          "text": "Minikube for Kubeflow",
+          "desc": "Quickly get Kubeflow running locally",
+          "link": "https://www.kubeflow.org/docs/started/getting-started-minikube/"
+        },
+        {
+          "text": "Kubeflow on GCP",
+          "desc": "Running Kubeflow on Kubernetes Engine and Google Cloud Platform",
+          "link": "https://www.kubeflow.org/docs/gke/"
+        },
+        {
+          "text": "Kubeflow on AWS",
+          "desc": "Running Kubeflow on Elastic Container Service and Amazon Web Services",
+          "link": "https://www.kubeflow.org/docs/aws/"
+        },
+        {
+          "text": "Requirements for Kubeflow",
+          "desc": "Get more detailed information about using Kubeflow and its components",
+          "link": "https://www.kubeflow.org/docs/started/requirements/"
+        }
+      ]
+    }
+kind: ConfigMap
+metadata:
+  labels:
+    app: centraldashboard
+    app.kubernetes.io/component: centraldashboard
+    app.kubernetes.io/name: centraldashboard
+    kustomize.component: centraldashboard
+  name: centraldashboard-links-config
+  namespace: kubeflow

--- a/tests/stacks/azure/test_data/expected/apps_v1_deployment_centraldashboard.yaml
+++ b/tests/stacks/azure/test_data/expected/apps_v1_deployment_centraldashboard.yaml
@@ -38,6 +38,8 @@ spec:
             configMapKeyRef:
               key: userid-prefix
               name: kubeflow-config-bk4bc7m928
+        - name: DASHBOARD_LINKS_CONFIGMAP
+          value: centraldashboard-links-config
         image: gcr.io/kubeflow-images-public/centraldashboard:vmaster-g8097cfeb
         imagePullPolicy: IfNotPresent
         livenessProbe:

--- a/tests/stacks/azure/test_data/expected/~g_v1_configmap_centraldashboard-links-config.yaml
+++ b/tests/stacks/azure/test_data/expected/~g_v1_configmap_centraldashboard-links-config.yaml
@@ -1,0 +1,88 @@
+apiVersion: v1
+data:
+  links: |-
+    {
+      "menuLinks": [
+        {
+          "link": "/pipeline/",
+          "text": "Pipelines"
+        },
+        {
+          "link": "/jupyter/",
+          "text": "Notebook Servers"
+        },
+        {
+          "link": "/katib/",
+          "text": "Katib"
+        }
+      ],
+      "externalLinks": [],
+      "quickLinks": [
+        {
+          "text": "Upload a pipeline",
+          "desc": "Pipelines",
+          "link": "/pipeline/"
+        },
+        {
+          "text": "View all pipeline runs",
+          "desc": "Pipelines",
+          "link": "/pipeline/#/runs"
+        },
+        {
+          "text": "Create a new Notebook server",
+          "desc": "Notebook Servers",
+          "link": "/jupyter/new?namespace=kubeflow"
+        },
+        {
+          "text": "View Katib Experiments",
+          "desc": "Katib",
+          "link": "/katib/"
+        }
+      ],
+      "documentationItems": [
+        {
+          "text": "Getting Started with Kubeflow",
+          "desc": "Get your machine-learning workflow up and running on Kubeflow",
+          "link": "https://www.kubeflow.org/docs/started/getting-started/"
+        },
+        {
+          "text": "MiniKF",
+          "desc": "A fast and easy way to deploy Kubeflow locally",
+          "link": "https://www.kubeflow.org/docs/started/getting-started-minikf/"
+        },
+        {
+          "text": "Microk8s for Kubeflow",
+          "desc": "Quickly get Kubeflow running locally on native hypervisors",
+          "link": "https://www.kubeflow.org/docs/started/getting-started-multipass/"
+        },
+        {
+          "text": "Minikube for Kubeflow",
+          "desc": "Quickly get Kubeflow running locally",
+          "link": "https://www.kubeflow.org/docs/started/getting-started-minikube/"
+        },
+        {
+          "text": "Kubeflow on GCP",
+          "desc": "Running Kubeflow on Kubernetes Engine and Google Cloud Platform",
+          "link": "https://www.kubeflow.org/docs/gke/"
+        },
+        {
+          "text": "Kubeflow on AWS",
+          "desc": "Running Kubeflow on Elastic Container Service and Amazon Web Services",
+          "link": "https://www.kubeflow.org/docs/aws/"
+        },
+        {
+          "text": "Requirements for Kubeflow",
+          "desc": "Get more detailed information about using Kubeflow and its components",
+          "link": "https://www.kubeflow.org/docs/started/requirements/"
+        }
+      ]
+    }
+kind: ConfigMap
+metadata:
+  labels:
+    app: centraldashboard
+    app.kubernetes.io/component: centraldashboard
+    app.kubernetes.io/name: centraldashboard
+    kustomize.component: centraldashboard
+  name: centraldashboard-links-config
+  namespace: kubeflow

--- a/tests/stacks/examples/alice/test_data/expected/apps_v1_deployment_centraldashboard.yaml
+++ b/tests/stacks/examples/alice/test_data/expected/apps_v1_deployment_centraldashboard.yaml
@@ -38,6 +38,8 @@ spec:
             configMapKeyRef:
               key: userid-prefix
               name: kubeflow-config-bmh8k74f52
+        - name: DASHBOARD_LINKS_CONFIGMAP
+          value: centraldashboard-links-config
         image: gcr.io/kubeflow-images-public/centraldashboard:vmaster-g8097cfeb
         imagePullPolicy: IfNotPresent
         livenessProbe:

--- a/tests/stacks/examples/alice/test_data/expected/~g_v1_configmap_centraldashboard-links-config.yaml
+++ b/tests/stacks/examples/alice/test_data/expected/~g_v1_configmap_centraldashboard-links-config.yaml
@@ -1,0 +1,88 @@
+apiVersion: v1
+data:
+  links: |-
+    {
+      "menuLinks": [
+        {
+          "link": "/pipeline/",
+          "text": "Pipelines"
+        },
+        {
+          "link": "/jupyter/",
+          "text": "Notebook Servers"
+        },
+        {
+          "link": "/katib/",
+          "text": "Katib"
+        }
+      ],
+      "externalLinks": [],
+      "quickLinks": [
+        {
+          "text": "Upload a pipeline",
+          "desc": "Pipelines",
+          "link": "/pipeline/"
+        },
+        {
+          "text": "View all pipeline runs",
+          "desc": "Pipelines",
+          "link": "/pipeline/#/runs"
+        },
+        {
+          "text": "Create a new Notebook server",
+          "desc": "Notebook Servers",
+          "link": "/jupyter/new?namespace=kubeflow"
+        },
+        {
+          "text": "View Katib Experiments",
+          "desc": "Katib",
+          "link": "/katib/"
+        }
+      ],
+      "documentationItems": [
+        {
+          "text": "Getting Started with Kubeflow",
+          "desc": "Get your machine-learning workflow up and running on Kubeflow",
+          "link": "https://www.kubeflow.org/docs/started/getting-started/"
+        },
+        {
+          "text": "MiniKF",
+          "desc": "A fast and easy way to deploy Kubeflow locally",
+          "link": "https://www.kubeflow.org/docs/started/getting-started-minikf/"
+        },
+        {
+          "text": "Microk8s for Kubeflow",
+          "desc": "Quickly get Kubeflow running locally on native hypervisors",
+          "link": "https://www.kubeflow.org/docs/started/getting-started-multipass/"
+        },
+        {
+          "text": "Minikube for Kubeflow",
+          "desc": "Quickly get Kubeflow running locally",
+          "link": "https://www.kubeflow.org/docs/started/getting-started-minikube/"
+        },
+        {
+          "text": "Kubeflow on GCP",
+          "desc": "Running Kubeflow on Kubernetes Engine and Google Cloud Platform",
+          "link": "https://www.kubeflow.org/docs/gke/"
+        },
+        {
+          "text": "Kubeflow on AWS",
+          "desc": "Running Kubeflow on Elastic Container Service and Amazon Web Services",
+          "link": "https://www.kubeflow.org/docs/aws/"
+        },
+        {
+          "text": "Requirements for Kubeflow",
+          "desc": "Get more detailed information about using Kubeflow and its components",
+          "link": "https://www.kubeflow.org/docs/started/requirements/"
+        }
+      ]
+    }
+kind: ConfigMap
+metadata:
+  labels:
+    app: centraldashboard
+    app.kubernetes.io/component: centraldashboard
+    app.kubernetes.io/name: centraldashboard
+    kustomize.component: centraldashboard
+  name: centraldashboard-links-config
+  namespace: kubeflow

--- a/tests/stacks/gcp/test_data/expected/apps_v1_deployment_centraldashboard.yaml
+++ b/tests/stacks/gcp/test_data/expected/apps_v1_deployment_centraldashboard.yaml
@@ -38,6 +38,8 @@ spec:
             configMapKeyRef:
               key: userid-prefix
               name: kubeflow-config-c644m77455
+        - name: DASHBOARD_LINKS_CONFIGMAP
+          value: centraldashboard-links-config
         image: gcr.io/kubeflow-images-public/centraldashboard:vmaster-g8097cfeb
         imagePullPolicy: IfNotPresent
         livenessProbe:

--- a/tests/stacks/gcp/test_data/expected/~g_v1_configmap_centraldashboard-links-config.yaml
+++ b/tests/stacks/gcp/test_data/expected/~g_v1_configmap_centraldashboard-links-config.yaml
@@ -1,0 +1,88 @@
+apiVersion: v1
+data:
+  links: |-
+    {
+      "menuLinks": [
+        {
+          "link": "/pipeline/",
+          "text": "Pipelines"
+        },
+        {
+          "link": "/jupyter/",
+          "text": "Notebook Servers"
+        },
+        {
+          "link": "/katib/",
+          "text": "Katib"
+        }
+      ],
+      "externalLinks": [],
+      "quickLinks": [
+        {
+          "text": "Upload a pipeline",
+          "desc": "Pipelines",
+          "link": "/pipeline/"
+        },
+        {
+          "text": "View all pipeline runs",
+          "desc": "Pipelines",
+          "link": "/pipeline/#/runs"
+        },
+        {
+          "text": "Create a new Notebook server",
+          "desc": "Notebook Servers",
+          "link": "/jupyter/new?namespace=kubeflow"
+        },
+        {
+          "text": "View Katib Experiments",
+          "desc": "Katib",
+          "link": "/katib/"
+        }
+      ],
+      "documentationItems": [
+        {
+          "text": "Getting Started with Kubeflow",
+          "desc": "Get your machine-learning workflow up and running on Kubeflow",
+          "link": "https://www.kubeflow.org/docs/started/getting-started/"
+        },
+        {
+          "text": "MiniKF",
+          "desc": "A fast and easy way to deploy Kubeflow locally",
+          "link": "https://www.kubeflow.org/docs/started/getting-started-minikf/"
+        },
+        {
+          "text": "Microk8s for Kubeflow",
+          "desc": "Quickly get Kubeflow running locally on native hypervisors",
+          "link": "https://www.kubeflow.org/docs/started/getting-started-multipass/"
+        },
+        {
+          "text": "Minikube for Kubeflow",
+          "desc": "Quickly get Kubeflow running locally",
+          "link": "https://www.kubeflow.org/docs/started/getting-started-minikube/"
+        },
+        {
+          "text": "Kubeflow on GCP",
+          "desc": "Running Kubeflow on Kubernetes Engine and Google Cloud Platform",
+          "link": "https://www.kubeflow.org/docs/gke/"
+        },
+        {
+          "text": "Kubeflow on AWS",
+          "desc": "Running Kubeflow on Elastic Container Service and Amazon Web Services",
+          "link": "https://www.kubeflow.org/docs/aws/"
+        },
+        {
+          "text": "Requirements for Kubeflow",
+          "desc": "Get more detailed information about using Kubeflow and its components",
+          "link": "https://www.kubeflow.org/docs/started/requirements/"
+        }
+      ]
+    }
+kind: ConfigMap
+metadata:
+  labels:
+    app: centraldashboard
+    app.kubernetes.io/component: centraldashboard
+    app.kubernetes.io/name: centraldashboard
+    kustomize.component: centraldashboard
+  name: centraldashboard-links-config
+  namespace: kubeflow

--- a/tests/stacks/generic/test_data/expected/apps_v1_deployment_centraldashboard.yaml
+++ b/tests/stacks/generic/test_data/expected/apps_v1_deployment_centraldashboard.yaml
@@ -38,6 +38,8 @@ spec:
             configMapKeyRef:
               key: userid-prefix
               name: kubeflow-config-988m2m9m87
+        - name: DASHBOARD_LINKS_CONFIGMAP
+          value: centraldashboard-links-config
         image: gcr.io/kubeflow-images-public/centraldashboard:vmaster-g8097cfeb
         imagePullPolicy: IfNotPresent
         livenessProbe:

--- a/tests/stacks/generic/test_data/expected/~g_v1_configmap_centraldashboard-links-config.yaml
+++ b/tests/stacks/generic/test_data/expected/~g_v1_configmap_centraldashboard-links-config.yaml
@@ -1,0 +1,88 @@
+apiVersion: v1
+data:
+  links: |-
+    {
+      "menuLinks": [
+        {
+          "link": "/pipeline/",
+          "text": "Pipelines"
+        },
+        {
+          "link": "/jupyter/",
+          "text": "Notebook Servers"
+        },
+        {
+          "link": "/katib/",
+          "text": "Katib"
+        }
+      ],
+      "externalLinks": [],
+      "quickLinks": [
+        {
+          "text": "Upload a pipeline",
+          "desc": "Pipelines",
+          "link": "/pipeline/"
+        },
+        {
+          "text": "View all pipeline runs",
+          "desc": "Pipelines",
+          "link": "/pipeline/#/runs"
+        },
+        {
+          "text": "Create a new Notebook server",
+          "desc": "Notebook Servers",
+          "link": "/jupyter/new?namespace=kubeflow"
+        },
+        {
+          "text": "View Katib Experiments",
+          "desc": "Katib",
+          "link": "/katib/"
+        }
+      ],
+      "documentationItems": [
+        {
+          "text": "Getting Started with Kubeflow",
+          "desc": "Get your machine-learning workflow up and running on Kubeflow",
+          "link": "https://www.kubeflow.org/docs/started/getting-started/"
+        },
+        {
+          "text": "MiniKF",
+          "desc": "A fast and easy way to deploy Kubeflow locally",
+          "link": "https://www.kubeflow.org/docs/started/getting-started-minikf/"
+        },
+        {
+          "text": "Microk8s for Kubeflow",
+          "desc": "Quickly get Kubeflow running locally on native hypervisors",
+          "link": "https://www.kubeflow.org/docs/started/getting-started-multipass/"
+        },
+        {
+          "text": "Minikube for Kubeflow",
+          "desc": "Quickly get Kubeflow running locally",
+          "link": "https://www.kubeflow.org/docs/started/getting-started-minikube/"
+        },
+        {
+          "text": "Kubeflow on GCP",
+          "desc": "Running Kubeflow on Kubernetes Engine and Google Cloud Platform",
+          "link": "https://www.kubeflow.org/docs/gke/"
+        },
+        {
+          "text": "Kubeflow on AWS",
+          "desc": "Running Kubeflow on Elastic Container Service and Amazon Web Services",
+          "link": "https://www.kubeflow.org/docs/aws/"
+        },
+        {
+          "text": "Requirements for Kubeflow",
+          "desc": "Get more detailed information about using Kubeflow and its components",
+          "link": "https://www.kubeflow.org/docs/started/requirements/"
+        }
+      ]
+    }
+kind: ConfigMap
+metadata:
+  labels:
+    app: centraldashboard
+    app.kubernetes.io/component: centraldashboard
+    app.kubernetes.io/name: centraldashboard
+    kustomize.component: centraldashboard
+  name: centraldashboard-links-config
+  namespace: kubeflow

--- a/tests/stacks/ibm/application/profile-control-plane/test_data/expected/apps_v1_deployment_centraldashboard.yaml
+++ b/tests/stacks/ibm/application/profile-control-plane/test_data/expected/apps_v1_deployment_centraldashboard.yaml
@@ -38,6 +38,8 @@ spec:
             configMapKeyRef:
               key: userid-prefix
               name: kubeflow-config-bk4bc7m928
+        - name: DASHBOARD_LINKS_CONFIGMAP
+          value: centraldashboard-links-config
         image: gcr.io/kubeflow-images-public/centraldashboard:vmaster-g8097cfeb
         imagePullPolicy: IfNotPresent
         livenessProbe:

--- a/tests/stacks/ibm/application/profile-control-plane/test_data/expected/~g_v1_configmap_centraldashboard-links-config.yaml
+++ b/tests/stacks/ibm/application/profile-control-plane/test_data/expected/~g_v1_configmap_centraldashboard-links-config.yaml
@@ -1,0 +1,88 @@
+apiVersion: v1
+data:
+  links: |-
+    {
+      "menuLinks": [
+        {
+          "link": "/pipeline/",
+          "text": "Pipelines"
+        },
+        {
+          "link": "/jupyter/",
+          "text": "Notebook Servers"
+        },
+        {
+          "link": "/katib/",
+          "text": "Katib"
+        }
+      ],
+      "externalLinks": [],
+      "quickLinks": [
+        {
+          "text": "Upload a pipeline",
+          "desc": "Pipelines",
+          "link": "/pipeline/"
+        },
+        {
+          "text": "View all pipeline runs",
+          "desc": "Pipelines",
+          "link": "/pipeline/#/runs"
+        },
+        {
+          "text": "Create a new Notebook server",
+          "desc": "Notebook Servers",
+          "link": "/jupyter/new?namespace=kubeflow"
+        },
+        {
+          "text": "View Katib Experiments",
+          "desc": "Katib",
+          "link": "/katib/"
+        }
+      ],
+      "documentationItems": [
+        {
+          "text": "Getting Started with Kubeflow",
+          "desc": "Get your machine-learning workflow up and running on Kubeflow",
+          "link": "https://www.kubeflow.org/docs/started/getting-started/"
+        },
+        {
+          "text": "MiniKF",
+          "desc": "A fast and easy way to deploy Kubeflow locally",
+          "link": "https://www.kubeflow.org/docs/started/getting-started-minikf/"
+        },
+        {
+          "text": "Microk8s for Kubeflow",
+          "desc": "Quickly get Kubeflow running locally on native hypervisors",
+          "link": "https://www.kubeflow.org/docs/started/getting-started-multipass/"
+        },
+        {
+          "text": "Minikube for Kubeflow",
+          "desc": "Quickly get Kubeflow running locally",
+          "link": "https://www.kubeflow.org/docs/started/getting-started-minikube/"
+        },
+        {
+          "text": "Kubeflow on GCP",
+          "desc": "Running Kubeflow on Kubernetes Engine and Google Cloud Platform",
+          "link": "https://www.kubeflow.org/docs/gke/"
+        },
+        {
+          "text": "Kubeflow on AWS",
+          "desc": "Running Kubeflow on Elastic Container Service and Amazon Web Services",
+          "link": "https://www.kubeflow.org/docs/aws/"
+        },
+        {
+          "text": "Requirements for Kubeflow",
+          "desc": "Get more detailed information about using Kubeflow and its components",
+          "link": "https://www.kubeflow.org/docs/started/requirements/"
+        }
+      ]
+    }
+kind: ConfigMap
+metadata:
+  labels:
+    app: centraldashboard
+    app.kubernetes.io/component: centraldashboard
+    app.kubernetes.io/name: centraldashboard
+    kustomize.component: centraldashboard
+  name: centraldashboard-links-config
+  namespace: kubeflow

--- a/tests/stacks/ibm/multi-user/test_data/expected/apps_v1_deployment_centraldashboard.yaml
+++ b/tests/stacks/ibm/multi-user/test_data/expected/apps_v1_deployment_centraldashboard.yaml
@@ -38,6 +38,8 @@ spec:
             configMapKeyRef:
               key: userid-prefix
               name: kubeflow-config-bk4bc7m928
+        - name: DASHBOARD_LINKS_CONFIGMAP
+          value: centraldashboard-links-config
         image: gcr.io/kubeflow-images-public/centraldashboard:vmaster-g8097cfeb
         imagePullPolicy: IfNotPresent
         livenessProbe:

--- a/tests/stacks/ibm/multi-user/test_data/expected/~g_v1_configmap_centraldashboard-links-config.yaml
+++ b/tests/stacks/ibm/multi-user/test_data/expected/~g_v1_configmap_centraldashboard-links-config.yaml
@@ -1,0 +1,88 @@
+apiVersion: v1
+data:
+  links: |-
+    {
+      "menuLinks": [
+        {
+          "link": "/pipeline/",
+          "text": "Pipelines"
+        },
+        {
+          "link": "/jupyter/",
+          "text": "Notebook Servers"
+        },
+        {
+          "link": "/katib/",
+          "text": "Katib"
+        }
+      ],
+      "externalLinks": [],
+      "quickLinks": [
+        {
+          "text": "Upload a pipeline",
+          "desc": "Pipelines",
+          "link": "/pipeline/"
+        },
+        {
+          "text": "View all pipeline runs",
+          "desc": "Pipelines",
+          "link": "/pipeline/#/runs"
+        },
+        {
+          "text": "Create a new Notebook server",
+          "desc": "Notebook Servers",
+          "link": "/jupyter/new?namespace=kubeflow"
+        },
+        {
+          "text": "View Katib Experiments",
+          "desc": "Katib",
+          "link": "/katib/"
+        }
+      ],
+      "documentationItems": [
+        {
+          "text": "Getting Started with Kubeflow",
+          "desc": "Get your machine-learning workflow up and running on Kubeflow",
+          "link": "https://www.kubeflow.org/docs/started/getting-started/"
+        },
+        {
+          "text": "MiniKF",
+          "desc": "A fast and easy way to deploy Kubeflow locally",
+          "link": "https://www.kubeflow.org/docs/started/getting-started-minikf/"
+        },
+        {
+          "text": "Microk8s for Kubeflow",
+          "desc": "Quickly get Kubeflow running locally on native hypervisors",
+          "link": "https://www.kubeflow.org/docs/started/getting-started-multipass/"
+        },
+        {
+          "text": "Minikube for Kubeflow",
+          "desc": "Quickly get Kubeflow running locally",
+          "link": "https://www.kubeflow.org/docs/started/getting-started-minikube/"
+        },
+        {
+          "text": "Kubeflow on GCP",
+          "desc": "Running Kubeflow on Kubernetes Engine and Google Cloud Platform",
+          "link": "https://www.kubeflow.org/docs/gke/"
+        },
+        {
+          "text": "Kubeflow on AWS",
+          "desc": "Running Kubeflow on Elastic Container Service and Amazon Web Services",
+          "link": "https://www.kubeflow.org/docs/aws/"
+        },
+        {
+          "text": "Requirements for Kubeflow",
+          "desc": "Get more detailed information about using Kubeflow and its components",
+          "link": "https://www.kubeflow.org/docs/started/requirements/"
+        }
+      ]
+    }
+kind: ConfigMap
+metadata:
+  labels:
+    app: centraldashboard
+    app.kubernetes.io/component: centraldashboard
+    app.kubernetes.io/name: centraldashboard
+    kustomize.component: centraldashboard
+  name: centraldashboard-links-config
+  namespace: kubeflow

--- a/tests/stacks/ibm/test_data/expected/apps_v1_deployment_centraldashboard.yaml
+++ b/tests/stacks/ibm/test_data/expected/apps_v1_deployment_centraldashboard.yaml
@@ -38,6 +38,8 @@ spec:
             configMapKeyRef:
               key: userid-prefix
               name: kubeflow-config-bk4bc7m928
+        - name: DASHBOARD_LINKS_CONFIGMAP
+          value: centraldashboard-links-config
         image: gcr.io/kubeflow-images-public/centraldashboard:vmaster-g8097cfeb
         imagePullPolicy: IfNotPresent
         livenessProbe:

--- a/tests/stacks/ibm/test_data/expected/~g_v1_configmap_centraldashboard-links-config.yaml
+++ b/tests/stacks/ibm/test_data/expected/~g_v1_configmap_centraldashboard-links-config.yaml
@@ -1,0 +1,88 @@
+apiVersion: v1
+data:
+  links: |-
+    {
+      "menuLinks": [
+        {
+          "link": "/pipeline/",
+          "text": "Pipelines"
+        },
+        {
+          "link": "/jupyter/",
+          "text": "Notebook Servers"
+        },
+        {
+          "link": "/katib/",
+          "text": "Katib"
+        }
+      ],
+      "externalLinks": [],
+      "quickLinks": [
+        {
+          "text": "Upload a pipeline",
+          "desc": "Pipelines",
+          "link": "/pipeline/"
+        },
+        {
+          "text": "View all pipeline runs",
+          "desc": "Pipelines",
+          "link": "/pipeline/#/runs"
+        },
+        {
+          "text": "Create a new Notebook server",
+          "desc": "Notebook Servers",
+          "link": "/jupyter/new?namespace=kubeflow"
+        },
+        {
+          "text": "View Katib Experiments",
+          "desc": "Katib",
+          "link": "/katib/"
+        }
+      ],
+      "documentationItems": [
+        {
+          "text": "Getting Started with Kubeflow",
+          "desc": "Get your machine-learning workflow up and running on Kubeflow",
+          "link": "https://www.kubeflow.org/docs/started/getting-started/"
+        },
+        {
+          "text": "MiniKF",
+          "desc": "A fast and easy way to deploy Kubeflow locally",
+          "link": "https://www.kubeflow.org/docs/started/getting-started-minikf/"
+        },
+        {
+          "text": "Microk8s for Kubeflow",
+          "desc": "Quickly get Kubeflow running locally on native hypervisors",
+          "link": "https://www.kubeflow.org/docs/started/getting-started-multipass/"
+        },
+        {
+          "text": "Minikube for Kubeflow",
+          "desc": "Quickly get Kubeflow running locally",
+          "link": "https://www.kubeflow.org/docs/started/getting-started-minikube/"
+        },
+        {
+          "text": "Kubeflow on GCP",
+          "desc": "Running Kubeflow on Kubernetes Engine and Google Cloud Platform",
+          "link": "https://www.kubeflow.org/docs/gke/"
+        },
+        {
+          "text": "Kubeflow on AWS",
+          "desc": "Running Kubeflow on Elastic Container Service and Amazon Web Services",
+          "link": "https://www.kubeflow.org/docs/aws/"
+        },
+        {
+          "text": "Requirements for Kubeflow",
+          "desc": "Get more detailed information about using Kubeflow and its components",
+          "link": "https://www.kubeflow.org/docs/started/requirements/"
+        }
+      ]
+    }
+kind: ConfigMap
+metadata:
+  labels:
+    app: centraldashboard
+    app.kubernetes.io/component: centraldashboard
+    app.kubernetes.io/name: centraldashboard
+    kustomize.component: centraldashboard
+  name: centraldashboard-links-config
+  namespace: kubeflow

--- a/tests/stacks/kubernetes/test_data/expected/apps_v1_deployment_centraldashboard.yaml
+++ b/tests/stacks/kubernetes/test_data/expected/apps_v1_deployment_centraldashboard.yaml
@@ -38,6 +38,8 @@ spec:
             configMapKeyRef:
               key: userid-prefix
               name: kubeflow-config
+        - name: DASHBOARD_LINKS_CONFIGMAP
+          value: centraldashboard-links-config
         image: gcr.io/kubeflow-images-public/centraldashboard:vmaster-g8097cfeb
         imagePullPolicy: IfNotPresent
         livenessProbe:

--- a/tests/stacks/kubernetes/test_data/expected/~g_v1_configmap_centraldashboard-links-config.yaml
+++ b/tests/stacks/kubernetes/test_data/expected/~g_v1_configmap_centraldashboard-links-config.yaml
@@ -1,0 +1,88 @@
+apiVersion: v1
+data:
+  links: |-
+    {
+      "menuLinks": [
+        {
+          "link": "/pipeline/",
+          "text": "Pipelines"
+        },
+        {
+          "link": "/jupyter/",
+          "text": "Notebook Servers"
+        },
+        {
+          "link": "/katib/",
+          "text": "Katib"
+        }
+      ],
+      "externalLinks": [],
+      "quickLinks": [
+        {
+          "text": "Upload a pipeline",
+          "desc": "Pipelines",
+          "link": "/pipeline/"
+        },
+        {
+          "text": "View all pipeline runs",
+          "desc": "Pipelines",
+          "link": "/pipeline/#/runs"
+        },
+        {
+          "text": "Create a new Notebook server",
+          "desc": "Notebook Servers",
+          "link": "/jupyter/new?namespace=kubeflow"
+        },
+        {
+          "text": "View Katib Experiments",
+          "desc": "Katib",
+          "link": "/katib/"
+        }
+      ],
+      "documentationItems": [
+        {
+          "text": "Getting Started with Kubeflow",
+          "desc": "Get your machine-learning workflow up and running on Kubeflow",
+          "link": "https://www.kubeflow.org/docs/started/getting-started/"
+        },
+        {
+          "text": "MiniKF",
+          "desc": "A fast and easy way to deploy Kubeflow locally",
+          "link": "https://www.kubeflow.org/docs/started/getting-started-minikf/"
+        },
+        {
+          "text": "Microk8s for Kubeflow",
+          "desc": "Quickly get Kubeflow running locally on native hypervisors",
+          "link": "https://www.kubeflow.org/docs/started/getting-started-multipass/"
+        },
+        {
+          "text": "Minikube for Kubeflow",
+          "desc": "Quickly get Kubeflow running locally",
+          "link": "https://www.kubeflow.org/docs/started/getting-started-minikube/"
+        },
+        {
+          "text": "Kubeflow on GCP",
+          "desc": "Running Kubeflow on Kubernetes Engine and Google Cloud Platform",
+          "link": "https://www.kubeflow.org/docs/gke/"
+        },
+        {
+          "text": "Kubeflow on AWS",
+          "desc": "Running Kubeflow on Elastic Container Service and Amazon Web Services",
+          "link": "https://www.kubeflow.org/docs/aws/"
+        },
+        {
+          "text": "Requirements for Kubeflow",
+          "desc": "Get more detailed information about using Kubeflow and its components",
+          "link": "https://www.kubeflow.org/docs/started/requirements/"
+        }
+      ]
+    }
+kind: ConfigMap
+metadata:
+  labels:
+    app: centraldashboard
+    app.kubernetes.io/component: centraldashboard
+    app.kubernetes.io/name: centraldashboard
+    kustomize.component: centraldashboard
+  name: centraldashboard-links-config
+  namespace: kubeflow

--- a/tests/stacks/openshift/test_data/expected/apps_v1_deployment_centraldashboard.yaml
+++ b/tests/stacks/openshift/test_data/expected/apps_v1_deployment_centraldashboard.yaml
@@ -38,6 +38,8 @@ spec:
             configMapKeyRef:
               key: userid-prefix
               name: kubeflow-config-f5fk62kk74
+        - name: DASHBOARD_LINKS_CONFIGMAP
+          value: centraldashboard-links-config
         image: gcr.io/kubeflow-images-public/centraldashboard:vmaster-g8097cfeb
         imagePullPolicy: IfNotPresent
         livenessProbe:

--- a/tests/stacks/openshift/test_data/expected/~g_v1_configmap_centraldashboard-links-config.yaml
+++ b/tests/stacks/openshift/test_data/expected/~g_v1_configmap_centraldashboard-links-config.yaml
@@ -1,0 +1,88 @@
+apiVersion: v1
+data:
+  links: |-
+    {
+      "menuLinks": [
+        {
+          "link": "/pipeline/",
+          "text": "Pipelines"
+        },
+        {
+          "link": "/jupyter/",
+          "text": "Notebook Servers"
+        },
+        {
+          "link": "/katib/",
+          "text": "Katib"
+        }
+      ],
+      "externalLinks": [],
+      "quickLinks": [
+        {
+          "text": "Upload a pipeline",
+          "desc": "Pipelines",
+          "link": "/pipeline/"
+        },
+        {
+          "text": "View all pipeline runs",
+          "desc": "Pipelines",
+          "link": "/pipeline/#/runs"
+        },
+        {
+          "text": "Create a new Notebook server",
+          "desc": "Notebook Servers",
+          "link": "/jupyter/new?namespace=kubeflow"
+        },
+        {
+          "text": "View Katib Experiments",
+          "desc": "Katib",
+          "link": "/katib/"
+        }
+      ],
+      "documentationItems": [
+        {
+          "text": "Getting Started with Kubeflow",
+          "desc": "Get your machine-learning workflow up and running on Kubeflow",
+          "link": "https://www.kubeflow.org/docs/started/getting-started/"
+        },
+        {
+          "text": "MiniKF",
+          "desc": "A fast and easy way to deploy Kubeflow locally",
+          "link": "https://www.kubeflow.org/docs/started/getting-started-minikf/"
+        },
+        {
+          "text": "Microk8s for Kubeflow",
+          "desc": "Quickly get Kubeflow running locally on native hypervisors",
+          "link": "https://www.kubeflow.org/docs/started/getting-started-multipass/"
+        },
+        {
+          "text": "Minikube for Kubeflow",
+          "desc": "Quickly get Kubeflow running locally",
+          "link": "https://www.kubeflow.org/docs/started/getting-started-minikube/"
+        },
+        {
+          "text": "Kubeflow on GCP",
+          "desc": "Running Kubeflow on Kubernetes Engine and Google Cloud Platform",
+          "link": "https://www.kubeflow.org/docs/gke/"
+        },
+        {
+          "text": "Kubeflow on AWS",
+          "desc": "Running Kubeflow on Elastic Container Service and Amazon Web Services",
+          "link": "https://www.kubeflow.org/docs/aws/"
+        },
+        {
+          "text": "Requirements for Kubeflow",
+          "desc": "Get more detailed information about using Kubeflow and its components",
+          "link": "https://www.kubeflow.org/docs/started/requirements/"
+        }
+      ]
+    }
+kind: ConfigMap
+metadata:
+  labels:
+    app: centraldashboard
+    app.kubernetes.io/component: centraldashboard
+    app.kubernetes.io/name: centraldashboard
+    kustomize.component: centraldashboard
+  name: centraldashboard-links-config
+  namespace: kubeflow


### PR DESCRIPTION
**Which issue is resolved by this Pull Request:**
Resolves #

**Description of your changes:**
For safety reason, I only patch configmap env, this should be good enough to customize links in central dashbaord. We need to bring this back to 1.2.. 

**Checklist:**
- [x] Unit tests have been rebuilt: 
    1. `cd manifests/tests`
    2. `make generate-changed-only`
    3. `make test`
