### PR TITLE
Add linguist configuration

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,2 @@
+*.yaml linguist-detectable=true
+*.json linguist-detectable=true


### PR DESCRIPTION
By default, GitHub does not detect YAML files in a repository. As a result, this repository shows as being mostly Python, Go and Shell scripts. However, this is not an accurate representation of the repository for users (see below).

![image](https://user-images.githubusercontent.com/28541758/122044703-180e7800-cddd-11eb-855a-d74c5df7ca7a.png)

This PR adds a `.gitattributes` file that enables the detection of YAML and JSON by GitHub and takes these into account in the Languages section. Below is an example of what this would look like (from a different repository).

![image](https://user-images.githubusercontent.com/28541758/122044741-2492d080-cddd-11eb-88b6-5f506a25d95b.png)

/cc @kubeflow/wg-manifests-leads 