### PR TITLE
Update the example installation

### DIFF
--- a/example/kustomization.yaml
+++ b/example/kustomization.yaml
@@ -14,7 +14,7 @@ resources:
 # Dex
 - ../common/dex/overlays/istio
 # KNative
-- ../common/knative/knative-serving/base
+- ../common/knative/knative-serving/overlays/gateways
 - ../common/knative/knative-eventing/base
 - ../common/istio-1-9/cluster-local-gateway/base
 # Kubeflow namespace


### PR DESCRIPTION
Since the example installation is using Dex/AuthService it should also use the new overlay introduced from https://github.com/kubeflow/manifests/pull/2048

/cc @elikatsis 