### PR TITLE
kserve: Add distinct file for cluster-roles

### DIFF
--- a/contrib/kserve/kserve/aggregated-roles.yaml
+++ b/contrib/kserve/kserve/aggregated-roles.yaml
@@ -1,0 +1,89 @@
+aggregationRule:
+  clusterRoleSelectors:
+  - matchLabels:
+      rbac.authorization.kubeflow.org/aggregate-to-kubeflow-kserve-admin: "true"
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  labels:
+    app: kserve
+    app.kubernetes.io/name: kserve
+    rbac.authorization.kubeflow.org/aggregate-to-kubeflow-admin: "true"
+  name: kubeflow-kserve-admin
+rules: []
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  labels:
+    app: kserve
+    app.kubernetes.io/name: kserve
+    rbac.authorization.kubeflow.org/aggregate-to-kubeflow-edit: "true"
+    rbac.authorization.kubeflow.org/aggregate-to-kubeflow-kserve-admin: "true"
+  name: kubeflow-kserve-edit
+rules:
+- apiGroups:
+  - serving.kserve.io
+  resources:
+  - inferenceservices
+  verbs:
+  - get
+  - list
+  - watch
+  - create
+  - delete
+  - deletecollection
+  - patch
+  - update
+- apiGroups:
+  - serving.knative.dev
+  resources:
+  - services
+  - services/status
+  - routes
+  - routes/status
+  - configurations
+  - configurations/status
+  - revisions
+  - revisions/status
+  verbs:
+  - get
+  - list
+  - watch
+  - create
+  - delete
+  - deletecollection
+  - patch
+  - update
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  labels:
+    app: kserve
+    app.kubernetes.io/name: kserve
+    rbac.authorization.kubeflow.org/aggregate-to-kubeflow-view: "true"
+  name: kubeflow-kserve-view
+rules:
+- apiGroups:
+  - serving.kserve.io
+  resources:
+  - inferenceservices
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - serving.knative.dev
+  resources:
+  - services
+  - services/status
+  - routes
+  - routes/status
+  - configurations
+  - configurations/status
+  - revisions
+  - revisions/status
+  verbs:
+  - get
+  - list

--- a/contrib/kserve/kserve/kustomization.yaml
+++ b/contrib/kserve/kserve/kustomization.yaml
@@ -2,6 +2,7 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
 - kserve.yaml
+- aggregated-roles.yaml
 # For KF 1.5 we are including both KFServing and KServe. Thus we install the
 # standalone kserve manifests, to avoid conflicts with 0.6.1 KFServing.
 #- kserve_kubeflow.yaml

--- a/example/kustomization.yaml
+++ b/example/kustomization.yaml
@@ -32,7 +32,7 @@ resources:
 # Katib
 - ../apps/katib/upstream/installs/katib-with-kubeflow
 # Central Dashboard
-- ../apps/centraldashboard/upstream/overlays/istio
+- ../apps/centraldashboard/upstream/overlays/kserve
 # Admission Webhook
 - ../apps/admission-webhook/upstream/overlays/cert-manager
 # Notebook Controller
@@ -54,4 +54,4 @@ resources:
 
 # KServe
 - ../contrib/kserve/kserve
-- ../contrib/kserve/models-web-app/base
+- ../contrib/kserve/models-web-app/overlays/kubeflow


### PR DESCRIPTION
When we install both KFServing 0.6.1 and KServe 0.7.0 we are using the standalone version of KServe 0.7.0. But, the standalone KServe installation does not include the aggregated roles for the KF `kubeflow-{admin,editor,viewer}` roles.

This PR adds the needed clusterroles/bingings as a distinct file to explicitly include them, when installing both KFServing and standalone KServe.

This should be removed within the next release.

Depends on:
1. https://github.com/kserve/models-web-app/pull/32
3. https://github.com/kubeflow/kubeflow/pull/6383

cc @kubeflow/release-team 