### PR TITLE
fix(doc): PyTorch Operator instruction in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -267,7 +267,7 @@ kustomize build --load_restrictor=none apps/tf-training/upstream/overlays/kubefl
 Install the PyTorch Operator official Kubeflow component:
 
 ```sh
-kustomize build --load_restrictor=none apps/tensorboard/tensorboard-controller/upstream/overlays/kubeflow | kubectl apply -f -
+kustomize build --load_restrictor=none apps/pytorch-job/upstream/overlays/kubeflow | kubectl apply -f -
 ```
 
 #### MPI Operator


### PR DESCRIPTION
The kustomize target is not correct.

**Which issue is resolved by this Pull Request:**
Resolves #

**Description of your changes:**


**Checklist:**
- [ ] Unit tests pass:
  **Make sure you have installed kustomize == 3.2.1**
    1. `make generate-changed-only`
    2. `make test`
