### PR TITLE
Update the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ This repo periodically syncs all official Kubeflow components from their respect
 
 | Component | Local Manifests Path | Upstream Revision |
 | - | - | - |
-| Training Operator | apps/training-operator/upstream | [v1.4.0-rc.0](https://github.com/kubeflow/tf-operator/tree/v1.4.0-rc.0/manifests) |
+| Training Operator | apps/training-operator/upstream | [v1.4.0](https://github.com/kubeflow/tf-operator/tree/v1.4.0/manifests) |
 | Notebook Controller | apps/jupyter/notebook-controller/upstream | [v1.5.0-rc.1](https://github.com/kubeflow/kubeflow/tree/v1.5.0-rc.1/components/notebook-controller/config) |
 | Tensorboard Controller | apps/tensorboard/tensorboard-controller/upstream | [v1.5.0-rc.1](https://github.com/kubeflow/kubeflow/tree/v1.5.0-rc.1/components/tensorboard-controller/config) |
 | Central Dashboard | apps/centraldashboard/upstream | [v1.5.0-rc.1](https://github.com/kubeflow/kubeflow/tree/v1.5.0-rc.1/components/centraldashboard/manifests) |


### PR DESCRIPTION
Refs https://github.com/kubeflow/manifests/issues/2105

The manifests are the same with the RC0 of Training Operator, thus the only change here is the README.

cc @kubeflow/wg-training-leads 