### PR TITLE
feat: allow default-editor to edit argo workflows

### DIFF
--- a/apps/pipeline/upstream/base/installs/multi-user/view-edit-cluster-roles.yaml
+++ b/apps/pipeline/upstream/base/installs/multi-user/view-edit-cluster-roles.yaml
@@ -78,6 +78,21 @@ rules:
   - delete
   - disable
   - enable
+- apiGroups:
+  - kubeflow.org
+  verbs:
+  - '*'
+  resources:
+  - scheduledworkflows
+- apiGroups:
+  - argoproj.io
+  verbs:
+  - '*'
+  resources:
+  - cronworkflows
+  - workflows
+  - workfloweventbindings
+  - workflowtemplates
 
 ---
 


### PR DESCRIPTION
**Which issue is resolved by this Pull Request:**
Resolves #

**Description of your changes:**

@Bobgy Currently the jupyterlab user has no way to cleanup his workspace


**Checklist:**
- [ ] Unit tests pass:
  **Make sure you have installed kustomize == 3.2.1**
    1. `make generate-changed-only`
    2. `make test`
