### PR TITLE
fix(naming): fix default user email in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -361,7 +361,7 @@ kustomize build apps/xgboost-job/upstream/overlays/kubeflow | kubectl apply -f -
 
 #### User Namespace
 
-Finally, create a new namespace (named `kubeflow-user-example-com`) for the the default user (named `user@example.com`).
+Finally, create a new namespace (named `kubeflow-user-example-com`) for the default user (named `user@example.com`).
 
 ```sh
 kustomize build common/user-namespace/base | kubectl apply -f -

--- a/README.md
+++ b/README.md
@@ -136,7 +136,7 @@ kustomize build common/istio-1-9-0/istio-install/base | kubectl apply -f -
 
 #### Dex
 
-Dex is an OpenID Connect Identity (OIDC) with multiple authentication backends. In this default installation, it includes a static user named `user` with E-mail `user@example.com`. By default, the user's password is `12341234`. For any production Kubeflow deployment, you should change the default password by following [the relevant section](#change-default-user-password).
+Dex is an OpenID Connect Identity (OIDC) with multiple authentication backends. In this default installation, it includes a static user named `user@example.com`. By default, the user's password is `12341234`. For any production Kubeflow deployment, you should change the default password by following [the relevant section](#change-default-user-password).
 
 Install Dex:
 
@@ -361,7 +361,7 @@ kustomize build apps/xgboost-job/upstream/overlays/kubeflow | kubectl apply -f -
 
 #### User Namespace
 
-Finally, create a new namespace for the the default user (named `user-example-com`).
+Finally, create a new namespace (named `kubeflow-user-example-com`) for the the default user (named `user@example.com`).
 
 ```sh
 kustomize build common/user-namespace/base | kubectl apply -f -

--- a/README.md
+++ b/README.md
@@ -71,7 +71,7 @@ Option 2 targets customization and ability to pick and choose individual compone
 
 The `example` directory contains an example kustomization for the single command to be able to run.
 
-:warning: In both options, we use a default username (`user`) and password (`12341234`). For any production Kubeflow deployment, you should change the default password by following [the relevant section](#change-default-user-password).
+:warning: In both options, we use a default username (`user@example.com`) and password (`12341234`). For any production Kubeflow deployment, you should change the default password by following [the relevant section](#change-default-user-password).
 
 ### Prerequisites
 
@@ -136,7 +136,7 @@ kustomize build common/istio-1-9-0/istio-install/base | kubectl apply -f -
 
 #### Dex
 
-Dex is an OpenID Connect Identity (OIDC) with multiple authentication backends. In this default installation, it includes a static user named `user`. By default, the user's password is `12341234`. For any production Kubeflow deployment, you should change the default password by following [the relevant section](#change-default-user-password).
+Dex is an OpenID Connect Identity (OIDC) with multiple authentication backends. In this default installation, it includes a static user named `user` with E-mail `user@example.com`. By default, the user's password is `12341234`. For any production Kubeflow deployment, you should change the default password by following [the relevant section](#change-default-user-password).
 
 Install Dex:
 
@@ -361,7 +361,7 @@ kustomize build apps/xgboost-job/upstream/overlays/kubeflow | kubectl apply -f -
 
 #### User Namespace
 
-Finally, create a new namespace for the the default user (named `user`).
+Finally, create a new namespace for the the default user (named `user-example-com`).
 
 ```sh
 kustomize build common/user-namespace/base | kubectl apply -f -


### PR DESCRIPTION
Fixes https://github.com/kubeflow/manifests/issues/1870

**Which issue is resolved by this Pull Request:**
Resolves #1870

**Description of your changes:**
Just update `READMD.md` to reflect default user name to a valid email address

**Checklist:**
- [x] Unit tests pass:
  **Make sure you have installed kustomize == 3.2.1**
    1. `make generate-changed-only`
    2. `make test`
