### PR TITLE
Update manifests for Katib v0.13.0-rc.1 release

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ This repo periodically syncs all official Kubeflow components from their respect
 | Jupyter Web App | apps/jupyter/jupyter-web-app/upstream | [v1.5.0-rc.1](https://github.com/kubeflow/kubeflow/tree/v1.5.0-rc.1/components/crud-web-apps/jupyter/manifests) |
 | Tensorboards Web App | apps/tensorboard/tensorboards-web-app/upstream | [v1.5.0-rc.1](https://github.com/kubeflow/kubeflow/tree/v1.5.0-rc.1/components/crud-web-apps/tensorboards/manifests) |
 | Volumes Web App | apps/volumes-web-app/upstream | [v1.5.0-rc.1](https://github.com/kubeflow/kubeflow/tree/v1.5.0-rc.1/components/crud-web-apps/volumes/manifests) |
-| Katib | apps/katib/upstream | [v0.13.0-rc.0](https://github.com/kubeflow/katib/tree/v0.13.0-rc.0/manifests/v1beta1) |
+| Katib | apps/katib/upstream | [v0.13.0-rc.1](https://github.com/kubeflow/katib/tree/v0.13.0-rc.1/manifests/v1beta1) |
 | KFServing | apps/kfserving/upstream | [v0.6.1](https://github.com/kubeflow/kfserving/releases/tag/v0.6.1) |
 | KServe | contrib/kserve/upstream | [v0.7.0](https://github.com/kserve/kserve/tree/v0.7.0) |
 | Kubeflow Pipelines | apps/pipeline/upstream | [1.8.0-rc.2](https://github.com/kubeflow/pipelines/tree/1.8.0-rc.2/manifests/kustomize) |

--- a/apps/katib/upstream/components/controller/katib-config.yaml
+++ b/apps/katib/upstream/components/controller/katib-config.yaml
@@ -7,13 +7,13 @@ data:
   metrics-collector-sidecar: |-
     {
       "StdOut": {
-        "image": "docker.io/kubeflowkatib/file-metrics-collector:v0.13.0-rc.0"
+        "image": "docker.io/kubeflowkatib/file-metrics-collector:v0.13.0-rc.1"
       },
       "File": {
-        "image": "docker.io/kubeflowkatib/file-metrics-collector:v0.13.0-rc.0"
+        "image": "docker.io/kubeflowkatib/file-metrics-collector:v0.13.0-rc.1"
       },
       "TensorFlowEvent": {
-        "image": "docker.io/kubeflowkatib/tfevent-metrics-collector:v0.13.0-rc.0",
+        "image": "docker.io/kubeflowkatib/tfevent-metrics-collector:v0.13.0-rc.1",
         "resources": {
           "limits": {
             "memory": "1Gi"
@@ -24,31 +24,31 @@ data:
   suggestion: |-
     {
       "random": {
-        "image": "docker.io/kubeflowkatib/suggestion-hyperopt:v0.13.0-rc.0"
+        "image": "docker.io/kubeflowkatib/suggestion-hyperopt:v0.13.0-rc.1"
       },
       "tpe": {
-        "image": "docker.io/kubeflowkatib/suggestion-hyperopt:v0.13.0-rc.0"
+        "image": "docker.io/kubeflowkatib/suggestion-hyperopt:v0.13.0-rc.1"
       },
       "grid": {
-        "image": "docker.io/kubeflowkatib/suggestion-chocolate:v0.13.0-rc.0"
+        "image": "docker.io/kubeflowkatib/suggestion-chocolate:v0.13.0-rc.1"
       },
       "hyperband": {
-        "image": "docker.io/kubeflowkatib/suggestion-hyperband:v0.13.0-rc.0"
+        "image": "docker.io/kubeflowkatib/suggestion-hyperband:v0.13.0-rc.1"
       },
       "bayesianoptimization": {
-        "image": "docker.io/kubeflowkatib/suggestion-skopt:v0.13.0-rc.0"
+        "image": "docker.io/kubeflowkatib/suggestion-skopt:v0.13.0-rc.1"
       },
       "cmaes": {
-        "image": "docker.io/kubeflowkatib/suggestion-goptuna:v0.13.0-rc.0"
+        "image": "docker.io/kubeflowkatib/suggestion-goptuna:v0.13.0-rc.1"
       },
       "sobol": {
-        "image": "docker.io/kubeflowkatib/suggestion-goptuna:v0.13.0-rc.0"
+        "image": "docker.io/kubeflowkatib/suggestion-goptuna:v0.13.0-rc.1"
       },
       "multivariate-tpe": {
-        "image": "docker.io/kubeflowkatib/suggestion-optuna:v0.13.0-rc.0"
+        "image": "docker.io/kubeflowkatib/suggestion-optuna:v0.13.0-rc.1"
       },
       "enas": {
-        "image": "docker.io/kubeflowkatib/suggestion-enas:v0.13.0-rc.0",
+        "image": "docker.io/kubeflowkatib/suggestion-enas:v0.13.0-rc.1",
         "resources": {
           "limits": {
             "memory": "200Mi"
@@ -56,12 +56,12 @@ data:
         }
       },
       "darts": {
-        "image": "docker.io/kubeflowkatib/suggestion-darts:v0.13.0-rc.0"
+        "image": "docker.io/kubeflowkatib/suggestion-darts:v0.13.0-rc.1"
       }
     }
   early-stopping: |-
     {
       "medianstop": {
-        "image": "docker.io/kubeflowkatib/earlystopping-medianstop:v0.13.0-rc.0"
+        "image": "docker.io/kubeflowkatib/earlystopping-medianstop:v0.13.0-rc.1"
       }
     }

--- a/apps/katib/upstream/components/controller/trial-templates.yaml
+++ b/apps/katib/upstream/components/controller/trial-templates.yaml
@@ -14,7 +14,7 @@ data:
         spec:
           containers:
             - name: training-container
-              image: docker.io/kubeflowkatib/mxnet-mnist:v0.13.0-rc.0
+              image: docker.io/kubeflowkatib/mxnet-mnist:v0.13.0-rc.1
               command:
                 - "python3"
                 - "/opt/mxnet-mnist/mnist.py"
@@ -32,7 +32,7 @@ data:
         spec:
           containers:
             - name: training-container
-              image: docker.io/kubeflowkatib/enas-cnn-cifar10-cpu:v0.13.0-rc.0
+              image: docker.io/kubeflowkatib/enas-cnn-cifar10-cpu:v0.13.0-rc.1
               command:
                 - python3
                 - -u
@@ -53,7 +53,7 @@ data:
             spec:
               containers:
                 - name: pytorch
-                  image: docker.io/kubeflowkatib/pytorch-mnist:v0.13.0-rc.0
+                  image: docker.io/kubeflowkatib/pytorch-mnist:v0.13.0-rc.1
                   imagePullPolicy: Always
                   command:
                     - "python3"
@@ -68,7 +68,7 @@ data:
             spec:
               containers:
                 - name: pytorch
-                  image: docker.io/kubeflowkatib/pytorch-mnist:v0.13.0-rc.0
+                  image: docker.io/kubeflowkatib/pytorch-mnist:v0.13.0-rc.1
                   imagePullPolicy: Always
                   command:
                     - "python3"

--- a/apps/katib/upstream/installs/katib-cert-manager/kustomization.yaml
+++ b/apps/katib/upstream/installs/katib-cert-manager/kustomization.yaml
@@ -21,13 +21,13 @@ resources:
 images:
   - name: docker.io/kubeflowkatib/katib-controller
     newName: docker.io/kubeflowkatib/katib-controller
-    newTag: v0.13.0-rc.0
+    newTag: v0.13.0-rc.1
   - name: docker.io/kubeflowkatib/katib-db-manager
     newName: docker.io/kubeflowkatib/katib-db-manager
-    newTag: v0.13.0-rc.0
+    newTag: v0.13.0-rc.1
   - name: docker.io/kubeflowkatib/katib-ui
     newName: docker.io/kubeflowkatib/katib-ui
-    newTag: v0.13.0-rc.0
+    newTag: v0.13.0-rc.1
 
 patchesStrategicMerge:
   - patches/katib-cert-injection.yaml

--- a/apps/katib/upstream/installs/katib-external-db/kustomization.yaml
+++ b/apps/katib/upstream/installs/katib-external-db/kustomization.yaml
@@ -19,16 +19,16 @@ resources:
 images:
   - name: docker.io/kubeflowkatib/katib-controller
     newName: docker.io/kubeflowkatib/katib-controller
-    newTag: v0.13.0-rc.0
+    newTag: v0.13.0-rc.1
   - name: docker.io/kubeflowkatib/katib-db-manager
     newName: docker.io/kubeflowkatib/katib-db-manager
-    newTag: v0.13.0-rc.0
+    newTag: v0.13.0-rc.1
   - name: docker.io/kubeflowkatib/katib-ui
     newName: docker.io/kubeflowkatib/katib-ui
-    newTag: v0.13.0-rc.0
+    newTag: v0.13.0-rc.1
   - name: docker.io/kubeflowkatib/cert-generator
     newName: docker.io/kubeflowkatib/cert-generator
-    newTag: v0.13.0-rc.0
+    newTag: v0.13.0-rc.1
 patchesStrategicMerge:
   - patches/db-manager.yaml
 # Modify katib-mysql-secrets with parameters for the DB.

--- a/apps/katib/upstream/installs/katib-openshift/kustomization.yaml
+++ b/apps/katib/upstream/installs/katib-openshift/kustomization.yaml
@@ -30,13 +30,13 @@ resources:
 images:
   - name: docker.io/kubeflowkatib/katib-controller
     newName: docker.io/kubeflowkatib/katib-controller
-    newTag: v0.13.0-rc.0
+    newTag: v0.13.0-rc.1
   - name: docker.io/kubeflowkatib/katib-db-manager
     newName: docker.io/kubeflowkatib/katib-db-manager
-    newTag: v0.13.0-rc.0
+    newTag: v0.13.0-rc.1
   - name: docker.io/kubeflowkatib/katib-ui
     newName: docker.io/kubeflowkatib/katib-ui
-    newTag: v0.13.0-rc.0
+    newTag: v0.13.0-rc.1
 
 patchesJson6902:
   # Annotate Service to delegate TLS-secret generation to OpenShift service controller

--- a/apps/katib/upstream/installs/katib-standalone/kustomization.yaml
+++ b/apps/katib/upstream/installs/katib-standalone/kustomization.yaml
@@ -21,13 +21,13 @@ resources:
 images:
   - name: docker.io/kubeflowkatib/katib-controller
     newName: docker.io/kubeflowkatib/katib-controller
-    newTag: v0.13.0-rc.0
+    newTag: v0.13.0-rc.1
   - name: docker.io/kubeflowkatib/katib-db-manager
     newName: docker.io/kubeflowkatib/katib-db-manager
-    newTag: v0.13.0-rc.0
+    newTag: v0.13.0-rc.1
   - name: docker.io/kubeflowkatib/katib-ui
     newName: docker.io/kubeflowkatib/katib-ui
-    newTag: v0.13.0-rc.0
+    newTag: v0.13.0-rc.1
   - name: docker.io/kubeflowkatib/cert-generator
     newName: docker.io/kubeflowkatib/cert-generator
-    newTag: v0.13.0-rc.0
+    newTag: v0.13.0-rc.1

--- a/apps/katib/upstream/installs/katib-with-kubeflow/kustomization.yaml
+++ b/apps/katib/upstream/installs/katib-with-kubeflow/kustomization.yaml
@@ -9,13 +9,13 @@ resources:
 images:
   - name: docker.io/kubeflowkatib/katib-controller
     newName: docker.io/kubeflowkatib/katib-controller
-    newTag: v0.13.0-rc.0
+    newTag: v0.13.0-rc.1
   - name: docker.io/kubeflowkatib/katib-db-manager
     newName: docker.io/kubeflowkatib/katib-db-manager
-    newTag: v0.13.0-rc.0
+    newTag: v0.13.0-rc.1
   - name: docker.io/kubeflowkatib/katib-ui
     newName: docker.io/kubeflowkatib/katib-ui
-    newTag: v0.13.0-rc.0
+    newTag: v0.13.0-rc.1
 
 patchesStrategicMerge:
   - patches/remove-namespace.yaml


### PR DESCRIPTION
**Which issue is resolved by this Pull Request:**
Related https://github.com/kubeflow/katib/issues/1774

**Description of your changes:**
I updated manifests for Katib v0.13.0-rc.1 release.
This RC fixes labels problem discussed under: https://github.com/kubeflow/manifests/issues/2106#issuecomment-1034674392.

/assign @kubeflow/wg-automl-leads @kubeflow/release-team  @yhwang

**Checklist:**
- [ ] Unit tests pass:
  **Make sure you have installed kustomize == 3.2.1**
    1. `make generate-changed-only`
    2. `make test`
