### PR TITLE
hack: Don't error if namespace kubeflow exists

### DIFF
--- a/hack/setup-kubeflow-light.sh
+++ b/hack/setup-kubeflow-light.sh
@@ -20,7 +20,7 @@ set -euo pipefail
 TIMEOUT=600s  # 10mins
 
 echo "Creating Kubeflow namespace..."
-kubectl create namespace kubeflow
+kubectl create namespace kubeflow --dry-run=client -o yaml | kubectl apply -f -
 
 echo "Deploying Cert-Manager."
 kustomize build common/cert-manager/cert-manager/base | kubectl apply -f -

--- a/hack/setup-kubeflow.sh
+++ b/hack/setup-kubeflow.sh
@@ -20,7 +20,7 @@ set -euo pipefail
 TIMEOUT=600s  # 10mins
 
 echo "Creating Kubeflow namespace..."
-kubectl create namespace kubeflow
+kubectl create namespace kubeflow --dry-run=client -o yaml | kubectl apply -f -
 
 echo "Deploying all Kubeflow components..."
 function install_kubeflow {


### PR DESCRIPTION
Right now the helper scripts for installing kubeflow will try to create the `kubeflow` namespace. But if it already exists, then the script will fail altogether, since we have `-e`.

There have been a lot of cases where I needed to re-run the script in the same cluster, and had to comment out this line. 

Instead I've updated the scripts to try and apply the `kubeflow` namespace, so that it won't fail if it already exists