### PR TITLE
WIP: Fixing KF 1.3 on OCP after cert-manager and istio upgrades

### DIFF
--- a/distributions/kfdef/kfctl_openshift_v1.3.0.yaml
+++ b/distributions/kfdef/kfctl_openshift_v1.3.0.yaml
@@ -13,7 +13,7 @@ spec:
   - kustomizeConfig:
       repoRef:
         name: manifests
-        path: distributions/stacks/openshift/application/istio-1-9-Openshift
+        path: distributions/stacks/openshift/application/istio-1-9-0-Openshift
     name: istio-stack
   - kustomizeConfig:
       repoRef:

--- a/distributions/stacks/openshift/application/cert-manager/kustomization.yaml
+++ b/distributions/stacks/openshift/application/cert-manager/kustomization.yaml
@@ -4,8 +4,7 @@ commonLabels:
   app.kubernetes.io/name: cert-manager
   kustomize.component: cert-manager
 kind: Kustomization
-#namespace: cert-manager
+namespace: cert-manager
 resources:
-- ../../../../../common/cert-manager/cert-manager-kube-system-resources/base
-- ../../../../../common/cert-manager/cert-manager-crds/base
-- ../../../../../common/cert-manager/cert-manager/overlays/self-signed
+- ../../../../../common/cert-manager/cert-manager/base/
+- ../../../../../common/cert-manager/kubeflow-issuer/base

--- a/distributions/stacks/openshift/application/cert-manager/kustomization.yaml
+++ b/distributions/stacks/openshift/application/cert-manager/kustomization.yaml
@@ -4,7 +4,7 @@ commonLabels:
   app.kubernetes.io/name: cert-manager
   kustomize.component: cert-manager
 kind: Kustomization
-namespace: cert-manager
+#namespace: cert-manager
 resources:
 - ../../../../../common/cert-manager/cert-manager/base/
 - ../../../../../common/cert-manager/kubeflow-issuer/base

--- a/distributions/stacks/openshift/application/knative/kustomization.yaml
+++ b/distributions/stacks/openshift/application/knative/kustomization.yaml
@@ -2,5 +2,6 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
 - ../../../../../common/knative/knative-serving/base
+- network-attachment.yaml
 - ../../../../../common/istio-1-9/cluster-local-gateway/base
 - ../../../../../common/knative/knative-eventing/base

--- a/distributions/stacks/openshift/application/knative/kustomization.yaml
+++ b/distributions/stacks/openshift/application/knative/kustomization.yaml
@@ -1,8 +1,6 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
-- ../../../../../common/knative/knative-serving-crds/base
-- ../../../../../common/knative/knative-serving-install/base
-- ../../../../../common/knative/knative-eventing-crds/base
-- ../../../../../common/knative/knative-eventing-install/base
+- ../../../../../common/knative/knative-serving/base
 - ../../../../../common/istio-1-9/cluster-local-gateway/base
+- ../../../../../common/knative/knative-eventing/base

--- a/distributions/stacks/openshift/application/openshift/openshift-scc/kustomization.yaml
+++ b/distributions/stacks/openshift/application/openshift/openshift-scc/kustomization.yaml
@@ -6,6 +6,7 @@ resources:
 - kubeflow-privileged-scc-istio.yaml
 - kubeflow-anyuid-scc.yaml
 - tekton-anyuid-scc.yaml
+- knative-anyuid-scc.yaml
 vars:
   - name: NAMESPACE
     objref:
@@ -21,6 +22,13 @@ vars:
       name: scc-namespace-check
     fieldref:
       fieldpath: data.tekton-namespace
+  - name: KNATIVE-NAMESPACE
+    objref:
+      apiVersion: v1
+      kind: ConfigMap
+      name: scc-namespace-check
+    fieldref:
+      fieldpath: data.knative-namespace
 generatorOptions:
   disableNameSuffixHash: true
 configMapGenerator:

--- a/distributions/stacks/openshift/application/openshift/openshift-scc/params.env
+++ b/distributions/stacks/openshift/application/openshift/openshift-scc/params.env
@@ -1,2 +1,3 @@
 namespace=kubeflow
 tekton-namespace=tekton-pipelines
+knative-namespace=knative-serving

--- a/distributions/stacks/openshift/kustomization.yaml
+++ b/distributions/stacks/openshift/kustomization.yaml
@@ -8,7 +8,7 @@ resources:
   - ../../../common/istio-1-9/kubeflow-istio-resources/base
 ## Per istion 1.9 installation on openshift https://istio.io/latest/docs/setup/platform-setup/openshift/
 # This is here because it needs to install in namespace kubeflow
-  - application/istio-1-9-Openshift/network-attachment.yaml
+  - application/istio-1-9-0-Openshift/network-attachment.yaml
   - ../../../apps/centraldashboard/upstream/overlays/istio
 #Admission webhooks
   - ../../../apps/admission-webhook/upstream/overlays/cert-manager


### PR DESCRIPTION
**Which issue is resolved by this Pull Request:**
Resolves #
After the upgrade of istio and cert-manger for KF1.3 this broke the Openshift distribution stack
**Description of your changes:**


**Checklist:**
- [ ] Unit tests pass:
  **Make sure you have installed kustomize == 3.2.1**
    1. `make generate-changed-only`
    2. `make test`
