### PR TITLE
fix katib application selectors

### DIFF
--- a/katib/installs/katib-external-db/kustomization.yaml
+++ b/katib/installs/katib-external-db/kustomization.yaml
@@ -11,6 +11,12 @@ secretGenerator:
   - name: katib-mysql-secrets
     envs:
       - secrets.env
-commonLabels:
-  app.kubernetes.io/component: katib
-  app.kubernetes.io/name: katib-controller
+patches:
+  - patch: |-
+      apiVersion: v1
+      kind: Secret
+      metadata:
+        name: katib-mysql-secrets
+        labels:
+          app.kubernetes.io/component: katib
+          app.kubernetes.io/name: katib-controller

--- a/katib/katib-controller/overlays/application/application.yaml
+++ b/katib/katib-controller/overlays/application/application.yaml
@@ -6,11 +6,17 @@ spec:
   addOwnerRef: true
   componentKinds:
     - group: core
-      kind: Service
+      kind: ConfigMap
     - group: apps
       kind: Deployment
     - group: core
       kind: Secret
+    - group: core
+      kind: Service
+    - group: core
+      kind: ServiceAccount
+    - group: networking.istio.io
+      kind: VirtualService
     - group: core
       kind: ServiceAccount
     - group: kubeflow.org
@@ -59,7 +65,4 @@ spec:
   selector:
     matchLabels:
       app.kubernetes.io/component: katib
-      app.kubernetes.io/instance: katib-controller
-      app.kubernetes.io/managed-by: kfctl
       app.kubernetes.io/name: katib-controller
-      app.kubernetes.io/part-of: kubeflow

--- a/katib/katib-crds/overlays/application/application.yaml
+++ b/katib/katib-crds/overlays/application/application.yaml
@@ -5,18 +5,8 @@ metadata:
 spec:
   addOwnerRef: true
   componentKinds:
-    - group: core
-      kind: Service
-    - group: apps
-      kind: Deployment
-    - group: core
-      kind: ServiceAccount
-    - group: kubeflow.org
-      kind: Experiment
-    - group: kubeflow.org
-      kind: Suggestion
-    - group: kubeflow.org
-      kind: Trial
+    - group: apiextensions.k8s.io
+      kind: CustomResourceDefinition
   descriptor:
     description: Katib is a service for hyperparameter tuning and neural architecture search.
     keywords:
@@ -57,7 +47,4 @@ spec:
   selector:
     matchLabels:
       app.kubernetes.io/component: katib
-      app.kubernetes.io/instance: katib-crds
-      app.kubernetes.io/managed-by: kfctl
       app.kubernetes.io/name: katib-crds
-      app.kubernetes.io/part-of: kubeflow

--- a/tests/katib/installs/katib-external-db/test_data/expected/apiextensions.k8s.io_v1beta1_customresourcedefinition_experiments.kubeflow.org.yaml
+++ b/tests/katib/installs/katib-external-db/test_data/expected/apiextensions.k8s.io_v1beta1_customresourcedefinition_experiments.kubeflow.org.yaml
@@ -3,7 +3,7 @@ kind: CustomResourceDefinition
 metadata:
   labels:
     app.kubernetes.io/component: katib
-    app.kubernetes.io/name: katib-controller
+    app.kubernetes.io/name: katib-crds
   name: experiments.kubeflow.org
 spec:
   additionalPrinterColumns:

--- a/tests/katib/installs/katib-external-db/test_data/expected/apiextensions.k8s.io_v1beta1_customresourcedefinition_suggestions.kubeflow.org.yaml
+++ b/tests/katib/installs/katib-external-db/test_data/expected/apiextensions.k8s.io_v1beta1_customresourcedefinition_suggestions.kubeflow.org.yaml
@@ -3,7 +3,7 @@ kind: CustomResourceDefinition
 metadata:
   labels:
     app.kubernetes.io/component: katib
-    app.kubernetes.io/name: katib-controller
+    app.kubernetes.io/name: katib-crds
   name: suggestions.kubeflow.org
 spec:
   additionalPrinterColumns:

--- a/tests/katib/installs/katib-external-db/test_data/expected/apiextensions.k8s.io_v1beta1_customresourcedefinition_trials.kubeflow.org.yaml
+++ b/tests/katib/installs/katib-external-db/test_data/expected/apiextensions.k8s.io_v1beta1_customresourcedefinition_trials.kubeflow.org.yaml
@@ -3,7 +3,7 @@ kind: CustomResourceDefinition
 metadata:
   labels:
     app.kubernetes.io/component: katib
-    app.kubernetes.io/name: katib-controller
+    app.kubernetes.io/name: katib-crds
   name: trials.kubeflow.org
 spec:
   additionalPrinterColumns:

--- a/tests/katib/installs/katib-external-db/test_data/expected/app.k8s.io_v1beta1_application_katib-controller.yaml
+++ b/tests/katib/installs/katib-external-db/test_data/expected/app.k8s.io_v1beta1_application_katib-controller.yaml
@@ -10,11 +10,17 @@ spec:
   addOwnerRef: true
   componentKinds:
   - group: core
-    kind: Service
+    kind: ConfigMap
   - group: apps
     kind: Deployment
   - group: core
     kind: Secret
+  - group: core
+    kind: Service
+  - group: core
+    kind: ServiceAccount
+  - group: networking.istio.io
+    kind: VirtualService
   - group: core
     kind: ServiceAccount
   - group: kubeflow.org
@@ -64,7 +70,4 @@ spec:
   selector:
     matchLabels:
       app.kubernetes.io/component: katib
-      app.kubernetes.io/instance: katib-controller
-      app.kubernetes.io/managed-by: kfctl
       app.kubernetes.io/name: katib-controller
-      app.kubernetes.io/part-of: kubeflow

--- a/tests/katib/installs/katib-external-db/test_data/expected/app.k8s.io_v1beta1_application_katib-crds.yaml
+++ b/tests/katib/installs/katib-external-db/test_data/expected/app.k8s.io_v1beta1_application_katib-crds.yaml
@@ -3,24 +3,14 @@ kind: Application
 metadata:
   labels:
     app.kubernetes.io/component: katib
-    app.kubernetes.io/name: katib-controller
+    app.kubernetes.io/name: katib-crds
   name: katib-crds
   namespace: kubeflow
 spec:
   addOwnerRef: true
   componentKinds:
-  - group: core
-    kind: Service
-  - group: apps
-    kind: Deployment
-  - group: core
-    kind: ServiceAccount
-  - group: kubeflow.org
-    kind: Experiment
-  - group: kubeflow.org
-    kind: Suggestion
-  - group: kubeflow.org
-    kind: Trial
+  - group: apiextensions.k8s.io
+    kind: CustomResourceDefinition
   descriptor:
     description: Katib is a service for hyperparameter tuning and neural architecture
       search.
@@ -62,7 +52,4 @@ spec:
   selector:
     matchLabels:
       app.kubernetes.io/component: katib
-      app.kubernetes.io/instance: katib-crds
-      app.kubernetes.io/managed-by: kfctl
       app.kubernetes.io/name: katib-crds
-      app.kubernetes.io/part-of: kubeflow

--- a/tests/katib/installs/katib-standalone-ibm/test_data/expected/app.k8s.io_v1beta1_application_katib-controller.yaml
+++ b/tests/katib/installs/katib-standalone-ibm/test_data/expected/app.k8s.io_v1beta1_application_katib-controller.yaml
@@ -10,11 +10,17 @@ spec:
   addOwnerRef: true
   componentKinds:
   - group: core
-    kind: Service
+    kind: ConfigMap
   - group: apps
     kind: Deployment
   - group: core
     kind: Secret
+  - group: core
+    kind: Service
+  - group: core
+    kind: ServiceAccount
+  - group: networking.istio.io
+    kind: VirtualService
   - group: core
     kind: ServiceAccount
   - group: kubeflow.org
@@ -64,7 +70,4 @@ spec:
   selector:
     matchLabels:
       app.kubernetes.io/component: katib
-      app.kubernetes.io/instance: katib-controller
-      app.kubernetes.io/managed-by: kfctl
       app.kubernetes.io/name: katib-controller
-      app.kubernetes.io/part-of: kubeflow

--- a/tests/katib/installs/katib-standalone-ibm/test_data/expected/app.k8s.io_v1beta1_application_katib-crds.yaml
+++ b/tests/katib/installs/katib-standalone-ibm/test_data/expected/app.k8s.io_v1beta1_application_katib-crds.yaml
@@ -9,18 +9,8 @@ metadata:
 spec:
   addOwnerRef: true
   componentKinds:
-  - group: core
-    kind: Service
-  - group: apps
-    kind: Deployment
-  - group: core
-    kind: ServiceAccount
-  - group: kubeflow.org
-    kind: Experiment
-  - group: kubeflow.org
-    kind: Suggestion
-  - group: kubeflow.org
-    kind: Trial
+  - group: apiextensions.k8s.io
+    kind: CustomResourceDefinition
   descriptor:
     description: Katib is a service for hyperparameter tuning and neural architecture
       search.
@@ -62,7 +52,4 @@ spec:
   selector:
     matchLabels:
       app.kubernetes.io/component: katib
-      app.kubernetes.io/instance: katib-crds
-      app.kubernetes.io/managed-by: kfctl
       app.kubernetes.io/name: katib-crds
-      app.kubernetes.io/part-of: kubeflow

--- a/tests/katib/installs/katib-standalone/test_data/expected/app.k8s.io_v1beta1_application_katib-controller.yaml
+++ b/tests/katib/installs/katib-standalone/test_data/expected/app.k8s.io_v1beta1_application_katib-controller.yaml
@@ -10,11 +10,17 @@ spec:
   addOwnerRef: true
   componentKinds:
   - group: core
-    kind: Service
+    kind: ConfigMap
   - group: apps
     kind: Deployment
   - group: core
     kind: Secret
+  - group: core
+    kind: Service
+  - group: core
+    kind: ServiceAccount
+  - group: networking.istio.io
+    kind: VirtualService
   - group: core
     kind: ServiceAccount
   - group: kubeflow.org
@@ -64,7 +70,4 @@ spec:
   selector:
     matchLabels:
       app.kubernetes.io/component: katib
-      app.kubernetes.io/instance: katib-controller
-      app.kubernetes.io/managed-by: kfctl
       app.kubernetes.io/name: katib-controller
-      app.kubernetes.io/part-of: kubeflow

--- a/tests/katib/installs/katib-standalone/test_data/expected/app.k8s.io_v1beta1_application_katib-crds.yaml
+++ b/tests/katib/installs/katib-standalone/test_data/expected/app.k8s.io_v1beta1_application_katib-crds.yaml
@@ -9,18 +9,8 @@ metadata:
 spec:
   addOwnerRef: true
   componentKinds:
-  - group: core
-    kind: Service
-  - group: apps
-    kind: Deployment
-  - group: core
-    kind: ServiceAccount
-  - group: kubeflow.org
-    kind: Experiment
-  - group: kubeflow.org
-    kind: Suggestion
-  - group: kubeflow.org
-    kind: Trial
+  - group: apiextensions.k8s.io
+    kind: CustomResourceDefinition
   descriptor:
     description: Katib is a service for hyperparameter tuning and neural architecture
       search.
@@ -62,7 +52,4 @@ spec:
   selector:
     matchLabels:
       app.kubernetes.io/component: katib
-      app.kubernetes.io/instance: katib-crds
-      app.kubernetes.io/managed-by: kfctl
       app.kubernetes.io/name: katib-crds
-      app.kubernetes.io/part-of: kubeflow

--- a/tests/stacks/aws/test_data/expected/app.k8s.io_v1beta1_application_katib-controller.yaml
+++ b/tests/stacks/aws/test_data/expected/app.k8s.io_v1beta1_application_katib-controller.yaml
@@ -10,11 +10,17 @@ spec:
   addOwnerRef: true
   componentKinds:
   - group: core
-    kind: Service
+    kind: ConfigMap
   - group: apps
     kind: Deployment
   - group: core
     kind: Secret
+  - group: core
+    kind: Service
+  - group: core
+    kind: ServiceAccount
+  - group: networking.istio.io
+    kind: VirtualService
   - group: core
     kind: ServiceAccount
   - group: kubeflow.org
@@ -64,7 +70,4 @@ spec:
   selector:
     matchLabels:
       app.kubernetes.io/component: katib
-      app.kubernetes.io/instance: katib-controller
-      app.kubernetes.io/managed-by: kfctl
       app.kubernetes.io/name: katib-controller
-      app.kubernetes.io/part-of: kubeflow

--- a/tests/stacks/aws/test_data/expected/app.k8s.io_v1beta1_application_katib-crds.yaml
+++ b/tests/stacks/aws/test_data/expected/app.k8s.io_v1beta1_application_katib-crds.yaml
@@ -9,18 +9,8 @@ metadata:
 spec:
   addOwnerRef: true
   componentKinds:
-  - group: core
-    kind: Service
-  - group: apps
-    kind: Deployment
-  - group: core
-    kind: ServiceAccount
-  - group: kubeflow.org
-    kind: Experiment
-  - group: kubeflow.org
-    kind: Suggestion
-  - group: kubeflow.org
-    kind: Trial
+  - group: apiextensions.k8s.io
+    kind: CustomResourceDefinition
   descriptor:
     description: Katib is a service for hyperparameter tuning and neural architecture
       search.
@@ -62,7 +52,4 @@ spec:
   selector:
     matchLabels:
       app.kubernetes.io/component: katib
-      app.kubernetes.io/instance: katib-crds
-      app.kubernetes.io/managed-by: kfctl
       app.kubernetes.io/name: katib-crds
-      app.kubernetes.io/part-of: kubeflow

--- a/tests/stacks/azure/test_data/expected/app.k8s.io_v1beta1_application_katib-controller.yaml
+++ b/tests/stacks/azure/test_data/expected/app.k8s.io_v1beta1_application_katib-controller.yaml
@@ -10,11 +10,17 @@ spec:
   addOwnerRef: true
   componentKinds:
   - group: core
-    kind: Service
+    kind: ConfigMap
   - group: apps
     kind: Deployment
   - group: core
     kind: Secret
+  - group: core
+    kind: Service
+  - group: core
+    kind: ServiceAccount
+  - group: networking.istio.io
+    kind: VirtualService
   - group: core
     kind: ServiceAccount
   - group: kubeflow.org
@@ -64,7 +70,4 @@ spec:
   selector:
     matchLabels:
       app.kubernetes.io/component: katib
-      app.kubernetes.io/instance: katib-controller
-      app.kubernetes.io/managed-by: kfctl
       app.kubernetes.io/name: katib-controller
-      app.kubernetes.io/part-of: kubeflow

--- a/tests/stacks/azure/test_data/expected/app.k8s.io_v1beta1_application_katib-crds.yaml
+++ b/tests/stacks/azure/test_data/expected/app.k8s.io_v1beta1_application_katib-crds.yaml
@@ -9,18 +9,8 @@ metadata:
 spec:
   addOwnerRef: true
   componentKinds:
-  - group: core
-    kind: Service
-  - group: apps
-    kind: Deployment
-  - group: core
-    kind: ServiceAccount
-  - group: kubeflow.org
-    kind: Experiment
-  - group: kubeflow.org
-    kind: Suggestion
-  - group: kubeflow.org
-    kind: Trial
+  - group: apiextensions.k8s.io
+    kind: CustomResourceDefinition
   descriptor:
     description: Katib is a service for hyperparameter tuning and neural architecture
       search.
@@ -62,7 +52,4 @@ spec:
   selector:
     matchLabels:
       app.kubernetes.io/component: katib
-      app.kubernetes.io/instance: katib-crds
-      app.kubernetes.io/managed-by: kfctl
       app.kubernetes.io/name: katib-crds
-      app.kubernetes.io/part-of: kubeflow

--- a/tests/stacks/examples/alice/test_data/expected/app.k8s.io_v1beta1_application_katib-controller.yaml
+++ b/tests/stacks/examples/alice/test_data/expected/app.k8s.io_v1beta1_application_katib-controller.yaml
@@ -10,11 +10,17 @@ spec:
   addOwnerRef: true
   componentKinds:
   - group: core
-    kind: Service
+    kind: ConfigMap
   - group: apps
     kind: Deployment
   - group: core
     kind: Secret
+  - group: core
+    kind: Service
+  - group: core
+    kind: ServiceAccount
+  - group: networking.istio.io
+    kind: VirtualService
   - group: core
     kind: ServiceAccount
   - group: kubeflow.org
@@ -64,7 +70,4 @@ spec:
   selector:
     matchLabels:
       app.kubernetes.io/component: katib
-      app.kubernetes.io/instance: katib-controller
-      app.kubernetes.io/managed-by: kfctl
       app.kubernetes.io/name: katib-controller
-      app.kubernetes.io/part-of: kubeflow

--- a/tests/stacks/examples/alice/test_data/expected/app.k8s.io_v1beta1_application_katib-crds.yaml
+++ b/tests/stacks/examples/alice/test_data/expected/app.k8s.io_v1beta1_application_katib-crds.yaml
@@ -9,18 +9,8 @@ metadata:
 spec:
   addOwnerRef: true
   componentKinds:
-  - group: core
-    kind: Service
-  - group: apps
-    kind: Deployment
-  - group: core
-    kind: ServiceAccount
-  - group: kubeflow.org
-    kind: Experiment
-  - group: kubeflow.org
-    kind: Suggestion
-  - group: kubeflow.org
-    kind: Trial
+  - group: apiextensions.k8s.io
+    kind: CustomResourceDefinition
   descriptor:
     description: Katib is a service for hyperparameter tuning and neural architecture
       search.
@@ -62,7 +52,4 @@ spec:
   selector:
     matchLabels:
       app.kubernetes.io/component: katib
-      app.kubernetes.io/instance: katib-crds
-      app.kubernetes.io/managed-by: kfctl
       app.kubernetes.io/name: katib-crds
-      app.kubernetes.io/part-of: kubeflow

--- a/tests/stacks/gcp/test_data/expected/app.k8s.io_v1beta1_application_katib-controller.yaml
+++ b/tests/stacks/gcp/test_data/expected/app.k8s.io_v1beta1_application_katib-controller.yaml
@@ -10,11 +10,17 @@ spec:
   addOwnerRef: true
   componentKinds:
   - group: core
-    kind: Service
+    kind: ConfigMap
   - group: apps
     kind: Deployment
   - group: core
     kind: Secret
+  - group: core
+    kind: Service
+  - group: core
+    kind: ServiceAccount
+  - group: networking.istio.io
+    kind: VirtualService
   - group: core
     kind: ServiceAccount
   - group: kubeflow.org
@@ -64,7 +70,4 @@ spec:
   selector:
     matchLabels:
       app.kubernetes.io/component: katib
-      app.kubernetes.io/instance: katib-controller
-      app.kubernetes.io/managed-by: kfctl
       app.kubernetes.io/name: katib-controller
-      app.kubernetes.io/part-of: kubeflow

--- a/tests/stacks/gcp/test_data/expected/app.k8s.io_v1beta1_application_katib-crds.yaml
+++ b/tests/stacks/gcp/test_data/expected/app.k8s.io_v1beta1_application_katib-crds.yaml
@@ -9,18 +9,8 @@ metadata:
 spec:
   addOwnerRef: true
   componentKinds:
-  - group: core
-    kind: Service
-  - group: apps
-    kind: Deployment
-  - group: core
-    kind: ServiceAccount
-  - group: kubeflow.org
-    kind: Experiment
-  - group: kubeflow.org
-    kind: Suggestion
-  - group: kubeflow.org
-    kind: Trial
+  - group: apiextensions.k8s.io
+    kind: CustomResourceDefinition
   descriptor:
     description: Katib is a service for hyperparameter tuning and neural architecture
       search.
@@ -62,7 +52,4 @@ spec:
   selector:
     matchLabels:
       app.kubernetes.io/component: katib
-      app.kubernetes.io/instance: katib-crds
-      app.kubernetes.io/managed-by: kfctl
       app.kubernetes.io/name: katib-crds
-      app.kubernetes.io/part-of: kubeflow

--- a/tests/stacks/generic/test_data/expected/app.k8s.io_v1beta1_application_katib-controller.yaml
+++ b/tests/stacks/generic/test_data/expected/app.k8s.io_v1beta1_application_katib-controller.yaml
@@ -10,11 +10,17 @@ spec:
   addOwnerRef: true
   componentKinds:
   - group: core
-    kind: Service
+    kind: ConfigMap
   - group: apps
     kind: Deployment
   - group: core
     kind: Secret
+  - group: core
+    kind: Service
+  - group: core
+    kind: ServiceAccount
+  - group: networking.istio.io
+    kind: VirtualService
   - group: core
     kind: ServiceAccount
   - group: kubeflow.org
@@ -64,7 +70,4 @@ spec:
   selector:
     matchLabels:
       app.kubernetes.io/component: katib
-      app.kubernetes.io/instance: katib-controller
-      app.kubernetes.io/managed-by: kfctl
       app.kubernetes.io/name: katib-controller
-      app.kubernetes.io/part-of: kubeflow

--- a/tests/stacks/generic/test_data/expected/app.k8s.io_v1beta1_application_katib-crds.yaml
+++ b/tests/stacks/generic/test_data/expected/app.k8s.io_v1beta1_application_katib-crds.yaml
@@ -9,18 +9,8 @@ metadata:
 spec:
   addOwnerRef: true
   componentKinds:
-  - group: core
-    kind: Service
-  - group: apps
-    kind: Deployment
-  - group: core
-    kind: ServiceAccount
-  - group: kubeflow.org
-    kind: Experiment
-  - group: kubeflow.org
-    kind: Suggestion
-  - group: kubeflow.org
-    kind: Trial
+  - group: apiextensions.k8s.io
+    kind: CustomResourceDefinition
   descriptor:
     description: Katib is a service for hyperparameter tuning and neural architecture
       search.
@@ -62,7 +52,4 @@ spec:
   selector:
     matchLabels:
       app.kubernetes.io/component: katib
-      app.kubernetes.io/instance: katib-crds
-      app.kubernetes.io/managed-by: kfctl
       app.kubernetes.io/name: katib-crds
-      app.kubernetes.io/part-of: kubeflow

--- a/tests/stacks/ibm/application/katib/test_data/expected/app.k8s.io_v1beta1_application_katib-controller.yaml
+++ b/tests/stacks/ibm/application/katib/test_data/expected/app.k8s.io_v1beta1_application_katib-controller.yaml
@@ -10,11 +10,17 @@ spec:
   addOwnerRef: true
   componentKinds:
   - group: core
-    kind: Service
+    kind: ConfigMap
   - group: apps
     kind: Deployment
   - group: core
     kind: Secret
+  - group: core
+    kind: Service
+  - group: core
+    kind: ServiceAccount
+  - group: networking.istio.io
+    kind: VirtualService
   - group: core
     kind: ServiceAccount
   - group: kubeflow.org
@@ -64,7 +70,4 @@ spec:
   selector:
     matchLabels:
       app.kubernetes.io/component: katib
-      app.kubernetes.io/instance: katib-controller
-      app.kubernetes.io/managed-by: kfctl
       app.kubernetes.io/name: katib-controller
-      app.kubernetes.io/part-of: kubeflow

--- a/tests/stacks/ibm/application/katib/test_data/expected/app.k8s.io_v1beta1_application_katib-crds.yaml
+++ b/tests/stacks/ibm/application/katib/test_data/expected/app.k8s.io_v1beta1_application_katib-crds.yaml
@@ -9,18 +9,8 @@ metadata:
 spec:
   addOwnerRef: true
   componentKinds:
-  - group: core
-    kind: Service
-  - group: apps
-    kind: Deployment
-  - group: core
-    kind: ServiceAccount
-  - group: kubeflow.org
-    kind: Experiment
-  - group: kubeflow.org
-    kind: Suggestion
-  - group: kubeflow.org
-    kind: Trial
+  - group: apiextensions.k8s.io
+    kind: CustomResourceDefinition
   descriptor:
     description: Katib is a service for hyperparameter tuning and neural architecture
       search.
@@ -62,7 +52,4 @@ spec:
   selector:
     matchLabels:
       app.kubernetes.io/component: katib
-      app.kubernetes.io/instance: katib-crds
-      app.kubernetes.io/managed-by: kfctl
       app.kubernetes.io/name: katib-crds
-      app.kubernetes.io/part-of: kubeflow

--- a/tests/stacks/ibm/multi-user/test_data/expected/app.k8s.io_v1beta1_application_katib-controller.yaml
+++ b/tests/stacks/ibm/multi-user/test_data/expected/app.k8s.io_v1beta1_application_katib-controller.yaml
@@ -10,11 +10,17 @@ spec:
   addOwnerRef: true
   componentKinds:
   - group: core
-    kind: Service
+    kind: ConfigMap
   - group: apps
     kind: Deployment
   - group: core
     kind: Secret
+  - group: core
+    kind: Service
+  - group: core
+    kind: ServiceAccount
+  - group: networking.istio.io
+    kind: VirtualService
   - group: core
     kind: ServiceAccount
   - group: kubeflow.org
@@ -64,7 +70,4 @@ spec:
   selector:
     matchLabels:
       app.kubernetes.io/component: katib
-      app.kubernetes.io/instance: katib-controller
-      app.kubernetes.io/managed-by: kfctl
       app.kubernetes.io/name: katib-controller
-      app.kubernetes.io/part-of: kubeflow

--- a/tests/stacks/ibm/multi-user/test_data/expected/app.k8s.io_v1beta1_application_katib-crds.yaml
+++ b/tests/stacks/ibm/multi-user/test_data/expected/app.k8s.io_v1beta1_application_katib-crds.yaml
@@ -9,18 +9,8 @@ metadata:
 spec:
   addOwnerRef: true
   componentKinds:
-  - group: core
-    kind: Service
-  - group: apps
-    kind: Deployment
-  - group: core
-    kind: ServiceAccount
-  - group: kubeflow.org
-    kind: Experiment
-  - group: kubeflow.org
-    kind: Suggestion
-  - group: kubeflow.org
-    kind: Trial
+  - group: apiextensions.k8s.io
+    kind: CustomResourceDefinition
   descriptor:
     description: Katib is a service for hyperparameter tuning and neural architecture
       search.
@@ -62,7 +52,4 @@ spec:
   selector:
     matchLabels:
       app.kubernetes.io/component: katib
-      app.kubernetes.io/instance: katib-crds
-      app.kubernetes.io/managed-by: kfctl
       app.kubernetes.io/name: katib-crds
-      app.kubernetes.io/part-of: kubeflow

--- a/tests/stacks/ibm/test_data/expected/app.k8s.io_v1beta1_application_katib-controller.yaml
+++ b/tests/stacks/ibm/test_data/expected/app.k8s.io_v1beta1_application_katib-controller.yaml
@@ -10,11 +10,17 @@ spec:
   addOwnerRef: true
   componentKinds:
   - group: core
-    kind: Service
+    kind: ConfigMap
   - group: apps
     kind: Deployment
   - group: core
     kind: Secret
+  - group: core
+    kind: Service
+  - group: core
+    kind: ServiceAccount
+  - group: networking.istio.io
+    kind: VirtualService
   - group: core
     kind: ServiceAccount
   - group: kubeflow.org
@@ -64,7 +70,4 @@ spec:
   selector:
     matchLabels:
       app.kubernetes.io/component: katib
-      app.kubernetes.io/instance: katib-controller
-      app.kubernetes.io/managed-by: kfctl
       app.kubernetes.io/name: katib-controller
-      app.kubernetes.io/part-of: kubeflow

--- a/tests/stacks/ibm/test_data/expected/app.k8s.io_v1beta1_application_katib-crds.yaml
+++ b/tests/stacks/ibm/test_data/expected/app.k8s.io_v1beta1_application_katib-crds.yaml
@@ -9,18 +9,8 @@ metadata:
 spec:
   addOwnerRef: true
   componentKinds:
-  - group: core
-    kind: Service
-  - group: apps
-    kind: Deployment
-  - group: core
-    kind: ServiceAccount
-  - group: kubeflow.org
-    kind: Experiment
-  - group: kubeflow.org
-    kind: Suggestion
-  - group: kubeflow.org
-    kind: Trial
+  - group: apiextensions.k8s.io
+    kind: CustomResourceDefinition
   descriptor:
     description: Katib is a service for hyperparameter tuning and neural architecture
       search.
@@ -62,7 +52,4 @@ spec:
   selector:
     matchLabels:
       app.kubernetes.io/component: katib
-      app.kubernetes.io/instance: katib-crds
-      app.kubernetes.io/managed-by: kfctl
       app.kubernetes.io/name: katib-crds
-      app.kubernetes.io/part-of: kubeflow

--- a/tests/stacks/kubernetes/test_data/expected/app.k8s.io_v1beta1_application_katib-controller.yaml
+++ b/tests/stacks/kubernetes/test_data/expected/app.k8s.io_v1beta1_application_katib-controller.yaml
@@ -10,11 +10,17 @@ spec:
   addOwnerRef: true
   componentKinds:
   - group: core
-    kind: Service
+    kind: ConfigMap
   - group: apps
     kind: Deployment
   - group: core
     kind: Secret
+  - group: core
+    kind: Service
+  - group: core
+    kind: ServiceAccount
+  - group: networking.istio.io
+    kind: VirtualService
   - group: core
     kind: ServiceAccount
   - group: kubeflow.org
@@ -64,7 +70,4 @@ spec:
   selector:
     matchLabels:
       app.kubernetes.io/component: katib
-      app.kubernetes.io/instance: katib-controller
-      app.kubernetes.io/managed-by: kfctl
       app.kubernetes.io/name: katib-controller
-      app.kubernetes.io/part-of: kubeflow

--- a/tests/stacks/kubernetes/test_data/expected/app.k8s.io_v1beta1_application_katib-crds.yaml
+++ b/tests/stacks/kubernetes/test_data/expected/app.k8s.io_v1beta1_application_katib-crds.yaml
@@ -9,18 +9,8 @@ metadata:
 spec:
   addOwnerRef: true
   componentKinds:
-  - group: core
-    kind: Service
-  - group: apps
-    kind: Deployment
-  - group: core
-    kind: ServiceAccount
-  - group: kubeflow.org
-    kind: Experiment
-  - group: kubeflow.org
-    kind: Suggestion
-  - group: kubeflow.org
-    kind: Trial
+  - group: apiextensions.k8s.io
+    kind: CustomResourceDefinition
   descriptor:
     description: Katib is a service for hyperparameter tuning and neural architecture
       search.
@@ -62,7 +52,4 @@ spec:
   selector:
     matchLabels:
       app.kubernetes.io/component: katib
-      app.kubernetes.io/instance: katib-crds
-      app.kubernetes.io/managed-by: kfctl
       app.kubernetes.io/name: katib-crds
-      app.kubernetes.io/part-of: kubeflow

--- a/tests/stacks/openshift/application/katib/test_data/expected/app.k8s.io_v1beta1_application_katib-controller.yaml
+++ b/tests/stacks/openshift/application/katib/test_data/expected/app.k8s.io_v1beta1_application_katib-controller.yaml
@@ -10,11 +10,17 @@ spec:
   addOwnerRef: true
   componentKinds:
   - group: core
-    kind: Service
+    kind: ConfigMap
   - group: apps
     kind: Deployment
   - group: core
     kind: Secret
+  - group: core
+    kind: Service
+  - group: core
+    kind: ServiceAccount
+  - group: networking.istio.io
+    kind: VirtualService
   - group: core
     kind: ServiceAccount
   - group: kubeflow.org
@@ -64,7 +70,4 @@ spec:
   selector:
     matchLabels:
       app.kubernetes.io/component: katib
-      app.kubernetes.io/instance: katib-controller
-      app.kubernetes.io/managed-by: kfctl
       app.kubernetes.io/name: katib-controller
-      app.kubernetes.io/part-of: kubeflow

--- a/tests/stacks/openshift/application/katib/test_data/expected/app.k8s.io_v1beta1_application_katib-crds.yaml
+++ b/tests/stacks/openshift/application/katib/test_data/expected/app.k8s.io_v1beta1_application_katib-crds.yaml
@@ -9,18 +9,8 @@ metadata:
 spec:
   addOwnerRef: true
   componentKinds:
-  - group: core
-    kind: Service
-  - group: apps
-    kind: Deployment
-  - group: core
-    kind: ServiceAccount
-  - group: kubeflow.org
-    kind: Experiment
-  - group: kubeflow.org
-    kind: Suggestion
-  - group: kubeflow.org
-    kind: Trial
+  - group: apiextensions.k8s.io
+    kind: CustomResourceDefinition
   descriptor:
     description: Katib is a service for hyperparameter tuning and neural architecture
       search.
@@ -62,7 +52,4 @@ spec:
   selector:
     matchLabels:
       app.kubernetes.io/component: katib
-      app.kubernetes.io/instance: katib-crds
-      app.kubernetes.io/managed-by: kfctl
       app.kubernetes.io/name: katib-crds
-      app.kubernetes.io/part-of: kubeflow

--- a/tests/tests/legacy_kustomizations/katib-controller/test_data/expected/app.k8s.io_v1beta1_application_katib-controller.yaml
+++ b/tests/tests/legacy_kustomizations/katib-controller/test_data/expected/app.k8s.io_v1beta1_application_katib-controller.yaml
@@ -14,11 +14,17 @@ spec:
   addOwnerRef: true
   componentKinds:
   - group: core
-    kind: Service
+    kind: ConfigMap
   - group: apps
     kind: Deployment
   - group: core
     kind: Secret
+  - group: core
+    kind: Service
+  - group: core
+    kind: ServiceAccount
+  - group: networking.istio.io
+    kind: VirtualService
   - group: core
     kind: ServiceAccount
   - group: kubeflow.org
@@ -68,7 +74,4 @@ spec:
   selector:
     matchLabels:
       app.kubernetes.io/component: katib
-      app.kubernetes.io/instance: katib-controller
-      app.kubernetes.io/managed-by: kfctl
       app.kubernetes.io/name: katib-controller
-      app.kubernetes.io/part-of: kubeflow

--- a/tests/tests/legacy_kustomizations/katib-crds/test_data/expected/app.k8s.io_v1beta1_application_katib-crds.yaml
+++ b/tests/tests/legacy_kustomizations/katib-crds/test_data/expected/app.k8s.io_v1beta1_application_katib-crds.yaml
@@ -13,18 +13,8 @@ metadata:
 spec:
   addOwnerRef: true
   componentKinds:
-  - group: core
-    kind: Service
-  - group: apps
-    kind: Deployment
-  - group: core
-    kind: ServiceAccount
-  - group: kubeflow.org
-    kind: Experiment
-  - group: kubeflow.org
-    kind: Suggestion
-  - group: kubeflow.org
-    kind: Trial
+  - group: apiextensions.k8s.io
+    kind: CustomResourceDefinition
   descriptor:
     description: Katib is a service for hyperparameter tuning and neural architecture
       search.
@@ -66,7 +56,4 @@ spec:
   selector:
     matchLabels:
       app.kubernetes.io/component: katib
-      app.kubernetes.io/instance: katib-crds
-      app.kubernetes.io/managed-by: kfctl
       app.kubernetes.io/name: katib-crds
-      app.kubernetes.io/part-of: kubeflow


### PR DESCRIPTION
**Which issue is resolved by this Pull Request:**
Fixes #1573 (for katib)

**Checklist:**
- [X] Unit tests have been rebuilt: 
    1. `cd manifests/tests`
    2. `make generate-changed-only`
    3. `make test`
