### PR TITLE
Update jupyter-web-app with rbac.authorization.k8s.io/v1

### DIFF
--- a/apps/jupyter/jupyter-web-app/upstream/base/role-binding.yaml
+++ b/apps/jupyter/jupyter-web-app/upstream/base/role-binding.yaml
@@ -1,4 +1,4 @@
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   name: jupyter-notebook-role-binding

--- a/apps/jupyter/jupyter-web-app/upstream/base/role.yaml
+++ b/apps/jupyter/jupyter-web-app/upstream/base/role.yaml
@@ -1,4 +1,4 @@
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
   name: jupyter-notebook-role


### PR DESCRIPTION
**Description of your changes:**
The rbac.authorization.k8s.io/v1beta1 API version of ClusterRole, ClusterRoleBinding, Role, and RoleBinding is no longer served as of v1.22.

Migrate manifests and API clients to use the rbac.authorization.k8s.io/v1 API version, available since v1.8.
All existing persisted objects are accessible via the new APIs
No notable changes
https://kubernetes.io/docs/reference/using-api/deprecation-guide/#rbac-resources-v122