### PR TITLE
fix(kfp_cache): Use cert manager for kfp cache

### DIFF
--- a/apps/pipeline/upstream/env/aws/multi-user/base/kustomization.yaml
+++ b/apps/pipeline/upstream/env/aws/multi-user/base/kustomization.yaml
@@ -1,0 +1,5 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+bases:
+  - ../../../platform-agnostic-multi-user

--- a/apps/pipeline/upstream/env/aws/multi-user/cache-deployer-cert-manager/cache-cert-issuer.yaml
+++ b/apps/pipeline/upstream/env/aws/multi-user/cache-deployer-cert-manager/cache-cert-issuer.yaml
@@ -1,0 +1,6 @@
+apiVersion: cert-manager.io/v1
+kind: Issuer
+metadata:
+  name: kfp-cache-selfsigned-issuer
+spec:
+  selfSigned: {}

--- a/apps/pipeline/upstream/env/aws/multi-user/cache-deployer-cert-manager/cache-cert.yaml
+++ b/apps/pipeline/upstream/env/aws/multi-user/cache-deployer-cert-manager/cache-cert.yaml
@@ -1,0 +1,15 @@
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: kfp-cache-cert
+spec:
+  commonName: kfp-cache-cert
+  isCA: true
+  dnsNames:
+  - cache-server
+  - cache-server.$(kfp-namespace)
+  - cache-server.$(kfp-namespace).svc
+  issuerRef:
+    kind: Issuer
+    name: kfp-cache-selfsigned-issuer
+  secretName: webhook-server-tls

--- a/apps/pipeline/upstream/env/aws/multi-user/cache-deployer-cert-manager/cache-webhook-config.yaml
+++ b/apps/pipeline/upstream/env/aws/multi-user/cache-deployer-cert-manager/cache-webhook-config.yaml
@@ -1,0 +1,25 @@
+apiVersion: admissionregistration.k8s.io/v1
+kind: MutatingWebhookConfiguration
+metadata:
+  name: cache-webhook-kubeflow
+  annotations:
+    cert-manager.io/inject-ca-from: $(kfp-namespace)/kfp-cache-cert
+webhooks:
+  - name: cache-server.$(kfp-namespace).svc
+    clientConfig:
+      service:
+        name: cache-server
+        namespace: $(kfp-namespace)
+        path: "/mutate"
+    failurePolicy: Ignore
+    rules:
+    - operations: [ "CREATE" ]
+      apiGroups: [""]
+      apiVersions: ["v1"]
+      resources: ["pods"]
+    sideEffects: None
+    timeoutSeconds: 5
+    objectSelector:
+      matchLabels:
+        pipelines.kubeflow.org/cache_enabled: "true"
+    admissionReviewVersions: ["v1beta1"]

--- a/apps/pipeline/upstream/env/aws/multi-user/cache-deployer-cert-manager/kustomization.yaml
+++ b/apps/pipeline/upstream/env/aws/multi-user/cache-deployer-cert-manager/kustomization.yaml
@@ -1,0 +1,10 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+namespace: kubeflow 
+
+resources:
+  - cache-cert-issuer.yaml
+  - cache-cert.yaml
+  - cache-webhook-config.yaml
+commonLabels:
+  app: cache-deployer-cert-manager

--- a/apps/pipeline/upstream/env/aws/multi-user/cache-deployer-cert-manager/params.yaml
+++ b/apps/pipeline/upstream/env/aws/multi-user/cache-deployer-cert-manager/params.yaml
@@ -1,0 +1,9 @@
+varReference:
+  - path: spec/commonName
+    kind: Certificate
+  - path: spec/dnsNames
+    kind: Certificate
+  - path: spec/issuerRef/name
+    kind: Certificate
+  - path: metadata/annotations
+    kind: MutatingWebhookConfiguration

--- a/apps/pipeline/upstream/env/aws/multi-user/delete-cache-deployer.yaml
+++ b/apps/pipeline/upstream/env/aws/multi-user/delete-cache-deployer.yaml
@@ -1,0 +1,35 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: kubeflow-pipelines-cache-deployer-clusterrole
+$patch: delete
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: kubeflow-pipelines-cache-deployer-clusterrolebinding
+$patch: delete
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: kubeflow-pipelines-cache-deployer-sa
+$patch: delete
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: cache-deployer-deployment
+$patch: delete
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: kubeflow-pipelines-cache-deployer-role
+$patch: delete
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: kubeflow-pipelines-cache-deployer-rolebinding
+$patch: delete

--- a/apps/pipeline/upstream/env/aws/multi-user/kustomization.yaml
+++ b/apps/pipeline/upstream/env/aws/multi-user/kustomization.yaml
@@ -1,0 +1,29 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+bases:
+  - ./base
+  - ./cache-deployer-cert-manager
+
+namespace: kubeflow
+
+# Delete the cache deployer as we use the cert-manager instead 
+patchesStrategicMerge:
+  - ./delete-cache-deployer.yaml
+
+# Pass proper arguments to cache-server to use cert-manager certificate
+patches:
+- patch: |-
+    - op: add
+      path: /spec/template/spec/containers/0/args/-
+      value: "--tls_cert_filename=tls.crt"
+  target:
+    kind: Deployment
+    name: cache-server
+- patch: |-
+    - op: add
+      path: /spec/template/spec/containers/0/args/-
+      value: "--tls_key_filename=tls.key"
+  target:
+    kind: Deployment
+    name: cache-server

--- a/example/kustomization.yaml
+++ b/example/kustomization.yaml
@@ -26,7 +26,7 @@ resources:
 
 
 # Kubeflow Pipelines
-- ../apps/pipeline/upstream/env/platform-agnostic-multi-user
+- ../apps/pipeline/upstream/env/aws/multi-user
 # KFServing
 - ../apps/kfserving/upstream/overlays/kubeflow
 # Katib


### PR DESCRIPTION
Resolves https://github.com/kubeflow/manifests/issues/2165
First merge https://github.com/kubeflow/pipelines/pull/7538 and use new cache server image

**Description of your changes:**
Use cert manager instead of cache deployer for KFP
