### PR TITLE
Update kubeflow/pipelines manifests from 1.8.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ This repo periodically syncs all official Kubeflow components from their respect
 | Katib | apps/katib/upstream | [v0.13.0-rc.1](https://github.com/kubeflow/katib/tree/v0.13.0-rc.1/manifests/v1beta1) |
 | KFServing | apps/kfserving/upstream | [v0.6.1](https://github.com/kubeflow/kfserving/releases/tag/v0.6.1) |
 | KServe | contrib/kserve/upstream | [v0.7.0](https://github.com/kserve/kserve/tree/v0.7.0) |
-| Kubeflow Pipelines | apps/pipeline/upstream | [1.8.0-rc.2](https://github.com/kubeflow/pipelines/tree/1.8.0-rc.2/manifests/kustomize) |
+| Kubeflow Pipelines | apps/pipeline/upstream | [1.8.0](https://github.com/kubeflow/pipelines/tree/1.8.0/manifests/kustomize) |
 | Kubeflow Tekton Pipelines | apps/kfp-tekton/upstream | [v1.1.1](https://github.com/kubeflow/kfp-tekton/tree/v1.1.1/manifests/kustomize) |
 
 The following is also a matrix with versions from common components that are

--- a/apps/pipeline/upstream/base/cache-deployer/kustomization.yaml
+++ b/apps/pipeline/upstream/base/cache-deployer/kustomization.yaml
@@ -8,4 +8,4 @@ commonLabels:
   app: cache-deployer
 images:
   - name: gcr.io/ml-pipeline/cache-deployer
-    newTag: 1.8.0-rc.2
+    newTag: 1.8.0

--- a/apps/pipeline/upstream/base/cache/kustomization.yaml
+++ b/apps/pipeline/upstream/base/cache/kustomization.yaml
@@ -10,4 +10,4 @@ commonLabels:
   app: cache-server
 images:
   - name: gcr.io/ml-pipeline/cache-server
-    newTag: 1.8.0-rc.2
+    newTag: 1.8.0

--- a/apps/pipeline/upstream/base/installs/generic/pipeline-install-config.yaml
+++ b/apps/pipeline/upstream/base/installs/generic/pipeline-install-config.yaml
@@ -11,7 +11,7 @@ data:
     until the changes take effect. A quick way to restart all deployments in a
     namespace: `kubectl rollout restart deployment -n <your-namespace>`.
   appName: pipeline
-  appVersion: 1.8.0-rc.2
+  appVersion: 1.8.0
   dbHost: mysql
   dbPort: "3306"
   mlmdDb: metadb

--- a/apps/pipeline/upstream/base/installs/multi-user/pipelines-profile-controller/composite-controller.yaml
+++ b/apps/pipeline/upstream/base/installs/multi-user/pipelines-profile-controller/composite-controller.yaml
@@ -10,9 +10,6 @@ spec:
   parentResource:
     apiVersion: v1
     resource: namespaces
-    labelSelector:
-      matchLabels:
-        pipelines.kubeflow.org/enabled = "true"
   childResources:
   - apiVersion: v1
     resource: secrets

--- a/apps/pipeline/upstream/base/installs/multi-user/scheduled-workflow/cluster-role.yaml
+++ b/apps/pipeline/upstream/base/installs/multi-user/scheduled-workflow/cluster-role.yaml
@@ -19,6 +19,7 @@ rules:
   - kubeflow.org
   resources:
   - scheduledworkflows
+  - scheduledworkflows/finalizers
   verbs:
   - create
   - get

--- a/apps/pipeline/upstream/base/metadata/base/kustomization.yaml
+++ b/apps/pipeline/upstream/base/metadata/base/kustomization.yaml
@@ -9,4 +9,4 @@ resources:
   - metadata-grpc-sa.yaml
 images:
   - name: gcr.io/ml-pipeline/metadata-envoy
-    newTag: 1.8.0-rc.2
+    newTag: 1.8.0

--- a/apps/pipeline/upstream/base/pipeline/kustomization.yaml
+++ b/apps/pipeline/upstream/base/pipeline/kustomization.yaml
@@ -37,14 +37,14 @@ resources:
   - kfp-launcher-configmap.yaml
 images:
   - name: gcr.io/ml-pipeline/api-server
-    newTag: 1.8.0-rc.2
+    newTag: 1.8.0
   - name: gcr.io/ml-pipeline/persistenceagent
-    newTag: 1.8.0-rc.2
+    newTag: 1.8.0
   - name: gcr.io/ml-pipeline/scheduledworkflow
-    newTag: 1.8.0-rc.2
+    newTag: 1.8.0
   - name: gcr.io/ml-pipeline/frontend
-    newTag: 1.8.0-rc.2
+    newTag: 1.8.0
   - name: gcr.io/ml-pipeline/viewer-crd-controller
-    newTag: 1.8.0-rc.2
+    newTag: 1.8.0
   - name: gcr.io/ml-pipeline/visualization-server
-    newTag: 1.8.0-rc.2
+    newTag: 1.8.0

--- a/apps/pipeline/upstream/base/pipeline/metadata-writer/kustomization.yaml
+++ b/apps/pipeline/upstream/base/pipeline/metadata-writer/kustomization.yaml
@@ -7,4 +7,4 @@ resources:
   - metadata-writer-sa.yaml
 images:
   - name: gcr.io/ml-pipeline/metadata-writer
-    newTag: 1.8.0-rc.2
+    newTag: 1.8.0

--- a/apps/pipeline/upstream/base/pipeline/ml-pipeline-scheduledworkflow-role.yaml
+++ b/apps/pipeline/upstream/base/pipeline/ml-pipeline-scheduledworkflow-role.yaml
@@ -21,6 +21,7 @@ rules:
   - kubeflow.org
   resources:
   - scheduledworkflows
+  - scheduledworkflows/finalizers
   verbs:
   - create
   - get

--- a/apps/pipeline/upstream/env/gcp/inverse-proxy/kustomization.yaml
+++ b/apps/pipeline/upstream/env/gcp/inverse-proxy/kustomization.yaml
@@ -2,7 +2,7 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 images:
   - name: gcr.io/ml-pipeline/inverse-proxy-agent
-    newTag: 1.8.0-rc.2
+    newTag: 1.8.0
 resources:
   - proxy-configmap.yaml
   - proxy-deployment.yaml


### PR DESCRIPTION
Refs #2111 
Closes #2133 

Bumps the KFP manifests to `1.8.0` https://github.com/kubeflow/manifests/pull/2142#issuecomment-1041367206.

