### PR TITLE
fix jupyter-web-app image tag

### DIFF
--- a/jupyter/jupyter-web-app/base/kustomization.yaml
+++ b/jupyter/jupyter-web-app/base/kustomization.yaml
@@ -22,7 +22,7 @@ commonLabels:
 images:
 - name: gcr.io/kubeflow-images-public/jupyter-web-app
   newName: gcr.io/kubeflow-images-public/jupyter-web-app
-  newTag: vmaster-g845af298
+  newTag: vmaster-ge4456300
 # We need the name to be unique without the suffix because the original name is what
 # gets used with patches
 configMapGenerator:

--- a/jupyter/jupyter-web-app/base_v3/kustomization.yaml
+++ b/jupyter/jupyter-web-app/base_v3/kustomization.yaml
@@ -21,7 +21,7 @@ commonLabels:
 images:
 - name: gcr.io/kubeflow-images-public/jupyter-web-app
   newName: gcr.io/kubeflow-images-public/jupyter-web-app
-  newTag: vmaster-g845af298
+  newTag: vmaster-ge4456300
 resources:
 - ../base/cluster-role-binding.yaml
 - ../base/cluster-role.yaml

--- a/stacks/azure/application/jupyter-web-app/base/kustomization.yaml
+++ b/stacks/azure/application/jupyter-web-app/base/kustomization.yaml
@@ -10,7 +10,7 @@ namespace: kubeflow
 images:
 - name: gcr.io/kubeflow-images-public/jupyter-web-app
   newName: gcr.io/kubeflow-images-public/jupyter-web-app
-  newTag: vmaster-g845af298
+  newTag: vmaster-ge4456300
 resources:
 - ../../../../../jupyter/jupyter-web-app/base/cluster-role-binding.yaml
 - ../../../../../jupyter/jupyter-web-app/base/cluster-role.yaml

--- a/stacks/ibm/application/jupyter-web-app/base/kustomization.yaml
+++ b/stacks/ibm/application/jupyter-web-app/base/kustomization.yaml
@@ -10,7 +10,7 @@ namespace: kubeflow
 images:
 - name: gcr.io/kubeflow-images-public/jupyter-web-app
   newName: gcr.io/kubeflow-images-public/jupyter-web-app
-  newTag: vmaster-g845af298
+  newTag: vmaster-ge4456300
 resources:
 - ../../../../../jupyter/jupyter-web-app/base/cluster-role-binding.yaml
 - ../../../../../jupyter/jupyter-web-app/base/cluster-role.yaml

--- a/tests/stacks/aws/application/jupyter-web-app/test_data/expected/apps_v1_deployment_jupyter-web-app-deployment.yaml
+++ b/tests/stacks/aws/application/jupyter-web-app/test_data/expected/apps_v1_deployment_jupyter-web-app-deployment.yaml
@@ -32,7 +32,7 @@ spec:
             configMapKeyRef:
               key: userid-prefix
               name: kubeflow-config
-        image: gcr.io/kubeflow-images-public/jupyter-web-app:vmaster-g845af298
+        image: gcr.io/kubeflow-images-public/jupyter-web-app:vmaster-ge4456300
         name: jupyter-web-app
         ports:
         - containerPort: 5000

--- a/tests/stacks/aws/test_data/expected/apps_v1_deployment_jupyter-web-app-deployment.yaml
+++ b/tests/stacks/aws/test_data/expected/apps_v1_deployment_jupyter-web-app-deployment.yaml
@@ -32,7 +32,7 @@ spec:
             configMapKeyRef:
               key: userid-prefix
               name: kubeflow-config
-        image: gcr.io/kubeflow-images-public/jupyter-web-app:vmaster-g845af298
+        image: gcr.io/kubeflow-images-public/jupyter-web-app:vmaster-ge4456300
         name: jupyter-web-app
         ports:
         - containerPort: 5000

--- a/tests/stacks/azure/application/jupyter-web-app/base/test_data/expected/apps_v1_deployment_jupyter-web-app-deployment.yaml
+++ b/tests/stacks/azure/application/jupyter-web-app/base/test_data/expected/apps_v1_deployment_jupyter-web-app-deployment.yaml
@@ -48,7 +48,7 @@ spec:
             configMapKeyRef:
               key: userid-prefix
               name: kubeflow-config
-        image: gcr.io/kubeflow-images-public/jupyter-web-app:vmaster-g845af298
+        image: gcr.io/kubeflow-images-public/jupyter-web-app:vmaster-ge4456300
         imagePullPolicy: Always
         name: jupyter-web-app
         ports:

--- a/tests/stacks/azure/application/jupyter-web-app/test_data/expected/apps_v1_deployment_jupyter-web-app-deployment.yaml
+++ b/tests/stacks/azure/application/jupyter-web-app/test_data/expected/apps_v1_deployment_jupyter-web-app-deployment.yaml
@@ -48,7 +48,7 @@ spec:
             configMapKeyRef:
               key: userid-prefix
               name: kubeflow-config
-        image: gcr.io/kubeflow-images-public/jupyter-web-app:vmaster-g845af298
+        image: gcr.io/kubeflow-images-public/jupyter-web-app:vmaster-ge4456300
         imagePullPolicy: Always
         name: jupyter-web-app
         ports:

--- a/tests/stacks/azure/test_data/expected/apps_v1_deployment_jupyter-web-app-deployment.yaml
+++ b/tests/stacks/azure/test_data/expected/apps_v1_deployment_jupyter-web-app-deployment.yaml
@@ -48,7 +48,7 @@ spec:
             configMapKeyRef:
               key: userid-prefix
               name: kubeflow-config-bk4bc7m928
-        image: gcr.io/kubeflow-images-public/jupyter-web-app:vmaster-g845af298
+        image: gcr.io/kubeflow-images-public/jupyter-web-app:vmaster-ge4456300
         imagePullPolicy: Always
         name: jupyter-web-app
         ports:

--- a/tests/stacks/examples/alice/test_data/expected/apps_v1_deployment_jupyter-web-app-deployment.yaml
+++ b/tests/stacks/examples/alice/test_data/expected/apps_v1_deployment_jupyter-web-app-deployment.yaml
@@ -32,7 +32,7 @@ spec:
             configMapKeyRef:
               key: userid-prefix
               name: kubeflow-config-bmh8k74f52
-        image: gcr.io/kubeflow-images-public/jupyter-web-app:vmaster-g845af298
+        image: gcr.io/kubeflow-images-public/jupyter-web-app:vmaster-ge4456300
         name: jupyter-web-app
         ports:
         - containerPort: 5000

--- a/tests/stacks/gcp/test_data/expected/apps_v1_deployment_jupyter-web-app-deployment.yaml
+++ b/tests/stacks/gcp/test_data/expected/apps_v1_deployment_jupyter-web-app-deployment.yaml
@@ -32,7 +32,7 @@ spec:
             configMapKeyRef:
               key: userid-prefix
               name: kubeflow-config-c644m77455
-        image: gcr.io/kubeflow-images-public/jupyter-web-app:vmaster-g845af298
+        image: gcr.io/kubeflow-images-public/jupyter-web-app:vmaster-ge4456300
         name: jupyter-web-app
         ports:
         - containerPort: 5000

--- a/tests/stacks/generic/test_data/expected/apps_v1_deployment_jupyter-web-app-deployment.yaml
+++ b/tests/stacks/generic/test_data/expected/apps_v1_deployment_jupyter-web-app-deployment.yaml
@@ -32,7 +32,7 @@ spec:
             configMapKeyRef:
               key: userid-prefix
               name: kubeflow-config-988m2m9m87
-        image: gcr.io/kubeflow-images-public/jupyter-web-app:vmaster-g845af298
+        image: gcr.io/kubeflow-images-public/jupyter-web-app:vmaster-ge4456300
         name: jupyter-web-app
         ports:
         - containerPort: 5000

--- a/tests/stacks/ibm/application/jupyter-web-app/base/test_data/expected/apps_v1_deployment_jupyter-web-app-deployment.yaml
+++ b/tests/stacks/ibm/application/jupyter-web-app/base/test_data/expected/apps_v1_deployment_jupyter-web-app-deployment.yaml
@@ -48,7 +48,7 @@ spec:
             configMapKeyRef:
               key: userid-prefix
               name: kubeflow-config
-        image: gcr.io/kubeflow-images-public/jupyter-web-app:vmaster-g845af298
+        image: gcr.io/kubeflow-images-public/jupyter-web-app:vmaster-ge4456300
         imagePullPolicy: Always
         name: jupyter-web-app
         ports:

--- a/tests/stacks/ibm/application/jupyter-web-app/test_data/expected/apps_v1_deployment_jupyter-web-app-deployment.yaml
+++ b/tests/stacks/ibm/application/jupyter-web-app/test_data/expected/apps_v1_deployment_jupyter-web-app-deployment.yaml
@@ -48,7 +48,7 @@ spec:
             configMapKeyRef:
               key: userid-prefix
               name: kubeflow-config
-        image: gcr.io/kubeflow-images-public/jupyter-web-app:vmaster-g845af298
+        image: gcr.io/kubeflow-images-public/jupyter-web-app:vmaster-ge4456300
         imagePullPolicy: Always
         name: jupyter-web-app
         ports:

--- a/tests/stacks/ibm/application/notebooks/test_data/expected/apps_v1_deployment_jupyter-web-app-deployment.yaml
+++ b/tests/stacks/ibm/application/notebooks/test_data/expected/apps_v1_deployment_jupyter-web-app-deployment.yaml
@@ -48,7 +48,7 @@ spec:
             configMapKeyRef:
               key: userid-prefix
               name: kubeflow-config-bk4bc7m928
-        image: gcr.io/kubeflow-images-public/jupyter-web-app:vmaster-g845af298
+        image: gcr.io/kubeflow-images-public/jupyter-web-app:vmaster-ge4456300
         imagePullPolicy: Always
         name: jupyter-web-app
         ports:

--- a/tests/stacks/ibm/multi-user/test_data/expected/apps_v1_deployment_jupyter-web-app-deployment.yaml
+++ b/tests/stacks/ibm/multi-user/test_data/expected/apps_v1_deployment_jupyter-web-app-deployment.yaml
@@ -48,7 +48,7 @@ spec:
             configMapKeyRef:
               key: userid-prefix
               name: kubeflow-config-bk4bc7m928
-        image: gcr.io/kubeflow-images-public/jupyter-web-app:vmaster-g845af298
+        image: gcr.io/kubeflow-images-public/jupyter-web-app:vmaster-ge4456300
         imagePullPolicy: Always
         name: jupyter-web-app
         ports:

--- a/tests/stacks/ibm/test_data/expected/apps_v1_deployment_jupyter-web-app-deployment.yaml
+++ b/tests/stacks/ibm/test_data/expected/apps_v1_deployment_jupyter-web-app-deployment.yaml
@@ -48,7 +48,7 @@ spec:
             configMapKeyRef:
               key: userid-prefix
               name: kubeflow-config-bk4bc7m928
-        image: gcr.io/kubeflow-images-public/jupyter-web-app:vmaster-g845af298
+        image: gcr.io/kubeflow-images-public/jupyter-web-app:vmaster-ge4456300
         imagePullPolicy: Always
         name: jupyter-web-app
         ports:

--- a/tests/stacks/kubernetes/test_data/expected/apps_v1_deployment_jupyter-web-app-deployment.yaml
+++ b/tests/stacks/kubernetes/test_data/expected/apps_v1_deployment_jupyter-web-app-deployment.yaml
@@ -32,7 +32,7 @@ spec:
             configMapKeyRef:
               key: userid-prefix
               name: kubeflow-config
-        image: gcr.io/kubeflow-images-public/jupyter-web-app:vmaster-g845af298
+        image: gcr.io/kubeflow-images-public/jupyter-web-app:vmaster-ge4456300
         name: jupyter-web-app
         ports:
         - containerPort: 5000

--- a/tests/tests/legacy_kustomizations/jupyter-web-app/test_data/expected/apps_v1_deployment_jupyter-web-app-deployment.yaml
+++ b/tests/tests/legacy_kustomizations/jupyter-web-app/test_data/expected/apps_v1_deployment_jupyter-web-app-deployment.yaml
@@ -54,7 +54,7 @@ spec:
           value: X-Goog-Authenticated-User-Email
         - name: USERID_PREFIX
           value: 'accounts.google.com:'
-        image: gcr.io/kubeflow-images-public/jupyter-web-app:vmaster-g845af298
+        image: gcr.io/kubeflow-images-public/jupyter-web-app:vmaster-ge4456300
         imagePullPolicy: Always
         name: jupyter-web-app
         ports:


### PR DESCRIPTION
**Description of your changes:**
This fixes the version of the `jupyter-web-app` image to the version which is correct for Kubeflow 1.2.

Without this, the features from https://github.com/kubeflow/kubeflow/pull/5237 are NOT present.

**Checklist:**
- [X] Unit tests have been rebuilt: 
    1. `cd manifests/tests`
    2. `make generate-changed-only`
    3. `make test`
