### PR TITLE
feat: add seldon permissions to default-editor

### DIFF
--- a/contrib/seldon/seldon-core-operator/base/kubeflow-edit-seldon.yaml
+++ b/contrib/seldon/seldon-core-operator/base/kubeflow-edit-seldon.yaml
@@ -1,0 +1,17 @@
+# Kubeflow builds clusterrole kubeflow-edit by aggreagating multiple other clusterroles
+# So i add a clusterrole that allows seldon deployments and it will be aggreagted because
+# of its "aggregate-to-kubeflow-edit" label
+# kubeflow-edit is the default role, that is available in each user namespace
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  labels:
+    rbac.authorization.kubeflow.org/aggregate-to-kubeflow-edit: "true"
+  name: kubeflow-edit-seldon
+rules:
+- apiGroups:
+    - machinelearning.seldon.io
+  verbs:
+    - '*'
+  resources:
+    - '*'

--- a/contrib/seldon/seldon-core-operator/base/kustomization.yaml
+++ b/contrib/seldon/seldon-core-operator/base/kustomization.yaml
@@ -2,6 +2,7 @@
 # and emits as a YAML string
 resources:
 - resources.yaml
+- kubeflow-edit-seldon.yaml
 
 configurations:
   - kustomizeconfig.yaml


### PR DESCRIPTION
**Which issue is resolved by this Pull Request:**
Resolves #1764

@yanniszark @cliveseldon @Bobgy since it affects pipeline permissions

**Description of your changes:**

In a multi-user kubeflow installation each user should be able to create seldon AND kfserving deployments inside his namespace, especially from a pipeline.

 for kfserving this is enabled at https://github.com/kubeflow/manifests/blob/f4cca979d3020a04e45db65bc58d7bbfe386ffd6/apps/kfserving/upstream/kfserving-install/base/cluster-role.yaml#L174 AND https://github.com/kubeflow/manifests/blob/f4cca979d3020a04e45db65bc58d7bbfe386ffd6/apps/kfserving/upstream/installs/generic/cluster-role.yaml#L18

I would like to add the following somewhere to fix the problem for seldon too
```
# Kubeflow builds clusterrole kubeflow-edit by aggreagating multiple other clusterroles
# So i add a clusterrole that allows seldon deployments and it will be aggregated because
# of its "aggregate-to-kubeflow-edit" label
# kubeflow-edit is the default role, that is available in each user namespace and used for pipelines. So you can then create seldon deployments from pipelines

cat <<EOF | kubectl apply -f -
apiVersion: rbac.authorization.k8s.io/v1
kind: ClusterRole
metadata:
  labels:
    rbac.authorization.kubeflow.org/aggregate-to-kubeflow-edit: "true"
  name: kubeflow-seldon-edit
rules:
- apiGroups:
    - machinelearning.seldon.io
  verbs:
    - '*'
  resources:
    - 'seldondeployments'
EOF
```

