### PR TITLE
sync single-line install command with individual component install

### DIFF
--- a/README.md
+++ b/README.md
@@ -163,7 +163,7 @@ Knative is used by the KFServing official Kubeflow component.
 Install Knative Serving:
 
 ```sh
-kustomize build common/knative/knative-serving/base | kubectl apply -f -
+kustomize build common/knative/knative-serving/overlays/gateways | kubectl apply -f -
 kustomize build common/istio-1-11/cluster-local-gateway/base | kubectl apply -f -
 ```
 
@@ -282,7 +282,7 @@ kustomize build apps/katib/upstream/installs/katib-with-kubeflow | kubectl apply
 Install the Central Dashboard official Kubeflow component:
 
 ```sh
-kustomize build apps/centraldashboard/upstream/overlays/istio | kubectl apply -f -
+kustomize build apps/centraldashboard/upstream/overlays/kserve | kubectl apply -f -
 ```
 
 #### Admission Webhook


### PR DESCRIPTION
**Description of your changes:**
Update individual component instructions to match single line installation

**Note to reviewer**
Do we need to add a separate instructions for installing central dashboard with kfserving webapp similar to kserve/kfserving section?

**Checklist:**
- [ ] Unit tests pass:
  **Make sure you have installed kustomize == 3.2.1**
    1. `make generate-changed-only`
    2. `make test`
