### PR TITLE
Fix jupyter/notebook controller description in example/kustomization.yaml

### DIFF
--- a/example/kustomization.yaml
+++ b/example/kustomization.yaml
@@ -35,9 +35,9 @@ resources:
 - ../apps/centraldashboard/upstream/overlays/istio
 # Admission Webhook
 - ../apps/admission-webhook/upstream/overlays/cert-manager
-# Notebook Controller
-- ../apps/jupyter/jupyter-web-app/upstream/overlays/istio
 # Jupyter Web App
+- ../apps/jupyter/jupyter-web-app/upstream/overlays/istio
+# Notebook Controller
 - ../apps/jupyter/notebook-controller/upstream/overlays/kubeflow
 # Profiles + KFAM
 - ../apps/profiles/upstream/overlays/kubeflow


### PR DESCRIPTION
**Which issue is resolved by this Pull Request:**
Does not resolve any issue. Just stumbled over this typo.

**Description of your changes:**
 Comments above Notebook Controller and Jupyter Web App were swapped, which I have now fixed.

**Checklist:**
- [x] Unit tests pass:
  **Make sure you have installed kustomize == 3.2.1**
    1. `make generate-changed-only`
    2. `make test`
