### PR TITLE
readme: Use verify=false for the one-liner

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,7 +97,7 @@ The `example` directory contains an example kustomization for the single command
 You can install all Kubeflow official components (residing under `apps`) and all common services (residing under `common`) using the following command:
 
 ```sh
-while ! kustomize build example | kubectl apply -f -; do echo "Retrying to apply resources"; sleep 10; done
+while ! kustomize build example | kubectl apply -f - --validate=false; do echo "Retrying to apply resources"; sleep 10; done
 ```
 
 Once, everything is installed successfully, you can access the Kubeflow Central Dashboard [by logging in to your cluster](#connect-to-your-kubeflow-cluster).


### PR DESCRIPTION
Refs https://github.com/kubeflow/manifests/issues/2133#issuecomment-1040428877

We should remove the `--validate=false` flag once https://github.com/kubeflow/pipelines/pull/7311 is merged and the KFP manfiests are updated to include the fix

cc @juliusvonkohout 