### PR TITLE
Openshift distribution: Fixing the uri to point to a tag 1.3.0 and no…

### DIFF
--- a/distributions/kfdef/kfctl_openshift_v1.3.0.yaml
+++ b/distributions/kfdef/kfctl_openshift_v1.3.0.yaml
@@ -13,7 +13,7 @@ spec:
   - kustomizeConfig:
       repoRef:
         name: manifests
-        path: distributions/stacks/openshift/application/istio-1-9-Openshift
+        path: distributions/stacks/openshift/application/istio-1-9-0-Openshift
     name: istio-stack
   - kustomizeConfig:
       repoRef:
@@ -80,5 +80,5 @@ spec:
     name: kubeflow-apps
   repos:
   - name: manifests
-    uri: https://github.com/kubeflow/manifests/archive/v1.3-branch.tar.gz
-  version: v1.3-branch
+    uri: https://github.com/kubeflow/manifests/archive/v1.3.0.tar.gz
+  version: v1.3.0-tag


### PR DESCRIPTION
This is for cherry picking #1934 to v1.3-branch. For our KF 1.3.1 integration we will create an example kfdef with name kfctl_openshift_v1.3.1.yaml.
* Fixing the uri to point to a tag 1.3.0 and the istio folder name

* Specifying TAG 1.3.0

Co-authored-by: Juana Nakfour <nakfour>

**Which issue is resolved by this Pull Request:**
Resolves #

**Description of your changes:**


**Checklist:**
- [ ] Unit tests pass:
  **Make sure you have installed kustomize == 3.2.1**
    1. `make generate-changed-only`
    2. `make test`
