### PR TITLE
Configured Readiness probe for Central dashboard manifest.

### DIFF
--- a/apps/centraldashboard/upstream/base/deployment.yaml
+++ b/apps/centraldashboard/upstream/base/deployment.yaml
@@ -26,6 +26,12 @@ spec:
             port: 8082
           initialDelaySeconds: 30
           periodSeconds: 30
+        readinessProbe:
+          httpGet:
+            path: /readyz
+            port: 8082
+          initialDelaySeconds: 20
+          periodSeconds: 5
         ports:
         - containerPort: 8082
           protocol: TCP

--- a/apps/centraldashboard/upstream/base/deployment.yaml
+++ b/apps/centraldashboard/upstream/base/deployment.yaml
@@ -28,7 +28,7 @@ spec:
           periodSeconds: 30
         readinessProbe:
           httpGet:
-            path: /readyz
+            path: /healthz
             port: 8082
           initialDelaySeconds: 20
           periodSeconds: 5


### PR DESCRIPTION
/readyz endpoint shall be configured in central dashboard server.

Signed-off-by: Vijay Nag B S <vijay.bs@rakuten.com>

**Which issue is resolved by this Pull Request:**
Resolves https://github.com/kubeflow/kubeflow/issues/6154

Depends on https://github.com/kubeflow/kubeflow/pull/6155

**Description of your changes:**

Added Readiness probe, which probes /readyz endpoint (if the above PR is not merged have to change the probe path to /healthz) with intialDelaySeconds of 20s so that it doesn't overlap with liveness probe.

**Checklist:**
- [ ] Unit tests pass:
  **Make sure you have installed kustomize == 3.2.1**
    1. `make generate-changed-only`
    2. `make test`
