### PR TITLE
Add patches to remove namespaces and edit kustomization

### DIFF
--- a/apps/kfp-tekton/upstream/base/installs/multi-user/pipelines-profile-controller/patches/remove-namespace.yaml
+++ b/apps/kfp-tekton/upstream/base/installs/multi-user/pipelines-profile-controller/patches/remove-namespace.yaml
@@ -1,0 +1,2 @@
+- op: remove
+  path: /metadata/namespace

--- a/apps/pipeline/upstream/base/installs/multi-user/pipelines-profile-controller/patches/remove-namespace.yaml
+++ b/apps/pipeline/upstream/base/installs/multi-user/pipelines-profile-controller/patches/remove-namespace.yaml
@@ -1,0 +1,2 @@
+- op: remove
+  path: /metadata/namespace

--- a/apps/pipeline/upstream/env/platform-agnostic-multi-user/kustomization.yaml
+++ b/apps/pipeline/upstream/env/platform-agnostic-multi-user/kustomization.yaml
@@ -21,3 +21,10 @@ commonLabels:
 # !!! If you want to customize the namespace,
 # please also update base/cache-deployer/cluster-scoped/cache-deployer-clusterrolebinding.yaml
 namespace: kubeflow
+patchesJson6902:
+- target:
+    group: metacontroller.k8s.io
+    version: v1alpha1
+    kind: CompositeController
+    name: kubeflow-pipelines-profile-controller
+  path: patches/remove-namespace.yaml

--- a/apps/pipeline/upstream/env/platform-agnostic-multi-user/patches/remove-namespace.yaml
+++ b/apps/pipeline/upstream/env/platform-agnostic-multi-user/patches/remove-namespace.yaml
@@ -1,0 +1,2 @@
+- op: remove
+  path: /metadata/namespace

--- a/common/cert-manager/kubeflow-issuer/base/kustomization.yaml
+++ b/common/cert-manager/kubeflow-issuer/base/kustomization.yaml
@@ -8,3 +8,10 @@ commonLabels:
   app.kubernetes.io/name: cert-manager
 resources:
 - cluster-issuer.yaml
+patchesJson6902:
+- target:
+    group: cert-manager.io
+    version: v1alpha2
+    kind: ClusterIssuer
+    name: kubeflow-self-signing-issuer
+  path: patches/remove-namespace.yaml

--- a/common/cert-manager/kubeflow-issuer/base/patches/remove-namespace.yaml
+++ b/common/cert-manager/kubeflow-issuer/base/patches/remove-namespace.yaml
@@ -1,0 +1,2 @@
+- op: remove
+  path: /metadata/namespace


### PR DESCRIPTION
**Description of your changes:**
 When applying kustomize generated kubeflow manifests to a k8s cluster without kubectl, the k8s apiserver will error on several of them due to certain cluster-scoped (i.e. no namespace) manifests containing namespace metadata. To fix this, I've created JSON patches for the resources that I encountered issues with.

**Checklist:**
- [ ] Unit tests pass:
  **Make sure you have installed kustomize == 3.2.1**
    1. `make generate-changed-only`
    2. `make test`
