### PR TITLE
Fixes broken v1.3 OIDC auth manifest

### DIFF
--- a/common/oidc-authservice/base/kustomization.yaml
+++ b/common/oidc-authservice/base/kustomization.yaml
@@ -17,7 +17,8 @@ configMapGenerator:
 secretGenerator:
 - name: oidc-authservice-client
   type: Opaque
-  env: secret_params.env
+  envs:
+  - secret_params.env
 
 generatorOptions:
   disableNameSuffixHash: true


### PR DESCRIPTION
v1.3 OIDC auth manifests are broken

Example installation of Kubeflow v1.3 using kustomize provided by @yanniszark does not succeed as a result

**Which issue is resolved by this Pull Request:**
Corrects #1735 

**Description of your changes:**
Current OIDC Auth Service manifests are not valid. This addresses the syntax error.

Current error:

```
kustomize build --load_restrictor=none common/oidc-authservice/base
Error: json: unknown field "env"
```

**Checklist:**
- [ ] Unit tests pass:
  **Make sure you have installed kustomize == 3.2.1**
    1. `make generate-changed-only`
    2. `make test`
