### PR TITLE
KNative: reference the existing kustomization.yaml rather than the yaml files

### DIFF
--- a/common/knative/installs/eventing/kustomization.yaml
+++ b/common/knative/installs/eventing/kustomization.yaml
@@ -4,14 +4,7 @@ namespace: knative-eventing
 resources:
 - ../../knative-eventing-crds/base
 - ../../knative-eventing-crds/overlays/application
-- ../../knative-eventing-install/base/cluster-role.yaml
-- ../../knative-eventing-install/base/cluster-role-binding.yaml
-- ../../knative-eventing-install/base/secret.yaml
-- ../../knative-eventing-install/base/config-map.yaml
-- ../../knative-eventing-install/base/deployment.yaml
-- ../../knative-eventing-install/base/service-account.yaml
-- ../../knative-eventing-install/base/service.yaml
-- ../../knative-eventing-install/base/webhook-configuration.yaml
+- ../../knative-eventing-install/base
 - ../../knative-eventing-install/overlays/application
 commonLabels:
   kustomize.component: knative

--- a/common/knative/installs/generic/kustomization.yaml
+++ b/common/knative/installs/generic/kustomization.yaml
@@ -4,19 +4,7 @@ namespace: knative-serving
 resources:
 - ../../knative-serving-crds/base
 - ../../knative-serving-crds/overlays/application
-- ../../knative-serving-install/base/gateway.yaml
-- ../../knative-serving-install/base/cluster-role.yaml
-- ../../knative-serving-install/base/cluster-role-binding.yaml
-- ../../knative-serving-install/base/service-role.yaml
-- ../../knative-serving-install/base/service-role-binding.yaml
-- ../../knative-serving-install/base/config-map.yaml
-- ../../knative-serving-install/base/deployment.yaml
-- ../../knative-serving-install/base/secret.yaml
-- ../../knative-serving-install/base/service-account.yaml
-- ../../knative-serving-install/base/service.yaml
-- ../../knative-serving-install/base/image.yaml
-- ../../knative-serving-install/base/hpa.yaml
-- ../../knative-serving-install/base/webhook-configuration.yaml
+- ../../knative-serving-install/base
 - ../../knative-serving-install/overlays/application
 commonLabels:
   kustomize.component: knative


### PR DESCRIPTION
**Description of your changes:**
For some reason, the manifests were referencing the yaml files in the installation folder directly, rather than referencing the folder which already contains a `kustomization.yaml` file. Also, the `generic` installation contained references to files that did not exists and are not used in the `eventing` installation, so those have been removed so the manifest can actually be built. 

```
- ../../knative-serving-install/base/service-role.yaml
- ../../knative-serving-install/base/service-role-binding.yaml
```

**Checklist:**
- [ ] Unit tests pass:
  **Make sure you have installed kustomize == 3.2.1**
    1. `make generate-changed-only`
    2. `make test`
