### PR TITLE
Dex: Fix user must be valid email address

### DIFF
--- a/common/dex/base/config-map.yaml
+++ b/common/dex/base/config-map.yaml
@@ -18,7 +18,7 @@ data:
       skipApprovalScreen: true
     enablePasswordDB: true
     staticPasswords:
-    - email: user@kubeflow.org
+    - email: user@example.com
       hash: $2y$12$4K/VkmDd1q1Orb3xAt82zu8gk7Ad6ReFR4LCP9UeYE90NLiN9Df72
       # https://github.com/dexidp/dex/pull/1601/commits
       # FIXME: Use hashFromEnv instead

--- a/common/dex/base/config-map.yaml
+++ b/common/dex/base/config-map.yaml
@@ -18,7 +18,7 @@ data:
       skipApprovalScreen: true
     enablePasswordDB: true
     staticPasswords:
-    - email: user
+    - email: user@kubeflow.org
       hash: $2y$12$4K/VkmDd1q1Orb3xAt82zu8gk7Ad6ReFR4LCP9UeYE90NLiN9Df72
       # https://github.com/dexidp/dex/pull/1601/commits
       # FIXME: Use hashFromEnv instead

--- a/common/user-namespace/base/params.env
+++ b/common/user-namespace/base/params.env
@@ -1,2 +1,2 @@
-user=user
+user=user@kubeflow.org
 profile-name=kubeflow-user

--- a/common/user-namespace/base/params.env
+++ b/common/user-namespace/base/params.env
@@ -1,2 +1,2 @@
-user=user@kubeflow.org
-profile-name=kubeflow-user
+user=user@example.com
+profile-name=kubeflow-user-example-com


### PR DESCRIPTION
To be able to add contributors to your namespace the `name` value in the profile CR must be a valid email address. Currently, the default is set to `user` instead of `user@kubeflow.org`, which will break adding it as a contributor to other namespaces. This PR fixes the dex config so the `email` value is a "valid" email address and the associated Profile CR contains this email address. 

/cc @yanniszark 
Also /cc @berndverst as I think you might run into this as well as you are going through the deployment manifests now.


**Checklist:**
- [ ] Unit tests pass:
  **Make sure you have installed kustomize == 3.2.1**
    1. `make generate-changed-only`
    2. `make test`
