### PR TITLE
Update jupyter web app image tag for Azure Stack

### DIFF
--- a/stacks/azure/application/jupyter-web-app/base/kustomization.yaml
+++ b/stacks/azure/application/jupyter-web-app/base/kustomization.yaml
@@ -10,7 +10,7 @@ namespace: kubeflow
 images:
 - name: gcr.io/kubeflow-images-public/jupyter-web-app
   newName: gcr.io/kubeflow-images-public/jupyter-web-app
-  newTag: vmaster-gd9be4b9e
+  newTag: vmaster-g845af298
 resources:
 - ../../../../../jupyter/jupyter-web-app/base/cluster-role-binding.yaml
 - ../../../../../jupyter/jupyter-web-app/base/cluster-role.yaml

--- a/tests/stacks/azure/application/jupyter-web-app/base/test_data/expected/apps_v1_deployment_jupyter-web-app-deployment.yaml
+++ b/tests/stacks/azure/application/jupyter-web-app/base/test_data/expected/apps_v1_deployment_jupyter-web-app-deployment.yaml
@@ -48,7 +48,7 @@ spec:
             configMapKeyRef:
               key: userid-prefix
               name: kubeflow-config
-        image: gcr.io/kubeflow-images-public/jupyter-web-app:vmaster-gd9be4b9e
+        image: gcr.io/kubeflow-images-public/jupyter-web-app:vmaster-g845af298
         imagePullPolicy: Always
         name: jupyter-web-app
         ports:

--- a/tests/stacks/azure/application/jupyter-web-app/test_data/expected/apps_v1_deployment_jupyter-web-app-deployment.yaml
+++ b/tests/stacks/azure/application/jupyter-web-app/test_data/expected/apps_v1_deployment_jupyter-web-app-deployment.yaml
@@ -48,7 +48,7 @@ spec:
             configMapKeyRef:
               key: userid-prefix
               name: kubeflow-config
-        image: gcr.io/kubeflow-images-public/jupyter-web-app:vmaster-gd9be4b9e
+        image: gcr.io/kubeflow-images-public/jupyter-web-app:vmaster-g845af298
         imagePullPolicy: Always
         name: jupyter-web-app
         ports:

--- a/tests/stacks/azure/test_data/expected/apps_v1_deployment_jupyter-web-app-deployment.yaml
+++ b/tests/stacks/azure/test_data/expected/apps_v1_deployment_jupyter-web-app-deployment.yaml
@@ -48,7 +48,7 @@ spec:
             configMapKeyRef:
               key: userid-prefix
               name: kubeflow-config-bk4bc7m928
-        image: gcr.io/kubeflow-images-public/jupyter-web-app:vmaster-gd9be4b9e
+        image: gcr.io/kubeflow-images-public/jupyter-web-app:vmaster-g845af298
         imagePullPolicy: Always
         name: jupyter-web-app
         ports:


### PR DESCRIPTION
**Which issue is resolved by this Pull Request:**
Resolves #1645

**Description of your changes:**
Updates hardcoded image tag for Jupyter Web App in Azure Stack

**Checklist:**
- [X] Unit tests have been rebuilt: 
    1. `cd manifests/tests`
    2. `make generate-changed-only`
    3. `make test`
