### PR TITLE
Bump istio version to 1.3.1

### DIFF
--- a/kfdef/kfctl_aws_cognito.v1.2.0.yaml
+++ b/kfdef/kfctl_aws_cognito.v1.2.0.yaml
@@ -12,12 +12,12 @@ spec:
   - kustomizeConfig:
       repoRef:
         name: manifests
-        path: stacks/aws/application/istio-stack
+        path: stacks/aws/application/istio-1-3-1-stack
     name: istio-stack
   - kustomizeConfig:
       repoRef:
         name: manifests
-        path: stacks/aws/application/cluster-local-gateway
+        path: stacks/aws/application/cluster-local-gateway-1-3-1
     name: cluster-local-gateway
   - kustomizeConfig:
       repoRef:


### PR DESCRIPTION


**Which issue is resolved by this Pull Request:**
Resolves #https://github.com/kubeflow/kfserving/issues/1234

**Description of your changes:**
Istio 1.1.6 is not compatible with KFServing 0.4.1

**Checklist:**
- [ ] Unit tests have been rebuilt: 
    1. `cd manifests/tests`
    2. `make generate-changed-only`
    3. `make test`
