### PR TITLE
Use more consistent and sensible requests and limits for seldon

### DIFF
--- a/contrib/seldon/seldon-core-operator/base/resources.yaml
+++ b/contrib/seldon/seldon-core-operator/base/resources.yaml
@@ -4976,17 +4976,17 @@ spec:
         - name: DEFAULT_USER_ID
           value: '8888'
         - name: EXECUTOR_DEFAULT_CPU_REQUEST
-          value: '500m'
+          value: '100m'
         - name: EXECUTOR_DEFAULT_MEMORY_REQUEST
-          value: '512Mi'
+          value: '256Mi'
         - name: EXECUTOR_DEFAULT_CPU_LIMIT
           value: '500m'
         - name: EXECUTOR_DEFAULT_MEMORY_LIMIT
           value: '512Mi'
         - name: ENGINE_DEFAULT_CPU_REQUEST
-          value: '500m'
+          value: '100m'
         - name: ENGINE_DEFAULT_MEMORY_REQUEST
-          value: '512Mi'
+          value: '256Mi'
         - name: ENGINE_DEFAULT_CPU_LIMIT
           value: '500m'
         - name: ENGINE_DEFAULT_MEMORY_LIMIT


### PR DESCRIPTION
I lowered the requests, such that there is actually a reason to set separate limits and requests.

this is also done properly at other places in the same file https://github.com/kubeflow/manifests/blob/3eab165b37283f7965786dd0e906db577a6767af/contrib/seldon/seldon-core-operator/base/resources.yaml#L5004-L5010

Upstream https://github.com/SeldonIO/seldon-core/pull/3213
@cliveseldon 

