### PR TITLE
Change cluster-admin role to `ml-pipeline-persistenceagent` for the pipeline/persistent-agent sa

### DIFF
--- a/pipeline/persistent-agent/base/clusterrole-binding.yaml
+++ b/pipeline/persistent-agent/base/clusterrole-binding.yaml
@@ -5,7 +5,7 @@ metadata:
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
-  name: cluster-admin
+  name: ml-pipeline-persistenceagent
 subjects:
 - kind: ServiceAccount
   name: persistenceagent

--- a/tests/tests/legacy_kustomizations/persistent-agent/test_data/expected/rbac.authorization.k8s.io_v1beta1_clusterrolebinding_ml-pipeline-persistenceagent.yaml
+++ b/tests/tests/legacy_kustomizations/persistent-agent/test_data/expected/rbac.authorization.k8s.io_v1beta1_clusterrolebinding_ml-pipeline-persistenceagent.yaml
@@ -13,7 +13,7 @@ metadata:
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
-  name: cluster-admin
+  name: ml-pipeline-persistenceagent
 subjects:
 - kind: ServiceAccount
   name: ml-pipeline-persistenceagent


### PR DESCRIPTION
**Which issue is resolved by this Pull Request:**
Resolves #1711 

**Description of your changes:**
Change clusterrole given to `ml-pipeline-persistenceagent` serviceaccount

**Checklist:**
- [x] Unit tests have been rebuilt: 
    1. `cd manifests/tests`
    2. `make generate-changed-only`
    3. `make test`
