### PR TITLE
update to istio 1.9.2 and move image tags to kustomization

### DIFF
--- a/common/istio-1-9-0/cluster-local-gateway/base/cluster-local-gateway.yaml
+++ b/common/istio-1-9-0/cluster-local-gateway/base/cluster-local-gateway.yaml
@@ -151,7 +151,7 @@ spec:
           value: sni-dnat
         - name: ISTIO_META_CLUSTER_ID
           value: Kubernetes
-        image: docker.io/istio/proxyv2:1.9.0
+        image: docker.io/istio/proxyv2
         name: istio-proxy
         ports:
         - containerPort: 15020

--- a/common/istio-1-9-0/cluster-local-gateway/base/kustomization.yaml
+++ b/common/istio-1-9-0/cluster-local-gateway/base/kustomization.yaml
@@ -10,3 +10,8 @@ resources:
 
 patchesStrategicMerge:
 - patches/remove-pdb.yaml
+
+images:
+- name: docker.io/istio/proxyv2
+  newName: docker.io/istio/proxyv2
+  newTag: 1.9.1

--- a/common/istio-1-9-0/cluster-local-gateway/base/kustomization.yaml
+++ b/common/istio-1-9-0/cluster-local-gateway/base/kustomization.yaml
@@ -14,4 +14,4 @@ patchesStrategicMerge:
 images:
 - name: docker.io/istio/proxyv2
   newName: docker.io/istio/proxyv2
-  newTag: 1.9.1
+  newTag: 1.9.2

--- a/common/istio-1-9-0/istio-install/base/install.yaml
+++ b/common/istio-1-9-0/istio-install/base/install.yaml
@@ -1139,7 +1139,7 @@ data:
         "sts": {
           "servicePort": 0
         },
-        "tag": "1.9.0",
+        "tag": "1.9.1",
         "tracer": {
           "datadog": {
             "address": "$(HOST_IP):8126"
@@ -1865,7 +1865,7 @@ spec:
           value: standard
         - name: ISTIO_META_CLUSTER_ID
           value: Kubernetes
-        image: docker.io/istio/proxyv2:1.9.0
+        image: docker.io/istio/proxyv2
         name: istio-proxy
         ports:
         - containerPort: 15021
@@ -2060,7 +2060,7 @@ spec:
           value: Kubernetes
         - name: EXTERNAL_ISTIOD
           value: 'false'
-        image: docker.io/istio/pilot:1.9.0
+        image: docker.io/istio/pilot
         name: discovery
         ports:
         - containerPort: 8080

--- a/common/istio-1-9-0/istio-install/base/install.yaml
+++ b/common/istio-1-9-0/istio-install/base/install.yaml
@@ -1139,7 +1139,7 @@ data:
         "sts": {
           "servicePort": 0
         },
-        "tag": "1.9.1",
+        "tag": "1.9.2",
         "tracer": {
           "datadog": {
             "address": "$(HOST_IP):8126"

--- a/common/istio-1-9-0/istio-install/base/kustomization.yaml
+++ b/common/istio-1-9-0/istio-install/base/kustomization.yaml
@@ -10,5 +10,12 @@ resources:
 namespace: istio-system
 
 patchesStrategicMerge:
-- patches/service.yaml
 - patches/remove-pdb.yaml
+
+images:
+- name: docker.io/istio/proxyv2
+  newName: docker.io/istio/proxyv2
+  newTag: 1.9.1
+- name: docker.io/istio/pilot
+  newName: docker.io/istio/pilot
+  newTag: 1.9.1

--- a/common/istio-1-9-0/istio-install/base/kustomization.yaml
+++ b/common/istio-1-9-0/istio-install/base/kustomization.yaml
@@ -15,7 +15,7 @@ patchesStrategicMerge:
 images:
 - name: docker.io/istio/proxyv2
   newName: docker.io/istio/proxyv2
-  newTag: 1.9.1
+  newTag: 1.9.2
 - name: docker.io/istio/pilot
   newName: docker.io/istio/pilot
-  newTag: 1.9.1
+  newTag: 1.9.2

--- a/common/istio-1-9-0/profile.yaml
+++ b/common/istio-1-9-0/profile.yaml
@@ -58,7 +58,7 @@ spec:
       proxyMetadata: {}
     enablePrometheusMerge: true
   profile: demo
-  tag: 1.9.0
+  tag: 1.9.1
   values:
     base:
       enableCRDTemplates: false

--- a/common/istio-1-9-0/profile.yaml
+++ b/common/istio-1-9-0/profile.yaml
@@ -58,7 +58,7 @@ spec:
       proxyMetadata: {}
     enablePrometheusMerge: true
   profile: demo
-  tag: 1.9.1
+  tag: 1.9.2
   values:
     base:
       enableCRDTemplates: false


### PR DESCRIPTION
**Description of your changes:**
Update Istio images to 1.9.2 and move image tags to `kustomization.yaml`. 

@yanniszark Probably a good idea to update the patch version of Istio as I'm sure there were many bug fixes since the initial release of version 1.9.
