### PR TITLE
Fix Azure stack config for v1.2

### DIFF
--- a/stacks/azure/application/centraldashboard/links-configmap.yaml
+++ b/stacks/azure/application/centraldashboard/links-configmap.yaml
@@ -59,7 +59,7 @@ data:
           "text": "Azure Kubernetes Service Docs",
           "desc": "Azure Kubernetes Service Documentation",
           "link": "https://aka.ms/kubeflow-aks-docs"
-        },
+        }
       ]
     }
 kind: ConfigMap

--- a/stacks/azure/kustomization.yaml
+++ b/stacks/azure/kustomization.yaml
@@ -42,7 +42,21 @@ configMapGenerator:
   - ./config/params.env
 vars:
 # We need to define vars at the top level otherwise we will get
-# conflicts. 
+# conflicts.
+- fieldref:
+    fieldPath: data.clusterDomain
+  name: clusterDomain
+  objref:
+    apiVersion: v1
+    kind: ConfigMap
+    name: kubeflow-config
+- fieldref:
+    fieldPath: metadata.namespace
+  name: namespace
+  objref:
+    apiVersion: v1
+    kind: ConfigMap
+    name: kubeflow-config
 - fieldref:
     fieldpath: metadata.namespace
   name: katib-ui-namespace

--- a/tests/stacks/azure/application/centraldashboard/test_data/expected/~g_v1_configmap_centraldashboard-links-config.yaml
+++ b/tests/stacks/azure/application/centraldashboard/test_data/expected/~g_v1_configmap_centraldashboard-links-config.yaml
@@ -59,7 +59,7 @@ data:
           "text": "Azure Kubernetes Service Docs",
           "desc": "Azure Kubernetes Service Documentation",
           "link": "https://aka.ms/kubeflow-aks-docs"
-        },
+        }
       ]
     }
 kind: ConfigMap

--- a/tests/stacks/azure/test_data/expected/networking.istio.io_v1alpha3_virtualservice_argo-ui.yaml
+++ b/tests/stacks/azure/test_data/expected/networking.istio.io_v1alpha3_virtualservice_argo-ui.yaml
@@ -20,6 +20,6 @@ spec:
       uri: /
     route:
     - destination:
-        host: argo-ui.$(namespace).svc.$(clusterDomain)
+        host: argo-ui.kubeflow.svc.cluster.local
         port:
           number: 80

--- a/tests/stacks/azure/test_data/expected/networking.istio.io_v1alpha3_virtualservice_centraldashboard.yaml
+++ b/tests/stacks/azure/test_data/expected/networking.istio.io_v1alpha3_virtualservice_centraldashboard.yaml
@@ -19,6 +19,6 @@ spec:
       uri: /
     route:
     - destination:
-        host: centraldashboard.$(namespace).svc.$(clusterDomain)
+        host: centraldashboard.kubeflow.svc.cluster.local
         port:
           number: 80

--- a/tests/stacks/azure/test_data/expected/networking.istio.io_v1alpha3_virtualservice_jupyter-web-app.yaml
+++ b/tests/stacks/azure/test_data/expected/networking.istio.io_v1alpha3_virtualservice_jupyter-web-app.yaml
@@ -20,6 +20,6 @@ spec:
       uri: /
     route:
     - destination:
-        host: jupyter-web-app-service.$(namespace).svc.$(clusterDomain)
+        host: jupyter-web-app-service.kubeflow.svc.cluster.local
         port:
           number: 80

--- a/tests/stacks/azure/test_data/expected/networking.istio.io_v1alpha3_virtualservice_katib-ui.yaml
+++ b/tests/stacks/azure/test_data/expected/networking.istio.io_v1alpha3_virtualservice_katib-ui.yaml
@@ -19,6 +19,6 @@ spec:
       uri: /katib/
     route:
     - destination:
-        host: katib-ui.kubeflow.svc.$(clusterDomain)
+        host: katib-ui.kubeflow.svc.cluster.local
         port:
           number: 80

--- a/tests/stacks/azure/test_data/expected/networking.istio.io_v1alpha3_virtualservice_ml-pipeline-ui.yaml
+++ b/tests/stacks/azure/test_data/expected/networking.istio.io_v1alpha3_virtualservice_ml-pipeline-ui.yaml
@@ -19,7 +19,7 @@ spec:
       uri: /pipeline
     route:
     - destination:
-        host: ml-pipeline-ui.kubeflow.svc.$(clusterDomain)
+        host: ml-pipeline-ui.kubeflow.svc.cluster.local
         port:
           number: 80
     timeout: 300s

--- a/tests/stacks/azure/test_data/expected/networking.istio.io_v1alpha3_virtualservice_profiles-kfam.yaml
+++ b/tests/stacks/azure/test_data/expected/networking.istio.io_v1alpha3_virtualservice_profiles-kfam.yaml
@@ -22,6 +22,6 @@ spec:
       uri: /kfam/
     route:
     - destination:
-        host: profiles-kfam.$(namespace).svc.cluster.local
+        host: profiles-kfam.kubeflow.svc.cluster.local
         port:
           number: 8081

--- a/tests/stacks/azure/test_data/expected/~g_v1_configmap_centraldashboard-links-config.yaml
+++ b/tests/stacks/azure/test_data/expected/~g_v1_configmap_centraldashboard-links-config.yaml
@@ -59,7 +59,7 @@ data:
           "text": "Azure Kubernetes Service Docs",
           "desc": "Azure Kubernetes Service Documentation",
           "link": "https://aka.ms/kubeflow-aks-docs"
-        },
+        }
       ]
     }
 kind: ConfigMap

--- a/tests/stacks/azure/test_data/expected/~g_v1_service_centraldashboard.yaml
+++ b/tests/stacks/azure/test_data/expected/~g_v1_service_centraldashboard.yaml
@@ -9,7 +9,7 @@ metadata:
       name: centralui-mapping
       prefix: /
       rewrite: /
-      service: centraldashboard.$(namespace)
+      service: centraldashboard.kubeflow
   labels:
     app: centraldashboard
     app.kubernetes.io/component: centraldashboard

--- a/tests/stacks/azure/test_data/expected/~g_v1_service_jupyter-web-app-service.yaml
+++ b/tests/stacks/azure/test_data/expected/~g_v1_service_jupyter-web-app-service.yaml
@@ -8,7 +8,7 @@ metadata:
       kind:  Mapping
       name: webapp_mapping
       prefix: /jupyter/
-      service: jupyter-web-app-service.$(namespace)
+      service: jupyter-web-app-service.kubeflow
       add_request_headers:
         x-forwarded-prefix: /jupyter
   labels:


### PR DESCRIPTION
**Which issue is resolved by this Pull Request:**
Cherry picking commit from #1678 to fix Azure Stack config for v1.2

**Checklist:**
- [X ] Unit tests have been rebuilt: 
    1. `cd manifests/tests`
    2. `make generate-changed-only`
    3. `make test`
