### PR TITLE
Cherry-picking several Azure changes for v1.2 release

### DIFF
--- a/stacks/azure/application/centraldashboard/deployment_patch.yaml
+++ b/stacks/azure/application/centraldashboard/deployment_patch.yaml
@@ -1,0 +1,12 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: centraldashboard
+spec:
+  template:
+    spec:
+      containers:
+      - name: centraldashboard
+        env:
+        - name: DASHBOARD_LINKS_CONFIGMAP
+          value: centraldashboard-links-config

--- a/stacks/azure/application/centraldashboard/kustomization.yaml
+++ b/stacks/azure/application/centraldashboard/kustomization.yaml
@@ -1,0 +1,8 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+namespace: kubeflow
+resources:
+- ../../../../common/centraldashboard/overlays/stacks
+patchesStrategicMerge:
+- links-configmap.yaml
+- deployment_patch.yaml

--- a/stacks/azure/application/centraldashboard/links-configmap.yaml
+++ b/stacks/azure/application/centraldashboard/links-configmap.yaml
@@ -14,10 +14,6 @@ data:
         {
           "link": "/katib/",
           "text": "Katib"
-        },
-        {
-          "link": "/metadata/",
-          "text": "Artifact Store"
         }
       ],
       "externalLinks": [],
@@ -41,11 +37,6 @@ data:
           "text": "View Katib Experiments",
           "desc": "Katib",
           "link": "/katib/"
-        },
-        {
-          "text": "View Metadata Artifacts",
-          "desc": "Artifact Store",
-          "link": "/metadata/"
         }
       ],
       "documentationItems": [

--- a/stacks/azure/application/centraldashboard/links-configmap.yaml
+++ b/stacks/azure/application/centraldashboard/links-configmap.yaml
@@ -1,0 +1,76 @@
+apiVersion: v1
+data:
+  links: |-
+    {
+      "menuLinks": [
+        {
+          "link": "/pipeline/",
+          "text": "Pipelines"
+        },
+        {
+          "link": "/jupyter/",
+          "text": "Notebook Servers"
+        },
+        {
+          "link": "/katib/",
+          "text": "Katib"
+        },
+        {
+          "link": "/metadata/",
+          "text": "Artifact Store"
+        }
+      ],
+      "externalLinks": [],
+      "quickLinks": [
+        {
+          "text": "Upload a pipeline",
+          "desc": "Pipelines",
+          "link": "/pipeline/"
+        },
+        {
+          "text": "View all pipeline runs",
+          "desc": "Pipelines",
+          "link": "/pipeline/#/runs"
+        },
+        {
+          "text": "Create a new Notebook server",
+          "desc": "Notebook Servers",
+          "link": "/jupyter/new?namespace=kubeflow"
+        },
+        {
+          "text": "View Katib Experiments",
+          "desc": "Katib",
+          "link": "/katib/"
+        },
+        {
+          "text": "View Metadata Artifacts",
+          "desc": "Artifact Store",
+          "link": "/metadata/"
+        }
+      ],
+      "documentationItems": [
+        {
+          "text": "Kubeflow Overview",
+          "desc": "An overview of Kubeflow architecture and workflows",
+          "link": "https://www.kubeflow.org/docs/started/kubeflow-overview/"
+        },
+        {
+          "text": "Kubeflow on Azure",
+          "desc": "Running Kubeflow on AKS and Microsoft Azure",
+          "link": "https://www.kubeflow.org/docs/azure/"
+        },
+        {
+          "text": "Azure Machine Learning Docs",
+          "desc": "Azure Machine Learning Documentation",
+          "link": "https://aka.ms/kubeflow-azureml-docs"
+        },
+        {
+          "text": "Azure Kubernetes Service Docs",
+          "desc": "Azure Kubernetes Service Documentation",
+          "link": "https://aka.ms/kubeflow-aks-docs"
+        },
+      ]
+    }
+kind: ConfigMap
+metadata:
+  name: centraldashboard-links-config

--- a/stacks/azure/application/jupyter-web-app/base/kustomization.yaml
+++ b/stacks/azure/application/jupyter-web-app/base/kustomization.yaml
@@ -10,7 +10,7 @@ namespace: kubeflow
 images:
 - name: gcr.io/kubeflow-images-public/jupyter-web-app
   newName: gcr.io/kubeflow-images-public/jupyter-web-app
-  newTag: vmaster-gd9be4b9e
+  newTag: vmaster-g845af298
 resources:
 - ../../../../../jupyter/jupyter-web-app/base/cluster-role-binding.yaml
 - ../../../../../jupyter/jupyter-web-app/base/cluster-role.yaml

--- a/stacks/azure/kustomization.yaml
+++ b/stacks/azure/kustomization.yaml
@@ -3,13 +3,13 @@ kind: Kustomization
 namespace: kubeflow
 resources:
   - ../../admission-webhook/webhook/v3
-  - ../../common/centraldashboard/overlays/stacks
   - ../../kubeflow-roles/base
   - ./application/jupyter-web-app
   - ../../jupyter/notebook-controller/base_v3
   - ../../profiles/base_v3
   - ./application/spark-operator
   - ./application/spartakus
+  - ./application/centraldashboard
   # Training Operators
   - ../../pytorch-job/pytorch-job-crds/overlays/application
   - ../../pytorch-job/pytorch-operator/overlays/application

--- a/tests/stacks/azure/application/centraldashboard/kustomize_test.go
+++ b/tests/stacks/azure/application/centraldashboard/kustomize_test.go
@@ -1,0 +1,15 @@
+package centraldashboard
+
+import (
+	"github.com/kubeflow/manifests/tests"
+	"testing"
+)
+
+func TestKustomize(t *testing.T) {
+	testCase := &tests.KustomizeTestCase{
+		Package:  "../../../../../stacks/azure/application/centraldashboard",
+		Expected: "test_data/expected",
+	}
+
+	tests.RunTestCase(t, testCase)
+}

--- a/tests/stacks/azure/application/centraldashboard/test_data/expected/app.k8s.io_v1beta1_application_centraldashboard.yaml
+++ b/tests/stacks/azure/application/centraldashboard/test_data/expected/app.k8s.io_v1beta1_application_centraldashboard.yaml
@@ -1,0 +1,53 @@
+apiVersion: app.k8s.io/v1beta1
+kind: Application
+metadata:
+  labels:
+    app.kubernetes.io/component: centraldashboard
+    app.kubernetes.io/name: centraldashboard
+  name: centraldashboard
+  namespace: kubeflow
+spec:
+  addOwnerRef: true
+  componentKinds:
+  - group: core
+    kind: ConfigMap
+  - group: apps
+    kind: Deployment
+  - group: rbac.authorization.k8s.io
+    kind: Role
+  - group: rbac.authorization.k8s.io
+    kind: RoleBinding
+  - group: core
+    kind: Service
+  - group: core
+    kind: ServiceAccount
+  - group: networking.istio.io
+    kind: VirtualService
+  descriptor:
+    description: Provides a Dashboard UI for kubeflow
+    keywords:
+    - centraldashboard
+    - kubeflow
+    links:
+    - description: About
+      url: https://github.com/kubeflow/kubeflow/tree/master/components/centraldashboard
+    maintainers:
+    - email: prodonjs@gmail.com
+      name: Jason Prodonovich
+    - email: apverma@google.com
+      name: Apoorv Verma
+    - email: adhita94@gmail.com
+      name: Adhita Selvaraj
+    owners:
+    - email: prodonjs@gmail.com
+      name: Jason Prodonovich
+    - email: apverma@google.com
+      name: Apoorv Verma
+    - email: adhita94@gmail.com
+      name: Adhita Selvaraj
+    type: centraldashboard
+    version: v1beta1
+  selector:
+    matchLabels:
+      app.kubernetes.io/component: centraldashboard
+      app.kubernetes.io/name: centraldashboard

--- a/tests/stacks/azure/application/centraldashboard/test_data/expected/apps_v1_deployment_centraldashboard.yaml
+++ b/tests/stacks/azure/application/centraldashboard/test_data/expected/apps_v1_deployment_centraldashboard.yaml
@@ -1,0 +1,55 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  labels:
+    app: centraldashboard
+    app.kubernetes.io/component: centraldashboard
+    app.kubernetes.io/name: centraldashboard
+    kustomize.component: centraldashboard
+  name: centraldashboard
+  namespace: kubeflow
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: centraldashboard
+      app.kubernetes.io/component: centraldashboard
+      app.kubernetes.io/name: centraldashboard
+      kustomize.component: centraldashboard
+  template:
+    metadata:
+      annotations:
+        sidecar.istio.io/inject: "false"
+      labels:
+        app: centraldashboard
+        app.kubernetes.io/component: centraldashboard
+        app.kubernetes.io/name: centraldashboard
+        kustomize.component: centraldashboard
+    spec:
+      containers:
+      - env:
+        - name: USERID_HEADER
+          valueFrom:
+            configMapKeyRef:
+              key: userid-header
+              name: kubeflow-config
+        - name: USERID_PREFIX
+          valueFrom:
+            configMapKeyRef:
+              key: userid-prefix
+              name: kubeflow-config
+        - name: DASHBOARD_LINKS_CONFIGMAP
+          value: centraldashboard-links-config
+        image: gcr.io/kubeflow-images-public/centraldashboard:vmaster-g8097cfeb
+        imagePullPolicy: IfNotPresent
+        livenessProbe:
+          httpGet:
+            path: /healthz
+            port: 8082
+          initialDelaySeconds: 30
+          periodSeconds: 30
+        name: centraldashboard
+        ports:
+        - containerPort: 8082
+          protocol: TCP
+      serviceAccountName: centraldashboard

--- a/tests/stacks/azure/application/centraldashboard/test_data/expected/apps_v1_deployment_centraldashboard.yaml
+++ b/tests/stacks/azure/application/centraldashboard/test_data/expected/apps_v1_deployment_centraldashboard.yaml
@@ -5,7 +5,6 @@ metadata:
     app: centraldashboard
     app.kubernetes.io/component: centraldashboard
     app.kubernetes.io/name: centraldashboard
-    kustomize.component: centraldashboard
   name: centraldashboard
   namespace: kubeflow
 spec:
@@ -15,7 +14,6 @@ spec:
       app: centraldashboard
       app.kubernetes.io/component: centraldashboard
       app.kubernetes.io/name: centraldashboard
-      kustomize.component: centraldashboard
   template:
     metadata:
       annotations:
@@ -24,7 +22,6 @@ spec:
         app: centraldashboard
         app.kubernetes.io/component: centraldashboard
         app.kubernetes.io/name: centraldashboard
-        kustomize.component: centraldashboard
     spec:
       containers:
       - env:

--- a/tests/stacks/azure/application/centraldashboard/test_data/expected/networking.istio.io_v1alpha3_virtualservice_centraldashboard.yaml
+++ b/tests/stacks/azure/application/centraldashboard/test_data/expected/networking.istio.io_v1alpha3_virtualservice_centraldashboard.yaml
@@ -1,0 +1,24 @@
+apiVersion: networking.istio.io/v1alpha3
+kind: VirtualService
+metadata:
+  labels:
+    app.kubernetes.io/component: centraldashboard
+    app.kubernetes.io/name: centraldashboard
+  name: centraldashboard
+  namespace: kubeflow
+spec:
+  gateways:
+  - kubeflow-gateway
+  hosts:
+  - '*'
+  http:
+  - match:
+    - uri:
+        prefix: /
+    rewrite:
+      uri: /
+    route:
+    - destination:
+        host: centraldashboard.$(namespace).svc.$(clusterDomain)
+        port:
+          number: 80

--- a/tests/stacks/azure/application/centraldashboard/test_data/expected/rbac.authorization.k8s.io_v1_clusterrole_centraldashboard.yaml
+++ b/tests/stacks/azure/application/centraldashboard/test_data/expected/rbac.authorization.k8s.io_v1_clusterrole_centraldashboard.yaml
@@ -1,0 +1,20 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  labels:
+    app: centraldashboard
+    app.kubernetes.io/component: centraldashboard
+    app.kubernetes.io/name: centraldashboard
+    kustomize.component: centraldashboard
+  name: centraldashboard
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - events
+  - namespaces
+  - nodes
+  verbs:
+  - get
+  - list
+  - watch

--- a/tests/stacks/azure/application/centraldashboard/test_data/expected/rbac.authorization.k8s.io_v1_clusterrole_centraldashboard.yaml
+++ b/tests/stacks/azure/application/centraldashboard/test_data/expected/rbac.authorization.k8s.io_v1_clusterrole_centraldashboard.yaml
@@ -5,7 +5,6 @@ metadata:
     app: centraldashboard
     app.kubernetes.io/component: centraldashboard
     app.kubernetes.io/name: centraldashboard
-    kustomize.component: centraldashboard
   name: centraldashboard
 rules:
 - apiGroups:

--- a/tests/stacks/azure/application/centraldashboard/test_data/expected/rbac.authorization.k8s.io_v1_clusterrolebinding_centraldashboard.yaml
+++ b/tests/stacks/azure/application/centraldashboard/test_data/expected/rbac.authorization.k8s.io_v1_clusterrolebinding_centraldashboard.yaml
@@ -1,0 +1,17 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  labels:
+    app: centraldashboard
+    app.kubernetes.io/component: centraldashboard
+    app.kubernetes.io/name: centraldashboard
+    kustomize.component: centraldashboard
+  name: centraldashboard
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: centraldashboard
+subjects:
+- kind: ServiceAccount
+  name: centraldashboard
+  namespace: kubeflow

--- a/tests/stacks/azure/application/centraldashboard/test_data/expected/rbac.authorization.k8s.io_v1_clusterrolebinding_centraldashboard.yaml
+++ b/tests/stacks/azure/application/centraldashboard/test_data/expected/rbac.authorization.k8s.io_v1_clusterrolebinding_centraldashboard.yaml
@@ -5,7 +5,6 @@ metadata:
     app: centraldashboard
     app.kubernetes.io/component: centraldashboard
     app.kubernetes.io/name: centraldashboard
-    kustomize.component: centraldashboard
   name: centraldashboard
 roleRef:
   apiGroup: rbac.authorization.k8s.io

--- a/tests/stacks/azure/application/centraldashboard/test_data/expected/rbac.authorization.k8s.io_v1_role_centraldashboard.yaml
+++ b/tests/stacks/azure/application/centraldashboard/test_data/expected/rbac.authorization.k8s.io_v1_role_centraldashboard.yaml
@@ -1,0 +1,30 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  labels:
+    app: centraldashboard
+    app.kubernetes.io/component: centraldashboard
+    app.kubernetes.io/name: centraldashboard
+    kustomize.component: centraldashboard
+  name: centraldashboard
+  namespace: kubeflow
+rules:
+- apiGroups:
+  - ""
+  - app.k8s.io
+  resources:
+  - applications
+  - pods
+  - pods/exec
+  - pods/log
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - secrets
+  - configmaps
+  verbs:
+  - get

--- a/tests/stacks/azure/application/centraldashboard/test_data/expected/rbac.authorization.k8s.io_v1_role_centraldashboard.yaml
+++ b/tests/stacks/azure/application/centraldashboard/test_data/expected/rbac.authorization.k8s.io_v1_role_centraldashboard.yaml
@@ -5,7 +5,6 @@ metadata:
     app: centraldashboard
     app.kubernetes.io/component: centraldashboard
     app.kubernetes.io/name: centraldashboard
-    kustomize.component: centraldashboard
   name: centraldashboard
   namespace: kubeflow
 rules:

--- a/tests/stacks/azure/application/centraldashboard/test_data/expected/rbac.authorization.k8s.io_v1_rolebinding_centraldashboard.yaml
+++ b/tests/stacks/azure/application/centraldashboard/test_data/expected/rbac.authorization.k8s.io_v1_rolebinding_centraldashboard.yaml
@@ -1,0 +1,18 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  labels:
+    app: centraldashboard
+    app.kubernetes.io/component: centraldashboard
+    app.kubernetes.io/name: centraldashboard
+    kustomize.component: centraldashboard
+  name: centraldashboard
+  namespace: kubeflow
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: centraldashboard
+subjects:
+- kind: ServiceAccount
+  name: centraldashboard
+  namespace: kubeflow

--- a/tests/stacks/azure/application/centraldashboard/test_data/expected/rbac.authorization.k8s.io_v1_rolebinding_centraldashboard.yaml
+++ b/tests/stacks/azure/application/centraldashboard/test_data/expected/rbac.authorization.k8s.io_v1_rolebinding_centraldashboard.yaml
@@ -5,7 +5,6 @@ metadata:
     app: centraldashboard
     app.kubernetes.io/component: centraldashboard
     app.kubernetes.io/name: centraldashboard
-    kustomize.component: centraldashboard
   name: centraldashboard
   namespace: kubeflow
 roleRef:

--- a/tests/stacks/azure/application/centraldashboard/test_data/expected/~g_v1_configmap_centraldashboard-links-config.yaml
+++ b/tests/stacks/azure/application/centraldashboard/test_data/expected/~g_v1_configmap_centraldashboard-links-config.yaml
@@ -14,10 +14,6 @@ data:
         {
           "link": "/katib/",
           "text": "Katib"
-        },
-        {
-          "link": "/metadata/",
-          "text": "Artifact Store"
         }
       ],
       "externalLinks": [],
@@ -41,11 +37,6 @@ data:
           "text": "View Katib Experiments",
           "desc": "Katib",
           "link": "/katib/"
-        },
-        {
-          "text": "View Metadata Artifacts",
-          "desc": "Artifact Store",
-          "link": "/metadata/"
         }
       ],
       "documentationItems": [

--- a/tests/stacks/azure/application/centraldashboard/test_data/expected/~g_v1_configmap_centraldashboard-links-config.yaml
+++ b/tests/stacks/azure/application/centraldashboard/test_data/expected/~g_v1_configmap_centraldashboard-links-config.yaml
@@ -65,9 +65,7 @@ data:
 kind: ConfigMap
 metadata:
   labels:
-    app: centraldashboard
     app.kubernetes.io/component: centraldashboard
     app.kubernetes.io/name: centraldashboard
-    kustomize.component: centraldashboard
   name: centraldashboard-links-config
   namespace: kubeflow

--- a/tests/stacks/azure/application/centraldashboard/test_data/expected/~g_v1_configmap_centraldashboard-links-config.yaml
+++ b/tests/stacks/azure/application/centraldashboard/test_data/expected/~g_v1_configmap_centraldashboard-links-config.yaml
@@ -74,7 +74,9 @@ data:
 kind: ConfigMap
 metadata:
   labels:
+    app: centraldashboard
     app.kubernetes.io/component: centraldashboard
     app.kubernetes.io/name: centraldashboard
+    kustomize.component: centraldashboard
   name: centraldashboard-links-config
   namespace: kubeflow

--- a/tests/stacks/azure/application/centraldashboard/test_data/expected/~g_v1_service_centraldashboard.yaml
+++ b/tests/stacks/azure/application/centraldashboard/test_data/expected/~g_v1_service_centraldashboard.yaml
@@ -1,0 +1,31 @@
+apiVersion: v1
+kind: Service
+metadata:
+  annotations:
+    getambassador.io/config: |-
+      ---
+      apiVersion: ambassador/v0
+      kind:  Mapping
+      name: centralui-mapping
+      prefix: /
+      rewrite: /
+      service: centraldashboard.$(namespace)
+  labels:
+    app: centraldashboard
+    app.kubernetes.io/component: centraldashboard
+    app.kubernetes.io/name: centraldashboard
+    kustomize.component: centraldashboard
+  name: centraldashboard
+  namespace: kubeflow
+spec:
+  ports:
+  - port: 80
+    protocol: TCP
+    targetPort: 8082
+  selector:
+    app: centraldashboard
+    app.kubernetes.io/component: centraldashboard
+    app.kubernetes.io/name: centraldashboard
+    kustomize.component: centraldashboard
+  sessionAffinity: None
+  type: ClusterIP

--- a/tests/stacks/azure/application/centraldashboard/test_data/expected/~g_v1_service_centraldashboard.yaml
+++ b/tests/stacks/azure/application/centraldashboard/test_data/expected/~g_v1_service_centraldashboard.yaml
@@ -14,7 +14,6 @@ metadata:
     app: centraldashboard
     app.kubernetes.io/component: centraldashboard
     app.kubernetes.io/name: centraldashboard
-    kustomize.component: centraldashboard
   name: centraldashboard
   namespace: kubeflow
 spec:
@@ -26,6 +25,5 @@ spec:
     app: centraldashboard
     app.kubernetes.io/component: centraldashboard
     app.kubernetes.io/name: centraldashboard
-    kustomize.component: centraldashboard
   sessionAffinity: None
   type: ClusterIP

--- a/tests/stacks/azure/application/centraldashboard/test_data/expected/~g_v1_serviceaccount_centraldashboard.yaml
+++ b/tests/stacks/azure/application/centraldashboard/test_data/expected/~g_v1_serviceaccount_centraldashboard.yaml
@@ -1,0 +1,10 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  labels:
+    app: centraldashboard
+    app.kubernetes.io/component: centraldashboard
+    app.kubernetes.io/name: centraldashboard
+    kustomize.component: centraldashboard
+  name: centraldashboard
+  namespace: kubeflow

--- a/tests/stacks/azure/application/centraldashboard/test_data/expected/~g_v1_serviceaccount_centraldashboard.yaml
+++ b/tests/stacks/azure/application/centraldashboard/test_data/expected/~g_v1_serviceaccount_centraldashboard.yaml
@@ -2,9 +2,7 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   labels:
-    app: centraldashboard
     app.kubernetes.io/component: centraldashboard
     app.kubernetes.io/name: centraldashboard
-    kustomize.component: centraldashboard
   name: centraldashboard
   namespace: kubeflow

--- a/tests/stacks/azure/application/jupyter-web-app/base/test_data/expected/apps_v1_deployment_jupyter-web-app-deployment.yaml
+++ b/tests/stacks/azure/application/jupyter-web-app/base/test_data/expected/apps_v1_deployment_jupyter-web-app-deployment.yaml
@@ -48,7 +48,7 @@ spec:
             configMapKeyRef:
               key: userid-prefix
               name: kubeflow-config
-        image: gcr.io/kubeflow-images-public/jupyter-web-app:vmaster-gd9be4b9e
+        image: gcr.io/kubeflow-images-public/jupyter-web-app:vmaster-g845af298
         imagePullPolicy: Always
         name: jupyter-web-app
         ports:

--- a/tests/stacks/azure/application/jupyter-web-app/test_data/expected/apps_v1_deployment_jupyter-web-app-deployment.yaml
+++ b/tests/stacks/azure/application/jupyter-web-app/test_data/expected/apps_v1_deployment_jupyter-web-app-deployment.yaml
@@ -48,7 +48,7 @@ spec:
             configMapKeyRef:
               key: userid-prefix
               name: kubeflow-config
-        image: gcr.io/kubeflow-images-public/jupyter-web-app:vmaster-gd9be4b9e
+        image: gcr.io/kubeflow-images-public/jupyter-web-app:vmaster-g845af298
         imagePullPolicy: Always
         name: jupyter-web-app
         ports:

--- a/tests/stacks/azure/test_data/expected/apps_v1_deployment_jupyter-web-app-deployment.yaml
+++ b/tests/stacks/azure/test_data/expected/apps_v1_deployment_jupyter-web-app-deployment.yaml
@@ -48,7 +48,7 @@ spec:
             configMapKeyRef:
               key: userid-prefix
               name: kubeflow-config-bk4bc7m928
-        image: gcr.io/kubeflow-images-public/jupyter-web-app:vmaster-gd9be4b9e
+        image: gcr.io/kubeflow-images-public/jupyter-web-app:vmaster-g845af298
         imagePullPolicy: Always
         name: jupyter-web-app
         ports:

--- a/tests/stacks/azure/test_data/expected/~g_v1_configmap_centraldashboard-links-config.yaml
+++ b/tests/stacks/azure/test_data/expected/~g_v1_configmap_centraldashboard-links-config.yaml
@@ -14,10 +14,6 @@ data:
         {
           "link": "/katib/",
           "text": "Katib"
-        },
-        {
-          "link": "/metadata/",
-          "text": "Artifact Store"
         }
       ],
       "externalLinks": [],
@@ -41,11 +37,6 @@ data:
           "text": "View Katib Experiments",
           "desc": "Katib",
           "link": "/katib/"
-        },
-        {
-          "text": "View Metadata Artifacts",
-          "desc": "Artifact Store",
-          "link": "/metadata/"
         }
       ],
       "documentationItems": [


### PR DESCRIPTION
**Which issue is resolved by this Pull Request:**
Resolves #1597 for Azure

**Description of your changes:**
Cherry-picking changes for central dashboard customization for the Azure stack
Cherry-picking change to update hardcoded image tags

**Checklist:**
- [X] Unit tests have been rebuilt: 
    1. `cd manifests/tests`
    2. `make generate-changed-only`
    3. `make test`
