### PR TITLE
Allocate 3 weeks for distribution testing

### DIFF
--- a/docs/releases/release-1.4/README.md
+++ b/docs/releases/release-1.4/README.md
@@ -29,10 +29,10 @@ The 1.4 release cycle is proposed as follows
 | Mon Jun 7th 2021 | Week 1 | Community | [Development](../handbook.md#development-10-weeks) |
 | Sun Aug 15th 2021 | Week 10 | Release Team | [Feature Freeze](../handbook.md#feature-freeze-2-weeks) |
 | Sun Aug 15th 2021 | Week 10 | Docs Lead | [Documentation](../handbook.md#documentation) |
+| Sun Aug 29th 2021 | Week 12 | Release Team | [Manifests Testing](../handbook.md#manifests-testing-1-week) |
 | Sun Sep 5th 2021 | Week 13 | Docs Lead | End of [Documentation](../handbook.md#documentation) |
-| Mon Sep 6th 2021 | Week 13 | Release Team | [Manifests Testing](../handbook.md#manifests-testing-1-week) |
-| Sun Sep 12th 2021 | Week 14 | Release Team | End of [Manifests Testing](../handbook.md#manifests-testing-1-week) |
-| Mon Sep 13th 2021 | Week 14 | Release Team and Distribution Representative | [Distribution Testing](../handbook.md#distribution-testing-3-weeks) |
+| Sun Sep 5th 2021 | Week 13 | Release Team | End of [Manifests Testing](../handbook.md#manifests-testing-1-week) |
+| Mon Sep 6th 2021 | Week 14 | Release Team and Distribution Representative | [Distribution Testing](../handbook.md#distribution-testing-3-weeks) |
 | Sun Sep 26th 2021 | Week 17 | Release Team and Distribution Representative | End of [Distribution Testing](../handbook.md#distribution-testing-3-weeks) |
 | Mon Sep 27th 2021 | Week 17 | Release Team | **v1.4** [Release Day](../handbook.md/#release) |
 | Mon Sep 27th 2021 | Week 17 | Release Team | Publish Release Blog |


### PR DESCRIPTION
Right now we only give two weeks for distribution testing, but we should include 3 https://github.com/kubeflow/manifests/blob/master/docs/releases/handbook.md#timeline.

The manifests testing should happen 2 weeks after the feature freeze phase has started and in parallel with the docs effort. 

I missed this in the review of the initial PR https://github.com/kubeflow/manifests/pull/1974

/cc @annajung @kubeflow/release-team
