### PR TITLE
Add the release team as owners in the relevant dir

### DIFF
--- a/docs/release/OWNERS
+++ b/docs/release/OWNERS
@@ -1,0 +1,10 @@
+approvers:
+  - DavidSpek
+  - kimwnasptd
+  - mkbhanda
+  - RFMVasconcelos
+reviewers:
+  - DavidSpek
+  - kimwnasptd
+  - mkbhanda
+  - RFMVasconcelos


### PR DESCRIPTION
Adding the release team as owners to the `docs/release` directory.

cc @kubeflow/wg-manifests-leads 
/cc @RFMVasconcelos @DavidSpek @mkbhanda
/assign @kimwnasptd
