### PR TITLE
Update Katib images for Kubeflow 1.3.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ This repo periodically syncs all official Kubeflow components from their respect
 | Jupyter Web App | apps/jupyter/jupyter-web-app/upstream | [v1.3.0-rc.1](https://github.com/kubeflow/kubeflow/tree/v1.3.0-rc.1/components/crud-web-apps/jupyter/manifests) |
 | Tensorboards Web App | apps/tensorboard/tensorboards-web-app/upstream | [v1.3.0-rc.1](https://github.com/kubeflow/kubeflow/tree/v1.3.0-rc.1/components/crud-web-apps/tensorboards/manifests) |
 | Volumes Web App | apps/volumes-web-app/upstream | [v1.3.0-rc.1](https://github.com/kubeflow/kubeflow/tree/v1.3.0-rc.1/components/crud-web-apps/volumes/manifests) |
-| Katib | apps/katib/upstream | [origin/release-0.11 (7d7c34c72ab8bce74262c7abbe55ef9312291219)](https://github.com/kubeflow/katib/tree/7d7c34c72ab8bce74262c7abbe55ef9312291219/manifests/v1beta1) |
+| Katib | apps/katib/upstream | [v0.11.1](https://github.com/kubeflow/katib/tree/v0.11.1/manifests/v1beta1) |
 | KFServing | apps/kfserving/upstream | [origin/release-0.5 (e189a510121c09f764f749143b80f6ee6baaf48b)](https://github.com/kubeflow/kfserving/tree/e189a510121c09f764f749143b80f6ee6baaf48b/config) |
 | Kubeflow Pipelines | apps/pipeline/upstream | [1.5.0](https://github.com/kubeflow/pipelines/tree/1.5.0/manifests/kustomize) |
 | Kubeflow Tekton Pipelines | apps/kfp-tekton/upstream | [v0.8.0-rc0](https://github.com/kubeflow/kfp-tekton/tree/v0.8.0-rc0/manifests/kustomize) |

--- a/apps/katib/upstream/components/controller/katib-config.yaml
+++ b/apps/katib/upstream/components/controller/katib-config.yaml
@@ -7,13 +7,13 @@ data:
   metrics-collector-sidecar: |-
     {
       "StdOut": {
-        "image": "docker.io/kubeflowkatib/file-metrics-collector:v0.11.0"
+        "image": "docker.io/kubeflowkatib/file-metrics-collector:v0.11.1"
       },
       "File": {
-        "image": "docker.io/kubeflowkatib/file-metrics-collector:v0.11.0"
+        "image": "docker.io/kubeflowkatib/file-metrics-collector:v0.11.1"
       },
       "TensorFlowEvent": {
-        "image": "docker.io/kubeflowkatib/tfevent-metrics-collector:v0.11.0",
+        "image": "docker.io/kubeflowkatib/tfevent-metrics-collector:v0.11.1",
         "resources": {
           "limits": {
             "memory": "1Gi"
@@ -24,25 +24,25 @@ data:
   suggestion: |-
     {
       "random": {
-        "image": "docker.io/kubeflowkatib/suggestion-hyperopt:v0.11.0"
+        "image": "docker.io/kubeflowkatib/suggestion-hyperopt:v0.11.1"
       },
       "tpe": {
-        "image": "docker.io/kubeflowkatib/suggestion-hyperopt:v0.11.0"
+        "image": "docker.io/kubeflowkatib/suggestion-hyperopt:v0.11.1"
       },
       "grid": {
-        "image": "docker.io/kubeflowkatib/suggestion-chocolate:v0.11.0"
+        "image": "docker.io/kubeflowkatib/suggestion-chocolate:v0.11.1"
       },
       "hyperband": {
-        "image": "docker.io/kubeflowkatib/suggestion-hyperband:v0.11.0"
+        "image": "docker.io/kubeflowkatib/suggestion-hyperband:v0.11.1"
       },
       "bayesianoptimization": {
-        "image": "docker.io/kubeflowkatib/suggestion-skopt:v0.11.0"
+        "image": "docker.io/kubeflowkatib/suggestion-skopt:v0.11.1"
       },
       "cmaes": {
-        "image": "docker.io/kubeflowkatib/suggestion-goptuna:v0.11.0"
+        "image": "docker.io/kubeflowkatib/suggestion-goptuna:v0.11.1"
       },
       "enas": {
-        "image": "docker.io/kubeflowkatib/suggestion-enas:v0.11.0",
+        "image": "docker.io/kubeflowkatib/suggestion-enas:v0.11.1",
         "resources": {
           "limits": {
             "memory": "200Mi"
@@ -50,12 +50,12 @@ data:
         }
       },
       "darts": {
-        "image": "docker.io/kubeflowkatib/suggestion-darts:v0.11.0"
+        "image": "docker.io/kubeflowkatib/suggestion-darts:v0.11.1"
       }
     }
   early-stopping: |-
     {
       "medianstop": {
-        "image": "docker.io/kubeflowkatib/earlystopping-medianstop:v0.11.0"
+        "image": "docker.io/kubeflowkatib/earlystopping-medianstop:v0.11.1"
       }
     }

--- a/apps/katib/upstream/installs/katib-cert-manager/kustomization.yaml
+++ b/apps/katib/upstream/installs/katib-cert-manager/kustomization.yaml
@@ -21,13 +21,13 @@ resources:
 images:
   - name: docker.io/kubeflowkatib/katib-controller
     newName: docker.io/kubeflowkatib/katib-controller
-    newTag: v0.11.0
+    newTag: v0.11.1
   - name: docker.io/kubeflowkatib/katib-db-manager
     newName: docker.io/kubeflowkatib/katib-db-manager
-    newTag: v0.11.0
+    newTag: v0.11.1
   - name: docker.io/kubeflowkatib/katib-ui
     newName: docker.io/kubeflowkatib/katib-ui
-    newTag: v0.11.0
+    newTag: v0.11.1
 
 patchesStrategicMerge:
   - patches/katib-cert-injection.yaml

--- a/apps/katib/upstream/installs/katib-external-db/kustomization.yaml
+++ b/apps/katib/upstream/installs/katib-external-db/kustomization.yaml
@@ -19,16 +19,16 @@ resources:
 images:
   - name: docker.io/kubeflowkatib/katib-controller
     newName: docker.io/kubeflowkatib/katib-controller
-    newTag: v0.11.0
+    newTag: v0.11.1
   - name: docker.io/kubeflowkatib/katib-db-manager
     newName: docker.io/kubeflowkatib/katib-db-manager
-    newTag: v0.11.0
+    newTag: v0.11.1
   - name: docker.io/kubeflowkatib/katib-ui
     newName: docker.io/kubeflowkatib/katib-ui
-    newTag: v0.11.0
+    newTag: v0.11.1
   - name: docker.io/kubeflowkatib/cert-generator
     newName: docker.io/kubeflowkatib/cert-generator
-    newTag: v0.11.0
+    newTag: v0.11.1
 patchesStrategicMerge:
   - db-manager-patch.yaml
 # Modify katib-mysql-secrets with parameters for the DB.

--- a/apps/katib/upstream/installs/katib-standalone/kustomization.yaml
+++ b/apps/katib/upstream/installs/katib-standalone/kustomization.yaml
@@ -21,13 +21,13 @@ resources:
 images:
   - name: docker.io/kubeflowkatib/katib-controller
     newName: docker.io/kubeflowkatib/katib-controller
-    newTag: v0.11.0
+    newTag: v0.11.1
   - name: docker.io/kubeflowkatib/katib-db-manager
     newName: docker.io/kubeflowkatib/katib-db-manager
-    newTag: v0.11.0
+    newTag: v0.11.1
   - name: docker.io/kubeflowkatib/katib-ui
     newName: docker.io/kubeflowkatib/katib-ui
-    newTag: v0.11.0
+    newTag: v0.11.1
   - name: docker.io/kubeflowkatib/cert-generator
     newName: docker.io/kubeflowkatib/cert-generator
-    newTag: v0.11.0
+    newTag: v0.11.1

--- a/apps/katib/upstream/installs/katib-with-kubeflow/kustomization.yaml
+++ b/apps/katib/upstream/installs/katib-with-kubeflow/kustomization.yaml
@@ -9,13 +9,13 @@ resources:
 images:
   - name: docker.io/kubeflowkatib/katib-controller
     newName: docker.io/kubeflowkatib/katib-controller
-    newTag: v0.11.0
+    newTag: v0.11.1
   - name: docker.io/kubeflowkatib/katib-db-manager
     newName: docker.io/kubeflowkatib/katib-db-manager
-    newTag: v0.11.0
+    newTag: v0.11.1
   - name: docker.io/kubeflowkatib/katib-ui
     newName: docker.io/kubeflowkatib/katib-ui
-    newTag: v0.11.0
+    newTag: v0.11.1
 
 patchesStrategicMerge:
   - patches/remove-resources-patch.yaml


### PR DESCRIPTION
**Which issue is resolved by this Pull Request:**
Related: https://github.com/kubeflow/manifests/issues/1890.

**Description of your changes:**
This is updated Katib 0.11.1 images for Kubeflow 1.3.1 release.

/assign @yanniszark @gaocegege @johnugeorge 

**Checklist:**
- [ ] Unit tests pass:
  **Make sure you have installed kustomize == 3.2.1**
    1. `make generate-changed-only`
    2. `make test`
