### PR TITLE
Update training operator to v1.3.0-rc.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ This repo periodically syncs all official Kubeflow components from their respect
 
 | Component | Local Manifests Path | Upstream Revision |
 | - | - | - |
-| Training Operator | apps/training-operator/upstream | [v1.3.0-alpha.2](https://github.com/kubeflow/tf-operator/tree/v1.3.0-alpha.2/manifests) |
+| Training Operator | apps/training-operator/upstream | [v1.3.0-rc.1](https://github.com/kubeflow/tf-operator/tree/v1.3.0-rc.1/manifests) |
 | MPI Operator | apps/mpi-job/upstream | [v0.3.0](https://github.com/kubeflow/mpi-operator/tree/v0.3.0/manifests) |
 | Notebook Controller | apps/jupyter/notebook-controller/upstream | [v1.4-rc.0](https://github.com/kubeflow/kubeflow/tree/v1.4-rc.0/components/notebook-controller/config) |
 | Tensorboard Controller | apps/tensorboard/tensorboard-controller/upstream | [v1.4-rc.0](https://github.com/kubeflow/kubeflow/tree/v1.4-rc.0/components/tensorboard-controller/config) |

--- a/apps/training-operator/upstream/base/deployment.yaml
+++ b/apps/training-operator/upstream/base/deployment.yaml
@@ -21,6 +21,8 @@ spec:
             - /manager
           image: kubeflow/training-operator
           name: training-operator
+          ports:
+            - containerPort: 8080
           env:
             - name: MY_POD_NAMESPACE
               valueFrom:

--- a/apps/training-operator/upstream/base/service.yaml
+++ b/apps/training-operator/upstream/base/service.yaml
@@ -5,15 +5,15 @@ metadata:
   annotations:
     prometheus.io/path: /metrics
     prometheus.io/scrape: "true"
-    prometheus.io/port: "8443"
+    prometheus.io/port: "8080"
   labels:
     app: training-operator
   name: training-operator
 spec:
   ports:
   - name: monitoring-port
-    port: 8443
-    targetPort: 8443
+    port: 8080
+    targetPort: 8080
   selector:
-    name: training-operator
+    control-plane: kubeflow-training-operator
   type: ClusterIP

--- a/apps/training-operator/upstream/overlays/kubeflow/kustomization.yaml
+++ b/apps/training-operator/upstream/overlays/kubeflow/kustomization.yaml
@@ -7,4 +7,4 @@ resources:
 images:
   - name: kubeflow/training-operator
     newName: public.ecr.aws/j1r0q0g6/training/training-operator
-    newTag: "fb013e4faf6e8c2741829bf6941b99697f219a30"
+    newTag: "a1a0c188de17e0914bd7adfa79d16052276bffb1"

--- a/apps/training-operator/upstream/overlays/standalone/kustomization.yaml
+++ b/apps/training-operator/upstream/overlays/standalone/kustomization.yaml
@@ -7,4 +7,4 @@ resources:
 images:
   - name: kubeflow/training-operator
     newName: public.ecr.aws/j1r0q0g6/training/training-operator
-    newTag: "fb013e4faf6e8c2741829bf6941b99697f219a30"
+    newTag: "a1a0c188de17e0914bd7adfa79d16052276bffb1"


### PR DESCRIPTION
**Which issue is resolved by this Pull Request:**
Resolves https://github.com/kubeflow/manifests/issues/2018  https://github.com/kubeflow/manifests/issues/2005

**Description of your changes:**
Update training operator to v1.3.0-rc.1

/cc @kimwnasptd @johnugeorge @andreyvelich 

**Checklist:**
- [ ] Unit tests pass:
  **Make sure you have installed kustomize == 3.2.1**
    1. `make generate-changed-only`
    2. `make test`
