### PR TITLE
Knative: Use istio's local gateway

### DIFF
--- a/common/knative/knative-serving/overlays/gateways/kustomization.yaml
+++ b/common/knative/knative-serving/overlays/gateways/kustomization.yaml
@@ -1,0 +1,10 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+- ../../base
+
+# We want to Knative to use Istio's local Gateway and not the Ingress Gateway
+# See: https://github.com/kubeflow/manifests/issues/1966
+patchesStrategicMerge:
+- patches/gateway-selectors.yaml

--- a/common/knative/knative-serving/overlays/gateways/patches/gateway-selectors.yaml
+++ b/common/knative/knative-serving/overlays/gateways/patches/gateway-selectors.yaml
@@ -1,0 +1,19 @@
+apiVersion: networking.istio.io/v1alpha3
+kind: Gateway
+metadata:
+  name: knative-local-gateway
+  namespace: knative-serving
+spec:
+  selector:
+    app: cluster-local-gateway
+    istio: cluster-local-gateway
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: knative-local-gateway
+  namespace: istio-system
+spec:
+  selector:
+    app: cluster-local-gateway
+    istio: cluster-local-gateway


### PR DESCRIPTION
Closes https://github.com/kubeflow/manifests/issues/1966

By default Knative's local gateway will use the istio-ingressgateway Pod for configuring traffic and binding VirtualServices. This means that all in-cluster traffic will need to also pass via the ingress gateway.

We've noticed 302s from Notebooks curl-ing InferenceServices. This was because the AuthService is authenticating all requests that go through the ingress gateway. But since we now send in-cluster requests via the ingress gateway this means that AuthService will also check them.

To avoid the above we provide an overlay for making Knative's local gateway to use Istio's local gateway and not the ingress one.

cc @elikatsis 