### PR TITLE
add dependabot config script

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,50 @@
+updates:
+- assignees:
+  - andreyvelich
+  - Bobgy
+  - gaocegege
+  - jeffwan
+  - johnugeorge
+  - krishnadurai
+  - PatrickXYS
+  - kimwnasptd
+  - thesuperzapper
+  directory: tests/scripts
+  open-pull-requests-limit: 10
+  package-ecosystem: pip
+  schedule:
+    interval: daily
+- assignees:
+  - animeshsingh
+  - Bobgy
+  - elikatsis
+  - jlewi
+  - PatrickXYS
+  - StefanoFioravanzo
+  - swiftdiaries
+  - terrytangyuan
+  - vkoukis
+  - yanniszark
+  directory: .
+  open-pull-requests-limit: 10
+  package-ecosystem: gomod
+  reviewers:
+  - pvaneck
+  schedule:
+    interval: daily
+- assignees:
+  - andreyvelich
+  - Bobgy
+  - gaocegege
+  - jeffwan
+  - johnugeorge
+  - krishnadurai
+  - PatrickXYS
+  - kimwnasptd
+  - thesuperzapper
+  directory: tests
+  open-pull-requests-limit: 10
+  package-ecosystem: gomod
+  schedule:
+    interval: daily
+version: 2

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,2 @@
+build-dependabot:
+	python3 hack/create_dependabot.py

--- a/hack/create_dependabot.py
+++ b/hack/create_dependabot.py
@@ -2,8 +2,6 @@ import yaml
 import collections
 from pathlib import Path
 
-repo_path = Path(__file__).parents[1]
-
 dependabot = {}
 dependabot['version'] = 2
 dependabot['updates'] = []
@@ -64,29 +62,39 @@ def append_updates(ecosystem, directory, assignees, reviewers=None):
         config['reviewers'] = reviewers
     dependabot['updates'].append(config)
 
-for docker_path in get_docker_paths():
-    string_path = str(docker_path)
-    assignees = get_owners(docker_path).get('approvers')
-    reviewers = get_owners(docker_path).get('reviewers')
-    append_updates('docker', string_path, assignees, reviewers)
+def main():
+    for docker_path in get_docker_paths():
+        string_path = str(docker_path)
+        assignees = get_owners(docker_path).get('approvers')
+        reviewers = get_owners(docker_path).get('reviewers')
+        append_updates('docker', string_path, assignees, reviewers)
 
-for npm_path in get_npm_paths():
-    string_path = str(npm_path)
-    assignees = get_owners(npm_path).get('approvers')
-    reviewers = get_owners(npm_path).get('reviewers')
-    append_updates('npm', string_path, assignees, reviewers)
+    for npm_path in get_npm_paths():
+        string_path = str(npm_path)
+        assignees = get_owners(npm_path).get('approvers')
+        reviewers = get_owners(npm_path).get('reviewers')
+        append_updates('npm', string_path, assignees, reviewers)
 
-for pip_path in get_pip_paths():
-    string_path = str(pip_path)
-    assignees = get_owners(pip_path).get('approvers')
-    reviewers = get_owners(pip_path).get('reviewers')
-    append_updates('pip', string_path, assignees, reviewers)
+    for pip_path in get_pip_paths():
+        string_path = str(pip_path)
+        assignees = get_owners(pip_path).get('approvers')
+        reviewers = get_owners(pip_path).get('reviewers')
+        append_updates('pip', string_path, assignees, reviewers)
 
-for go_path in get_go_paths():
-    string_path = str(go_path)
-    assignees = get_owners(go_path).get('approvers')
-    reviewers = get_owners(go_path).get('reviewers')
-    append_updates('gomod', string_path, assignees, reviewers)
+    for go_path in get_go_paths():
+        string_path = str(go_path)
+        assignees = get_owners(go_path).get('approvers')
+        reviewers = get_owners(go_path).get('reviewers')
+        append_updates('gomod', string_path, assignees, reviewers)
 
-with open('.github/dependabot.yml', 'w') as outfile:
-    yaml.dump(dependabot, outfile, default_flow_style=False)
+    with open('.github/dependabot.yml', 'w') as outfile:
+        yaml.dump(dependabot, outfile, default_flow_style=False)
+
+    print(get_docker_paths())
+    print(get_npm_paths())
+    print(get_pip_paths())
+    print(get_go_paths())
+
+if __name__ == "__main__":
+    repo_path = Path(__file__).parents[1]
+    main()

--- a/hack/create_dependabot.py
+++ b/hack/create_dependabot.py
@@ -1,0 +1,92 @@
+import yaml
+import collections
+from pathlib import Path
+
+repo_path = Path(__file__).parents[1]
+
+dependabot = {}
+dependabot['version'] = 2
+dependabot['updates'] = []
+ignored_folders = ['node_modules', 'dist', '.git', 'deprecated']
+
+def get_owners(path):
+    while not Path(path/'OWNERS').is_file():
+        path = path.parent.absolute()
+    with open(path/'OWNERS') as owner_file:
+        owners = yaml.load(owner_file)
+        return owners
+
+def get_docker_paths():
+    dockerfile_list = list(repo_path.glob('**/*ockerfile*'))
+    docker_clean_list = []
+    for dockerfile in dockerfile_list:
+        if all(x not in str(dockerfile) for x in ignored_folders):
+            if dockerfile.parents[0] not in docker_clean_list:
+                docker_clean_list.append(dockerfile.parents[0])
+    return docker_clean_list
+
+def get_npm_paths():
+    npm_list = list(repo_path.glob('**/package*.json'))
+    npm_clean_list = []
+    for npm_file in npm_list:
+        if all(x not in str(npm_file) for x in ignored_folders):
+            if npm_file.parents[0] not in npm_clean_list:
+                npm_clean_list.append(npm_file.parents[0])
+    return npm_clean_list
+
+def get_pip_paths():
+    pip_list = list(repo_path.glob('**/*requirements.txt'))
+    pip_clean_list = []
+    for pip_file in pip_list:
+        if all(x not in str(pip_file) for x in ignored_folders):
+            if pip_file.parents[0] not in pip_clean_list:
+                pip_clean_list.append(pip_file.parents[0])
+    return pip_clean_list
+
+def get_go_paths():
+    go_list = list(repo_path.glob('**/go.*'))
+    go_clean_list = []
+    for go_file in go_list:
+        if all(x not in str(go_file) for x in ignored_folders):
+            if go_file.parents[0] not in go_clean_list:
+                go_clean_list.append(go_file.parents[0])
+    return go_clean_list
+
+def append_updates(ecosystem, directory, assignees, reviewers=None):
+    config = {}
+    config['package-ecosystem'] = ecosystem
+    config['directory'] = directory
+    config['schedule']= {}
+    config['schedule']['interval'] = 'daily'
+    config['open-pull-requests-limit'] = 10
+    config['assignees'] = assignees
+    if reviewers:
+        config['reviewers'] = reviewers
+    dependabot['updates'].append(config)
+
+for docker_path in get_docker_paths():
+    string_path = str(docker_path)
+    assignees = get_owners(docker_path).get('approvers')
+    reviewers = get_owners(docker_path).get('reviewers')
+    append_updates('docker', string_path, assignees, reviewers)
+
+for npm_path in get_npm_paths():
+    string_path = str(npm_path)
+    assignees = get_owners(npm_path).get('approvers')
+    reviewers = get_owners(npm_path).get('reviewers')
+    append_updates('npm', string_path, assignees, reviewers)
+
+for pip_path in get_pip_paths():
+    string_path = str(pip_path)
+    assignees = get_owners(pip_path).get('approvers')
+    reviewers = get_owners(pip_path).get('reviewers')
+    append_updates('pip', string_path, assignees, reviewers)
+
+for go_path in get_go_paths():
+    string_path = str(go_path)
+    assignees = get_owners(go_path).get('approvers')
+    reviewers = get_owners(go_path).get('reviewers')
+    append_updates('gomod', string_path, assignees, reviewers)
+
+with open('.github/dependabot.yml', 'w') as outfile:
+    yaml.dump(dependabot, outfile, default_flow_style=False)


### PR DESCRIPTION
**Which issue is resolved by this Pull Request:**
Resolves #

**Description of your changes:**
Inspired by https://github.com/kubeflow/pipelines/issues/4682  I created a script that will create a config file for depandabot so that it knows what directories to scan. It will scan the repository for files named `*ockerfile*`, `package*.json`, `*requirements.txt` and `go.*`.  It is setup for dockerfiles, npm packages, pip dependencies and gomod at the moment. It is trivial to further customize what folders are selected if further customization is needed. It also parses the closest `OWNERS` file for a given dependency listing file, and assigns the relevant approvers and adds the relevant reviewers to the PRs it creates. 

This is a sibling PR to https://github.com/kubeflow/pipelines/pull/5015, https://github.com/kubeflow/kubeflow/pull/5542, https://github.com/kubeflow/kfserving/pull/1309, https://github.com/kubeflow/arena/pull/403 and https://github.com/kubeflow/testing/pull/855.

As it stands now, there are 3 PRs that will be created with this configuration. 

For reference, the PRs that will be created can be found here: https://github.com/DavidSpek/manifests/pulls

**Checklist:**
- [ ] Unit tests have been rebuilt: 
    1. `cd manifests/tests`
    2. `make generate-changed-only`
    3. `make test`
