### PR TITLE
Add Test README support

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ If you are a contributor authoring or editing the packages please see [Best Prac
 Note, please use [kustomize v3.2.1](https://github.com/kubernetes-sigs/kustomize/releases/tag/kustomize%2Fv3.2.1) with manifests in this repo, before #538 is fixed which will allow latest kustomize to be used.
 
 
-# Obsolete information
+## Obsolete information
 
 The information below is obsolete. It pertains to using `kfctl` to generate `kustomization.yaml`. This was how things worked through Kubeflow 1.0.0.
 
@@ -238,3 +238,26 @@ kustomize
 ......
 ```
 
+## Test
+
+Currently, kubeflow/manifests exist with 2 types of general-purpose tests, unit test and E2E test.
+1. Unit test: uses deprecated ksonnet to generate unit test Argo workflow, detailed code can be found [here](https://github.com/kubeflow/manifests/blob/master/prow_config.yaml#L9-L15).
+2. E2E test: uses python generated E2E test Argo workflow, detailed code can be found [here](https://github.com/kubeflow/manifests/blob/master/prow_config.yaml#L16-L57).
+
+More specific, 
+
+1. Unit test's abstract test model: 
+```
+make test
+```
+Detailed code can be found [here](https://github.com/kubeflow/manifests/blob/master/tests/scripts/run-tests.sh)
+
+2. E2E test's abstract test model (same as kfctl):
+```
+1. Create EKS cluster
+2. Deploy Kubeflow by kfctl
+3. Test individual component's status
+4. Only a few component's functionality tests
+5. Report test status and clean up
+```
+Detailed code can be found [here](https://github.com/kubeflow/kfctl/blob/master/py/kubeflow/kfctl/testing/ci/kfctl_e2e_workflow.py)


### PR DESCRIPTION
**Which issue is resolved by this Pull Request:**
Resolves part of #1708

**Description of your changes:**
Add README documentation about current tests in kubeflow/manifests repo.

**Checklist:**
- [x] Unit tests have been rebuilt: 
    1. `cd manifests/tests`
    2. `make generate-changed-only`
    3. `make test`
