### PR TITLE
Update training operator to v1.3.0-rc.2

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ This repo periodically syncs all official Kubeflow components from their respect
 
 | Component | Local Manifests Path | Upstream Revision |
 | - | - | - |
-| Training Operator | apps/training-operator/upstream | [v1.3.0-rc.1](https://github.com/kubeflow/tf-operator/tree/v1.3.0-rc.1/manifests) |
+| Training Operator | apps/training-operator/upstream | [v1.3.0-rc.2](https://github.com/kubeflow/tf-operator/tree/v1.3.0-rc.2/manifests) |
 | MPI Operator | apps/mpi-job/upstream | [v0.3.0](https://github.com/kubeflow/mpi-operator/tree/v0.3.0/manifests) |
 | Notebook Controller | apps/jupyter/notebook-controller/upstream | [v1.4-rc.0](https://github.com/kubeflow/kubeflow/tree/v1.4-rc.0/components/notebook-controller/config) |
 | Tensorboard Controller | apps/tensorboard/tensorboard-controller/upstream | [v1.4-rc.0](https://github.com/kubeflow/kubeflow/tree/v1.4-rc.0/components/tensorboard-controller/config) |

--- a/apps/training-operator/upstream/base/kubeflow.org_mxjobs.yaml
+++ b/apps/training-operator/upstream/base/kubeflow.org_mxjobs.yaml
@@ -4,7 +4,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.4.1
+    controller-gen.kubebuilder.io/version: v0.6.0
   creationTimestamp: null
   name: mxjobs.kubeflow.org
 spec:
@@ -60,6 +60,23 @@ spec:
                       properties:
                         metadata:
                           description: 'Standard object''s metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata'
+                          properties:
+                            annotations:
+                              additionalProperties:
+                                type: string
+                              type: object
+                            finalizers:
+                              items:
+                                type: string
+                              type: array
+                            labels:
+                              additionalProperties:
+                                type: string
+                              type: object
+                            name:
+                              type: string
+                            namespace:
+                              type: string
                           type: object
                         spec:
                           description: 'Specification of the desired behavior of the
@@ -5582,6 +5599,23 @@ spec:
                                               that will be copied into the PVC when
                                               creating it. No other fields are allowed
                                               and will be rejected during validation.
+                                            properties:
+                                              annotations:
+                                                additionalProperties:
+                                                  type: string
+                                                type: object
+                                              finalizers:
+                                                items:
+                                                  type: string
+                                                type: array
+                                              labels:
+                                                additionalProperties:
+                                                  type: string
+                                                type: object
+                                              name:
+                                                type: string
+                                              namespace:
+                                                type: string
                                             type: object
                                           spec:
                                             description: The specification for the

--- a/apps/training-operator/upstream/base/kubeflow.org_pytorchjobs.yaml
+++ b/apps/training-operator/upstream/base/kubeflow.org_pytorchjobs.yaml
@@ -4,7 +4,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.4.1
+    controller-gen.kubebuilder.io/version: v0.6.0
   creationTimestamp: null
   name: pytorchjobs.kubeflow.org
 spec:
@@ -56,6 +56,23 @@ spec:
                       properties:
                         metadata:
                           description: 'Standard object''s metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata'
+                          properties:
+                            annotations:
+                              additionalProperties:
+                                type: string
+                              type: object
+                            finalizers:
+                              items:
+                                type: string
+                              type: array
+                            labels:
+                              additionalProperties:
+                                type: string
+                              type: object
+                            name:
+                              type: string
+                            namespace:
+                              type: string
                           type: object
                         spec:
                           description: 'Specification of the desired behavior of the
@@ -5578,6 +5595,23 @@ spec:
                                               that will be copied into the PVC when
                                               creating it. No other fields are allowed
                                               and will be rejected during validation.
+                                            properties:
+                                              annotations:
+                                                additionalProperties:
+                                                  type: string
+                                                type: object
+                                              finalizers:
+                                                items:
+                                                  type: string
+                                                type: array
+                                              labels:
+                                                additionalProperties:
+                                                  type: string
+                                                type: object
+                                              name:
+                                                type: string
+                                              namespace:
+                                                type: string
                                             type: object
                                           spec:
                                             description: The specification for the

--- a/apps/training-operator/upstream/base/kubeflow.org_tfjobs.yaml
+++ b/apps/training-operator/upstream/base/kubeflow.org_tfjobs.yaml
@@ -4,7 +4,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.4.1
+    controller-gen.kubebuilder.io/version: v0.6.0
   creationTimestamp: null
   name: tfjobs.kubeflow.org
 spec:
@@ -112,6 +112,23 @@ spec:
                       properties:
                         metadata:
                           description: 'Standard object''s metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata'
+                          properties:
+                            annotations:
+                              additionalProperties:
+                                type: string
+                              type: object
+                            finalizers:
+                              items:
+                                type: string
+                              type: array
+                            labels:
+                              additionalProperties:
+                                type: string
+                              type: object
+                            name:
+                              type: string
+                            namespace:
+                              type: string
                           type: object
                         spec:
                           description: 'Specification of the desired behavior of the
@@ -5634,6 +5651,23 @@ spec:
                                               that will be copied into the PVC when
                                               creating it. No other fields are allowed
                                               and will be rejected during validation.
+                                            properties:
+                                              annotations:
+                                                additionalProperties:
+                                                  type: string
+                                                type: object
+                                              finalizers:
+                                                items:
+                                                  type: string
+                                                type: array
+                                              labels:
+                                                additionalProperties:
+                                                  type: string
+                                                type: object
+                                              name:
+                                                type: string
+                                              namespace:
+                                                type: string
                                             type: object
                                           spec:
                                             description: The specification for the

--- a/apps/training-operator/upstream/base/kubeflow.org_xgboostjobs.yaml
+++ b/apps/training-operator/upstream/base/kubeflow.org_xgboostjobs.yaml
@@ -4,7 +4,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.4.1
+    controller-gen.kubebuilder.io/version: v0.6.0
   creationTimestamp: null
   name: xgboostjobs.kubeflow.org
 spec:
@@ -104,6 +104,23 @@ spec:
                       properties:
                         metadata:
                           description: 'Standard object''s metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata'
+                          properties:
+                            annotations:
+                              additionalProperties:
+                                type: string
+                              type: object
+                            finalizers:
+                              items:
+                                type: string
+                              type: array
+                            labels:
+                              additionalProperties:
+                                type: string
+                              type: object
+                            name:
+                              type: string
+                            namespace:
+                              type: string
                           type: object
                         spec:
                           description: 'Specification of the desired behavior of the
@@ -5626,6 +5643,23 @@ spec:
                                               that will be copied into the PVC when
                                               creating it. No other fields are allowed
                                               and will be rejected during validation.
+                                            properties:
+                                              annotations:
+                                                additionalProperties:
+                                                  type: string
+                                                type: object
+                                              finalizers:
+                                                items:
+                                                  type: string
+                                                type: array
+                                              labels:
+                                                additionalProperties:
+                                                  type: string
+                                                type: object
+                                              name:
+                                                type: string
+                                              namespace:
+                                                type: string
                                             type: object
                                           spec:
                                             description: The specification for the

--- a/apps/training-operator/upstream/overlays/kubeflow/kustomization.yaml
+++ b/apps/training-operator/upstream/overlays/kubeflow/kustomization.yaml
@@ -7,4 +7,4 @@ resources:
 images:
   - name: kubeflow/training-operator
     newName: public.ecr.aws/j1r0q0g6/training/training-operator
-    newTag: "a1a0c188de17e0914bd7adfa79d16052276bffb1"
+    newTag: "d4423c83124ce7ab58b9a61a2e909b2e9c14c236"

--- a/apps/training-operator/upstream/overlays/standalone/kustomization.yaml
+++ b/apps/training-operator/upstream/overlays/standalone/kustomization.yaml
@@ -7,4 +7,4 @@ resources:
 images:
   - name: kubeflow/training-operator
     newName: public.ecr.aws/j1r0q0g6/training/training-operator
-    newTag: "a1a0c188de17e0914bd7adfa79d16052276bffb1"
+    newTag: "d4423c83124ce7ab58b9a61a2e909b2e9c14c236"


### PR DESCRIPTION
**Which issue is resolved by this Pull Request:**
Resolves #https://github.com/kubeflow/gcp-blueprints/issues/317

**Description of your changes:**
Update training operator to v1.3.0-rc.2

**Checklist:**
- [x] Unit tests pass:
  **Make sure you have installed kustomize == 3.2.1**
    1. `make generate-changed-only`
    2. `make test`
