### PR TITLE
Correction of the name for the resource

### DIFF
--- a/example/kustomization.yaml
+++ b/example/kustomization.yaml
@@ -35,9 +35,9 @@ resources:
 - ../apps/centraldashboard/upstream/overlays/istio
 # Admission Webhook
 - ../apps/admission-webhook/upstream/overlays/cert-manager
-# Notebook Controller
-- ../apps/jupyter/jupyter-web-app/upstream/overlays/istio
 # Jupyter Web App
+- ../apps/jupyter/jupyter-web-app/upstream/overlays/istio
+# Notebook Controller
 - ../apps/jupyter/notebook-controller/upstream/overlays/kubeflow
 # Profiles + KFAM
 - ../apps/profiles/upstream/overlays/kubeflow


### PR DESCRIPTION


**Which issue is resolved by this Pull Request:**
Resolves #
Correction of the name for the resource

**Description of your changes:**
Notebook Controller and Jupyter Web App had them listed under each other names, fixed it by correcting it

**Checklist:**
- [ ] Unit tests pass:
  **Make sure you have installed kustomize == 3.2.1**
    1. `make generate-changed-only`
    2. `make test`
