### PR TITLE
Openshift distribution: Fixing the uri to point to a tag 1.3.0 and not a branch 1.3.0

### DIFF
--- a/distributions/kfdef/kfctl_openshift_v1.3.0.yaml
+++ b/distributions/kfdef/kfctl_openshift_v1.3.0.yaml
@@ -13,7 +13,7 @@ spec:
   - kustomizeConfig:
       repoRef:
         name: manifests
-        path: distributions/stacks/openshift/application/istio-1-9-Openshift
+        path: distributions/stacks/openshift/application/istio-1-9-0-Openshift
     name: istio-stack
   - kustomizeConfig:
       repoRef:
@@ -80,5 +80,5 @@ spec:
     name: kubeflow-apps
   repos:
   - name: manifests
-    uri: https://github.com/kubeflow/manifests/archive/v1.3-branch.tar.gz
-  version: v1.3-branch
+    uri: https://github.com/kubeflow/manifests/archive/v1.3.0.tar.gz
+  version: v1.3-tag

--- a/distributions/kfdef/kfctl_openshift_v1.3.0.yaml
+++ b/distributions/kfdef/kfctl_openshift_v1.3.0.yaml
@@ -81,4 +81,4 @@ spec:
   repos:
   - name: manifests
     uri: https://github.com/kubeflow/manifests/archive/v1.3.0.tar.gz
-  version: v1.3-tag
+  version: v1.3.0-tag


### PR DESCRIPTION
**Which issue is resolved by this Pull Request:**
#1933
**Description of your changes:**
Changing uri to point to a tag and not a branch. Also fixing the istio folder to the right name in the 1.3.0 tag

**Checklist:**
- [ ] Unit tests pass:
  **Make sure you have installed kustomize == 3.2.1**
    1. `make generate-changed-only`
    2. `make test`
