### PR TITLE
Use MPI operator tag v0.2.3

### DIFF
--- a/apps/mpi-job/upstream/overlays/kubeflow/kustomization.yaml
+++ b/apps/mpi-job/upstream/overlays/kubeflow/kustomization.yaml
@@ -8,3 +8,7 @@ commonLabels:
   app: mpi-operator
   app.kubernetes.io/name: mpi-operator
   app.kubernetes.io/component: mpijob
+images:
+- name: mpioperator/mpi-operator
+  newName: mpioperator/mpi-operator
+  newTag: v0.2.3

--- a/apps/mpi-job/upstream/overlays/standalone/kustomization.yaml
+++ b/apps/mpi-job/upstream/overlays/standalone/kustomization.yaml
@@ -9,3 +9,7 @@ commonLabels:
   app: mpi-operator
   app.kubernetes.io/name: mpi-operator
   app.kubernetes.io/component: mpijob
+images:
+- name: mpioperator/mpi-operator
+  newName: mpioperator/mpi-operator
+  newTag: v0.2.3


### PR DESCRIPTION
**Which issue is resolved by this Pull Request:**

Resolves #2009 

**Description of your changes:**

Use MPI operator tag v0.2.3

Ensure the v1alpha2 controller is used.


**Checklist:**
- [x] Unit tests pass:
  **Make sure you have installed kustomize == 3.2.1**
    1. `make generate-changed-only`
    2. `make test`
