### PR TITLE
feat: Reintroduce REGISTRATION_FLOW variable for central dashboard

### DIFF
--- a/apps/centraldashboard/upstream/overlays/stacks/deployment_kf_config.yaml
+++ b/apps/centraldashboard/upstream/overlays/stacks/deployment_kf_config.yaml
@@ -18,3 +18,8 @@ spec:
                 configMapKeyRef:
                   name: kubeflow-config
                   key: userid-prefix
+            - name: REGISTRATION_FLOW
+              valueFrom:
+                configMapKeyRef:
+                  name: kubeflow-config
+                  key: registration-flow

--- a/distributions/stacks/aws/config/params.env
+++ b/distributions/stacks/aws/config/params.env
@@ -3,3 +3,4 @@ userid-header=kubeflow-userid
 userid-prefix=
 cluster-name=
 istio-namespace=istio-system
+registration-flow=

--- a/distributions/stacks/azure/config/params.env
+++ b/distributions/stacks/azure/config/params.env
@@ -3,3 +3,4 @@ userid-header=kubeflow-userid
 userid-prefix=
 cluster-name=
 istio-namespace=istio-system
+registration-flow=

--- a/distributions/stacks/gcp/config/params.env
+++ b/distributions/stacks/gcp/config/params.env
@@ -1,3 +1,4 @@
 clusterDomain=cluster.local
 userid-header=x-goog-authenticated-user-email
 userid-prefix=accounts.google.com:
+registration-flow=

--- a/distributions/stacks/generic/config/params.env
+++ b/distributions/stacks/generic/config/params.env
@@ -1,3 +1,4 @@
 clusterDomain=cluster.local
 userid-header=X-Goog-Authenticated-User-Email
 userid-prefix=accounts.google.com:
+registration-flow=

--- a/distributions/stacks/ibm/base/config/params.env
+++ b/distributions/stacks/ibm/base/config/params.env
@@ -1,3 +1,4 @@
 clusterDomain=cluster.local
 userid-header=kubeflow-userid
 userid-prefix=
+registration-flow=

--- a/distributions/stacks/kubernetes/config/params.env
+++ b/distributions/stacks/kubernetes/config/params.env
@@ -3,3 +3,4 @@ userid-header=kubeflow-userid
 userid-prefix=
 cluster-name=
 istio-namespace=istio-system
+registration-flow=

--- a/distributions/stacks/openshift/config/params.env
+++ b/distributions/stacks/openshift/config/params.env
@@ -3,3 +3,4 @@ userid-header=kubeflow-userid
 userid-prefix=
 namespace=
 clusterdomain=
+registration-flow=


### PR DESCRIPTION
**Which issue is resolved by this Pull Request:**
Replaces: https://github.com/kubeflow/manifests/pull/1736 (I need to keep the original branch of the previous PR since I'm deploying from it, hence I'm creating a new PR, sorry)

**Description of your changes:**
Add the `REGISTRATION_FLOW` for central dashboard and makes the flag available in stacks

**Checklist:**
- [ ] Unit tests pass:  I'm unable to execute the `make generate-changes-only` due to `Error: accumulating resources: accumulating resources from '../../../pipeline/pipelines-ui/overlays/istio/virtual-service.yaml': open /home/tcoufal/Programming/AI-CoE/kubeflow/manifests/pipeline/pipelines-ui/overlays/istio/virtual-service.yaml: no such file or directory`, the tests were not yet adjusted to the new directory schema probably.
