### PR TITLE
Sync manifests for Notebooks WG v1.4-rc.0

### DIFF
--- a/apps/admission-webhook/upstream/base/crd.yaml
+++ b/apps/admission-webhook/upstream/base/crd.yaml
@@ -25,6 +25,8 @@ spec:
               type: string
             serviceAccountName:
               type: string
+            automountServiceAccountToken:
+              type: boolean
             env:
               items:
                 type: object

--- a/apps/admission-webhook/upstream/base/kustomization.yaml
+++ b/apps/admission-webhook/upstream/base/kustomization.yaml
@@ -16,7 +16,7 @@ commonLabels:
 images:
 - name: public.ecr.aws/j1r0q0g6/notebooks/admission-webhook
   newName: public.ecr.aws/j1r0q0g6/notebooks/admission-webhook
-  newTag: v1.3.1-rc.0
+  newTag: v1.4-rc.0
 namespace: kubeflow
 generatorOptions:
   disableNameSuffixHash: true

--- a/apps/centraldashboard/upstream/base/configmap.yaml
+++ b/apps/centraldashboard/upstream/base/configmap.yaml
@@ -27,6 +27,12 @@ data:
         },
         {
           "type": "item",
+          "link": "/models/",
+          "text": "Models",
+          "icon": "kubeflow:models"
+        },
+        {
+          "type": "item",
           "link": "/katib/",
           "text": "Experiments (AutoML)",
           "icon": "kubeflow:katib"

--- a/apps/centraldashboard/upstream/base/kustomization.yaml
+++ b/apps/centraldashboard/upstream/base/kustomization.yaml
@@ -18,7 +18,7 @@ commonLabels:
 images:
 - name: public.ecr.aws/j1r0q0g6/notebooks/central-dashboard
   newName: public.ecr.aws/j1r0q0g6/notebooks/central-dashboard
-  newTag: v1.3.1-rc.0
+  newTag: v1.4-rc.0
 configMapGenerator:
 - envs:
   - params.env

--- a/apps/jupyter/jupyter-web-app/upstream/base/configs/spawner_ui_config.yaml
+++ b/apps/jupyter/jupyter-web-app/upstream/base/configs/spawner_ui_config.yaml
@@ -17,23 +17,23 @@
 spawnerFormDefaults:
   image:
     # The container Image for the user's Jupyter Notebook
-    value: public.ecr.aws/j1r0q0g6/notebooks/notebook-servers/jupyter-scipy:v1.3.1-rc.0
+    value: public.ecr.aws/j1r0q0g6/notebooks/notebook-servers/jupyter-scipy:v1.4-rc.0
     # The list of available standard container Images
     options:
-    - public.ecr.aws/j1r0q0g6/notebooks/notebook-servers/jupyter-scipy:v1.3.1-rc.0
-    - public.ecr.aws/j1r0q0g6/notebooks/notebook-servers/jupyter-pytorch-full:v1.3.1-rc.0
-    - public.ecr.aws/j1r0q0g6/notebooks/notebook-servers/jupyter-pytorch-cuda-full:v1.3.1-rc.0
-    - public.ecr.aws/j1r0q0g6/notebooks/notebook-servers/jupyter-tensorflow-full:v1.3.1-rc.0
-    - public.ecr.aws/j1r0q0g6/notebooks/notebook-servers/jupyter-tensorflow-cuda-full:v1.3.1-rc.0
+    - public.ecr.aws/j1r0q0g6/notebooks/notebook-servers/jupyter-scipy:v1.4-rc.0
+    - public.ecr.aws/j1r0q0g6/notebooks/notebook-servers/jupyter-pytorch-full:v1.4-rc.0
+    - public.ecr.aws/j1r0q0g6/notebooks/notebook-servers/jupyter-pytorch-cuda-full:v1.4-rc.0
+    - public.ecr.aws/j1r0q0g6/notebooks/notebook-servers/jupyter-tensorflow-full:v1.4-rc.0
+    - public.ecr.aws/j1r0q0g6/notebooks/notebook-servers/jupyter-tensorflow-cuda-full:v1.4-rc.0
   imageGroupOne:
     # The container Image for the user's Group One Server
     # The annotation `notebooks.kubeflow.org/http-rewrite-uri: /`
     # is applied to notebook in this group, configuring
     # the Istio rewrite for containers that host their web UI at `/`
-    value: public.ecr.aws/j1r0q0g6/notebooks/notebook-servers/codeserver-python:v1.3.1-rc.0
+    value: public.ecr.aws/j1r0q0g6/notebooks/notebook-servers/codeserver-python:v1.4-rc.0
     # The list of available standard container Images
     options:
-    - public.ecr.aws/j1r0q0g6/notebooks/notebook-servers/codeserver-python:v1.3.1-rc.0
+    - public.ecr.aws/j1r0q0g6/notebooks/notebook-servers/codeserver-python:v1.4-rc.0
   imageGroupTwo:
     # The container Image for the user's Group Two Server
     # The annotation `notebooks.kubeflow.org/http-rewrite-uri: /`
@@ -42,12 +42,18 @@ spawnerFormDefaults:
     # The annotation `notebooks.kubeflow.org/http-headers-request-set`
     # is applied to notebook in this group, configuring Istio
     # to add the `X-RStudio-Root-Path` header to requests
-    value: public.ecr.aws/j1r0q0g6/notebooks/notebook-servers/rstudio-tidyverse:v1.3.1-rc.0
+    value: public.ecr.aws/j1r0q0g6/notebooks/notebook-servers/rstudio-tidyverse:v1.4-rc.0
     # The list of available standard container Images
     options:
-    - public.ecr.aws/j1r0q0g6/notebooks/notebook-servers/rstudio-tidyverse:v1.3.1-rc.0
+    - public.ecr.aws/j1r0q0g6/notebooks/notebook-servers/rstudio-tidyverse:v1.4-rc.0
+  # If true, hide registry and/or tag name in the image selection dropdown
+  hideRegistry: true
+  hideTag: false
   allowCustomImage: true
+  # If true, users can input custom images
+  # If false, users can only select from the images in this config
   imagePullPolicy:
+    # Supported values: Always, IfNotPresent, Never
     value: IfNotPresent
     readOnly: false
   cpu:
@@ -63,6 +69,9 @@ spawnerFormDefaults:
     # Factor by with to multiply request to calculate limit
     # if no limit is set, to disable set "none"
     limitFactor: "1.2"
+    readOnly: false
+  environment:
+    value: {}
     readOnly: false
   workspaceVolume:
     # Workspace Volume to be attached to user's Notebook
@@ -81,7 +90,7 @@ spawnerFormDefaults:
         value: 'workspace-{notebook-name}'
       size:
         # The Size of the Workspace Volume (in Gi)
-        value: '10Gi'
+        value: '5Gi'
       mountPath:
         # The Path that the Workspace Volume will be mounted
         value: /home/jovyan
@@ -146,6 +155,54 @@ spawnerFormDefaults:
       # Values: "" or a `limits-key` from the vendors list
       vendor: ""
     readOnly: false
+  affinityConfig:
+    # If readonly, the default value will be the only option
+    # value is a list of `configKey`s that we want to be selected by default
+    value: ""
+    # The list of available affinity configs
+    options: []
+    #options:
+    #  - configKey: "exclusive__n1-standard-2"
+    #    displayName: "Exclusive: n1-standard-2"
+    #    affinity:
+    #      # (Require) Node having label: `node_pool=notebook-n1-standard-2`
+    #      nodeAffinity:
+    #        requiredDuringSchedulingIgnoredDuringExecution:
+    #          nodeSelectorTerms:
+    #            - matchExpressions:
+    #                - key: "node_pool"
+    #                  operator: "In"
+    #                  values:
+    #                   - "notebook-n1-standard-2"
+    #      # (Require) Node WITHOUT existing Pod having label: `notebook-name`
+    #      podAntiAffinity:
+    #        requiredDuringSchedulingIgnoredDuringExecution:
+    #          - labelSelector:
+    #              matchExpressions:
+    #                - key: "notebook-name"
+    #                  operator: "Exists"
+    #            namespaces: []
+    #            topologyKey: "kubernetes.io/hostname"
+    #readOnly: false
+  tolerationGroup:
+    # The default `groupKey` from the options list
+    # If readonly, the default value will be the only option
+    value: ""
+    # The list of available tolerationGroup configs
+    options: []
+    #options:
+    #  - groupKey: "group_1"
+    #    displayName: "Group 1: description"
+    #    tolerations:
+    #      - key: "key1"
+    #        operator: "Equal"
+    #        value: "value1"
+    #        effect: "NoSchedule"
+    #      - key: "key2"
+    #        operator: "Equal"
+    #        value: "value2"
+    #        effect: "NoSchedule"
+    readOnly: false
   shm:
     value: true
     readOnly: false
@@ -155,54 +212,4 @@ spawnerFormDefaults:
     #   - add-gcp-secret
     #   - default-editor
     value: []
-    readOnly: false
-  affinityConfig:
-    # The default `configKey` from the options list
-    # If readonly, the default value will be the only option
-    value: "none"
-    # The list of available affinity configs
-    options: []
-    # # (DESC) Pod gets an exclusive "n1-standard-2" Node
-    # # (TIP) set PreferNoSchedule taint on this node-pool
-    # # (TIP) enable cluster-autoscaler on this node-pool
-    # # (TIP) dont let users request more CPU/MEMORY than the size of this node
-    # - configKey: "exclusive__n1-standard-2"
-    #   displayName: "Exclusive: n1-standard-2"
-    #   affinity:
-    #     # (Require) Node having label: `node_pool=notebook-n1-standard-2`
-    #     nodeAffinity:
-    #       requiredDuringSchedulingIgnoredDuringExecution:
-    #         nodeSelectorTerms:
-    #           - matchExpressions:
-    #               - key: "node_pool"
-    #                 operator: "In"
-    #                 values:
-    #                   - "notebook-n1-standard-2"
-    #     # (Require) Node WITHOUT existing Pod having label: `notebook-name`
-    #     podAntiAffinity:
-    #       requiredDuringSchedulingIgnoredDuringExecution:
-    #         - labelSelector:
-    #             matchExpressions:
-    #               - key: "notebook-name"
-    #                 operator: "Exists"
-    #           namespaces: []
-    #           topologyKey: "kubernetes.io/hostname"
-    readOnly: false
-  tolerationGroup:
-    # The default `groupKey` from the options list
-    # If readonly, the default value will be the only option
-    value: "none"
-    # The list of available tolerationGroup configs
-    options: []
-    # - groupKey: "group_1"
-    #   displayName: "Group 1: description"
-    #   tolerations:
-    #     - key: "key1"
-    #       operator: "Equal"
-    #       value: "value1"
-    #       effect: "NoSchedule"
-    #     - key: "key2"
-    #       operator: "Equal"
-    #       value: "value2"
-    #       effect: "NoSchedule"
     readOnly: false

--- a/apps/jupyter/jupyter-web-app/upstream/base/kustomization.yaml
+++ b/apps/jupyter/jupyter-web-app/upstream/base/kustomization.yaml
@@ -23,7 +23,7 @@ commonLabels:
 images:
 - name: public.ecr.aws/j1r0q0g6/notebooks/jupyter-web-app
   newName: public.ecr.aws/j1r0q0g6/notebooks/jupyter-web-app
-  newTag: v1.3.1-rc.0
+  newTag: v1.4-rc.0
 # We need the name to be unique without the suffix because the original name is what
 # gets used with patches
 configMapGenerator:

--- a/apps/jupyter/notebook-controller/upstream/base/kustomization.yaml
+++ b/apps/jupyter/notebook-controller/upstream/base/kustomization.yaml
@@ -5,4 +5,4 @@ resources:
 images:
 - name: public.ecr.aws/j1r0q0g6/notebooks/notebook-controller
   newName: public.ecr.aws/j1r0q0g6/notebooks/notebook-controller
-  newTag: v1.3.1-rc.0
+  newTag: v1.4-rc.0

--- a/apps/profiles/upstream/README.md
+++ b/apps/profiles/upstream/README.md
@@ -24,3 +24,10 @@ The breakdown is the following:
         - Add KFAM container.
         - Add KFAM Service and VirtualService.
     - `overlays/standalone`: Install `profile-controller` in its own namespace. Useful for testing or for users that prefer to install just the controller.
+
+
+### Settings
+
+#### Namespace label injection
+
+The Profile Controller applies several labels to every Profile namespace. These labels are configurable by editing the `namespace-labels` ConfigMap. Refer to the current value for usage instruction.

--- a/apps/profiles/upstream/base/kustomization.yaml
+++ b/apps/profiles/upstream/base/kustomization.yaml
@@ -6,7 +6,15 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
 - ../default
+patchesStrategicMerge:
+- patches/manager.yaml
+
 images:
 - name: public.ecr.aws/j1r0q0g6/notebooks/profile-controller
   newName: public.ecr.aws/j1r0q0g6/notebooks/profile-controller
-  newTag: v1.3.1-rc.0
+  newTag: v1.4-rc.0
+
+configMapGenerator:
+- name: namespace-labels-data
+  files:
+  - namespace-labels.yaml

--- a/apps/profiles/upstream/base/namespace-labels.yaml
+++ b/apps/profiles/upstream/base/namespace-labels.yaml
@@ -1,0 +1,18 @@
+# Below is a list of labels to be set by default.
+#
+# To add a namespace label, use `key: 'value'`, for example:
+# istio.io/rev: 'asm-191-1'
+#
+# To remove a namespace label, use `key: ''`. For example:
+# istio-injection: ''
+#
+# Profile controller will not replace a namespace label if its key already
+# exists. If you want to override the value of a previously applied label, you
+# need to:
+# 1. Remove the label by using `key: ''` and deploy.
+# 2. Add the label by using `key: 'value'` and deploy.
+#
+katib-metricscollector-injection:      'enabled'
+serving.kubeflow.org/inferenceservice: 'enabled'
+pipelines.kubeflow.org/enabled:        'true'
+app.kubernetes.io/part-of:             'kubeflow-profile'

--- a/apps/profiles/upstream/base/patches/manager.yaml
+++ b/apps/profiles/upstream/base/patches/manager.yaml
@@ -1,0 +1,19 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: deployment
+spec:
+  template:
+    spec:
+      volumes:
+        - name: namespace-labels
+          configMap:
+            # Provide the name of the ConfigMap containing the files you want
+            # to add to the container
+            name: namespace-labels-data
+      containers:
+      - name: manager
+        volumeMounts:
+        - name: namespace-labels
+          mountPath: /etc/profile-controller
+          readOnly: true

--- a/apps/profiles/upstream/overlays/kubeflow/kustomization.yaml
+++ b/apps/profiles/upstream/overlays/kubeflow/kustomization.yaml
@@ -28,4 +28,4 @@ vars:
 images:
 - name: public.ecr.aws/j1r0q0g6/notebooks/access-management
   newName: public.ecr.aws/j1r0q0g6/notebooks/access-management
-  newTag: v1.3.1-rc.0
+  newTag: v1.4-rc.0

--- a/apps/tensorboard/tensorboard-controller/upstream/base/kustomization.yaml
+++ b/apps/tensorboard/tensorboard-controller/upstream/base/kustomization.yaml
@@ -36,4 +36,4 @@ patches:
 images:
 - name: public.ecr.aws/j1r0q0g6/notebooks/tensorboard-controller
   newName: public.ecr.aws/j1r0q0g6/notebooks/tensorboard-controller
-  newTag: v1.3.1-rc.0
+  newTag: v1.4-rc.0

--- a/apps/tensorboard/tensorboard-controller/upstream/default/kustomization.yaml
+++ b/apps/tensorboard/tensorboard-controller/upstream/default/kustomization.yaml
@@ -9,8 +9,9 @@ namespace: tensorboard-controller-system
 namePrefix: tensorboard-controller-
 
 # Labels to add to all resources and selectors.
-#commonLabels:
-#  someName: someValue
+commonLabels:
+  app: tensorboard-controller
+  kustomize.component: tensorboard-controller
 
 bases:
 - ../crd

--- a/apps/tensorboard/tensorboards-web-app/upstream/base/kustomization.yaml
+++ b/apps/tensorboard/tensorboards-web-app/upstream/base/kustomization.yaml
@@ -14,7 +14,7 @@ commonLabels:
 images:
 - name: public.ecr.aws/j1r0q0g6/notebooks/tensorboards-web-app
   newName: public.ecr.aws/j1r0q0g6/notebooks/tensorboards-web-app
-  newTag: v1.3.1-rc.0
+  newTag: v1.4-rc.0
 # We need the name to be unique without the suffix because the original name is what
 # gets used with patches
 configMapGenerator:

--- a/apps/volumes-web-app/upstream/base/kustomization.yaml
+++ b/apps/volumes-web-app/upstream/base/kustomization.yaml
@@ -14,7 +14,7 @@ commonLabels:
 images:
 - name: public.ecr.aws/j1r0q0g6/notebooks/volumes-web-app
   newName: public.ecr.aws/j1r0q0g6/notebooks/volumes-web-app
-  newTag: v1.3.1-rc.0
+  newTag: v1.4-rc.0
 # We need the name to be unique without the suffix because the original name is what
 # gets used with patches
 configMapGenerator:


### PR DESCRIPTION
Closes #1972 

This PR uses the manifests from the https://github.com/kubeflow/kubeflow/tree/v1.4-rc.0 tag

/cc @kubeflow/wg-notebooks-leads 
