### PR TITLE
Sync kubeflow kubeflow manifests v1.5.0 rc.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,14 +42,14 @@ This repo periodically syncs all official Kubeflow components from their respect
 | Component | Local Manifests Path | Upstream Revision |
 | - | - | - |
 | Training Operator | apps/training-operator/upstream | [v1.4.0-rc.0](https://github.com/kubeflow/tf-operator/tree/v1.4.0-rc.0/manifests) |
-| Notebook Controller | apps/jupyter/notebook-controller/upstream | [v1.5.0-rc.0](https://github.com/kubeflow/kubeflow/tree/v1.5.0-rc.0/components/notebook-controller/config) |
-| Tensorboard Controller | apps/tensorboard/tensorboard-controller/upstream | [v1.5.0-rc.0](https://github.com/kubeflow/kubeflow/tree/v1.5.0-rc.0/components/tensorboard-controller/config) |
-| Central Dashboard | apps/centraldashboard/upstream | [v1.5.0-rc.0](https://github.com/kubeflow/kubeflow/tree/v1.5.0-rc.0/components/centraldashboard/manifests) |
-| Profiles + KFAM | apps/profiles/upstream | [v1.5.0-rc.0](https://github.com/kubeflow/kubeflow/tree/v1.5.0-rc.0/components/profile-controller/config) |
-| PodDefaults Webhook | apps/admission-webhook/upstream | [v1.5.0-rc.0](https://github.com/kubeflow/kubeflow/tree/v1.5.0-rc.0/components/admission-webhook/manifests) |
-| Jupyter Web App | apps/jupyter/jupyter-web-app/upstream | [v1.5.0-rc.0](https://github.com/kubeflow/kubeflow/tree/v1.5.0-rc.0/components/crud-web-apps/jupyter/manifests) |
-| Tensorboards Web App | apps/tensorboard/tensorboards-web-app/upstream | [v1.5.0-rc.0](https://github.com/kubeflow/kubeflow/tree/v1.5.0-rc.0/components/crud-web-apps/tensorboards/manifests) |
-| Volumes Web App | apps/volumes-web-app/upstream | [v1.5.0-rc.0](https://github.com/kubeflow/kubeflow/tree/v1.5.0-rc.0/components/crud-web-apps/volumes/manifests) |
+| Notebook Controller | apps/jupyter/notebook-controller/upstream | [v1.5.0-rc.1](https://github.com/kubeflow/kubeflow/tree/v1.5.0-rc.1/components/notebook-controller/config) |
+| Tensorboard Controller | apps/tensorboard/tensorboard-controller/upstream | [v1.5.0-rc.1](https://github.com/kubeflow/kubeflow/tree/v1.5.0-rc.1/components/tensorboard-controller/config) |
+| Central Dashboard | apps/centraldashboard/upstream | [v1.5.0-rc.1](https://github.com/kubeflow/kubeflow/tree/v1.5.0-rc.1/components/centraldashboard/manifests) |
+| Profiles + KFAM | apps/profiles/upstream | [v1.5.0-rc.1](https://github.com/kubeflow/kubeflow/tree/v1.5.0-rc.1/components/profile-controller/config) |
+| PodDefaults Webhook | apps/admission-webhook/upstream | [v1.5.0-rc.1](https://github.com/kubeflow/kubeflow/tree/v1.5.0-rc.1/components/admission-webhook/manifests) |
+| Jupyter Web App | apps/jupyter/jupyter-web-app/upstream | [v1.5.0-rc.1](https://github.com/kubeflow/kubeflow/tree/v1.5.0-rc.1/components/crud-web-apps/jupyter/manifests) |
+| Tensorboards Web App | apps/tensorboard/tensorboards-web-app/upstream | [v1.5.0-rc.1](https://github.com/kubeflow/kubeflow/tree/v1.5.0-rc.1/components/crud-web-apps/tensorboards/manifests) |
+| Volumes Web App | apps/volumes-web-app/upstream | [v1.5.0-rc.1](https://github.com/kubeflow/kubeflow/tree/v1.5.0-rc.1/components/crud-web-apps/volumes/manifests) |
 | Katib | apps/katib/upstream | [v0.13.0-rc.0](https://github.com/kubeflow/katib/tree/v0.13.0-rc.0/manifests/v1beta1) |
 | KFServing | apps/kfserving/upstream | [v0.6.1](https://github.com/kubeflow/kfserving/releases/tag/v0.6.1) |
 | KServe | contrib/kserve/upstream | [v0.7.0](https://github.com/kserve/kserve/tree/v0.7.0) |

--- a/apps/admission-webhook/upstream/base/kustomization.yaml
+++ b/apps/admission-webhook/upstream/base/kustomization.yaml
@@ -16,7 +16,7 @@ commonLabels:
 images:
 - name: public.ecr.aws/j1r0q0g6/notebooks/admission-webhook
   newName: public.ecr.aws/j1r0q0g6/notebooks/admission-webhook
-  newTag: v1.5.0-rc.0
+  newTag: v1.5.0-rc.1
 namespace: kubeflow
 generatorOptions:
   disableNameSuffixHash: true

--- a/apps/centraldashboard/upstream/base/kustomization.yaml
+++ b/apps/centraldashboard/upstream/base/kustomization.yaml
@@ -18,7 +18,7 @@ commonLabels:
 images:
 - name: public.ecr.aws/j1r0q0g6/notebooks/central-dashboard
   newName: public.ecr.aws/j1r0q0g6/notebooks/central-dashboard
-  newTag: v1.5.0-rc.0
+  newTag: v1.5.0-rc.1
 configMapGenerator:
 - envs:
   - params.env

--- a/apps/jupyter/jupyter-web-app/upstream/base/cluster-role.yaml
+++ b/apps/jupyter/jupyter-web-app/upstream/base/cluster-role.yaml
@@ -4,15 +4,6 @@ metadata:
   name: cluster-role
 rules:
 - apiGroups:
-  - ""
-  resources:
-  - namespaces
-  verbs:
-  - get
-  - list
-  - create
-  - delete
-- apiGroups:
   - authorization.k8s.io
   resources:
   - subjectaccessreviews

--- a/apps/jupyter/jupyter-web-app/upstream/base/configs/spawner_ui_config.yaml
+++ b/apps/jupyter/jupyter-web-app/upstream/base/configs/spawner_ui_config.yaml
@@ -17,23 +17,23 @@
 spawnerFormDefaults:
   image:
     # The container Image for the user's Jupyter Notebook
-    value: public.ecr.aws/j1r0q0g6/notebooks/notebook-servers/jupyter-scipy:v1.5.0-rc.0
+    value: public.ecr.aws/j1r0q0g6/notebooks/notebook-servers/jupyter-scipy:v1.5.0-rc.1
     # The list of available standard container Images
     options:
-    - public.ecr.aws/j1r0q0g6/notebooks/notebook-servers/jupyter-scipy:v1.5.0-rc.0
-    - public.ecr.aws/j1r0q0g6/notebooks/notebook-servers/jupyter-pytorch-full:v1.5.0-rc.0
-    - public.ecr.aws/j1r0q0g6/notebooks/notebook-servers/jupyter-pytorch-cuda-full:v1.5.0-rc.0
-    - public.ecr.aws/j1r0q0g6/notebooks/notebook-servers/jupyter-tensorflow-full:v1.5.0-rc.0
-    - public.ecr.aws/j1r0q0g6/notebooks/notebook-servers/jupyter-tensorflow-cuda-full:v1.5.0-rc.0
+    - public.ecr.aws/j1r0q0g6/notebooks/notebook-servers/jupyter-scipy:v1.5.0-rc.1
+    - public.ecr.aws/j1r0q0g6/notebooks/notebook-servers/jupyter-pytorch-full:v1.5.0-rc.1
+    - public.ecr.aws/j1r0q0g6/notebooks/notebook-servers/jupyter-pytorch-cuda-full:v1.5.0-rc.1
+    - public.ecr.aws/j1r0q0g6/notebooks/notebook-servers/jupyter-tensorflow-full:v1.5.0-rc.1
+    - public.ecr.aws/j1r0q0g6/notebooks/notebook-servers/jupyter-tensorflow-cuda-full:v1.5.0-rc.1
   imageGroupOne:
     # The container Image for the user's Group One Server
     # The annotation `notebooks.kubeflow.org/http-rewrite-uri: /`
     # is applied to notebook in this group, configuring
     # the Istio rewrite for containers that host their web UI at `/`
-    value: public.ecr.aws/j1r0q0g6/notebooks/notebook-servers/codeserver-python:v1.5.0-rc.0
+    value: public.ecr.aws/j1r0q0g6/notebooks/notebook-servers/codeserver-python:v1.5.0-rc.1
     # The list of available standard container Images
     options:
-    - public.ecr.aws/j1r0q0g6/notebooks/notebook-servers/codeserver-python:v1.5.0-rc.0
+    - public.ecr.aws/j1r0q0g6/notebooks/notebook-servers/codeserver-python:v1.5.0-rc.1
   imageGroupTwo:
     # The container Image for the user's Group Two Server
     # The annotation `notebooks.kubeflow.org/http-rewrite-uri: /`
@@ -42,10 +42,10 @@ spawnerFormDefaults:
     # The annotation `notebooks.kubeflow.org/http-headers-request-set`
     # is applied to notebook in this group, configuring Istio
     # to add the `X-RStudio-Root-Path` header to requests
-    value: public.ecr.aws/j1r0q0g6/notebooks/notebook-servers/rstudio-tidyverse:v1.5.0-rc.0
+    value: public.ecr.aws/j1r0q0g6/notebooks/notebook-servers/rstudio-tidyverse:v1.5.0-rc.1
     # The list of available standard container Images
     options:
-    - public.ecr.aws/j1r0q0g6/notebooks/notebook-servers/rstudio-tidyverse:v1.5.0-rc.0
+    - public.ecr.aws/j1r0q0g6/notebooks/notebook-servers/rstudio-tidyverse:v1.5.0-rc.1
   # If true, hide registry and/or tag name in the image selection dropdown
   hideRegistry: true
   hideTag: false
@@ -75,71 +75,38 @@ spawnerFormDefaults:
     readOnly: false
   workspaceVolume:
     # Workspace Volume to be attached to user's Notebook
-    # Each Workspace Volume is declared with the following attributes:
-    # Type, Name, Size, MountPath and Access Mode
+    # If you don't want a workspace volume then delete the 'value' key
     value:
-      type:
-        # The Type of the Workspace Volume
-        # Supported values: 'New', 'Existing'
-        value: New
-      name:
-        # The Name of the Workspace Volume
-        # Note that this is a templated value. Special values:
-        # {notebook-name}: Replaced with the name of the Notebook. The frontend
-        #                  will replace this value as the user types the name
-        value: 'workspace-{notebook-name}'
-      size:
-        # The Size of the Workspace Volume (in Gi)
-        value: '5Gi'
-      mountPath:
-        # The Path that the Workspace Volume will be mounted
-        value: /home/jovyan
-      accessModes:
-        # The Access Mode of the Workspace Volume
-        # Supported values: 'ReadWriteOnce', 'ReadWriteMany', 'ReadOnlyMany'
-        value: ReadWriteOnce
-      class:
-        # The StrageClass the PVC will use if type is New. Special values are:
-        # {none}: default StorageClass
-        # {empty}: empty string ""
-        value: '{none}'
+      mount: /home/jovyan
+      newPvc:
+        metadata:
+          name: '{notebook-name}-workspace'
+        spec:
+          resources:
+            requests:
+              storage: 10Gi
+          accessModes:
+          - ReadWriteOnce
     readOnly: false
   dataVolumes:
     # List of additional Data Volumes to be attached to the user's Notebook
     value: []
-    # Each Data Volume is declared with the following attributes:
-    # Type, Name, Size, MountPath and Access Mode
-    #
     # For example, a list with 2 Data Volumes:
     # value:
-    #   - value:
-    #       type:
-    #         value: New
-    #       name:
-    #         value: '{notebook-name}-vol-1'
-    #       size:
-    #         value: '10Gi'
-    #       class:
-    #         value: standard
-    #       mountPath:
-    #         value: /home/jovyan/vol-1
-    #       accessModes:
-    #         value: ReadWriteOnce
-    #       class:
-    #         value: {none}
-    #   - value:
-    #       type:
-    #         value: New
-    #       name:
-    #         value: '{notebook-name}-vol-2'
-    #       size:
-    #         value: '10Gi'
-    #       mountPath:
-    #         value: /home/jovyan/vol-2
-    #       accessModes:
-    #         value: ReadWriteMany
-    #       class:
-    #         value: {none}
+    #   - mount: /home/jovyan/datavol-1
+    #     newPvc:
+    #       metadata:
+    #         name: '{notebook-name}-datavol-1'
+    #       spec:
+    #         resources:
+    #           requests:
+    #             storage: 5Gi
+    #         accessModes:
+    #           - ReadWriteOnce
+    #   - mount: /home/jovyan/datavol-1
+    #     existingSource:
+    #       persistentVolumeClaim:
+    #         claimName: test-pvc
     readOnly: false
   gpus:
     # Number of GPUs to be assigned to the Notebook Container

--- a/apps/jupyter/jupyter-web-app/upstream/base/kustomization.yaml
+++ b/apps/jupyter/jupyter-web-app/upstream/base/kustomization.yaml
@@ -23,7 +23,7 @@ commonLabels:
 images:
 - name: public.ecr.aws/j1r0q0g6/notebooks/jupyter-web-app
   newName: public.ecr.aws/j1r0q0g6/notebooks/jupyter-web-app
-  newTag: v1.5.0-rc.0
+  newTag: v1.5.0-rc.1
 # We need the name to be unique without the suffix because the original name is what
 # gets used with patches
 configMapGenerator:

--- a/apps/jupyter/jupyter-web-app/upstream/base/role-binding.yaml
+++ b/apps/jupyter/jupyter-web-app/upstream/base/role-binding.yaml
@@ -1,4 +1,4 @@
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   name: jupyter-notebook-role-binding

--- a/apps/jupyter/jupyter-web-app/upstream/base/role.yaml
+++ b/apps/jupyter/jupyter-web-app/upstream/base/role.yaml
@@ -1,35 +1,48 @@
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
   name: jupyter-notebook-role
 rules:
 - apiGroups:
-  - ""
+  - authorization.k8s.io
   resources:
-  - pods
-  - pods/log
-  - secrets
-  - services
+  - subjectaccessreviews
   verbs:
-  - '*'
-- apiGroups:
-  - ""
-  - apps
-  - extensions
-  resources:
-  - deployments
-  - replicasets
-  verbs:
-  - '*'
+  - create
 - apiGroups:
   - kubeflow.org
   resources:
-  - '*'
+  - notebooks
+  - notebooks/finalizers
+  - poddefaults
   verbs:
-  - '*'
+  - get
+  - list
+  - create
+  - delete
+  - patch
+  - update
 - apiGroups:
-  - batch
+  - ""
   resources:
-  - jobs
+  - persistentvolumeclaims
   verbs:
-  - '*'
+  - create
+  - delete
+  - get
+  - list
+- apiGroups:
+  - ""
+  resources:
+  - events
+  - nodes
+  verbs:
+  - list
+- apiGroups:
+  - storage.k8s.io
+  resources:
+  - storageclasses
+  verbs:
+  - get
+  - list
+  - watch

--- a/apps/jupyter/notebook-controller/upstream/base/kustomization.yaml
+++ b/apps/jupyter/notebook-controller/upstream/base/kustomization.yaml
@@ -5,4 +5,4 @@ resources:
 images:
 - name: public.ecr.aws/j1r0q0g6/notebooks/notebook-controller
   newName: public.ecr.aws/j1r0q0g6/notebooks/notebook-controller
-  newTag: v1.5.0-rc.0
+  newTag: v1.5.0-rc.1

--- a/apps/profiles/upstream/base/kustomization.yaml
+++ b/apps/profiles/upstream/base/kustomization.yaml
@@ -12,7 +12,7 @@ patchesStrategicMerge:
 images:
 - name: public.ecr.aws/j1r0q0g6/notebooks/profile-controller
   newName: public.ecr.aws/j1r0q0g6/notebooks/profile-controller
-  newTag: v1.5.0-rc.0
+  newTag: v1.5.0-rc.1
 
 configMapGenerator:
 - name: namespace-labels-data

--- a/apps/profiles/upstream/overlays/kubeflow/kustomization.yaml
+++ b/apps/profiles/upstream/overlays/kubeflow/kustomization.yaml
@@ -29,4 +29,4 @@ vars:
 images:
 - name: public.ecr.aws/j1r0q0g6/notebooks/access-management
   newName: public.ecr.aws/j1r0q0g6/notebooks/access-management
-  newTag: v1.5.0-rc.0
+  newTag: v1.5.0-rc.1

--- a/apps/tensorboard/tensorboard-controller/upstream/base/kustomization.yaml
+++ b/apps/tensorboard/tensorboard-controller/upstream/base/kustomization.yaml
@@ -12,7 +12,7 @@ patchesStrategicMerge:
 - patches/add_service_account.yaml
 patches:
 - patch: |
-    apiVersion: rbac.authorization.k8s.io/v1beta1
+    apiVersion: rbac.authorization.k8s.io/v1
     kind: RoleBinding
     metadata:
       name: "*"
@@ -23,7 +23,7 @@ patches:
     kind: "RoleBinding"
     group: "rbac.authorization.k8s.io"
 - patch: |
-    apiVersion: rbac.authorization.k8s.io/v1beta1
+    apiVersion: rbac.authorization.k8s.io/v1
     kind: ClusterRoleBinding
     metadata:
       name: "*"
@@ -36,4 +36,4 @@ patches:
 images:
 - name: public.ecr.aws/j1r0q0g6/notebooks/tensorboard-controller
   newName: public.ecr.aws/j1r0q0g6/notebooks/tensorboard-controller
-  newTag: v1.5.0-rc.0
+  newTag: v1.5.0-rc.1

--- a/apps/tensorboard/tensorboards-web-app/upstream/base/kustomization.yaml
+++ b/apps/tensorboard/tensorboards-web-app/upstream/base/kustomization.yaml
@@ -14,7 +14,7 @@ commonLabels:
 images:
 - name: public.ecr.aws/j1r0q0g6/notebooks/tensorboards-web-app
   newName: public.ecr.aws/j1r0q0g6/notebooks/tensorboards-web-app
-  newTag: v1.5.0-rc.0
+  newTag: v1.5.0-rc.1
 # We need the name to be unique without the suffix because the original name is what
 # gets used with patches
 configMapGenerator:

--- a/apps/volumes-web-app/upstream/base/kustomization.yaml
+++ b/apps/volumes-web-app/upstream/base/kustomization.yaml
@@ -14,7 +14,7 @@ commonLabels:
 images:
 - name: public.ecr.aws/j1r0q0g6/notebooks/volumes-web-app
   newName: public.ecr.aws/j1r0q0g6/notebooks/volumes-web-app
-  newTag: v1.5.0-rc.0
+  newTag: v1.5.0-rc.1
 # We need the name to be unique without the suffix because the original name is what
 # gets used with patches
 configMapGenerator:

--- a/hack/sync-kubeflow-manifests.sh
+++ b/hack/sync-kubeflow-manifests.sh
@@ -52,40 +52,80 @@ DST_DIR=$MANIFESTS_DIR/apps/admission-webhook/upstream
 rm -r $DST_DIR
 cp $SRC_DIR/components/admission-webhook/manifests $DST_DIR -r
 
+echo "Updating README..."
+SRC_TXT="\[.*\](https://github.com/kubeflow/kubeflow/tree/.*/components/admission-webhook/manifests)"
+DST_TXT="\[$COMMIT\](https://github.com/kubeflow/kubeflow/tree/$COMMIT/components/admission-webhook/manifests)"
+sed -i "s|$SRC_TXT|$DST_TXT|g" ${MANIFESTS_DIR}/README.md
+
 echo "Copying centraldashboard manifests..."
 DST_DIR=$MANIFESTS_DIR/apps/centraldashboard/upstream
 rm -r $DST_DIR
 cp $SRC_DIR/components/centraldashboard/manifests $DST_DIR -r
+
+echo "Updating README..."
+SRC_TXT="\[.*\](https://github.com/kubeflow/kubeflow/tree/.*/components/centraldashboard/manifests)"
+DST_TXT="\[$COMMIT\](https://github.com/kubeflow/kubeflow/tree/$COMMIT/components/centraldashboard/manifests)"
+sed -i "s|$SRC_TXT|$DST_TXT|g" ${MANIFESTS_DIR}/README.md
 
 echo "Copying jupyter-web-app manifests..."
 DST_DIR=$MANIFESTS_DIR/apps/jupyter/jupyter-web-app/upstream
 rm -r $DST_DIR
 cp $SRC_DIR/components/crud-web-apps/jupyter/manifests $DST_DIR -r
 
+echo "Updating README..."
+SRC_TXT="\[.*\](https://github.com/kubeflow/kubeflow/tree/.*/components/crud-web-apps/jupyter/manifests)"
+DST_TXT="\[$COMMIT\](https://github.com/kubeflow/kubeflow/tree/$COMMIT/components/crud-web-apps/jupyter/manifests)"
+sed -i "s|$SRC_TXT|$DST_TXT|g" ${MANIFESTS_DIR}/README.md
+
 echo "Copying volumes-web-app manifests..."
 DST_DIR=$MANIFESTS_DIR/apps/volumes-web-app/upstream
 rm -r $DST_DIR
 cp $SRC_DIR/components/crud-web-apps/volumes/manifests $DST_DIR -r
+
+echo "Updating README..."
+SRC_TXT="\[.*\](https://github.com/kubeflow/kubeflow/tree/.*/components/crud-web-apps/volumes/manifests)"
+DST_TXT="\[$COMMIT\](https://github.com/kubeflow/kubeflow/tree/$COMMIT/components/crud-web-apps/volumes/manifests)"
+sed -i "s|$SRC_TXT|$DST_TXT|g" ${MANIFESTS_DIR}/README.md
 
 echo "Copying tensorboards-web-app manifests..."
 DST_DIR=$MANIFESTS_DIR/apps/tensorboard/tensorboards-web-app/upstream
 rm -r $DST_DIR
 cp $SRC_DIR/components/crud-web-apps/tensorboards/manifests $DST_DIR -r
 
+echo "Updating README..."
+SRC_TXT="\[.*\](https://github.com/kubeflow/kubeflow/tree/.*/components/crud-web-apps/tensorboards/manifests)"
+DST_TXT="\[$COMMIT\](https://github.com/kubeflow/kubeflow/tree/$COMMIT/components/crud-web-apps/tensorboards/manifests)"
+sed -i "s|$SRC_TXT|$DST_TXT|g" ${MANIFESTS_DIR}/README.md
+
 echo "Copying profile-controller manifests..."
 DST_DIR=$MANIFESTS_DIR/apps/profiles/upstream
 rm -r $DST_DIR
 cp $SRC_DIR/components/profile-controller/config $DST_DIR -r
+
+echo "Updating README..."
+SRC_TXT="\[.*\](https://github.com/kubeflow/kubeflow/tree/.*/components/profile-controller/config)"
+DST_TXT="\[$COMMIT\](https://github.com/kubeflow/kubeflow/tree/$COMMIT/components/profile-controller/config)"
+sed -i "s|$SRC_TXT|$DST_TXT|g" ${MANIFESTS_DIR}/README.md
 
 echo "Copying notebook-controller manifests..."
 DST_DIR=$MANIFESTS_DIR/apps/jupyter/notebook-controller/upstream
 rm -r $DST_DIR
 cp $SRC_DIR/components/notebook-controller/config $DST_DIR -r
 
+echo "Updating README..."
+SRC_TXT="\[.*\](https://github.com/kubeflow/kubeflow/tree/.*/components/notebook-controller/config)"
+DST_TXT="\[$COMMIT\](https://github.com/kubeflow/kubeflow/tree/$COMMIT/components/notebook-controller/config)"
+sed -i "s|$SRC_TXT|$DST_TXT|g" ${MANIFESTS_DIR}/README.md
+
 echo "Copying tensorboard-controller manifests..."
 DST_DIR=$MANIFESTS_DIR/apps/tensorboard/tensorboard-controller/upstream
 rm -r $DST_DIR
 cp $SRC_DIR/components/tensorboard-controller/config $DST_DIR -r
+
+echo "Updating README..."
+SRC_TXT="\[.*\](https://github.com/kubeflow/kubeflow/tree/.*/components/tensorboard-controller/config)"
+DST_TXT="\[$COMMIT\](https://github.com/kubeflow/kubeflow/tree/$COMMIT/components/tensorboard-controller/config)"
+sed -i "s|$SRC_TXT|$DST_TXT|g" ${MANIFESTS_DIR}/README.md
 
 echo "Successfully copied all manifests."
 
@@ -93,4 +133,5 @@ echo "Successfully copied all manifests."
 echo "Committing the changes..."
 cd $MANIFESTS_DIR
 git add apps
+git add README.md
 git commit -m "Update kubeflow/kubeflow manifests from ${COMMIT}"


### PR DESCRIPTION
Refs #2109 

I also updated the sync-scripts to be updating the README, so that we don't have to do this manually. The PR used the new [`v1.5-rc.1`](https://github.com/kubeflow/kubeflow/tree/v1.5.0-rc.1) tag in the kubeflow/kubeflow repo.

@kubeflow/release-team  this should be the last component to be updated before cutting the RC1, which distribution testing phase will use

EDIT: Correction, it's this and the update for including the models web app https://github.com/kserve/models-web-app/tree/release-0.7