### PR TITLE
oidc-authservice: fix secret generator envs

### DIFF
--- a/common/oidc-authservice/base/kustomization.yaml
+++ b/common/oidc-authservice/base/kustomization.yaml
@@ -17,7 +17,8 @@ configMapGenerator:
 secretGenerator:
 - name: oidc-authservice-client
   type: Opaque
-  env: secret_params.env
+  envs:
+  - secret_params.env
 
 generatorOptions:
   disableNameSuffixHash: true


### PR DESCRIPTION
Fix a small issue in the oidc-authservice manifests where `env: secret_params.env` is used instead of 
```yaml
envs:
  - secret_params.env
```