### PR TITLE
Add startup probe to pipeline API deployment

### DIFF
--- a/apps/pipeline/upstream/base/pipeline/ml-pipeline-apiserver-deployment.yaml
+++ b/apps/pipeline/upstream/base/pipeline/ml-pipeline-apiserver-deployment.yaml
@@ -105,6 +105,21 @@ spec:
           initialDelaySeconds: 3
           periodSeconds: 5
           timeoutSeconds: 2
+        # This startup probe provides up to a 60 second grace window before the
+        # liveness probe takes over to accomodate the occasional database
+        # migration.
+        startupProbe:
+          exec:
+            command:
+              - wget
+              - -q # quiet
+              - -S # show server response
+              - -O
+              - "-" # Redirect output to stdout
+              - http://localhost:8888/apis/v1beta1/healthz
+          failureThreshold: 12
+          periodSeconds: 5
+          timeoutSeconds: 2
         resources:
           requests:
             cpu: 250m


### PR DESCRIPTION
Co-authored-by: moorthy156 <narayanamoorthy.mari@gmail.com>

**Which issue is resolved by this Pull Request:**
Resolves # https://github.com/kubeflow/manifests/issues/2209

**Description of your changes:**
When we pivoted from an in-cluster mysql deployment to an externally hosted RDS instance for the metadata store, we ran into a scenario where the ml-pipeline-apiserver pod entered a crash loop because it didn't have a long enough grace period to complete its database migration.

This pod is unique in that its startup time is variable depending on whether or not a migration needs to occur. A [startup probe](https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-startup-probes/) is perfect for this, since it offers a grace period in the event of a migration, but doesn't delay pod readiness when a migration does not need to happen.

**Checklist:**
- [x] Unit tests pass:
  **Make sure you have installed kustomize == 3.2.1**
    1. `make generate-changed-only`
    2. `make test`
