### PR TITLE
fix(GCP): Set fixed Kubernetes version to be 1.16 for successful Kubeflow 1.2 deployment. Fixes kubeflow/gcp-blueprints#198

### DIFF
--- a/gcp/v2/cnrm/cluster/cluster.yaml
+++ b/gcp/v2/cnrm/cluster/cluster.yaml
@@ -42,7 +42,7 @@ spec:
   releaseChannel:
     # Per https://github.com/GoogleCloudPlatform/k8s-config-connector/issues/194
     # use upper case for the channels
-    channel: REGULAR
+    channel: UNSPECIFIED
   location: location # {"$kpt-set":"location"}
   workloadIdentityConfig:
     identityNamespace: project-id.svc.id.goog # {"$kpt-set":"identity-ns"}
@@ -60,3 +60,5 @@ spec:
       name: name-vm # {"$kpt-set":"name-vm"}
     workloadMetadataConfig:
       nodeMetadata: GKE_METADATA_SERVER
+  nodeVersion: '1.16'
+  minMasterVersion: '1.16'


### PR DESCRIPTION
Fix issue https://github.com/kubeflow/gcp-blueprints/issues/198.

**Description of your changes:**

Needs to be cherry-picked for 1.2.1 release to fix the current issue on Kubeflow 1.2. Kubeflow 1.2 was designed for Kubernetes 1.16 version, so we should enforce this Kubernetes version, because the latest Kubernetes version has deprecated support for many old versions of Kubeflow's dependencies, and caused the Kubeflow deployment error-prone.

Validation:
I am able to apply this change and successfully deploy Kubeflow.

Note:
Make sure to do the following:
`If using IAP: make sure you added https://<deployment>.endpoints.<project>.cloud.goog/_gcp_gatekeeper/authenticate as an authorized redirect URI for the OAUTH credentials used to create the deployment.`

See troubleshooting: https://www.kubeflow.org/docs/gke/troubleshooting-gke/#troubleshooting-kubeflow-deployment-on-gcp

**Checklist:**
- [ ] Unit tests pass:
  **Make sure you have installed kustomize == 3.2.1**
    1. `make generate-changed-only`
    2. `make test`
