### PR TITLE
Update minio and metadata-envoy networkpolicy

### DIFF
--- a/contrib/networkpolicies/kustomization.yaml
+++ b/contrib/networkpolicies/kustomization.yaml
@@ -13,6 +13,7 @@ resources:
   - kfserving.yaml
   - kserve-models-web-app.yaml
   - kserve.yaml
+  - metatada-envoy.yaml
   - metadata-grpc-server.yaml
   - minio.yaml
   - ml-pipeline-ui.yaml 

--- a/contrib/networkpolicies/metadata-envoy.yaml
+++ b/contrib/networkpolicies/metadata-envoy.yaml
@@ -1,0 +1,24 @@
+kind: NetworkPolicy
+apiVersion: networking.k8s.io/v1
+metadata:
+  name: metatada-envoy
+  namespace: kubeflow
+spec:
+  podSelector:
+    matchExpressions:
+      - key: component
+        operator: In
+        values:
+          - metadata-envoy
+  ingress:
+    - from:
+        - namespaceSelector:
+            matchExpressions:
+              - key: kubernetes.io/metadata.name
+                operator: In
+                values:
+                  - istio-system
+        - podSelector: {}
+  policyTypes:
+    - Ingress
+

--- a/contrib/networkpolicies/minio.yaml
+++ b/contrib/networkpolicies/minio.yaml
@@ -18,6 +18,12 @@ spec:
                 operator: In
                 values:
                   - kubeflow-profile
+        - namespaceSelector:
+            matchExpressions:
+              - key: kubernetes.io/metadata.name
+                operator: In
+                values:
+                  - istio-system
         - podSelector: {} # allow all pods from the same namespace
   policyTypes:
     - Ingress


### PR DESCRIPTION
@kimwnasptd 

minio should be reachable by authenticated users. it is anyway reachable from inside the cluster. This helps with external storage management

Without the metadata-envoy the corresponding part of the UI is broken.

**Checklist:**
- [ ] Unit tests pass:
  **Make sure you have installed kustomize == 3.2.1**
    1. `make generate-changed-only`
    2. `make test`
