### PR TITLE
Kubernetes API Destination Rule

### DIFF
--- a/istio/istio/base_v3/destination-rules.yaml
+++ b/istio/istio/base_v3/destination-rules.yaml
@@ -1,0 +1,13 @@
+apiVersion: networking.istio.io/v1alpha3
+kind: DestinationRule
+metadata:
+  name: kubernetes-api
+spec:
+  host: "kubernetes.default.svc.cluster.local"
+  trafficPolicy:
+    connectionPool:
+      tcp:
+        connectTimeout: 10s
+        tcpKeepalive:
+          time: 75s
+          interval: 75s 

--- a/istio/istio/base_v3/kustomization.yaml
+++ b/istio/istio/base_v3/kustomization.yaml
@@ -3,6 +3,7 @@ kind: Kustomization
 resources:
 - ../base/kf-istio-resources.yaml
 - ../base/cluster-roles.yaml
+- destination-rules.yaml
 namespace: kubeflow
 generatorOptions:
   disableNameSuffixHash: true

--- a/tests/stacks/ibm/application/istio/test_data/expected/networking.istio.io_v1alpha3_destinationrule_kubernetes-api.yaml
+++ b/tests/stacks/ibm/application/istio/test_data/expected/networking.istio.io_v1alpha3_destinationrule_kubernetes-api.yaml
@@ -1,0 +1,14 @@
+apiVersion: networking.istio.io/v1alpha3
+kind: DestinationRule
+metadata:
+  name: kubernetes-api
+  namespace: kubeflow
+spec:
+  host: kubernetes.default.svc.cluster.local
+  trafficPolicy:
+    connectionPool:
+      tcp:
+        connectTimeout: 10s
+        tcpKeepalive:
+          interval: 75s
+          time: 75s


### PR DESCRIPTION
This commit adds an Istio Destination Rule for the Kubernetes API to ensure that any client calls to the API are consistent across all platforms.

**Which issue is resolved by this Pull Request:**
Resolves # https://github.com/kubeflow/pipelines/issues/4407

**Description of your changes:**

This change creates a destination rule for the Kubernetes API, which will be applied when platforms use the istio/istio/base_v3 or as part of a patch. 

This rule ensure that calls to the Kubernetes API are consistent across all platforms, as mentioned on my issue the Kubeflow Pipelines and the Jupyter Web App were timing out on Azure. 

After applying this rule I was able to test both with the Kubernetes Python Client and the Golang Client that calls the API were successful regardless of the idle time. In the case of Azure it will result on a timeout after a 5 minute idle time. 

Resources:

https://preliminary.istio.io/latest/docs/reference/config/networking/destination-rule/#ConnectionPoolSettings
https://github.com/golang/go/blob/release-branch.go1.10/src/net/http/transport.go#L40-L51

Jobs to replicate issue and test fix: 

- https://github.com/maganaluis/k8s-api-python
- https://github.com/maganaluis/k8s-api-golang


**Checklist:**
- [x] Unit tests have been rebuilt: 
    1. `cd manifests/tests`
    2. `make generate-changed-only`
    3. `make test`
