### PR TITLE
knative-serving: Workaround Istio race wrt Gateway creation (#2092)

### DIFF
--- a/common/knative/knative-serving/base/kustomization.yaml
+++ b/common/knative/knative-serving/base/kustomization.yaml
@@ -8,6 +8,7 @@ patchesStrategicMerge:
 - patches/configmap-patch.yaml
 - patches/namespace-injection.yaml
 - patches/clusterrole-patch.yaml
+- patches/service-labels.yaml
 patches:
 - path: patches/sidecar-injection.yaml
   target:

--- a/common/knative/knative-serving/base/patches/service-labels.yaml
+++ b/common/knative/knative-serving/base/patches/service-labels.yaml
@@ -1,0 +1,7 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: knative-local-gateway
+  namespace: istio-system
+  labels:
+    experimental.istio.io/disable-gateway-port-translation: "true"


### PR DESCRIPTION
Cherry-picking https://github.com/kubeflow/manifests/pull/2092 into the 1.4 branch to prepare for the 1.4.1 patch release

/cc @elikatsis 