### PR TITLE
Migrate manifests repo

### DIFF
--- a/prow_config.yaml
+++ b/prow_config.yaml
@@ -7,48 +7,48 @@ python_paths:
   - kubeflow/kfctl/py
   - kubeflow/manifests/py
 workflows: []
-#   - py_func: kubeflow.kfctl.testing.ci.kfctl_e2e_workflow.create_workflow
-#     name: e2e
-#     job_types:
-#       - presubmit
-#       - postsubmit
-#       - periodic
-#     include_dirs:
-#       - admission-webhook/*
-#       - application/*
-#       - argo/*
-#       - aws/*
-#       - cert-manager/*
-#       - common/
-#       - default-install/*
-#       - dex-auth/*
-#       - experimental/*
-#       - istio-1-3-1/*
-#       - istio/*
-#       - jupyter/*
-#       - katib/*
-#       - kfdef/kfctl_istio_dex*
-#       - kfserving/*
-#       - knative/*
-#       - kubebench/*
-#       - kubeflow-roles/*
-#       - metacontroller/*
-#       - metadata/*
-#       - mpi-job/*
-#       - mxnet-job/*
-#       - namespaces/*
-#       - pipeline/*
-#       - profiles/*
-#       - pytorch-job/*
-#       - seldon/*
-#       - spark/*
-#       - stacks/*
-#       - tektoncd/*
-#       - tf-training/*
-#       - xgboost-job/*
-#     kwargs:
-#       build_and_apply: false
-#       config_path: https://raw.githubusercontent.com/kubeflow/manifests/master/kfdef/kfctl_istio_dex.yaml
+   - py_func: kubeflow.kfctl.testing.ci.kfctl_e2e_workflow.create_workflow
+     name: e2e
+     job_types:
+       - presubmit
+       - postsubmit
+       - periodic
+     include_dirs:
+       - admission-webhook/*
+       - application/*
+       - argo/*
+       - aws/*
+       - cert-manager/*
+       - common/
+       - default-install/*
+       - dex-auth/*
+       - experimental/*
+       - istio-1-3-1/*
+       - istio/*
+       - jupyter/*
+       - katib/*
+       - kfdef/kfctl_istio_dex*
+       - kfserving/*
+       - knative/*
+       - kubebench/*
+       - kubeflow-roles/*
+       - metacontroller/*
+       - metadata/*
+       - mpi-job/*
+       - mxnet-job/*
+       - namespaces/*
+       - pipeline/*
+       - profiles/*
+       - pytorch-job/*
+       - seldon/*
+       - spark/*
+       - stacks/*
+       - tektoncd/*
+       - tf-training/*
+       - xgboost-job/*
+     kwargs:
+       build_and_apply: false
+       config_path: https://raw.githubusercontent.com/kubeflow/manifests/master/kfdef/kfctl_istio_dex.yaml
 
 #   ####################################### AWS Specific Tests
 #   - py_func: kubeflow.kfctl.testing.ci.kfctl_e2e_workflow.create_workflow

--- a/prow_config.yaml
+++ b/prow_config.yaml
@@ -6,50 +6,50 @@ python_paths:
   - kubeflow/testing/py
   - kubeflow/kfctl/py
   - kubeflow/manifests/py
-workflows:
-   - py_func: kubeflow.kfctl.testing.ci.kfctl_e2e_workflow.create_workflow
-     name: e2e
-     job_types:
-       - presubmit
-       - postsubmit
-       - periodic
-     include_dirs:
-       - admission-webhook/*
-       - application/*
-       - argo/*
-       - aws/*
-       - cert-manager/*
-       - common/
-       - default-install/*
-       - dex-auth/*
-       - experimental/*
-       - istio-1-3-1/*
-       - istio/*
-       - jupyter/*
-       - katib/*
-       - kfdef/kfctl_istio_dex*
-       - kfserving/*
-       - knative/*
-       - kubebench/*
-       - kubeflow-roles/*
-       - metacontroller/*
-       - metadata/*
-       - mpi-job/*
-       - mxnet-job/*
-       - namespaces/*
-       - pipeline/*
-       - profiles/*
-       - prow_config.yaml
-       - pytorch-job/*
-       - seldon/*
-       - spark/*
-       - stacks/*
-       - tektoncd/*
-       - tf-training/*
-       - xgboost-job/*
-     kwargs:
-       build_and_apply: false
-       config_path: https://raw.githubusercontent.com/kubeflow/manifests/master/kfdef/kfctl_istio_dex.yaml
+workflows: []
+#   - py_func: kubeflow.kfctl.testing.ci.kfctl_e2e_workflow.create_workflow
+#     name: e2e
+#     job_types:
+#       - presubmit
+#       - postsubmit
+#       - periodic
+#     include_dirs:
+#       - admission-webhook/*
+#       - application/*
+#       - argo/*
+#       - aws/*
+#       - cert-manager/*
+#       - common/
+#       - default-install/*
+#       - dex-auth/*
+#       - experimental/*
+#       - istio-1-3-1/*
+#       - istio/*
+#       - jupyter/*
+#       - katib/*
+#       - kfdef/kfctl_istio_dex*
+#       - kfserving/*
+#       - knative/*
+#       - kubebench/*
+#       - kubeflow-roles/*
+#       - metacontroller/*
+#       - metadata/*
+#       - mpi-job/*
+#       - mxnet-job/*
+#       - namespaces/*
+#       - pipeline/*
+#       - profiles/*
+#       - prow_config.yaml
+#       - pytorch-job/*
+#       - seldon/*
+#       - spark/*
+#       - stacks/*
+#       - tektoncd/*
+#       - tf-training/*
+#       - xgboost-job/*
+#     kwargs:
+#       build_and_apply: false
+#       config_path: https://raw.githubusercontent.com/kubeflow/manifests/master/kfdef/kfctl_istio_dex.yaml
 
 #   ####################################### AWS Specific Tests
 #   - py_func: kubeflow.kfctl.testing.ci.kfctl_e2e_workflow.create_workflow

--- a/prow_config.yaml
+++ b/prow_config.yaml
@@ -39,6 +39,7 @@ workflows:
        - namespaces/*
        - pipeline/*
        - profiles/*
+       - prow_config.yaml
        - pytorch-job/*
        - seldon/*
        - spark/*

--- a/prow_config.yaml
+++ b/prow_config.yaml
@@ -6,7 +6,7 @@ python_paths:
   - kubeflow/testing/py
   - kubeflow/kfctl/py
   - kubeflow/manifests/py
-workflows: []
+workflows:
    - py_func: kubeflow.kfctl.testing.ci.kfctl_e2e_workflow.create_workflow
      name: e2e
      job_types:


### PR DESCRIPTION
**Which issue is resolved by this Pull Request:**
Part of https://github.com/kubeflow/testing/issues/861

Resolves #1725 

**Description of your changes:**
Migrate kubeflow/manifests to new test-infra, there's no difference between old test-infra and new test-infra from users' perspective.

Note: this PR is only used to validate if migration works or not. 

**Checklist:**
- [x] Unit tests have been rebuilt: 
    1. `cd manifests/tests`
    2. `make generate-changed-only`
    3. `make test`

/hold