### PR TITLE
Update oidc-authservice image tag

### DIFF
--- a/common/oidc-authservice/base/kustomization.yaml
+++ b/common/oidc-authservice/base/kustomization.yaml
@@ -43,4 +43,4 @@ configurations:
 images:
 - name: gcr.io/arrikto/kubeflow/oidc-authservice
   newName: gcr.io/arrikto/kubeflow/oidc-authservice
-  newTag: 28c59ef
+  newTag: fef11c3


### PR DESCRIPTION
While going through the image tags for the Kubeflow deployment I noticed that the image tag for the OIDC-authservice is from December 2019. Looking at the [registry](https://console.cloud.google.com/gcr/images/arrikto/GLOBAL/kubeflow/oidc-authservice?gcrImageListsize=30) there are some images that were created 12 days ago with a `-dirty` suffix, the image tag in this PR is the newest with this suffix.

@yanniszark I'm not sure what has changed with the OIDC-authservice, since this is an Arrikto project. Should this be updated? Do you know the difference between the regular and the `-dirty` image tags for the OIDC-authservice? I assume the newer versions contain bug/security fixes that Kubeflow distributions would then want to use.