### PR TITLE
Update user references in README to use email

### DIFF
--- a/README.md
+++ b/README.md
@@ -378,7 +378,7 @@ kubectl get pods -n auth
 kubectl get pods -n knative-eventing
 kubectl get pods -n knative-serving
 kubectl get pods -n kubeflow
-kubectl get pods -n kubeflow-user
+kubectl get pods -n kubeflow-user-example-com
 ```
 
 #### Port-Forward
@@ -392,7 +392,7 @@ kubectl port-forward svc/istio-ingressgateway -n istio-system 8080:80
 After running the command, you can access the Kubeflow Central Dashboard by doing the following:
 
 1. Open your browser and visit `http://localhost:8080`. You should get the Dex login screen.
-2. Login with the default user's credential. The default username is `user` and the default password is `12341234`.
+2. Login with the default user's credential. The default email address is `user@example.com` and the default password is `12341234`.
 
 #### NodePort / LoadBalancer / Ingress
 
@@ -411,7 +411,7 @@ If you absolutely need to expose Kubeflow over HTTP, you can disable the `Secure
 
 For security reasons, we don't want to use the default password for the default Kubeflow user when installing in security-sensitive environments. Instead, you should define your own password before deploying. To define a password for the default user:
 
-1. Pick a password for the default user, with handle `user`, and hash it using `bcrypt`:
+1. Pick a password for the default user, with email `user@example.com`, and hash it using `bcrypt`:
 
     ```sh
     python3 -c 'from passlib.hash import bcrypt; import getpass; print(bcrypt.using(rounds=12, ident="2y").hash(getpass.getpass()))'
@@ -422,7 +422,7 @@ For security reasons, we don't want to use the default password for the default 
     ```yaml
     ...
       staticPasswords:
-      - email: user
+      - email: user@example.com
         hash: <enter the generated hash here>
     ```
 


### PR DESCRIPTION
Some updates to the README to account for the change of the default user login from `user` to `user@example.com`.

/cc @yanniszark 