### PR TITLE
Sync kubeflow pipelines manifests 1.8.0 rc.2

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ This repo periodically syncs all official Kubeflow components from their respect
 | Katib | apps/katib/upstream | [v0.13.0-rc.0](https://github.com/kubeflow/katib/tree/v0.13.0-rc.0/manifests/v1beta1) |
 | KFServing | apps/kfserving/upstream | [v0.6.1](https://github.com/kubeflow/kfserving/releases/tag/v0.6.1) |
 | KServe | contrib/kserve/upstream | [v0.7.0](https://github.com/kserve/kserve/tree/v0.7.0) |
-| Kubeflow Pipelines | apps/pipeline/upstream | [1.8.0-rc.1](https://github.com/kubeflow/pipelines/tree/1.8.0-rc.1/manifests/kustomize) |
+| Kubeflow Pipelines | apps/pipeline/upstream | [1.8.0-rc.2](https://github.com/kubeflow/pipelines/tree/1.8.0-rc.2/manifests/kustomize) |
 | Kubeflow Tekton Pipelines | apps/kfp-tekton/upstream | [v1.1.0](https://github.com/kubeflow/kfp-tekton/tree/v1.1.0/manifests/kustomize) |
 
 The following is also a matrix with versions from common components that are

--- a/apps/pipeline/upstream/base/cache-deployer/kustomization.yaml
+++ b/apps/pipeline/upstream/base/cache-deployer/kustomization.yaml
@@ -8,4 +8,4 @@ commonLabels:
   app: cache-deployer
 images:
   - name: gcr.io/ml-pipeline/cache-deployer
-    newTag: 1.8.0-rc.1
+    newTag: 1.8.0-rc.2

--- a/apps/pipeline/upstream/base/cache/kustomization.yaml
+++ b/apps/pipeline/upstream/base/cache/kustomization.yaml
@@ -10,4 +10,4 @@ commonLabels:
   app: cache-server
 images:
   - name: gcr.io/ml-pipeline/cache-server
-    newTag: 1.8.0-rc.1
+    newTag: 1.8.0-rc.2

--- a/apps/pipeline/upstream/base/installs/generic/pipeline-install-config.yaml
+++ b/apps/pipeline/upstream/base/installs/generic/pipeline-install-config.yaml
@@ -11,7 +11,7 @@ data:
     until the changes take effect. A quick way to restart all deployments in a
     namespace: `kubectl rollout restart deployment -n <your-namespace>`.
   appName: pipeline
-  appVersion: 1.8.0-rc.1
+  appVersion: 1.8.0-rc.2
   dbHost: mysql
   dbPort: "3306"
   mlmdDb: metadb

--- a/apps/pipeline/upstream/base/metadata/base/kustomization.yaml
+++ b/apps/pipeline/upstream/base/metadata/base/kustomization.yaml
@@ -9,4 +9,4 @@ resources:
   - metadata-grpc-sa.yaml
 images:
   - name: gcr.io/ml-pipeline/metadata-envoy
-    newTag: 1.8.0-rc.1
+    newTag: 1.8.0-rc.2

--- a/apps/pipeline/upstream/base/pipeline/kustomization.yaml
+++ b/apps/pipeline/upstream/base/pipeline/kustomization.yaml
@@ -37,14 +37,14 @@ resources:
   - kfp-launcher-configmap.yaml
 images:
   - name: gcr.io/ml-pipeline/api-server
-    newTag: 1.8.0-rc.1
+    newTag: 1.8.0-rc.2
   - name: gcr.io/ml-pipeline/persistenceagent
-    newTag: 1.8.0-rc.1
+    newTag: 1.8.0-rc.2
   - name: gcr.io/ml-pipeline/scheduledworkflow
-    newTag: 1.8.0-rc.1
+    newTag: 1.8.0-rc.2
   - name: gcr.io/ml-pipeline/frontend
-    newTag: 1.8.0-rc.1
+    newTag: 1.8.0-rc.2
   - name: gcr.io/ml-pipeline/viewer-crd-controller
-    newTag: 1.8.0-rc.1
+    newTag: 1.8.0-rc.2
   - name: gcr.io/ml-pipeline/visualization-server
-    newTag: 1.8.0-rc.1
+    newTag: 1.8.0-rc.2

--- a/apps/pipeline/upstream/base/pipeline/metadata-writer/kustomization.yaml
+++ b/apps/pipeline/upstream/base/pipeline/metadata-writer/kustomization.yaml
@@ -7,4 +7,4 @@ resources:
   - metadata-writer-sa.yaml
 images:
   - name: gcr.io/ml-pipeline/metadata-writer
-    newTag: 1.8.0-rc.1
+    newTag: 1.8.0-rc.2

--- a/apps/pipeline/upstream/env/gcp/cloudsql-proxy/cloudsql-proxy-deployment.yaml
+++ b/apps/pipeline/upstream/env/gcp/cloudsql-proxy/cloudsql-proxy-deployment.yaml
@@ -43,7 +43,7 @@ spec:
           livenessProbe:
             httpGet:
               path: /liveness
-              port: '8090'
+              port: 8090
             # Number of seconds after the container has started before the first probe is scheduled. Defaults to 0.
             # Not necessary when the startup probe is in use.
             initialDelaySeconds: 0

--- a/apps/pipeline/upstream/env/gcp/inverse-proxy/kustomization.yaml
+++ b/apps/pipeline/upstream/env/gcp/inverse-proxy/kustomization.yaml
@@ -2,7 +2,7 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 images:
   - name: gcr.io/ml-pipeline/inverse-proxy-agent
-    newTag: 1.8.0-rc.1
+    newTag: 1.8.0-rc.2
 resources:
   - proxy-configmap.yaml
   - proxy-deployment.yaml

--- a/hack/sync-pipelines-manifests.sh
+++ b/hack/sync-pipelines-manifests.sh
@@ -55,8 +55,15 @@ cp $SRC_DIR/manifests/kustomize $DST_DIR -r
 
 echo "Successfully copied all manifests."
 
+echo "Updating README..."
+SRC_TXT="\[.*\](https://github.com/kubeflow/pipelines/tree/.*/manifests/kustomize)"
+DST_TXT="\[$COMMIT\](https://github.com/kubeflow/pipelines/tree/$COMMIT/manifests/kustomize)"
+
+sed -i "s|$SRC_TXT|$DST_TXT|g" ${MANIFESTS_DIR}/README.md
+
 # DEV: Comment out these commands when local testing
 echo "Committing the changes..."
 cd $MANIFESTS_DIR
 git add apps
+git add README.md
 git commit -m "Update kubeflow/pipelines manifests from ${COMMIT}"


### PR DESCRIPTION
Refs https://github.com/kubeflow/manifests/issues/2111

I've updated the manifests with the `1.8.0-rc.2` tag of Pipelines. I also updated the sync script to be changing the README file as well.