### PR TITLE
Set ENABLE_LEGACY_FSGROUP_INJECTION to false for istio

### DIFF
--- a/common/istio-1-11/istio-install/base/install.yaml
+++ b/common/istio-1-11/istio-install/base/install.yaml
@@ -3244,6 +3244,8 @@ spec:
           value: /var/run/secrets/remote/config
         - name: PILOT_TRACE_SAMPLING
           value: '100'
+        - name: ENABLE_LEGACY_FSGROUP_INJECTION
+          value: 'false'
         - name: PILOT_ENABLE_PROTOCOL_SNIFFING_FOR_OUTBOUND
           value: 'true'
         - name: PILOT_ENABLE_PROTOCOL_SNIFFING_FOR_INBOUND

--- a/common/istio-1-11/profile.yaml
+++ b/common/istio-1-11/profile.yaml
@@ -47,6 +47,8 @@ spec:
         env:
         - name: PILOT_TRACE_SAMPLING
           value: "100"
+        - name: ENABLE_LEGACY_FSGROUP_INJECTION
+          value: "false"
         resources:
           requests:
             cpu: 10m


### PR DESCRIPTION
remove unnecessary fsGroup ans its side effect.

**Which issue is resolved by this Pull Request:**
Resolves #2218


On kubernetes 1.19+, ENABLE_LEGACY_FSGROUP_INJECTION is not required.
istio 1.11~1.13 sets ENABLE_LEGACY_FSGROUP_INJECTION to true by default.

FYI, below are the versions supported in Kubeflow 1.5
* Kubernetes 1.21, 1.20, 1.19
* istio 1.11

https://github.com/istio/istio/pull/27367
https://github.com/istio/istio/issues/26882


**Checklist:**
- [ ] Unit tests pass:
  **Make sure you have installed kustomize == 3.2.1**
    1. `make generate-changed-only`
    2. `make test`
