### PR TITLE
Use MPI operator tag v0.3.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ This repo periodically syncs all official Kubeflow components from their respect
 | Component | Local Manifests Path | Upstream Revision |
 | - | - | - |
 | Training Operator | apps/training-operator/upstream | [v1.3.0-alpha.2](https://github.com/kubeflow/tf-operator/tree/v1.3.0-alpha.2/manifests) |
-| MPI Operator | apps/mpi-job/upstream | [b367aa55886d2b042f5089df359d8e067e49e8d1](https://github.com/kubeflow/mpi-operator/tree/b367aa55886d2b042f5089df359d8e067e49e8d1/manifests) |
+| MPI Operator | apps/mpi-job/upstream | [v0.3.0](https://github.com/kubeflow/mpi-operator/tree/v0.3.0/manifests) |
 | Notebook Controller | apps/jupyter/notebook-controller/upstream | [v1.4-rc.0](https://github.com/kubeflow/kubeflow/tree/v1.4-rc.0/components/notebook-controller/config) |
 | Tensorboard Controller | apps/tensorboard/tensorboard-controller/upstream | [v1.4-rc.0](https://github.com/kubeflow/kubeflow/tree/v1.4-rc.0/components/tensorboard-controller/config) |
 | Central Dashboard | apps/centraldashboard/upstream | [v1.4-rc.0](https://github.com/kubeflow/kubeflow/tree/v1.4-rc.0/components/centraldashboard/manifests) |

--- a/apps/mpi-job/upstream/base/deployment.yaml
+++ b/apps/mpi-job/upstream/base/deployment.yaml
@@ -15,7 +15,9 @@ spec:
         sidecar.istio.io/inject: "false"
     spec:
       containers:
-      - args:
+      - name: mpi-operator
+        command: ["/opt/mpi-operator.v1"]
+        args:
         - -alsologtostderr
         - --lock-namespace
         - $(lock-namespace)
@@ -23,5 +25,4 @@ spec:
         - $(kubectl-delivery-image)
         image: mpioperator/mpi-operator:latest
         imagePullPolicy: Always
-        name: mpi-operator
       serviceAccountName: mpi-operator

--- a/apps/mpi-job/upstream/overlays/kubeflow/kustomization.yaml
+++ b/apps/mpi-job/upstream/overlays/kubeflow/kustomization.yaml
@@ -8,3 +8,7 @@ commonLabels:
   app: mpi-operator
   app.kubernetes.io/name: mpi-operator
   app.kubernetes.io/component: mpijob
+images:
+- name: mpioperator/mpi-operator
+  newName: mpioperator/mpi-operator
+  newTag: 0.3.0

--- a/apps/mpi-job/upstream/overlays/standalone/kustomization.yaml
+++ b/apps/mpi-job/upstream/overlays/standalone/kustomization.yaml
@@ -9,3 +9,7 @@ commonLabels:
   app: mpi-operator
   app.kubernetes.io/name: mpi-operator
   app.kubernetes.io/component: mpijob
+images:
+- name: mpioperator/mpi-operator
+  newName: mpioperator/mpi-operator
+  newTag: 0.3.0


### PR DESCRIPTION
Part of kubeflow 1.4 release.

Use MPI operator tag v0.3.0, but ensure the v1 controller is used.
