### PR TITLE
bump gke node and master versions to 1.17 from 1.16 (#1887)

### DIFF
--- a/gcp/v2/cnrm/cluster/cluster.yaml
+++ b/gcp/v2/cnrm/cluster/cluster.yaml
@@ -60,5 +60,5 @@ spec:
       name: name-vm # {"$kpt-set":"name-vm"}
     workloadMetadataConfig:
       nodeMetadata: GKE_METADATA_SERVER
-  nodeVersion: '1.16'
-  minMasterVersion: '1.16'
+  nodeVersion: '1.17'
+  minMasterVersion: '1.17'


### PR DESCRIPTION
1.16 is no longer available. 1.17 seems to be the maximum version where kubeflow works in GCP.

**Which issue is resolved by this Pull Request:**
Resolves #1887

**Description of your changes:**
bump gke node and master versions to 1.17 from 1.16

**Checklist:**
- [x] Unit tests pass:
  **Make sure you have installed kustomize == 3.2.1**
    1. `make generate-changed-only`
    2. `make test`
