### PR TITLE
Update Katib manifests to v0.12.0 release

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ This repo periodically syncs all official Kubeflow components from their respect
 | Jupyter Web App | apps/jupyter/jupyter-web-app/upstream | [v1.4-rc.0](https://github.com/kubeflow/kubeflow/tree/v1.4-rc.0/components/crud-web-apps/jupyter/manifests) |
 | Tensorboards Web App | apps/tensorboard/tensorboards-web-app/upstream | [v1.4-rc.0](https://github.com/kubeflow/kubeflow/tree/v1.4-rc.0/components/crud-web-apps/tensorboards/manifests) |
 | Volumes Web App | apps/volumes-web-app/upstream | [v1.4-rc.0](https://github.com/kubeflow/kubeflow/tree/v1.4-rc.0/components/crud-web-apps/volumes/manifests) |
-| Katib | apps/katib/upstream | [v0.12.0-rc.1](https://github.com/kubeflow/katib/tree/v0.12.0-rc.1/manifests/v1beta1) |
+| Katib | apps/katib/upstream | [v0.12.0](https://github.com/kubeflow/katib/tree/v0.12.0/manifests/v1beta1) |
 | KFServing | apps/kfserving/upstream | [v0.6.0](https://github.com/kubeflow/kfserving/releases/tag/v0.6.0) |
 | Kubeflow Pipelines | apps/pipeline/upstream | [1.7.0](https://github.com/kubeflow/pipelines/tree/1.7.0/manifests/kustomize) |
 | Kubeflow Tekton Pipelines | apps/kfp-tekton/upstream | [v1.0.0](https://github.com/kubeflow/kfp-tekton/tree/v1.0.0/manifests/kustomize) |

--- a/apps/katib/upstream/components/controller/katib-config.yaml
+++ b/apps/katib/upstream/components/controller/katib-config.yaml
@@ -7,13 +7,13 @@ data:
   metrics-collector-sidecar: |-
     {
       "StdOut": {
-        "image": "docker.io/kubeflowkatib/file-metrics-collector:v0.12.0-rc.1"
+        "image": "docker.io/kubeflowkatib/file-metrics-collector:v0.12.0"
       },
       "File": {
-        "image": "docker.io/kubeflowkatib/file-metrics-collector:v0.12.0-rc.1"
+        "image": "docker.io/kubeflowkatib/file-metrics-collector:v0.12.0"
       },
       "TensorFlowEvent": {
-        "image": "docker.io/kubeflowkatib/tfevent-metrics-collector:v0.12.0-rc.1",
+        "image": "docker.io/kubeflowkatib/tfevent-metrics-collector:v0.12.0",
         "resources": {
           "limits": {
             "memory": "1Gi"
@@ -24,31 +24,31 @@ data:
   suggestion: |-
     {
       "random": {
-        "image": "docker.io/kubeflowkatib/suggestion-hyperopt:v0.12.0-rc.1"
+        "image": "docker.io/kubeflowkatib/suggestion-hyperopt:v0.12.0"
       },
       "tpe": {
-        "image": "docker.io/kubeflowkatib/suggestion-hyperopt:v0.12.0-rc.1"
+        "image": "docker.io/kubeflowkatib/suggestion-hyperopt:v0.12.0"
       },
       "grid": {
-        "image": "docker.io/kubeflowkatib/suggestion-chocolate:v0.12.0-rc.1"
+        "image": "docker.io/kubeflowkatib/suggestion-chocolate:v0.12.0"
       },
       "hyperband": {
-        "image": "docker.io/kubeflowkatib/suggestion-hyperband:v0.12.0-rc.1"
+        "image": "docker.io/kubeflowkatib/suggestion-hyperband:v0.12.0"
       },
       "bayesianoptimization": {
-        "image": "docker.io/kubeflowkatib/suggestion-skopt:v0.12.0-rc.1"
+        "image": "docker.io/kubeflowkatib/suggestion-skopt:v0.12.0"
       },
       "cmaes": {
-        "image": "docker.io/kubeflowkatib/suggestion-goptuna:v0.12.0-rc.1"
+        "image": "docker.io/kubeflowkatib/suggestion-goptuna:v0.12.0"
       },
       "sobol": {
-        "image": "docker.io/kubeflowkatib/suggestion-goptuna:v0.12.0-rc.1"
+        "image": "docker.io/kubeflowkatib/suggestion-goptuna:v0.12.0"
       },
       "multivariate-tpe": {
-        "image": "docker.io/kubeflowkatib/suggestion-optuna:v0.12.0-rc.1"
+        "image": "docker.io/kubeflowkatib/suggestion-optuna:v0.12.0"
       },
       "enas": {
-        "image": "docker.io/kubeflowkatib/suggestion-enas:v0.12.0-rc.1",
+        "image": "docker.io/kubeflowkatib/suggestion-enas:v0.12.0",
         "resources": {
           "limits": {
             "memory": "200Mi"
@@ -56,12 +56,12 @@ data:
         }
       },
       "darts": {
-        "image": "docker.io/kubeflowkatib/suggestion-darts:v0.12.0-rc.1"
+        "image": "docker.io/kubeflowkatib/suggestion-darts:v0.12.0"
       }
     }
   early-stopping: |-
     {
       "medianstop": {
-        "image": "docker.io/kubeflowkatib/earlystopping-medianstop:v0.12.0-rc.1"
+        "image": "docker.io/kubeflowkatib/earlystopping-medianstop:v0.12.0"
       }
     }

--- a/apps/katib/upstream/installs/katib-cert-manager/kustomization.yaml
+++ b/apps/katib/upstream/installs/katib-cert-manager/kustomization.yaml
@@ -21,13 +21,13 @@ resources:
 images:
   - name: docker.io/kubeflowkatib/katib-controller
     newName: docker.io/kubeflowkatib/katib-controller
-    newTag: v0.12.0-rc.1
+    newTag: v0.12.0
   - name: docker.io/kubeflowkatib/katib-db-manager
     newName: docker.io/kubeflowkatib/katib-db-manager
-    newTag: v0.12.0-rc.1
+    newTag: v0.12.0
   - name: docker.io/kubeflowkatib/katib-ui
     newName: docker.io/kubeflowkatib/katib-ui
-    newTag: v0.12.0-rc.1
+    newTag: v0.12.0
 
 patchesStrategicMerge:
   - patches/katib-cert-injection.yaml

--- a/apps/katib/upstream/installs/katib-external-db/kustomization.yaml
+++ b/apps/katib/upstream/installs/katib-external-db/kustomization.yaml
@@ -19,16 +19,16 @@ resources:
 images:
   - name: docker.io/kubeflowkatib/katib-controller
     newName: docker.io/kubeflowkatib/katib-controller
-    newTag: v0.12.0-rc.1
+    newTag: v0.12.0
   - name: docker.io/kubeflowkatib/katib-db-manager
     newName: docker.io/kubeflowkatib/katib-db-manager
-    newTag: v0.12.0-rc.1
+    newTag: v0.12.0
   - name: docker.io/kubeflowkatib/katib-ui
     newName: docker.io/kubeflowkatib/katib-ui
-    newTag: v0.12.0-rc.1
+    newTag: v0.12.0
   - name: docker.io/kubeflowkatib/cert-generator
     newName: docker.io/kubeflowkatib/cert-generator
-    newTag: v0.12.0-rc.1
+    newTag: v0.12.0
 patchesStrategicMerge:
   - patches/db-manager.yaml
 # Modify katib-mysql-secrets with parameters for the DB.

--- a/apps/katib/upstream/installs/katib-openshift/kustomization.yaml
+++ b/apps/katib/upstream/installs/katib-openshift/kustomization.yaml
@@ -30,13 +30,13 @@ resources:
 images:
   - name: docker.io/kubeflowkatib/katib-controller
     newName: docker.io/kubeflowkatib/katib-controller
-    newTag: v0.12.0-rc.1
+    newTag: v0.12.0
   - name: docker.io/kubeflowkatib/katib-db-manager
     newName: docker.io/kubeflowkatib/katib-db-manager
-    newTag: v0.12.0-rc.1
+    newTag: v0.12.0
   - name: docker.io/kubeflowkatib/katib-ui
     newName: docker.io/kubeflowkatib/katib-ui
-    newTag: v0.12.0-rc.1
+    newTag: v0.12.0
 
 patchesJson6902:
   # Annotate Service to delegate TLS-secret generation to OpenShift service controller

--- a/apps/katib/upstream/installs/katib-standalone/kustomization.yaml
+++ b/apps/katib/upstream/installs/katib-standalone/kustomization.yaml
@@ -21,13 +21,13 @@ resources:
 images:
   - name: docker.io/kubeflowkatib/katib-controller
     newName: docker.io/kubeflowkatib/katib-controller
-    newTag: v0.12.0-rc.1
+    newTag: v0.12.0
   - name: docker.io/kubeflowkatib/katib-db-manager
     newName: docker.io/kubeflowkatib/katib-db-manager
-    newTag: v0.12.0-rc.1
+    newTag: v0.12.0
   - name: docker.io/kubeflowkatib/katib-ui
     newName: docker.io/kubeflowkatib/katib-ui
-    newTag: v0.12.0-rc.1
+    newTag: v0.12.0
   - name: docker.io/kubeflowkatib/cert-generator
     newName: docker.io/kubeflowkatib/cert-generator
-    newTag: v0.12.0-rc.1
+    newTag: v0.12.0

--- a/apps/katib/upstream/installs/katib-with-kubeflow/kustomization.yaml
+++ b/apps/katib/upstream/installs/katib-with-kubeflow/kustomization.yaml
@@ -9,13 +9,13 @@ resources:
 images:
   - name: docker.io/kubeflowkatib/katib-controller
     newName: docker.io/kubeflowkatib/katib-controller
-    newTag: v0.12.0-rc.1
+    newTag: v0.12.0
   - name: docker.io/kubeflowkatib/katib-db-manager
     newName: docker.io/kubeflowkatib/katib-db-manager
-    newTag: v0.12.0-rc.1
+    newTag: v0.12.0
   - name: docker.io/kubeflowkatib/katib-ui
     newName: docker.io/kubeflowkatib/katib-ui
-    newTag: v0.12.0-rc.1
+    newTag: v0.12.0
 
 patchesStrategicMerge:
   - patches/remove-namespace.yaml


### PR DESCRIPTION
**Which issue is resolved by this Pull Request:**
Related: https://github.com/kubeflow/katib/issues/1597.


**Description of your changes:**
This is the manifests for Katib 0.12.0 release.

/assign @gaocegege @johnugeorge @kubeflow/release-team 

**Checklist:**
- [x] Unit tests pass:
  **Make sure you have installed kustomize == 3.2.1**
    1. `make generate-changed-only`
    2. `make test`
