### PR TITLE
cert-manager: Remove v3 manifests

### DIFF
--- a/common/cert-manager/cert-manager/kubeflow-issuer/kustomization.yaml
+++ b/common/cert-manager/cert-manager/kubeflow-issuer/kustomization.yaml
@@ -2,5 +2,9 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 namespace: cert-manager
+commonLabels:
+  kustomize.component: cert-manager
+  app.kubernetes.io/component: cert-manager
+  app.kubernetes.io/name: cert-manager
 resources:
-- ../overlays/self-signed/cluster-issuer.yaml 
+- ../overlays/self-signed/cluster-issuer.yaml

--- a/common/cert-manager/cert-manager/overlays/application/kustomization.yaml
+++ b/common/cert-manager/cert-manager/overlays/application/kustomization.yaml
@@ -2,6 +2,7 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 bases:
 - ../../base
 commonLabels:
+  kustomize.component: cert-manager
   app.kubernetes.io/component: cert-manager
   app.kubernetes.io/name: cert-manager
 configurations:

--- a/common/cert-manager/cert-manager/overlays/letsencrypt/kustomization.yaml
+++ b/common/cert-manager/cert-manager/overlays/letsencrypt/kustomization.yaml
@@ -7,6 +7,8 @@ resources:
 - cluster-issuer.yaml
 commonLabels:
   kustomize.component: cert-manager
+  app.kubernetes.io/component: cert-manager
+  app.kubernetes.io/name: cert-manager
 configMapGenerator:
 - name: cert-manager-parameters
   behavior: merge

--- a/common/cert-manager/cert-manager/overlays/self-signed/kustomization.yaml
+++ b/common/cert-manager/cert-manager/overlays/self-signed/kustomization.yaml
@@ -1,4 +1,4 @@
-# TODO(https://github.com/kubeflow/manifests/issues/1052) clean up 
+# TODO(https://github.com/kubeflow/manifests/issues/1052) clean up
 # the manifests after the refactor is done. We should move
 # cluster-issuer into the kubeflow-issuer package.
 apiVersion: kustomize.config.k8s.io/v1beta1
@@ -9,3 +9,5 @@ resources:
 - cluster-issuer.yaml
 commonLabels:
   kustomize.component: cert-manager
+  app.kubernetes.io/component: cert-manager
+  app.kubernetes.io/name: cert-manager

--- a/common/cert-manager/cert-manager/v3/kustomization.yaml
+++ b/common/cert-manager/cert-manager/v3/kustomization.yaml
@@ -1,9 +1,0 @@
-apiVersion: kustomize.config.k8s.io/v1beta1
-commonLabels:
-  app.kubernetes.io/component: cert-manager
-  app.kubernetes.io/name: cert-manager
-kind: Kustomization
-namespace: cert-manager
-resources:
-- ../base
-- ../overlays/application/application.yaml


### PR DESCRIPTION
Remove v3 manifests from cert-manager, since we use plain kustomize now.

