### PR TITLE
Automated cherry pick of #1693 [Update Tekton to use the fixed version of minio/mc image] to v1.2 branch

### DIFF
--- a/pipeline/installs/tekton/kfp-tekton/kfp-pipeline-config.yaml
+++ b/pipeline/installs/tekton/kfp-tekton/kfp-pipeline-config.yaml
@@ -6,7 +6,7 @@ data:
   artifact_bucket: "mlpipeline"
   artifact_endpoint: "minio-service.kubeflow:9000"
   artifact_endpoint_scheme: "http://"
-  artifact_image: "minio/mc"
+  artifact_image: "minio/mc:RELEASE.2020-11-25T23-04-07Z"
   archive_logs: "false"
   track_artifacts: "true"
   strip_eof: "false"

--- a/tests/stacks/ibm/application/kfp-tekton-multi-user/test_data/expected/~g_v1_configmap_kfp-tekton-config.yaml
+++ b/tests/stacks/ibm/application/kfp-tekton-multi-user/test_data/expected/~g_v1_configmap_kfp-tekton-config.yaml
@@ -4,7 +4,7 @@ data:
   artifact_bucket: mlpipeline
   artifact_endpoint: minio-service.kubeflow:9000
   artifact_endpoint_scheme: http://
-  artifact_image: minio/mc
+  artifact_image: minio/mc:RELEASE.2020-11-25T23-04-07Z
   artifact_script: |-
     #!/usr/bin/env sh
     push_artifact() {

--- a/tests/stacks/ibm/application/kfp-tekton/test_data/expected/~g_v1_configmap_kfp-tekton-config.yaml
+++ b/tests/stacks/ibm/application/kfp-tekton/test_data/expected/~g_v1_configmap_kfp-tekton-config.yaml
@@ -4,7 +4,7 @@ data:
   artifact_bucket: mlpipeline
   artifact_endpoint: minio-service.kubeflow:9000
   artifact_endpoint_scheme: http://
-  artifact_image: minio/mc
+  artifact_image: minio/mc:RELEASE.2020-11-25T23-04-07Z
   artifact_script: |-
     #!/usr/bin/env sh
     push_artifact() {


### PR DESCRIPTION
**Which issue is resolved by this Pull Request:**
Resolves #

**Description of your changes:**


**Checklist:**
- [x] Unit tests have been rebuilt: 
    1. `cd manifests/tests`
    2. `make generate-changed-only`
    3. `make test`
