### PR TITLE
Update Tekton to use the fixed version of minio/mc image

### DIFF
--- a/pipeline/installs/tekton/kfp-tekton/kfp-pipeline-config.yaml
+++ b/pipeline/installs/tekton/kfp-tekton/kfp-pipeline-config.yaml
@@ -6,7 +6,7 @@ data:
   artifact_bucket: "mlpipeline"
   artifact_endpoint: "minio-service.kubeflow:9000"
   artifact_endpoint_scheme: "http://"
-  artifact_image: "minio/mc"
+  artifact_image: "minio/mc:RELEASE.2020-11-25T23-04-07Z"
   archive_logs: "false"
   track_artifacts: "true"
   strip_eof: "false"

--- a/tests/stacks/ibm/application/kfp-tekton-multi-user/test_data/expected/~g_v1_configmap_kfp-tekton-config.yaml
+++ b/tests/stacks/ibm/application/kfp-tekton-multi-user/test_data/expected/~g_v1_configmap_kfp-tekton-config.yaml
@@ -4,7 +4,7 @@ data:
   artifact_bucket: mlpipeline
   artifact_endpoint: minio-service.kubeflow:9000
   artifact_endpoint_scheme: http://
-  artifact_image: minio/mc
+  artifact_image: minio/mc:RELEASE.2020-11-25T23-04-07Z
   artifact_script: |-
     #!/usr/bin/env sh
     push_artifact() {

--- a/tests/stacks/ibm/application/kfp-tekton/test_data/expected/~g_v1_configmap_kfp-tekton-config.yaml
+++ b/tests/stacks/ibm/application/kfp-tekton/test_data/expected/~g_v1_configmap_kfp-tekton-config.yaml
@@ -4,7 +4,7 @@ data:
   artifact_bucket: mlpipeline
   artifact_endpoint: minio-service.kubeflow:9000
   artifact_endpoint_scheme: http://
-  artifact_image: minio/mc
+  artifact_image: minio/mc:RELEASE.2020-11-25T23-04-07Z
   artifact_script: |-
     #!/usr/bin/env sh
     push_artifact() {


### PR DESCRIPTION
**Which issue is resolved by this Pull Request:**
Resolves #

**Description of your changes:**
minio/mc updated the release image few hours ago that's based on the RedHat UBI image. However, the new image now doesn't include the `tar` binary for Tekton to package the kfp artifacts into tar.gz. Thus, we make minio/mc to use the stable release that we have tested.

We need to cherry pick this into the v1.2 branch to stop users from pulling the latest minio/mc image.

**Checklist:**
- [x] Unit tests have been rebuilt: 
    1. `cd manifests/tests`
    2. `make generate-changed-only`
    3. `make test`
