### PR TITLE
Update training operator to v1.3.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ This repo periodically syncs all official Kubeflow components from their respect
 
 | Component | Local Manifests Path | Upstream Revision |
 | - | - | - |
-| Training Operator | apps/training-operator/upstream | [v1.3.0-rc.2](https://github.com/kubeflow/tf-operator/tree/v1.3.0-rc.2/manifests) |
+| Training Operator | apps/training-operator/upstream | [v1.3.0](https://github.com/kubeflow/tf-operator/tree/v1.3.0/manifests) |
 | MPI Operator | apps/mpi-job/upstream | [v0.3.0](https://github.com/kubeflow/mpi-operator/tree/v0.3.0/manifests) |
 | Notebook Controller | apps/jupyter/notebook-controller/upstream | [v1.4-rc.0](https://github.com/kubeflow/kubeflow/tree/v1.4-rc.0/components/notebook-controller/config) |
 | Tensorboard Controller | apps/tensorboard/tensorboard-controller/upstream | [v1.4-rc.0](https://github.com/kubeflow/kubeflow/tree/v1.4-rc.0/components/tensorboard-controller/config) |

--- a/apps/training-operator/upstream/overlays/kubeflow/kustomization.yaml
+++ b/apps/training-operator/upstream/overlays/kubeflow/kustomization.yaml
@@ -7,4 +7,4 @@ resources:
 images:
   - name: kubeflow/training-operator
     newName: public.ecr.aws/j1r0q0g6/training/training-operator
-    newTag: "d4423c83124ce7ab58b9a61a2e909b2e9c14c236"
+    newTag: "760ac1171dd30039a7363ffa03c77454bd714da5"

--- a/apps/training-operator/upstream/overlays/standalone/kustomization.yaml
+++ b/apps/training-operator/upstream/overlays/standalone/kustomization.yaml
@@ -7,4 +7,4 @@ resources:
 images:
   - name: kubeflow/training-operator
     newName: public.ecr.aws/j1r0q0g6/training/training-operator
-    newTag: "d4423c83124ce7ab58b9a61a2e909b2e9c14c236"
+    newTag: "760ac1171dd30039a7363ffa03c77454bd714da5"


### PR DESCRIPTION
**Which issue is resolved by this Pull Request:**
Resolves #

**Description of your changes:**
training-operator 1.3.0 has been released. We would like to use this version in Kubeflow v1.4

**Checklist:**
- [x] Unit tests pass:
  **Make sure you have installed kustomize == 3.2.1**
    1. `make generate-changed-only`
    2. `make test`
