### PR TITLE
Allow all containers in the kubeflow namespace to run as non root

### DIFF
--- a/apps/pipeline/upstream/installs/multi-user/pipelines-profile-controller/deployment.yaml
+++ b/apps/pipeline/upstream/installs/multi-user/pipelines-profile-controller/deployment.yaml
@@ -36,7 +36,7 @@ spec:
         - name: hooks
           mountPath: /hooks
         ports:
-        - containerPort: 80
+        - containerPort: 8080
       volumes:
       - name: hooks
         configMap:

--- a/apps/pipeline/upstream/installs/multi-user/pipelines-profile-controller/service.yaml
+++ b/apps/pipeline/upstream/installs/multi-user/pipelines-profile-controller/service.yaml
@@ -7,4 +7,4 @@ spec:
   - name: http
     port: 80
     protocol: TCP
-    targetPort: 80
+    targetPort: 8080

--- a/apps/pipeline/upstream/installs/multi-user/pipelines-profile-controller/sync.py
+++ b/apps/pipeline/upstream/installs/multi-user/pipelines-profile-controller/sync.py
@@ -266,4 +266,4 @@ class Controller(BaseHTTPRequestHandler):
         self.wfile.write(bytes(json.dumps(desired), 'utf-8'))
 
 
-HTTPServer(("", 80), Controller).serve_forever()
+HTTPServer(("", 8080), Controller).serve_forever()

--- a/apps/pipeline/upstream/mysql/base/deployment.yaml
+++ b/apps/pipeline/upstream/mysql/base/deployment.yaml
@@ -10,6 +10,7 @@ spec:
       annotations:
         sidecar.istio.io/inject: "false"
     spec:
+      serviceAccountName: mysql
       containers:
       - name: mysql
         env:

--- a/apps/pipeline/upstream/mysql/base/deployment.yaml
+++ b/apps/pipeline/upstream/mysql/base/deployment.yaml
@@ -12,14 +12,19 @@ spec:
     spec:
       serviceAccountName: mysql
       containers:
-      - name: mysql
+      - args:
+        - --datadir
+        - /var/lib/mysql/datadir
         env:
         - name: MYSQL_ALLOW_EMPTY_PASSWORD
           value: "true"
-        image: mysql:5.6
+        image: mysql:5.7
+        imagePullPolicy: IfNotPresent
+        name: mysql
         ports:
         - containerPort: 3306
           name: mysql
+          protocol: TCP
         volumeMounts:
         - mountPath: /var/lib/mysql
           name: mysql-persistent-storage

--- a/apps/pipeline/upstream/mysql/base/kustomization.yaml
+++ b/apps/pipeline/upstream/mysql/base/kustomization.yaml
@@ -6,6 +6,7 @@ resources:
 - deployment.yaml
 - service.yaml
 - persistent-volume-claim.yaml
+- serviceaccount.yaml
 configMapGenerator:
 - name: pipeline-mysql-parameters
   envs:

--- a/apps/pipeline/upstream/mysql/base/serviceaccount.yaml
+++ b/apps/pipeline/upstream/mysql/base/serviceaccount.yaml
@@ -1,0 +1,4 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: mysql

--- a/contrib/metadata/overlays/db/metadata-db-deployment.yaml
+++ b/contrib/metadata/overlays/db/metadata-db-deployment.yaml
@@ -21,7 +21,7 @@ spec:
     spec:
       containers:
       - name: db-container
-        image: mysql:8.0.3
+        image: mysql:8.0
         args:
         - --datadir
         - /var/lib/mysql/datadir
@@ -38,7 +38,7 @@ spec:
             command:
             - "/bin/bash"
             - "-c"
-            - "mysql -D $$MYSQL_DATABASE -p$$MYSQL_ROOT_PASSWORD -e 'SELECT 1'"
+            - "mysql --database=$MYSQL_DATABASE --password=$MYSQL_ROOT_PASSWORD --user=$MYSQL_USER_NAME -e 'SELECT 1'"
           initialDelaySeconds: 5
           periodSeconds: 2
           timeoutSeconds: 1

--- a/distributions/stacks/openshift/application/metadata/patchdb.yaml
+++ b/distributions/stacks/openshift/application/metadata/patchdb.yaml
@@ -1,3 +1,3 @@
 - op: replace
   path: /spec/template/spec/containers/0/readinessProbe/exec/command/2
-  value: "mysql -D $$MYSQL_DATABASE -u$$MYSQL_USER_NAME -p$$MYSQL_ROOT_PASSWORD -e 'SELECT 1'" 
+  value: "mysql --database=$MYSQL_DATABASE --password=$MYSQL_ROOT_PASSWORD --user=$MYSQL_USER_NAME -e 'SELECT 1" 

--- a/tests/stacks/openshift/application/metadata/test_data/expected/apps_v1_deployment_metadata-db.yaml
+++ b/tests/stacks/openshift/application/metadata/test_data/expected/apps_v1_deployment_metadata-db.yaml
@@ -42,8 +42,7 @@ spec:
             command:
             - /bin/bash
             - -c
-            - mysql -D $$MYSQL_DATABASE -u$$MYSQL_USER_NAME -p$$MYSQL_ROOT_PASSWORD
-              -e 'SELECT 1'
+            - mysql --database=$MYSQL_DATABASE --password=$MYSQL_ROOT_PASSWORD --user=$MYSQL_USER_NAME -e 'SELECT 1'
           initialDelaySeconds: 5
           periodSeconds: 2
           timeoutSeconds: 1


### PR DESCRIPTION
My goal is to run kubeflow completly rootless except for istio-system.
I will use the istio CNI plugin to use rootless init containers.

The following changes are necessary:

1. Use a port above 1024 in kubeflow-pipelines-profile-controller deployment to allow runasnonroot https://github.com/kubeflow/pipelines/pull/5294
2. The metadata-db readiness probe is wrong. It does only work if you run the container as root. You can run the container with a restricted psp as another user ("daemon") without root rights. Someone forgot to take into account that the readiness probe should use the correct username "root" form the environement variable instead of relying on the wrong assumption that your container user is always root and can be abused as mysql user. @Bobgy  wants to merge the deployments metadata-db(mysql 8.0) and mysql(mysql5.6) anyway https://github.com/kubeflow/pipelines/pull/5278
3. Use image:mysql:8.0 instead of mysql:8.0.3 for the metadata-db deployment
4. Use mysql 5.7 instead of 5.6 for the mysql deployment and make sure that it runs as non-root
5. In tandem with https://github.com/kubeflow/kubeflow/pull/5668 we can change admission-webhook-deployment port from 443 to 4443 which then allows runasnonroot
6. seldon-controller-manager port has already been changed from 443 to 4443 in https://github.com/kubeflow/manifests/commit/48ea3f8ed74ae4d14520119a9f3d13c16fb80110
7. #1759  should cover the spartakus-volunteer
8.  Cache-server and cache-deployment also need small changes, but maybe in another PR. It might just be enough to switch from /bin/bin to /tmp in https://github.com/kubeflow/pipelines/blob/280cae3718269d5522cafafa1650204fa0bb8f2e/backend/src/cache/deployer/deploy-cache-service.sh#L33
9. Kubeflow 1.3 uses argo 2.12 where even upstream uses runasnonroot https://github.com/argoproj/argo-workflows/blob/f1e0c6174b48af69d6e8ecd235a2d709f44f8095/manifests/base/workflow-controller/workflow-controller-deployment.yaml#L40

I really hope that this makes it into kubeflow 1.3, because rootless containers are forbidden in many enterprise environments

**Checklist:**
- [ ] Unit tests pass:
  **Make sure you have installed kustomize == 3.2.1**
    1. `make generate-changed-only`
    2. `make test`
