### PR TITLE
Fix for #2039-sha256 digests replaced by version tags

### DIFF
--- a/common/knative/knative-eventing/base/upstream/eventing-core.yaml
+++ b/common/knative/knative-eventing/base/upstream/eventing-core.yaml
@@ -472,7 +472,7 @@ spec:
       containers:
         - name: eventing-controller
           terminationMessagePolicy: FallbackToLogsOnError
-          image: gcr.io/knative-releases/knative.dev/eventing/cmd/controller@sha256:6ddffbc286a84048cfd090193d00b4ecda25a3a7bf2de1a8e873f8b3755cc913
+          image: gcr.io/knative-releases/knative.dev/eventing/cmd/controller:v0.22.1
           resources:
             requests:
               cpu: 100m
@@ -525,7 +525,7 @@ spec:
       enableServiceLinks: false
       containers:
         - name: dispatcher
-          image: gcr.io/knative-releases/knative.dev/eventing/cmd/mtping@sha256:edf462d03591e53e536640591a53538e6bea837fea15ed081eccfb42bc35a5c0
+          image: gcr.io/knative-releases/knative.dev/eventing/cmd/mtping:v0.22.1
           env:
             - name: SYSTEM_NAMESPACE
               value: ''
@@ -627,7 +627,7 @@ spec:
       containers:
         - name: eventing-webhook
           terminationMessagePolicy: FallbackToLogsOnError
-          image: gcr.io/knative-releases/knative.dev/eventing/cmd/webhook@sha256:9f70a2a8bb78781472fba0327c5d6ff91f13a29736d4502bf8ad3d60d3f16ccd
+          image: gcr.io/knative-releases/knative.dev/eventing/cmd/webhook:v0.22.1
           resources:
             requests:
               cpu: 100m

--- a/common/knative/knative-eventing/base/upstream/mt-channel-broker.yaml
+++ b/common/knative/knative-eventing/base/upstream/mt-channel-broker.yaml
@@ -156,7 +156,7 @@ spec:
       containers:
         - name: filter
           terminationMessagePolicy: FallbackToLogsOnError
-          image: gcr.io/knative-releases/knative.dev/eventing/cmd/broker/filter@sha256:0e25aa1613a3a1779b3f7b7f863e651e5f37520a7f6808ccad2164cc2b6a9b12
+          image: gcr.io/knative-releases/knative.dev/eventing/cmd/broker/filter:v0.22.1
           readinessProbe:
             failureThreshold: 3
             httpGet:
@@ -259,7 +259,7 @@ spec:
       containers:
         - name: ingress
           terminationMessagePolicy: FallbackToLogsOnError
-          image: gcr.io/knative-releases/knative.dev/eventing/cmd/broker/ingress@sha256:cf579f88aa2a37c240e25bb886c1ef5404e326e12c7caf571e49308612243eee
+          image: gcr.io/knative-releases/knative.dev/eventing/cmd/broker/ingress:v0.22.1
           readinessProbe:
             failureThreshold: 3
             httpGet:

--- a/common/knative/knative-serving/base/upstream/net-istio.yaml
+++ b/common/knative/knative-serving/base/upstream/net-istio.yaml
@@ -229,7 +229,7 @@ spec:
       serviceAccountName: controller
       containers:
         - name: networking-istio
-          image: gcr.io/knative-releases/knative.dev/net-istio/cmd/controller@sha256:ff8680da52ef47b8573ebc3393cbfa2f0f14b05c1e02232807f22699adbef57a
+          image: gcr.io/knative-releases/knative.dev/net-istio/cmd/controller:v0.22.1
           resources:
             requests:
               cpu: 30m
@@ -286,7 +286,7 @@ spec:
       serviceAccountName: controller
       containers:
         - name: webhook
-          image: gcr.io/knative-releases/knative.dev/net-istio/cmd/webhook@sha256:1e371db6b1a9f9265fc7a55d15d98c935c0c28925ffde351fb3b93f331c5a08e
+          image: gcr.io/knative-releases/knative.dev/net-istio/cmd/webhook:v0.22.1
           resources:
             requests:
               cpu: 20m

--- a/common/knative/knative-serving/base/upstream/serving-core.yaml
+++ b/common/knative/knative-serving/base/upstream/serving-core.yaml
@@ -651,7 +651,7 @@ metadata:
   labels:
     serving.knative.dev/release: "v0.22.1"
 spec:
-  image: gcr.io/knative-releases/knative.dev/serving/cmd/queue@sha256:0b8e031170354950f3395876961452af1c62f7ab5161c9e71867392c11881962
+  image: gcr.io/knative-releases/knative.dev/serving/cmd/queue:v0.22.1
 ---
 apiVersion: v1
 kind: ConfigMap
@@ -1713,7 +1713,7 @@ spec:
       serviceAccountName: controller
       containers:
         - name: activator
-          image: gcr.io/knative-releases/knative.dev/serving/cmd/activator@sha256:fed92af8b9779c97482906db8857f27b5d4826708b75d0298aa30fad8900671f
+          image: gcr.io/knative-releases/knative.dev/serving/cmd/activator:v0.22.1
           resources:
             requests:
               cpu: 300m
@@ -1833,7 +1833,7 @@ spec:
       serviceAccountName: controller
       containers:
         - name: autoscaler
-          image: gcr.io/knative-releases/knative.dev/serving/cmd/autoscaler@sha256:bc5ae3090ab0322ed0e4f9efddb60fa85f6ff3a29156411d24d0e4764b18eba7
+          image: gcr.io/knative-releases/knative.dev/serving/cmd/autoscaler:v0.22.1
           resources:
             requests:
               cpu: 100m
@@ -1941,7 +1941,7 @@ spec:
       serviceAccountName: controller
       containers:
         - name: controller
-          image: gcr.io/knative-releases/knative.dev/serving/cmd/controller@sha256:bd7c6350e5d5c4edaa197a86fb96cff78bdd3e61f33fcb77aa60930de0ec0827
+          image: gcr.io/knative-releases/knative.dev/serving/cmd/controller:v0.22.1
           resources:
             requests:
               cpu: 100m
@@ -2064,7 +2064,7 @@ spec:
       serviceAccountName: controller
       containers:
         - name: webhook
-          image: gcr.io/knative-releases/knative.dev/serving/cmd/webhook@sha256:6f41d379f1aacdfbb8f6d4f539e1769040e4f01bff3ad9c249b427e54dc56ea8
+          image: gcr.io/knative-releases/knative.dev/serving/cmd/webhook:v0.22.1
           resources:
             requests:
               cpu: 100m


### PR DESCRIPTION
* Fixes Bug: https://github.com/kubeflow/manifests/issues/2039

Signed-Off by: Julius Von Kohout <45896133+juliusvonkohout@users.noreply.github.com>

Co-authored-by: Julius Von Kohout <45896133+juliusvonkohout@users.noreply.github.com>

**Which issue is resolved by this Pull Request:**
Resolves #2039

**Description of your changes:**
Replaced SHA256 digests of listed images with corresponding tags from the repository.

**Checklist:**
- [ ] Unit tests pass:
  **Make sure you have installed kustomize == 3.2.1**
    1. `make generate-changed-only`
    2. `make test`
