### PR TITLE
Add Kubeflow overlay to Feast

### DIFF
--- a/contrib/feast/Makefile
+++ b/contrib/feast/Makefile
@@ -1,6 +1,6 @@
 
 feast/base: clean
-	cd feast/base && helm template -f ../../values.yaml kf-feast feast --namespace kubeflow --version 0.100.4 --repo https://feast-helm-charts.storage.googleapis.com > resources.yaml
+	cd feast/base && helm template -f ../../values.yaml kf-feast feast --namespace feast --version 0.100.4 --repo https://feast-helm-charts.storage.googleapis.com > resources.yaml
 
 .PHONY:clean-kustomize
 clean:

--- a/contrib/feast/README.md
+++ b/contrib/feast/README.md
@@ -1,14 +1,24 @@
-# Feast Kustomize 
+# Feast Kustomize
 
-## Generating/Updating Feast Kustomize
+## Installing with Kustomize
+
+### Standalone
 
 ```
-kustomize build feast/base | kubectl apply -n kubeflow -f -
+kustomize build feast/base | kubectl apply -n feast -f -
+```
+
+### With Kubeflow
+
+If installing Feast as a component of Kubeflow, use the `kubeflow` overlay.
+
+```
+kustomize build feast/overlays/kubeflow | kubectl apply -f -
 ```
 
 ## Updating
 
-The Feast Kustomize configuration in this folder is built from the Feast Helm charts and a custom values.yaml file.
+The Feast Kustomize configuration in this folder is built from the Feast Helm charts and a custom `values.yaml` file.
 
 Run the following command to regenerate the configuration:
 ```

--- a/contrib/feast/feast/base/resources.yaml
+++ b/contrib/feast/feast/base/resources.yaml
@@ -4,7 +4,7 @@ apiVersion: v1
 kind: Secret
 metadata:
   name: kf-feast-feast-core
-  namespace: kubeflow
+  namespace: feast
   labels:
     app: feast-core
     component: core
@@ -21,7 +21,7 @@ apiVersion: v1
 kind: Secret
 metadata:
   name: kf-feast-feast-serving
-  namespace: kubeflow
+  namespace: feast
   labels:
     app: feast-serving
     component: serving
@@ -38,7 +38,7 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: kf-feast-feast-core
-  namespace: kubeflow
+  namespace: feast
   labels:
     app: feast-core
     component: core
@@ -62,7 +62,7 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: kf-feast-feast-serving
-  namespace: kubeflow
+  namespace: feast
   labels:
     app: feast-serving
     component: serving
@@ -199,7 +199,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: kf-feast-feast-core
-  namespace: kubeflow
+  namespace: feast
   labels:
     app: feast-core
     chart: feast-core-0.25.0
@@ -224,7 +224,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: kf-feast-feast-jobservice
-  namespace: kubeflow
+  namespace: feast
   labels:
     app: feast-jobservice
     chart: feast-jobservice-0.9.2
@@ -249,7 +249,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: kf-feast-feast-serving
-  namespace: kubeflow
+  namespace: feast
   labels:
     app: feast-serving
     chart: feast-serving-0.25.0
@@ -379,7 +379,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: kf-feast-feast-core
-  namespace: kubeflow
+  namespace: feast
   labels:
     app: feast-core
     component: core
@@ -396,8 +396,8 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/configmap: ad1b83d64b77cd00800c6f70cb93b9d8f9c68597ff7d66e5bd2a85bdd022bfc0
-        checksum/secret: 56db71bbdb20bd5f5385591439f21dea0bb46cdf257e8491c87e40286d89a365
+        checksum/configmap: 65652a82857b1cc41cf1b96a3466be3004271fc1e9c7c100927ceade4f499ff4
+        checksum/secret: 534fff11a6f05225ea57b92e5ac8d9a74f9c1bb762c1f24930ea7bdc82728d52
         prometheus.io/path: /metrics
         prometheus.io/port: "8080"
         prometheus.io/scrape: "true"
@@ -465,7 +465,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: kf-feast-feast-jobservice
-  namespace: kubeflow
+  namespace: feast
   labels:
     app: feast-jobservice
     component: jobservice
@@ -528,7 +528,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: kf-feast-feast-serving
-  namespace: kubeflow
+  namespace: feast
   labels:
     app: feast-serving
     component: serving
@@ -545,8 +545,8 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/configmap: fc3f1499c79ca0a6fc96c95653c6b137af174923e4e042b449921455475fd733
-        checksum/secret: ba4e6b3c7f57dcf83c33c4e126ce851d21b49d000b33506fcdc290136f2df623
+        checksum/configmap: 179927bcdb9de7eadf95390cc6dca8046db451bad6320e4d5cf1ab3f28bf92b0
+        checksum/secret: 023c324d70d3e0d551c155dcba35b4c6addbf9aa8c844a67bc5f53b77e45e9b9
         prometheus.io/path: /metrics
         prometheus.io/port: "8080"
         prometheus.io/scrape: "true"
@@ -932,7 +932,7 @@ spec:
         - name: REDIS_REPLICATION_MODE
           value: slave
         - name: REDIS_MASTER_HOST
-          value: kf-feast-redis-master-0.kf-feast-redis-headless.kubeflow.svc.cluster.local
+          value: kf-feast-redis-master-0.kf-feast-redis-headless.feast.svc.cluster.local
         - name: REDIS_PORT
           value: "6379"
         - name: REDIS_MASTER_PORT_NUMBER

--- a/contrib/feast/feast/base/static.yaml
+++ b/contrib/feast/feast/base/static.yaml
@@ -4,10 +4,10 @@ data:
 kind: Secret
 metadata:
   name: feast-postgresql
-  namespace: kubeflow
+  namespace: feast
 type: Opaque
 ---
 apiVersion: v1
 kind: Namespace
 metadata:
-  name: kubeflow
+  name: feast

--- a/contrib/feast/feast/overlays/kubeflow/kustomization.yaml
+++ b/contrib/feast/feast/overlays/kubeflow/kustomization.yaml
@@ -1,0 +1,15 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+namespace: kubeflow
+commonLabels:
+  app.kubernetes.io/component: feast
+  app.kubernetes.io/name: feast
+bases:
+- ../../base
+patchesStrategicMerge:
+- patches/namespace.yaml
+- patches/redis.yaml
+# If Kafka is enabled, uncomment the following patches.
+# - patches/kafka.yaml
+# - patches/zookeeper.yaml
+

--- a/contrib/feast/feast/overlays/kubeflow/patches/kafka.yaml
+++ b/contrib/feast/feast/overlays/kubeflow/patches/kafka.yaml
@@ -1,0 +1,12 @@
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: kf-feast-kafka
+spec:
+  template:
+    spec:
+      containers:
+        - name: kafka
+          env:
+            - name: KAFKA_CFG_ADVERTISED_LISTENERS
+              value: "INTERNAL://kf-feast-kafka-0.kf-feast-kafka-headless.kubeflow.svc.cluster.local:9093,CLIENT://kf-feast-kafka-0.kf-feast-kafka-headless.kubeflow.svc.cluster.local:9092"

--- a/contrib/feast/feast/overlays/kubeflow/patches/namespace.yaml
+++ b/contrib/feast/feast/overlays/kubeflow/patches/namespace.yaml
@@ -1,0 +1,6 @@
+# Remove namespace resource as Kubeflow namespace will already exist.
+$patch: delete
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: feast

--- a/contrib/feast/feast/overlays/kubeflow/patches/redis.yaml
+++ b/contrib/feast/feast/overlays/kubeflow/patches/redis.yaml
@@ -1,0 +1,12 @@
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: kf-feast-redis-slave
+spec:
+  template:
+    spec:
+      containers:
+        - name: kf-feast-redis
+          env:
+            - name: REDIS_MASTER_HOST
+              value: kf-feast-redis-master-0.kf-feast-redis-headless.kubeflow.svc.cluster.local

--- a/contrib/feast/feast/overlays/kubeflow/patches/zookeeper.yaml
+++ b/contrib/feast/feast/overlays/kubeflow/patches/zookeeper.yaml
@@ -1,0 +1,13 @@
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: kf-feast-zookeeper
+  namespace: feast
+spec:
+  template:
+    spec:
+      containers:
+        - name: zookeeper
+          env:
+            - name: ZOO_SERVERS
+              value: kf-feast-zookeeper-0.kf-feast-zookeeper-headless.kubeflow.svc.cluster.local:2888:3888

--- a/contrib/feast/values.yaml
+++ b/contrib/feast/values.yaml
@@ -28,7 +28,7 @@ feast-jobservice:
   # feast-jobservice.enabled -- Flag to install Feast Job Service
   image:
     repository: gcr.io/kf-feast/feast-jobservice
-  enabled: false
+  enabled: true
 
 postgresql:
   # postgresql.enabled -- Flag to install Postgresql


### PR DESCRIPTION
In order to make the Feast Kustomize manifests installable as both standalone and as a part of Kubeflow, the base install will continue to use the `feast` namespace and the `kubeflow` overlay can be used for those looking to use Feast with Kubeflow. The kubeflow overlay will change namespace references to `kubeflow` instead of `feast`. This allows for a bit more flexibility for those using the manifests.

- In values.yaml, `feast-jobservice` was enabled to reflect what is currently in `feast/base/resources.yaml`.

/cc @tedhtchang @woop 