### PR TITLE
Make ingress gateway HTTPS by default

### DIFF
--- a/common/istio-1-9-0/kubeflow-istio-resources/base/certificate.yaml
+++ b/common/istio-1-9-0/kubeflow-istio-resources/base/certificate.yaml
@@ -1,0 +1,13 @@
+apiVersion: cert-manager.io/v1alpha2
+kind: Certificate
+metadata:
+  name: istio-ingressgateway-certs
+  namespace: istio-system
+spec:
+  secretName: istio-ingressgateway-certs
+  issuerRef:
+    name: kubeflow-self-signing-issuer
+    kind: ClusterIssuer
+  commonName: kubeflow.example.com
+  dnsNames:
+    - kubeflow.example.com

--- a/common/istio-1-9-0/kubeflow-istio-resources/base/kf-istio-resources.yaml
+++ b/common/istio-1-9-0/kubeflow-istio-resources/base/kf-istio-resources.yaml
@@ -6,9 +6,22 @@ spec:
   selector:
     istio: ingressgateway
   servers:
-  - port:
-      number: 80
+  - hosts:
+    - '*'
+    port:
       name: http
+      number: 80
       protocol: HTTP
-    hosts:
-    - "*"
+    # Upgrade HTTP to HTTPS
+    tls:
+      httpsRedirect: true
+  - hosts:
+    - '*'
+    port:
+      name: https
+      number: 443
+      protocol: HTTPS
+    tls:
+      mode: SIMPLE
+      privateKey: /etc/istio/ingressgateway-certs/tls.key
+      serverCertificate: /etc/istio/ingressgateway-certs/tls.crt

--- a/common/istio-1-9-0/kubeflow-istio-resources/base/kustomization.yaml
+++ b/common/istio-1-9-0/kubeflow-istio-resources/base/kustomization.yaml
@@ -3,4 +3,5 @@ kind: Kustomization
 resources:
 - kf-istio-resources.yaml
 - cluster-roles.yaml
+- certificate.yaml
 namespace: kubeflow


### PR DESCRIPTION
**Which issue is resolved by this Pull Request:**
Closes: https://github.com/kubeflow/manifests/issues/1812 https://github.com/kubeflow/kubeflow/issues/5803

**Description of your changes:**
Currently the Jupyter, Tensorboards and Volumes Web Apps are setup to require secure cookies. However, as the istio ingress-gateway that Kubeflow uses is setup for HTTP, by default users will run into errors causing these web apps to not work. To mitigate this (and promote the use of HTTPS), this PR sets the ingress-gateway to use HTTPS by default with a certificate created by the `kubeflow-self-signing-issuer` that other kubeflow components already use.

/cc @yanniszark 

**Checklist:**
- [x] Unit tests pass:
  **Make sure you have installed kustomize == 3.2.1**
    1. `make generate-changed-only`
    2. `make test`
