### PR TITLE
Fix dex for Kubernetes 1.21

### DIFF
--- a/common/dex/base/deployment.yaml
+++ b/common/dex/base/deployment.yaml
@@ -28,6 +28,11 @@ spec:
         envFrom:
           - secretRef:
               name: dex-oidc-client
+        env:
+          - name: KUBERNETES_POD_NAMESPACE
+            valueFrom:
+              fieldRef:
+                fieldPath: metadata.namespace
       volumes:
       - name: config
         configMap:


### PR DESCRIPTION
Add KUBERNETES_POD_NAMESPACE environment variable for namespace discovery.

This fixes issue #1882 

This workaround has been mentioned [here](https://github.com/dexidp/dex/issues/2082#issuecomment-818124478) in the upstream dex project.

Tested on microk8s 1.21.

**Which issue is resolved by this Pull Request:**
Resolves #

**Description of your changes:**


**Checklist:**
- [ ] Unit tests pass:
  **Make sure you have installed kustomize == 3.2.1**
    1. `make generate-changed-only`
    2. `make test`
