### PR TITLE
Pin Azure v1.2 kfdef to include fix

### DIFF
--- a/kfdef/kfctl_azure.v1.2.0.yaml
+++ b/kfdef/kfctl_azure.v1.2.0.yaml
@@ -53,6 +53,5 @@ spec:
     name: kubeflow-apps
   repos:
   - name: manifests
-    uri: https://github.com/kubeflow/manifests/archive/v1.2.0.tar.gz
+    uri: https://github.com/kubeflow/manifests/archive/6bec7b6ec8dae064cf00620b4f2669cb2e191c12.tar.gz
   version: v1.2-branch
-

--- a/kfdef/kfctl_azure_aad.v1.2.0.yaml
+++ b/kfdef/kfctl_azure_aad.v1.2.0.yaml
@@ -61,5 +61,5 @@ spec:
     name: kubeflow-apps
   repos:
   - name: manifests
-    uri: https://github.com/kubeflow/manifests/archive/v1.2.0.tar.gz    
+    uri: https://github.com/kubeflow/manifests/archive/6bec7b6ec8dae064cf00620b4f2669cb2e191c12.tar.gz
   version: v1.2-branch


### PR DESCRIPTION
**Which issue is resolved by this Pull Request:**
Pins Azure kfdef to particular commit which includes Azure Stack config fix

**Checklist:**
- [X] Unit tests have been rebuilt: 
    1. `cd manifests/tests`
    2. `make generate-changed-only`
    3. `make test`
