### PR TITLE
kserve: Update the Models web app

### DIFF
--- a/contrib/kserve/models-web-app/base/istio.yaml
+++ b/contrib/kserve/models-web-app/base/istio.yaml
@@ -5,7 +5,7 @@ metadata:
   namespace: kserve
 spec:
   gateways:
-  - $(ingressGateway)
+  - knative-serving/knative-ingress-gateway
   hosts:
   - '*'
   http:

--- a/contrib/kserve/models-web-app/base/kustomization.yaml
+++ b/contrib/kserve/models-web-app/base/kustomization.yaml
@@ -12,5 +12,6 @@ images:
   newTag: v0.7.0
 configMapGenerator:
   - name: kserve-models-web-app-config
+    namespace: kserve
     literals:
     - APP_DISABLE_AUTH="True"

--- a/contrib/kserve/models-web-app/overlays/kubeflow/kustomization.yaml
+++ b/contrib/kserve/models-web-app/overlays/kubeflow/kustomization.yaml
@@ -33,9 +33,11 @@ generatorOptions:
 # kserve namespace in webhook configurations
 configMapGenerator:
   - name: kserve-models-web-app-config
+    namespace: kserve
     behavior: replace
     literals:
     - USERID_HEADER=kubeflow-userid
+    - APP_PREFIX=/kserve-endpoints
 
 configurations:
 - params.yaml

--- a/contrib/kserve/models-web-app/overlays/kubeflow/patches/web-app-vsvc.yaml
+++ b/contrib/kserve/models-web-app/overlays/kubeflow/patches/web-app-vsvc.yaml
@@ -1,4 +1,8 @@
 - op: replace
+  path: /spec/gateways
+  value:
+    - kubeflow/kubeflow-gateway
+- op: replace
   path: /spec/http/0/route/0/destination
   value:
     host: kserve-models-web-app.kubeflow.svc.cluster.local


### PR DESCRIPTION
Update the app's manifests to:
1. Work under the /kserve-endpoints prefix https://github.com/kserve/models-web-app/pull/32
2. Use the correct gatway in the manifests https://github.com/kserve/models-web-app/pull/32
3. Use the correct namespace in for the app's ConfigMap https://github.com/kserve/models-web-app/pull/33

cc @kubeflow/release-team 
