### PR TITLE
Pin manifest to stable tag v1.2.0

### DIFF
--- a/kfdef/kfctl_aws.v1.2.0.yaml
+++ b/kfdef/kfctl_aws.v1.2.0.yaml
@@ -110,5 +110,5 @@ spec:
       #- eksctl-kubeflow-aws-nodegroup-ng-a2-NodeInstanceRole-xxxxxxx
   repos:
   - name: manifests
-    uri: https://github.com/kubeflow/manifests/archive/v1.2-branch.tar.gz
+    uri: https://github.com/kubeflow/manifests/archive/v1.2.0.tar.gz
   version: v1.2-branch

--- a/kfdef/kfctl_aws_cognito.v1.2.0.yaml
+++ b/kfdef/kfctl_aws_cognito.v1.2.0.yaml
@@ -107,5 +107,5 @@ spec:
       #- eksctl-kubeflow-aws-nodegroup-ng-a2-NodeInstanceRole-xxxxxxx
   repos:
   - name: manifests
-    uri: https://github.com/kubeflow/manifests/archive/v1.2-branch.tar.gz
+    uri: https://github.com/kubeflow/manifests/archive/v1.2.0.tar.gz
   version: v1.2-branch

--- a/kfdef/kfctl_azure.v1.2.0.yaml
+++ b/kfdef/kfctl_azure.v1.2.0.yaml
@@ -53,6 +53,6 @@ spec:
     name: kubeflow-apps
   repos:
   - name: manifests
-    uri: https://github.com/kubeflow/manifests/archive/v1.2-branch.tar.gz
+    uri: https://github.com/kubeflow/manifests/archive/v1.2.0.tar.gz
   version: v1.2-branch
 

--- a/kfdef/kfctl_azure_aad.v1.2.0.yaml
+++ b/kfdef/kfctl_azure_aad.v1.2.0.yaml
@@ -61,5 +61,5 @@ spec:
     name: kubeflow-apps
   repos:
   - name: manifests
-    uri: https://github.com/kubeflow/manifests/archive/v1.2-branch.tar.gz    
+    uri: https://github.com/kubeflow/manifests/archive/v1.2.0.tar.gz    
   version: v1.2-branch

--- a/kfdef/kfctl_ibm.v1.2.0.yaml
+++ b/kfdef/kfctl_ibm.v1.2.0.yaml
@@ -154,5 +154,5 @@ spec:
   #   name: spark-operator
   repos:
   - name: manifests
-    uri: https://github.com/kubeflow/manifests/archive/v1.2-branch.tar.gz
+    uri: https://github.com/kubeflow/manifests/archive/v1.2.0.tar.gz
   version: v1.2-branch

--- a/kfdef/kfctl_ibm_multi_user.v1.2.0.yaml
+++ b/kfdef/kfctl_ibm_multi_user.v1.2.0.yaml
@@ -152,5 +152,5 @@ spec:
   #   name: spark-operator
   repos:
   - name: manifests
-    uri: https://github.com/kubeflow/manifests/archive/v1.2-branch.tar.gz
+    uri: https://github.com/kubeflow/manifests/archive/v1.2.0.tar.gz
   version: v1.2-branch

--- a/kfdef/kfctl_istio_dex.v1.2.0.yaml
+++ b/kfdef/kfctl_istio_dex.v1.2.0.yaml
@@ -86,5 +86,5 @@ spec:
     name: kfserving
   repos:
   - name: manifests
-    uri: https://github.com/kubeflow/manifests/archive/v1.2-branch.tar.gz
+    uri: https://github.com/kubeflow/manifests/archive/v1.2.0.tar.gz
   version: v1.2-branch

--- a/kfdef/kfctl_k8s_istio.v1.2.0.yaml
+++ b/kfdef/kfctl_k8s_istio.v1.2.0.yaml
@@ -88,5 +88,5 @@ spec:
     name: spartakus
   repos:
   - name: manifests
-    uri: https://github.com/kubeflow/manifests/archive/v1.2-branch.tar.gz
+    uri: https://github.com/kubeflow/manifests/archive/v1.2.0.tar.gz
   version: v1.2-branch

--- a/kfdef/kfctl_openshift.v1.2.0.yaml
+++ b/kfdef/kfctl_openshift.v1.2.0.yaml
@@ -99,5 +99,5 @@ spec:
     name: kubeflow-apps
   repos:
   - name: manifests
-    uri: https://github.com/kubeflow/manifests/archive/v1.2-branch.tar.gz
+    uri: https://github.com/kubeflow/manifests/archive/v1.2.0.tar.gz
   version: v1.2-branch


### PR DESCRIPTION
**Which issue is resolved by this Pull Request:**
Resolves #

**Description of your changes:**
Pin manifests to official release tag. Following cherry-pick won't affect stable deployment


**Checklist:**
- [x] Unit tests have been rebuilt: 
    1. `cd manifests/tests`
    2. `make generate-changed-only`
    3. `make test`
