### PR TITLE
OpenShift jupyter-web-app update imagetag to v2.0.0

### DIFF
--- a/stacks/openshift/application/jupyter-web-app/kustomization.yaml
+++ b/stacks/openshift/application/jupyter-web-app/kustomization.yaml
@@ -31,6 +31,6 @@ vars:
 
 images:
 - name: gcr.io/kubeflow-images-public/jupyter-web-app
-  newTag: v1.0.0
+  newTag: v2.0.0
   newName: quay.io/kubeflow/jupyter-web-app
 

--- a/tests/stacks/openshift/application/jupyter-web-app/test_data/expected/apps_v1_deployment_jupyter-web-app-deployment.yaml
+++ b/tests/stacks/openshift/application/jupyter-web-app/test_data/expected/apps_v1_deployment_jupyter-web-app-deployment.yaml
@@ -32,7 +32,7 @@ spec:
             configMapKeyRef:
               key: userid-prefix
               name: kubeflow-config-f5fk62kk74
-        image: quay.io/kubeflow/jupyter-web-app:v1.0.0
+        image: quay.io/kubeflow/jupyter-web-app:v2.0.0
         name: jupyter-web-app
         ports:
         - containerPort: 5000


### PR DESCRIPTION
**Which issue is resolved by this Pull Request:**
Reference #1553
See https://github.com/kubeflow/manifests/pull/1645#issuecomment-728706141

**Description of your changes:**
Update the `jupyter-web-app` image to `v2.0.0` in the openshift stack

**Checklist:**
- [x] Unit tests have been rebuilt: 
    1. `cd manifests/tests`
    2. `make generate-changed-only`
    3. `make test`
