### PR TITLE
 Pin IBM 1.2 kfdef to include cherry-pick fixes

### DIFF
--- a/kfdef/kfctl_ibm.v1.2.0.yaml
+++ b/kfdef/kfctl_ibm.v1.2.0.yaml
@@ -154,5 +154,5 @@ spec:
   #   name: spark-operator
   repos:
   - name: manifests
-    uri: https://github.com/kubeflow/manifests/archive/v1.2.0.tar.gz
+    uri: https://github.com/kubeflow/manifests/archive/bc798a24a3a2c973e42ef5d627ac97b5dfa1a24d.tar.gz
   version: v1.2-branch

--- a/kfdef/kfctl_ibm_multi_user.v1.2.0.yaml
+++ b/kfdef/kfctl_ibm_multi_user.v1.2.0.yaml
@@ -152,5 +152,5 @@ spec:
   #   name: spark-operator
   repos:
   - name: manifests
-    uri: https://github.com/kubeflow/manifests/archive/v1.2.0.tar.gz
+    uri: https://github.com/kubeflow/manifests/archive/bc798a24a3a2c973e42ef5d627ac97b5dfa1a24d.tar.gz
   version: v1.2-branch


### PR DESCRIPTION
**Which issue is resolved by this Pull Request:**
Resolves #

**Description of your changes:**
From Kubeflow 1.2, by default the stable release no longer take changes from cherry-pick. So we need to pin the cherry pick commit to our stable release kfdef.

**Checklist:**
- [x] Unit tests have been rebuilt: 
    1. `cd manifests/tests`
    2. `make generate-changed-only`
    3. `make test`
