### PR TITLE
Update envoy-filter.yaml

### DIFF
--- a/common/oidc-authservice/base/envoy-filter.yaml
+++ b/common/oidc-authservice/base/envoy-filter.yaml
@@ -10,12 +10,10 @@ spec:
     - applyTo: HTTP_FILTER
       match:
         context: GATEWAY
-      listener:
-        filterChain:
-          filter:
-            name: "envoy.http_connection_manager"
-            subFilter:
-              name: ""
+        listener:
+          filterChain:
+            filter:
+              name: "envoy.filters.network.http_connection_manager"
       patch:
         # For some reason, INSERT_FIRST doesn't work
         operation: INSERT_BEFORE


### PR DESCRIPTION
**Which issue is resolved by this Pull Request:**
Resolves #1947 and deprecation warning: `using deprecated filter name "envoy.http_connection_manager"; use "envoy.filters.network.http_connection_manager" instead`


**Description of your changes:**


**Checklist:**
- [ ] Unit tests pass:
  **Make sure you have installed kustomize == 3.2.1**
    1. `make generate-changed-only`
    2. `make test`
