### PR TITLE
knative: Remove use of last yaml ref

### DIFF
--- a/common/knative/knative-serving-install/base/deployment.yaml
+++ b/common/knative/knative-serving-install/base/deployment.yaml
@@ -113,7 +113,7 @@ spec:
         - name: METRICS_DOMAIN
           value: knative.dev/serving
         image: 'gcr.io/knative-releases/knative.dev/serving/cmd/autoscaler@sha256:f89fd23889c3e0ca3d8e42c9b189dc2f93aa5b3a91c64e8aab75e952a210eeb3'
-        livenessProbe: &ref_0
+        livenessProbe:
           httpGet:
             httpHeaders:
             - name: k-kubelet-probe
@@ -129,7 +129,12 @@ spec:
           name: custom-metrics
         - containerPort: 8008
           name: profiling
-        readinessProbe: *ref_0
+        readinessProbe:
+          httpGet:
+            httpHeaders:
+            - name: k-kubelet-probe
+              value: autoscaler
+            port: 8080
         resources:
           limits:
             cpu: 300m


### PR DESCRIPTION
Missed this reference somehow in the last PR 🤦 (https://github.com/kubeflow/manifests/pull/1827)

cc @kubeflow/wg-manifests-leads 
cc @DavidSpek 