### PR TITLE
Update Knative manifests to support newer kustomize versions

### DIFF
--- a/common/knative/knative-eventing-install/base/cluster-role.yaml
+++ b/common/knative/knative-eventing-install/base/cluster-role.yaml
@@ -315,7 +315,7 @@ rules:
   - endpoints
   - events
   - serviceaccounts
-  verbs: &ref_0
+  verbs:
   - get
   - list
   - create
@@ -327,12 +327,26 @@ rules:
   - apps
   resources:
   - deployments
-  verbs: *ref_0
+  verbs:
+  - get
+  - list
+  - create
+  - update
+  - delete
+  - patch
+  - watch
 - apiGroups:
   - rbac.authorization.k8s.io
   resources:
   - rolebindings
-  verbs: *ref_0
+  verbs:
+  - get
+  - list
+  - create
+  - update
+  - delete
+  - patch
+  - watch
 - apiGroups:
   - eventing.knative.dev
   resources:
@@ -342,7 +356,14 @@ rules:
   - triggers/status
   - eventtypes
   - eventtypes/status
-  verbs: *ref_0
+  verbs:
+  - get
+  - list
+  - create
+  - update
+  - delete
+  - patch
+  - watch
 - apiGroups:
   - eventing.knative.dev
   resources:
@@ -361,7 +382,14 @@ rules:
   - parallels/status
   - subscriptions
   - subscriptions/status
-  verbs: *ref_0
+  verbs:
+  - get
+  - list
+  - create
+  - update
+  - delete
+  - patch
+  - watch
 - apiGroups:
   - flows.knative.dev
   resources:
@@ -369,7 +397,14 @@ rules:
   - sequences/status
   - parallels
   - parallels/status
-  verbs: *ref_0
+  verbs:
+  - get
+  - list
+  - create
+  - update
+  - delete
+  - patch
+  - watch
 - apiGroups:
   - messaging.knative.dev
   resources:
@@ -518,7 +553,7 @@ rules:
   - secrets
   - configmaps
   - services
-  verbs: &ref_0
+  verbs:
   - get
   - list
   - create
@@ -530,7 +565,14 @@ rules:
   - apps
   resources:
   - deployments
-  verbs: *ref_0
+  verbs:
+  - get
+  - list
+  - create
+  - update
+  - delete
+  - patch
+  - watch
 - apiGroups:
   - sources.knative.dev
   resources:
@@ -546,22 +588,50 @@ rules:
   - containersources
   - containersources/status
   - containersources/finalizers
-  verbs: *ref_0
+  verbs:
+  - get
+  - list
+  - create
+  - update
+  - delete
+  - patch
+  - watch
 - apiGroups:
   - serving.knative.dev
   resources:
   - services
-  verbs: *ref_0
+  verbs:
+  - get
+  - list
+  - create
+  - update
+  - delete
+  - patch
+  - watch
 - apiGroups:
   - eventing.knative.dev
   resources:
   - eventtypes
-  verbs: *ref_0
+  verbs:
+  - get
+  - list
+  - create
+  - update
+  - delete
+  - patch
+  - watch
 - apiGroups:
   - ''
   resources:
   - events
-  verbs: *ref_0
+  verbs:
+  - get
+  - list
+  - create
+  - update
+  - delete
+  - patch
+  - watch
 - apiGroups:
   - authorization.k8s.io
   resources:
@@ -611,7 +681,7 @@ rules:
   resources:
   - mutatingwebhookconfigurations
   - validatingwebhookconfigurations
-  verbs: &ref_0
+  verbs:
   - get
   - list
   - create
@@ -625,7 +695,14 @@ rules:
   - sinkbindings
   - sinkbindings/status
   - sinkbindings/finalizers
-  verbs: *ref_0
+  verbs:
+  - get
+  - list
+  - create
+  - update
+  - delete
+  - patch
+  - watch
 - apiGroups:
   - apiextensions.k8s.io
   resources:
@@ -751,7 +828,7 @@ rules:
   resources:
   - services
   - serviceaccounts
-  verbs: &ref_0
+  verbs:
   - get
   - list
   - watch
@@ -770,12 +847,24 @@ rules:
   - rbac.authorization.k8s.io
   resources:
   - rolebindings
-  verbs: *ref_0
+  verbs:
+  - get
+  - list
+  - watch
+  - create
+  - update
+  - patch
 - apiGroups:
   - apps
   resources:
   - deployments
-  verbs: *ref_0
+  verbs:
+  - get
+  - list
+  - watch
+  - create
+  - update
+  - patch
 - apiGroups:
   - apps
   resources:
@@ -803,7 +892,13 @@ rules:
   - coordination.k8s.io
   resources:
   - leases
-  verbs: *ref_0
+  verbs:
+  - get
+  - list
+  - watch
+  - create
+  - update
+  - patch
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole

--- a/common/knative/knative-eventing-install/base/deployment.yaml
+++ b/common/knative/knative-eventing-install/base/deployment.yaml
@@ -116,12 +116,14 @@ metadata:
 spec:
   replicas: 1
   selector:
-    matchLabels: &ref_0
+    matchLabels:
       app: eventing-webhook
       role: eventing-webhook
   template:
     metadata:
-      labels: *ref_0
+      labels:
+        app: eventing-webhook
+        role: eventing-webhook
     spec:
       containers:
       - env:
@@ -168,12 +170,14 @@ metadata:
 spec:
   replicas: 1
   selector:
-    matchLabels: &ref_0
+    matchLabels:
       messaging.knative.dev/channel: in-memory-channel
       messaging.knative.dev/role: controller
   template:
     metadata:
-      labels: *ref_0
+      labels:
+        messaging.knative.dev/channel: in-memory-channel
+        messaging.knative.dev/role: controller
     spec:
       containers:
       - env:
@@ -210,12 +214,14 @@ metadata:
 spec:
   replicas: 1
   selector:
-    matchLabels: &ref_0
+    matchLabels:
       messaging.knative.dev/channel: in-memory-channel
       messaging.knative.dev/role: dispatcher
   template:
     metadata:
-      labels: *ref_0
+      labels:
+        messaging.knative.dev/channel: in-memory-channel
+        messaging.knative.dev/role: dispatcher
     spec:
       containers:
       - env:

--- a/common/knative/knative-serving-install/base/deployment.yaml
+++ b/common/knative/knative-serving-install/base/deployment.yaml
@@ -43,7 +43,7 @@ spec:
         - name: METRICS_DOMAIN
           value: knative.dev/internal/serving
         image: 'gcr.io/knative-releases/knative.dev/serving/cmd/activator@sha256:ffa3d72ee6c2eeb2357999248191a643405288061b7080381f22875cb703e929'
-        livenessProbe: &ref_0
+        livenessProbe:
           httpGet:
             httpHeaders:
             - name: k-kubelet-probe
@@ -59,7 +59,12 @@ spec:
           name: metrics
         - containerPort: 8008
           name: profiling
-        readinessProbe: *ref_0
+        readinessProbe:
+          httpGet:
+            httpHeaders:
+            - name: k-kubelet-probe
+              value: activator
+            port: 8012
         resources:
           limits:
             cpu: 1000m
@@ -108,7 +113,7 @@ spec:
         - name: METRICS_DOMAIN
           value: knative.dev/serving
         image: 'gcr.io/knative-releases/knative.dev/serving/cmd/autoscaler@sha256:f89fd23889c3e0ca3d8e42c9b189dc2f93aa5b3a91c64e8aab75e952a210eeb3'
-        livenessProbe: &ref_0
+        livenessProbe:
           httpGet:
             httpHeaders:
             - name: k-kubelet-probe
@@ -124,7 +129,12 @@ spec:
           name: custom-metrics
         - containerPort: 8008
           name: profiling
-        readinessProbe: *ref_0
+        readinessProbe:
+          httpGet:
+            httpHeaders:
+            - name: k-kubelet-probe
+              value: autoscaler
+            port: 8080
         resources:
           limits:
             cpu: 300m


### PR DESCRIPTION
**Which issue is resolved by this Pull Request:**
WIP for #1797 

**Description of your changes:**

Kustomize 3.9.2 and beyond (including latest 4.X) does not seem to handle pointers / references in YAML anymore. Removing pointers appears to fix deployment problems with modern versions of Kustomize.

Can deploy with:
```
kustomize version
{Version:kustomize/v4.0.5 GitCommit:9e8e7a7fe99ec9fbf801463e8607928322fc5245 BuildDate:2021-03-08T20:53:03Z GoOs:darwin GoArch:amd64}
```

```
cd ~/src/berndverst/manifests/example
kustomize build --load-restrictor LoadRestrictionsNone .
```


**Checklist:**
- [ ] Unit tests pass:
  **Make sure you have installed kustomize == 3.2.1**
    1. `make generate-changed-only`
    2. `make test`
