### PR TITLE
remove spartakus from kfctl_k8s_istio.yaml

### DIFF
--- a/distributions/kfdef/kfctl_k8s_istio.yaml
+++ b/distributions/kfdef/kfctl_k8s_istio.yaml
@@ -209,18 +209,6 @@ spec:
   - kustomizeConfig:
       overlays:
       - application
-      parameters:
-      - name: usageId
-        value: <randomly-generated-id>
-      - name: reportUsage
-        value: 'true'
-      repoRef:
-        name: manifests
-        path: common/spartakus
-    name: spartakus
-  - kustomizeConfig:
-      overlays:
-      - application
       repoRef:
         name: manifests
         path: tf-training/tf-job-crds


### PR DESCRIPTION
**Which issue is resolved by this Pull Request:**
Resolves #1757 

As discussed with @PatrickXYS  in the issue #1757  i just remove spartakus for plain kubernetes, as it was done for the dex version before.


**Checklist:**
- [ ] Unit tests pass:
  **Make sure you have installed kustomize == 3.2.1**
    1. `make generate-changed-only`
    2. `make test`
