### PR TITLE
OWNERS: Update top-level owners to match wg-manifests charter

### DIFF
--- a/OWNERS
+++ b/OWNERS
@@ -1,13 +1,12 @@
 approvers:
-  - animeshsingh
-  - Bobgy
   - elikatsis
-  - jlewi
   - PatrickXYS
   - StefanoFioravanzo
-  - swiftdiaries
-  - terrytangyuan
   - vkoukis
   - yanniszark
 reviewers:
-  - pvaneck
+  - elikatsis
+  - PatrickXYS
+  - StefanoFioravanzo
+  - vkoukis
+  - yanniszark


### PR DESCRIPTION
**Description of your changes:**

Similar to what all the other WGs have done in their respective repos, I am updating the OWNERS file of the `manifests` repo to include only the people in the Manifests Working Group, as described and agreed upon in the charter:
https://github.com/kubeflow/community/blob/8b830413cc3511404af63b32a37bc741bdfa23df/wgs.yaml#L201-L234

cc @kubeflow/wg-manifests-leads

Just a courtesy cc for people being removed:
@animeshsingh @Bobgy @jlewi @swiftdiaries @terrytangyuan @pvaneck