### PR TITLE
Dex-overlays use reference instead of base

### DIFF
--- a/common/dex/overlays/github/kustomization.yaml
+++ b/common/dex/overlays/github/kustomization.yaml
@@ -1,10 +1,9 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 namespace: auth
-bases:
-- ../../base
 resources:
 - virtual-service.yaml
+- ../../base
 
 patchesStrategicMerge:
 - config-map.yaml

--- a/common/dex/overlays/istio/kustomization.yaml
+++ b/common/dex/overlays/istio/kustomization.yaml
@@ -1,8 +1,8 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
-bases:
-- ../../base
+
 resources:
+- ../../base
 - virtual-service.yaml
 
 namespace: auth

--- a/common/dex/overlays/ldap/kustomization.yaml
+++ b/common/dex/overlays/ldap/kustomization.yaml
@@ -1,7 +1,7 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 namespace: auth
-bases:
+resources:
 - ../../base
 
 patchesStrategicMerge:


### PR DESCRIPTION
Fixes the manifests not building with some versions of kustomize. Changes were tested with kustomize v3.2.1 and still build successfully. 

/cc @yanniszark @PatrickXYS 
