### PR TITLE
Remove Katib label from Kubeflow namespace

### DIFF
--- a/common/kubeflow-namespace/base/namespace.yaml
+++ b/common/kubeflow-namespace/base/namespace.yaml
@@ -5,4 +5,3 @@ metadata:
   labels:
     control-plane: kubeflow
     istio-injection: enabled
-    katib-metricscollector-injection: enabled


### PR DESCRIPTION
**Description of your changes:**

I notice that we added Katib Metrics Collector injection label to `kubeflow` namespace in this PR: https://github.com/kubeflow/manifests/pull/1787.

We should not do that since users have to submit Katib Experiments only in Profile's namespaces.

/assign @gaocegege @johnugeorge @yanniszark @kimwnasptd 

**Checklist:**
- [ ] Unit tests pass:
  **Make sure you have installed kustomize == 3.2.1**
    1. `make generate-changed-only`
    2. `make test`
