### PR TITLE
update dex and dex-authenticator

### DIFF
--- a/common/dex-auth/dex-authenticator/base/deployment.yaml
+++ b/common/dex-auth/dex-authenticator/base/deployment.yaml
@@ -17,7 +17,7 @@ spec:
     spec:
       containers:
       - name: dex-k8s-authenticator
-        image: "mintel/dex-k8s-authenticator:1.2.0"
+        image: "mintel/dex-k8s-authenticator:1.4.0"
         imagePullPolicy: Always
         args: [ "--config", "config.yaml" ]
         ports:

--- a/common/dex-auth/dex-authenticator/base_v3/kustomization.yaml
+++ b/common/dex-auth/dex-authenticator/base_v3/kustomization.yaml
@@ -65,4 +65,4 @@ configurations:
 images:
 - name: mintel/dex-k8s-authenticator
   newName: mintel/dex-k8s-authenticator
-  newTag: 1.2.0
+  newTag: 1.4.0

--- a/common/dex-auth/dex-crds/base/deployment.yaml
+++ b/common/dex-auth/dex-crds/base/deployment.yaml
@@ -16,7 +16,7 @@ spec:
     spec:
       serviceAccountName: dex
       containers:
-      - image: quay.io/dexidp/dex:v2.22.0
+      - image: ghcr.io/dexidp/dex:v2.28.0
         name: dex
         command: ["dex", "serve", "/etc/dex/cfg/config.yaml"]
         ports:

--- a/common/dex-auth/dex-crds/base_v3/kustomization.yaml
+++ b/common/dex-auth/dex-crds/base_v3/kustomization.yaml
@@ -80,6 +80,6 @@ vars:
 configurations:
 - ../base/params.yaml
 images:
-- name: quay.io/dexidp/dex
-  newName: quay.io/dexidp/dex
-  newTag: v2.22.0
+- name: ghcr.io/dexidp/dex
+  newName: ghcr.io/dexidp/dex
+  newTag: v2.28.0


### PR DESCRIPTION
Updates the manifests to the new `ghcr.io/dexidp/dex` registry and updates dex and `dex-k8s-authenticator` to the latest version. 
