### PR TITLE
fix: assign and remove namespace to namespace and cluster scoped resources

### DIFF
--- a/common/cert-manager/kubeflow-issuer/base/kustomization.yaml
+++ b/common/cert-manager/kubeflow-issuer/base/kustomization.yaml
@@ -1,7 +1,6 @@
 # Define the self-signed issuer for Kubeflow
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
-namespace: cert-manager
 commonLabels:
   kustomize.component: cert-manager
   app.kubernetes.io/component: cert-manager

--- a/common/user-namespace/base/kustomization.yaml
+++ b/common/user-namespace/base/kustomization.yaml
@@ -6,6 +6,7 @@ resources:
 - profile-instance.yaml
 configMapGenerator:
 - name: default-install-config
+  namespace: default
   envs:
   - params.env
 vars:
@@ -15,6 +16,7 @@ vars:
   objref:
     kind: ConfigMap
     name: default-install-config
+    namespace: default
     apiVersion: v1
   fieldref:
     fieldpath: data.user
@@ -22,6 +24,7 @@ vars:
   objref:
     kind: ConfigMap
     name: default-install-config
+    namespace: default
     apiVersion: v1
   fieldref:
     fieldpath: data.profile-name

--- a/example/kustomization.yaml
+++ b/example/kustomization.yaml
@@ -53,3 +53,13 @@ resources:
 - ../apps/mpi-job/upstream/overlays/kubeflow
 # User namespace
 - ../common/user-namespace/base
+
+patchesJson6902:
+  - target:
+      group: metacontroller.k8s.io
+      version: v1alpha1
+      kind: CompositeController
+      name: kubeflow-pipelines-profile-controller
+    patch: |-
+      - op: remove
+        path: /metadata/namespace


### PR DESCRIPTION
**Description of your changes:**

This prevent creation failure errors due to "server could not find the requested resource" when deploying via the kustomization Terraform provider.

**Checklist:**
- [x] Unit tests pass:
  **Make sure you have installed kustomize == 3.2.1**
    1. `make generate-changed-only`
    2. `make test`
