### PR TITLE
knative-serving: Workaround Istio race wrt Gateway creation

### DIFF
--- a/common/knative/knative-serving/base/kustomization.yaml
+++ b/common/knative/knative-serving/base/kustomization.yaml
@@ -8,6 +8,7 @@ patchesStrategicMerge:
 - patches/configmap-patch.yaml
 - patches/namespace-injection.yaml
 - patches/clusterrole-patch.yaml
+- patches/service-labels.yaml
 patches:
 - path: patches/sidecar-injection.yaml
   target:

--- a/common/knative/knative-serving/base/patches/service-labels.yaml
+++ b/common/knative/knative-serving/base/patches/service-labels.yaml
@@ -1,0 +1,7 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: knative-local-gateway
+  namespace: istio-system
+  labels:
+    experimental.istio.io/disable-gateway-port-translation: "true"


### PR DESCRIPTION
**Which issue is resolved by this Pull Request:**
Resolves #2082

**Description of your changes:**
When deploying knative-serving there a race due to an Istio issue that ends up having cluster-local-gateway misconfigured because of conflicting ports. In a nutshell Istio creates listeners based on Gateway ports and the corresponding Services (if any) and in our case we have two Services (cluster-local-gateway, knative-local-gateway) with port 80 and different targetPort (8080, 8081). In normal operation the pod gets the following listeners:
```
ADDRESS PORT  MATCH DESTINATION
0.0.0.0 8080  ALL   Route: http.80
0.0.0.0 8081  ALL   Route: http.8081
```

We have seen on fresh deployment to end up with only 8081:8081 and istio complaining with:
```
Error adding/updating listener(s) 0.0.0.0_8081: duplicate listener 0.0.0.0_8081 found
```

To fix that add a label in knative-local-gateway service so that it gets ignored by istio when translating gateway ports.

/cc @elikatsis 