### PR TITLE
Sync kubeflow training operator manifests v1.5.0 rc.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ This repo periodically syncs all official Kubeflow components from their respect
 
 | Component | Local Manifests Path | Upstream Revision |
 | - | - | - |
-| Training Operator | apps/training-operator/upstream | [v1.4.0](https://github.com/kubeflow/tf-operator/tree/v1.4.0/manifests) |
+| Training Operator | apps/training-operator/upstream | [v1.4.0](https://github.com/kubeflow/training-operator/tree/v1.4.0/manifests) |
 | Notebook Controller | apps/jupyter/notebook-controller/upstream | [v1.5.0](https://github.com/kubeflow/kubeflow/tree/v1.5.0/components/notebook-controller/config) |
 | Tensorboard Controller | apps/tensorboard/tensorboard-controller/upstream | [v1.5.0](https://github.com/kubeflow/kubeflow/tree/v1.5.0/components/tensorboard-controller/config) |
 | Central Dashboard | apps/centraldashboard/upstream | [v1.5.0](https://github.com/kubeflow/kubeflow/tree/v1.5.0/components/centraldashboard/manifests) |

--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ This repo periodically syncs all official Kubeflow components from their respect
 
 | Component | Local Manifests Path | Upstream Revision |
 | - | - | - |
-| Training Operator | apps/training-operator/upstream | [v1.4.0](https://github.com/kubeflow/training-operator/tree/v1.4.0/manifests) |
+| Training Operator | apps/training-operator/upstream | [v1.5.0-rc.0](https://github.com/kubeflow/training-operator/tree/v1.5.0-rc.0/manifests) |
 | Notebook Controller | apps/jupyter/notebook-controller/upstream | [v1.5.0](https://github.com/kubeflow/kubeflow/tree/v1.5.0/components/notebook-controller/config) |
 | Tensorboard Controller | apps/tensorboard/tensorboard-controller/upstream | [v1.5.0](https://github.com/kubeflow/kubeflow/tree/v1.5.0/components/tensorboard-controller/config) |
 | Central Dashboard | apps/centraldashboard/upstream | [v1.5.0](https://github.com/kubeflow/kubeflow/tree/v1.5.0/components/centraldashboard/manifests) |

--- a/apps/training-operator/upstream/base/crds/kubeflow.org_mpijobs.yaml
+++ b/apps/training-operator/upstream/base/crds/kubeflow.org_mpijobs.yaml
@@ -424,12 +424,85 @@ spec:
                                                       are ANDed.
                                                     type: object
                                                 type: object
+                                              namespaceSelector:
+                                                description: A label query over the
+                                                  set of namespaces that the term
+                                                  applies to. The term is applied
+                                                  to the union of the namespaces selected
+                                                  by this field and the ones listed
+                                                  in the namespaces field. null selector
+                                                  and null or empty namespaces list
+                                                  means "this pod's namespace". An
+                                                  empty selector ({}) matches all
+                                                  namespaces.
+                                                properties:
+                                                  matchExpressions:
+                                                    description: matchExpressions
+                                                      is a list of label selector
+                                                      requirements. The requirements
+                                                      are ANDed.
+                                                    items:
+                                                      description: A label selector
+                                                        requirement is a selector
+                                                        that contains values, a key,
+                                                        and an operator that relates
+                                                        the key and values.
+                                                      properties:
+                                                        key:
+                                                          description: key is the
+                                                            label key that the selector
+                                                            applies to.
+                                                          type: string
+                                                        operator:
+                                                          description: operator represents
+                                                            a key's relationship to
+                                                            a set of values. Valid
+                                                            operators are In, NotIn,
+                                                            Exists and DoesNotExist.
+                                                          type: string
+                                                        values:
+                                                          description: values is an
+                                                            array of string values.
+                                                            If the operator is In
+                                                            or NotIn, the values array
+                                                            must be non-empty. If
+                                                            the operator is Exists
+                                                            or DoesNotExist, the values
+                                                            array must be empty. This
+                                                            array is replaced during
+                                                            a strategic merge patch.
+                                                          items:
+                                                            type: string
+                                                          type: array
+                                                      required:
+                                                      - key
+                                                      - operator
+                                                      type: object
+                                                    type: array
+                                                  matchLabels:
+                                                    additionalProperties:
+                                                      type: string
+                                                    description: matchLabels is a
+                                                      map of {key,value} pairs. A
+                                                      single {key,value} in the matchLabels
+                                                      map is equivalent to an element
+                                                      of matchExpressions, whose key
+                                                      field is "key", the operator
+                                                      is "In", and the values array
+                                                      contains only "value". The requirements
+                                                      are ANDed.
+                                                    type: object
+                                                type: object
                                               namespaces:
                                                 description: namespaces specifies
-                                                  which namespaces the labelSelector
-                                                  applies to (matches against); null
-                                                  or empty list means "this pod's
-                                                  namespace"
+                                                  a static list of namespace names
+                                                  that the term applies to. The term
+                                                  is applied to the union of the namespaces
+                                                  listed in this field and the ones
+                                                  selected by namespaceSelector. null
+                                                  or empty namespaces list and null
+                                                  namespaceSelector means "this pod's
+                                                  namespace".
                                                 items:
                                                   type: string
                                                 type: array
@@ -539,11 +612,78 @@ spec:
                                                   ANDed.
                                                 type: object
                                             type: object
+                                          namespaceSelector:
+                                            description: A label query over the set
+                                              of namespaces that the term applies
+                                              to. The term is applied to the union
+                                              of the namespaces selected by this field
+                                              and the ones listed in the namespaces
+                                              field. null selector and null or empty
+                                              namespaces list means "this pod's namespace".
+                                              An empty selector ({}) matches all namespaces.
+                                            properties:
+                                              matchExpressions:
+                                                description: matchExpressions is a
+                                                  list of label selector requirements.
+                                                  The requirements are ANDed.
+                                                items:
+                                                  description: A label selector requirement
+                                                    is a selector that contains values,
+                                                    a key, and an operator that relates
+                                                    the key and values.
+                                                  properties:
+                                                    key:
+                                                      description: key is the label
+                                                        key that the selector applies
+                                                        to.
+                                                      type: string
+                                                    operator:
+                                                      description: operator represents
+                                                        a key's relationship to a
+                                                        set of values. Valid operators
+                                                        are In, NotIn, Exists and
+                                                        DoesNotExist.
+                                                      type: string
+                                                    values:
+                                                      description: values is an array
+                                                        of string values. If the operator
+                                                        is In or NotIn, the values
+                                                        array must be non-empty. If
+                                                        the operator is Exists or
+                                                        DoesNotExist, the values array
+                                                        must be empty. This array
+                                                        is replaced during a strategic
+                                                        merge patch.
+                                                      items:
+                                                        type: string
+                                                      type: array
+                                                  required:
+                                                  - key
+                                                  - operator
+                                                  type: object
+                                                type: array
+                                              matchLabels:
+                                                additionalProperties:
+                                                  type: string
+                                                description: matchLabels is a map
+                                                  of {key,value} pairs. A single {key,value}
+                                                  in the matchLabels map is equivalent
+                                                  to an element of matchExpressions,
+                                                  whose key field is "key", the operator
+                                                  is "In", and the values array contains
+                                                  only "value". The requirements are
+                                                  ANDed.
+                                                type: object
+                                            type: object
                                           namespaces:
-                                            description: namespaces specifies which
-                                              namespaces the labelSelector applies
-                                              to (matches against); null or empty
-                                              list means "this pod's namespace"
+                                            description: namespaces specifies a static
+                                              list of namespace names that the term
+                                              applies to. The term is applied to the
+                                              union of the namespaces listed in this
+                                              field and the ones selected by namespaceSelector.
+                                              null or empty namespaces list and null
+                                              namespaceSelector means "this pod's
+                                              namespace".
                                             items:
                                               type: string
                                             type: array
@@ -655,12 +795,85 @@ spec:
                                                       are ANDed.
                                                     type: object
                                                 type: object
+                                              namespaceSelector:
+                                                description: A label query over the
+                                                  set of namespaces that the term
+                                                  applies to. The term is applied
+                                                  to the union of the namespaces selected
+                                                  by this field and the ones listed
+                                                  in the namespaces field. null selector
+                                                  and null or empty namespaces list
+                                                  means "this pod's namespace". An
+                                                  empty selector ({}) matches all
+                                                  namespaces.
+                                                properties:
+                                                  matchExpressions:
+                                                    description: matchExpressions
+                                                      is a list of label selector
+                                                      requirements. The requirements
+                                                      are ANDed.
+                                                    items:
+                                                      description: A label selector
+                                                        requirement is a selector
+                                                        that contains values, a key,
+                                                        and an operator that relates
+                                                        the key and values.
+                                                      properties:
+                                                        key:
+                                                          description: key is the
+                                                            label key that the selector
+                                                            applies to.
+                                                          type: string
+                                                        operator:
+                                                          description: operator represents
+                                                            a key's relationship to
+                                                            a set of values. Valid
+                                                            operators are In, NotIn,
+                                                            Exists and DoesNotExist.
+                                                          type: string
+                                                        values:
+                                                          description: values is an
+                                                            array of string values.
+                                                            If the operator is In
+                                                            or NotIn, the values array
+                                                            must be non-empty. If
+                                                            the operator is Exists
+                                                            or DoesNotExist, the values
+                                                            array must be empty. This
+                                                            array is replaced during
+                                                            a strategic merge patch.
+                                                          items:
+                                                            type: string
+                                                          type: array
+                                                      required:
+                                                      - key
+                                                      - operator
+                                                      type: object
+                                                    type: array
+                                                  matchLabels:
+                                                    additionalProperties:
+                                                      type: string
+                                                    description: matchLabels is a
+                                                      map of {key,value} pairs. A
+                                                      single {key,value} in the matchLabels
+                                                      map is equivalent to an element
+                                                      of matchExpressions, whose key
+                                                      field is "key", the operator
+                                                      is "In", and the values array
+                                                      contains only "value". The requirements
+                                                      are ANDed.
+                                                    type: object
+                                                type: object
                                               namespaces:
                                                 description: namespaces specifies
-                                                  which namespaces the labelSelector
-                                                  applies to (matches against); null
-                                                  or empty list means "this pod's
-                                                  namespace"
+                                                  a static list of namespace names
+                                                  that the term applies to. The term
+                                                  is applied to the union of the namespaces
+                                                  listed in this field and the ones
+                                                  selected by namespaceSelector. null
+                                                  or empty namespaces list and null
+                                                  namespaceSelector means "this pod's
+                                                  namespace".
                                                 items:
                                                   type: string
                                                 type: array
@@ -770,11 +983,78 @@ spec:
                                                   ANDed.
                                                 type: object
                                             type: object
+                                          namespaceSelector:
+                                            description: A label query over the set
+                                              of namespaces that the term applies
+                                              to. The term is applied to the union
+                                              of the namespaces selected by this field
+                                              and the ones listed in the namespaces
+                                              field. null selector and null or empty
+                                              namespaces list means "this pod's namespace".
+                                              An empty selector ({}) matches all namespaces.
+                                            properties:
+                                              matchExpressions:
+                                                description: matchExpressions is a
+                                                  list of label selector requirements.
+                                                  The requirements are ANDed.
+                                                items:
+                                                  description: A label selector requirement
+                                                    is a selector that contains values,
+                                                    a key, and an operator that relates
+                                                    the key and values.
+                                                  properties:
+                                                    key:
+                                                      description: key is the label
+                                                        key that the selector applies
+                                                        to.
+                                                      type: string
+                                                    operator:
+                                                      description: operator represents
+                                                        a key's relationship to a
+                                                        set of values. Valid operators
+                                                        are In, NotIn, Exists and
+                                                        DoesNotExist.
+                                                      type: string
+                                                    values:
+                                                      description: values is an array
+                                                        of string values. If the operator
+                                                        is In or NotIn, the values
+                                                        array must be non-empty. If
+                                                        the operator is Exists or
+                                                        DoesNotExist, the values array
+                                                        must be empty. This array
+                                                        is replaced during a strategic
+                                                        merge patch.
+                                                      items:
+                                                        type: string
+                                                      type: array
+                                                  required:
+                                                  - key
+                                                  - operator
+                                                  type: object
+                                                type: array
+                                              matchLabels:
+                                                additionalProperties:
+                                                  type: string
+                                                description: matchLabels is a map
+                                                  of {key,value} pairs. A single {key,value}
+                                                  in the matchLabels map is equivalent
+                                                  to an element of matchExpressions,
+                                                  whose key field is "key", the operator
+                                                  is "In", and the values array contains
+                                                  only "value". The requirements are
+                                                  ANDed.
+                                                type: object
+                                            type: object
                                           namespaces:
-                                            description: namespaces specifies which
-                                              namespaces the labelSelector applies
-                                              to (matches against); null or empty
-                                              list means "this pod's namespace"
+                                            description: namespaces specifies a static
+                                              list of namespace names that the term
+                                              applies to. The term is applied to the
+                                              union of the namespaces listed in this
+                                              field and the ones selected by namespaceSelector.
+                                              null or empty namespaces list and null
+                                              namespaceSelector means "this pod's
+                                              namespace".
                                             items:
                                               type: string
                                             type: array
@@ -811,12 +1091,14 @@ spec:
                                 properties:
                                   args:
                                     description: 'Arguments to the entrypoint. The
-                                      docker image''s CMD is used if this is not provided.
-                                      Variable references $(VAR_NAME) are expanded
-                                      using the container''s environment. If a variable
-                                      cannot be resolved, the reference in the input
-                                      string will be unchanged. The $(VAR_NAME) syntax
-                                      can be escaped with a double $$, ie: $$(VAR_NAME).
+                                      container image''s CMD is used if this is not
+                                      provided. Variable references $(VAR_NAME) are
+                                      expanded using the container''s environment.
+                                      If a variable cannot be resolved, the reference
+                                      in the input string will be unchanged. Double
+                                      $$ are reduced to a single $, which allows for
+                                      escaping the $(VAR_NAME) syntax: i.e. "$$(VAR_NAME)"
+                                      will produce the string literal "$(VAR_NAME)".
                                       Escaped references will never be expanded, regardless
                                       of whether the variable exists or not. Cannot
                                       be updated. More info: https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell'
@@ -825,16 +1107,17 @@ spec:
                                     type: array
                                   command:
                                     description: 'Entrypoint array. Not executed within
-                                      a shell. The docker image''s ENTRYPOINT is used
-                                      if this is not provided. Variable references
+                                      a shell. The container image''s ENTRYPOINT is
+                                      used if this is not provided. Variable references
                                       $(VAR_NAME) are expanded using the container''s
                                       environment. If a variable cannot be resolved,
                                       the reference in the input string will be unchanged.
-                                      The $(VAR_NAME) syntax can be escaped with a
-                                      double $$, ie: $$(VAR_NAME). Escaped references
-                                      will never be expanded, regardless of whether
-                                      the variable exists or not. Cannot be updated.
-                                      More info: https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell'
+                                      Double $$ are reduced to a single $, which allows
+                                      for escaping the $(VAR_NAME) syntax: i.e. "$$(VAR_NAME)"
+                                      will produce the string literal "$(VAR_NAME)".
+                                      Escaped references will never be expanded, regardless
+                                      of whether the variable exists or not. Cannot
+                                      be updated. More info: https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell'
                                     items:
                                       type: string
                                     type: array
@@ -851,13 +1134,15 @@ spec:
                                           type: string
                                         value:
                                           description: 'Variable references $(VAR_NAME)
-                                            are expanded using the previous defined
+                                            are expanded using the previously defined
                                             environment variables in the container
                                             and any service environment variables.
                                             If a variable cannot be resolved, the
                                             reference in the input string will be
-                                            unchanged. The $(VAR_NAME) syntax can
-                                            be escaped with a double $$, ie: $$(VAR_NAME).
+                                            unchanged. Double $$ are reduced to a
+                                            single $, which allows for escaping the
+                                            $(VAR_NAME) syntax: i.e. "$$(VAR_NAME)"
+                                            will produce the string literal "$(VAR_NAME)".
                                             Escaped references will never be expanded,
                                             regardless of whether the variable exists
                                             or not. Defaults to "".'
@@ -1011,7 +1296,8 @@ spec:
                                       type: object
                                     type: array
                                   image:
-                                    description: 'Docker image name. More info: https://kubernetes.io/docs/concepts/containers/images
+                                    description: 'Container image name. More info:
+                                      https://kubernetes.io/docs/concepts/containers/images
                                       This field is optional to allow higher level
                                       config management to default or override container
                                       images in workload controllers like Deployments
@@ -1037,9 +1323,8 @@ spec:
                                           More info: https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/#container-hooks'
                                         properties:
                                           exec:
-                                            description: One and only one of the following
-                                              should be specified. Exec specifies
-                                              the action to take.
+                                            description: Exec specifies the action
+                                              to take.
                                             properties:
                                               command:
                                                 description: Command is the command
@@ -1110,10 +1395,12 @@ spec:
                                             - port
                                             type: object
                                           tcpSocket:
-                                            description: 'TCPSocket specifies an action
-                                              involving a TCP port. TCP hooks not
-                                              yet supported TODO: implement a realistic
-                                              TCP lifecycle hook'
+                                            description: Deprecated. TCPSocket is
+                                              NOT supported as a LifecycleHandler
+                                              and kept for the backward compatibility.
+                                              There are no validation of this field
+                                              and lifecycle hooks will fail in runtime
+                                              when tcp handler is specified.
                                             properties:
                                               host:
                                                 description: 'Optional: Host name
@@ -1140,21 +1427,19 @@ spec:
                                           as liveness/startup probe failure, preemption,
                                           resource contention, etc. The handler is
                                           not called if the container crashes or exits.
-                                          The reason for termination is passed to
-                                          the handler. The Pod''s termination grace
-                                          period countdown begins before the PreStop
-                                          hooked is executed. Regardless of the outcome
-                                          of the handler, the container will eventually
-                                          terminate within the Pod''s termination
-                                          grace period. Other management of the container
-                                          blocks until the hook completes or until
-                                          the termination grace period is reached.
-                                          More info: https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/#container-hooks'
+                                          The Pod''s termination grace period countdown
+                                          begins before the PreStop hook is executed.
+                                          Regardless of the outcome of the handler,
+                                          the container will eventually terminate
+                                          within the Pod''s termination grace period
+                                          (unless delayed by finalizers). Other management
+                                          of the container blocks until the hook completes
+                                          or until the termination grace period is
+                                          reached. More info: https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/#container-hooks'
                                         properties:
                                           exec:
-                                            description: One and only one of the following
-                                              should be specified. Exec specifies
-                                              the action to take.
+                                            description: Exec specifies the action
+                                              to take.
                                             properties:
                                               command:
                                                 description: Command is the command
@@ -1225,10 +1510,12 @@ spec:
                                             - port
                                             type: object
                                           tcpSocket:
-                                            description: 'TCPSocket specifies an action
-                                              involving a TCP port. TCP hooks not
-                                              yet supported TODO: implement a realistic
-                                              TCP lifecycle hook'
+                                            description: Deprecated. TCPSocket is
+                                              NOT supported as a LifecycleHandler
+                                              and kept for the backward compatibility.
+                                              There are no validation of this field
+                                              and lifecycle hooks will fail in runtime
+                                              when tcp handler is specified.
                                             properties:
                                               host:
                                                 description: 'Optional: Host name
@@ -1255,9 +1542,8 @@ spec:
                                       Cannot be updated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
                                     properties:
                                       exec:
-                                        description: One and only one of the following
-                                          should be specified. Exec specifies the
-                                          action to take.
+                                        description: Exec specifies the action to
+                                          take.
                                         properties:
                                           command:
                                             description: Command is the command line
@@ -1282,6 +1568,26 @@ spec:
                                           value is 1.
                                         format: int32
                                         type: integer
+                                      grpc:
+                                        description: GRPC specifies an action involving
+                                          a GRPC port. This is a beta field and requires
+                                          enabling GRPCContainerProbe feature gate.
+                                        properties:
+                                          port:
+                                            description: Port number of the gRPC service.
+                                              Number must be in the range 1 to 65535.
+                                            format: int32
+                                            type: integer
+                                          service:
+                                            description: "Service is the name of the
+                                              service to place in the gRPC HealthCheckRequest
+                                              (see https://github.com/grpc/grpc/blob/master/doc/health-checking.md).
+                                              \n If this is not specified, the default
+                                              behavior is defined by gRPC."
+                                            type: string
+                                        required:
+                                        - port
+                                        type: object
                                       httpGet:
                                         description: HTTPGet specifies the http request
                                           to perform.
@@ -1350,10 +1656,8 @@ spec:
                                         format: int32
                                         type: integer
                                       tcpSocket:
-                                        description: 'TCPSocket specifies an action
-                                          involving a TCP port. TCP hooks not yet
-                                          supported TODO: implement a realistic TCP
-                                          lifecycle hook'
+                                        description: TCPSocket specifies an action
+                                          involving a TCP port.
                                         properties:
                                           host:
                                             description: 'Optional: Host name to connect
@@ -1371,6 +1675,28 @@ spec:
                                         required:
                                         - port
                                         type: object
+                                      terminationGracePeriodSeconds:
+                                        description: Optional duration in seconds
+                                          the pod needs to terminate gracefully upon
+                                          probe failure. The grace period is the duration
+                                          in seconds after the processes running in
+                                          the pod are sent a termination signal and
+                                          the time when the processes are forcibly
+                                          halted with a kill signal. Set this value
+                                          longer than the expected cleanup time for
+                                          your process. If this value is nil, the
+                                          pod's terminationGracePeriodSeconds will
+                                          be used. Otherwise, this value overrides
+                                          the value provided by the pod spec. Value
+                                          must be non-negative integer. The value
+                                          zero indicates stop immediately via the
+                                          kill signal (no opportunity to shut down).
+                                          This is a beta field and requires enabling
+                                          ProbeTerminationGracePeriod feature gate.
+                                          Minimum value is 1. spec.terminationGracePeriodSeconds
+                                          is used if unset.
+                                        format: int64
+                                        type: integer
                                       timeoutSeconds:
                                         description: 'Number of seconds after which
                                           the probe times out. Defaults to 1 second.
@@ -1442,9 +1768,8 @@ spec:
                                       More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
                                     properties:
                                       exec:
-                                        description: One and only one of the following
-                                          should be specified. Exec specifies the
-                                          action to take.
+                                        description: Exec specifies the action to
+                                          take.
                                         properties:
                                           command:
                                             description: Command is the command line
@@ -1469,6 +1794,26 @@ spec:
                                           value is 1.
                                         format: int32
                                         type: integer
+                                      grpc:
+                                        description: GRPC specifies an action involving
+                                          a GRPC port. This is a beta field and requires
+                                          enabling GRPCContainerProbe feature gate.
+                                        properties:
+                                          port:
+                                            description: Port number of the gRPC service.
+                                              Number must be in the range 1 to 65535.
+                                            format: int32
+                                            type: integer
+                                          service:
+                                            description: "Service is the name of the
+                                              service to place in the gRPC HealthCheckRequest
+                                              (see https://github.com/grpc/grpc/blob/master/doc/health-checking.md).
+                                              \n If this is not specified, the default
+                                              behavior is defined by gRPC."
+                                            type: string
+                                        required:
+                                        - port
+                                        type: object
                                       httpGet:
                                         description: HTTPGet specifies the http request
                                           to perform.
@@ -1537,10 +1882,8 @@ spec:
                                         format: int32
                                         type: integer
                                       tcpSocket:
-                                        description: 'TCPSocket specifies an action
-                                          involving a TCP port. TCP hooks not yet
-                                          supported TODO: implement a realistic TCP
-                                          lifecycle hook'
+                                        description: TCPSocket specifies an action
+                                          involving a TCP port.
                                         properties:
                                           host:
                                             description: 'Optional: Host name to connect
@@ -1558,6 +1901,28 @@ spec:
                                         required:
                                         - port
                                         type: object
+                                      terminationGracePeriodSeconds:
+                                        description: Optional duration in seconds
+                                          the pod needs to terminate gracefully upon
+                                          probe failure. The grace period is the duration
+                                          in seconds after the processes running in
+                                          the pod are sent a termination signal and
+                                          the time when the processes are forcibly
+                                          halted with a kill signal. Set this value
+                                          longer than the expected cleanup time for
+                                          your process. If this value is nil, the
+                                          pod's terminationGracePeriodSeconds will
+                                          be used. Otherwise, this value overrides
+                                          the value provided by the pod spec. Value
+                                          must be non-negative integer. The value
+                                          zero indicates stop immediately via the
+                                          kill signal (no opportunity to shut down).
+                                          This is a beta field and requires enabling
+                                          ProbeTerminationGracePeriod feature gate.
+                                          Minimum value is 1. spec.terminationGracePeriodSeconds
+                                          is used if unset.
+                                        format: int64
+                                        type: integer
                                       timeoutSeconds:
                                         description: 'Number of seconds after which
                                           the probe times out. Defaults to 1 second.
@@ -1567,7 +1932,7 @@ spec:
                                     type: object
                                   resources:
                                     description: 'Compute Resources required by this
-                                      container. Cannot be updated. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
+                                      container. Cannot be updated. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
                                     properties:
                                       limits:
                                         additionalProperties:
@@ -1578,7 +1943,7 @@ spec:
                                           x-kubernetes-int-or-string: true
                                         description: 'Limits describes the maximum
                                           amount of compute resources allowed. More
-                                          info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
+                                          info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
                                         type: object
                                       requests:
                                         additionalProperties:
@@ -1592,12 +1957,14 @@ spec:
                                           Requests is omitted for a container, it
                                           defaults to Limits if that is explicitly
                                           specified, otherwise to an implementation-defined
-                                          value. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
+                                          value. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
                                         type: object
                                     type: object
                                   securityContext:
-                                    description: 'Security options the pod should
-                                      run with. More info: https://kubernetes.io/docs/concepts/policy/security-context/
+                                    description: 'SecurityContext defines the security
+                                      options the container should be run with. If
+                                      set, the fields of SecurityContext override
+                                      the equivalent fields of PodSecurityContext.
                                       More info: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/'
                                     properties:
                                       allowPrivilegeEscalation:
@@ -1607,13 +1974,16 @@ spec:
                                           controls if the no_new_privs flag will be
                                           set on the container process. AllowPrivilegeEscalation
                                           is true always when the container is: 1)
-                                          run as Privileged 2) has CAP_SYS_ADMIN'
+                                          run as Privileged 2) has CAP_SYS_ADMIN Note
+                                          that this field cannot be set when spec.os.name
+                                          is windows.'
                                         type: boolean
                                       capabilities:
                                         description: The capabilities to add/drop
                                           when running containers. Defaults to the
                                           default set of capabilities granted by the
-                                          container runtime.
+                                          container runtime. Note that this field
+                                          cannot be set when spec.os.name is windows.
                                         properties:
                                           add:
                                             description: Added capabilities
@@ -1634,7 +2004,8 @@ spec:
                                         description: Run container in privileged mode.
                                           Processes in privileged containers are essentially
                                           equivalent to root on the host. Defaults
-                                          to false.
+                                          to false. Note that this field cannot be
+                                          set when spec.os.name is windows.
                                         type: boolean
                                       procMount:
                                         description: procMount denotes the type of
@@ -1643,10 +2014,14 @@ spec:
                                           container runtime defaults for readonly
                                           paths and masked paths. This requires the
                                           ProcMountType feature flag to be enabled.
+                                          Note that this field cannot be set when
+                                          spec.os.name is windows.
                                         type: string
                                       readOnlyRootFilesystem:
                                         description: Whether this container has a
                                           read-only root filesystem. Default is false.
+                                          Note that this field cannot be set when
+                                          spec.os.name is windows.
                                         type: boolean
                                       runAsGroup:
                                         description: The GID to run the entrypoint
@@ -1654,7 +2029,8 @@ spec:
                                           if unset. May also be set in PodSecurityContext.  If
                                           set in both SecurityContext and PodSecurityContext,
                                           the value specified in SecurityContext takes
-                                          precedence.
+                                          precedence. Note that this field cannot
+                                          be set when spec.os.name is windows.
                                         format: int64
                                         type: integer
                                       runAsNonRoot:
@@ -1676,7 +2052,8 @@ spec:
                                           May also be set in PodSecurityContext.  If
                                           set in both SecurityContext and PodSecurityContext,
                                           the value specified in SecurityContext takes
-                                          precedence.
+                                          precedence. Note that this field cannot
+                                          be set when spec.os.name is windows.
                                         format: int64
                                         type: integer
                                       seLinuxOptions:
@@ -1686,7 +2063,9 @@ spec:
                                           for each container.  May also be set in
                                           PodSecurityContext.  If set in both SecurityContext
                                           and PodSecurityContext, the value specified
-                                          in SecurityContext takes precedence.
+                                          in SecurityContext takes precedence. Note
+                                          that this field cannot be set when spec.os.name
+                                          is windows.
                                         properties:
                                           level:
                                             description: Level is SELinux level label
@@ -1709,7 +2088,9 @@ spec:
                                         description: The seccomp options to use by
                                           this container. If seccomp options are provided
                                           at both the pod & container level, the container
-                                          options override the pod options.
+                                          options override the pod options. Note that
+                                          this field cannot be set when spec.os.name
+                                          is windows.
                                         properties:
                                           localhostProfile:
                                             description: localhostProfile indicates
@@ -1740,7 +2121,9 @@ spec:
                                           the options from the PodSecurityContext
                                           will be used. If set in both SecurityContext
                                           and PodSecurityContext, the value specified
-                                          in SecurityContext takes precedence.
+                                          in SecurityContext takes precedence. Note
+                                          that this field cannot be set when spec.os.name
+                                          is linux.
                                         properties:
                                           gmsaCredentialSpec:
                                             description: GMSACredentialSpec is where
@@ -1754,6 +2137,22 @@ spec:
                                               the name of the GMSA credential spec
                                               to use.
                                             type: string
+                                          hostProcess:
+                                            description: HostProcess determines if
+                                              a container should be run as a 'Host
+                                              Process' container. This field is alpha-level
+                                              and will only be honored by components
+                                              that enable the WindowsHostProcessContainers
+                                              feature flag. Setting this field without
+                                              the feature flag will result in errors
+                                              when validating the Pod. All of a Pod's
+                                              containers must have the same effective
+                                              HostProcess value (it is not allowed
+                                              to have a mix of HostProcess containers
+                                              and non-HostProcess containers).  In
+                                              addition, if HostProcess is true then
+                                              HostNetwork must also be set to true.
+                                            type: boolean
                                           runAsUserName:
                                             description: The UserName in Windows to
                                               run the entrypoint of the container
@@ -1776,14 +2175,11 @@ spec:
                                       parameters at the beginning of a Pod''s lifecycle,
                                       when it might take a long time to load data
                                       or warm a cache, than during steady-state operation.
-                                      This cannot be updated. This is a beta feature
-                                      enabled by the StartupProbe feature flag. More
-                                      info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                                      This cannot be updated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
                                     properties:
                                       exec:
-                                        description: One and only one of the following
-                                          should be specified. Exec specifies the
-                                          action to take.
+                                        description: Exec specifies the action to
+                                          take.
                                         properties:
                                           command:
                                             description: Command is the command line
@@ -1808,6 +2204,26 @@ spec:
                                           value is 1.
                                         format: int32
                                         type: integer
+                                      grpc:
+                                        description: GRPC specifies an action involving
+                                          a GRPC port. This is a beta field and requires
+                                          enabling GRPCContainerProbe feature gate.
+                                        properties:
+                                          port:
+                                            description: Port number of the gRPC service.
+                                              Number must be in the range 1 to 65535.
+                                            format: int32
+                                            type: integer
+                                          service:
+                                            description: "Service is the name of the
+                                              service to place in the gRPC HealthCheckRequest
+                                              (see https://github.com/grpc/grpc/blob/master/doc/health-checking.md).
+                                              \n If this is not specified, the default
+                                              behavior is defined by gRPC."
+                                            type: string
+                                        required:
+                                        - port
+                                        type: object
                                       httpGet:
                                         description: HTTPGet specifies the http request
                                           to perform.
@@ -1876,10 +2292,8 @@ spec:
                                         format: int32
                                         type: integer
                                       tcpSocket:
-                                        description: 'TCPSocket specifies an action
-                                          involving a TCP port. TCP hooks not yet
-                                          supported TODO: implement a realistic TCP
-                                          lifecycle hook'
+                                        description: TCPSocket specifies an action
+                                          involving a TCP port.
                                         properties:
                                           host:
                                             description: 'Optional: Host name to connect
@@ -1897,6 +2311,28 @@ spec:
                                         required:
                                         - port
                                         type: object
+                                      terminationGracePeriodSeconds:
+                                        description: Optional duration in seconds
+                                          the pod needs to terminate gracefully upon
+                                          probe failure. The grace period is the duration
+                                          in seconds after the processes running in
+                                          the pod are sent a termination signal and
+                                          the time when the processes are forcibly
+                                          halted with a kill signal. Set this value
+                                          longer than the expected cleanup time for
+                                          your process. If this value is nil, the
+                                          pod's terminationGracePeriodSeconds will
+                                          be used. Otherwise, this value overrides
+                                          the value provided by the pod spec. Value
+                                          must be non-negative integer. The value
+                                          zero indicates stop immediately via the
+                                          kill signal (no opportunity to shut down).
+                                          This is a beta field and requires enabling
+                                          ProbeTerminationGracePeriod feature gate.
+                                          Minimum value is 1. spec.terminationGracePeriodSeconds
+                                          is used if unset.
+                                        format: int64
+                                        type: integer
                                       timeoutSeconds:
                                         description: 'Number of seconds after which
                                           the probe times out. Defaults to 1 second.
@@ -2094,33 +2530,35 @@ spec:
                                 and it cannot be modified by updating the pod spec.
                                 In order to add an ephemeral container to an existing
                                 pod, use the pod's ephemeralcontainers subresource.
-                                This field is alpha-level and is only honored by servers
-                                that enable the EphemeralContainers feature.
+                                This field is beta-level and available on clusters
+                                that haven't disabled the EphemeralContainers feature
+                                gate.
                               items:
-                                description: An EphemeralContainer is a container
-                                  that may be added temporarily to an existing pod
-                                  for user-initiated activities such as debugging.
-                                  Ephemeral containers have no resource or scheduling
-                                  guarantees, and they will not be restarted when
-                                  they exit or when a pod is removed or restarted.
-                                  If an ephemeral container causes a pod to exceed
-                                  its resource allocation, the pod may be evicted.
-                                  Ephemeral containers may not be added by directly
-                                  updating the pod spec. They must be added via the
-                                  pod's ephemeralcontainers subresource, and they
-                                  will appear in the pod spec once added. This is
-                                  an alpha feature enabled by the EphemeralContainers
-                                  feature flag.
+                                description: "An EphemeralContainer is a temporary
+                                  container that you may add to an existing Pod for
+                                  user-initiated activities such as debugging. Ephemeral
+                                  containers have no resource or scheduling guarantees,
+                                  and they will not be restarted when they exit or
+                                  when a Pod is removed or restarted. The kubelet
+                                  may evict a Pod if an ephemeral container causes
+                                  the Pod to exceed its resource allocation. \n To
+                                  add an ephemeral container, use the ephemeralcontainers
+                                  subresource of an existing Pod. Ephemeral containers
+                                  may not be removed or restarted. \n This is a beta
+                                  feature available on clusters that haven't disabled
+                                  the EphemeralContainers feature gate."
                                 properties:
                                   args:
                                     description: 'Arguments to the entrypoint. The
-                                      docker image''s CMD is used if this is not provided.
+                                      image''s CMD is used if this is not provided.
                                       Variable references $(VAR_NAME) are expanded
                                       using the container''s environment. If a variable
                                       cannot be resolved, the reference in the input
-                                      string will be unchanged. The $(VAR_NAME) syntax
-                                      can be escaped with a double $$, ie: $$(VAR_NAME).
-                                      Escaped references will never be expanded, regardless
+                                      string will be unchanged. Double $$ are reduced
+                                      to a single $, which allows for escaping the
+                                      $(VAR_NAME) syntax: i.e. "$$(VAR_NAME)" will
+                                      produce the string literal "$(VAR_NAME)". Escaped
+                                      references will never be expanded, regardless
                                       of whether the variable exists or not. Cannot
                                       be updated. More info: https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell'
                                     items:
@@ -2128,16 +2566,17 @@ spec:
                                     type: array
                                   command:
                                     description: 'Entrypoint array. Not executed within
-                                      a shell. The docker image''s ENTRYPOINT is used
-                                      if this is not provided. Variable references
-                                      $(VAR_NAME) are expanded using the container''s
-                                      environment. If a variable cannot be resolved,
-                                      the reference in the input string will be unchanged.
-                                      The $(VAR_NAME) syntax can be escaped with a
-                                      double $$, ie: $$(VAR_NAME). Escaped references
-                                      will never be expanded, regardless of whether
-                                      the variable exists or not. Cannot be updated.
-                                      More info: https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell'
+                                      a shell. The image''s ENTRYPOINT is used if
+                                      this is not provided. Variable references $(VAR_NAME)
+                                      are expanded using the container''s environment.
+                                      If a variable cannot be resolved, the reference
+                                      in the input string will be unchanged. Double
+                                      $$ are reduced to a single $, which allows for
+                                      escaping the $(VAR_NAME) syntax: i.e. "$$(VAR_NAME)"
+                                      will produce the string literal "$(VAR_NAME)".
+                                      Escaped references will never be expanded, regardless
+                                      of whether the variable exists or not. Cannot
+                                      be updated. More info: https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell'
                                     items:
                                       type: string
                                     type: array
@@ -2154,13 +2593,15 @@ spec:
                                           type: string
                                         value:
                                           description: 'Variable references $(VAR_NAME)
-                                            are expanded using the previous defined
+                                            are expanded using the previously defined
                                             environment variables in the container
                                             and any service environment variables.
                                             If a variable cannot be resolved, the
                                             reference in the input string will be
-                                            unchanged. The $(VAR_NAME) syntax can
-                                            be escaped with a double $$, ie: $$(VAR_NAME).
+                                            unchanged. Double $$ are reduced to a
+                                            single $, which allows for escaping the
+                                            $(VAR_NAME) syntax: i.e. "$$(VAR_NAME)"
+                                            will produce the string literal "$(VAR_NAME)".
                                             Escaped references will never be expanded,
                                             regardless of whether the variable exists
                                             or not. Defaults to "".'
@@ -2314,7 +2755,8 @@ spec:
                                       type: object
                                     type: array
                                   image:
-                                    description: 'Docker image name. More info: https://kubernetes.io/docs/concepts/containers/images'
+                                    description: 'Container image name. More info:
+                                      https://kubernetes.io/docs/concepts/containers/images'
                                     type: string
                                   imagePullPolicy:
                                     description: 'Image pull policy. One of Always,
@@ -2335,9 +2777,8 @@ spec:
                                           More info: https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/#container-hooks'
                                         properties:
                                           exec:
-                                            description: One and only one of the following
-                                              should be specified. Exec specifies
-                                              the action to take.
+                                            description: Exec specifies the action
+                                              to take.
                                             properties:
                                               command:
                                                 description: Command is the command
@@ -2408,10 +2849,12 @@ spec:
                                             - port
                                             type: object
                                           tcpSocket:
-                                            description: 'TCPSocket specifies an action
-                                              involving a TCP port. TCP hooks not
-                                              yet supported TODO: implement a realistic
-                                              TCP lifecycle hook'
+                                            description: Deprecated. TCPSocket is
+                                              NOT supported as a LifecycleHandler
+                                              and kept for the backward compatibility.
+                                              There are no validation of this field
+                                              and lifecycle hooks will fail in runtime
+                                              when tcp handler is specified.
                                             properties:
                                               host:
                                                 description: 'Optional: Host name
@@ -2438,21 +2881,19 @@ spec:
                                           as liveness/startup probe failure, preemption,
                                           resource contention, etc. The handler is
                                           not called if the container crashes or exits.
-                                          The reason for termination is passed to
-                                          the handler. The Pod''s termination grace
-                                          period countdown begins before the PreStop
-                                          hooked is executed. Regardless of the outcome
-                                          of the handler, the container will eventually
-                                          terminate within the Pod''s termination
-                                          grace period. Other management of the container
-                                          blocks until the hook completes or until
-                                          the termination grace period is reached.
-                                          More info: https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/#container-hooks'
+                                          The Pod''s termination grace period countdown
+                                          begins before the PreStop hook is executed.
+                                          Regardless of the outcome of the handler,
+                                          the container will eventually terminate
+                                          within the Pod''s termination grace period
+                                          (unless delayed by finalizers). Other management
+                                          of the container blocks until the hook completes
+                                          or until the termination grace period is
+                                          reached. More info: https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/#container-hooks'
                                         properties:
                                           exec:
-                                            description: One and only one of the following
-                                              should be specified. Exec specifies
-                                              the action to take.
+                                            description: Exec specifies the action
+                                              to take.
                                             properties:
                                               command:
                                                 description: Command is the command
@@ -2523,10 +2964,12 @@ spec:
                                             - port
                                             type: object
                                           tcpSocket:
-                                            description: 'TCPSocket specifies an action
-                                              involving a TCP port. TCP hooks not
-                                              yet supported TODO: implement a realistic
-                                              TCP lifecycle hook'
+                                            description: Deprecated. TCPSocket is
+                                              NOT supported as a LifecycleHandler
+                                              and kept for the backward compatibility.
+                                              There are no validation of this field
+                                              and lifecycle hooks will fail in runtime
+                                              when tcp handler is specified.
                                             properties:
                                               host:
                                                 description: 'Optional: Host name
@@ -2552,9 +2995,8 @@ spec:
                                       containers.
                                     properties:
                                       exec:
-                                        description: One and only one of the following
-                                          should be specified. Exec specifies the
-                                          action to take.
+                                        description: Exec specifies the action to
+                                          take.
                                         properties:
                                           command:
                                             description: Command is the command line
@@ -2579,6 +3021,26 @@ spec:
                                           value is 1.
                                         format: int32
                                         type: integer
+                                      grpc:
+                                        description: GRPC specifies an action involving
+                                          a GRPC port. This is a beta field and requires
+                                          enabling GRPCContainerProbe feature gate.
+                                        properties:
+                                          port:
+                                            description: Port number of the gRPC service.
+                                              Number must be in the range 1 to 65535.
+                                            format: int32
+                                            type: integer
+                                          service:
+                                            description: "Service is the name of the
+                                              service to place in the gRPC HealthCheckRequest
+                                              (see https://github.com/grpc/grpc/blob/master/doc/health-checking.md).
+                                              \n If this is not specified, the default
+                                              behavior is defined by gRPC."
+                                            type: string
+                                        required:
+                                        - port
+                                        type: object
                                       httpGet:
                                         description: HTTPGet specifies the http request
                                           to perform.
@@ -2647,10 +3109,8 @@ spec:
                                         format: int32
                                         type: integer
                                       tcpSocket:
-                                        description: 'TCPSocket specifies an action
-                                          involving a TCP port. TCP hooks not yet
-                                          supported TODO: implement a realistic TCP
-                                          lifecycle hook'
+                                        description: TCPSocket specifies an action
+                                          involving a TCP port.
                                         properties:
                                           host:
                                             description: 'Optional: Host name to connect
@@ -2668,6 +3128,28 @@ spec:
                                         required:
                                         - port
                                         type: object
+                                      terminationGracePeriodSeconds:
+                                        description: Optional duration in seconds
+                                          the pod needs to terminate gracefully upon
+                                          probe failure. The grace period is the duration
+                                          in seconds after the processes running in
+                                          the pod are sent a termination signal and
+                                          the time when the processes are forcibly
+                                          halted with a kill signal. Set this value
+                                          longer than the expected cleanup time for
+                                          your process. If this value is nil, the
+                                          pod's terminationGracePeriodSeconds will
+                                          be used. Otherwise, this value overrides
+                                          the value provided by the pod spec. Value
+                                          must be non-negative integer. The value
+                                          zero indicates stop immediately via the
+                                          kill signal (no opportunity to shut down).
+                                          This is a beta field and requires enabling
+                                          ProbeTerminationGracePeriod feature gate.
+                                          Minimum value is 1. spec.terminationGracePeriodSeconds
+                                          is used if unset.
+                                        format: int64
+                                        type: integer
                                       timeoutSeconds:
                                         description: 'Number of seconds after which
                                           the probe times out. Defaults to 1 second.
@@ -2722,14 +3204,17 @@ spec:
                                       - containerPort
                                       type: object
                                     type: array
+                                    x-kubernetes-list-map-keys:
+                                    - containerPort
+                                    - protocol
+                                    x-kubernetes-list-type: map
                                   readinessProbe:
                                     description: Probes are not allowed for ephemeral
                                       containers.
                                     properties:
                                       exec:
-                                        description: One and only one of the following
-                                          should be specified. Exec specifies the
-                                          action to take.
+                                        description: Exec specifies the action to
+                                          take.
                                         properties:
                                           command:
                                             description: Command is the command line
@@ -2754,6 +3239,26 @@ spec:
                                           value is 1.
                                         format: int32
                                         type: integer
+                                      grpc:
+                                        description: GRPC specifies an action involving
+                                          a GRPC port. This is a beta field and requires
+                                          enabling GRPCContainerProbe feature gate.
+                                        properties:
+                                          port:
+                                            description: Port number of the gRPC service.
+                                              Number must be in the range 1 to 65535.
+                                            format: int32
+                                            type: integer
+                                          service:
+                                            description: "Service is the name of the
+                                              service to place in the gRPC HealthCheckRequest
+                                              (see https://github.com/grpc/grpc/blob/master/doc/health-checking.md).
+                                              \n If this is not specified, the default
+                                              behavior is defined by gRPC."
+                                            type: string
+                                        required:
+                                        - port
+                                        type: object
                                       httpGet:
                                         description: HTTPGet specifies the http request
                                           to perform.
@@ -2822,10 +3327,8 @@ spec:
                                         format: int32
                                         type: integer
                                       tcpSocket:
-                                        description: 'TCPSocket specifies an action
-                                          involving a TCP port. TCP hooks not yet
-                                          supported TODO: implement a realistic TCP
-                                          lifecycle hook'
+                                        description: TCPSocket specifies an action
+                                          involving a TCP port.
                                         properties:
                                           host:
                                             description: 'Optional: Host name to connect
@@ -2843,6 +3346,28 @@ spec:
                                         required:
                                         - port
                                         type: object
+                                      terminationGracePeriodSeconds:
+                                        description: Optional duration in seconds
+                                          the pod needs to terminate gracefully upon
+                                          probe failure. The grace period is the duration
+                                          in seconds after the processes running in
+                                          the pod are sent a termination signal and
+                                          the time when the processes are forcibly
+                                          halted with a kill signal. Set this value
+                                          longer than the expected cleanup time for
+                                          your process. If this value is nil, the
+                                          pod's terminationGracePeriodSeconds will
+                                          be used. Otherwise, this value overrides
+                                          the value provided by the pod spec. Value
+                                          must be non-negative integer. The value
+                                          zero indicates stop immediately via the
+                                          kill signal (no opportunity to shut down).
+                                          This is a beta field and requires enabling
+                                          ProbeTerminationGracePeriod feature gate.
+                                          Minimum value is 1. spec.terminationGracePeriodSeconds
+                                          is used if unset.
+                                        format: int64
+                                        type: integer
                                       timeoutSeconds:
                                         description: 'Number of seconds after which
                                           the probe times out. Defaults to 1 second.
@@ -2864,7 +3389,7 @@ spec:
                                           x-kubernetes-int-or-string: true
                                         description: 'Limits describes the maximum
                                           amount of compute resources allowed. More
-                                          info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
+                                          info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
                                         type: object
                                       requests:
                                         additionalProperties:
@@ -2878,12 +3403,14 @@ spec:
                                           Requests is omitted for a container, it
                                           defaults to Limits if that is explicitly
                                           specified, otherwise to an implementation-defined
-                                          value. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
+                                          value. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
                                         type: object
                                     type: object
                                   securityContext:
-                                    description: SecurityContext is not allowed for
-                                      ephemeral containers.
+                                    description: 'Optional: SecurityContext defines
+                                      the security options the ephemeral container
+                                      should be run with. If set, the fields of SecurityContext
+                                      override the equivalent fields of PodSecurityContext.'
                                     properties:
                                       allowPrivilegeEscalation:
                                         description: 'AllowPrivilegeEscalation controls
@@ -2892,13 +3419,16 @@ spec:
                                           controls if the no_new_privs flag will be
                                           set on the container process. AllowPrivilegeEscalation
                                           is true always when the container is: 1)
-                                          run as Privileged 2) has CAP_SYS_ADMIN'
+                                          run as Privileged 2) has CAP_SYS_ADMIN Note
+                                          that this field cannot be set when spec.os.name
+                                          is windows.'
                                         type: boolean
                                       capabilities:
                                         description: The capabilities to add/drop
                                           when running containers. Defaults to the
                                           default set of capabilities granted by the
-                                          container runtime.
+                                          container runtime. Note that this field
+                                          cannot be set when spec.os.name is windows.
                                         properties:
                                           add:
                                             description: Added capabilities
@@ -2919,7 +3449,8 @@ spec:
                                         description: Run container in privileged mode.
                                           Processes in privileged containers are essentially
                                           equivalent to root on the host. Defaults
-                                          to false.
+                                          to false. Note that this field cannot be
+                                          set when spec.os.name is windows.
                                         type: boolean
                                       procMount:
                                         description: procMount denotes the type of
@@ -2928,10 +3459,14 @@ spec:
                                           container runtime defaults for readonly
                                           paths and masked paths. This requires the
                                           ProcMountType feature flag to be enabled.
+                                          Note that this field cannot be set when
+                                          spec.os.name is windows.
                                         type: string
                                       readOnlyRootFilesystem:
                                         description: Whether this container has a
                                           read-only root filesystem. Default is false.
+                                          Note that this field cannot be set when
+                                          spec.os.name is windows.
                                         type: boolean
                                       runAsGroup:
                                         description: The GID to run the entrypoint
@@ -2939,7 +3474,8 @@ spec:
                                           if unset. May also be set in PodSecurityContext.  If
                                           set in both SecurityContext and PodSecurityContext,
                                           the value specified in SecurityContext takes
-                                          precedence.
+                                          precedence. Note that this field cannot
+                                          be set when spec.os.name is windows.
                                         format: int64
                                         type: integer
                                       runAsNonRoot:
@@ -2961,7 +3497,8 @@ spec:
                                           May also be set in PodSecurityContext.  If
                                           set in both SecurityContext and PodSecurityContext,
                                           the value specified in SecurityContext takes
-                                          precedence.
+                                          precedence. Note that this field cannot
+                                          be set when spec.os.name is windows.
                                         format: int64
                                         type: integer
                                       seLinuxOptions:
@@ -2971,7 +3508,9 @@ spec:
                                           for each container.  May also be set in
                                           PodSecurityContext.  If set in both SecurityContext
                                           and PodSecurityContext, the value specified
-                                          in SecurityContext takes precedence.
+                                          in SecurityContext takes precedence. Note
+                                          that this field cannot be set when spec.os.name
+                                          is windows.
                                         properties:
                                           level:
                                             description: Level is SELinux level label
@@ -2994,7 +3533,9 @@ spec:
                                         description: The seccomp options to use by
                                           this container. If seccomp options are provided
                                           at both the pod & container level, the container
-                                          options override the pod options.
+                                          options override the pod options. Note that
+                                          this field cannot be set when spec.os.name
+                                          is windows.
                                         properties:
                                           localhostProfile:
                                             description: localhostProfile indicates
@@ -3025,7 +3566,9 @@ spec:
                                           the options from the PodSecurityContext
                                           will be used. If set in both SecurityContext
                                           and PodSecurityContext, the value specified
-                                          in SecurityContext takes precedence.
+                                          in SecurityContext takes precedence. Note
+                                          that this field cannot be set when spec.os.name
+                                          is linux.
                                         properties:
                                           gmsaCredentialSpec:
                                             description: GMSACredentialSpec is where
@@ -3039,6 +3582,22 @@ spec:
                                               the name of the GMSA credential spec
                                               to use.
                                             type: string
+                                          hostProcess:
+                                            description: HostProcess determines if
+                                              a container should be run as a 'Host
+                                              Process' container. This field is alpha-level
+                                              and will only be honored by components
+                                              that enable the WindowsHostProcessContainers
+                                              feature flag. Setting this field without
+                                              the feature flag will result in errors
+                                              when validating the Pod. All of a Pod's
+                                              containers must have the same effective
+                                              HostProcess value (it is not allowed
+                                              to have a mix of HostProcess containers
+                                              and non-HostProcess containers).  In
+                                              addition, if HostProcess is true then
+                                              HostNetwork must also be set to true.
+                                            type: boolean
                                           runAsUserName:
                                             description: The UserName in Windows to
                                               run the entrypoint of the container
@@ -3056,9 +3615,8 @@ spec:
                                       containers.
                                     properties:
                                       exec:
-                                        description: One and only one of the following
-                                          should be specified. Exec specifies the
-                                          action to take.
+                                        description: Exec specifies the action to
+                                          take.
                                         properties:
                                           command:
                                             description: Command is the command line
@@ -3083,6 +3641,26 @@ spec:
                                           value is 1.
                                         format: int32
                                         type: integer
+                                      grpc:
+                                        description: GRPC specifies an action involving
+                                          a GRPC port. This is a beta field and requires
+                                          enabling GRPCContainerProbe feature gate.
+                                        properties:
+                                          port:
+                                            description: Port number of the gRPC service.
+                                              Number must be in the range 1 to 65535.
+                                            format: int32
+                                            type: integer
+                                          service:
+                                            description: "Service is the name of the
+                                              service to place in the gRPC HealthCheckRequest
+                                              (see https://github.com/grpc/grpc/blob/master/doc/health-checking.md).
+                                              \n If this is not specified, the default
+                                              behavior is defined by gRPC."
+                                            type: string
+                                        required:
+                                        - port
+                                        type: object
                                       httpGet:
                                         description: HTTPGet specifies the http request
                                           to perform.
@@ -3151,10 +3729,8 @@ spec:
                                         format: int32
                                         type: integer
                                       tcpSocket:
-                                        description: 'TCPSocket specifies an action
-                                          involving a TCP port. TCP hooks not yet
-                                          supported TODO: implement a realistic TCP
-                                          lifecycle hook'
+                                        description: TCPSocket specifies an action
+                                          involving a TCP port.
                                         properties:
                                           host:
                                             description: 'Optional: Host name to connect
@@ -3172,6 +3748,28 @@ spec:
                                         required:
                                         - port
                                         type: object
+                                      terminationGracePeriodSeconds:
+                                        description: Optional duration in seconds
+                                          the pod needs to terminate gracefully upon
+                                          probe failure. The grace period is the duration
+                                          in seconds after the processes running in
+                                          the pod are sent a termination signal and
+                                          the time when the processes are forcibly
+                                          halted with a kill signal. Set this value
+                                          longer than the expected cleanup time for
+                                          your process. If this value is nil, the
+                                          pod's terminationGracePeriodSeconds will
+                                          be used. Otherwise, this value overrides
+                                          the value provided by the pod spec. Value
+                                          must be non-negative integer. The value
+                                          zero indicates stop immediately via the
+                                          kill signal (no opportunity to shut down).
+                                          This is a beta field and requires enabling
+                                          ProbeTerminationGracePeriod feature gate.
+                                          Minimum value is 1. spec.terminationGracePeriodSeconds
+                                          is used if unset.
+                                        format: int64
+                                        type: integer
                                       timeoutSeconds:
                                         description: 'Number of seconds after which
                                           the probe times out. Defaults to 1 second.
@@ -3202,13 +3800,15 @@ spec:
                                       EOF. Default is false
                                     type: boolean
                                   targetContainerName:
-                                    description: If set, the name of the container
+                                    description: "If set, the name of the container
                                       from PodSpec that this ephemeral container targets.
                                       The ephemeral container will be run in the namespaces
                                       (IPC, PID, etc) of this container. If not set
-                                      then the ephemeral container is run in whatever
-                                      namespaces are shared for the pod. Note that
-                                      the container runtime must support this feature.
+                                      then the ephemeral container uses the namespaces
+                                      configured in the Pod spec. \n The container
+                                      runtime must implement support for this feature.
+                                      If the runtime does not support namespace targeting
+                                      then the result of setting this field is undefined."
                                     type: string
                                   terminationMessagePath:
                                     description: 'Optional: Path at which the file
@@ -3261,7 +3861,8 @@ spec:
                                     type: array
                                   volumeMounts:
                                     description: Pod volumes to mount into the container's
-                                      filesystem. Cannot be updated.
+                                      filesystem. Subpath mounts are not allowed for
+                                      ephemeral containers. Cannot be updated.
                                     items:
                                       description: VolumeMount describes a mounting
                                         of a Volume within a container.
@@ -3360,9 +3961,8 @@ spec:
                                 references to secrets in the same namespace to use
                                 for pulling any of the images used by this PodSpec.
                                 If specified, these secrets will be passed to individual
-                                puller implementations for them to use. For example,
-                                in the case of docker, only DockerConfig type secrets
-                                are honored. More info: https://kubernetes.io/docs/concepts/containers/images#specifying-imagepullsecrets-on-a-pod'
+                                puller implementations for them to use. More info:
+                                https://kubernetes.io/docs/concepts/containers/images#specifying-imagepullsecrets-on-a-pod'
                               items:
                                 description: LocalObjectReference contains enough
                                   information to let you locate the referenced object
@@ -3399,12 +3999,14 @@ spec:
                                 properties:
                                   args:
                                     description: 'Arguments to the entrypoint. The
-                                      docker image''s CMD is used if this is not provided.
-                                      Variable references $(VAR_NAME) are expanded
-                                      using the container''s environment. If a variable
-                                      cannot be resolved, the reference in the input
-                                      string will be unchanged. The $(VAR_NAME) syntax
-                                      can be escaped with a double $$, ie: $$(VAR_NAME).
+                                      container image''s CMD is used if this is not
+                                      provided. Variable references $(VAR_NAME) are
+                                      expanded using the container''s environment.
+                                      If a variable cannot be resolved, the reference
+                                      in the input string will be unchanged. Double
+                                      $$ are reduced to a single $, which allows for
+                                      escaping the $(VAR_NAME) syntax: i.e. "$$(VAR_NAME)"
+                                      will produce the string literal "$(VAR_NAME)".
                                       Escaped references will never be expanded, regardless
                                       of whether the variable exists or not. Cannot
                                       be updated. More info: https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell'
@@ -3413,16 +4015,17 @@ spec:
                                     type: array
                                   command:
                                     description: 'Entrypoint array. Not executed within
-                                      a shell. The docker image''s ENTRYPOINT is used
-                                      if this is not provided. Variable references
+                                      a shell. The container image''s ENTRYPOINT is
+                                      used if this is not provided. Variable references
                                       $(VAR_NAME) are expanded using the container''s
                                       environment. If a variable cannot be resolved,
                                       the reference in the input string will be unchanged.
-                                      The $(VAR_NAME) syntax can be escaped with a
-                                      double $$, ie: $$(VAR_NAME). Escaped references
-                                      will never be expanded, regardless of whether
-                                      the variable exists or not. Cannot be updated.
-                                      More info: https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell'
+                                      Double $$ are reduced to a single $, which allows
+                                      for escaping the $(VAR_NAME) syntax: i.e. "$$(VAR_NAME)"
+                                      will produce the string literal "$(VAR_NAME)".
+                                      Escaped references will never be expanded, regardless
+                                      of whether the variable exists or not. Cannot
+                                      be updated. More info: https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell'
                                     items:
                                       type: string
                                     type: array
@@ -3439,13 +4042,15 @@ spec:
                                           type: string
                                         value:
                                           description: 'Variable references $(VAR_NAME)
-                                            are expanded using the previous defined
+                                            are expanded using the previously defined
                                             environment variables in the container
                                             and any service environment variables.
                                             If a variable cannot be resolved, the
                                             reference in the input string will be
-                                            unchanged. The $(VAR_NAME) syntax can
-                                            be escaped with a double $$, ie: $$(VAR_NAME).
+                                            unchanged. Double $$ are reduced to a
+                                            single $, which allows for escaping the
+                                            $(VAR_NAME) syntax: i.e. "$$(VAR_NAME)"
+                                            will produce the string literal "$(VAR_NAME)".
                                             Escaped references will never be expanded,
                                             regardless of whether the variable exists
                                             or not. Defaults to "".'
@@ -3599,7 +4204,8 @@ spec:
                                       type: object
                                     type: array
                                   image:
-                                    description: 'Docker image name. More info: https://kubernetes.io/docs/concepts/containers/images
+                                    description: 'Container image name. More info:
+                                      https://kubernetes.io/docs/concepts/containers/images
                                       This field is optional to allow higher level
                                       config management to default or override container
                                       images in workload controllers like Deployments
@@ -3625,9 +4231,8 @@ spec:
                                           More info: https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/#container-hooks'
                                         properties:
                                           exec:
-                                            description: One and only one of the following
-                                              should be specified. Exec specifies
-                                              the action to take.
+                                            description: Exec specifies the action
+                                              to take.
                                             properties:
                                               command:
                                                 description: Command is the command
@@ -3698,10 +4303,12 @@ spec:
                                             - port
                                             type: object
                                           tcpSocket:
-                                            description: 'TCPSocket specifies an action
-                                              involving a TCP port. TCP hooks not
-                                              yet supported TODO: implement a realistic
-                                              TCP lifecycle hook'
+                                            description: Deprecated. TCPSocket is
+                                              NOT supported as a LifecycleHandler
+                                              and kept for the backward compatibility.
+                                              There are no validation of this field
+                                              and lifecycle hooks will fail in runtime
+                                              when tcp handler is specified.
                                             properties:
                                               host:
                                                 description: 'Optional: Host name
@@ -3728,21 +4335,19 @@ spec:
                                           as liveness/startup probe failure, preemption,
                                           resource contention, etc. The handler is
                                           not called if the container crashes or exits.
-                                          The reason for termination is passed to
-                                          the handler. The Pod''s termination grace
-                                          period countdown begins before the PreStop
-                                          hooked is executed. Regardless of the outcome
-                                          of the handler, the container will eventually
-                                          terminate within the Pod''s termination
-                                          grace period. Other management of the container
-                                          blocks until the hook completes or until
-                                          the termination grace period is reached.
-                                          More info: https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/#container-hooks'
+                                          The Pod''s termination grace period countdown
+                                          begins before the PreStop hook is executed.
+                                          Regardless of the outcome of the handler,
+                                          the container will eventually terminate
+                                          within the Pod''s termination grace period
+                                          (unless delayed by finalizers). Other management
+                                          of the container blocks until the hook completes
+                                          or until the termination grace period is
+                                          reached. More info: https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/#container-hooks'
                                         properties:
                                           exec:
-                                            description: One and only one of the following
-                                              should be specified. Exec specifies
-                                              the action to take.
+                                            description: Exec specifies the action
+                                              to take.
                                             properties:
                                               command:
                                                 description: Command is the command
@@ -3813,10 +4418,12 @@ spec:
                                             - port
                                             type: object
                                           tcpSocket:
-                                            description: 'TCPSocket specifies an action
-                                              involving a TCP port. TCP hooks not
-                                              yet supported TODO: implement a realistic
-                                              TCP lifecycle hook'
+                                            description: Deprecated. TCPSocket is
+                                              NOT supported as a LifecycleHandler
+                                              and kept for the backward compatibility.
+                                              There are no validation of this field
+                                              and lifecycle hooks will fail in runtime
+                                              when tcp handler is specified.
                                             properties:
                                               host:
                                                 description: 'Optional: Host name
@@ -3843,9 +4450,8 @@ spec:
                                       Cannot be updated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
                                     properties:
                                       exec:
-                                        description: One and only one of the following
-                                          should be specified. Exec specifies the
-                                          action to take.
+                                        description: Exec specifies the action to
+                                          take.
                                         properties:
                                           command:
                                             description: Command is the command line
@@ -3870,6 +4476,26 @@ spec:
                                           value is 1.
                                         format: int32
                                         type: integer
+                                      grpc:
+                                        description: GRPC specifies an action involving
+                                          a GRPC port. This is a beta field and requires
+                                          enabling GRPCContainerProbe feature gate.
+                                        properties:
+                                          port:
+                                            description: Port number of the gRPC service.
+                                              Number must be in the range 1 to 65535.
+                                            format: int32
+                                            type: integer
+                                          service:
+                                            description: "Service is the name of the
+                                              service to place in the gRPC HealthCheckRequest
+                                              (see https://github.com/grpc/grpc/blob/master/doc/health-checking.md).
+                                              \n If this is not specified, the default
+                                              behavior is defined by gRPC."
+                                            type: string
+                                        required:
+                                        - port
+                                        type: object
                                       httpGet:
                                         description: HTTPGet specifies the http request
                                           to perform.
@@ -3938,10 +4564,8 @@ spec:
                                         format: int32
                                         type: integer
                                       tcpSocket:
-                                        description: 'TCPSocket specifies an action
-                                          involving a TCP port. TCP hooks not yet
-                                          supported TODO: implement a realistic TCP
-                                          lifecycle hook'
+                                        description: TCPSocket specifies an action
+                                          involving a TCP port.
                                         properties:
                                           host:
                                             description: 'Optional: Host name to connect
@@ -3959,6 +4583,28 @@ spec:
                                         required:
                                         - port
                                         type: object
+                                      terminationGracePeriodSeconds:
+                                        description: Optional duration in seconds
+                                          the pod needs to terminate gracefully upon
+                                          probe failure. The grace period is the duration
+                                          in seconds after the processes running in
+                                          the pod are sent a termination signal and
+                                          the time when the processes are forcibly
+                                          halted with a kill signal. Set this value
+                                          longer than the expected cleanup time for
+                                          your process. If this value is nil, the
+                                          pod's terminationGracePeriodSeconds will
+                                          be used. Otherwise, this value overrides
+                                          the value provided by the pod spec. Value
+                                          must be non-negative integer. The value
+                                          zero indicates stop immediately via the
+                                          kill signal (no opportunity to shut down).
+                                          This is a beta field and requires enabling
+                                          ProbeTerminationGracePeriod feature gate.
+                                          Minimum value is 1. spec.terminationGracePeriodSeconds
+                                          is used if unset.
+                                        format: int64
+                                        type: integer
                                       timeoutSeconds:
                                         description: 'Number of seconds after which
                                           the probe times out. Defaults to 1 second.
@@ -4030,9 +4676,8 @@ spec:
                                       More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
                                     properties:
                                       exec:
-                                        description: One and only one of the following
-                                          should be specified. Exec specifies the
-                                          action to take.
+                                        description: Exec specifies the action to
+                                          take.
                                         properties:
                                           command:
                                             description: Command is the command line
@@ -4057,6 +4702,26 @@ spec:
                                           value is 1.
                                         format: int32
                                         type: integer
+                                      grpc:
+                                        description: GRPC specifies an action involving
+                                          a GRPC port. This is a beta field and requires
+                                          enabling GRPCContainerProbe feature gate.
+                                        properties:
+                                          port:
+                                            description: Port number of the gRPC service.
+                                              Number must be in the range 1 to 65535.
+                                            format: int32
+                                            type: integer
+                                          service:
+                                            description: "Service is the name of the
+                                              service to place in the gRPC HealthCheckRequest
+                                              (see https://github.com/grpc/grpc/blob/master/doc/health-checking.md).
+                                              \n If this is not specified, the default
+                                              behavior is defined by gRPC."
+                                            type: string
+                                        required:
+                                        - port
+                                        type: object
                                       httpGet:
                                         description: HTTPGet specifies the http request
                                           to perform.
@@ -4125,10 +4790,8 @@ spec:
                                         format: int32
                                         type: integer
                                       tcpSocket:
-                                        description: 'TCPSocket specifies an action
-                                          involving a TCP port. TCP hooks not yet
-                                          supported TODO: implement a realistic TCP
-                                          lifecycle hook'
+                                        description: TCPSocket specifies an action
+                                          involving a TCP port.
                                         properties:
                                           host:
                                             description: 'Optional: Host name to connect
@@ -4146,6 +4809,28 @@ spec:
                                         required:
                                         - port
                                         type: object
+                                      terminationGracePeriodSeconds:
+                                        description: Optional duration in seconds
+                                          the pod needs to terminate gracefully upon
+                                          probe failure. The grace period is the duration
+                                          in seconds after the processes running in
+                                          the pod are sent a termination signal and
+                                          the time when the processes are forcibly
+                                          halted with a kill signal. Set this value
+                                          longer than the expected cleanup time for
+                                          your process. If this value is nil, the
+                                          pod's terminationGracePeriodSeconds will
+                                          be used. Otherwise, this value overrides
+                                          the value provided by the pod spec. Value
+                                          must be non-negative integer. The value
+                                          zero indicates stop immediately via the
+                                          kill signal (no opportunity to shut down).
+                                          This is a beta field and requires enabling
+                                          ProbeTerminationGracePeriod feature gate.
+                                          Minimum value is 1. spec.terminationGracePeriodSeconds
+                                          is used if unset.
+                                        format: int64
+                                        type: integer
                                       timeoutSeconds:
                                         description: 'Number of seconds after which
                                           the probe times out. Defaults to 1 second.
@@ -4155,7 +4840,7 @@ spec:
                                     type: object
                                   resources:
                                     description: 'Compute Resources required by this
-                                      container. Cannot be updated. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
+                                      container. Cannot be updated. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
                                     properties:
                                       limits:
                                         additionalProperties:
@@ -4166,7 +4851,7 @@ spec:
                                           x-kubernetes-int-or-string: true
                                         description: 'Limits describes the maximum
                                           amount of compute resources allowed. More
-                                          info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
+                                          info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
                                         type: object
                                       requests:
                                         additionalProperties:
@@ -4180,12 +4865,14 @@ spec:
                                           Requests is omitted for a container, it
                                           defaults to Limits if that is explicitly
                                           specified, otherwise to an implementation-defined
-                                          value. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
+                                          value. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
                                         type: object
                                     type: object
                                   securityContext:
-                                    description: 'Security options the pod should
-                                      run with. More info: https://kubernetes.io/docs/concepts/policy/security-context/
+                                    description: 'SecurityContext defines the security
+                                      options the container should be run with. If
+                                      set, the fields of SecurityContext override
+                                      the equivalent fields of PodSecurityContext.
                                       More info: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/'
                                     properties:
                                       allowPrivilegeEscalation:
@@ -4195,13 +4882,16 @@ spec:
                                           controls if the no_new_privs flag will be
                                           set on the container process. AllowPrivilegeEscalation
                                           is true always when the container is: 1)
-                                          run as Privileged 2) has CAP_SYS_ADMIN'
+                                          run as Privileged 2) has CAP_SYS_ADMIN Note
+                                          that this field cannot be set when spec.os.name
+                                          is windows.'
                                         type: boolean
                                       capabilities:
                                         description: The capabilities to add/drop
                                           when running containers. Defaults to the
                                           default set of capabilities granted by the
-                                          container runtime.
+                                          container runtime. Note that this field
+                                          cannot be set when spec.os.name is windows.
                                         properties:
                                           add:
                                             description: Added capabilities
@@ -4222,7 +4912,8 @@ spec:
                                         description: Run container in privileged mode.
                                           Processes in privileged containers are essentially
                                           equivalent to root on the host. Defaults
-                                          to false.
+                                          to false. Note that this field cannot be
+                                          set when spec.os.name is windows.
                                         type: boolean
                                       procMount:
                                         description: procMount denotes the type of
@@ -4231,10 +4922,14 @@ spec:
                                           container runtime defaults for readonly
                                           paths and masked paths. This requires the
                                           ProcMountType feature flag to be enabled.
+                                          Note that this field cannot be set when
+                                          spec.os.name is windows.
                                         type: string
                                       readOnlyRootFilesystem:
                                         description: Whether this container has a
                                           read-only root filesystem. Default is false.
+                                          Note that this field cannot be set when
+                                          spec.os.name is windows.
                                         type: boolean
                                       runAsGroup:
                                         description: The GID to run the entrypoint
@@ -4242,7 +4937,8 @@ spec:
                                           if unset. May also be set in PodSecurityContext.  If
                                           set in both SecurityContext and PodSecurityContext,
                                           the value specified in SecurityContext takes
-                                          precedence.
+                                          precedence. Note that this field cannot
+                                          be set when spec.os.name is windows.
                                         format: int64
                                         type: integer
                                       runAsNonRoot:
@@ -4264,7 +4960,8 @@ spec:
                                           May also be set in PodSecurityContext.  If
                                           set in both SecurityContext and PodSecurityContext,
                                           the value specified in SecurityContext takes
-                                          precedence.
+                                          precedence. Note that this field cannot
+                                          be set when spec.os.name is windows.
                                         format: int64
                                         type: integer
                                       seLinuxOptions:
@@ -4274,7 +4971,9 @@ spec:
                                           for each container.  May also be set in
                                           PodSecurityContext.  If set in both SecurityContext
                                           and PodSecurityContext, the value specified
-                                          in SecurityContext takes precedence.
+                                          in SecurityContext takes precedence. Note
+                                          that this field cannot be set when spec.os.name
+                                          is windows.
                                         properties:
                                           level:
                                             description: Level is SELinux level label
@@ -4297,7 +4996,9 @@ spec:
                                         description: The seccomp options to use by
                                           this container. If seccomp options are provided
                                           at both the pod & container level, the container
-                                          options override the pod options.
+                                          options override the pod options. Note that
+                                          this field cannot be set when spec.os.name
+                                          is windows.
                                         properties:
                                           localhostProfile:
                                             description: localhostProfile indicates
@@ -4328,7 +5029,9 @@ spec:
                                           the options from the PodSecurityContext
                                           will be used. If set in both SecurityContext
                                           and PodSecurityContext, the value specified
-                                          in SecurityContext takes precedence.
+                                          in SecurityContext takes precedence. Note
+                                          that this field cannot be set when spec.os.name
+                                          is linux.
                                         properties:
                                           gmsaCredentialSpec:
                                             description: GMSACredentialSpec is where
@@ -4342,6 +5045,22 @@ spec:
                                               the name of the GMSA credential spec
                                               to use.
                                             type: string
+                                          hostProcess:
+                                            description: HostProcess determines if
+                                              a container should be run as a 'Host
+                                              Process' container. This field is alpha-level
+                                              and will only be honored by components
+                                              that enable the WindowsHostProcessContainers
+                                              feature flag. Setting this field without
+                                              the feature flag will result in errors
+                                              when validating the Pod. All of a Pod's
+                                              containers must have the same effective
+                                              HostProcess value (it is not allowed
+                                              to have a mix of HostProcess containers
+                                              and non-HostProcess containers).  In
+                                              addition, if HostProcess is true then
+                                              HostNetwork must also be set to true.
+                                            type: boolean
                                           runAsUserName:
                                             description: The UserName in Windows to
                                               run the entrypoint of the container
@@ -4364,14 +5083,11 @@ spec:
                                       parameters at the beginning of a Pod''s lifecycle,
                                       when it might take a long time to load data
                                       or warm a cache, than during steady-state operation.
-                                      This cannot be updated. This is a beta feature
-                                      enabled by the StartupProbe feature flag. More
-                                      info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                                      This cannot be updated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
                                     properties:
                                       exec:
-                                        description: One and only one of the following
-                                          should be specified. Exec specifies the
-                                          action to take.
+                                        description: Exec specifies the action to
+                                          take.
                                         properties:
                                           command:
                                             description: Command is the command line
@@ -4396,6 +5112,26 @@ spec:
                                           value is 1.
                                         format: int32
                                         type: integer
+                                      grpc:
+                                        description: GRPC specifies an action involving
+                                          a GRPC port. This is a beta field and requires
+                                          enabling GRPCContainerProbe feature gate.
+                                        properties:
+                                          port:
+                                            description: Port number of the gRPC service.
+                                              Number must be in the range 1 to 65535.
+                                            format: int32
+                                            type: integer
+                                          service:
+                                            description: "Service is the name of the
+                                              service to place in the gRPC HealthCheckRequest
+                                              (see https://github.com/grpc/grpc/blob/master/doc/health-checking.md).
+                                              \n If this is not specified, the default
+                                              behavior is defined by gRPC."
+                                            type: string
+                                        required:
+                                        - port
+                                        type: object
                                       httpGet:
                                         description: HTTPGet specifies the http request
                                           to perform.
@@ -4464,10 +5200,8 @@ spec:
                                         format: int32
                                         type: integer
                                       tcpSocket:
-                                        description: 'TCPSocket specifies an action
-                                          involving a TCP port. TCP hooks not yet
-                                          supported TODO: implement a realistic TCP
-                                          lifecycle hook'
+                                        description: TCPSocket specifies an action
+                                          involving a TCP port.
                                         properties:
                                           host:
                                             description: 'Optional: Host name to connect
@@ -4485,6 +5219,28 @@ spec:
                                         required:
                                         - port
                                         type: object
+                                      terminationGracePeriodSeconds:
+                                        description: Optional duration in seconds
+                                          the pod needs to terminate gracefully upon
+                                          probe failure. The grace period is the duration
+                                          in seconds after the processes running in
+                                          the pod are sent a termination signal and
+                                          the time when the processes are forcibly
+                                          halted with a kill signal. Set this value
+                                          longer than the expected cleanup time for
+                                          your process. If this value is nil, the
+                                          pod's terminationGracePeriodSeconds will
+                                          be used. Otherwise, this value overrides
+                                          the value provided by the pod spec. Value
+                                          must be non-negative integer. The value
+                                          zero indicates stop immediately via the
+                                          kill signal (no opportunity to shut down).
+                                          This is a beta field and requires enabling
+                                          ProbeTerminationGracePeriod feature gate.
+                                          Minimum value is 1. spec.terminationGracePeriodSeconds
+                                          is used if unset.
+                                        format: int64
+                                        type: integer
                                       timeoutSeconds:
                                         description: 'Number of seconds after which
                                           the probe times out. Defaults to 1 second.
@@ -4634,6 +5390,40 @@ spec:
                                 must match a node''s labels for the pod to be scheduled
                                 on that node. More info: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/'
                               type: object
+                              x-kubernetes-map-type: atomic
+                            os:
+                              description: "Specifies the OS of the containers in
+                                the pod. Some pod and container fields are restricted
+                                if this is set. \n If the OS field is set to linux,
+                                the following fields must be unset: -securityContext.windowsOptions
+                                \n If the OS field is set to windows, following fields
+                                must be unset: - spec.hostPID - spec.hostIPC - spec.securityContext.seLinuxOptions
+                                - spec.securityContext.seccompProfile - spec.securityContext.fsGroup
+                                - spec.securityContext.fsGroupChangePolicy - spec.securityContext.sysctls
+                                - spec.shareProcessNamespace - spec.securityContext.runAsUser
+                                - spec.securityContext.runAsGroup - spec.securityContext.supplementalGroups
+                                - spec.containers[*].securityContext.seLinuxOptions
+                                - spec.containers[*].securityContext.seccompProfile
+                                - spec.containers[*].securityContext.capabilities
+                                - spec.containers[*].securityContext.readOnlyRootFilesystem
+                                - spec.containers[*].securityContext.privileged -
+                                spec.containers[*].securityContext.allowPrivilegeEscalation
+                                - spec.containers[*].securityContext.procMount - spec.containers[*].securityContext.runAsUser
+                                - spec.containers[*].securityContext.runAsGroup This
+                                is a beta field and requires the IdentifyPodOS feature"
+                              properties:
+                                name:
+                                  description: 'Name is the name of the operating
+                                    system. The currently supported values are linux
+                                    and windows. Additional value may be defined in
+                                    future and can be one of: https://github.com/opencontainers/runtime-spec/blob/master/config.md#platform-specific-configuration
+                                    Clients should expect to handle additional values
+                                    and treat unrecognized values in this field as
+                                    os: null'
+                                  type: string
+                              required:
+                              - name
+                              type: object
                             overhead:
                               additionalProperties:
                                 anyOf:
@@ -4652,17 +5442,12 @@ spec:
                                 and selected in the PodSpec, Overhead will be set
                                 to the value defined in the corresponding RuntimeClass,
                                 otherwise it will remain unset and treated as zero.
-                                More info: https://git.k8s.io/enhancements/keps/sig-node/20190226-pod-overhead.md
-                                This field is alpha-level as of Kubernetes v1.16,
-                                and is only honored by servers that enable the PodOverhead
-                                feature.'
+                                More info: https://git.k8s.io/enhancements/keps/sig-node/688-pod-overhead/README.md'
                               type: object
                             preemptionPolicy:
                               description: PreemptionPolicy is the Policy for preempting
                                 pods with lower priority. One of Never, PreemptLowerPriority.
-                                Defaults to PreemptLowerPriority if unset. This field
-                                is beta-level, gated by the NonPreemptingPriority
-                                feature-gate.
+                                Defaults to PreemptLowerPriority if unset.
                               type: string
                             priority:
                               description: The priority value. Various system components
@@ -4687,7 +5472,7 @@ spec:
                                 be evaluated for pod readiness. A pod is ready when
                                 all its containers are ready AND all conditions specified
                                 in the readiness gates have status equal to "True"
-                                More info: https://git.k8s.io/enhancements/keps/sig-network/0007-pod-ready%2B%2B.md'
+                                More info: https://git.k8s.io/enhancements/keps/sig-network/580-pod-readiness-gates'
                               items:
                                 description: PodReadinessGate contains the reference
                                   to a pod condition
@@ -4713,8 +5498,7 @@ spec:
                                 or empty, the "legacy" RuntimeClass will be used,
                                 which is an implicit class with an empty definition
                                 that uses the default runtime handler. More info:
-                                https://git.k8s.io/enhancements/keps/sig-node/runtime-class.md
-                                This is a beta feature as of Kubernetes v1.14.'
+                                https://git.k8s.io/enhancements/keps/sig-node/585-runtime-class'
                               type: string
                             schedulerName:
                               description: If specified, the pod will be dispatched
@@ -4736,7 +5520,9 @@ spec:
                                     is set (new files created in the volume will be
                                     owned by FSGroup) 3. The permission bits are OR'd
                                     with rw-rw---- \n If unset, the Kubelet will not
-                                    modify the ownership and permissions of any volume."
+                                    modify the ownership and permissions of any volume.
+                                    Note that this field cannot be set when spec.os.name
+                                    is windows."
                                   format: int64
                                   type: integer
                                 fsGroupChangePolicy:
@@ -4747,7 +5533,9 @@ spec:
                                     based ownership(and permissions). It will have
                                     no effect on ephemeral volume types such as: secret,
                                     configmaps and emptydir. Valid values are "OnRootMismatch"
-                                    and "Always". If not specified defaults to "Always".'
+                                    and "Always". If not specified, "Always" is used.
+                                    Note that this field cannot be set when spec.os.name
+                                    is windows.'
                                   type: string
                                 runAsGroup:
                                   description: The GID to run the entrypoint of the
@@ -4755,7 +5543,8 @@ spec:
                                     May also be set in SecurityContext.  If set in
                                     both SecurityContext and PodSecurityContext, the
                                     value specified in SecurityContext takes precedence
-                                    for that container.
+                                    for that container. Note that this field cannot
+                                    be set when spec.os.name is windows.
                                   format: int64
                                   type: integer
                                 runAsNonRoot:
@@ -4776,6 +5565,8 @@ spec:
                                     set in SecurityContext.  If set in both SecurityContext
                                     and PodSecurityContext, the value specified in
                                     SecurityContext takes precedence for that container.
+                                    Note that this field cannot be set when spec.os.name
+                                    is windows.
                                   format: int64
                                   type: integer
                                 seLinuxOptions:
@@ -4785,7 +5576,8 @@ spec:
                                     for each container.  May also be set in SecurityContext.  If
                                     set in both SecurityContext and PodSecurityContext,
                                     the value specified in SecurityContext takes precedence
-                                    for that container.
+                                    for that container. Note that this field cannot
+                                    be set when spec.os.name is windows.
                                   properties:
                                     level:
                                       description: Level is SELinux level label that
@@ -4806,7 +5598,8 @@ spec:
                                   type: object
                                 seccompProfile:
                                   description: The seccomp options to use by the containers
-                                    in this pod.
+                                    in this pod. Note that this field cannot be set
+                                    when spec.os.name is windows.
                                   properties:
                                     localhostProfile:
                                       description: localhostProfile indicates a profile
@@ -4832,7 +5625,9 @@ spec:
                                   description: A list of groups applied to the first
                                     process run in each container, in addition to
                                     the container's primary GID.  If unspecified,
-                                    no groups will be added to any container.
+                                    no groups will be added to any container. Note
+                                    that this field cannot be set when spec.os.name
+                                    is windows.
                                   items:
                                     format: int64
                                     type: integer
@@ -4841,6 +5636,8 @@ spec:
                                   description: Sysctls hold a list of namespaced sysctls
                                     used for the pod. Pods with unsupported sysctls
                                     (by the container runtime) might fail to launch.
+                                    Note that this field cannot be set when spec.os.name
+                                    is windows.
                                   items:
                                     description: Sysctl defines a kernel parameter
                                       to be set
@@ -4862,6 +5659,8 @@ spec:
                                     within a container's SecurityContext will be used.
                                     If set in both SecurityContext and PodSecurityContext,
                                     the value specified in SecurityContext takes precedence.
+                                    Note that this field cannot be set when spec.os.name
+                                    is linux.
                                   properties:
                                     gmsaCredentialSpec:
                                       description: GMSACredentialSpec is where the
@@ -4873,6 +5672,20 @@ spec:
                                       description: GMSACredentialSpecName is the name
                                         of the GMSA credential spec to use.
                                       type: string
+                                    hostProcess:
+                                      description: HostProcess determines if a container
+                                        should be run as a 'Host Process' container.
+                                        This field is alpha-level and will only be
+                                        honored by components that enable the WindowsHostProcessContainers
+                                        feature flag. Setting this field without the
+                                        feature flag will result in errors when validating
+                                        the Pod. All of a Pod's containers must have
+                                        the same effective HostProcess value (it is
+                                        not allowed to have a mix of HostProcess containers
+                                        and non-HostProcess containers).  In addition,
+                                        if HostProcess is true then HostNetwork must
+                                        also be set to true.
+                                      type: boolean
                                     runAsUserName:
                                       description: The UserName in Windows to run
                                         the entrypoint of the container process. Defaults
@@ -4924,10 +5737,11 @@ spec:
                               description: Optional duration in seconds the pod needs
                                 to terminate gracefully. May be decreased in delete
                                 request. Value must be non-negative integer. The value
-                                zero indicates delete immediately. If this value is
-                                nil, the default grace period will be used instead.
-                                The grace period is the duration in seconds after
-                                the processes running in the pod are sent a termination
+                                zero indicates stop immediately via the kill signal
+                                (no opportunity to shut down). If this value is nil,
+                                the default grace period will be used instead. The
+                                grace period is the duration in seconds after the
+                                processes running in the pod are sent a termination
                                 signal and the time when the processes are forcibly
                                 halted with a kill signal. Set this value longer than
                                 the expected cleanup time for your process. Defaults
@@ -5047,19 +5861,53 @@ spec:
                                       `whenUnsatisfiable=DoNotSchedule`, it is the
                                       maximum permitted difference between the number
                                       of matching pods in the target topology and
-                                      the global minimum. For example, in a 3-zone
+                                      the global minimum. The global minimum is the
+                                      minimum number of matching pods in an eligible
+                                      domain or zero if the number of eligible domains
+                                      is less than MinDomains. For example, in a 3-zone
                                       cluster, MaxSkew is set to 1, and pods with
-                                      the same labelSelector spread as 1/1/0: | zone1
-                                      | zone2 | zone3 | |   P   |   P   |       |
-                                      - if MaxSkew is 1, incoming pod can only be
-                                      scheduled to zone3 to become 1/1/1; scheduling
-                                      it onto zone1(zone2) would make the ActualSkew(2-0)
-                                      on zone1(zone2) violate MaxSkew(1). - if MaxSkew
-                                      is 2, incoming pod can be scheduled onto any
-                                      zone. When `whenUnsatisfiable=ScheduleAnyway`,
+                                      the same labelSelector spread as 2/2/1: In this
+                                      case, the global minimum is 1. | zone1 | zone2
+                                      | zone3 | |  P P  |  P P  |   P   | - if MaxSkew
+                                      is 1, incoming pod can only be scheduled to
+                                      zone3 to become 2/2/2; scheduling it onto zone1(zone2)
+                                      would make the ActualSkew(3-1) on zone1(zone2)
+                                      violate MaxSkew(1). - if MaxSkew is 2, incoming
+                                      pod can be scheduled onto any zone. When `whenUnsatisfiable=ScheduleAnyway`,
                                       it is used to give higher precedence to topologies
                                       that satisfy it. It''s a required field. Default
                                       value is 1 and 0 is not allowed.'
+                                    format: int32
+                                    type: integer
+                                  minDomains:
+                                    description: "MinDomains indicates a minimum number
+                                      of eligible domains. When the number of eligible
+                                      domains with matching topology keys is less
+                                      than minDomains, Pod Topology Spread treats
+                                      \"global minimum\" as 0, and then the calculation
+                                      of Skew is performed. And when the number of
+                                      eligible domains with matching topology keys
+                                      equals or greater than minDomains, this value
+                                      has no effect on scheduling. As a result, when
+                                      the number of eligible domains is less than
+                                      minDomains, scheduler won't schedule more than
+                                      maxSkew Pods to those domains. If value is nil,
+                                      the constraint behaves as if MinDomains is equal
+                                      to 1. Valid values are integers greater than
+                                      0. When value is not nil, WhenUnsatisfiable
+                                      must be DoNotSchedule. \n For example, in a
+                                      3-zone cluster, MaxSkew is set to 2, MinDomains
+                                      is set to 5 and pods with the same labelSelector
+                                      spread as 2/2/2: | zone1 | zone2 | zone3 | |
+                                      \ P P  |  P P  |  P P  | The number of domains
+                                      is less than 5(MinDomains), so \"global minimum\"
+                                      is treated as 0. In this situation, new pod
+                                      with the same labelSelector cannot be scheduled,
+                                      because computed skew will be 3(3 - 0) if new
+                                      Pod is scheduled to any of the three zones,
+                                      it will violate MaxSkew. \n This is an alpha
+                                      field and requires enabling MinDomainsInPodTopologySpread
+                                      feature gate."
                                     format: int32
                                     type: integer
                                   topologyKey:
@@ -5068,7 +5916,14 @@ spec:
                                       values are considered to be in the same topology.
                                       We consider each <key, value> as a "bucket",
                                       and try to put balanced number of pods into
-                                      each bucket. It's a required field.
+                                      each bucket. We define a domain as a particular
+                                      instance of a topology. Also, we define an eligible
+                                      domain as a domain whose nodes match the node
+                                      selector. e.g. If TopologyKey is "kubernetes.io/hostname",
+                                      each Node is a domain of that topology. And,
+                                      if TopologyKey is "topology.kubernetes.io/zone",
+                                      each zone is a domain of that topology. It's
+                                      a required field.
                                     type: string
                                   whenUnsatisfiable:
                                     description: 'WhenUnsatisfiable indicates how
@@ -5080,7 +5935,7 @@ spec:
                                       topologies that would help reduce the   skew.
                                       A constraint is considered "Unsatisfiable" for
                                       an incoming pod if and only if every possible
-                                      node assigment for that pod would violate "MaxSkew"
+                                      node assignment for that pod would violate "MaxSkew"
                                       on some topology. For example, in a 3-zone cluster,
                                       MaxSkew is set to 1, and pods with the same
                                       labelSelector spread as 3/1/1: | zone1 | zone2
@@ -5111,77 +5966,78 @@ spec:
                                   pod.
                                 properties:
                                   awsElasticBlockStore:
-                                    description: 'AWSElasticBlockStore represents
+                                    description: 'awsElasticBlockStore represents
                                       an AWS Disk resource that is attached to a kubelet''s
                                       host machine and then exposed to the pod. More
                                       info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore'
                                     properties:
                                       fsType:
-                                        description: 'Filesystem type of the volume
-                                          that you want to mount. Tip: Ensure that
-                                          the filesystem type is supported by the
-                                          host operating system. Examples: "ext4",
-                                          "xfs", "ntfs". Implicitly inferred to be
-                                          "ext4" if unspecified. More info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore
+                                        description: 'fsType is the filesystem type
+                                          of the volume that you want to mount. Tip:
+                                          Ensure that the filesystem type is supported
+                                          by the host operating system. Examples:
+                                          "ext4", "xfs", "ntfs". Implicitly inferred
+                                          to be "ext4" if unspecified. More info:
+                                          https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore
                                           TODO: how do we prevent errors in the filesystem
                                           from compromising the machine'
                                         type: string
                                       partition:
-                                        description: 'The partition in the volume
-                                          that you want to mount. If omitted, the
-                                          default is to mount by volume name. Examples:
-                                          For volume /dev/sda1, you specify the partition
-                                          as "1". Similarly, the volume partition
-                                          for /dev/sda is "0" (or you can leave the
-                                          property empty).'
+                                        description: 'partition is the partition in
+                                          the volume that you want to mount. If omitted,
+                                          the default is to mount by volume name.
+                                          Examples: For volume /dev/sda1, you specify
+                                          the partition as "1". Similarly, the volume
+                                          partition for /dev/sda is "0" (or you can
+                                          leave the property empty).'
                                         format: int32
                                         type: integer
                                       readOnly:
-                                        description: 'Specify "true" to force and
-                                          set the ReadOnly property in VolumeMounts
-                                          to "true". If omitted, the default is "false".
-                                          More info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore'
+                                        description: 'readOnly value true will force
+                                          the readOnly setting in VolumeMounts. More
+                                          info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore'
                                         type: boolean
                                       volumeID:
-                                        description: 'Unique ID of the persistent
-                                          disk resource in AWS (Amazon EBS volume).
-                                          More info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore'
+                                        description: 'volumeID is unique ID of the
+                                          persistent disk resource in AWS (Amazon
+                                          EBS volume). More info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore'
                                         type: string
                                     required:
                                     - volumeID
                                     type: object
                                   azureDisk:
-                                    description: AzureDisk represents an Azure Data
+                                    description: azureDisk represents an Azure Data
                                       Disk mount on the host and bind mount to the
                                       pod.
                                     properties:
                                       cachingMode:
-                                        description: 'Host Caching mode: None, Read
-                                          Only, Read Write.'
+                                        description: 'cachingMode is the Host Caching
+                                          mode: None, Read Only, Read Write.'
                                         type: string
                                       diskName:
-                                        description: The Name of the data disk in
-                                          the blob storage
+                                        description: diskName is the Name of the data
+                                          disk in the blob storage
                                         type: string
                                       diskURI:
-                                        description: The URI the data disk in the
-                                          blob storage
+                                        description: diskURI is the URI of data disk
+                                          in the blob storage
                                         type: string
                                       fsType:
-                                        description: Filesystem type to mount. Must
-                                          be a filesystem type supported by the host
-                                          operating system. Ex. "ext4", "xfs", "ntfs".
-                                          Implicitly inferred to be "ext4" if unspecified.
+                                        description: fsType is Filesystem type to
+                                          mount. Must be a filesystem type supported
+                                          by the host operating system. Ex. "ext4",
+                                          "xfs", "ntfs". Implicitly inferred to be
+                                          "ext4" if unspecified.
                                         type: string
                                       kind:
-                                        description: 'Expected values Shared: multiple
-                                          blob disks per storage account  Dedicated:
+                                        description: 'kind expected values are Shared:
+                                          multiple blob disks per storage account  Dedicated:
                                           single blob disk per storage account  Managed:
                                           azure managed data disk (only in managed
                                           availability set). defaults to shared'
                                         type: string
                                       readOnly:
-                                        description: Defaults to false (read/write).
+                                        description: readOnly Defaults to false (read/write).
                                           ReadOnly here will force the ReadOnly setting
                                           in VolumeMounts.
                                         type: boolean
@@ -5190,56 +6046,59 @@ spec:
                                     - diskURI
                                     type: object
                                   azureFile:
-                                    description: AzureFile represents an Azure File
+                                    description: azureFile represents an Azure File
                                       Service mount on the host and bind mount to
                                       the pod.
                                     properties:
                                       readOnly:
-                                        description: Defaults to false (read/write).
+                                        description: readOnly defaults to false (read/write).
                                           ReadOnly here will force the ReadOnly setting
                                           in VolumeMounts.
                                         type: boolean
                                       secretName:
-                                        description: the name of secret that contains
-                                          Azure Storage Account Name and Key
+                                        description: secretName is the  name of secret
+                                          that contains Azure Storage Account Name
+                                          and Key
                                         type: string
                                       shareName:
-                                        description: Share Name
+                                        description: shareName is the azure share
+                                          Name
                                         type: string
                                     required:
                                     - secretName
                                     - shareName
                                     type: object
                                   cephfs:
-                                    description: CephFS represents a Ceph FS mount
+                                    description: cephFS represents a Ceph FS mount
                                       on the host that shares a pod's lifetime
                                     properties:
                                       monitors:
-                                        description: 'Required: Monitors is a collection
-                                          of Ceph monitors More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it'
+                                        description: 'monitors is Required: Monitors
+                                          is a collection of Ceph monitors More info:
+                                          https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it'
                                         items:
                                           type: string
                                         type: array
                                       path:
-                                        description: 'Optional: Used as the mounted
-                                          root, rather than the full Ceph tree, default
-                                          is /'
+                                        description: 'path is Optional: Used as the
+                                          mounted root, rather than the full Ceph
+                                          tree, default is /'
                                         type: string
                                       readOnly:
-                                        description: 'Optional: Defaults to false
-                                          (read/write). ReadOnly here will force the
-                                          ReadOnly setting in VolumeMounts. More info:
-                                          https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it'
+                                        description: 'readOnly is Optional: Defaults
+                                          to false (read/write). ReadOnly here will
+                                          force the ReadOnly setting in VolumeMounts.
+                                          More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it'
                                         type: boolean
                                       secretFile:
-                                        description: 'Optional: SecretFile is the
-                                          path to key ring for User, default is /etc/ceph/user.secret
-                                          More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it'
+                                        description: 'secretFile is Optional: SecretFile
+                                          is the path to key ring for User, default
+                                          is /etc/ceph/user.secret More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it'
                                         type: string
                                       secretRef:
-                                        description: 'Optional: SecretRef is reference
-                                          to the authentication secret for User, default
-                                          is empty. More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it'
+                                        description: 'secretRef is Optional: SecretRef
+                                          is reference to the authentication secret
+                                          for User, default is empty. More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it'
                                         properties:
                                           name:
                                             description: 'Name of the referent. More
@@ -5249,34 +6108,35 @@ spec:
                                             type: string
                                         type: object
                                       user:
-                                        description: 'Optional: User is the rados
-                                          user name, default is admin More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it'
+                                        description: 'user is optional: User is the
+                                          rados user name, default is admin More info:
+                                          https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it'
                                         type: string
                                     required:
                                     - monitors
                                     type: object
                                   cinder:
-                                    description: 'Cinder represents a cinder volume
+                                    description: 'cinder represents a cinder volume
                                       attached and mounted on kubelets host machine.
                                       More info: https://examples.k8s.io/mysql-cinder-pd/README.md'
                                     properties:
                                       fsType:
-                                        description: 'Filesystem type to mount. Must
-                                          be a filesystem type supported by the host
-                                          operating system. Examples: "ext4", "xfs",
-                                          "ntfs". Implicitly inferred to be "ext4"
-                                          if unspecified. More info: https://examples.k8s.io/mysql-cinder-pd/README.md'
+                                        description: 'fsType is the filesystem type
+                                          to mount. Must be a filesystem type supported
+                                          by the host operating system. Examples:
+                                          "ext4", "xfs", "ntfs". Implicitly inferred
+                                          to be "ext4" if unspecified. More info:
+                                          https://examples.k8s.io/mysql-cinder-pd/README.md'
                                         type: string
                                       readOnly:
-                                        description: 'Optional: Defaults to false
-                                          (read/write). ReadOnly here will force the
-                                          ReadOnly setting in VolumeMounts. More info:
-                                          https://examples.k8s.io/mysql-cinder-pd/README.md'
+                                        description: 'readOnly defaults to false (read/write).
+                                          ReadOnly here will force the ReadOnly setting
+                                          in VolumeMounts. More info: https://examples.k8s.io/mysql-cinder-pd/README.md'
                                         type: boolean
                                       secretRef:
-                                        description: 'Optional: points to a secret
-                                          object containing parameters used to connect
-                                          to OpenStack.'
+                                        description: 'secretRef is optional: points
+                                          to a secret object containing parameters
+                                          used to connect to OpenStack.'
                                         properties:
                                           name:
                                             description: 'Name of the referent. More
@@ -5286,32 +6146,33 @@ spec:
                                             type: string
                                         type: object
                                       volumeID:
-                                        description: 'volume id used to identify the
+                                        description: 'volumeID used to identify the
                                           volume in cinder. More info: https://examples.k8s.io/mysql-cinder-pd/README.md'
                                         type: string
                                     required:
                                     - volumeID
                                     type: object
                                   configMap:
-                                    description: ConfigMap represents a configMap
+                                    description: configMap represents a configMap
                                       that should populate this volume
                                     properties:
                                       defaultMode:
-                                        description: 'Optional: mode bits used to
-                                          set permissions on created files by default.
-                                          Must be an octal value between 0000 and
-                                          0777 or a decimal value between 0 and 511.
-                                          YAML accepts both octal and decimal values,
-                                          JSON requires decimal values for mode bits.
-                                          Defaults to 0644. Directories within the
-                                          path are not affected by this setting. This
-                                          might be in conflict with other options
-                                          that affect the file mode, like fsGroup,
-                                          and the result can be other mode bits set.'
+                                        description: 'defaultMode is optional: mode
+                                          bits used to set permissions on created
+                                          files by default. Must be an octal value
+                                          between 0000 and 0777 or a decimal value
+                                          between 0 and 511. YAML accepts both octal
+                                          and decimal values, JSON requires decimal
+                                          values for mode bits. Defaults to 0644.
+                                          Directories within the path are not affected
+                                          by this setting. This might be in conflict
+                                          with other options that affect the file
+                                          mode, like fsGroup, and the result can be
+                                          other mode bits set.'
                                         format: int32
                                         type: integer
                                       items:
-                                        description: If unspecified, each key-value
+                                        description: items if unspecified, each key-value
                                           pair in the Data field of the referenced
                                           ConfigMap will be projected into the volume
                                           as a file whose name is the key and content
@@ -5328,27 +6189,27 @@ spec:
                                             within a volume.
                                           properties:
                                             key:
-                                              description: The key to project.
+                                              description: key is the key to project.
                                               type: string
                                             mode:
-                                              description: 'Optional: mode bits used
-                                                to set permissions on this file. Must
-                                                be an octal value between 0000 and
-                                                0777 or a decimal value between 0
-                                                and 511. YAML accepts both octal and
-                                                decimal values, JSON requires decimal
-                                                values for mode bits. If not specified,
-                                                the volume defaultMode will be used.
-                                                This might be in conflict with other
-                                                options that affect the file mode,
-                                                like fsGroup, and the result can be
-                                                other mode bits set.'
+                                              description: 'mode is Optional: mode
+                                                bits used to set permissions on this
+                                                file. Must be an octal value between
+                                                0000 and 0777 or a decimal value between
+                                                0 and 511. YAML accepts both octal
+                                                and decimal values, JSON requires
+                                                decimal values for mode bits. If not
+                                                specified, the volume defaultMode
+                                                will be used. This might be in conflict
+                                                with other options that affect the
+                                                file mode, like fsGroup, and the result
+                                                can be other mode bits set.'
                                               format: int32
                                               type: integer
                                             path:
-                                              description: The relative path of the
-                                                file to map the key to. May not be
-                                                an absolute path. May not contain
+                                              description: path is the relative path
+                                                of the file to map the key to. May
+                                                not be an absolute path. May not contain
                                                 the path element '..'. May not start
                                                 with the string '..'.
                                               type: string
@@ -5364,30 +6225,30 @@ spec:
                                           kind, uid?'
                                         type: string
                                       optional:
-                                        description: Specify whether the ConfigMap
-                                          or its keys must be defined
+                                        description: optional specify whether the
+                                          ConfigMap or its keys must be defined
                                         type: boolean
                                     type: object
                                   csi:
-                                    description: CSI (Container Storage Interface)
+                                    description: csi (Container Storage Interface)
                                       represents ephemeral storage that is handled
                                       by certain external CSI drivers (Beta feature).
                                     properties:
                                       driver:
-                                        description: Driver is the name of the CSI
+                                        description: driver is the name of the CSI
                                           driver that handles this volume. Consult
                                           with your admin for the correct name as
                                           registered in the cluster.
                                         type: string
                                       fsType:
-                                        description: Filesystem type to mount. Ex.
-                                          "ext4", "xfs", "ntfs". If not provided,
-                                          the empty value is passed to the associated
-                                          CSI driver which will determine the default
-                                          filesystem to apply.
+                                        description: fsType to mount. Ex. "ext4",
+                                          "xfs", "ntfs". If not provided, the empty
+                                          value is passed to the associated CSI driver
+                                          which will determine the default filesystem
+                                          to apply.
                                         type: string
                                       nodePublishSecretRef:
-                                        description: NodePublishSecretRef is a reference
+                                        description: nodePublishSecretRef is a reference
                                           to the secret object containing sensitive
                                           information to pass to the CSI driver to
                                           complete the CSI NodePublishVolume and NodeUnpublishVolume
@@ -5404,13 +6265,14 @@ spec:
                                             type: string
                                         type: object
                                       readOnly:
-                                        description: Specifies a read-only configuration
-                                          for the volume. Defaults to false (read/write).
+                                        description: readOnly specifies a read-only
+                                          configuration for the volume. Defaults to
+                                          false (read/write).
                                         type: boolean
                                       volumeAttributes:
                                         additionalProperties:
                                           type: string
-                                        description: VolumeAttributes stores driver-specific
+                                        description: volumeAttributes stores driver-specific
                                           properties that are passed to the CSI driver.
                                           Consult your driver's documentation for
                                           supported values.
@@ -5419,7 +6281,7 @@ spec:
                                     - driver
                                     type: object
                                   downwardAPI:
-                                    description: DownwardAPI represents downward API
+                                    description: downwardAPI represents downward API
                                       about the pod that should populate this volume
                                     properties:
                                       defaultMode:
@@ -5520,62 +6382,59 @@ spec:
                                         type: array
                                     type: object
                                   emptyDir:
-                                    description: 'EmptyDir represents a temporary
+                                    description: 'emptyDir represents a temporary
                                       directory that shares a pod''s lifetime. More
                                       info: https://kubernetes.io/docs/concepts/storage/volumes#emptydir'
                                     properties:
                                       medium:
-                                        description: 'What type of storage medium
-                                          should back this directory. The default
-                                          is "" which means to use the node''s default
-                                          medium. Must be an empty string (default)
-                                          or Memory. More info: https://kubernetes.io/docs/concepts/storage/volumes#emptydir'
+                                        description: 'medium represents what type
+                                          of storage medium should back this directory.
+                                          The default is "" which means to use the
+                                          node''s default medium. Must be an empty
+                                          string (default) or Memory. More info: https://kubernetes.io/docs/concepts/storage/volumes#emptydir'
                                         type: string
                                       sizeLimit:
                                         anyOf:
                                         - type: integer
                                         - type: string
-                                        description: 'Total amount of local storage
-                                          required for this EmptyDir volume. The size
-                                          limit is also applicable for memory medium.
-                                          The maximum usage on memory medium EmptyDir
-                                          would be the minimum value between the SizeLimit
-                                          specified here and the sum of memory limits
-                                          of all containers in a pod. The default
-                                          is nil which means that the limit is undefined.
-                                          More info: http://kubernetes.io/docs/user-guide/volumes#emptydir'
+                                        description: 'sizeLimit is the total amount
+                                          of local storage required for this EmptyDir
+                                          volume. The size limit is also applicable
+                                          for memory medium. The maximum usage on
+                                          memory medium EmptyDir would be the minimum
+                                          value between the SizeLimit specified here
+                                          and the sum of memory limits of all containers
+                                          in a pod. The default is nil which means
+                                          that the limit is undefined. More info:
+                                          http://kubernetes.io/docs/user-guide/volumes#emptydir'
                                         pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                         x-kubernetes-int-or-string: true
                                     type: object
                                   ephemeral:
-                                    description: "Ephemeral represents a volume that
-                                      is handled by a cluster storage driver (Alpha
-                                      feature). The volume's lifecycle is tied to
-                                      the pod that defines it - it will be created
-                                      before the pod starts, and deleted when the
-                                      pod is removed. \n Use this if: a) the volume
-                                      is only needed while the pod runs, b) features
-                                      of normal volumes like restoring from snapshot
-                                      or capacity    tracking are needed, c) the storage
-                                      driver is specified through a storage class,
-                                      and d) the storage driver supports dynamic volume
-                                      provisioning through    a PersistentVolumeClaim
-                                      (see EphemeralVolumeSource for more    information
-                                      on the connection between this volume type    and
-                                      PersistentVolumeClaim). \n Use PersistentVolumeClaim
-                                      or one of the vendor-specific APIs for volumes
-                                      that persist for longer than the lifecycle of
-                                      an individual pod. \n Use CSI for light-weight
-                                      local ephemeral volumes if the CSI driver is
-                                      meant to be used that way - see the documentation
-                                      of the driver for more information. \n A pod
-                                      can use both types of ephemeral volumes and
-                                      persistent volumes at the same time."
+                                    description: "ephemeral represents a volume that
+                                      is handled by a cluster storage driver. The
+                                      volume's lifecycle is tied to the pod that defines
+                                      it - it will be created before the pod starts,
+                                      and deleted when the pod is removed. \n Use
+                                      this if: a) the volume is only needed while
+                                      the pod runs, b) features of normal volumes
+                                      like restoring from snapshot or capacity    tracking
+                                      are needed, c) the storage driver is specified
+                                      through a storage class, and d) the storage
+                                      driver supports dynamic volume provisioning
+                                      through    a PersistentVolumeClaim (see EphemeralVolumeSource
+                                      for more    information on the connection between
+                                      this volume type    and PersistentVolumeClaim).
+                                      \n Use PersistentVolumeClaim or one of the vendor-specific
+                                      APIs for volumes that persist for longer than
+                                      the lifecycle of an individual pod. \n Use CSI
+                                      for light-weight local ephemeral volumes if
+                                      the CSI driver is meant to be used that way
+                                      - see the documentation of the driver for more
+                                      information. \n A pod can use both types of
+                                      ephemeral volumes and persistent volumes at
+                                      the same time."
                                     properties:
-                                      readOnly:
-                                        description: Specifies a read-only configuration
-                                          for the volume. Defaults to false (read/write).
-                                        type: boolean
                                       volumeClaimTemplate:
                                         description: "Will be used to create a stand-alone
                                           PVC to provision the volume. The pod in
@@ -5635,34 +6494,82 @@ spec:
                                               are also valid here.
                                             properties:
                                               accessModes:
-                                                description: 'AccessModes contains
+                                                description: 'accessModes contains
                                                   the desired access modes the volume
                                                   should have. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#access-modes-1'
                                                 items:
                                                   type: string
                                                 type: array
                                               dataSource:
-                                                description: 'This field can be used
-                                                  to specify either: * An existing
-                                                  VolumeSnapshot object (snapshot.storage.k8s.io/VolumeSnapshot
-                                                  - Beta) * An existing PVC (PersistentVolumeClaim)
-                                                  * An existing custom resource/object
-                                                  that implements data population
-                                                  (Alpha) In order to use VolumeSnapshot
-                                                  object types, the appropriate feature
-                                                  gate must be enabled (VolumeSnapshotDataSource
-                                                  or AnyVolumeDataSource) If the provisioner
-                                                  or an external controller can support
-                                                  the specified data source, it will
-                                                  create a new volume based on the
-                                                  contents of the specified data source.
-                                                  If the specified data source is
-                                                  not supported, the volume will not
-                                                  be created and the failure will
-                                                  be reported as an event. In the
-                                                  future, we plan to support more
-                                                  data source types and the behavior
-                                                  of the provisioner may change.'
+                                                description: 'dataSource field can
+                                                  be used to specify either: * An
+                                                  existing VolumeSnapshot object (snapshot.storage.k8s.io/VolumeSnapshot)
+                                                  * An existing PVC (PersistentVolumeClaim)
+                                                  If the provisioner or an external
+                                                  controller can support the specified
+                                                  data source, it will create a new
+                                                  volume based on the contents of
+                                                  the specified data source. If the
+                                                  AnyVolumeDataSource feature gate
+                                                  is enabled, this field will always
+                                                  have the same contents as the DataSourceRef
+                                                  field.'
+                                                properties:
+                                                  apiGroup:
+                                                    description: APIGroup is the group
+                                                      for the resource being referenced.
+                                                      If APIGroup is not specified,
+                                                      the specified Kind must be in
+                                                      the core API group. For any
+                                                      other third-party types, APIGroup
+                                                      is required.
+                                                    type: string
+                                                  kind:
+                                                    description: Kind is the type
+                                                      of resource being referenced
+                                                    type: string
+                                                  name:
+                                                    description: Name is the name
+                                                      of resource being referenced
+                                                    type: string
+                                                required:
+                                                - kind
+                                                - name
+                                                type: object
+                                              dataSourceRef:
+                                                description: 'dataSourceRef specifies
+                                                  the object from which to populate
+                                                  the volume with data, if a non-empty
+                                                  volume is desired. This may be any
+                                                  local object from a non-empty API
+                                                  group (non core object) or a PersistentVolumeClaim
+                                                  object. When this field is specified,
+                                                  volume binding will only succeed
+                                                  if the type of the specified object
+                                                  matches some installed volume populator
+                                                  or dynamic provisioner. This field
+                                                  will replace the functionality of
+                                                  the DataSource field and as such
+                                                  if both fields are non-empty, they
+                                                  must have the same value. For backwards
+                                                  compatibility, both fields (DataSource
+                                                  and DataSourceRef) will be set to
+                                                  the same value automatically if
+                                                  one of them is empty and the other
+                                                  is non-empty. There are two important
+                                                  differences between DataSource and
+                                                  DataSourceRef: * While DataSource
+                                                  only allows two specific types of
+                                                  objects, DataSourceRef   allows
+                                                  any non-core object, as well as
+                                                  PersistentVolumeClaim objects. *
+                                                  While DataSource ignores disallowed
+                                                  values (dropping them), DataSourceRef   preserves
+                                                  all values, and generates an error
+                                                  if a disallowed value is   specified.
+                                                  (Beta) Using this field requires
+                                                  the AnyVolumeDataSource feature
+                                                  gate to be enabled.'
                                                 properties:
                                                   apiGroup:
                                                     description: APIGroup is the group
@@ -5686,9 +6593,15 @@ spec:
                                                 - name
                                                 type: object
                                               resources:
-                                                description: 'Resources represents
+                                                description: 'resources represents
                                                   the minimum resources the volume
-                                                  should have. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#resources'
+                                                  should have. If RecoverVolumeExpansionFailure
+                                                  feature is enabled users are allowed
+                                                  to specify resource requirements
+                                                  that are lower than previous value
+                                                  but must still be higher than capacity
+                                                  recorded in the status field of
+                                                  the claim. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#resources'
                                                 properties:
                                                   limits:
                                                     additionalProperties:
@@ -5700,7 +6613,7 @@ spec:
                                                     description: 'Limits describes
                                                       the maximum amount of compute
                                                       resources allowed. More info:
-                                                      https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
+                                                      https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
                                                     type: object
                                                   requests:
                                                     additionalProperties:
@@ -5716,12 +6629,12 @@ spec:
                                                       it defaults to Limits if that
                                                       is explicitly specified, otherwise
                                                       to an implementation-defined
-                                                      value. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
+                                                      value. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
                                                     type: object
                                                 type: object
                                               selector:
-                                                description: A label query over volumes
-                                                  to consider for binding.
+                                                description: selector is a label query
+                                                  over volumes to consider for binding.
                                                 properties:
                                                   matchExpressions:
                                                     description: matchExpressions
@@ -5781,9 +6694,9 @@ spec:
                                                     type: object
                                                 type: object
                                               storageClassName:
-                                                description: 'Name of the StorageClass
-                                                  required by the claim. More info:
-                                                  https://kubernetes.io/docs/concepts/storage/persistent-volumes#class-1'
+                                                description: 'storageClassName is
+                                                  the name of the StorageClass required
+                                                  by the claim. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#class-1'
                                                 type: string
                                               volumeMode:
                                                 description: volumeMode defines what
@@ -5792,7 +6705,7 @@ spec:
                                                   when not included in claim spec.
                                                 type: string
                                               volumeName:
-                                                description: VolumeName is the binding
+                                                description: volumeName is the binding
                                                   reference to the PersistentVolume
                                                   backing this claim.
                                                 type: string
@@ -5802,77 +6715,79 @@ spec:
                                         type: object
                                     type: object
                                   fc:
-                                    description: FC represents a Fibre Channel resource
+                                    description: fc represents a Fibre Channel resource
                                       that is attached to a kubelet's host machine
                                       and then exposed to the pod.
                                     properties:
                                       fsType:
-                                        description: 'Filesystem type to mount. Must
-                                          be a filesystem type supported by the host
-                                          operating system. Ex. "ext4", "xfs", "ntfs".
-                                          Implicitly inferred to be "ext4" if unspecified.
-                                          TODO: how do we prevent errors in the filesystem
-                                          from compromising the machine'
+                                        description: 'fsType is the filesystem type
+                                          to mount. Must be a filesystem type supported
+                                          by the host operating system. Ex. "ext4",
+                                          "xfs", "ntfs". Implicitly inferred to be
+                                          "ext4" if unspecified. TODO: how do we prevent
+                                          errors in the filesystem from compromising
+                                          the machine'
                                         type: string
                                       lun:
-                                        description: 'Optional: FC target lun number'
+                                        description: 'lun is Optional: FC target lun
+                                          number'
                                         format: int32
                                         type: integer
                                       readOnly:
-                                        description: 'Optional: Defaults to false
-                                          (read/write). ReadOnly here will force the
-                                          ReadOnly setting in VolumeMounts.'
+                                        description: 'readOnly is Optional: Defaults
+                                          to false (read/write). ReadOnly here will
+                                          force the ReadOnly setting in VolumeMounts.'
                                         type: boolean
                                       targetWWNs:
-                                        description: 'Optional: FC target worldwide
-                                          names (WWNs)'
+                                        description: 'targetWWNs is Optional: FC target
+                                          worldwide names (WWNs)'
                                         items:
                                           type: string
                                         type: array
                                       wwids:
-                                        description: 'Optional: FC volume world wide
-                                          identifiers (wwids) Either wwids or combination
-                                          of targetWWNs and lun must be set, but not
-                                          both simultaneously.'
+                                        description: 'wwids Optional: FC volume world
+                                          wide identifiers (wwids) Either wwids or
+                                          combination of targetWWNs and lun must be
+                                          set, but not both simultaneously.'
                                         items:
                                           type: string
                                         type: array
                                     type: object
                                   flexVolume:
-                                    description: FlexVolume represents a generic volume
+                                    description: flexVolume represents a generic volume
                                       resource that is provisioned/attached using
                                       an exec based plugin.
                                     properties:
                                       driver:
-                                        description: Driver is the name of the driver
+                                        description: driver is the name of the driver
                                           to use for this volume.
                                         type: string
                                       fsType:
-                                        description: Filesystem type to mount. Must
-                                          be a filesystem type supported by the host
-                                          operating system. Ex. "ext4", "xfs", "ntfs".
-                                          The default filesystem depends on FlexVolume
-                                          script.
+                                        description: fsType is the filesystem type
+                                          to mount. Must be a filesystem type supported
+                                          by the host operating system. Ex. "ext4",
+                                          "xfs", "ntfs". The default filesystem depends
+                                          on FlexVolume script.
                                         type: string
                                       options:
                                         additionalProperties:
                                           type: string
-                                        description: 'Optional: Extra command options
-                                          if any.'
+                                        description: 'options is Optional: this field
+                                          holds extra command options if any.'
                                         type: object
                                       readOnly:
-                                        description: 'Optional: Defaults to false
-                                          (read/write). ReadOnly here will force the
-                                          ReadOnly setting in VolumeMounts.'
+                                        description: 'readOnly is Optional: defaults
+                                          to false (read/write). ReadOnly here will
+                                          force the ReadOnly setting in VolumeMounts.'
                                         type: boolean
                                       secretRef:
-                                        description: 'Optional: SecretRef is reference
-                                          to the secret object containing sensitive
-                                          information to pass to the plugin scripts.
-                                          This may be empty if no secret object is
-                                          specified. If the secret object contains
-                                          more than one secret, all secrets are passed
-                                          to the plugin scripts.'
+                                        description: 'secretRef is Optional: secretRef
+                                          is reference to the secret object containing
+                                          sensitive information to pass to the plugin
+                                          scripts. This may be empty if no secret
+                                          object is specified. If the secret object
+                                          contains more than one secret, all secrets
+                                          are passed to the plugin scripts.'
                                         properties:
                                           name:
                                             description: 'Name of the referent. More
@@ -5885,53 +6800,55 @@ spec:
                                     - driver
                                     type: object
                                   flocker:
-                                    description: Flocker represents a Flocker volume
+                                    description: flocker represents a Flocker volume
                                       attached to a kubelet's host machine. This depends
                                       on the Flocker control service being running
                                     properties:
                                       datasetName:
-                                        description: Name of the dataset stored as
-                                          metadata -> name on the dataset for Flocker
-                                          should be considered as deprecated
+                                        description: datasetName is Name of the dataset
+                                          stored as metadata -> name on the dataset
+                                          for Flocker should be considered as deprecated
                                         type: string
                                       datasetUUID:
-                                        description: UUID of the dataset. This is
-                                          unique identifier of a Flocker dataset
+                                        description: datasetUUID is the UUID of the
+                                          dataset. This is unique identifier of a
+                                          Flocker dataset
                                         type: string
                                     type: object
                                   gcePersistentDisk:
-                                    description: 'GCEPersistentDisk represents a GCE
+                                    description: 'gcePersistentDisk represents a GCE
                                       Disk resource that is attached to a kubelet''s
                                       host machine and then exposed to the pod. More
                                       info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk'
                                     properties:
                                       fsType:
-                                        description: 'Filesystem type of the volume
-                                          that you want to mount. Tip: Ensure that
-                                          the filesystem type is supported by the
-                                          host operating system. Examples: "ext4",
-                                          "xfs", "ntfs". Implicitly inferred to be
-                                          "ext4" if unspecified. More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk
+                                        description: 'fsType is filesystem type of
+                                          the volume that you want to mount. Tip:
+                                          Ensure that the filesystem type is supported
+                                          by the host operating system. Examples:
+                                          "ext4", "xfs", "ntfs". Implicitly inferred
+                                          to be "ext4" if unspecified. More info:
+                                          https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk
                                           TODO: how do we prevent errors in the filesystem
                                           from compromising the machine'
                                         type: string
                                       partition:
-                                        description: 'The partition in the volume
-                                          that you want to mount. If omitted, the
-                                          default is to mount by volume name. Examples:
-                                          For volume /dev/sda1, you specify the partition
-                                          as "1". Similarly, the volume partition
-                                          for /dev/sda is "0" (or you can leave the
-                                          property empty). More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk'
+                                        description: 'partition is the partition in
+                                          the volume that you want to mount. If omitted,
+                                          the default is to mount by volume name.
+                                          Examples: For volume /dev/sda1, you specify
+                                          the partition as "1". Similarly, the volume
+                                          partition for /dev/sda is "0" (or you can
+                                          leave the property empty). More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk'
                                         format: int32
                                         type: integer
                                       pdName:
-                                        description: 'Unique name of the PD resource
-                                          in GCE. Used to identify the disk in GCE.
-                                          More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk'
+                                        description: 'pdName is unique name of the
+                                          PD resource in GCE. Used to identify the
+                                          disk in GCE. More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk'
                                         type: string
                                       readOnly:
-                                        description: 'ReadOnly here will force the
+                                        description: 'readOnly here will force the
                                           ReadOnly setting in VolumeMounts. Defaults
                                           to false. More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk'
                                         type: boolean
@@ -5939,7 +6856,7 @@ spec:
                                     - pdName
                                     type: object
                                   gitRepo:
-                                    description: 'GitRepo represents a git repository
+                                    description: 'gitRepo represents a git repository
                                       at a particular revision. DEPRECATED: GitRepo
                                       is deprecated. To provision a container with
                                       a git repo, mount an EmptyDir into an InitContainer
@@ -5947,39 +6864,39 @@ spec:
                                       EmptyDir into the Pod''s container.'
                                     properties:
                                       directory:
-                                        description: Target directory name. Must not
-                                          contain or start with '..'.  If '.' is supplied,
-                                          the volume directory will be the git repository.  Otherwise,
-                                          if specified, the volume will contain the
-                                          git repository in the subdirectory with
-                                          the given name.
+                                        description: directory is the target directory
+                                          name. Must not contain or start with '..'.  If
+                                          '.' is supplied, the volume directory will
+                                          be the git repository.  Otherwise, if specified,
+                                          the volume will contain the git repository
+                                          in the subdirectory with the given name.
                                         type: string
                                       repository:
-                                        description: Repository URL
+                                        description: repository is the URL
                                         type: string
                                       revision:
-                                        description: Commit hash for the specified
-                                          revision.
+                                        description: revision is the commit hash for
+                                          the specified revision.
                                         type: string
                                     required:
                                     - repository
                                     type: object
                                   glusterfs:
-                                    description: 'Glusterfs represents a Glusterfs
+                                    description: 'glusterfs represents a Glusterfs
                                       mount on the host that shares a pod''s lifetime.
                                       More info: https://examples.k8s.io/volumes/glusterfs/README.md'
                                     properties:
                                       endpoints:
-                                        description: 'EndpointsName is the endpoint
-                                          name that details Glusterfs topology. More
-                                          info: https://examples.k8s.io/volumes/glusterfs/README.md#create-a-pod'
+                                        description: 'endpoints is the endpoint name
+                                          that details Glusterfs topology. More info:
+                                          https://examples.k8s.io/volumes/glusterfs/README.md#create-a-pod'
                                         type: string
                                       path:
-                                        description: 'Path is the Glusterfs volume
+                                        description: 'path is the Glusterfs volume
                                           path. More info: https://examples.k8s.io/volumes/glusterfs/README.md#create-a-pod'
                                         type: string
                                       readOnly:
-                                        description: 'ReadOnly here will force the
+                                        description: 'readOnly here will force the
                                           Glusterfs volume to be mounted with read-only
                                           permissions. Defaults to false. More info:
                                           https://examples.k8s.io/volumes/glusterfs/README.md#create-a-pod'
@@ -5989,7 +6906,7 @@ spec:
                                     - path
                                     type: object
                                   hostPath:
-                                    description: 'HostPath represents a pre-existing
+                                    description: 'hostPath represents a pre-existing
                                       file or directory on the host machine that is
                                       directly exposed to the container. This is generally
                                       used for system agents or other privileged things
@@ -6000,76 +6917,79 @@ spec:
                                       mount host directories as read/write.'
                                     properties:
                                       path:
-                                        description: 'Path of the directory on the
+                                        description: 'path of the directory on the
                                           host. If the path is a symlink, it will
                                           follow the link to the real path. More info:
                                           https://kubernetes.io/docs/concepts/storage/volumes#hostpath'
                                         type: string
                                       type:
-                                        description: 'Type for HostPath Volume Defaults
+                                        description: 'type for HostPath Volume Defaults
                                           to "" More info: https://kubernetes.io/docs/concepts/storage/volumes#hostpath'
                                         type: string
                                     required:
                                     - path
                                     type: object
                                   iscsi:
-                                    description: 'ISCSI represents an ISCSI Disk resource
+                                    description: 'iscsi represents an ISCSI Disk resource
                                       that is attached to a kubelet''s host machine
                                       and then exposed to the pod. More info: https://examples.k8s.io/volumes/iscsi/README.md'
                                     properties:
                                       chapAuthDiscovery:
-                                        description: whether support iSCSI Discovery
-                                          CHAP authentication
+                                        description: chapAuthDiscovery defines whether
+                                          support iSCSI Discovery CHAP authentication
                                         type: boolean
                                       chapAuthSession:
-                                        description: whether support iSCSI Session
-                                          CHAP authentication
+                                        description: chapAuthSession defines whether
+                                          support iSCSI Session CHAP authentication
                                         type: boolean
                                       fsType:
-                                        description: 'Filesystem type of the volume
-                                          that you want to mount. Tip: Ensure that
-                                          the filesystem type is supported by the
-                                          host operating system. Examples: "ext4",
-                                          "xfs", "ntfs". Implicitly inferred to be
-                                          "ext4" if unspecified. More info: https://kubernetes.io/docs/concepts/storage/volumes#iscsi
+                                        description: 'fsType is the filesystem type
+                                          of the volume that you want to mount. Tip:
+                                          Ensure that the filesystem type is supported
+                                          by the host operating system. Examples:
+                                          "ext4", "xfs", "ntfs". Implicitly inferred
+                                          to be "ext4" if unspecified. More info:
+                                          https://kubernetes.io/docs/concepts/storage/volumes#iscsi
                                           TODO: how do we prevent errors in the filesystem
                                           from compromising the machine'
                                         type: string
                                       initiatorName:
-                                        description: Custom iSCSI Initiator Name.
-                                          If initiatorName is specified with iscsiInterface
-                                          simultaneously, new iSCSI interface <target
-                                          portal>:<volume name> will be created for
-                                          the connection.
+                                        description: initiatorName is the custom iSCSI
+                                          Initiator Name. If initiatorName is specified
+                                          with iscsiInterface simultaneously, new
+                                          iSCSI interface <target portal>:<volume
+                                          name> will be created for the connection.
                                         type: string
                                       iqn:
-                                        description: Target iSCSI Qualified Name.
+                                        description: iqn is the target iSCSI Qualified
+                                          Name.
                                         type: string
                                       iscsiInterface:
-                                        description: iSCSI Interface Name that uses
-                                          an iSCSI transport. Defaults to 'default'
-                                          (tcp).
+                                        description: iscsiInterface is the interface
+                                          Name that uses an iSCSI transport. Defaults
+                                          to 'default' (tcp).
                                         type: string
                                       lun:
-                                        description: iSCSI Target Lun number.
+                                        description: lun represents iSCSI Target Lun
+                                          number.
                                         format: int32
                                         type: integer
                                       portals:
-                                        description: iSCSI Target Portal List. The
-                                          portal is either an IP or ip_addr:port if
-                                          the port is other than default (typically
+                                        description: portals is the iSCSI Target Portal
+                                          List. The portal is either an IP or ip_addr:port
+                                          if the port is other than default (typically
                                           TCP ports 860 and 3260).
                                         items:
                                           type: string
                                         type: array
                                       readOnly:
-                                        description: ReadOnly here will force the
+                                        description: readOnly here will force the
                                           ReadOnly setting in VolumeMounts. Defaults
                                           to false.
                                         type: boolean
                                       secretRef:
-                                        description: CHAP Secret for iSCSI target
-                                          and initiator authentication
+                                        description: secretRef is the CHAP Secret
+                                          for iSCSI target and initiator authentication
                                         properties:
                                           name:
                                             description: 'Name of the referent. More
@@ -6079,10 +6999,10 @@ spec:
                                             type: string
                                         type: object
                                       targetPortal:
-                                        description: iSCSI Target Portal. The Portal
-                                          is either an IP or ip_addr:port if the port
-                                          is other than default (typically TCP ports
-                                          860 and 3260).
+                                        description: targetPortal is iSCSI Target
+                                          Portal. The Portal is either an IP or ip_addr:port
+                                          if the port is other than default (typically
+                                          TCP ports 860 and 3260).
                                         type: string
                                     required:
                                     - iqn
@@ -6090,26 +7010,26 @@ spec:
                                     - targetPortal
                                     type: object
                                   name:
-                                    description: 'Volume''s name. Must be a DNS_LABEL
+                                    description: 'name of the volume. Must be a DNS_LABEL
                                       and unique within the pod. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
                                     type: string
                                   nfs:
-                                    description: 'NFS represents an NFS mount on the
+                                    description: 'nfs represents an NFS mount on the
                                       host that shares a pod''s lifetime More info:
                                       https://kubernetes.io/docs/concepts/storage/volumes#nfs'
                                     properties:
                                       path:
-                                        description: 'Path that is exported by the
+                                        description: 'path that is exported by the
                                           NFS server. More info: https://kubernetes.io/docs/concepts/storage/volumes#nfs'
                                         type: string
                                       readOnly:
-                                        description: 'ReadOnly here will force the
+                                        description: 'readOnly here will force the
                                           NFS export to be mounted with read-only
                                           permissions. Defaults to false. More info:
                                           https://kubernetes.io/docs/concepts/storage/volumes#nfs'
                                         type: boolean
                                       server:
-                                        description: 'Server is the hostname or IP
+                                        description: 'server is the hostname or IP
                                           address of the NFS server. More info: https://kubernetes.io/docs/concepts/storage/volumes#nfs'
                                         type: string
                                     required:
@@ -6117,99 +7037,101 @@ spec:
                                     - server
                                     type: object
                                   persistentVolumeClaim:
-                                    description: 'PersistentVolumeClaimVolumeSource
+                                    description: 'persistentVolumeClaimVolumeSource
                                       represents a reference to a PersistentVolumeClaim
                                       in the same namespace. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#persistentvolumeclaims'
                                     properties:
                                       claimName:
-                                        description: 'ClaimName is the name of a PersistentVolumeClaim
+                                        description: 'claimName is the name of a PersistentVolumeClaim
                                           in the same namespace as the pod using this
                                           volume. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#persistentvolumeclaims'
                                         type: string
                                       readOnly:
-                                        description: Will force the ReadOnly setting
-                                          in VolumeMounts. Default false.
+                                        description: readOnly Will force the ReadOnly
+                                          setting in VolumeMounts. Default false.
                                         type: boolean
                                     required:
                                     - claimName
                                     type: object
                                   photonPersistentDisk:
-                                    description: PhotonPersistentDisk represents a
+                                    description: photonPersistentDisk represents a
                                       PhotonController persistent disk attached and
                                       mounted on kubelets host machine
                                     properties:
                                       fsType:
-                                        description: Filesystem type to mount. Must
-                                          be a filesystem type supported by the host
-                                          operating system. Ex. "ext4", "xfs", "ntfs".
-                                          Implicitly inferred to be "ext4" if unspecified.
+                                        description: fsType is the filesystem type
+                                          to mount. Must be a filesystem type supported
+                                          by the host operating system. Ex. "ext4",
+                                          "xfs", "ntfs". Implicitly inferred to be
+                                          "ext4" if unspecified.
                                         type: string
                                       pdID:
-                                        description: ID that identifies Photon Controller
-                                          persistent disk
+                                        description: pdID is the ID that identifies
+                                          Photon Controller persistent disk
                                         type: string
                                     required:
                                     - pdID
                                     type: object
                                   portworxVolume:
-                                    description: PortworxVolume represents a portworx
+                                    description: portworxVolume represents a portworx
                                       volume attached and mounted on kubelets host
                                       machine
                                     properties:
                                       fsType:
-                                        description: FSType represents the filesystem
+                                        description: fSType represents the filesystem
                                           type to mount Must be a filesystem type
                                           supported by the host operating system.
                                           Ex. "ext4", "xfs". Implicitly inferred to
                                           be "ext4" if unspecified.
                                         type: string
                                       readOnly:
-                                        description: Defaults to false (read/write).
+                                        description: readOnly defaults to false (read/write).
                                           ReadOnly here will force the ReadOnly setting
                                           in VolumeMounts.
                                         type: boolean
                                       volumeID:
-                                        description: VolumeID uniquely identifies
+                                        description: volumeID uniquely identifies
                                           a Portworx volume
                                         type: string
                                     required:
                                     - volumeID
                                     type: object
                                   projected:
-                                    description: Items for all in one resources secrets,
-                                      configmaps, and downward API
+                                    description: projected items for all in one resources
+                                      secrets, configmaps, and downward API
                                     properties:
                                       defaultMode:
-                                        description: Mode bits used to set permissions
-                                          on created files by default. Must be an
-                                          octal value between 0000 and 0777 or a decimal
-                                          value between 0 and 511. YAML accepts both
-                                          octal and decimal values, JSON requires
-                                          decimal values for mode bits. Directories
-                                          within the path are not affected by this
-                                          setting. This might be in conflict with
-                                          other options that affect the file mode,
-                                          like fsGroup, and the result can be other
-                                          mode bits set.
+                                        description: defaultMode are the mode bits
+                                          used to set permissions on created files
+                                          by default. Must be an octal value between
+                                          0000 and 0777 or a decimal value between
+                                          0 and 511. YAML accepts both octal and decimal
+                                          values, JSON requires decimal values for
+                                          mode bits. Directories within the path are
+                                          not affected by this setting. This might
+                                          be in conflict with other options that affect
+                                          the file mode, like fsGroup, and the result
+                                          can be other mode bits set.
                                         format: int32
                                         type: integer
                                       sources:
-                                        description: list of volume projections
+                                        description: sources is the list of volume
+                                          projections
                                         items:
                                           description: Projection that may be projected
                                             along with other supported volume types
                                           properties:
                                             configMap:
-                                              description: information about the configMap
-                                                data to project
+                                              description: configMap information about
+                                                the configMap data to project
                                               properties:
                                                 items:
-                                                  description: If unspecified, each
-                                                    key-value pair in the Data field
-                                                    of the referenced ConfigMap will
-                                                    be projected into the volume as
-                                                    a file whose name is the key and
-                                                    content is the value. If specified,
+                                                  description: items if unspecified,
+                                                    each key-value pair in the Data
+                                                    field of the referenced ConfigMap
+                                                    will be projected into the volume
+                                                    as a file whose name is the key
+                                                    and content is the value. If specified,
                                                     the listed keys will be projected
                                                     into the specified paths, and
                                                     unlisted keys will not be present.
@@ -6224,11 +7146,12 @@ spec:
                                                       to a path within a volume.
                                                     properties:
                                                       key:
-                                                        description: The key to project.
+                                                        description: key is the key
+                                                          to project.
                                                         type: string
                                                       mode:
-                                                        description: 'Optional: mode
-                                                          bits used to set permissions
+                                                        description: 'mode is Optional:
+                                                          mode bits used to set permissions
                                                           on this file. Must be an
                                                           octal value between 0000
                                                           and 0777 or a decimal value
@@ -6246,7 +7169,7 @@ spec:
                                                         format: int32
                                                         type: integer
                                                       path:
-                                                        description: The relative
+                                                        description: path is the relative
                                                           path of the file to map
                                                           the key to. May not be an
                                                           absolute path. May not contain
@@ -6266,14 +7189,14 @@ spec:
                                                     apiVersion, kind, uid?'
                                                   type: string
                                                 optional:
-                                                  description: Specify whether the
-                                                    ConfigMap or its keys must be
-                                                    defined
+                                                  description: optional specify whether
+                                                    the ConfigMap or its keys must
+                                                    be defined
                                                   type: boolean
                                               type: object
                                             downwardAPI:
-                                              description: information about the downwardAPI
-                                                data to project
+                                              description: downwardAPI information
+                                                about the downwardAPI data to project
                                               properties:
                                                 items:
                                                   description: Items is a list of
@@ -6370,16 +7293,16 @@ spec:
                                                   type: array
                                               type: object
                                             secret:
-                                              description: information about the secret
-                                                data to project
+                                              description: secret information about
+                                                the secret data to project
                                               properties:
                                                 items:
-                                                  description: If unspecified, each
-                                                    key-value pair in the Data field
-                                                    of the referenced Secret will
-                                                    be projected into the volume as
-                                                    a file whose name is the key and
-                                                    content is the value. If specified,
+                                                  description: items if unspecified,
+                                                    each key-value pair in the Data
+                                                    field of the referenced Secret
+                                                    will be projected into the volume
+                                                    as a file whose name is the key
+                                                    and content is the value. If specified,
                                                     the listed keys will be projected
                                                     into the specified paths, and
                                                     unlisted keys will not be present.
@@ -6394,11 +7317,12 @@ spec:
                                                       to a path within a volume.
                                                     properties:
                                                       key:
-                                                        description: The key to project.
+                                                        description: key is the key
+                                                          to project.
                                                         type: string
                                                       mode:
-                                                        description: 'Optional: mode
-                                                          bits used to set permissions
+                                                        description: 'mode is Optional:
+                                                          mode bits used to set permissions
                                                           on this file. Must be an
                                                           octal value between 0000
                                                           and 0777 or a decimal value
@@ -6416,7 +7340,7 @@ spec:
                                                         format: int32
                                                         type: integer
                                                       path:
-                                                        description: The relative
+                                                        description: path is the relative
                                                           path of the file to map
                                                           the key to. May not be an
                                                           absolute path. May not contain
@@ -6436,16 +7360,18 @@ spec:
                                                     apiVersion, kind, uid?'
                                                   type: string
                                                 optional:
-                                                  description: Specify whether the
-                                                    Secret or its key must be defined
+                                                  description: optional field specify
+                                                    whether the Secret or its key
+                                                    must be defined
                                                   type: boolean
                                               type: object
                                             serviceAccountToken:
-                                              description: information about the serviceAccountToken
+                                              description: serviceAccountToken is
+                                                information about the serviceAccountToken
                                                 data to project
                                               properties:
                                                 audience:
-                                                  description: Audience is the intended
+                                                  description: audience is the intended
                                                     audience of the token. A recipient
                                                     of a token must identify itself
                                                     with an identifier specified in
@@ -6455,7 +7381,7 @@ spec:
                                                     of the apiserver.
                                                   type: string
                                                 expirationSeconds:
-                                                  description: ExpirationSeconds is
+                                                  description: expirationSeconds is
                                                     the requested duration of validity
                                                     of the service account token.
                                                     As the token approaches expiration,
@@ -6471,7 +7397,7 @@ spec:
                                                   format: int64
                                                   type: integer
                                                 path:
-                                                  description: Path is the path relative
+                                                  description: path is the path relative
                                                     to the mount point of the file
                                                     to project the token into.
                                                   type: string
@@ -6480,41 +7406,39 @@ spec:
                                               type: object
                                           type: object
                                         type: array
-                                    required:
-                                    - sources
                                     type: object
                                   quobyte:
-                                    description: Quobyte represents a Quobyte mount
+                                    description: quobyte represents a Quobyte mount
                                       on the host that shares a pod's lifetime
                                     properties:
                                       group:
-                                        description: Group to map volume access to
+                                        description: group to map volume access to
                                           Default is no group
                                         type: string
                                       readOnly:
-                                        description: ReadOnly here will force the
+                                        description: readOnly here will force the
                                           Quobyte volume to be mounted with read-only
                                           permissions. Defaults to false.
                                         type: boolean
                                       registry:
-                                        description: Registry represents a single
+                                        description: registry represents a single
                                           or multiple Quobyte Registry services specified
                                           as a string as host:port pair (multiple
                                           entries are separated with commas) which
                                           acts as the central registry for volumes
                                         type: string
                                       tenant:
-                                        description: Tenant owning the given Quobyte
+                                        description: tenant owning the given Quobyte
                                           volume in the Backend Used with dynamically
                                           provisioned Quobyte volumes, value is set
                                           by the plugin
                                         type: string
                                       user:
-                                        description: User to map volume access to
+                                        description: user to map volume access to
                                           Defaults to serivceaccount user
                                         type: string
                                       volume:
-                                        description: Volume is a string that references
+                                        description: volume is a string that references
                                           an already created Quobyte volume by name.
                                         type: string
                                     required:
@@ -6522,46 +7446,47 @@ spec:
                                     - volume
                                     type: object
                                   rbd:
-                                    description: 'RBD represents a Rados Block Device
+                                    description: 'rbd represents a Rados Block Device
                                       mount on the host that shares a pod''s lifetime.
                                       More info: https://examples.k8s.io/volumes/rbd/README.md'
                                     properties:
                                       fsType:
-                                        description: 'Filesystem type of the volume
-                                          that you want to mount. Tip: Ensure that
-                                          the filesystem type is supported by the
-                                          host operating system. Examples: "ext4",
-                                          "xfs", "ntfs". Implicitly inferred to be
-                                          "ext4" if unspecified. More info: https://kubernetes.io/docs/concepts/storage/volumes#rbd
+                                        description: 'fsType is the filesystem type
+                                          of the volume that you want to mount. Tip:
+                                          Ensure that the filesystem type is supported
+                                          by the host operating system. Examples:
+                                          "ext4", "xfs", "ntfs". Implicitly inferred
+                                          to be "ext4" if unspecified. More info:
+                                          https://kubernetes.io/docs/concepts/storage/volumes#rbd
                                           TODO: how do we prevent errors in the filesystem
                                           from compromising the machine'
                                         type: string
                                       image:
-                                        description: 'The rados image name. More info:
-                                          https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
+                                        description: 'image is the rados image name.
+                                          More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
                                         type: string
                                       keyring:
-                                        description: 'Keyring is the path to key ring
+                                        description: 'keyring is the path to key ring
                                           for RBDUser. Default is /etc/ceph/keyring.
                                           More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
                                         type: string
                                       monitors:
-                                        description: 'A collection of Ceph monitors.
-                                          More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
+                                        description: 'monitors is a collection of
+                                          Ceph monitors. More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
                                         items:
                                           type: string
                                         type: array
                                       pool:
-                                        description: 'The rados pool name. Default
-                                          is rbd. More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
+                                        description: 'pool is the rados pool name.
+                                          Default is rbd. More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
                                         type: string
                                       readOnly:
-                                        description: 'ReadOnly here will force the
+                                        description: 'readOnly here will force the
                                           ReadOnly setting in VolumeMounts. Defaults
                                           to false. More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
                                         type: boolean
                                       secretRef:
-                                        description: 'SecretRef is name of the authentication
+                                        description: 'secretRef is name of the authentication
                                           secret for RBDUser. If provided overrides
                                           keyring. Default is nil. More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
                                         properties:
@@ -6573,38 +7498,39 @@ spec:
                                             type: string
                                         type: object
                                       user:
-                                        description: 'The rados user name. Default
-                                          is admin. More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
+                                        description: 'user is the rados user name.
+                                          Default is admin. More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
                                         type: string
                                     required:
                                     - image
                                     - monitors
                                     type: object
                                   scaleIO:
-                                    description: ScaleIO represents a ScaleIO persistent
+                                    description: scaleIO represents a ScaleIO persistent
                                       volume attached and mounted on Kubernetes nodes.
                                     properties:
                                       fsType:
-                                        description: Filesystem type to mount. Must
-                                          be a filesystem type supported by the host
-                                          operating system. Ex. "ext4", "xfs", "ntfs".
-                                          Default is "xfs".
+                                        description: fsType is the filesystem type
+                                          to mount. Must be a filesystem type supported
+                                          by the host operating system. Ex. "ext4",
+                                          "xfs", "ntfs". Default is "xfs".
                                         type: string
                                       gateway:
-                                        description: The host address of the ScaleIO
-                                          API Gateway.
+                                        description: gateway is the host address of
+                                          the ScaleIO API Gateway.
                                         type: string
                                       protectionDomain:
-                                        description: The name of the ScaleIO Protection
-                                          Domain for the configured storage.
+                                        description: protectionDomain is the name
+                                          of the ScaleIO Protection Domain for the
+                                          configured storage.
                                         type: string
                                       readOnly:
-                                        description: Defaults to false (read/write).
+                                        description: readOnly Defaults to false (read/write).
                                           ReadOnly here will force the ReadOnly setting
                                           in VolumeMounts.
                                         type: boolean
                                       secretRef:
-                                        description: SecretRef references to the secret
+                                        description: secretRef references to the secret
                                           for ScaleIO user and other sensitive information.
                                           If this is not provided, Login operation
                                           will fail.
@@ -6617,26 +7543,27 @@ spec:
                                             type: string
                                         type: object
                                       sslEnabled:
-                                        description: Flag to enable/disable SSL communication
-                                          with Gateway, default false
+                                        description: sslEnabled Flag enable/disable
+                                          SSL communication with Gateway, default
+                                          false
                                         type: boolean
                                       storageMode:
-                                        description: Indicates whether the storage
-                                          for a volume should be ThickProvisioned
+                                        description: storageMode indicates whether
+                                          the storage for a volume should be ThickProvisioned
                                           or ThinProvisioned. Default is ThinProvisioned.
                                         type: string
                                       storagePool:
-                                        description: The ScaleIO Storage Pool associated
-                                          with the protection domain.
+                                        description: storagePool is the ScaleIO Storage
+                                          Pool associated with the protection domain.
                                         type: string
                                       system:
-                                        description: The name of the storage system
-                                          as configured in ScaleIO.
+                                        description: system is the name of the storage
+                                          system as configured in ScaleIO.
                                         type: string
                                       volumeName:
-                                        description: The name of a volume already
-                                          created in the ScaleIO system that is associated
-                                          with this volume source.
+                                        description: volumeName is the name of a volume
+                                          already created in the ScaleIO system that
+                                          is associated with this volume source.
                                         type: string
                                     required:
                                     - gateway
@@ -6644,25 +7571,26 @@ spec:
                                     - system
                                     type: object
                                   secret:
-                                    description: 'Secret represents a secret that
+                                    description: 'secret represents a secret that
                                       should populate this volume. More info: https://kubernetes.io/docs/concepts/storage/volumes#secret'
                                     properties:
                                       defaultMode:
-                                        description: 'Optional: mode bits used to
-                                          set permissions on created files by default.
-                                          Must be an octal value between 0000 and
-                                          0777 or a decimal value between 0 and 511.
-                                          YAML accepts both octal and decimal values,
-                                          JSON requires decimal values for mode bits.
-                                          Defaults to 0644. Directories within the
-                                          path are not affected by this setting. This
-                                          might be in conflict with other options
-                                          that affect the file mode, like fsGroup,
-                                          and the result can be other mode bits set.'
+                                        description: 'defaultMode is Optional: mode
+                                          bits used to set permissions on created
+                                          files by default. Must be an octal value
+                                          between 0000 and 0777 or a decimal value
+                                          between 0 and 511. YAML accepts both octal
+                                          and decimal values, JSON requires decimal
+                                          values for mode bits. Defaults to 0644.
+                                          Directories within the path are not affected
+                                          by this setting. This might be in conflict
+                                          with other options that affect the file
+                                          mode, like fsGroup, and the result can be
+                                          other mode bits set.'
                                         format: int32
                                         type: integer
                                       items:
-                                        description: If unspecified, each key-value
+                                        description: items If unspecified, each key-value
                                           pair in the Data field of the referenced
                                           Secret will be projected into the volume
                                           as a file whose name is the key and content
@@ -6679,27 +7607,27 @@ spec:
                                             within a volume.
                                           properties:
                                             key:
-                                              description: The key to project.
+                                              description: key is the key to project.
                                               type: string
                                             mode:
-                                              description: 'Optional: mode bits used
-                                                to set permissions on this file. Must
-                                                be an octal value between 0000 and
-                                                0777 or a decimal value between 0
-                                                and 511. YAML accepts both octal and
-                                                decimal values, JSON requires decimal
-                                                values for mode bits. If not specified,
-                                                the volume defaultMode will be used.
-                                                This might be in conflict with other
-                                                options that affect the file mode,
-                                                like fsGroup, and the result can be
-                                                other mode bits set.'
+                                              description: 'mode is Optional: mode
+                                                bits used to set permissions on this
+                                                file. Must be an octal value between
+                                                0000 and 0777 or a decimal value between
+                                                0 and 511. YAML accepts both octal
+                                                and decimal values, JSON requires
+                                                decimal values for mode bits. If not
+                                                specified, the volume defaultMode
+                                                will be used. This might be in conflict
+                                                with other options that affect the
+                                                file mode, like fsGroup, and the result
+                                                can be other mode bits set.'
                                               format: int32
                                               type: integer
                                             path:
-                                              description: The relative path of the
-                                                file to map the key to. May not be
-                                                an absolute path. May not contain
+                                              description: path is the relative path
+                                                of the file to map the key to. May
+                                                not be an absolute path. May not contain
                                                 the path element '..'. May not start
                                                 with the string '..'.
                                               type: string
@@ -6709,31 +7637,33 @@ spec:
                                           type: object
                                         type: array
                                       optional:
-                                        description: Specify whether the Secret or
-                                          its keys must be defined
+                                        description: optional field specify whether
+                                          the Secret or its keys must be defined
                                         type: boolean
                                       secretName:
-                                        description: 'Name of the secret in the pod''s
-                                          namespace to use. More info: https://kubernetes.io/docs/concepts/storage/volumes#secret'
+                                        description: 'secretName is the name of the
+                                          secret in the pod''s namespace to use. More
+                                          info: https://kubernetes.io/docs/concepts/storage/volumes#secret'
                                         type: string
                                     type: object
                                   storageos:
-                                    description: StorageOS represents a StorageOS
+                                    description: storageOS represents a StorageOS
                                       volume attached and mounted on Kubernetes nodes.
                                     properties:
                                       fsType:
-                                        description: Filesystem type to mount. Must
-                                          be a filesystem type supported by the host
-                                          operating system. Ex. "ext4", "xfs", "ntfs".
-                                          Implicitly inferred to be "ext4" if unspecified.
+                                        description: fsType is the filesystem type
+                                          to mount. Must be a filesystem type supported
+                                          by the host operating system. Ex. "ext4",
+                                          "xfs", "ntfs". Implicitly inferred to be
+                                          "ext4" if unspecified.
                                         type: string
                                       readOnly:
-                                        description: Defaults to false (read/write).
+                                        description: readOnly defaults to false (read/write).
                                           ReadOnly here will force the ReadOnly setting
                                           in VolumeMounts.
                                         type: boolean
                                       secretRef:
-                                        description: SecretRef specifies the secret
+                                        description: secretRef specifies the secret
                                           to use for obtaining the StorageOS API credentials.  If
                                           not specified, default values will be attempted.
                                         properties:
@@ -6745,12 +7675,12 @@ spec:
                                             type: string
                                         type: object
                                       volumeName:
-                                        description: VolumeName is the human-readable
+                                        description: volumeName is the human-readable
                                           name of the StorageOS volume.  Volume names
                                           are only unique within a namespace.
                                         type: string
                                       volumeNamespace:
-                                        description: VolumeNamespace specifies the
+                                        description: volumeNamespace specifies the
                                           scope of the volume within StorageOS.  If
                                           no namespace is specified then the Pod's
                                           namespace will be used.  This allows the
@@ -6763,27 +7693,29 @@ spec:
                                         type: string
                                     type: object
                                   vsphereVolume:
-                                    description: VsphereVolume represents a vSphere
+                                    description: vsphereVolume represents a vSphere
                                       volume attached and mounted on kubelets host
                                       machine
                                     properties:
                                       fsType:
-                                        description: Filesystem type to mount. Must
-                                          be a filesystem type supported by the host
-                                          operating system. Ex. "ext4", "xfs", "ntfs".
-                                          Implicitly inferred to be "ext4" if unspecified.
+                                        description: fsType is filesystem type to
+                                          mount. Must be a filesystem type supported
+                                          by the host operating system. Ex. "ext4",
+                                          "xfs", "ntfs". Implicitly inferred to be
+                                          "ext4" if unspecified.
                                         type: string
                                       storagePolicyID:
-                                        description: Storage Policy Based Management
-                                          (SPBM) profile ID associated with the StoragePolicyName.
+                                        description: storagePolicyID is the storage
+                                          Policy Based Management (SPBM) profile ID
+                                          associated with the StoragePolicyName.
                                         type: string
                                       storagePolicyName:
-                                        description: Storage Policy Based Management
-                                          (SPBM) profile name.
+                                        description: storagePolicyName is the storage
+                                          Policy Based Management (SPBM) profile name.
                                         type: string
                                       volumePath:
-                                        description: Path that identifies vSphere
-                                          volume vmdk
+                                        description: volumePath is the path that identifies
+                                          vSphere volume vmdk
                                         type: string
                                     required:
                                     - volumePath

--- a/apps/training-operator/upstream/base/crds/kubeflow.org_mxjobs.yaml
+++ b/apps/training-operator/upstream/base/crds/kubeflow.org_mxjobs.yaml
@@ -422,12 +422,85 @@ spec:
                                                       are ANDed.
                                                     type: object
                                                 type: object
+                                              namespaceSelector:
+                                                description: A label query over the
+                                                  set of namespaces that the term
+                                                  applies to. The term is applied
+                                                  to the union of the namespaces selected
+                                                  by this field and the ones listed
+                                                  in the namespaces field. null selector
+                                                  and null or empty namespaces list
+                                                  means "this pod's namespace". An
+                                                  empty selector ({}) matches all
+                                                  namespaces.
+                                                properties:
+                                                  matchExpressions:
+                                                    description: matchExpressions
+                                                      is a list of label selector
+                                                      requirements. The requirements
+                                                      are ANDed.
+                                                    items:
+                                                      description: A label selector
+                                                        requirement is a selector
+                                                        that contains values, a key,
+                                                        and an operator that relates
+                                                        the key and values.
+                                                      properties:
+                                                        key:
+                                                          description: key is the
+                                                            label key that the selector
+                                                            applies to.
+                                                          type: string
+                                                        operator:
+                                                          description: operator represents
+                                                            a key's relationship to
+                                                            a set of values. Valid
+                                                            operators are In, NotIn,
+                                                            Exists and DoesNotExist.
+                                                          type: string
+                                                        values:
+                                                          description: values is an
+                                                            array of string values.
+                                                            If the operator is In
+                                                            or NotIn, the values array
+                                                            must be non-empty. If
+                                                            the operator is Exists
+                                                            or DoesNotExist, the values
+                                                            array must be empty. This
+                                                            array is replaced during
+                                                            a strategic merge patch.
+                                                          items:
+                                                            type: string
+                                                          type: array
+                                                      required:
+                                                      - key
+                                                      - operator
+                                                      type: object
+                                                    type: array
+                                                  matchLabels:
+                                                    additionalProperties:
+                                                      type: string
+                                                    description: matchLabels is a
+                                                      map of {key,value} pairs. A
+                                                      single {key,value} in the matchLabels
+                                                      map is equivalent to an element
+                                                      of matchExpressions, whose key
+                                                      field is "key", the operator
+                                                      is "In", and the values array
+                                                      contains only "value". The requirements
+                                                      are ANDed.
+                                                    type: object
+                                                type: object
                                               namespaces:
                                                 description: namespaces specifies
-                                                  which namespaces the labelSelector
-                                                  applies to (matches against); null
-                                                  or empty list means "this pod's
-                                                  namespace"
+                                                  a static list of namespace names
+                                                  that the term applies to. The term
+                                                  is applied to the union of the namespaces
+                                                  listed in this field and the ones
+                                                  selected by namespaceSelector. null
+                                                  or empty namespaces list and null
+                                                  namespaceSelector means "this pod's
+                                                  namespace".
                                                 items:
                                                   type: string
                                                 type: array
@@ -537,11 +610,78 @@ spec:
                                                   ANDed.
                                                 type: object
                                             type: object
+                                          namespaceSelector:
+                                            description: A label query over the set
+                                              of namespaces that the term applies
+                                              to. The term is applied to the union
+                                              of the namespaces selected by this field
+                                              and the ones listed in the namespaces
+                                              field. null selector and null or empty
+                                              namespaces list means "this pod's namespace".
+                                              An empty selector ({}) matches all namespaces.
+                                            properties:
+                                              matchExpressions:
+                                                description: matchExpressions is a
+                                                  list of label selector requirements.
+                                                  The requirements are ANDed.
+                                                items:
+                                                  description: A label selector requirement
+                                                    is a selector that contains values,
+                                                    a key, and an operator that relates
+                                                    the key and values.
+                                                  properties:
+                                                    key:
+                                                      description: key is the label
+                                                        key that the selector applies
+                                                        to.
+                                                      type: string
+                                                    operator:
+                                                      description: operator represents
+                                                        a key's relationship to a
+                                                        set of values. Valid operators
+                                                        are In, NotIn, Exists and
+                                                        DoesNotExist.
+                                                      type: string
+                                                    values:
+                                                      description: values is an array
+                                                        of string values. If the operator
+                                                        is In or NotIn, the values
+                                                        array must be non-empty. If
+                                                        the operator is Exists or
+                                                        DoesNotExist, the values array
+                                                        must be empty. This array
+                                                        is replaced during a strategic
+                                                        merge patch.
+                                                      items:
+                                                        type: string
+                                                      type: array
+                                                  required:
+                                                  - key
+                                                  - operator
+                                                  type: object
+                                                type: array
+                                              matchLabels:
+                                                additionalProperties:
+                                                  type: string
+                                                description: matchLabels is a map
+                                                  of {key,value} pairs. A single {key,value}
+                                                  in the matchLabels map is equivalent
+                                                  to an element of matchExpressions,
+                                                  whose key field is "key", the operator
+                                                  is "In", and the values array contains
+                                                  only "value". The requirements are
+                                                  ANDed.
+                                                type: object
+                                            type: object
                                           namespaces:
-                                            description: namespaces specifies which
-                                              namespaces the labelSelector applies
-                                              to (matches against); null or empty
-                                              list means "this pod's namespace"
+                                            description: namespaces specifies a static
+                                              list of namespace names that the term
+                                              applies to. The term is applied to the
+                                              union of the namespaces listed in this
+                                              field and the ones selected by namespaceSelector.
+                                              null or empty namespaces list and null
+                                              namespaceSelector means "this pod's
+                                              namespace".
                                             items:
                                               type: string
                                             type: array
@@ -653,12 +793,85 @@ spec:
                                                       are ANDed.
                                                     type: object
                                                 type: object
+                                              namespaceSelector:
+                                                description: A label query over the
+                                                  set of namespaces that the term
+                                                  applies to. The term is applied
+                                                  to the union of the namespaces selected
+                                                  by this field and the ones listed
+                                                  in the namespaces field. null selector
+                                                  and null or empty namespaces list
+                                                  means "this pod's namespace". An
+                                                  empty selector ({}) matches all
+                                                  namespaces.
+                                                properties:
+                                                  matchExpressions:
+                                                    description: matchExpressions
+                                                      is a list of label selector
+                                                      requirements. The requirements
+                                                      are ANDed.
+                                                    items:
+                                                      description: A label selector
+                                                        requirement is a selector
+                                                        that contains values, a key,
+                                                        and an operator that relates
+                                                        the key and values.
+                                                      properties:
+                                                        key:
+                                                          description: key is the
+                                                            label key that the selector
+                                                            applies to.
+                                                          type: string
+                                                        operator:
+                                                          description: operator represents
+                                                            a key's relationship to
+                                                            a set of values. Valid
+                                                            operators are In, NotIn,
+                                                            Exists and DoesNotExist.
+                                                          type: string
+                                                        values:
+                                                          description: values is an
+                                                            array of string values.
+                                                            If the operator is In
+                                                            or NotIn, the values array
+                                                            must be non-empty. If
+                                                            the operator is Exists
+                                                            or DoesNotExist, the values
+                                                            array must be empty. This
+                                                            array is replaced during
+                                                            a strategic merge patch.
+                                                          items:
+                                                            type: string
+                                                          type: array
+                                                      required:
+                                                      - key
+                                                      - operator
+                                                      type: object
+                                                    type: array
+                                                  matchLabels:
+                                                    additionalProperties:
+                                                      type: string
+                                                    description: matchLabels is a
+                                                      map of {key,value} pairs. A
+                                                      single {key,value} in the matchLabels
+                                                      map is equivalent to an element
+                                                      of matchExpressions, whose key
+                                                      field is "key", the operator
+                                                      is "In", and the values array
+                                                      contains only "value". The requirements
+                                                      are ANDed.
+                                                    type: object
+                                                type: object
                                               namespaces:
                                                 description: namespaces specifies
-                                                  which namespaces the labelSelector
-                                                  applies to (matches against); null
-                                                  or empty list means "this pod's
-                                                  namespace"
+                                                  a static list of namespace names
+                                                  that the term applies to. The term
+                                                  is applied to the union of the namespaces
+                                                  listed in this field and the ones
+                                                  selected by namespaceSelector. null
+                                                  or empty namespaces list and null
+                                                  namespaceSelector means "this pod's
+                                                  namespace".
                                                 items:
                                                   type: string
                                                 type: array
@@ -768,11 +981,78 @@ spec:
                                                   ANDed.
                                                 type: object
                                             type: object
+                                          namespaceSelector:
+                                            description: A label query over the set
+                                              of namespaces that the term applies
+                                              to. The term is applied to the union
+                                              of the namespaces selected by this field
+                                              and the ones listed in the namespaces
+                                              field. null selector and null or empty
+                                              namespaces list means "this pod's namespace".
+                                              An empty selector ({}) matches all namespaces.
+                                            properties:
+                                              matchExpressions:
+                                                description: matchExpressions is a
+                                                  list of label selector requirements.
+                                                  The requirements are ANDed.
+                                                items:
+                                                  description: A label selector requirement
+                                                    is a selector that contains values,
+                                                    a key, and an operator that relates
+                                                    the key and values.
+                                                  properties:
+                                                    key:
+                                                      description: key is the label
+                                                        key that the selector applies
+                                                        to.
+                                                      type: string
+                                                    operator:
+                                                      description: operator represents
+                                                        a key's relationship to a
+                                                        set of values. Valid operators
+                                                        are In, NotIn, Exists and
+                                                        DoesNotExist.
+                                                      type: string
+                                                    values:
+                                                      description: values is an array
+                                                        of string values. If the operator
+                                                        is In or NotIn, the values
+                                                        array must be non-empty. If
+                                                        the operator is Exists or
+                                                        DoesNotExist, the values array
+                                                        must be empty. This array
+                                                        is replaced during a strategic
+                                                        merge patch.
+                                                      items:
+                                                        type: string
+                                                      type: array
+                                                  required:
+                                                  - key
+                                                  - operator
+                                                  type: object
+                                                type: array
+                                              matchLabels:
+                                                additionalProperties:
+                                                  type: string
+                                                description: matchLabels is a map
+                                                  of {key,value} pairs. A single {key,value}
+                                                  in the matchLabels map is equivalent
+                                                  to an element of matchExpressions,
+                                                  whose key field is "key", the operator
+                                                  is "In", and the values array contains
+                                                  only "value". The requirements are
+                                                  ANDed.
+                                                type: object
+                                            type: object
                                           namespaces:
-                                            description: namespaces specifies which
-                                              namespaces the labelSelector applies
-                                              to (matches against); null or empty
-                                              list means "this pod's namespace"
+                                            description: namespaces specifies a static
+                                              list of namespace names that the term
+                                              applies to. The term is applied to the
+                                              union of the namespaces listed in this
+                                              field and the ones selected by namespaceSelector.
+                                              null or empty namespaces list and null
+                                              namespaceSelector means "this pod's
+                                              namespace".
                                             items:
                                               type: string
                                             type: array
@@ -809,12 +1089,14 @@ spec:
                                 properties:
                                   args:
                                     description: 'Arguments to the entrypoint. The
-                                      docker image''s CMD is used if this is not provided.
-                                      Variable references $(VAR_NAME) are expanded
-                                      using the container''s environment. If a variable
-                                      cannot be resolved, the reference in the input
-                                      string will be unchanged. The $(VAR_NAME) syntax
-                                      can be escaped with a double $$, ie: $$(VAR_NAME).
+                                      container image''s CMD is used if this is not
+                                      provided. Variable references $(VAR_NAME) are
+                                      expanded using the container''s environment.
+                                      If a variable cannot be resolved, the reference
+                                      in the input string will be unchanged. Double
+                                      $$ are reduced to a single $, which allows for
+                                      escaping the $(VAR_NAME) syntax: i.e. "$$(VAR_NAME)"
+                                      will produce the string literal "$(VAR_NAME)".
                                       Escaped references will never be expanded, regardless
                                       of whether the variable exists or not. Cannot
                                       be updated. More info: https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell'
@@ -823,16 +1105,17 @@ spec:
                                     type: array
                                   command:
                                     description: 'Entrypoint array. Not executed within
-                                      a shell. The docker image''s ENTRYPOINT is used
-                                      if this is not provided. Variable references
+                                      a shell. The container image''s ENTRYPOINT is
+                                      used if this is not provided. Variable references
                                       $(VAR_NAME) are expanded using the container''s
                                       environment. If a variable cannot be resolved,
                                       the reference in the input string will be unchanged.
-                                      The $(VAR_NAME) syntax can be escaped with a
-                                      double $$, ie: $$(VAR_NAME). Escaped references
-                                      will never be expanded, regardless of whether
-                                      the variable exists or not. Cannot be updated.
-                                      More info: https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell'
+                                      Double $$ are reduced to a single $, which allows
+                                      for escaping the $(VAR_NAME) syntax: i.e. "$$(VAR_NAME)"
+                                      will produce the string literal "$(VAR_NAME)".
+                                      Escaped references will never be expanded, regardless
+                                      of whether the variable exists or not. Cannot
+                                      be updated. More info: https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell'
                                     items:
                                       type: string
                                     type: array
@@ -849,13 +1132,15 @@ spec:
                                           type: string
                                         value:
                                           description: 'Variable references $(VAR_NAME)
-                                            are expanded using the previous defined
+                                            are expanded using the previously defined
                                             environment variables in the container
                                             and any service environment variables.
                                             If a variable cannot be resolved, the
                                             reference in the input string will be
-                                            unchanged. The $(VAR_NAME) syntax can
-                                            be escaped with a double $$, ie: $$(VAR_NAME).
+                                            unchanged. Double $$ are reduced to a
+                                            single $, which allows for escaping the
+                                            $(VAR_NAME) syntax: i.e. "$$(VAR_NAME)"
+                                            will produce the string literal "$(VAR_NAME)".
                                             Escaped references will never be expanded,
                                             regardless of whether the variable exists
                                             or not. Defaults to "".'
@@ -1009,7 +1294,8 @@ spec:
                                       type: object
                                     type: array
                                   image:
-                                    description: 'Docker image name. More info: https://kubernetes.io/docs/concepts/containers/images
+                                    description: 'Container image name. More info:
+                                      https://kubernetes.io/docs/concepts/containers/images
                                       This field is optional to allow higher level
                                       config management to default or override container
                                       images in workload controllers like Deployments
@@ -1035,9 +1321,8 @@ spec:
                                           More info: https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/#container-hooks'
                                         properties:
                                           exec:
-                                            description: One and only one of the following
-                                              should be specified. Exec specifies
-                                              the action to take.
+                                            description: Exec specifies the action
+                                              to take.
                                             properties:
                                               command:
                                                 description: Command is the command
@@ -1108,10 +1393,12 @@ spec:
                                             - port
                                             type: object
                                           tcpSocket:
-                                            description: 'TCPSocket specifies an action
-                                              involving a TCP port. TCP hooks not
-                                              yet supported TODO: implement a realistic
-                                              TCP lifecycle hook'
+                                            description: Deprecated. TCPSocket is
+                                              NOT supported as a LifecycleHandler
+                                              and kept for the backward compatibility.
+                                              There are no validation of this field
+                                              and lifecycle hooks will fail in runtime
+                                              when tcp handler is specified.
                                             properties:
                                               host:
                                                 description: 'Optional: Host name
@@ -1138,21 +1425,19 @@ spec:
                                           as liveness/startup probe failure, preemption,
                                           resource contention, etc. The handler is
                                           not called if the container crashes or exits.
-                                          The reason for termination is passed to
-                                          the handler. The Pod''s termination grace
-                                          period countdown begins before the PreStop
-                                          hooked is executed. Regardless of the outcome
-                                          of the handler, the container will eventually
-                                          terminate within the Pod''s termination
-                                          grace period. Other management of the container
-                                          blocks until the hook completes or until
-                                          the termination grace period is reached.
-                                          More info: https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/#container-hooks'
+                                          The Pod''s termination grace period countdown
+                                          begins before the PreStop hook is executed.
+                                          Regardless of the outcome of the handler,
+                                          the container will eventually terminate
+                                          within the Pod''s termination grace period
+                                          (unless delayed by finalizers). Other management
+                                          of the container blocks until the hook completes
+                                          or until the termination grace period is
+                                          reached. More info: https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/#container-hooks'
                                         properties:
                                           exec:
-                                            description: One and only one of the following
-                                              should be specified. Exec specifies
-                                              the action to take.
+                                            description: Exec specifies the action
+                                              to take.
                                             properties:
                                               command:
                                                 description: Command is the command
@@ -1223,10 +1508,12 @@ spec:
                                             - port
                                             type: object
                                           tcpSocket:
-                                            description: 'TCPSocket specifies an action
-                                              involving a TCP port. TCP hooks not
-                                              yet supported TODO: implement a realistic
-                                              TCP lifecycle hook'
+                                            description: Deprecated. TCPSocket is
+                                              NOT supported as a LifecycleHandler
+                                              and kept for the backward compatibility.
+                                              There are no validation of this field
+                                              and lifecycle hooks will fail in runtime
+                                              when tcp handler is specified.
                                             properties:
                                               host:
                                                 description: 'Optional: Host name
@@ -1253,9 +1540,8 @@ spec:
                                       Cannot be updated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
                                     properties:
                                       exec:
-                                        description: One and only one of the following
-                                          should be specified. Exec specifies the
-                                          action to take.
+                                        description: Exec specifies the action to
+                                          take.
                                         properties:
                                           command:
                                             description: Command is the command line
@@ -1280,6 +1566,26 @@ spec:
                                           value is 1.
                                         format: int32
                                         type: integer
+                                      grpc:
+                                        description: GRPC specifies an action involving
+                                          a GRPC port. This is a beta field and requires
+                                          enabling GRPCContainerProbe feature gate.
+                                        properties:
+                                          port:
+                                            description: Port number of the gRPC service.
+                                              Number must be in the range 1 to 65535.
+                                            format: int32
+                                            type: integer
+                                          service:
+                                            description: "Service is the name of the
+                                              service to place in the gRPC HealthCheckRequest
+                                              (see https://github.com/grpc/grpc/blob/master/doc/health-checking.md).
+                                              \n If this is not specified, the default
+                                              behavior is defined by gRPC."
+                                            type: string
+                                        required:
+                                        - port
+                                        type: object
                                       httpGet:
                                         description: HTTPGet specifies the http request
                                           to perform.
@@ -1348,10 +1654,8 @@ spec:
                                         format: int32
                                         type: integer
                                       tcpSocket:
-                                        description: 'TCPSocket specifies an action
-                                          involving a TCP port. TCP hooks not yet
-                                          supported TODO: implement a realistic TCP
-                                          lifecycle hook'
+                                        description: TCPSocket specifies an action
+                                          involving a TCP port.
                                         properties:
                                           host:
                                             description: 'Optional: Host name to connect
@@ -1369,6 +1673,28 @@ spec:
                                         required:
                                         - port
                                         type: object
+                                      terminationGracePeriodSeconds:
+                                        description: Optional duration in seconds
+                                          the pod needs to terminate gracefully upon
+                                          probe failure. The grace period is the duration
+                                          in seconds after the processes running in
+                                          the pod are sent a termination signal and
+                                          the time when the processes are forcibly
+                                          halted with a kill signal. Set this value
+                                          longer than the expected cleanup time for
+                                          your process. If this value is nil, the
+                                          pod's terminationGracePeriodSeconds will
+                                          be used. Otherwise, this value overrides
+                                          the value provided by the pod spec. Value
+                                          must be non-negative integer. The value
+                                          zero indicates stop immediately via the
+                                          kill signal (no opportunity to shut down).
+                                          This is a beta field and requires enabling
+                                          ProbeTerminationGracePeriod feature gate.
+                                          Minimum value is 1. spec.terminationGracePeriodSeconds
+                                          is used if unset.
+                                        format: int64
+                                        type: integer
                                       timeoutSeconds:
                                         description: 'Number of seconds after which
                                           the probe times out. Defaults to 1 second.
@@ -1440,9 +1766,8 @@ spec:
                                       More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
                                     properties:
                                       exec:
-                                        description: One and only one of the following
-                                          should be specified. Exec specifies the
-                                          action to take.
+                                        description: Exec specifies the action to
+                                          take.
                                         properties:
                                           command:
                                             description: Command is the command line
@@ -1467,6 +1792,26 @@ spec:
                                           value is 1.
                                         format: int32
                                         type: integer
+                                      grpc:
+                                        description: GRPC specifies an action involving
+                                          a GRPC port. This is a beta field and requires
+                                          enabling GRPCContainerProbe feature gate.
+                                        properties:
+                                          port:
+                                            description: Port number of the gRPC service.
+                                              Number must be in the range 1 to 65535.
+                                            format: int32
+                                            type: integer
+                                          service:
+                                            description: "Service is the name of the
+                                              service to place in the gRPC HealthCheckRequest
+                                              (see https://github.com/grpc/grpc/blob/master/doc/health-checking.md).
+                                              \n If this is not specified, the default
+                                              behavior is defined by gRPC."
+                                            type: string
+                                        required:
+                                        - port
+                                        type: object
                                       httpGet:
                                         description: HTTPGet specifies the http request
                                           to perform.
@@ -1535,10 +1880,8 @@ spec:
                                         format: int32
                                         type: integer
                                       tcpSocket:
-                                        description: 'TCPSocket specifies an action
-                                          involving a TCP port. TCP hooks not yet
-                                          supported TODO: implement a realistic TCP
-                                          lifecycle hook'
+                                        description: TCPSocket specifies an action
+                                          involving a TCP port.
                                         properties:
                                           host:
                                             description: 'Optional: Host name to connect
@@ -1556,6 +1899,28 @@ spec:
                                         required:
                                         - port
                                         type: object
+                                      terminationGracePeriodSeconds:
+                                        description: Optional duration in seconds
+                                          the pod needs to terminate gracefully upon
+                                          probe failure. The grace period is the duration
+                                          in seconds after the processes running in
+                                          the pod are sent a termination signal and
+                                          the time when the processes are forcibly
+                                          halted with a kill signal. Set this value
+                                          longer than the expected cleanup time for
+                                          your process. If this value is nil, the
+                                          pod's terminationGracePeriodSeconds will
+                                          be used. Otherwise, this value overrides
+                                          the value provided by the pod spec. Value
+                                          must be non-negative integer. The value
+                                          zero indicates stop immediately via the
+                                          kill signal (no opportunity to shut down).
+                                          This is a beta field and requires enabling
+                                          ProbeTerminationGracePeriod feature gate.
+                                          Minimum value is 1. spec.terminationGracePeriodSeconds
+                                          is used if unset.
+                                        format: int64
+                                        type: integer
                                       timeoutSeconds:
                                         description: 'Number of seconds after which
                                           the probe times out. Defaults to 1 second.
@@ -1565,7 +1930,7 @@ spec:
                                     type: object
                                   resources:
                                     description: 'Compute Resources required by this
-                                      container. Cannot be updated. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
+                                      container. Cannot be updated. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
                                     properties:
                                       limits:
                                         additionalProperties:
@@ -1576,7 +1941,7 @@ spec:
                                           x-kubernetes-int-or-string: true
                                         description: 'Limits describes the maximum
                                           amount of compute resources allowed. More
-                                          info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
+                                          info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
                                         type: object
                                       requests:
                                         additionalProperties:
@@ -1590,12 +1955,14 @@ spec:
                                           Requests is omitted for a container, it
                                           defaults to Limits if that is explicitly
                                           specified, otherwise to an implementation-defined
-                                          value. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
+                                          value. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
                                         type: object
                                     type: object
                                   securityContext:
-                                    description: 'Security options the pod should
-                                      run with. More info: https://kubernetes.io/docs/concepts/policy/security-context/
+                                    description: 'SecurityContext defines the security
+                                      options the container should be run with. If
+                                      set, the fields of SecurityContext override
+                                      the equivalent fields of PodSecurityContext.
                                       More info: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/'
                                     properties:
                                       allowPrivilegeEscalation:
@@ -1605,13 +1972,16 @@ spec:
                                           controls if the no_new_privs flag will be
                                           set on the container process. AllowPrivilegeEscalation
                                           is true always when the container is: 1)
-                                          run as Privileged 2) has CAP_SYS_ADMIN'
+                                          run as Privileged 2) has CAP_SYS_ADMIN Note
+                                          that this field cannot be set when spec.os.name
+                                          is windows.'
                                         type: boolean
                                       capabilities:
                                         description: The capabilities to add/drop
                                           when running containers. Defaults to the
                                           default set of capabilities granted by the
-                                          container runtime.
+                                          container runtime. Note that this field
+                                          cannot be set when spec.os.name is windows.
                                         properties:
                                           add:
                                             description: Added capabilities
@@ -1632,7 +2002,8 @@ spec:
                                         description: Run container in privileged mode.
                                           Processes in privileged containers are essentially
                                           equivalent to root on the host. Defaults
-                                          to false.
+                                          to false. Note that this field cannot be
+                                          set when spec.os.name is windows.
                                         type: boolean
                                       procMount:
                                         description: procMount denotes the type of
@@ -1641,10 +2012,14 @@ spec:
                                           container runtime defaults for readonly
                                           paths and masked paths. This requires the
                                           ProcMountType feature flag to be enabled.
+                                          Note that this field cannot be set when
+                                          spec.os.name is windows.
                                         type: string
                                       readOnlyRootFilesystem:
                                         description: Whether this container has a
                                           read-only root filesystem. Default is false.
+                                          Note that this field cannot be set when
+                                          spec.os.name is windows.
                                         type: boolean
                                       runAsGroup:
                                         description: The GID to run the entrypoint
@@ -1652,7 +2027,8 @@ spec:
                                           if unset. May also be set in PodSecurityContext.  If
                                           set in both SecurityContext and PodSecurityContext,
                                           the value specified in SecurityContext takes
-                                          precedence.
+                                          precedence. Note that this field cannot
+                                          be set when spec.os.name is windows.
                                         format: int64
                                         type: integer
                                       runAsNonRoot:
@@ -1674,7 +2050,8 @@ spec:
                                           May also be set in PodSecurityContext.  If
                                           set in both SecurityContext and PodSecurityContext,
                                           the value specified in SecurityContext takes
-                                          precedence.
+                                          precedence. Note that this field cannot
+                                          be set when spec.os.name is windows.
                                         format: int64
                                         type: integer
                                       seLinuxOptions:
@@ -1684,7 +2061,9 @@ spec:
                                           for each container.  May also be set in
                                           PodSecurityContext.  If set in both SecurityContext
                                           and PodSecurityContext, the value specified
-                                          in SecurityContext takes precedence.
+                                          in SecurityContext takes precedence. Note
+                                          that this field cannot be set when spec.os.name
+                                          is windows.
                                         properties:
                                           level:
                                             description: Level is SELinux level label
@@ -1707,7 +2086,9 @@ spec:
                                         description: The seccomp options to use by
                                           this container. If seccomp options are provided
                                           at both the pod & container level, the container
-                                          options override the pod options.
+                                          options override the pod options. Note that
+                                          this field cannot be set when spec.os.name
+                                          is windows.
                                         properties:
                                           localhostProfile:
                                             description: localhostProfile indicates
@@ -1738,7 +2119,9 @@ spec:
                                           the options from the PodSecurityContext
                                           will be used. If set in both SecurityContext
                                           and PodSecurityContext, the value specified
-                                          in SecurityContext takes precedence.
+                                          in SecurityContext takes precedence. Note
+                                          that this field cannot be set when spec.os.name
+                                          is linux.
                                         properties:
                                           gmsaCredentialSpec:
                                             description: GMSACredentialSpec is where
@@ -1752,6 +2135,22 @@ spec:
                                               the name of the GMSA credential spec
                                               to use.
                                             type: string
+                                          hostProcess:
+                                            description: HostProcess determines if
+                                              a container should be run as a 'Host
+                                              Process' container. This field is alpha-level
+                                              and will only be honored by components
+                                              that enable the WindowsHostProcessContainers
+                                              feature flag. Setting this field without
+                                              the feature flag will result in errors
+                                              when validating the Pod. All of a Pod's
+                                              containers must have the same effective
+                                              HostProcess value (it is not allowed
+                                              to have a mix of HostProcess containers
+                                              and non-HostProcess containers).  In
+                                              addition, if HostProcess is true then
+                                              HostNetwork must also be set to true.
+                                            type: boolean
                                           runAsUserName:
                                             description: The UserName in Windows to
                                               run the entrypoint of the container
@@ -1774,14 +2173,11 @@ spec:
                                       parameters at the beginning of a Pod''s lifecycle,
                                       when it might take a long time to load data
                                       or warm a cache, than during steady-state operation.
-                                      This cannot be updated. This is a beta feature
-                                      enabled by the StartupProbe feature flag. More
-                                      info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                                      This cannot be updated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
                                     properties:
                                       exec:
-                                        description: One and only one of the following
-                                          should be specified. Exec specifies the
-                                          action to take.
+                                        description: Exec specifies the action to
+                                          take.
                                         properties:
                                           command:
                                             description: Command is the command line
@@ -1806,6 +2202,26 @@ spec:
                                           value is 1.
                                         format: int32
                                         type: integer
+                                      grpc:
+                                        description: GRPC specifies an action involving
+                                          a GRPC port. This is a beta field and requires
+                                          enabling GRPCContainerProbe feature gate.
+                                        properties:
+                                          port:
+                                            description: Port number of the gRPC service.
+                                              Number must be in the range 1 to 65535.
+                                            format: int32
+                                            type: integer
+                                          service:
+                                            description: "Service is the name of the
+                                              service to place in the gRPC HealthCheckRequest
+                                              (see https://github.com/grpc/grpc/blob/master/doc/health-checking.md).
+                                              \n If this is not specified, the default
+                                              behavior is defined by gRPC."
+                                            type: string
+                                        required:
+                                        - port
+                                        type: object
                                       httpGet:
                                         description: HTTPGet specifies the http request
                                           to perform.
@@ -1874,10 +2290,8 @@ spec:
                                         format: int32
                                         type: integer
                                       tcpSocket:
-                                        description: 'TCPSocket specifies an action
-                                          involving a TCP port. TCP hooks not yet
-                                          supported TODO: implement a realistic TCP
-                                          lifecycle hook'
+                                        description: TCPSocket specifies an action
+                                          involving a TCP port.
                                         properties:
                                           host:
                                             description: 'Optional: Host name to connect
@@ -1895,6 +2309,28 @@ spec:
                                         required:
                                         - port
                                         type: object
+                                      terminationGracePeriodSeconds:
+                                        description: Optional duration in seconds
+                                          the pod needs to terminate gracefully upon
+                                          probe failure. The grace period is the duration
+                                          in seconds after the processes running in
+                                          the pod are sent a termination signal and
+                                          the time when the processes are forcibly
+                                          halted with a kill signal. Set this value
+                                          longer than the expected cleanup time for
+                                          your process. If this value is nil, the
+                                          pod's terminationGracePeriodSeconds will
+                                          be used. Otherwise, this value overrides
+                                          the value provided by the pod spec. Value
+                                          must be non-negative integer. The value
+                                          zero indicates stop immediately via the
+                                          kill signal (no opportunity to shut down).
+                                          This is a beta field and requires enabling
+                                          ProbeTerminationGracePeriod feature gate.
+                                          Minimum value is 1. spec.terminationGracePeriodSeconds
+                                          is used if unset.
+                                        format: int64
+                                        type: integer
                                       timeoutSeconds:
                                         description: 'Number of seconds after which
                                           the probe times out. Defaults to 1 second.
@@ -2092,33 +2528,35 @@ spec:
                                 and it cannot be modified by updating the pod spec.
                                 In order to add an ephemeral container to an existing
                                 pod, use the pod's ephemeralcontainers subresource.
-                                This field is alpha-level and is only honored by servers
-                                that enable the EphemeralContainers feature.
+                                This field is beta-level and available on clusters
+                                that haven't disabled the EphemeralContainers feature
+                                gate.
                               items:
-                                description: An EphemeralContainer is a container
-                                  that may be added temporarily to an existing pod
-                                  for user-initiated activities such as debugging.
-                                  Ephemeral containers have no resource or scheduling
-                                  guarantees, and they will not be restarted when
-                                  they exit or when a pod is removed or restarted.
-                                  If an ephemeral container causes a pod to exceed
-                                  its resource allocation, the pod may be evicted.
-                                  Ephemeral containers may not be added by directly
-                                  updating the pod spec. They must be added via the
-                                  pod's ephemeralcontainers subresource, and they
-                                  will appear in the pod spec once added. This is
-                                  an alpha feature enabled by the EphemeralContainers
-                                  feature flag.
+                                description: "An EphemeralContainer is a temporary
+                                  container that you may add to an existing Pod for
+                                  user-initiated activities such as debugging. Ephemeral
+                                  containers have no resource or scheduling guarantees,
+                                  and they will not be restarted when they exit or
+                                  when a Pod is removed or restarted. The kubelet
+                                  may evict a Pod if an ephemeral container causes
+                                  the Pod to exceed its resource allocation. \n To
+                                  add an ephemeral container, use the ephemeralcontainers
+                                  subresource of an existing Pod. Ephemeral containers
+                                  may not be removed or restarted. \n This is a beta
+                                  feature available on clusters that haven't disabled
+                                  the EphemeralContainers feature gate."
                                 properties:
                                   args:
                                     description: 'Arguments to the entrypoint. The
-                                      docker image''s CMD is used if this is not provided.
+                                      image''s CMD is used if this is not provided.
                                       Variable references $(VAR_NAME) are expanded
                                       using the container''s environment. If a variable
                                       cannot be resolved, the reference in the input
-                                      string will be unchanged. The $(VAR_NAME) syntax
-                                      can be escaped with a double $$, ie: $$(VAR_NAME).
-                                      Escaped references will never be expanded, regardless
+                                      string will be unchanged. Double $$ are reduced
+                                      to a single $, which allows for escaping the
+                                      $(VAR_NAME) syntax: i.e. "$$(VAR_NAME)" will
+                                      produce the string literal "$(VAR_NAME)". Escaped
+                                      references will never be expanded, regardless
                                       of whether the variable exists or not. Cannot
                                       be updated. More info: https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell'
                                     items:
@@ -2126,16 +2564,17 @@ spec:
                                     type: array
                                   command:
                                     description: 'Entrypoint array. Not executed within
-                                      a shell. The docker image''s ENTRYPOINT is used
-                                      if this is not provided. Variable references
-                                      $(VAR_NAME) are expanded using the container''s
-                                      environment. If a variable cannot be resolved,
-                                      the reference in the input string will be unchanged.
-                                      The $(VAR_NAME) syntax can be escaped with a
-                                      double $$, ie: $$(VAR_NAME). Escaped references
-                                      will never be expanded, regardless of whether
-                                      the variable exists or not. Cannot be updated.
-                                      More info: https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell'
+                                      a shell. The image''s ENTRYPOINT is used if
+                                      this is not provided. Variable references $(VAR_NAME)
+                                      are expanded using the container''s environment.
+                                      If a variable cannot be resolved, the reference
+                                      in the input string will be unchanged. Double
+                                      $$ are reduced to a single $, which allows for
+                                      escaping the $(VAR_NAME) syntax: i.e. "$$(VAR_NAME)"
+                                      will produce the string literal "$(VAR_NAME)".
+                                      Escaped references will never be expanded, regardless
+                                      of whether the variable exists or not. Cannot
+                                      be updated. More info: https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell'
                                     items:
                                       type: string
                                     type: array
@@ -2152,13 +2591,15 @@ spec:
                                           type: string
                                         value:
                                           description: 'Variable references $(VAR_NAME)
-                                            are expanded using the previous defined
+                                            are expanded using the previously defined
                                             environment variables in the container
                                             and any service environment variables.
                                             If a variable cannot be resolved, the
                                             reference in the input string will be
-                                            unchanged. The $(VAR_NAME) syntax can
-                                            be escaped with a double $$, ie: $$(VAR_NAME).
+                                            unchanged. Double $$ are reduced to a
+                                            single $, which allows for escaping the
+                                            $(VAR_NAME) syntax: i.e. "$$(VAR_NAME)"
+                                            will produce the string literal "$(VAR_NAME)".
                                             Escaped references will never be expanded,
                                             regardless of whether the variable exists
                                             or not. Defaults to "".'
@@ -2312,7 +2753,8 @@ spec:
                                       type: object
                                     type: array
                                   image:
-                                    description: 'Docker image name. More info: https://kubernetes.io/docs/concepts/containers/images'
+                                    description: 'Container image name. More info:
+                                      https://kubernetes.io/docs/concepts/containers/images'
                                     type: string
                                   imagePullPolicy:
                                     description: 'Image pull policy. One of Always,
@@ -2333,9 +2775,8 @@ spec:
                                           More info: https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/#container-hooks'
                                         properties:
                                           exec:
-                                            description: One and only one of the following
-                                              should be specified. Exec specifies
-                                              the action to take.
+                                            description: Exec specifies the action
+                                              to take.
                                             properties:
                                               command:
                                                 description: Command is the command
@@ -2406,10 +2847,12 @@ spec:
                                             - port
                                             type: object
                                           tcpSocket:
-                                            description: 'TCPSocket specifies an action
-                                              involving a TCP port. TCP hooks not
-                                              yet supported TODO: implement a realistic
-                                              TCP lifecycle hook'
+                                            description: Deprecated. TCPSocket is
+                                              NOT supported as a LifecycleHandler
+                                              and kept for the backward compatibility.
+                                              There are no validation of this field
+                                              and lifecycle hooks will fail in runtime
+                                              when tcp handler is specified.
                                             properties:
                                               host:
                                                 description: 'Optional: Host name
@@ -2436,21 +2879,19 @@ spec:
                                           as liveness/startup probe failure, preemption,
                                           resource contention, etc. The handler is
                                           not called if the container crashes or exits.
-                                          The reason for termination is passed to
-                                          the handler. The Pod''s termination grace
-                                          period countdown begins before the PreStop
-                                          hooked is executed. Regardless of the outcome
-                                          of the handler, the container will eventually
-                                          terminate within the Pod''s termination
-                                          grace period. Other management of the container
-                                          blocks until the hook completes or until
-                                          the termination grace period is reached.
-                                          More info: https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/#container-hooks'
+                                          The Pod''s termination grace period countdown
+                                          begins before the PreStop hook is executed.
+                                          Regardless of the outcome of the handler,
+                                          the container will eventually terminate
+                                          within the Pod''s termination grace period
+                                          (unless delayed by finalizers). Other management
+                                          of the container blocks until the hook completes
+                                          or until the termination grace period is
+                                          reached. More info: https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/#container-hooks'
                                         properties:
                                           exec:
-                                            description: One and only one of the following
-                                              should be specified. Exec specifies
-                                              the action to take.
+                                            description: Exec specifies the action
+                                              to take.
                                             properties:
                                               command:
                                                 description: Command is the command
@@ -2521,10 +2962,12 @@ spec:
                                             - port
                                             type: object
                                           tcpSocket:
-                                            description: 'TCPSocket specifies an action
-                                              involving a TCP port. TCP hooks not
-                                              yet supported TODO: implement a realistic
-                                              TCP lifecycle hook'
+                                            description: Deprecated. TCPSocket is
+                                              NOT supported as a LifecycleHandler
+                                              and kept for the backward compatibility.
+                                              There are no validation of this field
+                                              and lifecycle hooks will fail in runtime
+                                              when tcp handler is specified.
                                             properties:
                                               host:
                                                 description: 'Optional: Host name
@@ -2550,9 +2993,8 @@ spec:
                                       containers.
                                     properties:
                                       exec:
-                                        description: One and only one of the following
-                                          should be specified. Exec specifies the
-                                          action to take.
+                                        description: Exec specifies the action to
+                                          take.
                                         properties:
                                           command:
                                             description: Command is the command line
@@ -2577,6 +3019,26 @@ spec:
                                           value is 1.
                                         format: int32
                                         type: integer
+                                      grpc:
+                                        description: GRPC specifies an action involving
+                                          a GRPC port. This is a beta field and requires
+                                          enabling GRPCContainerProbe feature gate.
+                                        properties:
+                                          port:
+                                            description: Port number of the gRPC service.
+                                              Number must be in the range 1 to 65535.
+                                            format: int32
+                                            type: integer
+                                          service:
+                                            description: "Service is the name of the
+                                              service to place in the gRPC HealthCheckRequest
+                                              (see https://github.com/grpc/grpc/blob/master/doc/health-checking.md).
+                                              \n If this is not specified, the default
+                                              behavior is defined by gRPC."
+                                            type: string
+                                        required:
+                                        - port
+                                        type: object
                                       httpGet:
                                         description: HTTPGet specifies the http request
                                           to perform.
@@ -2645,10 +3107,8 @@ spec:
                                         format: int32
                                         type: integer
                                       tcpSocket:
-                                        description: 'TCPSocket specifies an action
-                                          involving a TCP port. TCP hooks not yet
-                                          supported TODO: implement a realistic TCP
-                                          lifecycle hook'
+                                        description: TCPSocket specifies an action
+                                          involving a TCP port.
                                         properties:
                                           host:
                                             description: 'Optional: Host name to connect
@@ -2666,6 +3126,28 @@ spec:
                                         required:
                                         - port
                                         type: object
+                                      terminationGracePeriodSeconds:
+                                        description: Optional duration in seconds
+                                          the pod needs to terminate gracefully upon
+                                          probe failure. The grace period is the duration
+                                          in seconds after the processes running in
+                                          the pod are sent a termination signal and
+                                          the time when the processes are forcibly
+                                          halted with a kill signal. Set this value
+                                          longer than the expected cleanup time for
+                                          your process. If this value is nil, the
+                                          pod's terminationGracePeriodSeconds will
+                                          be used. Otherwise, this value overrides
+                                          the value provided by the pod spec. Value
+                                          must be non-negative integer. The value
+                                          zero indicates stop immediately via the
+                                          kill signal (no opportunity to shut down).
+                                          This is a beta field and requires enabling
+                                          ProbeTerminationGracePeriod feature gate.
+                                          Minimum value is 1. spec.terminationGracePeriodSeconds
+                                          is used if unset.
+                                        format: int64
+                                        type: integer
                                       timeoutSeconds:
                                         description: 'Number of seconds after which
                                           the probe times out. Defaults to 1 second.
@@ -2720,14 +3202,17 @@ spec:
                                       - containerPort
                                       type: object
                                     type: array
+                                    x-kubernetes-list-map-keys:
+                                    - containerPort
+                                    - protocol
+                                    x-kubernetes-list-type: map
                                   readinessProbe:
                                     description: Probes are not allowed for ephemeral
                                       containers.
                                     properties:
                                       exec:
-                                        description: One and only one of the following
-                                          should be specified. Exec specifies the
-                                          action to take.
+                                        description: Exec specifies the action to
+                                          take.
                                         properties:
                                           command:
                                             description: Command is the command line
@@ -2752,6 +3237,26 @@ spec:
                                           value is 1.
                                         format: int32
                                         type: integer
+                                      grpc:
+                                        description: GRPC specifies an action involving
+                                          a GRPC port. This is a beta field and requires
+                                          enabling GRPCContainerProbe feature gate.
+                                        properties:
+                                          port:
+                                            description: Port number of the gRPC service.
+                                              Number must be in the range 1 to 65535.
+                                            format: int32
+                                            type: integer
+                                          service:
+                                            description: "Service is the name of the
+                                              service to place in the gRPC HealthCheckRequest
+                                              (see https://github.com/grpc/grpc/blob/master/doc/health-checking.md).
+                                              \n If this is not specified, the default
+                                              behavior is defined by gRPC."
+                                            type: string
+                                        required:
+                                        - port
+                                        type: object
                                       httpGet:
                                         description: HTTPGet specifies the http request
                                           to perform.
@@ -2820,10 +3325,8 @@ spec:
                                         format: int32
                                         type: integer
                                       tcpSocket:
-                                        description: 'TCPSocket specifies an action
-                                          involving a TCP port. TCP hooks not yet
-                                          supported TODO: implement a realistic TCP
-                                          lifecycle hook'
+                                        description: TCPSocket specifies an action
+                                          involving a TCP port.
                                         properties:
                                           host:
                                             description: 'Optional: Host name to connect
@@ -2841,6 +3344,28 @@ spec:
                                         required:
                                         - port
                                         type: object
+                                      terminationGracePeriodSeconds:
+                                        description: Optional duration in seconds
+                                          the pod needs to terminate gracefully upon
+                                          probe failure. The grace period is the duration
+                                          in seconds after the processes running in
+                                          the pod are sent a termination signal and
+                                          the time when the processes are forcibly
+                                          halted with a kill signal. Set this value
+                                          longer than the expected cleanup time for
+                                          your process. If this value is nil, the
+                                          pod's terminationGracePeriodSeconds will
+                                          be used. Otherwise, this value overrides
+                                          the value provided by the pod spec. Value
+                                          must be non-negative integer. The value
+                                          zero indicates stop immediately via the
+                                          kill signal (no opportunity to shut down).
+                                          This is a beta field and requires enabling
+                                          ProbeTerminationGracePeriod feature gate.
+                                          Minimum value is 1. spec.terminationGracePeriodSeconds
+                                          is used if unset.
+                                        format: int64
+                                        type: integer
                                       timeoutSeconds:
                                         description: 'Number of seconds after which
                                           the probe times out. Defaults to 1 second.
@@ -2862,7 +3387,7 @@ spec:
                                           x-kubernetes-int-or-string: true
                                         description: 'Limits describes the maximum
                                           amount of compute resources allowed. More
-                                          info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
+                                          info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
                                         type: object
                                       requests:
                                         additionalProperties:
@@ -2876,12 +3401,14 @@ spec:
                                           Requests is omitted for a container, it
                                           defaults to Limits if that is explicitly
                                           specified, otherwise to an implementation-defined
-                                          value. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
+                                          value. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
                                         type: object
                                     type: object
                                   securityContext:
-                                    description: SecurityContext is not allowed for
-                                      ephemeral containers.
+                                    description: 'Optional: SecurityContext defines
+                                      the security options the ephemeral container
+                                      should be run with. If set, the fields of SecurityContext
+                                      override the equivalent fields of PodSecurityContext.'
                                     properties:
                                       allowPrivilegeEscalation:
                                         description: 'AllowPrivilegeEscalation controls
@@ -2890,13 +3417,16 @@ spec:
                                           controls if the no_new_privs flag will be
                                           set on the container process. AllowPrivilegeEscalation
                                           is true always when the container is: 1)
-                                          run as Privileged 2) has CAP_SYS_ADMIN'
+                                          run as Privileged 2) has CAP_SYS_ADMIN Note
+                                          that this field cannot be set when spec.os.name
+                                          is windows.'
                                         type: boolean
                                       capabilities:
                                         description: The capabilities to add/drop
                                           when running containers. Defaults to the
                                           default set of capabilities granted by the
-                                          container runtime.
+                                          container runtime. Note that this field
+                                          cannot be set when spec.os.name is windows.
                                         properties:
                                           add:
                                             description: Added capabilities
@@ -2917,7 +3447,8 @@ spec:
                                         description: Run container in privileged mode.
                                           Processes in privileged containers are essentially
                                           equivalent to root on the host. Defaults
-                                          to false.
+                                          to false. Note that this field cannot be
+                                          set when spec.os.name is windows.
                                         type: boolean
                                       procMount:
                                         description: procMount denotes the type of
@@ -2926,10 +3457,14 @@ spec:
                                           container runtime defaults for readonly
                                           paths and masked paths. This requires the
                                           ProcMountType feature flag to be enabled.
+                                          Note that this field cannot be set when
+                                          spec.os.name is windows.
                                         type: string
                                       readOnlyRootFilesystem:
                                         description: Whether this container has a
                                           read-only root filesystem. Default is false.
+                                          Note that this field cannot be set when
+                                          spec.os.name is windows.
                                         type: boolean
                                       runAsGroup:
                                         description: The GID to run the entrypoint
@@ -2937,7 +3472,8 @@ spec:
                                           if unset. May also be set in PodSecurityContext.  If
                                           set in both SecurityContext and PodSecurityContext,
                                           the value specified in SecurityContext takes
-                                          precedence.
+                                          precedence. Note that this field cannot
+                                          be set when spec.os.name is windows.
                                         format: int64
                                         type: integer
                                       runAsNonRoot:
@@ -2959,7 +3495,8 @@ spec:
                                           May also be set in PodSecurityContext.  If
                                           set in both SecurityContext and PodSecurityContext,
                                           the value specified in SecurityContext takes
-                                          precedence.
+                                          precedence. Note that this field cannot
+                                          be set when spec.os.name is windows.
                                         format: int64
                                         type: integer
                                       seLinuxOptions:
@@ -2969,7 +3506,9 @@ spec:
                                           for each container.  May also be set in
                                           PodSecurityContext.  If set in both SecurityContext
                                           and PodSecurityContext, the value specified
-                                          in SecurityContext takes precedence.
+                                          in SecurityContext takes precedence. Note
+                                          that this field cannot be set when spec.os.name
+                                          is windows.
                                         properties:
                                           level:
                                             description: Level is SELinux level label
@@ -2992,7 +3531,9 @@ spec:
                                         description: The seccomp options to use by
                                           this container. If seccomp options are provided
                                           at both the pod & container level, the container
-                                          options override the pod options.
+                                          options override the pod options. Note that
+                                          this field cannot be set when spec.os.name
+                                          is windows.
                                         properties:
                                           localhostProfile:
                                             description: localhostProfile indicates
@@ -3023,7 +3564,9 @@ spec:
                                           the options from the PodSecurityContext
                                           will be used. If set in both SecurityContext
                                           and PodSecurityContext, the value specified
-                                          in SecurityContext takes precedence.
+                                          in SecurityContext takes precedence. Note
+                                          that this field cannot be set when spec.os.name
+                                          is linux.
                                         properties:
                                           gmsaCredentialSpec:
                                             description: GMSACredentialSpec is where
@@ -3037,6 +3580,22 @@ spec:
                                               the name of the GMSA credential spec
                                               to use.
                                             type: string
+                                          hostProcess:
+                                            description: HostProcess determines if
+                                              a container should be run as a 'Host
+                                              Process' container. This field is alpha-level
+                                              and will only be honored by components
+                                              that enable the WindowsHostProcessContainers
+                                              feature flag. Setting this field without
+                                              the feature flag will result in errors
+                                              when validating the Pod. All of a Pod's
+                                              containers must have the same effective
+                                              HostProcess value (it is not allowed
+                                              to have a mix of HostProcess containers
+                                              and non-HostProcess containers).  In
+                                              addition, if HostProcess is true then
+                                              HostNetwork must also be set to true.
+                                            type: boolean
                                           runAsUserName:
                                             description: The UserName in Windows to
                                               run the entrypoint of the container
@@ -3054,9 +3613,8 @@ spec:
                                       containers.
                                     properties:
                                       exec:
-                                        description: One and only one of the following
-                                          should be specified. Exec specifies the
-                                          action to take.
+                                        description: Exec specifies the action to
+                                          take.
                                         properties:
                                           command:
                                             description: Command is the command line
@@ -3081,6 +3639,26 @@ spec:
                                           value is 1.
                                         format: int32
                                         type: integer
+                                      grpc:
+                                        description: GRPC specifies an action involving
+                                          a GRPC port. This is a beta field and requires
+                                          enabling GRPCContainerProbe feature gate.
+                                        properties:
+                                          port:
+                                            description: Port number of the gRPC service.
+                                              Number must be in the range 1 to 65535.
+                                            format: int32
+                                            type: integer
+                                          service:
+                                            description: "Service is the name of the
+                                              service to place in the gRPC HealthCheckRequest
+                                              (see https://github.com/grpc/grpc/blob/master/doc/health-checking.md).
+                                              \n If this is not specified, the default
+                                              behavior is defined by gRPC."
+                                            type: string
+                                        required:
+                                        - port
+                                        type: object
                                       httpGet:
                                         description: HTTPGet specifies the http request
                                           to perform.
@@ -3149,10 +3727,8 @@ spec:
                                         format: int32
                                         type: integer
                                       tcpSocket:
-                                        description: 'TCPSocket specifies an action
-                                          involving a TCP port. TCP hooks not yet
-                                          supported TODO: implement a realistic TCP
-                                          lifecycle hook'
+                                        description: TCPSocket specifies an action
+                                          involving a TCP port.
                                         properties:
                                           host:
                                             description: 'Optional: Host name to connect
@@ -3170,6 +3746,28 @@ spec:
                                         required:
                                         - port
                                         type: object
+                                      terminationGracePeriodSeconds:
+                                        description: Optional duration in seconds
+                                          the pod needs to terminate gracefully upon
+                                          probe failure. The grace period is the duration
+                                          in seconds after the processes running in
+                                          the pod are sent a termination signal and
+                                          the time when the processes are forcibly
+                                          halted with a kill signal. Set this value
+                                          longer than the expected cleanup time for
+                                          your process. If this value is nil, the
+                                          pod's terminationGracePeriodSeconds will
+                                          be used. Otherwise, this value overrides
+                                          the value provided by the pod spec. Value
+                                          must be non-negative integer. The value
+                                          zero indicates stop immediately via the
+                                          kill signal (no opportunity to shut down).
+                                          This is a beta field and requires enabling
+                                          ProbeTerminationGracePeriod feature gate.
+                                          Minimum value is 1. spec.terminationGracePeriodSeconds
+                                          is used if unset.
+                                        format: int64
+                                        type: integer
                                       timeoutSeconds:
                                         description: 'Number of seconds after which
                                           the probe times out. Defaults to 1 second.
@@ -3200,13 +3798,15 @@ spec:
                                       EOF. Default is false
                                     type: boolean
                                   targetContainerName:
-                                    description: If set, the name of the container
+                                    description: "If set, the name of the container
                                       from PodSpec that this ephemeral container targets.
                                       The ephemeral container will be run in the namespaces
                                       (IPC, PID, etc) of this container. If not set
-                                      then the ephemeral container is run in whatever
-                                      namespaces are shared for the pod. Note that
-                                      the container runtime must support this feature.
+                                      then the ephemeral container uses the namespaces
+                                      configured in the Pod spec. \n The container
+                                      runtime must implement support for this feature.
+                                      If the runtime does not support namespace targeting
+                                      then the result of setting this field is undefined."
                                     type: string
                                   terminationMessagePath:
                                     description: 'Optional: Path at which the file
@@ -3259,7 +3859,8 @@ spec:
                                     type: array
                                   volumeMounts:
                                     description: Pod volumes to mount into the container's
-                                      filesystem. Cannot be updated.
+                                      filesystem. Subpath mounts are not allowed for
+                                      ephemeral containers. Cannot be updated.
                                     items:
                                       description: VolumeMount describes a mounting
                                         of a Volume within a container.
@@ -3358,9 +3959,8 @@ spec:
                                 references to secrets in the same namespace to use
                                 for pulling any of the images used by this PodSpec.
                                 If specified, these secrets will be passed to individual
-                                puller implementations for them to use. For example,
-                                in the case of docker, only DockerConfig type secrets
-                                are honored. More info: https://kubernetes.io/docs/concepts/containers/images#specifying-imagepullsecrets-on-a-pod'
+                                puller implementations for them to use. More info:
+                                https://kubernetes.io/docs/concepts/containers/images#specifying-imagepullsecrets-on-a-pod'
                               items:
                                 description: LocalObjectReference contains enough
                                   information to let you locate the referenced object
@@ -3397,12 +3997,14 @@ spec:
                                 properties:
                                   args:
                                     description: 'Arguments to the entrypoint. The
-                                      docker image''s CMD is used if this is not provided.
-                                      Variable references $(VAR_NAME) are expanded
-                                      using the container''s environment. If a variable
-                                      cannot be resolved, the reference in the input
-                                      string will be unchanged. The $(VAR_NAME) syntax
-                                      can be escaped with a double $$, ie: $$(VAR_NAME).
+                                      container image''s CMD is used if this is not
+                                      provided. Variable references $(VAR_NAME) are
+                                      expanded using the container''s environment.
+                                      If a variable cannot be resolved, the reference
+                                      in the input string will be unchanged. Double
+                                      $$ are reduced to a single $, which allows for
+                                      escaping the $(VAR_NAME) syntax: i.e. "$$(VAR_NAME)"
+                                      will produce the string literal "$(VAR_NAME)".
                                       Escaped references will never be expanded, regardless
                                       of whether the variable exists or not. Cannot
                                       be updated. More info: https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell'
@@ -3411,16 +4013,17 @@ spec:
                                     type: array
                                   command:
                                     description: 'Entrypoint array. Not executed within
-                                      a shell. The docker image''s ENTRYPOINT is used
-                                      if this is not provided. Variable references
+                                      a shell. The container image''s ENTRYPOINT is
+                                      used if this is not provided. Variable references
                                       $(VAR_NAME) are expanded using the container''s
                                       environment. If a variable cannot be resolved,
                                       the reference in the input string will be unchanged.
-                                      The $(VAR_NAME) syntax can be escaped with a
-                                      double $$, ie: $$(VAR_NAME). Escaped references
-                                      will never be expanded, regardless of whether
-                                      the variable exists or not. Cannot be updated.
-                                      More info: https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell'
+                                      Double $$ are reduced to a single $, which allows
+                                      for escaping the $(VAR_NAME) syntax: i.e. "$$(VAR_NAME)"
+                                      will produce the string literal "$(VAR_NAME)".
+                                      Escaped references will never be expanded, regardless
+                                      of whether the variable exists or not. Cannot
+                                      be updated. More info: https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell'
                                     items:
                                       type: string
                                     type: array
@@ -3437,13 +4040,15 @@ spec:
                                           type: string
                                         value:
                                           description: 'Variable references $(VAR_NAME)
-                                            are expanded using the previous defined
+                                            are expanded using the previously defined
                                             environment variables in the container
                                             and any service environment variables.
                                             If a variable cannot be resolved, the
                                             reference in the input string will be
-                                            unchanged. The $(VAR_NAME) syntax can
-                                            be escaped with a double $$, ie: $$(VAR_NAME).
+                                            unchanged. Double $$ are reduced to a
+                                            single $, which allows for escaping the
+                                            $(VAR_NAME) syntax: i.e. "$$(VAR_NAME)"
+                                            will produce the string literal "$(VAR_NAME)".
                                             Escaped references will never be expanded,
                                             regardless of whether the variable exists
                                             or not. Defaults to "".'
@@ -3597,7 +4202,8 @@ spec:
                                       type: object
                                     type: array
                                   image:
-                                    description: 'Docker image name. More info: https://kubernetes.io/docs/concepts/containers/images
+                                    description: 'Container image name. More info:
+                                      https://kubernetes.io/docs/concepts/containers/images
                                       This field is optional to allow higher level
                                       config management to default or override container
                                       images in workload controllers like Deployments
@@ -3623,9 +4229,8 @@ spec:
                                           More info: https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/#container-hooks'
                                         properties:
                                           exec:
-                                            description: One and only one of the following
-                                              should be specified. Exec specifies
-                                              the action to take.
+                                            description: Exec specifies the action
+                                              to take.
                                             properties:
                                               command:
                                                 description: Command is the command
@@ -3696,10 +4301,12 @@ spec:
                                             - port
                                             type: object
                                           tcpSocket:
-                                            description: 'TCPSocket specifies an action
-                                              involving a TCP port. TCP hooks not
-                                              yet supported TODO: implement a realistic
-                                              TCP lifecycle hook'
+                                            description: Deprecated. TCPSocket is
+                                              NOT supported as a LifecycleHandler
+                                              and kept for the backward compatibility.
+                                              There are no validation of this field
+                                              and lifecycle hooks will fail in runtime
+                                              when tcp handler is specified.
                                             properties:
                                               host:
                                                 description: 'Optional: Host name
@@ -3726,21 +4333,19 @@ spec:
                                           as liveness/startup probe failure, preemption,
                                           resource contention, etc. The handler is
                                           not called if the container crashes or exits.
-                                          The reason for termination is passed to
-                                          the handler. The Pod''s termination grace
-                                          period countdown begins before the PreStop
-                                          hooked is executed. Regardless of the outcome
-                                          of the handler, the container will eventually
-                                          terminate within the Pod''s termination
-                                          grace period. Other management of the container
-                                          blocks until the hook completes or until
-                                          the termination grace period is reached.
-                                          More info: https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/#container-hooks'
+                                          The Pod''s termination grace period countdown
+                                          begins before the PreStop hook is executed.
+                                          Regardless of the outcome of the handler,
+                                          the container will eventually terminate
+                                          within the Pod''s termination grace period
+                                          (unless delayed by finalizers). Other management
+                                          of the container blocks until the hook completes
+                                          or until the termination grace period is
+                                          reached. More info: https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/#container-hooks'
                                         properties:
                                           exec:
-                                            description: One and only one of the following
-                                              should be specified. Exec specifies
-                                              the action to take.
+                                            description: Exec specifies the action
+                                              to take.
                                             properties:
                                               command:
                                                 description: Command is the command
@@ -3811,10 +4416,12 @@ spec:
                                             - port
                                             type: object
                                           tcpSocket:
-                                            description: 'TCPSocket specifies an action
-                                              involving a TCP port. TCP hooks not
-                                              yet supported TODO: implement a realistic
-                                              TCP lifecycle hook'
+                                            description: Deprecated. TCPSocket is
+                                              NOT supported as a LifecycleHandler
+                                              and kept for the backward compatibility.
+                                              There are no validation of this field
+                                              and lifecycle hooks will fail in runtime
+                                              when tcp handler is specified.
                                             properties:
                                               host:
                                                 description: 'Optional: Host name
@@ -3841,9 +4448,8 @@ spec:
                                       Cannot be updated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
                                     properties:
                                       exec:
-                                        description: One and only one of the following
-                                          should be specified. Exec specifies the
-                                          action to take.
+                                        description: Exec specifies the action to
+                                          take.
                                         properties:
                                           command:
                                             description: Command is the command line
@@ -3868,6 +4474,26 @@ spec:
                                           value is 1.
                                         format: int32
                                         type: integer
+                                      grpc:
+                                        description: GRPC specifies an action involving
+                                          a GRPC port. This is a beta field and requires
+                                          enabling GRPCContainerProbe feature gate.
+                                        properties:
+                                          port:
+                                            description: Port number of the gRPC service.
+                                              Number must be in the range 1 to 65535.
+                                            format: int32
+                                            type: integer
+                                          service:
+                                            description: "Service is the name of the
+                                              service to place in the gRPC HealthCheckRequest
+                                              (see https://github.com/grpc/grpc/blob/master/doc/health-checking.md).
+                                              \n If this is not specified, the default
+                                              behavior is defined by gRPC."
+                                            type: string
+                                        required:
+                                        - port
+                                        type: object
                                       httpGet:
                                         description: HTTPGet specifies the http request
                                           to perform.
@@ -3936,10 +4562,8 @@ spec:
                                         format: int32
                                         type: integer
                                       tcpSocket:
-                                        description: 'TCPSocket specifies an action
-                                          involving a TCP port. TCP hooks not yet
-                                          supported TODO: implement a realistic TCP
-                                          lifecycle hook'
+                                        description: TCPSocket specifies an action
+                                          involving a TCP port.
                                         properties:
                                           host:
                                             description: 'Optional: Host name to connect
@@ -3957,6 +4581,28 @@ spec:
                                         required:
                                         - port
                                         type: object
+                                      terminationGracePeriodSeconds:
+                                        description: Optional duration in seconds
+                                          the pod needs to terminate gracefully upon
+                                          probe failure. The grace period is the duration
+                                          in seconds after the processes running in
+                                          the pod are sent a termination signal and
+                                          the time when the processes are forcibly
+                                          halted with a kill signal. Set this value
+                                          longer than the expected cleanup time for
+                                          your process. If this value is nil, the
+                                          pod's terminationGracePeriodSeconds will
+                                          be used. Otherwise, this value overrides
+                                          the value provided by the pod spec. Value
+                                          must be non-negative integer. The value
+                                          zero indicates stop immediately via the
+                                          kill signal (no opportunity to shut down).
+                                          This is a beta field and requires enabling
+                                          ProbeTerminationGracePeriod feature gate.
+                                          Minimum value is 1. spec.terminationGracePeriodSeconds
+                                          is used if unset.
+                                        format: int64
+                                        type: integer
                                       timeoutSeconds:
                                         description: 'Number of seconds after which
                                           the probe times out. Defaults to 1 second.
@@ -4028,9 +4674,8 @@ spec:
                                       More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
                                     properties:
                                       exec:
-                                        description: One and only one of the following
-                                          should be specified. Exec specifies the
-                                          action to take.
+                                        description: Exec specifies the action to
+                                          take.
                                         properties:
                                           command:
                                             description: Command is the command line
@@ -4055,6 +4700,26 @@ spec:
                                           value is 1.
                                         format: int32
                                         type: integer
+                                      grpc:
+                                        description: GRPC specifies an action involving
+                                          a GRPC port. This is a beta field and requires
+                                          enabling GRPCContainerProbe feature gate.
+                                        properties:
+                                          port:
+                                            description: Port number of the gRPC service.
+                                              Number must be in the range 1 to 65535.
+                                            format: int32
+                                            type: integer
+                                          service:
+                                            description: "Service is the name of the
+                                              service to place in the gRPC HealthCheckRequest
+                                              (see https://github.com/grpc/grpc/blob/master/doc/health-checking.md).
+                                              \n If this is not specified, the default
+                                              behavior is defined by gRPC."
+                                            type: string
+                                        required:
+                                        - port
+                                        type: object
                                       httpGet:
                                         description: HTTPGet specifies the http request
                                           to perform.
@@ -4123,10 +4788,8 @@ spec:
                                         format: int32
                                         type: integer
                                       tcpSocket:
-                                        description: 'TCPSocket specifies an action
-                                          involving a TCP port. TCP hooks not yet
-                                          supported TODO: implement a realistic TCP
-                                          lifecycle hook'
+                                        description: TCPSocket specifies an action
+                                          involving a TCP port.
                                         properties:
                                           host:
                                             description: 'Optional: Host name to connect
@@ -4144,6 +4807,28 @@ spec:
                                         required:
                                         - port
                                         type: object
+                                      terminationGracePeriodSeconds:
+                                        description: Optional duration in seconds
+                                          the pod needs to terminate gracefully upon
+                                          probe failure. The grace period is the duration
+                                          in seconds after the processes running in
+                                          the pod are sent a termination signal and
+                                          the time when the processes are forcibly
+                                          halted with a kill signal. Set this value
+                                          longer than the expected cleanup time for
+                                          your process. If this value is nil, the
+                                          pod's terminationGracePeriodSeconds will
+                                          be used. Otherwise, this value overrides
+                                          the value provided by the pod spec. Value
+                                          must be non-negative integer. The value
+                                          zero indicates stop immediately via the
+                                          kill signal (no opportunity to shut down).
+                                          This is a beta field and requires enabling
+                                          ProbeTerminationGracePeriod feature gate.
+                                          Minimum value is 1. spec.terminationGracePeriodSeconds
+                                          is used if unset.
+                                        format: int64
+                                        type: integer
                                       timeoutSeconds:
                                         description: 'Number of seconds after which
                                           the probe times out. Defaults to 1 second.
@@ -4153,7 +4838,7 @@ spec:
                                     type: object
                                   resources:
                                     description: 'Compute Resources required by this
-                                      container. Cannot be updated. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
+                                      container. Cannot be updated. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
                                     properties:
                                       limits:
                                         additionalProperties:
@@ -4164,7 +4849,7 @@ spec:
                                           x-kubernetes-int-or-string: true
                                         description: 'Limits describes the maximum
                                           amount of compute resources allowed. More
-                                          info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
+                                          info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
                                         type: object
                                       requests:
                                         additionalProperties:
@@ -4178,12 +4863,14 @@ spec:
                                           Requests is omitted for a container, it
                                           defaults to Limits if that is explicitly
                                           specified, otherwise to an implementation-defined
-                                          value. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
+                                          value. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
                                         type: object
                                     type: object
                                   securityContext:
-                                    description: 'Security options the pod should
-                                      run with. More info: https://kubernetes.io/docs/concepts/policy/security-context/
+                                    description: 'SecurityContext defines the security
+                                      options the container should be run with. If
+                                      set, the fields of SecurityContext override
+                                      the equivalent fields of PodSecurityContext.
                                       More info: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/'
                                     properties:
                                       allowPrivilegeEscalation:
@@ -4193,13 +4880,16 @@ spec:
                                           controls if the no_new_privs flag will be
                                           set on the container process. AllowPrivilegeEscalation
                                           is true always when the container is: 1)
-                                          run as Privileged 2) has CAP_SYS_ADMIN'
+                                          run as Privileged 2) has CAP_SYS_ADMIN Note
+                                          that this field cannot be set when spec.os.name
+                                          is windows.'
                                         type: boolean
                                       capabilities:
                                         description: The capabilities to add/drop
                                           when running containers. Defaults to the
                                           default set of capabilities granted by the
-                                          container runtime.
+                                          container runtime. Note that this field
+                                          cannot be set when spec.os.name is windows.
                                         properties:
                                           add:
                                             description: Added capabilities
@@ -4220,7 +4910,8 @@ spec:
                                         description: Run container in privileged mode.
                                           Processes in privileged containers are essentially
                                           equivalent to root on the host. Defaults
-                                          to false.
+                                          to false. Note that this field cannot be
+                                          set when spec.os.name is windows.
                                         type: boolean
                                       procMount:
                                         description: procMount denotes the type of
@@ -4229,10 +4920,14 @@ spec:
                                           container runtime defaults for readonly
                                           paths and masked paths. This requires the
                                           ProcMountType feature flag to be enabled.
+                                          Note that this field cannot be set when
+                                          spec.os.name is windows.
                                         type: string
                                       readOnlyRootFilesystem:
                                         description: Whether this container has a
                                           read-only root filesystem. Default is false.
+                                          Note that this field cannot be set when
+                                          spec.os.name is windows.
                                         type: boolean
                                       runAsGroup:
                                         description: The GID to run the entrypoint
@@ -4240,7 +4935,8 @@ spec:
                                           if unset. May also be set in PodSecurityContext.  If
                                           set in both SecurityContext and PodSecurityContext,
                                           the value specified in SecurityContext takes
-                                          precedence.
+                                          precedence. Note that this field cannot
+                                          be set when spec.os.name is windows.
                                         format: int64
                                         type: integer
                                       runAsNonRoot:
@@ -4262,7 +4958,8 @@ spec:
                                           May also be set in PodSecurityContext.  If
                                           set in both SecurityContext and PodSecurityContext,
                                           the value specified in SecurityContext takes
-                                          precedence.
+                                          precedence. Note that this field cannot
+                                          be set when spec.os.name is windows.
                                         format: int64
                                         type: integer
                                       seLinuxOptions:
@@ -4272,7 +4969,9 @@ spec:
                                           for each container.  May also be set in
                                           PodSecurityContext.  If set in both SecurityContext
                                           and PodSecurityContext, the value specified
-                                          in SecurityContext takes precedence.
+                                          in SecurityContext takes precedence. Note
+                                          that this field cannot be set when spec.os.name
+                                          is windows.
                                         properties:
                                           level:
                                             description: Level is SELinux level label
@@ -4295,7 +4994,9 @@ spec:
                                         description: The seccomp options to use by
                                           this container. If seccomp options are provided
                                           at both the pod & container level, the container
-                                          options override the pod options.
+                                          options override the pod options. Note that
+                                          this field cannot be set when spec.os.name
+                                          is windows.
                                         properties:
                                           localhostProfile:
                                             description: localhostProfile indicates
@@ -4326,7 +5027,9 @@ spec:
                                           the options from the PodSecurityContext
                                           will be used. If set in both SecurityContext
                                           and PodSecurityContext, the value specified
-                                          in SecurityContext takes precedence.
+                                          in SecurityContext takes precedence. Note
+                                          that this field cannot be set when spec.os.name
+                                          is linux.
                                         properties:
                                           gmsaCredentialSpec:
                                             description: GMSACredentialSpec is where
@@ -4340,6 +5043,22 @@ spec:
                                               the name of the GMSA credential spec
                                               to use.
                                             type: string
+                                          hostProcess:
+                                            description: HostProcess determines if
+                                              a container should be run as a 'Host
+                                              Process' container. This field is alpha-level
+                                              and will only be honored by components
+                                              that enable the WindowsHostProcessContainers
+                                              feature flag. Setting this field without
+                                              the feature flag will result in errors
+                                              when validating the Pod. All of a Pod's
+                                              containers must have the same effective
+                                              HostProcess value (it is not allowed
+                                              to have a mix of HostProcess containers
+                                              and non-HostProcess containers).  In
+                                              addition, if HostProcess is true then
+                                              HostNetwork must also be set to true.
+                                            type: boolean
                                           runAsUserName:
                                             description: The UserName in Windows to
                                               run the entrypoint of the container
@@ -4362,14 +5081,11 @@ spec:
                                       parameters at the beginning of a Pod''s lifecycle,
                                       when it might take a long time to load data
                                       or warm a cache, than during steady-state operation.
-                                      This cannot be updated. This is a beta feature
-                                      enabled by the StartupProbe feature flag. More
-                                      info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                                      This cannot be updated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
                                     properties:
                                       exec:
-                                        description: One and only one of the following
-                                          should be specified. Exec specifies the
-                                          action to take.
+                                        description: Exec specifies the action to
+                                          take.
                                         properties:
                                           command:
                                             description: Command is the command line
@@ -4394,6 +5110,26 @@ spec:
                                           value is 1.
                                         format: int32
                                         type: integer
+                                      grpc:
+                                        description: GRPC specifies an action involving
+                                          a GRPC port. This is a beta field and requires
+                                          enabling GRPCContainerProbe feature gate.
+                                        properties:
+                                          port:
+                                            description: Port number of the gRPC service.
+                                              Number must be in the range 1 to 65535.
+                                            format: int32
+                                            type: integer
+                                          service:
+                                            description: "Service is the name of the
+                                              service to place in the gRPC HealthCheckRequest
+                                              (see https://github.com/grpc/grpc/blob/master/doc/health-checking.md).
+                                              \n If this is not specified, the default
+                                              behavior is defined by gRPC."
+                                            type: string
+                                        required:
+                                        - port
+                                        type: object
                                       httpGet:
                                         description: HTTPGet specifies the http request
                                           to perform.
@@ -4462,10 +5198,8 @@ spec:
                                         format: int32
                                         type: integer
                                       tcpSocket:
-                                        description: 'TCPSocket specifies an action
-                                          involving a TCP port. TCP hooks not yet
-                                          supported TODO: implement a realistic TCP
-                                          lifecycle hook'
+                                        description: TCPSocket specifies an action
+                                          involving a TCP port.
                                         properties:
                                           host:
                                             description: 'Optional: Host name to connect
@@ -4483,6 +5217,28 @@ spec:
                                         required:
                                         - port
                                         type: object
+                                      terminationGracePeriodSeconds:
+                                        description: Optional duration in seconds
+                                          the pod needs to terminate gracefully upon
+                                          probe failure. The grace period is the duration
+                                          in seconds after the processes running in
+                                          the pod are sent a termination signal and
+                                          the time when the processes are forcibly
+                                          halted with a kill signal. Set this value
+                                          longer than the expected cleanup time for
+                                          your process. If this value is nil, the
+                                          pod's terminationGracePeriodSeconds will
+                                          be used. Otherwise, this value overrides
+                                          the value provided by the pod spec. Value
+                                          must be non-negative integer. The value
+                                          zero indicates stop immediately via the
+                                          kill signal (no opportunity to shut down).
+                                          This is a beta field and requires enabling
+                                          ProbeTerminationGracePeriod feature gate.
+                                          Minimum value is 1. spec.terminationGracePeriodSeconds
+                                          is used if unset.
+                                        format: int64
+                                        type: integer
                                       timeoutSeconds:
                                         description: 'Number of seconds after which
                                           the probe times out. Defaults to 1 second.
@@ -4632,6 +5388,40 @@ spec:
                                 must match a node''s labels for the pod to be scheduled
                                 on that node. More info: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/'
                               type: object
+                              x-kubernetes-map-type: atomic
+                            os:
+                              description: "Specifies the OS of the containers in
+                                the pod. Some pod and container fields are restricted
+                                if this is set. \n If the OS field is set to linux,
+                                the following fields must be unset: -securityContext.windowsOptions
+                                \n If the OS field is set to windows, following fields
+                                must be unset: - spec.hostPID - spec.hostIPC - spec.securityContext.seLinuxOptions
+                                - spec.securityContext.seccompProfile - spec.securityContext.fsGroup
+                                - spec.securityContext.fsGroupChangePolicy - spec.securityContext.sysctls
+                                - spec.shareProcessNamespace - spec.securityContext.runAsUser
+                                - spec.securityContext.runAsGroup - spec.securityContext.supplementalGroups
+                                - spec.containers[*].securityContext.seLinuxOptions
+                                - spec.containers[*].securityContext.seccompProfile
+                                - spec.containers[*].securityContext.capabilities
+                                - spec.containers[*].securityContext.readOnlyRootFilesystem
+                                - spec.containers[*].securityContext.privileged -
+                                spec.containers[*].securityContext.allowPrivilegeEscalation
+                                - spec.containers[*].securityContext.procMount - spec.containers[*].securityContext.runAsUser
+                                - spec.containers[*].securityContext.runAsGroup This
+                                is a beta field and requires the IdentifyPodOS feature"
+                              properties:
+                                name:
+                                  description: 'Name is the name of the operating
+                                    system. The currently supported values are linux
+                                    and windows. Additional value may be defined in
+                                    future and can be one of: https://github.com/opencontainers/runtime-spec/blob/master/config.md#platform-specific-configuration
+                                    Clients should expect to handle additional values
+                                    and treat unrecognized values in this field as
+                                    os: null'
+                                  type: string
+                              required:
+                              - name
+                              type: object
                             overhead:
                               additionalProperties:
                                 anyOf:
@@ -4650,17 +5440,12 @@ spec:
                                 and selected in the PodSpec, Overhead will be set
                                 to the value defined in the corresponding RuntimeClass,
                                 otherwise it will remain unset and treated as zero.
-                                More info: https://git.k8s.io/enhancements/keps/sig-node/20190226-pod-overhead.md
-                                This field is alpha-level as of Kubernetes v1.16,
-                                and is only honored by servers that enable the PodOverhead
-                                feature.'
+                                More info: https://git.k8s.io/enhancements/keps/sig-node/688-pod-overhead/README.md'
                               type: object
                             preemptionPolicy:
                               description: PreemptionPolicy is the Policy for preempting
                                 pods with lower priority. One of Never, PreemptLowerPriority.
-                                Defaults to PreemptLowerPriority if unset. This field
-                                is beta-level, gated by the NonPreemptingPriority
-                                feature-gate.
+                                Defaults to PreemptLowerPriority if unset.
                               type: string
                             priority:
                               description: The priority value. Various system components
@@ -4685,7 +5470,7 @@ spec:
                                 be evaluated for pod readiness. A pod is ready when
                                 all its containers are ready AND all conditions specified
                                 in the readiness gates have status equal to "True"
-                                More info: https://git.k8s.io/enhancements/keps/sig-network/0007-pod-ready%2B%2B.md'
+                                More info: https://git.k8s.io/enhancements/keps/sig-network/580-pod-readiness-gates'
                               items:
                                 description: PodReadinessGate contains the reference
                                   to a pod condition
@@ -4711,8 +5496,7 @@ spec:
                                 or empty, the "legacy" RuntimeClass will be used,
                                 which is an implicit class with an empty definition
                                 that uses the default runtime handler. More info:
-                                https://git.k8s.io/enhancements/keps/sig-node/runtime-class.md
-                                This is a beta feature as of Kubernetes v1.14.'
+                                https://git.k8s.io/enhancements/keps/sig-node/585-runtime-class'
                               type: string
                             schedulerName:
                               description: If specified, the pod will be dispatched
@@ -4734,7 +5518,9 @@ spec:
                                     is set (new files created in the volume will be
                                     owned by FSGroup) 3. The permission bits are OR'd
                                     with rw-rw---- \n If unset, the Kubelet will not
-                                    modify the ownership and permissions of any volume."
+                                    modify the ownership and permissions of any volume.
+                                    Note that this field cannot be set when spec.os.name
+                                    is windows."
                                   format: int64
                                   type: integer
                                 fsGroupChangePolicy:
@@ -4745,7 +5531,9 @@ spec:
                                     based ownership(and permissions). It will have
                                     no effect on ephemeral volume types such as: secret,
                                     configmaps and emptydir. Valid values are "OnRootMismatch"
-                                    and "Always". If not specified defaults to "Always".'
+                                    and "Always". If not specified, "Always" is used.
+                                    Note that this field cannot be set when spec.os.name
+                                    is windows.'
                                   type: string
                                 runAsGroup:
                                   description: The GID to run the entrypoint of the
@@ -4753,7 +5541,8 @@ spec:
                                     May also be set in SecurityContext.  If set in
                                     both SecurityContext and PodSecurityContext, the
                                     value specified in SecurityContext takes precedence
-                                    for that container.
+                                    for that container. Note that this field cannot
+                                    be set when spec.os.name is windows.
                                   format: int64
                                   type: integer
                                 runAsNonRoot:
@@ -4774,6 +5563,8 @@ spec:
                                     set in SecurityContext.  If set in both SecurityContext
                                     and PodSecurityContext, the value specified in
                                     SecurityContext takes precedence for that container.
+                                    Note that this field cannot be set when spec.os.name
+                                    is windows.
                                   format: int64
                                   type: integer
                                 seLinuxOptions:
@@ -4783,7 +5574,8 @@ spec:
                                     for each container.  May also be set in SecurityContext.  If
                                     set in both SecurityContext and PodSecurityContext,
                                     the value specified in SecurityContext takes precedence
-                                    for that container.
+                                    for that container. Note that this field cannot
+                                    be set when spec.os.name is windows.
                                   properties:
                                     level:
                                       description: Level is SELinux level label that
@@ -4804,7 +5596,8 @@ spec:
                                   type: object
                                 seccompProfile:
                                   description: The seccomp options to use by the containers
-                                    in this pod.
+                                    in this pod. Note that this field cannot be set
+                                    when spec.os.name is windows.
                                   properties:
                                     localhostProfile:
                                       description: localhostProfile indicates a profile
@@ -4830,7 +5623,9 @@ spec:
                                   description: A list of groups applied to the first
                                     process run in each container, in addition to
                                     the container's primary GID.  If unspecified,
-                                    no groups will be added to any container.
+                                    no groups will be added to any container. Note
+                                    that this field cannot be set when spec.os.name
+                                    is windows.
                                   items:
                                     format: int64
                                     type: integer
@@ -4839,6 +5634,8 @@ spec:
                                   description: Sysctls hold a list of namespaced sysctls
                                     used for the pod. Pods with unsupported sysctls
                                     (by the container runtime) might fail to launch.
+                                    Note that this field cannot be set when spec.os.name
+                                    is windows.
                                   items:
                                     description: Sysctl defines a kernel parameter
                                       to be set
@@ -4860,6 +5657,8 @@ spec:
                                     within a container's SecurityContext will be used.
                                     If set in both SecurityContext and PodSecurityContext,
                                     the value specified in SecurityContext takes precedence.
+                                    Note that this field cannot be set when spec.os.name
+                                    is linux.
                                   properties:
                                     gmsaCredentialSpec:
                                       description: GMSACredentialSpec is where the
@@ -4871,6 +5670,20 @@ spec:
                                       description: GMSACredentialSpecName is the name
                                         of the GMSA credential spec to use.
                                       type: string
+                                    hostProcess:
+                                      description: HostProcess determines if a container
+                                        should be run as a 'Host Process' container.
+                                        This field is alpha-level and will only be
+                                        honored by components that enable the WindowsHostProcessContainers
+                                        feature flag. Setting this field without the
+                                        feature flag will result in errors when validating
+                                        the Pod. All of a Pod's containers must have
+                                        the same effective HostProcess value (it is
+                                        not allowed to have a mix of HostProcess containers
+                                        and non-HostProcess containers).  In addition,
+                                        if HostProcess is true then HostNetwork must
+                                        also be set to true.
+                                      type: boolean
                                     runAsUserName:
                                       description: The UserName in Windows to run
                                         the entrypoint of the container process. Defaults
@@ -4922,10 +5735,11 @@ spec:
                               description: Optional duration in seconds the pod needs
                                 to terminate gracefully. May be decreased in delete
                                 request. Value must be non-negative integer. The value
-                                zero indicates delete immediately. If this value is
-                                nil, the default grace period will be used instead.
-                                The grace period is the duration in seconds after
-                                the processes running in the pod are sent a termination
+                                zero indicates stop immediately via the kill signal
+                                (no opportunity to shut down). If this value is nil,
+                                the default grace period will be used instead. The
+                                grace period is the duration in seconds after the
+                                processes running in the pod are sent a termination
                                 signal and the time when the processes are forcibly
                                 halted with a kill signal. Set this value longer than
                                 the expected cleanup time for your process. Defaults
@@ -5045,19 +5859,53 @@ spec:
                                       `whenUnsatisfiable=DoNotSchedule`, it is the
                                       maximum permitted difference between the number
                                       of matching pods in the target topology and
-                                      the global minimum. For example, in a 3-zone
+                                      the global minimum. The global minimum is the
+                                      minimum number of matching pods in an eligible
+                                      domain or zero if the number of eligible domains
+                                      is less than MinDomains. For example, in a 3-zone
                                       cluster, MaxSkew is set to 1, and pods with
-                                      the same labelSelector spread as 1/1/0: | zone1
-                                      | zone2 | zone3 | |   P   |   P   |       |
-                                      - if MaxSkew is 1, incoming pod can only be
-                                      scheduled to zone3 to become 1/1/1; scheduling
-                                      it onto zone1(zone2) would make the ActualSkew(2-0)
-                                      on zone1(zone2) violate MaxSkew(1). - if MaxSkew
-                                      is 2, incoming pod can be scheduled onto any
-                                      zone. When `whenUnsatisfiable=ScheduleAnyway`,
+                                      the same labelSelector spread as 2/2/1: In this
+                                      case, the global minimum is 1. | zone1 | zone2
+                                      | zone3 | |  P P  |  P P  |   P   | - if MaxSkew
+                                      is 1, incoming pod can only be scheduled to
+                                      zone3 to become 2/2/2; scheduling it onto zone1(zone2)
+                                      would make the ActualSkew(3-1) on zone1(zone2)
+                                      violate MaxSkew(1). - if MaxSkew is 2, incoming
+                                      pod can be scheduled onto any zone. When `whenUnsatisfiable=ScheduleAnyway`,
                                       it is used to give higher precedence to topologies
                                       that satisfy it. It''s a required field. Default
                                       value is 1 and 0 is not allowed.'
+                                    format: int32
+                                    type: integer
+                                  minDomains:
+                                    description: "MinDomains indicates a minimum number
+                                      of eligible domains. When the number of eligible
+                                      domains with matching topology keys is less
+                                      than minDomains, Pod Topology Spread treats
+                                      \"global minimum\" as 0, and then the calculation
+                                      of Skew is performed. And when the number of
+                                      eligible domains with matching topology keys
+                                      equals or greater than minDomains, this value
+                                      has no effect on scheduling. As a result, when
+                                      the number of eligible domains is less than
+                                      minDomains, scheduler won't schedule more than
+                                      maxSkew Pods to those domains. If value is nil,
+                                      the constraint behaves as if MinDomains is equal
+                                      to 1. Valid values are integers greater than
+                                      0. When value is not nil, WhenUnsatisfiable
+                                      must be DoNotSchedule. \n For example, in a
+                                      3-zone cluster, MaxSkew is set to 2, MinDomains
+                                      is set to 5 and pods with the same labelSelector
+                                      spread as 2/2/2: | zone1 | zone2 | zone3 | |
+                                      \ P P  |  P P  |  P P  | The number of domains
+                                      is less than 5(MinDomains), so \"global minimum\"
+                                      is treated as 0. In this situation, new pod
+                                      with the same labelSelector cannot be scheduled,
+                                      because computed skew will be 3(3 - 0) if new
+                                      Pod is scheduled to any of the three zones,
+                                      it will violate MaxSkew. \n This is an alpha
+                                      field and requires enabling MinDomainsInPodTopologySpread
+                                      feature gate."
                                     format: int32
                                     type: integer
                                   topologyKey:
@@ -5066,7 +5914,14 @@ spec:
                                       values are considered to be in the same topology.
                                       We consider each <key, value> as a "bucket",
                                       and try to put balanced number of pods into
-                                      each bucket. It's a required field.
+                                      each bucket. We define a domain as a particular
+                                      instance of a topology. Also, we define an eligible
+                                      domain as a domain whose nodes match the node
+                                      selector. e.g. If TopologyKey is "kubernetes.io/hostname",
+                                      each Node is a domain of that topology. And,
+                                      if TopologyKey is "topology.kubernetes.io/zone",
+                                      each zone is a domain of that topology. It's
+                                      a required field.
                                     type: string
                                   whenUnsatisfiable:
                                     description: 'WhenUnsatisfiable indicates how
@@ -5078,7 +5933,7 @@ spec:
                                       topologies that would help reduce the   skew.
                                       A constraint is considered "Unsatisfiable" for
                                       an incoming pod if and only if every possible
-                                      node assigment for that pod would violate "MaxSkew"
+                                      node assignment for that pod would violate "MaxSkew"
                                       on some topology. For example, in a 3-zone cluster,
                                       MaxSkew is set to 1, and pods with the same
                                       labelSelector spread as 3/1/1: | zone1 | zone2
@@ -5109,77 +5964,78 @@ spec:
                                   pod.
                                 properties:
                                   awsElasticBlockStore:
-                                    description: 'AWSElasticBlockStore represents
+                                    description: 'awsElasticBlockStore represents
                                       an AWS Disk resource that is attached to a kubelet''s
                                       host machine and then exposed to the pod. More
                                       info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore'
                                     properties:
                                       fsType:
-                                        description: 'Filesystem type of the volume
-                                          that you want to mount. Tip: Ensure that
-                                          the filesystem type is supported by the
-                                          host operating system. Examples: "ext4",
-                                          "xfs", "ntfs". Implicitly inferred to be
-                                          "ext4" if unspecified. More info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore
+                                        description: 'fsType is the filesystem type
+                                          of the volume that you want to mount. Tip:
+                                          Ensure that the filesystem type is supported
+                                          by the host operating system. Examples:
+                                          "ext4", "xfs", "ntfs". Implicitly inferred
+                                          to be "ext4" if unspecified. More info:
+                                          https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore
                                           TODO: how do we prevent errors in the filesystem
                                           from compromising the machine'
                                         type: string
                                       partition:
-                                        description: 'The partition in the volume
-                                          that you want to mount. If omitted, the
-                                          default is to mount by volume name. Examples:
-                                          For volume /dev/sda1, you specify the partition
-                                          as "1". Similarly, the volume partition
-                                          for /dev/sda is "0" (or you can leave the
-                                          property empty).'
+                                        description: 'partition is the partition in
+                                          the volume that you want to mount. If omitted,
+                                          the default is to mount by volume name.
+                                          Examples: For volume /dev/sda1, you specify
+                                          the partition as "1". Similarly, the volume
+                                          partition for /dev/sda is "0" (or you can
+                                          leave the property empty).'
                                         format: int32
                                         type: integer
                                       readOnly:
-                                        description: 'Specify "true" to force and
-                                          set the ReadOnly property in VolumeMounts
-                                          to "true". If omitted, the default is "false".
-                                          More info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore'
+                                        description: 'readOnly value true will force
+                                          the readOnly setting in VolumeMounts. More
+                                          info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore'
                                         type: boolean
                                       volumeID:
-                                        description: 'Unique ID of the persistent
-                                          disk resource in AWS (Amazon EBS volume).
-                                          More info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore'
+                                        description: 'volumeID is unique ID of the
+                                          persistent disk resource in AWS (Amazon
+                                          EBS volume). More info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore'
                                         type: string
                                     required:
                                     - volumeID
                                     type: object
                                   azureDisk:
-                                    description: AzureDisk represents an Azure Data
+                                    description: azureDisk represents an Azure Data
                                       Disk mount on the host and bind mount to the
                                       pod.
                                     properties:
                                       cachingMode:
-                                        description: 'Host Caching mode: None, Read
-                                          Only, Read Write.'
+                                        description: 'cachingMode is the Host Caching
+                                          mode: None, Read Only, Read Write.'
                                         type: string
                                       diskName:
-                                        description: The Name of the data disk in
-                                          the blob storage
+                                        description: diskName is the Name of the data
+                                          disk in the blob storage
                                         type: string
                                       diskURI:
-                                        description: The URI the data disk in the
-                                          blob storage
+                                        description: diskURI is the URI of data disk
+                                          in the blob storage
                                         type: string
                                       fsType:
-                                        description: Filesystem type to mount. Must
-                                          be a filesystem type supported by the host
-                                          operating system. Ex. "ext4", "xfs", "ntfs".
-                                          Implicitly inferred to be "ext4" if unspecified.
+                                        description: fsType is Filesystem type to
+                                          mount. Must be a filesystem type supported
+                                          by the host operating system. Ex. "ext4",
+                                          "xfs", "ntfs". Implicitly inferred to be
+                                          "ext4" if unspecified.
                                         type: string
                                       kind:
-                                        description: 'Expected values Shared: multiple
-                                          blob disks per storage account  Dedicated:
+                                        description: 'kind expected values are Shared:
+                                          multiple blob disks per storage account  Dedicated:
                                           single blob disk per storage account  Managed:
                                           azure managed data disk (only in managed
                                           availability set). defaults to shared'
                                         type: string
                                       readOnly:
-                                        description: Defaults to false (read/write).
+                                        description: readOnly Defaults to false (read/write).
                                           ReadOnly here will force the ReadOnly setting
                                           in VolumeMounts.
                                         type: boolean
@@ -5188,56 +6044,59 @@ spec:
                                     - diskURI
                                     type: object
                                   azureFile:
-                                    description: AzureFile represents an Azure File
+                                    description: azureFile represents an Azure File
                                       Service mount on the host and bind mount to
                                       the pod.
                                     properties:
                                       readOnly:
-                                        description: Defaults to false (read/write).
+                                        description: readOnly defaults to false (read/write).
                                           ReadOnly here will force the ReadOnly setting
                                           in VolumeMounts.
                                         type: boolean
                                       secretName:
-                                        description: the name of secret that contains
-                                          Azure Storage Account Name and Key
+                                        description: secretName is the  name of secret
+                                          that contains Azure Storage Account Name
+                                          and Key
                                         type: string
                                       shareName:
-                                        description: Share Name
+                                        description: shareName is the azure share
+                                          Name
                                         type: string
                                     required:
                                     - secretName
                                     - shareName
                                     type: object
                                   cephfs:
-                                    description: CephFS represents a Ceph FS mount
+                                    description: cephFS represents a Ceph FS mount
                                       on the host that shares a pod's lifetime
                                     properties:
                                       monitors:
-                                        description: 'Required: Monitors is a collection
-                                          of Ceph monitors More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it'
+                                        description: 'monitors is Required: Monitors
+                                          is a collection of Ceph monitors More info:
+                                          https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it'
                                         items:
                                           type: string
                                         type: array
                                       path:
-                                        description: 'Optional: Used as the mounted
-                                          root, rather than the full Ceph tree, default
-                                          is /'
+                                        description: 'path is Optional: Used as the
+                                          mounted root, rather than the full Ceph
+                                          tree, default is /'
                                         type: string
                                       readOnly:
-                                        description: 'Optional: Defaults to false
-                                          (read/write). ReadOnly here will force the
-                                          ReadOnly setting in VolumeMounts. More info:
-                                          https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it'
+                                        description: 'readOnly is Optional: Defaults
+                                          to false (read/write). ReadOnly here will
+                                          force the ReadOnly setting in VolumeMounts.
+                                          More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it'
                                         type: boolean
                                       secretFile:
-                                        description: 'Optional: SecretFile is the
-                                          path to key ring for User, default is /etc/ceph/user.secret
-                                          More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it'
+                                        description: 'secretFile is Optional: SecretFile
+                                          is the path to key ring for User, default
+                                          is /etc/ceph/user.secret More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it'
                                         type: string
                                       secretRef:
-                                        description: 'Optional: SecretRef is reference
-                                          to the authentication secret for User, default
-                                          is empty. More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it'
+                                        description: 'secretRef is Optional: SecretRef
+                                          is reference to the authentication secret
+                                          for User, default is empty. More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it'
                                         properties:
                                           name:
                                             description: 'Name of the referent. More
@@ -5247,34 +6106,35 @@ spec:
                                             type: string
                                         type: object
                                       user:
-                                        description: 'Optional: User is the rados
-                                          user name, default is admin More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it'
+                                        description: 'user is optional: User is the
+                                          rados user name, default is admin More info:
+                                          https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it'
                                         type: string
                                     required:
                                     - monitors
                                     type: object
                                   cinder:
-                                    description: 'Cinder represents a cinder volume
+                                    description: 'cinder represents a cinder volume
                                       attached and mounted on kubelets host machine.
                                       More info: https://examples.k8s.io/mysql-cinder-pd/README.md'
                                     properties:
                                       fsType:
-                                        description: 'Filesystem type to mount. Must
-                                          be a filesystem type supported by the host
-                                          operating system. Examples: "ext4", "xfs",
-                                          "ntfs". Implicitly inferred to be "ext4"
-                                          if unspecified. More info: https://examples.k8s.io/mysql-cinder-pd/README.md'
+                                        description: 'fsType is the filesystem type
+                                          to mount. Must be a filesystem type supported
+                                          by the host operating system. Examples:
+                                          "ext4", "xfs", "ntfs". Implicitly inferred
+                                          to be "ext4" if unspecified. More info:
+                                          https://examples.k8s.io/mysql-cinder-pd/README.md'
                                         type: string
                                       readOnly:
-                                        description: 'Optional: Defaults to false
-                                          (read/write). ReadOnly here will force the
-                                          ReadOnly setting in VolumeMounts. More info:
-                                          https://examples.k8s.io/mysql-cinder-pd/README.md'
+                                        description: 'readOnly defaults to false (read/write).
+                                          ReadOnly here will force the ReadOnly setting
+                                          in VolumeMounts. More info: https://examples.k8s.io/mysql-cinder-pd/README.md'
                                         type: boolean
                                       secretRef:
-                                        description: 'Optional: points to a secret
-                                          object containing parameters used to connect
-                                          to OpenStack.'
+                                        description: 'secretRef is optional: points
+                                          to a secret object containing parameters
+                                          used to connect to OpenStack.'
                                         properties:
                                           name:
                                             description: 'Name of the referent. More
@@ -5284,32 +6144,33 @@ spec:
                                             type: string
                                         type: object
                                       volumeID:
-                                        description: 'volume id used to identify the
+                                        description: 'volumeID used to identify the
                                           volume in cinder. More info: https://examples.k8s.io/mysql-cinder-pd/README.md'
                                         type: string
                                     required:
                                     - volumeID
                                     type: object
                                   configMap:
-                                    description: ConfigMap represents a configMap
+                                    description: configMap represents a configMap
                                       that should populate this volume
                                     properties:
                                       defaultMode:
-                                        description: 'Optional: mode bits used to
-                                          set permissions on created files by default.
-                                          Must be an octal value between 0000 and
-                                          0777 or a decimal value between 0 and 511.
-                                          YAML accepts both octal and decimal values,
-                                          JSON requires decimal values for mode bits.
-                                          Defaults to 0644. Directories within the
-                                          path are not affected by this setting. This
-                                          might be in conflict with other options
-                                          that affect the file mode, like fsGroup,
-                                          and the result can be other mode bits set.'
+                                        description: 'defaultMode is optional: mode
+                                          bits used to set permissions on created
+                                          files by default. Must be an octal value
+                                          between 0000 and 0777 or a decimal value
+                                          between 0 and 511. YAML accepts both octal
+                                          and decimal values, JSON requires decimal
+                                          values for mode bits. Defaults to 0644.
+                                          Directories within the path are not affected
+                                          by this setting. This might be in conflict
+                                          with other options that affect the file
+                                          mode, like fsGroup, and the result can be
+                                          other mode bits set.'
                                         format: int32
                                         type: integer
                                       items:
-                                        description: If unspecified, each key-value
+                                        description: items if unspecified, each key-value
                                           pair in the Data field of the referenced
                                           ConfigMap will be projected into the volume
                                           as a file whose name is the key and content
@@ -5326,27 +6187,27 @@ spec:
                                             within a volume.
                                           properties:
                                             key:
-                                              description: The key to project.
+                                              description: key is the key to project.
                                               type: string
                                             mode:
-                                              description: 'Optional: mode bits used
-                                                to set permissions on this file. Must
-                                                be an octal value between 0000 and
-                                                0777 or a decimal value between 0
-                                                and 511. YAML accepts both octal and
-                                                decimal values, JSON requires decimal
-                                                values for mode bits. If not specified,
-                                                the volume defaultMode will be used.
-                                                This might be in conflict with other
-                                                options that affect the file mode,
-                                                like fsGroup, and the result can be
-                                                other mode bits set.'
+                                              description: 'mode is Optional: mode
+                                                bits used to set permissions on this
+                                                file. Must be an octal value between
+                                                0000 and 0777 or a decimal value between
+                                                0 and 511. YAML accepts both octal
+                                                and decimal values, JSON requires
+                                                decimal values for mode bits. If not
+                                                specified, the volume defaultMode
+                                                will be used. This might be in conflict
+                                                with other options that affect the
+                                                file mode, like fsGroup, and the result
+                                                can be other mode bits set.'
                                               format: int32
                                               type: integer
                                             path:
-                                              description: The relative path of the
-                                                file to map the key to. May not be
-                                                an absolute path. May not contain
+                                              description: path is the relative path
+                                                of the file to map the key to. May
+                                                not be an absolute path. May not contain
                                                 the path element '..'. May not start
                                                 with the string '..'.
                                               type: string
@@ -5362,30 +6223,30 @@ spec:
                                           kind, uid?'
                                         type: string
                                       optional:
-                                        description: Specify whether the ConfigMap
-                                          or its keys must be defined
+                                        description: optional specify whether the
+                                          ConfigMap or its keys must be defined
                                         type: boolean
                                     type: object
                                   csi:
-                                    description: CSI (Container Storage Interface)
+                                    description: csi (Container Storage Interface)
                                       represents ephemeral storage that is handled
                                       by certain external CSI drivers (Beta feature).
                                     properties:
                                       driver:
-                                        description: Driver is the name of the CSI
+                                        description: driver is the name of the CSI
                                           driver that handles this volume. Consult
                                           with your admin for the correct name as
                                           registered in the cluster.
                                         type: string
                                       fsType:
-                                        description: Filesystem type to mount. Ex.
-                                          "ext4", "xfs", "ntfs". If not provided,
-                                          the empty value is passed to the associated
-                                          CSI driver which will determine the default
-                                          filesystem to apply.
+                                        description: fsType to mount. Ex. "ext4",
+                                          "xfs", "ntfs". If not provided, the empty
+                                          value is passed to the associated CSI driver
+                                          which will determine the default filesystem
+                                          to apply.
                                         type: string
                                       nodePublishSecretRef:
-                                        description: NodePublishSecretRef is a reference
+                                        description: nodePublishSecretRef is a reference
                                           to the secret object containing sensitive
                                           information to pass to the CSI driver to
                                           complete the CSI NodePublishVolume and NodeUnpublishVolume
@@ -5402,13 +6263,14 @@ spec:
                                             type: string
                                         type: object
                                       readOnly:
-                                        description: Specifies a read-only configuration
-                                          for the volume. Defaults to false (read/write).
+                                        description: readOnly specifies a read-only
+                                          configuration for the volume. Defaults to
+                                          false (read/write).
                                         type: boolean
                                       volumeAttributes:
                                         additionalProperties:
                                           type: string
-                                        description: VolumeAttributes stores driver-specific
+                                        description: volumeAttributes stores driver-specific
                                           properties that are passed to the CSI driver.
                                           Consult your driver's documentation for
                                           supported values.
@@ -5417,7 +6279,7 @@ spec:
                                     - driver
                                     type: object
                                   downwardAPI:
-                                    description: DownwardAPI represents downward API
+                                    description: downwardAPI represents downward API
                                       about the pod that should populate this volume
                                     properties:
                                       defaultMode:
@@ -5518,62 +6380,59 @@ spec:
                                         type: array
                                     type: object
                                   emptyDir:
-                                    description: 'EmptyDir represents a temporary
+                                    description: 'emptyDir represents a temporary
                                       directory that shares a pod''s lifetime. More
                                       info: https://kubernetes.io/docs/concepts/storage/volumes#emptydir'
                                     properties:
                                       medium:
-                                        description: 'What type of storage medium
-                                          should back this directory. The default
-                                          is "" which means to use the node''s default
-                                          medium. Must be an empty string (default)
-                                          or Memory. More info: https://kubernetes.io/docs/concepts/storage/volumes#emptydir'
+                                        description: 'medium represents what type
+                                          of storage medium should back this directory.
+                                          The default is "" which means to use the
+                                          node''s default medium. Must be an empty
+                                          string (default) or Memory. More info: https://kubernetes.io/docs/concepts/storage/volumes#emptydir'
                                         type: string
                                       sizeLimit:
                                         anyOf:
                                         - type: integer
                                         - type: string
-                                        description: 'Total amount of local storage
-                                          required for this EmptyDir volume. The size
-                                          limit is also applicable for memory medium.
-                                          The maximum usage on memory medium EmptyDir
-                                          would be the minimum value between the SizeLimit
-                                          specified here and the sum of memory limits
-                                          of all containers in a pod. The default
-                                          is nil which means that the limit is undefined.
-                                          More info: http://kubernetes.io/docs/user-guide/volumes#emptydir'
+                                        description: 'sizeLimit is the total amount
+                                          of local storage required for this EmptyDir
+                                          volume. The size limit is also applicable
+                                          for memory medium. The maximum usage on
+                                          memory medium EmptyDir would be the minimum
+                                          value between the SizeLimit specified here
+                                          and the sum of memory limits of all containers
+                                          in a pod. The default is nil which means
+                                          that the limit is undefined. More info:
+                                          http://kubernetes.io/docs/user-guide/volumes#emptydir'
                                         pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                         x-kubernetes-int-or-string: true
                                     type: object
                                   ephemeral:
-                                    description: "Ephemeral represents a volume that
-                                      is handled by a cluster storage driver (Alpha
-                                      feature). The volume's lifecycle is tied to
-                                      the pod that defines it - it will be created
-                                      before the pod starts, and deleted when the
-                                      pod is removed. \n Use this if: a) the volume
-                                      is only needed while the pod runs, b) features
-                                      of normal volumes like restoring from snapshot
-                                      or capacity    tracking are needed, c) the storage
-                                      driver is specified through a storage class,
-                                      and d) the storage driver supports dynamic volume
-                                      provisioning through    a PersistentVolumeClaim
-                                      (see EphemeralVolumeSource for more    information
-                                      on the connection between this volume type    and
-                                      PersistentVolumeClaim). \n Use PersistentVolumeClaim
-                                      or one of the vendor-specific APIs for volumes
-                                      that persist for longer than the lifecycle of
-                                      an individual pod. \n Use CSI for light-weight
-                                      local ephemeral volumes if the CSI driver is
-                                      meant to be used that way - see the documentation
-                                      of the driver for more information. \n A pod
-                                      can use both types of ephemeral volumes and
-                                      persistent volumes at the same time."
+                                    description: "ephemeral represents a volume that
+                                      is handled by a cluster storage driver. The
+                                      volume's lifecycle is tied to the pod that defines
+                                      it - it will be created before the pod starts,
+                                      and deleted when the pod is removed. \n Use
+                                      this if: a) the volume is only needed while
+                                      the pod runs, b) features of normal volumes
+                                      like restoring from snapshot or capacity    tracking
+                                      are needed, c) the storage driver is specified
+                                      through a storage class, and d) the storage
+                                      driver supports dynamic volume provisioning
+                                      through    a PersistentVolumeClaim (see EphemeralVolumeSource
+                                      for more    information on the connection between
+                                      this volume type    and PersistentVolumeClaim).
+                                      \n Use PersistentVolumeClaim or one of the vendor-specific
+                                      APIs for volumes that persist for longer than
+                                      the lifecycle of an individual pod. \n Use CSI
+                                      for light-weight local ephemeral volumes if
+                                      the CSI driver is meant to be used that way
+                                      - see the documentation of the driver for more
+                                      information. \n A pod can use both types of
+                                      ephemeral volumes and persistent volumes at
+                                      the same time."
                                     properties:
-                                      readOnly:
-                                        description: Specifies a read-only configuration
-                                          for the volume. Defaults to false (read/write).
-                                        type: boolean
                                       volumeClaimTemplate:
                                         description: "Will be used to create a stand-alone
                                           PVC to provision the volume. The pod in
@@ -5633,34 +6492,82 @@ spec:
                                               are also valid here.
                                             properties:
                                               accessModes:
-                                                description: 'AccessModes contains
+                                                description: 'accessModes contains
                                                   the desired access modes the volume
                                                   should have. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#access-modes-1'
                                                 items:
                                                   type: string
                                                 type: array
                                               dataSource:
-                                                description: 'This field can be used
-                                                  to specify either: * An existing
-                                                  VolumeSnapshot object (snapshot.storage.k8s.io/VolumeSnapshot
-                                                  - Beta) * An existing PVC (PersistentVolumeClaim)
-                                                  * An existing custom resource/object
-                                                  that implements data population
-                                                  (Alpha) In order to use VolumeSnapshot
-                                                  object types, the appropriate feature
-                                                  gate must be enabled (VolumeSnapshotDataSource
-                                                  or AnyVolumeDataSource) If the provisioner
-                                                  or an external controller can support
-                                                  the specified data source, it will
-                                                  create a new volume based on the
-                                                  contents of the specified data source.
-                                                  If the specified data source is
-                                                  not supported, the volume will not
-                                                  be created and the failure will
-                                                  be reported as an event. In the
-                                                  future, we plan to support more
-                                                  data source types and the behavior
-                                                  of the provisioner may change.'
+                                                description: 'dataSource field can
+                                                  be used to specify either: * An
+                                                  existing VolumeSnapshot object (snapshot.storage.k8s.io/VolumeSnapshot)
+                                                  * An existing PVC (PersistentVolumeClaim)
+                                                  If the provisioner or an external
+                                                  controller can support the specified
+                                                  data source, it will create a new
+                                                  volume based on the contents of
+                                                  the specified data source. If the
+                                                  AnyVolumeDataSource feature gate
+                                                  is enabled, this field will always
+                                                  have the same contents as the DataSourceRef
+                                                  field.'
+                                                properties:
+                                                  apiGroup:
+                                                    description: APIGroup is the group
+                                                      for the resource being referenced.
+                                                      If APIGroup is not specified,
+                                                      the specified Kind must be in
+                                                      the core API group. For any
+                                                      other third-party types, APIGroup
+                                                      is required.
+                                                    type: string
+                                                  kind:
+                                                    description: Kind is the type
+                                                      of resource being referenced
+                                                    type: string
+                                                  name:
+                                                    description: Name is the name
+                                                      of resource being referenced
+                                                    type: string
+                                                required:
+                                                - kind
+                                                - name
+                                                type: object
+                                              dataSourceRef:
+                                                description: 'dataSourceRef specifies
+                                                  the object from which to populate
+                                                  the volume with data, if a non-empty
+                                                  volume is desired. This may be any
+                                                  local object from a non-empty API
+                                                  group (non core object) or a PersistentVolumeClaim
+                                                  object. When this field is specified,
+                                                  volume binding will only succeed
+                                                  if the type of the specified object
+                                                  matches some installed volume populator
+                                                  or dynamic provisioner. This field
+                                                  will replace the functionality of
+                                                  the DataSource field and as such
+                                                  if both fields are non-empty, they
+                                                  must have the same value. For backwards
+                                                  compatibility, both fields (DataSource
+                                                  and DataSourceRef) will be set to
+                                                  the same value automatically if
+                                                  one of them is empty and the other
+                                                  is non-empty. There are two important
+                                                  differences between DataSource and
+                                                  DataSourceRef: * While DataSource
+                                                  only allows two specific types of
+                                                  objects, DataSourceRef   allows
+                                                  any non-core object, as well as
+                                                  PersistentVolumeClaim objects. *
+                                                  While DataSource ignores disallowed
+                                                  values (dropping them), DataSourceRef   preserves
+                                                  all values, and generates an error
+                                                  if a disallowed value is   specified.
+                                                  (Beta) Using this field requires
+                                                  the AnyVolumeDataSource feature
+                                                  gate to be enabled.'
                                                 properties:
                                                   apiGroup:
                                                     description: APIGroup is the group
@@ -5684,9 +6591,15 @@ spec:
                                                 - name
                                                 type: object
                                               resources:
-                                                description: 'Resources represents
+                                                description: 'resources represents
                                                   the minimum resources the volume
-                                                  should have. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#resources'
+                                                  should have. If RecoverVolumeExpansionFailure
+                                                  feature is enabled users are allowed
+                                                  to specify resource requirements
+                                                  that are lower than previous value
+                                                  but must still be higher than capacity
+                                                  recorded in the status field of
+                                                  the claim. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#resources'
                                                 properties:
                                                   limits:
                                                     additionalProperties:
@@ -5698,7 +6611,7 @@ spec:
                                                     description: 'Limits describes
                                                       the maximum amount of compute
                                                       resources allowed. More info:
-                                                      https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
+                                                      https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
                                                     type: object
                                                   requests:
                                                     additionalProperties:
@@ -5714,12 +6627,12 @@ spec:
                                                       it defaults to Limits if that
                                                       is explicitly specified, otherwise
                                                       to an implementation-defined
-                                                      value. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
+                                                      value. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
                                                     type: object
                                                 type: object
                                               selector:
-                                                description: A label query over volumes
-                                                  to consider for binding.
+                                                description: selector is a label query
+                                                  over volumes to consider for binding.
                                                 properties:
                                                   matchExpressions:
                                                     description: matchExpressions
@@ -5779,9 +6692,9 @@ spec:
                                                     type: object
                                                 type: object
                                               storageClassName:
-                                                description: 'Name of the StorageClass
-                                                  required by the claim. More info:
-                                                  https://kubernetes.io/docs/concepts/storage/persistent-volumes#class-1'
+                                                description: 'storageClassName is
+                                                  the name of the StorageClass required
+                                                  by the claim. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#class-1'
                                                 type: string
                                               volumeMode:
                                                 description: volumeMode defines what
@@ -5790,7 +6703,7 @@ spec:
                                                   when not included in claim spec.
                                                 type: string
                                               volumeName:
-                                                description: VolumeName is the binding
+                                                description: volumeName is the binding
                                                   reference to the PersistentVolume
                                                   backing this claim.
                                                 type: string
@@ -5800,77 +6713,79 @@ spec:
                                         type: object
                                     type: object
                                   fc:
-                                    description: FC represents a Fibre Channel resource
+                                    description: fc represents a Fibre Channel resource
                                       that is attached to a kubelet's host machine
                                       and then exposed to the pod.
                                     properties:
                                       fsType:
-                                        description: 'Filesystem type to mount. Must
-                                          be a filesystem type supported by the host
-                                          operating system. Ex. "ext4", "xfs", "ntfs".
-                                          Implicitly inferred to be "ext4" if unspecified.
-                                          TODO: how do we prevent errors in the filesystem
-                                          from compromising the machine'
+                                        description: 'fsType is the filesystem type
+                                          to mount. Must be a filesystem type supported
+                                          by the host operating system. Ex. "ext4",
+                                          "xfs", "ntfs". Implicitly inferred to be
+                                          "ext4" if unspecified. TODO: how do we prevent
+                                          errors in the filesystem from compromising
+                                          the machine'
                                         type: string
                                       lun:
-                                        description: 'Optional: FC target lun number'
+                                        description: 'lun is Optional: FC target lun
+                                          number'
                                         format: int32
                                         type: integer
                                       readOnly:
-                                        description: 'Optional: Defaults to false
-                                          (read/write). ReadOnly here will force the
-                                          ReadOnly setting in VolumeMounts.'
+                                        description: 'readOnly is Optional: Defaults
+                                          to false (read/write). ReadOnly here will
+                                          force the ReadOnly setting in VolumeMounts.'
                                         type: boolean
                                       targetWWNs:
-                                        description: 'Optional: FC target worldwide
-                                          names (WWNs)'
+                                        description: 'targetWWNs is Optional: FC target
+                                          worldwide names (WWNs)'
                                         items:
                                           type: string
                                         type: array
                                       wwids:
-                                        description: 'Optional: FC volume world wide
-                                          identifiers (wwids) Either wwids or combination
-                                          of targetWWNs and lun must be set, but not
-                                          both simultaneously.'
+                                        description: 'wwids Optional: FC volume world
+                                          wide identifiers (wwids) Either wwids or
+                                          combination of targetWWNs and lun must be
+                                          set, but not both simultaneously.'
                                         items:
                                           type: string
                                         type: array
                                     type: object
                                   flexVolume:
-                                    description: FlexVolume represents a generic volume
+                                    description: flexVolume represents a generic volume
                                       resource that is provisioned/attached using
                                       an exec based plugin.
                                     properties:
                                       driver:
-                                        description: Driver is the name of the driver
+                                        description: driver is the name of the driver
                                           to use for this volume.
                                         type: string
                                       fsType:
-                                        description: Filesystem type to mount. Must
-                                          be a filesystem type supported by the host
-                                          operating system. Ex. "ext4", "xfs", "ntfs".
-                                          The default filesystem depends on FlexVolume
-                                          script.
+                                        description: fsType is the filesystem type
+                                          to mount. Must be a filesystem type supported
+                                          by the host operating system. Ex. "ext4",
+                                          "xfs", "ntfs". The default filesystem depends
+                                          on FlexVolume script.
                                         type: string
                                       options:
                                         additionalProperties:
                                           type: string
-                                        description: 'Optional: Extra command options
-                                          if any.'
+                                        description: 'options is Optional: this field
+                                          holds extra command options if any.'
                                         type: object
                                       readOnly:
-                                        description: 'Optional: Defaults to false
-                                          (read/write). ReadOnly here will force the
-                                          ReadOnly setting in VolumeMounts.'
+                                        description: 'readOnly is Optional: defaults
+                                          to false (read/write). ReadOnly here will
+                                          force the ReadOnly setting in VolumeMounts.'
                                         type: boolean
                                       secretRef:
-                                        description: 'Optional: SecretRef is reference
-                                          to the secret object containing sensitive
-                                          information to pass to the plugin scripts.
-                                          This may be empty if no secret object is
-                                          specified. If the secret object contains
-                                          more than one secret, all secrets are passed
-                                          to the plugin scripts.'
+                                        description: 'secretRef is Optional: secretRef
+                                          is reference to the secret object containing
+                                          sensitive information to pass to the plugin
+                                          scripts. This may be empty if no secret
+                                          object is specified. If the secret object
+                                          contains more than one secret, all secrets
+                                          are passed to the plugin scripts.'
                                         properties:
                                           name:
                                             description: 'Name of the referent. More
@@ -5883,53 +6798,55 @@ spec:
                                     - driver
                                     type: object
                                   flocker:
-                                    description: Flocker represents a Flocker volume
+                                    description: flocker represents a Flocker volume
                                       attached to a kubelet's host machine. This depends
                                       on the Flocker control service being running
                                     properties:
                                       datasetName:
-                                        description: Name of the dataset stored as
-                                          metadata -> name on the dataset for Flocker
-                                          should be considered as deprecated
+                                        description: datasetName is Name of the dataset
+                                          stored as metadata -> name on the dataset
+                                          for Flocker should be considered as deprecated
                                         type: string
                                       datasetUUID:
-                                        description: UUID of the dataset. This is
-                                          unique identifier of a Flocker dataset
+                                        description: datasetUUID is the UUID of the
+                                          dataset. This is unique identifier of a
+                                          Flocker dataset
                                         type: string
                                     type: object
                                   gcePersistentDisk:
-                                    description: 'GCEPersistentDisk represents a GCE
+                                    description: 'gcePersistentDisk represents a GCE
                                       Disk resource that is attached to a kubelet''s
                                       host machine and then exposed to the pod. More
                                       info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk'
                                     properties:
                                       fsType:
-                                        description: 'Filesystem type of the volume
-                                          that you want to mount. Tip: Ensure that
-                                          the filesystem type is supported by the
-                                          host operating system. Examples: "ext4",
-                                          "xfs", "ntfs". Implicitly inferred to be
-                                          "ext4" if unspecified. More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk
+                                        description: 'fsType is filesystem type of
+                                          the volume that you want to mount. Tip:
+                                          Ensure that the filesystem type is supported
+                                          by the host operating system. Examples:
+                                          "ext4", "xfs", "ntfs". Implicitly inferred
+                                          to be "ext4" if unspecified. More info:
+                                          https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk
                                           TODO: how do we prevent errors in the filesystem
                                           from compromising the machine'
                                         type: string
                                       partition:
-                                        description: 'The partition in the volume
-                                          that you want to mount. If omitted, the
-                                          default is to mount by volume name. Examples:
-                                          For volume /dev/sda1, you specify the partition
-                                          as "1". Similarly, the volume partition
-                                          for /dev/sda is "0" (or you can leave the
-                                          property empty). More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk'
+                                        description: 'partition is the partition in
+                                          the volume that you want to mount. If omitted,
+                                          the default is to mount by volume name.
+                                          Examples: For volume /dev/sda1, you specify
+                                          the partition as "1". Similarly, the volume
+                                          partition for /dev/sda is "0" (or you can
+                                          leave the property empty). More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk'
                                         format: int32
                                         type: integer
                                       pdName:
-                                        description: 'Unique name of the PD resource
-                                          in GCE. Used to identify the disk in GCE.
-                                          More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk'
+                                        description: 'pdName is unique name of the
+                                          PD resource in GCE. Used to identify the
+                                          disk in GCE. More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk'
                                         type: string
                                       readOnly:
-                                        description: 'ReadOnly here will force the
+                                        description: 'readOnly here will force the
                                           ReadOnly setting in VolumeMounts. Defaults
                                           to false. More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk'
                                         type: boolean
@@ -5937,7 +6854,7 @@ spec:
                                     - pdName
                                     type: object
                                   gitRepo:
-                                    description: 'GitRepo represents a git repository
+                                    description: 'gitRepo represents a git repository
                                       at a particular revision. DEPRECATED: GitRepo
                                       is deprecated. To provision a container with
                                       a git repo, mount an EmptyDir into an InitContainer
@@ -5945,39 +6862,39 @@ spec:
                                       EmptyDir into the Pod''s container.'
                                     properties:
                                       directory:
-                                        description: Target directory name. Must not
-                                          contain or start with '..'.  If '.' is supplied,
-                                          the volume directory will be the git repository.  Otherwise,
-                                          if specified, the volume will contain the
-                                          git repository in the subdirectory with
-                                          the given name.
+                                        description: directory is the target directory
+                                          name. Must not contain or start with '..'.  If
+                                          '.' is supplied, the volume directory will
+                                          be the git repository.  Otherwise, if specified,
+                                          the volume will contain the git repository
+                                          in the subdirectory with the given name.
                                         type: string
                                       repository:
-                                        description: Repository URL
+                                        description: repository is the URL
                                         type: string
                                       revision:
-                                        description: Commit hash for the specified
-                                          revision.
+                                        description: revision is the commit hash for
+                                          the specified revision.
                                         type: string
                                     required:
                                     - repository
                                     type: object
                                   glusterfs:
-                                    description: 'Glusterfs represents a Glusterfs
+                                    description: 'glusterfs represents a Glusterfs
                                       mount on the host that shares a pod''s lifetime.
                                       More info: https://examples.k8s.io/volumes/glusterfs/README.md'
                                     properties:
                                       endpoints:
-                                        description: 'EndpointsName is the endpoint
-                                          name that details Glusterfs topology. More
-                                          info: https://examples.k8s.io/volumes/glusterfs/README.md#create-a-pod'
+                                        description: 'endpoints is the endpoint name
+                                          that details Glusterfs topology. More info:
+                                          https://examples.k8s.io/volumes/glusterfs/README.md#create-a-pod'
                                         type: string
                                       path:
-                                        description: 'Path is the Glusterfs volume
+                                        description: 'path is the Glusterfs volume
                                           path. More info: https://examples.k8s.io/volumes/glusterfs/README.md#create-a-pod'
                                         type: string
                                       readOnly:
-                                        description: 'ReadOnly here will force the
+                                        description: 'readOnly here will force the
                                           Glusterfs volume to be mounted with read-only
                                           permissions. Defaults to false. More info:
                                           https://examples.k8s.io/volumes/glusterfs/README.md#create-a-pod'
@@ -5987,7 +6904,7 @@ spec:
                                     - path
                                     type: object
                                   hostPath:
-                                    description: 'HostPath represents a pre-existing
+                                    description: 'hostPath represents a pre-existing
                                       file or directory on the host machine that is
                                       directly exposed to the container. This is generally
                                       used for system agents or other privileged things
@@ -5998,76 +6915,79 @@ spec:
                                       mount host directories as read/write.'
                                     properties:
                                       path:
-                                        description: 'Path of the directory on the
+                                        description: 'path of the directory on the
                                           host. If the path is a symlink, it will
                                           follow the link to the real path. More info:
                                           https://kubernetes.io/docs/concepts/storage/volumes#hostpath'
                                         type: string
                                       type:
-                                        description: 'Type for HostPath Volume Defaults
+                                        description: 'type for HostPath Volume Defaults
                                           to "" More info: https://kubernetes.io/docs/concepts/storage/volumes#hostpath'
                                         type: string
                                     required:
                                     - path
                                     type: object
                                   iscsi:
-                                    description: 'ISCSI represents an ISCSI Disk resource
+                                    description: 'iscsi represents an ISCSI Disk resource
                                       that is attached to a kubelet''s host machine
                                       and then exposed to the pod. More info: https://examples.k8s.io/volumes/iscsi/README.md'
                                     properties:
                                       chapAuthDiscovery:
-                                        description: whether support iSCSI Discovery
-                                          CHAP authentication
+                                        description: chapAuthDiscovery defines whether
+                                          support iSCSI Discovery CHAP authentication
                                         type: boolean
                                       chapAuthSession:
-                                        description: whether support iSCSI Session
-                                          CHAP authentication
+                                        description: chapAuthSession defines whether
+                                          support iSCSI Session CHAP authentication
                                         type: boolean
                                       fsType:
-                                        description: 'Filesystem type of the volume
-                                          that you want to mount. Tip: Ensure that
-                                          the filesystem type is supported by the
-                                          host operating system. Examples: "ext4",
-                                          "xfs", "ntfs". Implicitly inferred to be
-                                          "ext4" if unspecified. More info: https://kubernetes.io/docs/concepts/storage/volumes#iscsi
+                                        description: 'fsType is the filesystem type
+                                          of the volume that you want to mount. Tip:
+                                          Ensure that the filesystem type is supported
+                                          by the host operating system. Examples:
+                                          "ext4", "xfs", "ntfs". Implicitly inferred
+                                          to be "ext4" if unspecified. More info:
+                                          https://kubernetes.io/docs/concepts/storage/volumes#iscsi
                                           TODO: how do we prevent errors in the filesystem
                                           from compromising the machine'
                                         type: string
                                       initiatorName:
-                                        description: Custom iSCSI Initiator Name.
-                                          If initiatorName is specified with iscsiInterface
-                                          simultaneously, new iSCSI interface <target
-                                          portal>:<volume name> will be created for
-                                          the connection.
+                                        description: initiatorName is the custom iSCSI
+                                          Initiator Name. If initiatorName is specified
+                                          with iscsiInterface simultaneously, new
+                                          iSCSI interface <target portal>:<volume
+                                          name> will be created for the connection.
                                         type: string
                                       iqn:
-                                        description: Target iSCSI Qualified Name.
+                                        description: iqn is the target iSCSI Qualified
+                                          Name.
                                         type: string
                                       iscsiInterface:
-                                        description: iSCSI Interface Name that uses
-                                          an iSCSI transport. Defaults to 'default'
-                                          (tcp).
+                                        description: iscsiInterface is the interface
+                                          Name that uses an iSCSI transport. Defaults
+                                          to 'default' (tcp).
                                         type: string
                                       lun:
-                                        description: iSCSI Target Lun number.
+                                        description: lun represents iSCSI Target Lun
+                                          number.
                                         format: int32
                                         type: integer
                                       portals:
-                                        description: iSCSI Target Portal List. The
-                                          portal is either an IP or ip_addr:port if
-                                          the port is other than default (typically
+                                        description: portals is the iSCSI Target Portal
+                                          List. The portal is either an IP or ip_addr:port
+                                          if the port is other than default (typically
                                           TCP ports 860 and 3260).
                                         items:
                                           type: string
                                         type: array
                                       readOnly:
-                                        description: ReadOnly here will force the
+                                        description: readOnly here will force the
                                           ReadOnly setting in VolumeMounts. Defaults
                                           to false.
                                         type: boolean
                                       secretRef:
-                                        description: CHAP Secret for iSCSI target
-                                          and initiator authentication
+                                        description: secretRef is the CHAP Secret
+                                          for iSCSI target and initiator authentication
                                         properties:
                                           name:
                                             description: 'Name of the referent. More
@@ -6077,10 +6997,10 @@ spec:
                                             type: string
                                         type: object
                                       targetPortal:
-                                        description: iSCSI Target Portal. The Portal
-                                          is either an IP or ip_addr:port if the port
-                                          is other than default (typically TCP ports
-                                          860 and 3260).
+                                        description: targetPortal is iSCSI Target
+                                          Portal. The Portal is either an IP or ip_addr:port
+                                          if the port is other than default (typically
+                                          TCP ports 860 and 3260).
                                         type: string
                                     required:
                                     - iqn
@@ -6088,26 +7008,26 @@ spec:
                                     - targetPortal
                                     type: object
                                   name:
-                                    description: 'Volume''s name. Must be a DNS_LABEL
+                                    description: 'name of the volume. Must be a DNS_LABEL
                                       and unique within the pod. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
                                     type: string
                                   nfs:
-                                    description: 'NFS represents an NFS mount on the
+                                    description: 'nfs represents an NFS mount on the
                                       host that shares a pod''s lifetime More info:
                                       https://kubernetes.io/docs/concepts/storage/volumes#nfs'
                                     properties:
                                       path:
-                                        description: 'Path that is exported by the
+                                        description: 'path that is exported by the
                                           NFS server. More info: https://kubernetes.io/docs/concepts/storage/volumes#nfs'
                                         type: string
                                       readOnly:
-                                        description: 'ReadOnly here will force the
+                                        description: 'readOnly here will force the
                                           NFS export to be mounted with read-only
                                           permissions. Defaults to false. More info:
                                           https://kubernetes.io/docs/concepts/storage/volumes#nfs'
                                         type: boolean
                                       server:
-                                        description: 'Server is the hostname or IP
+                                        description: 'server is the hostname or IP
                                           address of the NFS server. More info: https://kubernetes.io/docs/concepts/storage/volumes#nfs'
                                         type: string
                                     required:
@@ -6115,99 +7035,101 @@ spec:
                                     - server
                                     type: object
                                   persistentVolumeClaim:
-                                    description: 'PersistentVolumeClaimVolumeSource
+                                    description: 'persistentVolumeClaimVolumeSource
                                       represents a reference to a PersistentVolumeClaim
                                       in the same namespace. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#persistentvolumeclaims'
                                     properties:
                                       claimName:
-                                        description: 'ClaimName is the name of a PersistentVolumeClaim
+                                        description: 'claimName is the name of a PersistentVolumeClaim
                                           in the same namespace as the pod using this
                                           volume. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#persistentvolumeclaims'
                                         type: string
                                       readOnly:
-                                        description: Will force the ReadOnly setting
-                                          in VolumeMounts. Default false.
+                                        description: readOnly Will force the ReadOnly
+                                          setting in VolumeMounts. Default false.
                                         type: boolean
                                     required:
                                     - claimName
                                     type: object
                                   photonPersistentDisk:
-                                    description: PhotonPersistentDisk represents a
+                                    description: photonPersistentDisk represents a
                                       PhotonController persistent disk attached and
                                       mounted on kubelets host machine
                                     properties:
                                       fsType:
-                                        description: Filesystem type to mount. Must
-                                          be a filesystem type supported by the host
-                                          operating system. Ex. "ext4", "xfs", "ntfs".
-                                          Implicitly inferred to be "ext4" if unspecified.
+                                        description: fsType is the filesystem type
+                                          to mount. Must be a filesystem type supported
+                                          by the host operating system. Ex. "ext4",
+                                          "xfs", "ntfs". Implicitly inferred to be
+                                          "ext4" if unspecified.
                                         type: string
                                       pdID:
-                                        description: ID that identifies Photon Controller
-                                          persistent disk
+                                        description: pdID is the ID that identifies
+                                          Photon Controller persistent disk
                                         type: string
                                     required:
                                     - pdID
                                     type: object
                                   portworxVolume:
-                                    description: PortworxVolume represents a portworx
+                                    description: portworxVolume represents a portworx
                                       volume attached and mounted on kubelets host
                                       machine
                                     properties:
                                       fsType:
-                                        description: FSType represents the filesystem
+                                        description: fSType represents the filesystem
                                           type to mount Must be a filesystem type
                                           supported by the host operating system.
                                           Ex. "ext4", "xfs". Implicitly inferred to
                                           be "ext4" if unspecified.
                                         type: string
                                       readOnly:
-                                        description: Defaults to false (read/write).
+                                        description: readOnly defaults to false (read/write).
                                           ReadOnly here will force the ReadOnly setting
                                           in VolumeMounts.
                                         type: boolean
                                       volumeID:
-                                        description: VolumeID uniquely identifies
+                                        description: volumeID uniquely identifies
                                           a Portworx volume
                                         type: string
                                     required:
                                     - volumeID
                                     type: object
                                   projected:
-                                    description: Items for all in one resources secrets,
-                                      configmaps, and downward API
+                                    description: projected items for all in one resources
+                                      secrets, configmaps, and downward API
                                     properties:
                                       defaultMode:
-                                        description: Mode bits used to set permissions
-                                          on created files by default. Must be an
-                                          octal value between 0000 and 0777 or a decimal
-                                          value between 0 and 511. YAML accepts both
-                                          octal and decimal values, JSON requires
-                                          decimal values for mode bits. Directories
-                                          within the path are not affected by this
-                                          setting. This might be in conflict with
-                                          other options that affect the file mode,
-                                          like fsGroup, and the result can be other
-                                          mode bits set.
+                                        description: defaultMode are the mode bits
+                                          used to set permissions on created files
+                                          by default. Must be an octal value between
+                                          0000 and 0777 or a decimal value between
+                                          0 and 511. YAML accepts both octal and decimal
+                                          values, JSON requires decimal values for
+                                          mode bits. Directories within the path are
+                                          not affected by this setting. This might
+                                          be in conflict with other options that affect
+                                          the file mode, like fsGroup, and the result
+                                          can be other mode bits set.
                                         format: int32
                                         type: integer
                                       sources:
-                                        description: list of volume projections
+                                        description: sources is the list of volume
+                                          projections
                                         items:
                                           description: Projection that may be projected
                                             along with other supported volume types
                                           properties:
                                             configMap:
-                                              description: information about the configMap
-                                                data to project
+                                              description: configMap information about
+                                                the configMap data to project
                                               properties:
                                                 items:
-                                                  description: If unspecified, each
-                                                    key-value pair in the Data field
-                                                    of the referenced ConfigMap will
-                                                    be projected into the volume as
-                                                    a file whose name is the key and
-                                                    content is the value. If specified,
+                                                  description: items if unspecified,
+                                                    each key-value pair in the Data
+                                                    field of the referenced ConfigMap
+                                                    will be projected into the volume
+                                                    as a file whose name is the key
+                                                    and content is the value. If specified,
                                                     the listed keys will be projected
                                                     into the specified paths, and
                                                     unlisted keys will not be present.
@@ -6222,11 +7144,12 @@ spec:
                                                       to a path within a volume.
                                                     properties:
                                                       key:
-                                                        description: The key to project.
+                                                        description: key is the key
+                                                          to project.
                                                         type: string
                                                       mode:
-                                                        description: 'Optional: mode
-                                                          bits used to set permissions
+                                                        description: 'mode is Optional:
+                                                          mode bits used to set permissions
                                                           on this file. Must be an
                                                           octal value between 0000
                                                           and 0777 or a decimal value
@@ -6244,7 +7167,7 @@ spec:
                                                         format: int32
                                                         type: integer
                                                       path:
-                                                        description: The relative
+                                                        description: path is the relative
                                                           path of the file to map
                                                           the key to. May not be an
                                                           absolute path. May not contain
@@ -6264,14 +7187,14 @@ spec:
                                                     apiVersion, kind, uid?'
                                                   type: string
                                                 optional:
-                                                  description: Specify whether the
-                                                    ConfigMap or its keys must be
-                                                    defined
+                                                  description: optional specify whether
+                                                    the ConfigMap or its keys must
+                                                    be defined
                                                   type: boolean
                                               type: object
                                             downwardAPI:
-                                              description: information about the downwardAPI
-                                                data to project
+                                              description: downwardAPI information
+                                                about the downwardAPI data to project
                                               properties:
                                                 items:
                                                   description: Items is a list of
@@ -6368,16 +7291,16 @@ spec:
                                                   type: array
                                               type: object
                                             secret:
-                                              description: information about the secret
-                                                data to project
+                                              description: secret information about
+                                                the secret data to project
                                               properties:
                                                 items:
-                                                  description: If unspecified, each
-                                                    key-value pair in the Data field
-                                                    of the referenced Secret will
-                                                    be projected into the volume as
-                                                    a file whose name is the key and
-                                                    content is the value. If specified,
+                                                  description: items if unspecified,
+                                                    each key-value pair in the Data
+                                                    field of the referenced Secret
+                                                    will be projected into the volume
+                                                    as a file whose name is the key
+                                                    and content is the value. If specified,
                                                     the listed keys will be projected
                                                     into the specified paths, and
                                                     unlisted keys will not be present.
@@ -6392,11 +7315,12 @@ spec:
                                                       to a path within a volume.
                                                     properties:
                                                       key:
-                                                        description: The key to project.
+                                                        description: key is the key
+                                                          to project.
                                                         type: string
                                                       mode:
-                                                        description: 'Optional: mode
-                                                          bits used to set permissions
+                                                        description: 'mode is Optional:
+                                                          mode bits used to set permissions
                                                           on this file. Must be an
                                                           octal value between 0000
                                                           and 0777 or a decimal value
@@ -6414,7 +7338,7 @@ spec:
                                                         format: int32
                                                         type: integer
                                                       path:
-                                                        description: The relative
+                                                        description: path is the relative
                                                           path of the file to map
                                                           the key to. May not be an
                                                           absolute path. May not contain
@@ -6434,16 +7358,18 @@ spec:
                                                     apiVersion, kind, uid?'
                                                   type: string
                                                 optional:
-                                                  description: Specify whether the
-                                                    Secret or its key must be defined
+                                                  description: optional field specify
+                                                    whether the Secret or its key
+                                                    must be defined
                                                   type: boolean
                                               type: object
                                             serviceAccountToken:
-                                              description: information about the serviceAccountToken
+                                              description: serviceAccountToken is
+                                                information about the serviceAccountToken
                                                 data to project
                                               properties:
                                                 audience:
-                                                  description: Audience is the intended
+                                                  description: audience is the intended
                                                     audience of the token. A recipient
                                                     of a token must identify itself
                                                     with an identifier specified in
@@ -6453,7 +7379,7 @@ spec:
                                                     of the apiserver.
                                                   type: string
                                                 expirationSeconds:
-                                                  description: ExpirationSeconds is
+                                                  description: expirationSeconds is
                                                     the requested duration of validity
                                                     of the service account token.
                                                     As the token approaches expiration,
@@ -6469,7 +7395,7 @@ spec:
                                                   format: int64
                                                   type: integer
                                                 path:
-                                                  description: Path is the path relative
+                                                  description: path is the path relative
                                                     to the mount point of the file
                                                     to project the token into.
                                                   type: string
@@ -6478,41 +7404,39 @@ spec:
                                               type: object
                                           type: object
                                         type: array
-                                    required:
-                                    - sources
                                     type: object
                                   quobyte:
-                                    description: Quobyte represents a Quobyte mount
+                                    description: quobyte represents a Quobyte mount
                                       on the host that shares a pod's lifetime
                                     properties:
                                       group:
-                                        description: Group to map volume access to
+                                        description: group to map volume access to
                                           Default is no group
                                         type: string
                                       readOnly:
-                                        description: ReadOnly here will force the
+                                        description: readOnly here will force the
                                           Quobyte volume to be mounted with read-only
                                           permissions. Defaults to false.
                                         type: boolean
                                       registry:
-                                        description: Registry represents a single
+                                        description: registry represents a single
                                           or multiple Quobyte Registry services specified
                                           as a string as host:port pair (multiple
                                           entries are separated with commas) which
                                           acts as the central registry for volumes
                                         type: string
                                       tenant:
-                                        description: Tenant owning the given Quobyte
+                                        description: tenant owning the given Quobyte
                                           volume in the Backend Used with dynamically
                                           provisioned Quobyte volumes, value is set
                                           by the plugin
                                         type: string
                                       user:
-                                        description: User to map volume access to
+                                        description: user to map volume access to
                                           Defaults to serivceaccount user
                                         type: string
                                       volume:
-                                        description: Volume is a string that references
+                                        description: volume is a string that references
                                           an already created Quobyte volume by name.
                                         type: string
                                     required:
@@ -6520,46 +7444,47 @@ spec:
                                     - volume
                                     type: object
                                   rbd:
-                                    description: 'RBD represents a Rados Block Device
+                                    description: 'rbd represents a Rados Block Device
                                       mount on the host that shares a pod''s lifetime.
                                       More info: https://examples.k8s.io/volumes/rbd/README.md'
                                     properties:
                                       fsType:
-                                        description: 'Filesystem type of the volume
-                                          that you want to mount. Tip: Ensure that
-                                          the filesystem type is supported by the
-                                          host operating system. Examples: "ext4",
-                                          "xfs", "ntfs". Implicitly inferred to be
-                                          "ext4" if unspecified. More info: https://kubernetes.io/docs/concepts/storage/volumes#rbd
+                                        description: 'fsType is the filesystem type
+                                          of the volume that you want to mount. Tip:
+                                          Ensure that the filesystem type is supported
+                                          by the host operating system. Examples:
+                                          "ext4", "xfs", "ntfs". Implicitly inferred
+                                          to be "ext4" if unspecified. More info:
+                                          https://kubernetes.io/docs/concepts/storage/volumes#rbd
                                           TODO: how do we prevent errors in the filesystem
                                           from compromising the machine'
                                         type: string
                                       image:
-                                        description: 'The rados image name. More info:
-                                          https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
+                                        description: 'image is the rados image name.
+                                          More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
                                         type: string
                                       keyring:
-                                        description: 'Keyring is the path to key ring
+                                        description: 'keyring is the path to key ring
                                           for RBDUser. Default is /etc/ceph/keyring.
                                           More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
                                         type: string
                                       monitors:
-                                        description: 'A collection of Ceph monitors.
-                                          More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
+                                        description: 'monitors is a collection of
+                                          Ceph monitors. More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
                                         items:
                                           type: string
                                         type: array
                                       pool:
-                                        description: 'The rados pool name. Default
-                                          is rbd. More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
+                                        description: 'pool is the rados pool name.
+                                          Default is rbd. More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
                                         type: string
                                       readOnly:
-                                        description: 'ReadOnly here will force the
+                                        description: 'readOnly here will force the
                                           ReadOnly setting in VolumeMounts. Defaults
                                           to false. More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
                                         type: boolean
                                       secretRef:
-                                        description: 'SecretRef is name of the authentication
+                                        description: 'secretRef is name of the authentication
                                           secret for RBDUser. If provided overrides
                                           keyring. Default is nil. More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
                                         properties:
@@ -6571,38 +7496,39 @@ spec:
                                             type: string
                                         type: object
                                       user:
-                                        description: 'The rados user name. Default
-                                          is admin. More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
+                                        description: 'user is the rados user name.
+                                          Default is admin. More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
                                         type: string
                                     required:
                                     - image
                                     - monitors
                                     type: object
                                   scaleIO:
-                                    description: ScaleIO represents a ScaleIO persistent
+                                    description: scaleIO represents a ScaleIO persistent
                                       volume attached and mounted on Kubernetes nodes.
                                     properties:
                                       fsType:
-                                        description: Filesystem type to mount. Must
-                                          be a filesystem type supported by the host
-                                          operating system. Ex. "ext4", "xfs", "ntfs".
-                                          Default is "xfs".
+                                        description: fsType is the filesystem type
+                                          to mount. Must be a filesystem type supported
+                                          by the host operating system. Ex. "ext4",
+                                          "xfs", "ntfs". Default is "xfs".
                                         type: string
                                       gateway:
-                                        description: The host address of the ScaleIO
-                                          API Gateway.
+                                        description: gateway is the host address of
+                                          the ScaleIO API Gateway.
                                         type: string
                                       protectionDomain:
-                                        description: The name of the ScaleIO Protection
-                                          Domain for the configured storage.
+                                        description: protectionDomain is the name
+                                          of the ScaleIO Protection Domain for the
+                                          configured storage.
                                         type: string
                                       readOnly:
-                                        description: Defaults to false (read/write).
+                                        description: readOnly Defaults to false (read/write).
                                           ReadOnly here will force the ReadOnly setting
                                           in VolumeMounts.
                                         type: boolean
                                       secretRef:
-                                        description: SecretRef references to the secret
+                                        description: secretRef references to the secret
                                           for ScaleIO user and other sensitive information.
                                           If this is not provided, Login operation
                                           will fail.
@@ -6615,26 +7541,27 @@ spec:
                                             type: string
                                         type: object
                                       sslEnabled:
-                                        description: Flag to enable/disable SSL communication
-                                          with Gateway, default false
+                                        description: sslEnabled Flag enable/disable
+                                          SSL communication with Gateway, default
+                                          false
                                         type: boolean
                                       storageMode:
-                                        description: Indicates whether the storage
-                                          for a volume should be ThickProvisioned
+                                        description: storageMode indicates whether
+                                          the storage for a volume should be ThickProvisioned
                                           or ThinProvisioned. Default is ThinProvisioned.
                                         type: string
                                       storagePool:
-                                        description: The ScaleIO Storage Pool associated
-                                          with the protection domain.
+                                        description: storagePool is the ScaleIO Storage
+                                          Pool associated with the protection domain.
                                         type: string
                                       system:
-                                        description: The name of the storage system
-                                          as configured in ScaleIO.
+                                        description: system is the name of the storage
+                                          system as configured in ScaleIO.
                                         type: string
                                       volumeName:
-                                        description: The name of a volume already
-                                          created in the ScaleIO system that is associated
-                                          with this volume source.
+                                        description: volumeName is the name of a volume
+                                          already created in the ScaleIO system that
+                                          is associated with this volume source.
                                         type: string
                                     required:
                                     - gateway
@@ -6642,25 +7569,26 @@ spec:
                                     - system
                                     type: object
                                   secret:
-                                    description: 'Secret represents a secret that
+                                    description: 'secret represents a secret that
                                       should populate this volume. More info: https://kubernetes.io/docs/concepts/storage/volumes#secret'
                                     properties:
                                       defaultMode:
-                                        description: 'Optional: mode bits used to
-                                          set permissions on created files by default.
-                                          Must be an octal value between 0000 and
-                                          0777 or a decimal value between 0 and 511.
-                                          YAML accepts both octal and decimal values,
-                                          JSON requires decimal values for mode bits.
-                                          Defaults to 0644. Directories within the
-                                          path are not affected by this setting. This
-                                          might be in conflict with other options
-                                          that affect the file mode, like fsGroup,
-                                          and the result can be other mode bits set.'
+                                        description: 'defaultMode is Optional: mode
+                                          bits used to set permissions on created
+                                          files by default. Must be an octal value
+                                          between 0000 and 0777 or a decimal value
+                                          between 0 and 511. YAML accepts both octal
+                                          and decimal values, JSON requires decimal
+                                          values for mode bits. Defaults to 0644.
+                                          Directories within the path are not affected
+                                          by this setting. This might be in conflict
+                                          with other options that affect the file
+                                          mode, like fsGroup, and the result can be
+                                          other mode bits set.'
                                         format: int32
                                         type: integer
                                       items:
-                                        description: If unspecified, each key-value
+                                        description: items If unspecified, each key-value
                                           pair in the Data field of the referenced
                                           Secret will be projected into the volume
                                           as a file whose name is the key and content
@@ -6677,27 +7605,27 @@ spec:
                                             within a volume.
                                           properties:
                                             key:
-                                              description: The key to project.
+                                              description: key is the key to project.
                                               type: string
                                             mode:
-                                              description: 'Optional: mode bits used
-                                                to set permissions on this file. Must
-                                                be an octal value between 0000 and
-                                                0777 or a decimal value between 0
-                                                and 511. YAML accepts both octal and
-                                                decimal values, JSON requires decimal
-                                                values for mode bits. If not specified,
-                                                the volume defaultMode will be used.
-                                                This might be in conflict with other
-                                                options that affect the file mode,
-                                                like fsGroup, and the result can be
-                                                other mode bits set.'
+                                              description: 'mode is Optional: mode
+                                                bits used to set permissions on this
+                                                file. Must be an octal value between
+                                                0000 and 0777 or a decimal value between
+                                                0 and 511. YAML accepts both octal
+                                                and decimal values, JSON requires
+                                                decimal values for mode bits. If not
+                                                specified, the volume defaultMode
+                                                will be used. This might be in conflict
+                                                with other options that affect the
+                                                file mode, like fsGroup, and the result
+                                                can be other mode bits set.'
                                               format: int32
                                               type: integer
                                             path:
-                                              description: The relative path of the
-                                                file to map the key to. May not be
-                                                an absolute path. May not contain
+                                              description: path is the relative path
+                                                of the file to map the key to. May
+                                                not be an absolute path. May not contain
                                                 the path element '..'. May not start
                                                 with the string '..'.
                                               type: string
@@ -6707,31 +7635,33 @@ spec:
                                           type: object
                                         type: array
                                       optional:
-                                        description: Specify whether the Secret or
-                                          its keys must be defined
+                                        description: optional field specify whether
+                                          the Secret or its keys must be defined
                                         type: boolean
                                       secretName:
-                                        description: 'Name of the secret in the pod''s
-                                          namespace to use. More info: https://kubernetes.io/docs/concepts/storage/volumes#secret'
+                                        description: 'secretName is the name of the
+                                          secret in the pod''s namespace to use. More
+                                          info: https://kubernetes.io/docs/concepts/storage/volumes#secret'
                                         type: string
                                     type: object
                                   storageos:
-                                    description: StorageOS represents a StorageOS
+                                    description: storageOS represents a StorageOS
                                       volume attached and mounted on Kubernetes nodes.
                                     properties:
                                       fsType:
-                                        description: Filesystem type to mount. Must
-                                          be a filesystem type supported by the host
-                                          operating system. Ex. "ext4", "xfs", "ntfs".
-                                          Implicitly inferred to be "ext4" if unspecified.
+                                        description: fsType is the filesystem type
+                                          to mount. Must be a filesystem type supported
+                                          by the host operating system. Ex. "ext4",
+                                          "xfs", "ntfs". Implicitly inferred to be
+                                          "ext4" if unspecified.
                                         type: string
                                       readOnly:
-                                        description: Defaults to false (read/write).
+                                        description: readOnly defaults to false (read/write).
                                           ReadOnly here will force the ReadOnly setting
                                           in VolumeMounts.
                                         type: boolean
                                       secretRef:
-                                        description: SecretRef specifies the secret
+                                        description: secretRef specifies the secret
                                           to use for obtaining the StorageOS API credentials.  If
                                           not specified, default values will be attempted.
                                         properties:
@@ -6743,12 +7673,12 @@ spec:
                                             type: string
                                         type: object
                                       volumeName:
-                                        description: VolumeName is the human-readable
+                                        description: volumeName is the human-readable
                                           name of the StorageOS volume.  Volume names
                                           are only unique within a namespace.
                                         type: string
                                       volumeNamespace:
-                                        description: VolumeNamespace specifies the
+                                        description: volumeNamespace specifies the
                                           scope of the volume within StorageOS.  If
                                           no namespace is specified then the Pod's
                                           namespace will be used.  This allows the
@@ -6761,27 +7691,29 @@ spec:
                                         type: string
                                     type: object
                                   vsphereVolume:
-                                    description: VsphereVolume represents a vSphere
+                                    description: vsphereVolume represents a vSphere
                                       volume attached and mounted on kubelets host
                                       machine
                                     properties:
                                       fsType:
-                                        description: Filesystem type to mount. Must
-                                          be a filesystem type supported by the host
-                                          operating system. Ex. "ext4", "xfs", "ntfs".
-                                          Implicitly inferred to be "ext4" if unspecified.
+                                        description: fsType is filesystem type to
+                                          mount. Must be a filesystem type supported
+                                          by the host operating system. Ex. "ext4",
+                                          "xfs", "ntfs". Implicitly inferred to be
+                                          "ext4" if unspecified.
                                         type: string
                                       storagePolicyID:
-                                        description: Storage Policy Based Management
-                                          (SPBM) profile ID associated with the StoragePolicyName.
+                                        description: storagePolicyID is the storage
+                                          Policy Based Management (SPBM) profile ID
+                                          associated with the StoragePolicyName.
                                         type: string
                                       storagePolicyName:
-                                        description: Storage Policy Based Management
-                                          (SPBM) profile name.
+                                        description: storagePolicyName is the storage
+                                          Policy Based Management (SPBM) profile name.
                                         type: string
                                       volumePath:
-                                        description: Path that identifies vSphere
-                                          volume vmdk
+                                        description: volumePath is the path that identifies
+                                          vSphere volume vmdk
                                         type: string
                                     required:
                                     - volumePath
@@ -6795,10 +7727,10 @@ spec:
                           type: object
                       type: object
                   type: object
-                description: 'MXReplicaSpecs is map of common.ReplicaType and common.ReplicaSpec
+                description: 'MXReplicaSpecs is map of commonv1.ReplicaType and commonv1.ReplicaSpec
                   specifies the MX replicas to run. For example,   {     "Scheduler":
-                  common.ReplicaSpec,     "Server": common.ReplicaSpec,     "Worker":
-                  common.ReplicaSpec,   }'
+                  commonv1.ReplicaSpec,     "Server": commonv1.ReplicaSpec,     "Worker":
+                  commonv1.ReplicaSpec,   }'
                 type: object
               runPolicy:
                 description: RunPolicy encapsulates various runtime policies of the

--- a/apps/training-operator/upstream/base/crds/kubeflow.org_pytorchjobs.yaml
+++ b/apps/training-operator/upstream/base/crds/kubeflow.org_pytorchjobs.yaml
@@ -69,6 +69,65 @@ spec:
                         metric (only `type` and one other matching field should be
                         set at once).
                       properties:
+                        containerResource:
+                          description: container resource refers to a resource metric
+                            (such as those specified in requests and limits) known
+                            to Kubernetes describing a single container in each pod
+                            of the current scale target (e.g. CPU or memory). Such
+                            metrics are built in to Kubernetes, and have special scaling
+                            options on top of those available to normal per-pod metrics
+                            using the "pods" source. This is an alpha feature and
+                            can be enabled by the HPAContainerMetrics feature flag.
+                          properties:
+                            container:
+                              description: container is the name of the container
+                                in the pods of the scaling target
+                              type: string
+                            name:
+                              description: name is the name of the resource in question.
+                              type: string
+                            target:
+                              description: target specifies the target value for the
+                                given metric
+                              properties:
+                                averageUtilization:
+                                  description: averageUtilization is the target value
+                                    of the average of the resource metric across all
+                                    relevant pods, represented as a percentage of
+                                    the requested value of the resource for the pods.
+                                    Currently only valid for Resource metric source
+                                    type
+                                  format: int32
+                                  type: integer
+                                averageValue:
+                                  anyOf:
+                                  - type: integer
+                                  - type: string
+                                  description: averageValue is the target value of
+                                    the average of the metric across all relevant
+                                    pods (as a quantity)
+                                  pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                  x-kubernetes-int-or-string: true
+                                type:
+                                  description: type represents whether the metric
+                                    type is Utilization, Value, or AverageValue
+                                  type: string
+                                value:
+                                  anyOf:
+                                  - type: integer
+                                  - type: string
+                                  description: value is the target value of the metric
+                                    (as a quantity).
+                                  pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                  x-kubernetes-int-or-string: true
+                              required:
+                              - type
+                              type: object
+                          required:
+                          - container
+                          - name
+                          - target
+                          type: object
                         external:
                           description: external refers to a global metric that is
                             not associated with any Kubernetes object. It allows autoscaling
@@ -476,9 +535,11 @@ spec:
                           - target
                           type: object
                         type:
-                          description: type is the type of metric source.  It should
-                            be one of "Object", "Pods" or "Resource", each mapping
-                            to a matching field in the object.
+                          description: 'type is the type of metric source.  It should
+                            be one of "ContainerResource", "External", "Object", "Pods"
+                            or "Resource", each mapping to a matching field in the
+                            object. Note: "ContainerResource" type is available on
+                            when the feature-gate HPAContainerMetrics is enabled'
                           type: string
                       required:
                       - type
@@ -898,12 +959,85 @@ spec:
                                                       are ANDed.
                                                     type: object
                                                 type: object
+                                              namespaceSelector:
+                                                description: A label query over the
+                                                  set of namespaces that the term
+                                                  applies to. The term is applied
+                                                  to the union of the namespaces selected
+                                                  by this field and the ones listed
+                                                  in the namespaces field. null selector
+                                                  and null or empty namespaces list
+                                                  means "this pod's namespace". An
+                                                  empty selector ({}) matches all
+                                                  namespaces.
+                                                properties:
+                                                  matchExpressions:
+                                                    description: matchExpressions
+                                                      is a list of label selector
+                                                      requirements. The requirements
+                                                      are ANDed.
+                                                    items:
+                                                      description: A label selector
+                                                        requirement is a selector
+                                                        that contains values, a key,
+                                                        and an operator that relates
+                                                        the key and values.
+                                                      properties:
+                                                        key:
+                                                          description: key is the
+                                                            label key that the selector
+                                                            applies to.
+                                                          type: string
+                                                        operator:
+                                                          description: operator represents
+                                                            a key's relationship to
+                                                            a set of values. Valid
+                                                            operators are In, NotIn,
+                                                            Exists and DoesNotExist.
+                                                          type: string
+                                                        values:
+                                                          description: values is an
+                                                            array of string values.
+                                                            If the operator is In
+                                                            or NotIn, the values array
+                                                            must be non-empty. If
+                                                            the operator is Exists
+                                                            or DoesNotExist, the values
+                                                            array must be empty. This
+                                                            array is replaced during
+                                                            a strategic merge patch.
+                                                          items:
+                                                            type: string
+                                                          type: array
+                                                      required:
+                                                      - key
+                                                      - operator
+                                                      type: object
+                                                    type: array
+                                                  matchLabels:
+                                                    additionalProperties:
+                                                      type: string
+                                                    description: matchLabels is a
+                                                      map of {key,value} pairs. A
+                                                      single {key,value} in the matchLabels
+                                                      map is equivalent to an element
+                                                      of matchExpressions, whose key
+                                                      field is "key", the operator
+                                                      is "In", and the values array
+                                                      contains only "value". The requirements
+                                                      are ANDed.
+                                                    type: object
+                                                type: object
                                               namespaces:
                                                 description: namespaces specifies
-                                                  which namespaces the labelSelector
-                                                  applies to (matches against); null
-                                                  or empty list means "this pod's
-                                                  namespace"
+                                                  a static list of namespace names
+                                                  that the term applies to. The term
+                                                  is applied to the union of the namespaces
+                                                  listed in this field and the ones
+                                                  selected by namespaceSelector. null
+                                                  or empty namespaces list and null
+                                                  namespaceSelector means "this pod's
+                                                  namespace".
                                                 items:
                                                   type: string
                                                 type: array
@@ -1013,11 +1147,78 @@ spec:
                                                   ANDed.
                                                 type: object
                                             type: object
+                                          namespaceSelector:
+                                            description: A label query over the set
+                                              of namespaces that the term applies
+                                              to. The term is applied to the union
+                                              of the namespaces selected by this field
+                                              and the ones listed in the namespaces
+                                              field. null selector and null or empty
+                                              namespaces list means "this pod's namespace".
+                                              An empty selector ({}) matches all namespaces.
+                                            properties:
+                                              matchExpressions:
+                                                description: matchExpressions is a
+                                                  list of label selector requirements.
+                                                  The requirements are ANDed.
+                                                items:
+                                                  description: A label selector requirement
+                                                    is a selector that contains values,
+                                                    a key, and an operator that relates
+                                                    the key and values.
+                                                  properties:
+                                                    key:
+                                                      description: key is the label
+                                                        key that the selector applies
+                                                        to.
+                                                      type: string
+                                                    operator:
+                                                      description: operator represents
+                                                        a key's relationship to a
+                                                        set of values. Valid operators
+                                                        are In, NotIn, Exists and
+                                                        DoesNotExist.
+                                                      type: string
+                                                    values:
+                                                      description: values is an array
+                                                        of string values. If the operator
+                                                        is In or NotIn, the values
+                                                        array must be non-empty. If
+                                                        the operator is Exists or
+                                                        DoesNotExist, the values array
+                                                        must be empty. This array
+                                                        is replaced during a strategic
+                                                        merge patch.
+                                                      items:
+                                                        type: string
+                                                      type: array
+                                                  required:
+                                                  - key
+                                                  - operator
+                                                  type: object
+                                                type: array
+                                              matchLabels:
+                                                additionalProperties:
+                                                  type: string
+                                                description: matchLabels is a map
+                                                  of {key,value} pairs. A single {key,value}
+                                                  in the matchLabels map is equivalent
+                                                  to an element of matchExpressions,
+                                                  whose key field is "key", the operator
+                                                  is "In", and the values array contains
+                                                  only "value". The requirements are
+                                                  ANDed.
+                                                type: object
+                                            type: object
                                           namespaces:
-                                            description: namespaces specifies which
-                                              namespaces the labelSelector applies
-                                              to (matches against); null or empty
-                                              list means "this pod's namespace"
+                                            description: namespaces specifies a static
+                                              list of namespace names that the term
+                                              applies to. The term is applied to the
+                                              union of the namespaces listed in this
+                                              field and the ones selected by namespaceSelector.
+                                              null or empty namespaces list and null
+                                              namespaceSelector means "this pod's
+                                              namespace".
                                             items:
                                               type: string
                                             type: array
@@ -1129,12 +1330,85 @@ spec:
                                                       are ANDed.
                                                     type: object
                                                 type: object
+                                              namespaceSelector:
+                                                description: A label query over the
+                                                  set of namespaces that the term
+                                                  applies to. The term is applied
+                                                  to the union of the namespaces selected
+                                                  by this field and the ones listed
+                                                  in the namespaces field. null selector
+                                                  and null or empty namespaces list
+                                                  means "this pod's namespace". An
+                                                  empty selector ({}) matches all
+                                                  namespaces.
+                                                properties:
+                                                  matchExpressions:
+                                                    description: matchExpressions
+                                                      is a list of label selector
+                                                      requirements. The requirements
+                                                      are ANDed.
+                                                    items:
+                                                      description: A label selector
+                                                        requirement is a selector
+                                                        that contains values, a key,
+                                                        and an operator that relates
+                                                        the key and values.
+                                                      properties:
+                                                        key:
+                                                          description: key is the
+                                                            label key that the selector
+                                                            applies to.
+                                                          type: string
+                                                        operator:
+                                                          description: operator represents
+                                                            a key's relationship to
+                                                            a set of values. Valid
+                                                            operators are In, NotIn,
+                                                            Exists and DoesNotExist.
+                                                          type: string
+                                                        values:
+                                                          description: values is an
+                                                            array of string values.
+                                                            If the operator is In
+                                                            or NotIn, the values array
+                                                            must be non-empty. If
+                                                            the operator is Exists
+                                                            or DoesNotExist, the values
+                                                            array must be empty. This
+                                                            array is replaced during
+                                                            a strategic merge patch.
+                                                          items:
+                                                            type: string
+                                                          type: array
+                                                      required:
+                                                      - key
+                                                      - operator
+                                                      type: object
+                                                    type: array
+                                                  matchLabels:
+                                                    additionalProperties:
+                                                      type: string
+                                                    description: matchLabels is a
+                                                      map of {key,value} pairs. A
+                                                      single {key,value} in the matchLabels
+                                                      map is equivalent to an element
+                                                      of matchExpressions, whose key
+                                                      field is "key", the operator
+                                                      is "In", and the values array
+                                                      contains only "value". The requirements
+                                                      are ANDed.
+                                                    type: object
+                                                type: object
                                               namespaces:
                                                 description: namespaces specifies
-                                                  which namespaces the labelSelector
-                                                  applies to (matches against); null
-                                                  or empty list means "this pod's
-                                                  namespace"
+                                                  a static list of namespace names
+                                                  that the term applies to. The term
+                                                  is applied to the union of the namespaces
+                                                  listed in this field and the ones
+                                                  selected by namespaceSelector. null
+                                                  or empty namespaces list and null
+                                                  namespaceSelector means "this pod's
+                                                  namespace".
                                                 items:
                                                   type: string
                                                 type: array
@@ -1244,11 +1518,78 @@ spec:
                                                   ANDed.
                                                 type: object
                                             type: object
+                                          namespaceSelector:
+                                            description: A label query over the set
+                                              of namespaces that the term applies
+                                              to. The term is applied to the union
+                                              of the namespaces selected by this field
+                                              and the ones listed in the namespaces
+                                              field. null selector and null or empty
+                                              namespaces list means "this pod's namespace".
+                                              An empty selector ({}) matches all namespaces.
+                                            properties:
+                                              matchExpressions:
+                                                description: matchExpressions is a
+                                                  list of label selector requirements.
+                                                  The requirements are ANDed.
+                                                items:
+                                                  description: A label selector requirement
+                                                    is a selector that contains values,
+                                                    a key, and an operator that relates
+                                                    the key and values.
+                                                  properties:
+                                                    key:
+                                                      description: key is the label
+                                                        key that the selector applies
+                                                        to.
+                                                      type: string
+                                                    operator:
+                                                      description: operator represents
+                                                        a key's relationship to a
+                                                        set of values. Valid operators
+                                                        are In, NotIn, Exists and
+                                                        DoesNotExist.
+                                                      type: string
+                                                    values:
+                                                      description: values is an array
+                                                        of string values. If the operator
+                                                        is In or NotIn, the values
+                                                        array must be non-empty. If
+                                                        the operator is Exists or
+                                                        DoesNotExist, the values array
+                                                        must be empty. This array
+                                                        is replaced during a strategic
+                                                        merge patch.
+                                                      items:
+                                                        type: string
+                                                      type: array
+                                                  required:
+                                                  - key
+                                                  - operator
+                                                  type: object
+                                                type: array
+                                              matchLabels:
+                                                additionalProperties:
+                                                  type: string
+                                                description: matchLabels is a map
+                                                  of {key,value} pairs. A single {key,value}
+                                                  in the matchLabels map is equivalent
+                                                  to an element of matchExpressions,
+                                                  whose key field is "key", the operator
+                                                  is "In", and the values array contains
+                                                  only "value". The requirements are
+                                                  ANDed.
+                                                type: object
+                                            type: object
                                           namespaces:
-                                            description: namespaces specifies which
-                                              namespaces the labelSelector applies
-                                              to (matches against); null or empty
-                                              list means "this pod's namespace"
+                                            description: namespaces specifies a static
+                                              list of namespace names that the term
+                                              applies to. The term is applied to the
+                                              union of the namespaces listed in this
+                                              field and the ones selected by namespaceSelector.
+                                              null or empty namespaces list and null
+                                              namespaceSelector means "this pod's
+                                              namespace".
                                             items:
                                               type: string
                                             type: array
@@ -1285,12 +1626,14 @@ spec:
                                 properties:
                                   args:
                                     description: 'Arguments to the entrypoint. The
-                                      docker image''s CMD is used if this is not provided.
-                                      Variable references $(VAR_NAME) are expanded
-                                      using the container''s environment. If a variable
-                                      cannot be resolved, the reference in the input
-                                      string will be unchanged. The $(VAR_NAME) syntax
-                                      can be escaped with a double $$, ie: $$(VAR_NAME).
+                                      container image''s CMD is used if this is not
+                                      provided. Variable references $(VAR_NAME) are
+                                      expanded using the container''s environment.
+                                      If a variable cannot be resolved, the reference
+                                      in the input string will be unchanged. Double
+                                      $$ are reduced to a single $, which allows for
+                                      escaping the $(VAR_NAME) syntax: i.e. "$$(VAR_NAME)"
+                                      will produce the string literal "$(VAR_NAME)".
                                       Escaped references will never be expanded, regardless
                                       of whether the variable exists or not. Cannot
                                       be updated. More info: https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell'
@@ -1299,16 +1642,17 @@ spec:
                                     type: array
                                   command:
                                     description: 'Entrypoint array. Not executed within
-                                      a shell. The docker image''s ENTRYPOINT is used
-                                      if this is not provided. Variable references
+                                      a shell. The container image''s ENTRYPOINT is
+                                      used if this is not provided. Variable references
                                       $(VAR_NAME) are expanded using the container''s
                                       environment. If a variable cannot be resolved,
                                       the reference in the input string will be unchanged.
-                                      The $(VAR_NAME) syntax can be escaped with a
-                                      double $$, ie: $$(VAR_NAME). Escaped references
-                                      will never be expanded, regardless of whether
-                                      the variable exists or not. Cannot be updated.
-                                      More info: https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell'
+                                      Double $$ are reduced to a single $, which allows
+                                      for escaping the $(VAR_NAME) syntax: i.e. "$$(VAR_NAME)"
+                                      will produce the string literal "$(VAR_NAME)".
+                                      Escaped references will never be expanded, regardless
+                                      of whether the variable exists or not. Cannot
+                                      be updated. More info: https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell'
                                     items:
                                       type: string
                                     type: array
@@ -1325,13 +1669,15 @@ spec:
                                           type: string
                                         value:
                                           description: 'Variable references $(VAR_NAME)
-                                            are expanded using the previous defined
+                                            are expanded using the previously defined
                                             environment variables in the container
                                             and any service environment variables.
                                             If a variable cannot be resolved, the
                                             reference in the input string will be
-                                            unchanged. The $(VAR_NAME) syntax can
-                                            be escaped with a double $$, ie: $$(VAR_NAME).
+                                            unchanged. Double $$ are reduced to a
+                                            single $, which allows for escaping the
+                                            $(VAR_NAME) syntax: i.e. "$$(VAR_NAME)"
+                                            will produce the string literal "$(VAR_NAME)".
                                             Escaped references will never be expanded,
                                             regardless of whether the variable exists
                                             or not. Defaults to "".'
@@ -1485,7 +1831,8 @@ spec:
                                       type: object
                                     type: array
                                   image:
-                                    description: 'Docker image name. More info: https://kubernetes.io/docs/concepts/containers/images
+                                    description: 'Container image name. More info:
+                                      https://kubernetes.io/docs/concepts/containers/images
                                       This field is optional to allow higher level
                                       config management to default or override container
                                       images in workload controllers like Deployments
@@ -1511,9 +1858,8 @@ spec:
                                           More info: https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/#container-hooks'
                                         properties:
                                           exec:
-                                            description: One and only one of the following
-                                              should be specified. Exec specifies
-                                              the action to take.
+                                            description: Exec specifies the action
+                                              to take.
                                             properties:
                                               command:
                                                 description: Command is the command
@@ -1584,10 +1930,12 @@ spec:
                                             - port
                                             type: object
                                           tcpSocket:
-                                            description: 'TCPSocket specifies an action
-                                              involving a TCP port. TCP hooks not
-                                              yet supported TODO: implement a realistic
-                                              TCP lifecycle hook'
+                                            description: Deprecated. TCPSocket is
+                                              NOT supported as a LifecycleHandler
+                                              and kept for the backward compatibility.
+                                              There are no validation of this field
+                                              and lifecycle hooks will fail in runtime
+                                              when tcp handler is specified.
                                             properties:
                                               host:
                                                 description: 'Optional: Host name
@@ -1614,21 +1962,19 @@ spec:
                                           as liveness/startup probe failure, preemption,
                                           resource contention, etc. The handler is
                                           not called if the container crashes or exits.
-                                          The reason for termination is passed to
-                                          the handler. The Pod''s termination grace
-                                          period countdown begins before the PreStop
-                                          hooked is executed. Regardless of the outcome
-                                          of the handler, the container will eventually
-                                          terminate within the Pod''s termination
-                                          grace period. Other management of the container
-                                          blocks until the hook completes or until
-                                          the termination grace period is reached.
-                                          More info: https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/#container-hooks'
+                                          The Pod''s termination grace period countdown
+                                          begins before the PreStop hook is executed.
+                                          Regardless of the outcome of the handler,
+                                          the container will eventually terminate
+                                          within the Pod''s termination grace period
+                                          (unless delayed by finalizers). Other management
+                                          of the container blocks until the hook completes
+                                          or until the termination grace period is
+                                          reached. More info: https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/#container-hooks'
                                         properties:
                                           exec:
-                                            description: One and only one of the following
-                                              should be specified. Exec specifies
-                                              the action to take.
+                                            description: Exec specifies the action
+                                              to take.
                                             properties:
                                               command:
                                                 description: Command is the command
@@ -1699,10 +2045,12 @@ spec:
                                             - port
                                             type: object
                                           tcpSocket:
-                                            description: 'TCPSocket specifies an action
-                                              involving a TCP port. TCP hooks not
-                                              yet supported TODO: implement a realistic
-                                              TCP lifecycle hook'
+                                            description: Deprecated. TCPSocket is
+                                              NOT supported as a LifecycleHandler
+                                              and kept for the backward compatibility.
+                                              There are no validation of this field
+                                              and lifecycle hooks will fail in runtime
+                                              when tcp handler is specified.
                                             properties:
                                               host:
                                                 description: 'Optional: Host name
@@ -1729,9 +2077,8 @@ spec:
                                       Cannot be updated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
                                     properties:
                                       exec:
-                                        description: One and only one of the following
-                                          should be specified. Exec specifies the
-                                          action to take.
+                                        description: Exec specifies the action to
+                                          take.
                                         properties:
                                           command:
                                             description: Command is the command line
@@ -1756,6 +2103,26 @@ spec:
                                           value is 1.
                                         format: int32
                                         type: integer
+                                      grpc:
+                                        description: GRPC specifies an action involving
+                                          a GRPC port. This is a beta field and requires
+                                          enabling GRPCContainerProbe feature gate.
+                                        properties:
+                                          port:
+                                            description: Port number of the gRPC service.
+                                              Number must be in the range 1 to 65535.
+                                            format: int32
+                                            type: integer
+                                          service:
+                                            description: "Service is the name of the
+                                              service to place in the gRPC HealthCheckRequest
+                                              (see https://github.com/grpc/grpc/blob/master/doc/health-checking.md).
+                                              \n If this is not specified, the default
+                                              behavior is defined by gRPC."
+                                            type: string
+                                        required:
+                                        - port
+                                        type: object
                                       httpGet:
                                         description: HTTPGet specifies the http request
                                           to perform.
@@ -1824,10 +2191,8 @@ spec:
                                         format: int32
                                         type: integer
                                       tcpSocket:
-                                        description: 'TCPSocket specifies an action
-                                          involving a TCP port. TCP hooks not yet
-                                          supported TODO: implement a realistic TCP
-                                          lifecycle hook'
+                                        description: TCPSocket specifies an action
+                                          involving a TCP port.
                                         properties:
                                           host:
                                             description: 'Optional: Host name to connect
@@ -1845,6 +2210,28 @@ spec:
                                         required:
                                         - port
                                         type: object
+                                      terminationGracePeriodSeconds:
+                                        description: Optional duration in seconds
+                                          the pod needs to terminate gracefully upon
+                                          probe failure. The grace period is the duration
+                                          in seconds after the processes running in
+                                          the pod are sent a termination signal and
+                                          the time when the processes are forcibly
+                                          halted with a kill signal. Set this value
+                                          longer than the expected cleanup time for
+                                          your process. If this value is nil, the
+                                          pod's terminationGracePeriodSeconds will
+                                          be used. Otherwise, this value overrides
+                                          the value provided by the pod spec. Value
+                                          must be non-negative integer. The value
+                                          zero indicates stop immediately via the
+                                          kill signal (no opportunity to shut down).
+                                          This is a beta field and requires enabling
+                                          ProbeTerminationGracePeriod feature gate.
+                                          Minimum value is 1. spec.terminationGracePeriodSeconds
+                                          is used if unset.
+                                        format: int64
+                                        type: integer
                                       timeoutSeconds:
                                         description: 'Number of seconds after which
                                           the probe times out. Defaults to 1 second.
@@ -1916,9 +2303,8 @@ spec:
                                       More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
                                     properties:
                                       exec:
-                                        description: One and only one of the following
-                                          should be specified. Exec specifies the
-                                          action to take.
+                                        description: Exec specifies the action to
+                                          take.
                                         properties:
                                           command:
                                             description: Command is the command line
@@ -1943,6 +2329,26 @@ spec:
                                           value is 1.
                                         format: int32
                                         type: integer
+                                      grpc:
+                                        description: GRPC specifies an action involving
+                                          a GRPC port. This is a beta field and requires
+                                          enabling GRPCContainerProbe feature gate.
+                                        properties:
+                                          port:
+                                            description: Port number of the gRPC service.
+                                              Number must be in the range 1 to 65535.
+                                            format: int32
+                                            type: integer
+                                          service:
+                                            description: "Service is the name of the
+                                              service to place in the gRPC HealthCheckRequest
+                                              (see https://github.com/grpc/grpc/blob/master/doc/health-checking.md).
+                                              \n If this is not specified, the default
+                                              behavior is defined by gRPC."
+                                            type: string
+                                        required:
+                                        - port
+                                        type: object
                                       httpGet:
                                         description: HTTPGet specifies the http request
                                           to perform.
@@ -2011,10 +2417,8 @@ spec:
                                         format: int32
                                         type: integer
                                       tcpSocket:
-                                        description: 'TCPSocket specifies an action
-                                          involving a TCP port. TCP hooks not yet
-                                          supported TODO: implement a realistic TCP
-                                          lifecycle hook'
+                                        description: TCPSocket specifies an action
+                                          involving a TCP port.
                                         properties:
                                           host:
                                             description: 'Optional: Host name to connect
@@ -2032,6 +2436,28 @@ spec:
                                         required:
                                         - port
                                         type: object
+                                      terminationGracePeriodSeconds:
+                                        description: Optional duration in seconds
+                                          the pod needs to terminate gracefully upon
+                                          probe failure. The grace period is the duration
+                                          in seconds after the processes running in
+                                          the pod are sent a termination signal and
+                                          the time when the processes are forcibly
+                                          halted with a kill signal. Set this value
+                                          longer than the expected cleanup time for
+                                          your process. If this value is nil, the
+                                          pod's terminationGracePeriodSeconds will
+                                          be used. Otherwise, this value overrides
+                                          the value provided by the pod spec. Value
+                                          must be non-negative integer. The value
+                                          zero indicates stop immediately via the
+                                          kill signal (no opportunity to shut down).
+                                          This is a beta field and requires enabling
+                                          ProbeTerminationGracePeriod feature gate.
+                                          Minimum value is 1. spec.terminationGracePeriodSeconds
+                                          is used if unset.
+                                        format: int64
+                                        type: integer
                                       timeoutSeconds:
                                         description: 'Number of seconds after which
                                           the probe times out. Defaults to 1 second.
@@ -2041,7 +2467,7 @@ spec:
                                     type: object
                                   resources:
                                     description: 'Compute Resources required by this
-                                      container. Cannot be updated. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
+                                      container. Cannot be updated. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
                                     properties:
                                       limits:
                                         additionalProperties:
@@ -2052,7 +2478,7 @@ spec:
                                           x-kubernetes-int-or-string: true
                                         description: 'Limits describes the maximum
                                           amount of compute resources allowed. More
-                                          info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
+                                          info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
                                         type: object
                                       requests:
                                         additionalProperties:
@@ -2066,12 +2492,14 @@ spec:
                                           Requests is omitted for a container, it
                                           defaults to Limits if that is explicitly
                                           specified, otherwise to an implementation-defined
-                                          value. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
+                                          value. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
                                         type: object
                                     type: object
                                   securityContext:
-                                    description: 'Security options the pod should
-                                      run with. More info: https://kubernetes.io/docs/concepts/policy/security-context/
+                                    description: 'SecurityContext defines the security
+                                      options the container should be run with. If
+                                      set, the fields of SecurityContext override
+                                      the equivalent fields of PodSecurityContext.
                                       More info: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/'
                                     properties:
                                       allowPrivilegeEscalation:
@@ -2081,13 +2509,16 @@ spec:
                                           controls if the no_new_privs flag will be
                                           set on the container process. AllowPrivilegeEscalation
                                           is true always when the container is: 1)
-                                          run as Privileged 2) has CAP_SYS_ADMIN'
+                                          run as Privileged 2) has CAP_SYS_ADMIN Note
+                                          that this field cannot be set when spec.os.name
+                                          is windows.'
                                         type: boolean
                                       capabilities:
                                         description: The capabilities to add/drop
                                           when running containers. Defaults to the
                                           default set of capabilities granted by the
-                                          container runtime.
+                                          container runtime. Note that this field
+                                          cannot be set when spec.os.name is windows.
                                         properties:
                                           add:
                                             description: Added capabilities
@@ -2108,7 +2539,8 @@ spec:
                                         description: Run container in privileged mode.
                                           Processes in privileged containers are essentially
                                           equivalent to root on the host. Defaults
-                                          to false.
+                                          to false. Note that this field cannot be
+                                          set when spec.os.name is windows.
                                         type: boolean
                                       procMount:
                                         description: procMount denotes the type of
@@ -2117,10 +2549,14 @@ spec:
                                           container runtime defaults for readonly
                                           paths and masked paths. This requires the
                                           ProcMountType feature flag to be enabled.
+                                          Note that this field cannot be set when
+                                          spec.os.name is windows.
                                         type: string
                                       readOnlyRootFilesystem:
                                         description: Whether this container has a
                                           read-only root filesystem. Default is false.
+                                          Note that this field cannot be set when
+                                          spec.os.name is windows.
                                         type: boolean
                                       runAsGroup:
                                         description: The GID to run the entrypoint
@@ -2128,7 +2564,8 @@ spec:
                                           if unset. May also be set in PodSecurityContext.  If
                                           set in both SecurityContext and PodSecurityContext,
                                           the value specified in SecurityContext takes
-                                          precedence.
+                                          precedence. Note that this field cannot
+                                          be set when spec.os.name is windows.
                                         format: int64
                                         type: integer
                                       runAsNonRoot:
@@ -2150,7 +2587,8 @@ spec:
                                           May also be set in PodSecurityContext.  If
                                           set in both SecurityContext and PodSecurityContext,
                                           the value specified in SecurityContext takes
-                                          precedence.
+                                          precedence. Note that this field cannot
+                                          be set when spec.os.name is windows.
                                         format: int64
                                         type: integer
                                       seLinuxOptions:
@@ -2160,7 +2598,9 @@ spec:
                                           for each container.  May also be set in
                                           PodSecurityContext.  If set in both SecurityContext
                                           and PodSecurityContext, the value specified
-                                          in SecurityContext takes precedence.
+                                          in SecurityContext takes precedence. Note
+                                          that this field cannot be set when spec.os.name
+                                          is windows.
                                         properties:
                                           level:
                                             description: Level is SELinux level label
@@ -2183,7 +2623,9 @@ spec:
                                         description: The seccomp options to use by
                                           this container. If seccomp options are provided
                                           at both the pod & container level, the container
-                                          options override the pod options.
+                                          options override the pod options. Note that
+                                          this field cannot be set when spec.os.name
+                                          is windows.
                                         properties:
                                           localhostProfile:
                                             description: localhostProfile indicates
@@ -2214,7 +2656,9 @@ spec:
                                           the options from the PodSecurityContext
                                           will be used. If set in both SecurityContext
                                           and PodSecurityContext, the value specified
-                                          in SecurityContext takes precedence.
+                                          in SecurityContext takes precedence. Note
+                                          that this field cannot be set when spec.os.name
+                                          is linux.
                                         properties:
                                           gmsaCredentialSpec:
                                             description: GMSACredentialSpec is where
@@ -2228,6 +2672,22 @@ spec:
                                               the name of the GMSA credential spec
                                               to use.
                                             type: string
+                                          hostProcess:
+                                            description: HostProcess determines if
+                                              a container should be run as a 'Host
+                                              Process' container. This field is alpha-level
+                                              and will only be honored by components
+                                              that enable the WindowsHostProcessContainers
+                                              feature flag. Setting this field without
+                                              the feature flag will result in errors
+                                              when validating the Pod. All of a Pod's
+                                              containers must have the same effective
+                                              HostProcess value (it is not allowed
+                                              to have a mix of HostProcess containers
+                                              and non-HostProcess containers).  In
+                                              addition, if HostProcess is true then
+                                              HostNetwork must also be set to true.
+                                            type: boolean
                                           runAsUserName:
                                             description: The UserName in Windows to
                                               run the entrypoint of the container
@@ -2250,14 +2710,11 @@ spec:
                                       parameters at the beginning of a Pod''s lifecycle,
                                       when it might take a long time to load data
                                       or warm a cache, than during steady-state operation.
-                                      This cannot be updated. This is a beta feature
-                                      enabled by the StartupProbe feature flag. More
-                                      info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                                      This cannot be updated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
                                     properties:
                                       exec:
-                                        description: One and only one of the following
-                                          should be specified. Exec specifies the
-                                          action to take.
+                                        description: Exec specifies the action to
+                                          take.
                                         properties:
                                           command:
                                             description: Command is the command line
@@ -2282,6 +2739,26 @@ spec:
                                           value is 1.
                                         format: int32
                                         type: integer
+                                      grpc:
+                                        description: GRPC specifies an action involving
+                                          a GRPC port. This is a beta field and requires
+                                          enabling GRPCContainerProbe feature gate.
+                                        properties:
+                                          port:
+                                            description: Port number of the gRPC service.
+                                              Number must be in the range 1 to 65535.
+                                            format: int32
+                                            type: integer
+                                          service:
+                                            description: "Service is the name of the
+                                              service to place in the gRPC HealthCheckRequest
+                                              (see https://github.com/grpc/grpc/blob/master/doc/health-checking.md).
+                                              \n If this is not specified, the default
+                                              behavior is defined by gRPC."
+                                            type: string
+                                        required:
+                                        - port
+                                        type: object
                                       httpGet:
                                         description: HTTPGet specifies the http request
                                           to perform.
@@ -2350,10 +2827,8 @@ spec:
                                         format: int32
                                         type: integer
                                       tcpSocket:
-                                        description: 'TCPSocket specifies an action
-                                          involving a TCP port. TCP hooks not yet
-                                          supported TODO: implement a realistic TCP
-                                          lifecycle hook'
+                                        description: TCPSocket specifies an action
+                                          involving a TCP port.
                                         properties:
                                           host:
                                             description: 'Optional: Host name to connect
@@ -2371,6 +2846,28 @@ spec:
                                         required:
                                         - port
                                         type: object
+                                      terminationGracePeriodSeconds:
+                                        description: Optional duration in seconds
+                                          the pod needs to terminate gracefully upon
+                                          probe failure. The grace period is the duration
+                                          in seconds after the processes running in
+                                          the pod are sent a termination signal and
+                                          the time when the processes are forcibly
+                                          halted with a kill signal. Set this value
+                                          longer than the expected cleanup time for
+                                          your process. If this value is nil, the
+                                          pod's terminationGracePeriodSeconds will
+                                          be used. Otherwise, this value overrides
+                                          the value provided by the pod spec. Value
+                                          must be non-negative integer. The value
+                                          zero indicates stop immediately via the
+                                          kill signal (no opportunity to shut down).
+                                          This is a beta field and requires enabling
+                                          ProbeTerminationGracePeriod feature gate.
+                                          Minimum value is 1. spec.terminationGracePeriodSeconds
+                                          is used if unset.
+                                        format: int64
+                                        type: integer
                                       timeoutSeconds:
                                         description: 'Number of seconds after which
                                           the probe times out. Defaults to 1 second.
@@ -2568,33 +3065,35 @@ spec:
                                 and it cannot be modified by updating the pod spec.
                                 In order to add an ephemeral container to an existing
                                 pod, use the pod's ephemeralcontainers subresource.
-                                This field is alpha-level and is only honored by servers
-                                that enable the EphemeralContainers feature.
+                                This field is beta-level and available on clusters
+                                that haven't disabled the EphemeralContainers feature
+                                gate.
                               items:
-                                description: An EphemeralContainer is a container
-                                  that may be added temporarily to an existing pod
-                                  for user-initiated activities such as debugging.
-                                  Ephemeral containers have no resource or scheduling
-                                  guarantees, and they will not be restarted when
-                                  they exit or when a pod is removed or restarted.
-                                  If an ephemeral container causes a pod to exceed
-                                  its resource allocation, the pod may be evicted.
-                                  Ephemeral containers may not be added by directly
-                                  updating the pod spec. They must be added via the
-                                  pod's ephemeralcontainers subresource, and they
-                                  will appear in the pod spec once added. This is
-                                  an alpha feature enabled by the EphemeralContainers
-                                  feature flag.
+                                description: "An EphemeralContainer is a temporary
+                                  container that you may add to an existing Pod for
+                                  user-initiated activities such as debugging. Ephemeral
+                                  containers have no resource or scheduling guarantees,
+                                  and they will not be restarted when they exit or
+                                  when a Pod is removed or restarted. The kubelet
+                                  may evict a Pod if an ephemeral container causes
+                                  the Pod to exceed its resource allocation. \n To
+                                  add an ephemeral container, use the ephemeralcontainers
+                                  subresource of an existing Pod. Ephemeral containers
+                                  may not be removed or restarted. \n This is a beta
+                                  feature available on clusters that haven't disabled
+                                  the EphemeralContainers feature gate."
                                 properties:
                                   args:
                                     description: 'Arguments to the entrypoint. The
-                                      docker image''s CMD is used if this is not provided.
+                                      image''s CMD is used if this is not provided.
                                       Variable references $(VAR_NAME) are expanded
                                       using the container''s environment. If a variable
                                       cannot be resolved, the reference in the input
-                                      string will be unchanged. The $(VAR_NAME) syntax
-                                      can be escaped with a double $$, ie: $$(VAR_NAME).
-                                      Escaped references will never be expanded, regardless
+                                      string will be unchanged. Double $$ are reduced
+                                      to a single $, which allows for escaping the
+                                      $(VAR_NAME) syntax: i.e. "$$(VAR_NAME)" will
+                                      produce the string literal "$(VAR_NAME)". Escaped
+                                      references will never be expanded, regardless
                                       of whether the variable exists or not. Cannot
                                       be updated. More info: https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell'
                                     items:
@@ -2602,16 +3101,17 @@ spec:
                                     type: array
                                   command:
                                     description: 'Entrypoint array. Not executed within
-                                      a shell. The docker image''s ENTRYPOINT is used
-                                      if this is not provided. Variable references
-                                      $(VAR_NAME) are expanded using the container''s
-                                      environment. If a variable cannot be resolved,
-                                      the reference in the input string will be unchanged.
-                                      The $(VAR_NAME) syntax can be escaped with a
-                                      double $$, ie: $$(VAR_NAME). Escaped references
-                                      will never be expanded, regardless of whether
-                                      the variable exists or not. Cannot be updated.
-                                      More info: https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell'
+                                      a shell. The image''s ENTRYPOINT is used if
+                                      this is not provided. Variable references $(VAR_NAME)
+                                      are expanded using the container''s environment.
+                                      If a variable cannot be resolved, the reference
+                                      in the input string will be unchanged. Double
+                                      $$ are reduced to a single $, which allows for
+                                      escaping the $(VAR_NAME) syntax: i.e. "$$(VAR_NAME)"
+                                      will produce the string literal "$(VAR_NAME)".
+                                      Escaped references will never be expanded, regardless
+                                      of whether the variable exists or not. Cannot
+                                      be updated. More info: https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell'
                                     items:
                                       type: string
                                     type: array
@@ -2628,13 +3128,15 @@ spec:
                                           type: string
                                         value:
                                           description: 'Variable references $(VAR_NAME)
-                                            are expanded using the previous defined
+                                            are expanded using the previously defined
                                             environment variables in the container
                                             and any service environment variables.
                                             If a variable cannot be resolved, the
                                             reference in the input string will be
-                                            unchanged. The $(VAR_NAME) syntax can
-                                            be escaped with a double $$, ie: $$(VAR_NAME).
+                                            unchanged. Double $$ are reduced to a
+                                            single $, which allows for escaping the
+                                            $(VAR_NAME) syntax: i.e. "$$(VAR_NAME)"
+                                            will produce the string literal "$(VAR_NAME)".
                                             Escaped references will never be expanded,
                                             regardless of whether the variable exists
                                             or not. Defaults to "".'
@@ -2788,7 +3290,8 @@ spec:
                                       type: object
                                     type: array
                                   image:
-                                    description: 'Docker image name. More info: https://kubernetes.io/docs/concepts/containers/images'
+                                    description: 'Container image name. More info:
+                                      https://kubernetes.io/docs/concepts/containers/images'
                                     type: string
                                   imagePullPolicy:
                                     description: 'Image pull policy. One of Always,
@@ -2809,9 +3312,8 @@ spec:
                                           More info: https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/#container-hooks'
                                         properties:
                                           exec:
-                                            description: One and only one of the following
-                                              should be specified. Exec specifies
-                                              the action to take.
+                                            description: Exec specifies the action
+                                              to take.
                                             properties:
                                               command:
                                                 description: Command is the command
@@ -2882,10 +3384,12 @@ spec:
                                             - port
                                             type: object
                                           tcpSocket:
-                                            description: 'TCPSocket specifies an action
-                                              involving a TCP port. TCP hooks not
-                                              yet supported TODO: implement a realistic
-                                              TCP lifecycle hook'
+                                            description: Deprecated. TCPSocket is
+                                              NOT supported as a LifecycleHandler
+                                              and kept for the backward compatibility.
+                                              There are no validation of this field
+                                              and lifecycle hooks will fail in runtime
+                                              when tcp handler is specified.
                                             properties:
                                               host:
                                                 description: 'Optional: Host name
@@ -2912,21 +3416,19 @@ spec:
                                           as liveness/startup probe failure, preemption,
                                           resource contention, etc. The handler is
                                           not called if the container crashes or exits.
-                                          The reason for termination is passed to
-                                          the handler. The Pod''s termination grace
-                                          period countdown begins before the PreStop
-                                          hooked is executed. Regardless of the outcome
-                                          of the handler, the container will eventually
-                                          terminate within the Pod''s termination
-                                          grace period. Other management of the container
-                                          blocks until the hook completes or until
-                                          the termination grace period is reached.
-                                          More info: https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/#container-hooks'
+                                          The Pod''s termination grace period countdown
+                                          begins before the PreStop hook is executed.
+                                          Regardless of the outcome of the handler,
+                                          the container will eventually terminate
+                                          within the Pod''s termination grace period
+                                          (unless delayed by finalizers). Other management
+                                          of the container blocks until the hook completes
+                                          or until the termination grace period is
+                                          reached. More info: https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/#container-hooks'
                                         properties:
                                           exec:
-                                            description: One and only one of the following
-                                              should be specified. Exec specifies
-                                              the action to take.
+                                            description: Exec specifies the action
+                                              to take.
                                             properties:
                                               command:
                                                 description: Command is the command
@@ -2997,10 +3499,12 @@ spec:
                                             - port
                                             type: object
                                           tcpSocket:
-                                            description: 'TCPSocket specifies an action
-                                              involving a TCP port. TCP hooks not
-                                              yet supported TODO: implement a realistic
-                                              TCP lifecycle hook'
+                                            description: Deprecated. TCPSocket is
+                                              NOT supported as a LifecycleHandler
+                                              and kept for the backward compatibility.
+                                              There are no validation of this field
+                                              and lifecycle hooks will fail in runtime
+                                              when tcp handler is specified.
                                             properties:
                                               host:
                                                 description: 'Optional: Host name
@@ -3026,9 +3530,8 @@ spec:
                                       containers.
                                     properties:
                                       exec:
-                                        description: One and only one of the following
-                                          should be specified. Exec specifies the
-                                          action to take.
+                                        description: Exec specifies the action to
+                                          take.
                                         properties:
                                           command:
                                             description: Command is the command line
@@ -3053,6 +3556,26 @@ spec:
                                           value is 1.
                                         format: int32
                                         type: integer
+                                      grpc:
+                                        description: GRPC specifies an action involving
+                                          a GRPC port. This is a beta field and requires
+                                          enabling GRPCContainerProbe feature gate.
+                                        properties:
+                                          port:
+                                            description: Port number of the gRPC service.
+                                              Number must be in the range 1 to 65535.
+                                            format: int32
+                                            type: integer
+                                          service:
+                                            description: "Service is the name of the
+                                              service to place in the gRPC HealthCheckRequest
+                                              (see https://github.com/grpc/grpc/blob/master/doc/health-checking.md).
+                                              \n If this is not specified, the default
+                                              behavior is defined by gRPC."
+                                            type: string
+                                        required:
+                                        - port
+                                        type: object
                                       httpGet:
                                         description: HTTPGet specifies the http request
                                           to perform.
@@ -3121,10 +3644,8 @@ spec:
                                         format: int32
                                         type: integer
                                       tcpSocket:
-                                        description: 'TCPSocket specifies an action
-                                          involving a TCP port. TCP hooks not yet
-                                          supported TODO: implement a realistic TCP
-                                          lifecycle hook'
+                                        description: TCPSocket specifies an action
+                                          involving a TCP port.
                                         properties:
                                           host:
                                             description: 'Optional: Host name to connect
@@ -3142,6 +3663,28 @@ spec:
                                         required:
                                         - port
                                         type: object
+                                      terminationGracePeriodSeconds:
+                                        description: Optional duration in seconds
+                                          the pod needs to terminate gracefully upon
+                                          probe failure. The grace period is the duration
+                                          in seconds after the processes running in
+                                          the pod are sent a termination signal and
+                                          the time when the processes are forcibly
+                                          halted with a kill signal. Set this value
+                                          longer than the expected cleanup time for
+                                          your process. If this value is nil, the
+                                          pod's terminationGracePeriodSeconds will
+                                          be used. Otherwise, this value overrides
+                                          the value provided by the pod spec. Value
+                                          must be non-negative integer. The value
+                                          zero indicates stop immediately via the
+                                          kill signal (no opportunity to shut down).
+                                          This is a beta field and requires enabling
+                                          ProbeTerminationGracePeriod feature gate.
+                                          Minimum value is 1. spec.terminationGracePeriodSeconds
+                                          is used if unset.
+                                        format: int64
+                                        type: integer
                                       timeoutSeconds:
                                         description: 'Number of seconds after which
                                           the probe times out. Defaults to 1 second.
@@ -3196,14 +3739,17 @@ spec:
                                       - containerPort
                                       type: object
                                     type: array
+                                    x-kubernetes-list-map-keys:
+                                    - containerPort
+                                    - protocol
+                                    x-kubernetes-list-type: map
                                   readinessProbe:
                                     description: Probes are not allowed for ephemeral
                                       containers.
                                     properties:
                                       exec:
-                                        description: One and only one of the following
-                                          should be specified. Exec specifies the
-                                          action to take.
+                                        description: Exec specifies the action to
+                                          take.
                                         properties:
                                           command:
                                             description: Command is the command line
@@ -3228,6 +3774,26 @@ spec:
                                           value is 1.
                                         format: int32
                                         type: integer
+                                      grpc:
+                                        description: GRPC specifies an action involving
+                                          a GRPC port. This is a beta field and requires
+                                          enabling GRPCContainerProbe feature gate.
+                                        properties:
+                                          port:
+                                            description: Port number of the gRPC service.
+                                              Number must be in the range 1 to 65535.
+                                            format: int32
+                                            type: integer
+                                          service:
+                                            description: "Service is the name of the
+                                              service to place in the gRPC HealthCheckRequest
+                                              (see https://github.com/grpc/grpc/blob/master/doc/health-checking.md).
+                                              \n If this is not specified, the default
+                                              behavior is defined by gRPC."
+                                            type: string
+                                        required:
+                                        - port
+                                        type: object
                                       httpGet:
                                         description: HTTPGet specifies the http request
                                           to perform.
@@ -3296,10 +3862,8 @@ spec:
                                         format: int32
                                         type: integer
                                       tcpSocket:
-                                        description: 'TCPSocket specifies an action
-                                          involving a TCP port. TCP hooks not yet
-                                          supported TODO: implement a realistic TCP
-                                          lifecycle hook'
+                                        description: TCPSocket specifies an action
+                                          involving a TCP port.
                                         properties:
                                           host:
                                             description: 'Optional: Host name to connect
@@ -3317,6 +3881,28 @@ spec:
                                         required:
                                         - port
                                         type: object
+                                      terminationGracePeriodSeconds:
+                                        description: Optional duration in seconds
+                                          the pod needs to terminate gracefully upon
+                                          probe failure. The grace period is the duration
+                                          in seconds after the processes running in
+                                          the pod are sent a termination signal and
+                                          the time when the processes are forcibly
+                                          halted with a kill signal. Set this value
+                                          longer than the expected cleanup time for
+                                          your process. If this value is nil, the
+                                          pod's terminationGracePeriodSeconds will
+                                          be used. Otherwise, this value overrides
+                                          the value provided by the pod spec. Value
+                                          must be non-negative integer. The value
+                                          zero indicates stop immediately via the
+                                          kill signal (no opportunity to shut down).
+                                          This is a beta field and requires enabling
+                                          ProbeTerminationGracePeriod feature gate.
+                                          Minimum value is 1. spec.terminationGracePeriodSeconds
+                                          is used if unset.
+                                        format: int64
+                                        type: integer
                                       timeoutSeconds:
                                         description: 'Number of seconds after which
                                           the probe times out. Defaults to 1 second.
@@ -3338,7 +3924,7 @@ spec:
                                           x-kubernetes-int-or-string: true
                                         description: 'Limits describes the maximum
                                           amount of compute resources allowed. More
-                                          info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
+                                          info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
                                         type: object
                                       requests:
                                         additionalProperties:
@@ -3352,12 +3938,14 @@ spec:
                                           Requests is omitted for a container, it
                                           defaults to Limits if that is explicitly
                                           specified, otherwise to an implementation-defined
-                                          value. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
+                                          value. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
                                         type: object
                                     type: object
                                   securityContext:
-                                    description: SecurityContext is not allowed for
-                                      ephemeral containers.
+                                    description: 'Optional: SecurityContext defines
+                                      the security options the ephemeral container
+                                      should be run with. If set, the fields of SecurityContext
+                                      override the equivalent fields of PodSecurityContext.'
                                     properties:
                                       allowPrivilegeEscalation:
                                         description: 'AllowPrivilegeEscalation controls
@@ -3366,13 +3954,16 @@ spec:
                                           controls if the no_new_privs flag will be
                                           set on the container process. AllowPrivilegeEscalation
                                           is true always when the container is: 1)
-                                          run as Privileged 2) has CAP_SYS_ADMIN'
+                                          run as Privileged 2) has CAP_SYS_ADMIN Note
+                                          that this field cannot be set when spec.os.name
+                                          is windows.'
                                         type: boolean
                                       capabilities:
                                         description: The capabilities to add/drop
                                           when running containers. Defaults to the
                                           default set of capabilities granted by the
-                                          container runtime.
+                                          container runtime. Note that this field
+                                          cannot be set when spec.os.name is windows.
                                         properties:
                                           add:
                                             description: Added capabilities
@@ -3393,7 +3984,8 @@ spec:
                                         description: Run container in privileged mode.
                                           Processes in privileged containers are essentially
                                           equivalent to root on the host. Defaults
-                                          to false.
+                                          to false. Note that this field cannot be
+                                          set when spec.os.name is windows.
                                         type: boolean
                                       procMount:
                                         description: procMount denotes the type of
@@ -3402,10 +3994,14 @@ spec:
                                           container runtime defaults for readonly
                                           paths and masked paths. This requires the
                                           ProcMountType feature flag to be enabled.
+                                          Note that this field cannot be set when
+                                          spec.os.name is windows.
                                         type: string
                                       readOnlyRootFilesystem:
                                         description: Whether this container has a
                                           read-only root filesystem. Default is false.
+                                          Note that this field cannot be set when
+                                          spec.os.name is windows.
                                         type: boolean
                                       runAsGroup:
                                         description: The GID to run the entrypoint
@@ -3413,7 +4009,8 @@ spec:
                                           if unset. May also be set in PodSecurityContext.  If
                                           set in both SecurityContext and PodSecurityContext,
                                           the value specified in SecurityContext takes
-                                          precedence.
+                                          precedence. Note that this field cannot
+                                          be set when spec.os.name is windows.
                                         format: int64
                                         type: integer
                                       runAsNonRoot:
@@ -3435,7 +4032,8 @@ spec:
                                           May also be set in PodSecurityContext.  If
                                           set in both SecurityContext and PodSecurityContext,
                                           the value specified in SecurityContext takes
-                                          precedence.
+                                          precedence. Note that this field cannot
+                                          be set when spec.os.name is windows.
                                         format: int64
                                         type: integer
                                       seLinuxOptions:
@@ -3445,7 +4043,9 @@ spec:
                                           for each container.  May also be set in
                                           PodSecurityContext.  If set in both SecurityContext
                                           and PodSecurityContext, the value specified
-                                          in SecurityContext takes precedence.
+                                          in SecurityContext takes precedence. Note
+                                          that this field cannot be set when spec.os.name
+                                          is windows.
                                         properties:
                                           level:
                                             description: Level is SELinux level label
@@ -3468,7 +4068,9 @@ spec:
                                         description: The seccomp options to use by
                                           this container. If seccomp options are provided
                                           at both the pod & container level, the container
-                                          options override the pod options.
+                                          options override the pod options. Note that
+                                          this field cannot be set when spec.os.name
+                                          is windows.
                                         properties:
                                           localhostProfile:
                                             description: localhostProfile indicates
@@ -3499,7 +4101,9 @@ spec:
                                           the options from the PodSecurityContext
                                           will be used. If set in both SecurityContext
                                           and PodSecurityContext, the value specified
-                                          in SecurityContext takes precedence.
+                                          in SecurityContext takes precedence. Note
+                                          that this field cannot be set when spec.os.name
+                                          is linux.
                                         properties:
                                           gmsaCredentialSpec:
                                             description: GMSACredentialSpec is where
@@ -3513,6 +4117,22 @@ spec:
                                               the name of the GMSA credential spec
                                               to use.
                                             type: string
+                                          hostProcess:
+                                            description: HostProcess determines if
+                                              a container should be run as a 'Host
+                                              Process' container. This field is alpha-level
+                                              and will only be honored by components
+                                              that enable the WindowsHostProcessContainers
+                                              feature flag. Setting this field without
+                                              the feature flag will result in errors
+                                              when validating the Pod. All of a Pod's
+                                              containers must have the same effective
+                                              HostProcess value (it is not allowed
+                                              to have a mix of HostProcess containers
+                                              and non-HostProcess containers).  In
+                                              addition, if HostProcess is true then
+                                              HostNetwork must also be set to true.
+                                            type: boolean
                                           runAsUserName:
                                             description: The UserName in Windows to
                                               run the entrypoint of the container
@@ -3530,9 +4150,8 @@ spec:
                                       containers.
                                     properties:
                                       exec:
-                                        description: One and only one of the following
-                                          should be specified. Exec specifies the
-                                          action to take.
+                                        description: Exec specifies the action to
+                                          take.
                                         properties:
                                           command:
                                             description: Command is the command line
@@ -3557,6 +4176,26 @@ spec:
                                           value is 1.
                                         format: int32
                                         type: integer
+                                      grpc:
+                                        description: GRPC specifies an action involving
+                                          a GRPC port. This is a beta field and requires
+                                          enabling GRPCContainerProbe feature gate.
+                                        properties:
+                                          port:
+                                            description: Port number of the gRPC service.
+                                              Number must be in the range 1 to 65535.
+                                            format: int32
+                                            type: integer
+                                          service:
+                                            description: "Service is the name of the
+                                              service to place in the gRPC HealthCheckRequest
+                                              (see https://github.com/grpc/grpc/blob/master/doc/health-checking.md).
+                                              \n If this is not specified, the default
+                                              behavior is defined by gRPC."
+                                            type: string
+                                        required:
+                                        - port
+                                        type: object
                                       httpGet:
                                         description: HTTPGet specifies the http request
                                           to perform.
@@ -3625,10 +4264,8 @@ spec:
                                         format: int32
                                         type: integer
                                       tcpSocket:
-                                        description: 'TCPSocket specifies an action
-                                          involving a TCP port. TCP hooks not yet
-                                          supported TODO: implement a realistic TCP
-                                          lifecycle hook'
+                                        description: TCPSocket specifies an action
+                                          involving a TCP port.
                                         properties:
                                           host:
                                             description: 'Optional: Host name to connect
@@ -3646,6 +4283,28 @@ spec:
                                         required:
                                         - port
                                         type: object
+                                      terminationGracePeriodSeconds:
+                                        description: Optional duration in seconds
+                                          the pod needs to terminate gracefully upon
+                                          probe failure. The grace period is the duration
+                                          in seconds after the processes running in
+                                          the pod are sent a termination signal and
+                                          the time when the processes are forcibly
+                                          halted with a kill signal. Set this value
+                                          longer than the expected cleanup time for
+                                          your process. If this value is nil, the
+                                          pod's terminationGracePeriodSeconds will
+                                          be used. Otherwise, this value overrides
+                                          the value provided by the pod spec. Value
+                                          must be non-negative integer. The value
+                                          zero indicates stop immediately via the
+                                          kill signal (no opportunity to shut down).
+                                          This is a beta field and requires enabling
+                                          ProbeTerminationGracePeriod feature gate.
+                                          Minimum value is 1. spec.terminationGracePeriodSeconds
+                                          is used if unset.
+                                        format: int64
+                                        type: integer
                                       timeoutSeconds:
                                         description: 'Number of seconds after which
                                           the probe times out. Defaults to 1 second.
@@ -3676,13 +4335,15 @@ spec:
                                       EOF. Default is false
                                     type: boolean
                                   targetContainerName:
-                                    description: If set, the name of the container
+                                    description: "If set, the name of the container
                                       from PodSpec that this ephemeral container targets.
                                       The ephemeral container will be run in the namespaces
                                       (IPC, PID, etc) of this container. If not set
-                                      then the ephemeral container is run in whatever
-                                      namespaces are shared for the pod. Note that
-                                      the container runtime must support this feature.
+                                      then the ephemeral container uses the namespaces
+                                      configured in the Pod spec. \n The container
+                                      runtime must implement support for this feature.
+                                      If the runtime does not support namespace targeting
+                                      then the result of setting this field is undefined."
                                     type: string
                                   terminationMessagePath:
                                     description: 'Optional: Path at which the file
@@ -3735,7 +4396,8 @@ spec:
                                     type: array
                                   volumeMounts:
                                     description: Pod volumes to mount into the container's
-                                      filesystem. Cannot be updated.
+                                      filesystem. Subpath mounts are not allowed for
+                                      ephemeral containers. Cannot be updated.
                                     items:
                                       description: VolumeMount describes a mounting
                                         of a Volume within a container.
@@ -3834,9 +4496,8 @@ spec:
                                 references to secrets in the same namespace to use
                                 for pulling any of the images used by this PodSpec.
                                 If specified, these secrets will be passed to individual
-                                puller implementations for them to use. For example,
-                                in the case of docker, only DockerConfig type secrets
-                                are honored. More info: https://kubernetes.io/docs/concepts/containers/images#specifying-imagepullsecrets-on-a-pod'
+                                puller implementations for them to use. More info:
+                                https://kubernetes.io/docs/concepts/containers/images#specifying-imagepullsecrets-on-a-pod'
                               items:
                                 description: LocalObjectReference contains enough
                                   information to let you locate the referenced object
@@ -3873,12 +4534,14 @@ spec:
                                 properties:
                                   args:
                                     description: 'Arguments to the entrypoint. The
-                                      docker image''s CMD is used if this is not provided.
-                                      Variable references $(VAR_NAME) are expanded
-                                      using the container''s environment. If a variable
-                                      cannot be resolved, the reference in the input
-                                      string will be unchanged. The $(VAR_NAME) syntax
-                                      can be escaped with a double $$, ie: $$(VAR_NAME).
+                                      container image''s CMD is used if this is not
+                                      provided. Variable references $(VAR_NAME) are
+                                      expanded using the container''s environment.
+                                      If a variable cannot be resolved, the reference
+                                      in the input string will be unchanged. Double
+                                      $$ are reduced to a single $, which allows for
+                                      escaping the $(VAR_NAME) syntax: i.e. "$$(VAR_NAME)"
+                                      will produce the string literal "$(VAR_NAME)".
                                       Escaped references will never be expanded, regardless
                                       of whether the variable exists or not. Cannot
                                       be updated. More info: https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell'
@@ -3887,16 +4550,17 @@ spec:
                                     type: array
                                   command:
                                     description: 'Entrypoint array. Not executed within
-                                      a shell. The docker image''s ENTRYPOINT is used
-                                      if this is not provided. Variable references
+                                      a shell. The container image''s ENTRYPOINT is
+                                      used if this is not provided. Variable references
                                       $(VAR_NAME) are expanded using the container''s
                                       environment. If a variable cannot be resolved,
                                       the reference in the input string will be unchanged.
-                                      The $(VAR_NAME) syntax can be escaped with a
-                                      double $$, ie: $$(VAR_NAME). Escaped references
-                                      will never be expanded, regardless of whether
-                                      the variable exists or not. Cannot be updated.
-                                      More info: https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell'
+                                      Double $$ are reduced to a single $, which allows
+                                      for escaping the $(VAR_NAME) syntax: i.e. "$$(VAR_NAME)"
+                                      will produce the string literal "$(VAR_NAME)".
+                                      Escaped references will never be expanded, regardless
+                                      of whether the variable exists or not. Cannot
+                                      be updated. More info: https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell'
                                     items:
                                       type: string
                                     type: array
@@ -3913,13 +4577,15 @@ spec:
                                           type: string
                                         value:
                                           description: 'Variable references $(VAR_NAME)
-                                            are expanded using the previous defined
+                                            are expanded using the previously defined
                                             environment variables in the container
                                             and any service environment variables.
                                             If a variable cannot be resolved, the
                                             reference in the input string will be
-                                            unchanged. The $(VAR_NAME) syntax can
-                                            be escaped with a double $$, ie: $$(VAR_NAME).
+                                            unchanged. Double $$ are reduced to a
+                                            single $, which allows for escaping the
+                                            $(VAR_NAME) syntax: i.e. "$$(VAR_NAME)"
+                                            will produce the string literal "$(VAR_NAME)".
                                             Escaped references will never be expanded,
                                             regardless of whether the variable exists
                                             or not. Defaults to "".'
@@ -4073,7 +4739,8 @@ spec:
                                       type: object
                                     type: array
                                   image:
-                                    description: 'Docker image name. More info: https://kubernetes.io/docs/concepts/containers/images
+                                    description: 'Container image name. More info:
+                                      https://kubernetes.io/docs/concepts/containers/images
                                       This field is optional to allow higher level
                                       config management to default or override container
                                       images in workload controllers like Deployments
@@ -4099,9 +4766,8 @@ spec:
                                           More info: https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/#container-hooks'
                                         properties:
                                           exec:
-                                            description: One and only one of the following
-                                              should be specified. Exec specifies
-                                              the action to take.
+                                            description: Exec specifies the action
+                                              to take.
                                             properties:
                                               command:
                                                 description: Command is the command
@@ -4172,10 +4838,12 @@ spec:
                                             - port
                                             type: object
                                           tcpSocket:
-                                            description: 'TCPSocket specifies an action
-                                              involving a TCP port. TCP hooks not
-                                              yet supported TODO: implement a realistic
-                                              TCP lifecycle hook'
+                                            description: Deprecated. TCPSocket is
+                                              NOT supported as a LifecycleHandler
+                                              and kept for the backward compatibility.
+                                              There are no validation of this field
+                                              and lifecycle hooks will fail in runtime
+                                              when tcp handler is specified.
                                             properties:
                                               host:
                                                 description: 'Optional: Host name
@@ -4202,21 +4870,19 @@ spec:
                                           as liveness/startup probe failure, preemption,
                                           resource contention, etc. The handler is
                                           not called if the container crashes or exits.
-                                          The reason for termination is passed to
-                                          the handler. The Pod''s termination grace
-                                          period countdown begins before the PreStop
-                                          hooked is executed. Regardless of the outcome
-                                          of the handler, the container will eventually
-                                          terminate within the Pod''s termination
-                                          grace period. Other management of the container
-                                          blocks until the hook completes or until
-                                          the termination grace period is reached.
-                                          More info: https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/#container-hooks'
+                                          The Pod''s termination grace period countdown
+                                          begins before the PreStop hook is executed.
+                                          Regardless of the outcome of the handler,
+                                          the container will eventually terminate
+                                          within the Pod''s termination grace period
+                                          (unless delayed by finalizers). Other management
+                                          of the container blocks until the hook completes
+                                          or until the termination grace period is
+                                          reached. More info: https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/#container-hooks'
                                         properties:
                                           exec:
-                                            description: One and only one of the following
-                                              should be specified. Exec specifies
-                                              the action to take.
+                                            description: Exec specifies the action
+                                              to take.
                                             properties:
                                               command:
                                                 description: Command is the command
@@ -4287,10 +4953,12 @@ spec:
                                             - port
                                             type: object
                                           tcpSocket:
-                                            description: 'TCPSocket specifies an action
-                                              involving a TCP port. TCP hooks not
-                                              yet supported TODO: implement a realistic
-                                              TCP lifecycle hook'
+                                            description: Deprecated. TCPSocket is
+                                              NOT supported as a LifecycleHandler
+                                              and kept for the backward compatibility.
+                                              There are no validation of this field
+                                              and lifecycle hooks will fail in runtime
+                                              when tcp handler is specified.
                                             properties:
                                               host:
                                                 description: 'Optional: Host name
@@ -4317,9 +4985,8 @@ spec:
                                       Cannot be updated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
                                     properties:
                                       exec:
-                                        description: One and only one of the following
-                                          should be specified. Exec specifies the
-                                          action to take.
+                                        description: Exec specifies the action to
+                                          take.
                                         properties:
                                           command:
                                             description: Command is the command line
@@ -4344,6 +5011,26 @@ spec:
                                           value is 1.
                                         format: int32
                                         type: integer
+                                      grpc:
+                                        description: GRPC specifies an action involving
+                                          a GRPC port. This is a beta field and requires
+                                          enabling GRPCContainerProbe feature gate.
+                                        properties:
+                                          port:
+                                            description: Port number of the gRPC service.
+                                              Number must be in the range 1 to 65535.
+                                            format: int32
+                                            type: integer
+                                          service:
+                                            description: "Service is the name of the
+                                              service to place in the gRPC HealthCheckRequest
+                                              (see https://github.com/grpc/grpc/blob/master/doc/health-checking.md).
+                                              \n If this is not specified, the default
+                                              behavior is defined by gRPC."
+                                            type: string
+                                        required:
+                                        - port
+                                        type: object
                                       httpGet:
                                         description: HTTPGet specifies the http request
                                           to perform.
@@ -4412,10 +5099,8 @@ spec:
                                         format: int32
                                         type: integer
                                       tcpSocket:
-                                        description: 'TCPSocket specifies an action
-                                          involving a TCP port. TCP hooks not yet
-                                          supported TODO: implement a realistic TCP
-                                          lifecycle hook'
+                                        description: TCPSocket specifies an action
+                                          involving a TCP port.
                                         properties:
                                           host:
                                             description: 'Optional: Host name to connect
@@ -4433,6 +5118,28 @@ spec:
                                         required:
                                         - port
                                         type: object
+                                      terminationGracePeriodSeconds:
+                                        description: Optional duration in seconds
+                                          the pod needs to terminate gracefully upon
+                                          probe failure. The grace period is the duration
+                                          in seconds after the processes running in
+                                          the pod are sent a termination signal and
+                                          the time when the processes are forcibly
+                                          halted with a kill signal. Set this value
+                                          longer than the expected cleanup time for
+                                          your process. If this value is nil, the
+                                          pod's terminationGracePeriodSeconds will
+                                          be used. Otherwise, this value overrides
+                                          the value provided by the pod spec. Value
+                                          must be non-negative integer. The value
+                                          zero indicates stop immediately via the
+                                          kill signal (no opportunity to shut down).
+                                          This is a beta field and requires enabling
+                                          ProbeTerminationGracePeriod feature gate.
+                                          Minimum value is 1. spec.terminationGracePeriodSeconds
+                                          is used if unset.
+                                        format: int64
+                                        type: integer
                                       timeoutSeconds:
                                         description: 'Number of seconds after which
                                           the probe times out. Defaults to 1 second.
@@ -4504,9 +5211,8 @@ spec:
                                       More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
                                     properties:
                                       exec:
-                                        description: One and only one of the following
-                                          should be specified. Exec specifies the
-                                          action to take.
+                                        description: Exec specifies the action to
+                                          take.
                                         properties:
                                           command:
                                             description: Command is the command line
@@ -4531,6 +5237,26 @@ spec:
                                           value is 1.
                                         format: int32
                                         type: integer
+                                      grpc:
+                                        description: GRPC specifies an action involving
+                                          a GRPC port. This is a beta field and requires
+                                          enabling GRPCContainerProbe feature gate.
+                                        properties:
+                                          port:
+                                            description: Port number of the gRPC service.
+                                              Number must be in the range 1 to 65535.
+                                            format: int32
+                                            type: integer
+                                          service:
+                                            description: "Service is the name of the
+                                              service to place in the gRPC HealthCheckRequest
+                                              (see https://github.com/grpc/grpc/blob/master/doc/health-checking.md).
+                                              \n If this is not specified, the default
+                                              behavior is defined by gRPC."
+                                            type: string
+                                        required:
+                                        - port
+                                        type: object
                                       httpGet:
                                         description: HTTPGet specifies the http request
                                           to perform.
@@ -4599,10 +5325,8 @@ spec:
                                         format: int32
                                         type: integer
                                       tcpSocket:
-                                        description: 'TCPSocket specifies an action
-                                          involving a TCP port. TCP hooks not yet
-                                          supported TODO: implement a realistic TCP
-                                          lifecycle hook'
+                                        description: TCPSocket specifies an action
+                                          involving a TCP port.
                                         properties:
                                           host:
                                             description: 'Optional: Host name to connect
@@ -4620,6 +5344,28 @@ spec:
                                         required:
                                         - port
                                         type: object
+                                      terminationGracePeriodSeconds:
+                                        description: Optional duration in seconds
+                                          the pod needs to terminate gracefully upon
+                                          probe failure. The grace period is the duration
+                                          in seconds after the processes running in
+                                          the pod are sent a termination signal and
+                                          the time when the processes are forcibly
+                                          halted with a kill signal. Set this value
+                                          longer than the expected cleanup time for
+                                          your process. If this value is nil, the
+                                          pod's terminationGracePeriodSeconds will
+                                          be used. Otherwise, this value overrides
+                                          the value provided by the pod spec. Value
+                                          must be non-negative integer. The value
+                                          zero indicates stop immediately via the
+                                          kill signal (no opportunity to shut down).
+                                          This is a beta field and requires enabling
+                                          ProbeTerminationGracePeriod feature gate.
+                                          Minimum value is 1. spec.terminationGracePeriodSeconds
+                                          is used if unset.
+                                        format: int64
+                                        type: integer
                                       timeoutSeconds:
                                         description: 'Number of seconds after which
                                           the probe times out. Defaults to 1 second.
@@ -4629,7 +5375,7 @@ spec:
                                     type: object
                                   resources:
                                     description: 'Compute Resources required by this
-                                      container. Cannot be updated. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
+                                      container. Cannot be updated. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
                                     properties:
                                       limits:
                                         additionalProperties:
@@ -4640,7 +5386,7 @@ spec:
                                           x-kubernetes-int-or-string: true
                                         description: 'Limits describes the maximum
                                           amount of compute resources allowed. More
-                                          info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
+                                          info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
                                         type: object
                                       requests:
                                         additionalProperties:
@@ -4654,12 +5400,14 @@ spec:
                                           Requests is omitted for a container, it
                                           defaults to Limits if that is explicitly
                                           specified, otherwise to an implementation-defined
-                                          value. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
+                                          value. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
                                         type: object
                                     type: object
                                   securityContext:
-                                    description: 'Security options the pod should
-                                      run with. More info: https://kubernetes.io/docs/concepts/policy/security-context/
+                                    description: 'SecurityContext defines the security
+                                      options the container should be run with. If
+                                      set, the fields of SecurityContext override
+                                      the equivalent fields of PodSecurityContext.
                                       More info: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/'
                                     properties:
                                       allowPrivilegeEscalation:
@@ -4669,13 +5417,16 @@ spec:
                                           controls if the no_new_privs flag will be
                                           set on the container process. AllowPrivilegeEscalation
                                           is true always when the container is: 1)
-                                          run as Privileged 2) has CAP_SYS_ADMIN'
+                                          run as Privileged 2) has CAP_SYS_ADMIN Note
+                                          that this field cannot be set when spec.os.name
+                                          is windows.'
                                         type: boolean
                                       capabilities:
                                         description: The capabilities to add/drop
                                           when running containers. Defaults to the
                                           default set of capabilities granted by the
-                                          container runtime.
+                                          container runtime. Note that this field
+                                          cannot be set when spec.os.name is windows.
                                         properties:
                                           add:
                                             description: Added capabilities
@@ -4696,7 +5447,8 @@ spec:
                                         description: Run container in privileged mode.
                                           Processes in privileged containers are essentially
                                           equivalent to root on the host. Defaults
-                                          to false.
+                                          to false. Note that this field cannot be
+                                          set when spec.os.name is windows.
                                         type: boolean
                                       procMount:
                                         description: procMount denotes the type of
@@ -4705,10 +5457,14 @@ spec:
                                           container runtime defaults for readonly
                                           paths and masked paths. This requires the
                                           ProcMountType feature flag to be enabled.
+                                          Note that this field cannot be set when
+                                          spec.os.name is windows.
                                         type: string
                                       readOnlyRootFilesystem:
                                         description: Whether this container has a
                                           read-only root filesystem. Default is false.
+                                          Note that this field cannot be set when
+                                          spec.os.name is windows.
                                         type: boolean
                                       runAsGroup:
                                         description: The GID to run the entrypoint
@@ -4716,7 +5472,8 @@ spec:
                                           if unset. May also be set in PodSecurityContext.  If
                                           set in both SecurityContext and PodSecurityContext,
                                           the value specified in SecurityContext takes
-                                          precedence.
+                                          precedence. Note that this field cannot
+                                          be set when spec.os.name is windows.
                                         format: int64
                                         type: integer
                                       runAsNonRoot:
@@ -4738,7 +5495,8 @@ spec:
                                           May also be set in PodSecurityContext.  If
                                           set in both SecurityContext and PodSecurityContext,
                                           the value specified in SecurityContext takes
-                                          precedence.
+                                          precedence. Note that this field cannot
+                                          be set when spec.os.name is windows.
                                         format: int64
                                         type: integer
                                       seLinuxOptions:
@@ -4748,7 +5506,9 @@ spec:
                                           for each container.  May also be set in
                                           PodSecurityContext.  If set in both SecurityContext
                                           and PodSecurityContext, the value specified
-                                          in SecurityContext takes precedence.
+                                          in SecurityContext takes precedence. Note
+                                          that this field cannot be set when spec.os.name
+                                          is windows.
                                         properties:
                                           level:
                                             description: Level is SELinux level label
@@ -4771,7 +5531,9 @@ spec:
                                         description: The seccomp options to use by
                                           this container. If seccomp options are provided
                                           at both the pod & container level, the container
-                                          options override the pod options.
+                                          options override the pod options. Note that
+                                          this field cannot be set when spec.os.name
+                                          is windows.
                                         properties:
                                           localhostProfile:
                                             description: localhostProfile indicates
@@ -4802,7 +5564,9 @@ spec:
                                           the options from the PodSecurityContext
                                           will be used. If set in both SecurityContext
                                           and PodSecurityContext, the value specified
-                                          in SecurityContext takes precedence.
+                                          in SecurityContext takes precedence. Note
+                                          that this field cannot be set when spec.os.name
+                                          is linux.
                                         properties:
                                           gmsaCredentialSpec:
                                             description: GMSACredentialSpec is where
@@ -4816,6 +5580,22 @@ spec:
                                               the name of the GMSA credential spec
                                               to use.
                                             type: string
+                                          hostProcess:
+                                            description: HostProcess determines if
+                                              a container should be run as a 'Host
+                                              Process' container. This field is alpha-level
+                                              and will only be honored by components
+                                              that enable the WindowsHostProcessContainers
+                                              feature flag. Setting this field without
+                                              the feature flag will result in errors
+                                              when validating the Pod. All of a Pod's
+                                              containers must have the same effective
+                                              HostProcess value (it is not allowed
+                                              to have a mix of HostProcess containers
+                                              and non-HostProcess containers).  In
+                                              addition, if HostProcess is true then
+                                              HostNetwork must also be set to true.
+                                            type: boolean
                                           runAsUserName:
                                             description: The UserName in Windows to
                                               run the entrypoint of the container
@@ -4838,14 +5618,11 @@ spec:
                                       parameters at the beginning of a Pod''s lifecycle,
                                       when it might take a long time to load data
                                       or warm a cache, than during steady-state operation.
-                                      This cannot be updated. This is a beta feature
-                                      enabled by the StartupProbe feature flag. More
-                                      info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                                      This cannot be updated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
                                     properties:
                                       exec:
-                                        description: One and only one of the following
-                                          should be specified. Exec specifies the
-                                          action to take.
+                                        description: Exec specifies the action to
+                                          take.
                                         properties:
                                           command:
                                             description: Command is the command line
@@ -4870,6 +5647,26 @@ spec:
                                           value is 1.
                                         format: int32
                                         type: integer
+                                      grpc:
+                                        description: GRPC specifies an action involving
+                                          a GRPC port. This is a beta field and requires
+                                          enabling GRPCContainerProbe feature gate.
+                                        properties:
+                                          port:
+                                            description: Port number of the gRPC service.
+                                              Number must be in the range 1 to 65535.
+                                            format: int32
+                                            type: integer
+                                          service:
+                                            description: "Service is the name of the
+                                              service to place in the gRPC HealthCheckRequest
+                                              (see https://github.com/grpc/grpc/blob/master/doc/health-checking.md).
+                                              \n If this is not specified, the default
+                                              behavior is defined by gRPC."
+                                            type: string
+                                        required:
+                                        - port
+                                        type: object
                                       httpGet:
                                         description: HTTPGet specifies the http request
                                           to perform.
@@ -4938,10 +5735,8 @@ spec:
                                         format: int32
                                         type: integer
                                       tcpSocket:
-                                        description: 'TCPSocket specifies an action
-                                          involving a TCP port. TCP hooks not yet
-                                          supported TODO: implement a realistic TCP
-                                          lifecycle hook'
+                                        description: TCPSocket specifies an action
+                                          involving a TCP port.
                                         properties:
                                           host:
                                             description: 'Optional: Host name to connect
@@ -4959,6 +5754,28 @@ spec:
                                         required:
                                         - port
                                         type: object
+                                      terminationGracePeriodSeconds:
+                                        description: Optional duration in seconds
+                                          the pod needs to terminate gracefully upon
+                                          probe failure. The grace period is the duration
+                                          in seconds after the processes running in
+                                          the pod are sent a termination signal and
+                                          the time when the processes are forcibly
+                                          halted with a kill signal. Set this value
+                                          longer than the expected cleanup time for
+                                          your process. If this value is nil, the
+                                          pod's terminationGracePeriodSeconds will
+                                          be used. Otherwise, this value overrides
+                                          the value provided by the pod spec. Value
+                                          must be non-negative integer. The value
+                                          zero indicates stop immediately via the
+                                          kill signal (no opportunity to shut down).
+                                          This is a beta field and requires enabling
+                                          ProbeTerminationGracePeriod feature gate.
+                                          Minimum value is 1. spec.terminationGracePeriodSeconds
+                                          is used if unset.
+                                        format: int64
+                                        type: integer
                                       timeoutSeconds:
                                         description: 'Number of seconds after which
                                           the probe times out. Defaults to 1 second.
@@ -5108,6 +5925,40 @@ spec:
                                 must match a node''s labels for the pod to be scheduled
                                 on that node. More info: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/'
                               type: object
+                              x-kubernetes-map-type: atomic
+                            os:
+                              description: "Specifies the OS of the containers in
+                                the pod. Some pod and container fields are restricted
+                                if this is set. \n If the OS field is set to linux,
+                                the following fields must be unset: -securityContext.windowsOptions
+                                \n If the OS field is set to windows, following fields
+                                must be unset: - spec.hostPID - spec.hostIPC - spec.securityContext.seLinuxOptions
+                                - spec.securityContext.seccompProfile - spec.securityContext.fsGroup
+                                - spec.securityContext.fsGroupChangePolicy - spec.securityContext.sysctls
+                                - spec.shareProcessNamespace - spec.securityContext.runAsUser
+                                - spec.securityContext.runAsGroup - spec.securityContext.supplementalGroups
+                                - spec.containers[*].securityContext.seLinuxOptions
+                                - spec.containers[*].securityContext.seccompProfile
+                                - spec.containers[*].securityContext.capabilities
+                                - spec.containers[*].securityContext.readOnlyRootFilesystem
+                                - spec.containers[*].securityContext.privileged -
+                                spec.containers[*].securityContext.allowPrivilegeEscalation
+                                - spec.containers[*].securityContext.procMount - spec.containers[*].securityContext.runAsUser
+                                - spec.containers[*].securityContext.runAsGroup This
+                                is a beta field and requires the IdentifyPodOS feature"
+                              properties:
+                                name:
+                                  description: 'Name is the name of the operating
+                                    system. The currently supported values are linux
+                                    and windows. Additional value may be defined in
+                                    future and can be one of: https://github.com/opencontainers/runtime-spec/blob/master/config.md#platform-specific-configuration
+                                    Clients should expect to handle additional values
+                                    and treat unrecognized values in this field as
+                                    os: null'
+                                  type: string
+                              required:
+                              - name
+                              type: object
                             overhead:
                               additionalProperties:
                                 anyOf:
@@ -5126,17 +5977,12 @@ spec:
                                 and selected in the PodSpec, Overhead will be set
                                 to the value defined in the corresponding RuntimeClass,
                                 otherwise it will remain unset and treated as zero.
-                                More info: https://git.k8s.io/enhancements/keps/sig-node/20190226-pod-overhead.md
-                                This field is alpha-level as of Kubernetes v1.16,
-                                and is only honored by servers that enable the PodOverhead
-                                feature.'
+                                More info: https://git.k8s.io/enhancements/keps/sig-node/688-pod-overhead/README.md'
                               type: object
                             preemptionPolicy:
                               description: PreemptionPolicy is the Policy for preempting
                                 pods with lower priority. One of Never, PreemptLowerPriority.
-                                Defaults to PreemptLowerPriority if unset. This field
-                                is beta-level, gated by the NonPreemptingPriority
-                                feature-gate.
+                                Defaults to PreemptLowerPriority if unset.
                               type: string
                             priority:
                               description: The priority value. Various system components
@@ -5161,7 +6007,7 @@ spec:
                                 be evaluated for pod readiness. A pod is ready when
                                 all its containers are ready AND all conditions specified
                                 in the readiness gates have status equal to "True"
-                                More info: https://git.k8s.io/enhancements/keps/sig-network/0007-pod-ready%2B%2B.md'
+                                More info: https://git.k8s.io/enhancements/keps/sig-network/580-pod-readiness-gates'
                               items:
                                 description: PodReadinessGate contains the reference
                                   to a pod condition
@@ -5187,8 +6033,7 @@ spec:
                                 or empty, the "legacy" RuntimeClass will be used,
                                 which is an implicit class with an empty definition
                                 that uses the default runtime handler. More info:
-                                https://git.k8s.io/enhancements/keps/sig-node/runtime-class.md
-                                This is a beta feature as of Kubernetes v1.14.'
+                                https://git.k8s.io/enhancements/keps/sig-node/585-runtime-class'
                               type: string
                             schedulerName:
                               description: If specified, the pod will be dispatched
@@ -5210,7 +6055,9 @@ spec:
                                     is set (new files created in the volume will be
                                     owned by FSGroup) 3. The permission bits are OR'd
                                     with rw-rw---- \n If unset, the Kubelet will not
-                                    modify the ownership and permissions of any volume."
+                                    modify the ownership and permissions of any volume.
+                                    Note that this field cannot be set when spec.os.name
+                                    is windows."
                                   format: int64
                                   type: integer
                                 fsGroupChangePolicy:
@@ -5221,7 +6068,9 @@ spec:
                                     based ownership(and permissions). It will have
                                     no effect on ephemeral volume types such as: secret,
                                     configmaps and emptydir. Valid values are "OnRootMismatch"
-                                    and "Always". If not specified defaults to "Always".'
+                                    and "Always". If not specified, "Always" is used.
+                                    Note that this field cannot be set when spec.os.name
+                                    is windows.'
                                   type: string
                                 runAsGroup:
                                   description: The GID to run the entrypoint of the
@@ -5229,7 +6078,8 @@ spec:
                                     May also be set in SecurityContext.  If set in
                                     both SecurityContext and PodSecurityContext, the
                                     value specified in SecurityContext takes precedence
-                                    for that container.
+                                    for that container. Note that this field cannot
+                                    be set when spec.os.name is windows.
                                   format: int64
                                   type: integer
                                 runAsNonRoot:
@@ -5250,6 +6100,8 @@ spec:
                                     set in SecurityContext.  If set in both SecurityContext
                                     and PodSecurityContext, the value specified in
                                     SecurityContext takes precedence for that container.
+                                    Note that this field cannot be set when spec.os.name
+                                    is windows.
                                   format: int64
                                   type: integer
                                 seLinuxOptions:
@@ -5259,7 +6111,8 @@ spec:
                                     for each container.  May also be set in SecurityContext.  If
                                     set in both SecurityContext and PodSecurityContext,
                                     the value specified in SecurityContext takes precedence
-                                    for that container.
+                                    for that container. Note that this field cannot
+                                    be set when spec.os.name is windows.
                                   properties:
                                     level:
                                       description: Level is SELinux level label that
@@ -5280,7 +6133,8 @@ spec:
                                   type: object
                                 seccompProfile:
                                   description: The seccomp options to use by the containers
-                                    in this pod.
+                                    in this pod. Note that this field cannot be set
+                                    when spec.os.name is windows.
                                   properties:
                                     localhostProfile:
                                       description: localhostProfile indicates a profile
@@ -5306,7 +6160,9 @@ spec:
                                   description: A list of groups applied to the first
                                     process run in each container, in addition to
                                     the container's primary GID.  If unspecified,
-                                    no groups will be added to any container.
+                                    no groups will be added to any container. Note
+                                    that this field cannot be set when spec.os.name
+                                    is windows.
                                   items:
                                     format: int64
                                     type: integer
@@ -5315,6 +6171,8 @@ spec:
                                   description: Sysctls hold a list of namespaced sysctls
                                     used for the pod. Pods with unsupported sysctls
                                     (by the container runtime) might fail to launch.
+                                    Note that this field cannot be set when spec.os.name
+                                    is windows.
                                   items:
                                     description: Sysctl defines a kernel parameter
                                       to be set
@@ -5336,6 +6194,8 @@ spec:
                                     within a container's SecurityContext will be used.
                                     If set in both SecurityContext and PodSecurityContext,
                                     the value specified in SecurityContext takes precedence.
+                                    Note that this field cannot be set when spec.os.name
+                                    is linux.
                                   properties:
                                     gmsaCredentialSpec:
                                       description: GMSACredentialSpec is where the
@@ -5347,6 +6207,20 @@ spec:
                                       description: GMSACredentialSpecName is the name
                                         of the GMSA credential spec to use.
                                       type: string
+                                    hostProcess:
+                                      description: HostProcess determines if a container
+                                        should be run as a 'Host Process' container.
+                                        This field is alpha-level and will only be
+                                        honored by components that enable the WindowsHostProcessContainers
+                                        feature flag. Setting this field without the
+                                        feature flag will result in errors when validating
+                                        the Pod. All of a Pod's containers must have
+                                        the same effective HostProcess value (it is
+                                        not allowed to have a mix of HostProcess containers
+                                        and non-HostProcess containers).  In addition,
+                                        if HostProcess is true then HostNetwork must
+                                        also be set to true.
+                                      type: boolean
                                     runAsUserName:
                                       description: The UserName in Windows to run
                                         the entrypoint of the container process. Defaults
@@ -5398,10 +6272,11 @@ spec:
                               description: Optional duration in seconds the pod needs
                                 to terminate gracefully. May be decreased in delete
                                 request. Value must be non-negative integer. The value
-                                zero indicates delete immediately. If this value is
-                                nil, the default grace period will be used instead.
-                                The grace period is the duration in seconds after
-                                the processes running in the pod are sent a termination
+                                zero indicates stop immediately via the kill signal
+                                (no opportunity to shut down). If this value is nil,
+                                the default grace period will be used instead. The
+                                grace period is the duration in seconds after the
+                                processes running in the pod are sent a termination
                                 signal and the time when the processes are forcibly
                                 halted with a kill signal. Set this value longer than
                                 the expected cleanup time for your process. Defaults
@@ -5521,19 +6396,53 @@ spec:
                                       `whenUnsatisfiable=DoNotSchedule`, it is the
                                       maximum permitted difference between the number
                                       of matching pods in the target topology and
-                                      the global minimum. For example, in a 3-zone
+                                      the global minimum. The global minimum is the
+                                      minimum number of matching pods in an eligible
+                                      domain or zero if the number of eligible domains
+                                      is less than MinDomains. For example, in a 3-zone
                                       cluster, MaxSkew is set to 1, and pods with
-                                      the same labelSelector spread as 1/1/0: | zone1
-                                      | zone2 | zone3 | |   P   |   P   |       |
-                                      - if MaxSkew is 1, incoming pod can only be
-                                      scheduled to zone3 to become 1/1/1; scheduling
-                                      it onto zone1(zone2) would make the ActualSkew(2-0)
-                                      on zone1(zone2) violate MaxSkew(1). - if MaxSkew
-                                      is 2, incoming pod can be scheduled onto any
-                                      zone. When `whenUnsatisfiable=ScheduleAnyway`,
+                                      the same labelSelector spread as 2/2/1: In this
+                                      case, the global minimum is 1. | zone1 | zone2
+                                      | zone3 | |  P P  |  P P  |   P   | - if MaxSkew
+                                      is 1, incoming pod can only be scheduled to
+                                      zone3 to become 2/2/2; scheduling it onto zone1(zone2)
+                                      would make the ActualSkew(3-1) on zone1(zone2)
+                                      violate MaxSkew(1). - if MaxSkew is 2, incoming
+                                      pod can be scheduled onto any zone. When `whenUnsatisfiable=ScheduleAnyway`,
                                       it is used to give higher precedence to topologies
                                       that satisfy it. It''s a required field. Default
                                       value is 1 and 0 is not allowed.'
+                                    format: int32
+                                    type: integer
+                                  minDomains:
+                                    description: "MinDomains indicates a minimum number
+                                      of eligible domains. When the number of eligible
+                                      domains with matching topology keys is less
+                                      than minDomains, Pod Topology Spread treats
+                                      \"global minimum\" as 0, and then the calculation
+                                      of Skew is performed. And when the number of
+                                      eligible domains with matching topology keys
+                                      equals or greater than minDomains, this value
+                                      has no effect on scheduling. As a result, when
+                                      the number of eligible domains is less than
+                                      minDomains, scheduler won't schedule more than
+                                      maxSkew Pods to those domains. If value is nil,
+                                      the constraint behaves as if MinDomains is equal
+                                      to 1. Valid values are integers greater than
+                                      0. When value is not nil, WhenUnsatisfiable
+                                      must be DoNotSchedule. \n For example, in a
+                                      3-zone cluster, MaxSkew is set to 2, MinDomains
+                                      is set to 5 and pods with the same labelSelector
+                                      spread as 2/2/2: | zone1 | zone2 | zone3 | |
+                                      \ P P  |  P P  |  P P  | The number of domains
+                                      is less than 5(MinDomains), so \"global minimum\"
+                                      is treated as 0. In this situation, new pod
+                                      with the same labelSelector cannot be scheduled,
+                                      because computed skew will be 3(3 - 0) if new
+                                      Pod is scheduled to any of the three zones,
+                                      it will violate MaxSkew. \n This is an alpha
+                                      field and requires enabling MinDomainsInPodTopologySpread
+                                      feature gate."
                                     format: int32
                                     type: integer
                                   topologyKey:
@@ -5542,7 +6451,14 @@ spec:
                                       values are considered to be in the same topology.
                                       We consider each <key, value> as a "bucket",
                                       and try to put balanced number of pods into
-                                      each bucket. It's a required field.
+                                      each bucket. We define a domain as a particular
+                                      instance of a topology. Also, we define an eligible
+                                      domain as a domain whose nodes match the node
+                                      selector. e.g. If TopologyKey is "kubernetes.io/hostname",
+                                      each Node is a domain of that topology. And,
+                                      if TopologyKey is "topology.kubernetes.io/zone",
+                                      each zone is a domain of that topology. It's
+                                      a required field.
                                     type: string
                                   whenUnsatisfiable:
                                     description: 'WhenUnsatisfiable indicates how
@@ -5554,7 +6470,7 @@ spec:
                                       topologies that would help reduce the   skew.
                                       A constraint is considered "Unsatisfiable" for
                                       an incoming pod if and only if every possible
-                                      node assigment for that pod would violate "MaxSkew"
+                                      node assignment for that pod would violate "MaxSkew"
                                       on some topology. For example, in a 3-zone cluster,
                                       MaxSkew is set to 1, and pods with the same
                                       labelSelector spread as 3/1/1: | zone1 | zone2
@@ -5585,77 +6501,78 @@ spec:
                                   pod.
                                 properties:
                                   awsElasticBlockStore:
-                                    description: 'AWSElasticBlockStore represents
+                                    description: 'awsElasticBlockStore represents
                                       an AWS Disk resource that is attached to a kubelet''s
                                       host machine and then exposed to the pod. More
                                       info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore'
                                     properties:
                                       fsType:
-                                        description: 'Filesystem type of the volume
-                                          that you want to mount. Tip: Ensure that
-                                          the filesystem type is supported by the
-                                          host operating system. Examples: "ext4",
-                                          "xfs", "ntfs". Implicitly inferred to be
-                                          "ext4" if unspecified. More info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore
+                                        description: 'fsType is the filesystem type
+                                          of the volume that you want to mount. Tip:
+                                          Ensure that the filesystem type is supported
+                                          by the host operating system. Examples:
+                                          "ext4", "xfs", "ntfs". Implicitly inferred
+                                          to be "ext4" if unspecified. More info:
+                                          https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore
                                           TODO: how do we prevent errors in the filesystem
                                           from compromising the machine'
                                         type: string
                                       partition:
-                                        description: 'The partition in the volume
-                                          that you want to mount. If omitted, the
-                                          default is to mount by volume name. Examples:
-                                          For volume /dev/sda1, you specify the partition
-                                          as "1". Similarly, the volume partition
-                                          for /dev/sda is "0" (or you can leave the
-                                          property empty).'
+                                        description: 'partition is the partition in
+                                          the volume that you want to mount. If omitted,
+                                          the default is to mount by volume name.
+                                          Examples: For volume /dev/sda1, you specify
+                                          the partition as "1". Similarly, the volume
+                                          partition for /dev/sda is "0" (or you can
+                                          leave the property empty).'
                                         format: int32
                                         type: integer
                                       readOnly:
-                                        description: 'Specify "true" to force and
-                                          set the ReadOnly property in VolumeMounts
-                                          to "true". If omitted, the default is "false".
-                                          More info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore'
+                                        description: 'readOnly value true will force
+                                          the readOnly setting in VolumeMounts. More
+                                          info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore'
                                         type: boolean
                                       volumeID:
-                                        description: 'Unique ID of the persistent
-                                          disk resource in AWS (Amazon EBS volume).
-                                          More info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore'
+                                        description: 'volumeID is unique ID of the
+                                          persistent disk resource in AWS (Amazon
+                                          EBS volume). More info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore'
                                         type: string
                                     required:
                                     - volumeID
                                     type: object
                                   azureDisk:
-                                    description: AzureDisk represents an Azure Data
+                                    description: azureDisk represents an Azure Data
                                       Disk mount on the host and bind mount to the
                                       pod.
                                     properties:
                                       cachingMode:
-                                        description: 'Host Caching mode: None, Read
-                                          Only, Read Write.'
+                                        description: 'cachingMode is the Host Caching
+                                          mode: None, Read Only, Read Write.'
                                         type: string
                                       diskName:
-                                        description: The Name of the data disk in
-                                          the blob storage
+                                        description: diskName is the Name of the data
+                                          disk in the blob storage
                                         type: string
                                       diskURI:
-                                        description: The URI the data disk in the
-                                          blob storage
+                                        description: diskURI is the URI of data disk
+                                          in the blob storage
                                         type: string
                                       fsType:
-                                        description: Filesystem type to mount. Must
-                                          be a filesystem type supported by the host
-                                          operating system. Ex. "ext4", "xfs", "ntfs".
-                                          Implicitly inferred to be "ext4" if unspecified.
+                                        description: fsType is Filesystem type to
+                                          mount. Must be a filesystem type supported
+                                          by the host operating system. Ex. "ext4",
+                                          "xfs", "ntfs". Implicitly inferred to be
+                                          "ext4" if unspecified.
                                         type: string
                                       kind:
-                                        description: 'Expected values Shared: multiple
-                                          blob disks per storage account  Dedicated:
+                                        description: 'kind expected values are Shared:
+                                          multiple blob disks per storage account  Dedicated:
                                           single blob disk per storage account  Managed:
                                           azure managed data disk (only in managed
                                           availability set). defaults to shared'
                                         type: string
                                       readOnly:
-                                        description: Defaults to false (read/write).
+                                        description: readOnly Defaults to false (read/write).
                                           ReadOnly here will force the ReadOnly setting
                                           in VolumeMounts.
                                         type: boolean
@@ -5664,56 +6581,59 @@ spec:
                                     - diskURI
                                     type: object
                                   azureFile:
-                                    description: AzureFile represents an Azure File
+                                    description: azureFile represents an Azure File
                                       Service mount on the host and bind mount to
                                       the pod.
                                     properties:
                                       readOnly:
-                                        description: Defaults to false (read/write).
+                                        description: readOnly defaults to false (read/write).
                                           ReadOnly here will force the ReadOnly setting
                                           in VolumeMounts.
                                         type: boolean
                                       secretName:
-                                        description: the name of secret that contains
-                                          Azure Storage Account Name and Key
+                                        description: secretName is the  name of secret
+                                          that contains Azure Storage Account Name
+                                          and Key
                                         type: string
                                       shareName:
-                                        description: Share Name
+                                        description: shareName is the azure share
+                                          Name
                                         type: string
                                     required:
                                     - secretName
                                     - shareName
                                     type: object
                                   cephfs:
-                                    description: CephFS represents a Ceph FS mount
+                                    description: cephFS represents a Ceph FS mount
                                       on the host that shares a pod's lifetime
                                     properties:
                                       monitors:
-                                        description: 'Required: Monitors is a collection
-                                          of Ceph monitors More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it'
+                                        description: 'monitors is Required: Monitors
+                                          is a collection of Ceph monitors More info:
+                                          https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it'
                                         items:
                                           type: string
                                         type: array
                                       path:
-                                        description: 'Optional: Used as the mounted
-                                          root, rather than the full Ceph tree, default
-                                          is /'
+                                        description: 'path is Optional: Used as the
+                                          mounted root, rather than the full Ceph
+                                          tree, default is /'
                                         type: string
                                       readOnly:
-                                        description: 'Optional: Defaults to false
-                                          (read/write). ReadOnly here will force the
-                                          ReadOnly setting in VolumeMounts. More info:
-                                          https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it'
+                                        description: 'readOnly is Optional: Defaults
+                                          to false (read/write). ReadOnly here will
+                                          force the ReadOnly setting in VolumeMounts.
+                                          More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it'
                                         type: boolean
                                       secretFile:
-                                        description: 'Optional: SecretFile is the
-                                          path to key ring for User, default is /etc/ceph/user.secret
-                                          More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it'
+                                        description: 'secretFile is Optional: SecretFile
+                                          is the path to key ring for User, default
+                                          is /etc/ceph/user.secret More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it'
                                         type: string
                                       secretRef:
-                                        description: 'Optional: SecretRef is reference
-                                          to the authentication secret for User, default
-                                          is empty. More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it'
+                                        description: 'secretRef is Optional: SecretRef
+                                          is reference to the authentication secret
+                                          for User, default is empty. More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it'
                                         properties:
                                           name:
                                             description: 'Name of the referent. More
@@ -5723,34 +6643,35 @@ spec:
                                             type: string
                                         type: object
                                       user:
-                                        description: 'Optional: User is the rados
-                                          user name, default is admin More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it'
+                                        description: 'user is optional: User is the
+                                          rados user name, default is admin More info:
+                                          https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it'
                                         type: string
                                     required:
                                     - monitors
                                     type: object
                                   cinder:
-                                    description: 'Cinder represents a cinder volume
+                                    description: 'cinder represents a cinder volume
                                       attached and mounted on kubelets host machine.
                                       More info: https://examples.k8s.io/mysql-cinder-pd/README.md'
                                     properties:
                                       fsType:
-                                        description: 'Filesystem type to mount. Must
-                                          be a filesystem type supported by the host
-                                          operating system. Examples: "ext4", "xfs",
-                                          "ntfs". Implicitly inferred to be "ext4"
-                                          if unspecified. More info: https://examples.k8s.io/mysql-cinder-pd/README.md'
+                                        description: 'fsType is the filesystem type
+                                          to mount. Must be a filesystem type supported
+                                          by the host operating system. Examples:
+                                          "ext4", "xfs", "ntfs". Implicitly inferred
+                                          to be "ext4" if unspecified. More info:
+                                          https://examples.k8s.io/mysql-cinder-pd/README.md'
                                         type: string
                                       readOnly:
-                                        description: 'Optional: Defaults to false
-                                          (read/write). ReadOnly here will force the
-                                          ReadOnly setting in VolumeMounts. More info:
-                                          https://examples.k8s.io/mysql-cinder-pd/README.md'
+                                        description: 'readOnly defaults to false (read/write).
+                                          ReadOnly here will force the ReadOnly setting
+                                          in VolumeMounts. More info: https://examples.k8s.io/mysql-cinder-pd/README.md'
                                         type: boolean
                                       secretRef:
-                                        description: 'Optional: points to a secret
-                                          object containing parameters used to connect
-                                          to OpenStack.'
+                                        description: 'secretRef is optional: points
+                                          to a secret object containing parameters
+                                          used to connect to OpenStack.'
                                         properties:
                                           name:
                                             description: 'Name of the referent. More
@@ -5760,32 +6681,33 @@ spec:
                                             type: string
                                         type: object
                                       volumeID:
-                                        description: 'volume id used to identify the
+                                        description: 'volumeID used to identify the
                                           volume in cinder. More info: https://examples.k8s.io/mysql-cinder-pd/README.md'
                                         type: string
                                     required:
                                     - volumeID
                                     type: object
                                   configMap:
-                                    description: ConfigMap represents a configMap
+                                    description: configMap represents a configMap
                                       that should populate this volume
                                     properties:
                                       defaultMode:
-                                        description: 'Optional: mode bits used to
-                                          set permissions on created files by default.
-                                          Must be an octal value between 0000 and
-                                          0777 or a decimal value between 0 and 511.
-                                          YAML accepts both octal and decimal values,
-                                          JSON requires decimal values for mode bits.
-                                          Defaults to 0644. Directories within the
-                                          path are not affected by this setting. This
-                                          might be in conflict with other options
-                                          that affect the file mode, like fsGroup,
-                                          and the result can be other mode bits set.'
+                                        description: 'defaultMode is optional: mode
+                                          bits used to set permissions on created
+                                          files by default. Must be an octal value
+                                          between 0000 and 0777 or a decimal value
+                                          between 0 and 511. YAML accepts both octal
+                                          and decimal values, JSON requires decimal
+                                          values for mode bits. Defaults to 0644.
+                                          Directories within the path are not affected
+                                          by this setting. This might be in conflict
+                                          with other options that affect the file
+                                          mode, like fsGroup, and the result can be
+                                          other mode bits set.'
                                         format: int32
                                         type: integer
                                       items:
-                                        description: If unspecified, each key-value
+                                        description: items if unspecified, each key-value
                                           pair in the Data field of the referenced
                                           ConfigMap will be projected into the volume
                                           as a file whose name is the key and content
@@ -5802,27 +6724,27 @@ spec:
                                             within a volume.
                                           properties:
                                             key:
-                                              description: The key to project.
+                                              description: key is the key to project.
                                               type: string
                                             mode:
-                                              description: 'Optional: mode bits used
-                                                to set permissions on this file. Must
-                                                be an octal value between 0000 and
-                                                0777 or a decimal value between 0
-                                                and 511. YAML accepts both octal and
-                                                decimal values, JSON requires decimal
-                                                values for mode bits. If not specified,
-                                                the volume defaultMode will be used.
-                                                This might be in conflict with other
-                                                options that affect the file mode,
-                                                like fsGroup, and the result can be
-                                                other mode bits set.'
+                                              description: 'mode is Optional: mode
+                                                bits used to set permissions on this
+                                                file. Must be an octal value between
+                                                0000 and 0777 or a decimal value between
+                                                0 and 511. YAML accepts both octal
+                                                and decimal values, JSON requires
+                                                decimal values for mode bits. If not
+                                                specified, the volume defaultMode
+                                                will be used. This might be in conflict
+                                                with other options that affect the
+                                                file mode, like fsGroup, and the result
+                                                can be other mode bits set.'
                                               format: int32
                                               type: integer
                                             path:
-                                              description: The relative path of the
-                                                file to map the key to. May not be
-                                                an absolute path. May not contain
+                                              description: path is the relative path
+                                                of the file to map the key to. May
+                                                not be an absolute path. May not contain
                                                 the path element '..'. May not start
                                                 with the string '..'.
                                               type: string
@@ -5838,30 +6760,30 @@ spec:
                                           kind, uid?'
                                         type: string
                                       optional:
-                                        description: Specify whether the ConfigMap
-                                          or its keys must be defined
+                                        description: optional specify whether the
+                                          ConfigMap or its keys must be defined
                                         type: boolean
                                     type: object
                                   csi:
-                                    description: CSI (Container Storage Interface)
+                                    description: csi (Container Storage Interface)
                                       represents ephemeral storage that is handled
                                       by certain external CSI drivers (Beta feature).
                                     properties:
                                       driver:
-                                        description: Driver is the name of the CSI
+                                        description: driver is the name of the CSI
                                           driver that handles this volume. Consult
                                           with your admin for the correct name as
                                           registered in the cluster.
                                         type: string
                                       fsType:
-                                        description: Filesystem type to mount. Ex.
-                                          "ext4", "xfs", "ntfs". If not provided,
-                                          the empty value is passed to the associated
-                                          CSI driver which will determine the default
-                                          filesystem to apply.
+                                        description: fsType to mount. Ex. "ext4",
+                                          "xfs", "ntfs". If not provided, the empty
+                                          value is passed to the associated CSI driver
+                                          which will determine the default filesystem
+                                          to apply.
                                         type: string
                                       nodePublishSecretRef:
-                                        description: NodePublishSecretRef is a reference
+                                        description: nodePublishSecretRef is a reference
                                           to the secret object containing sensitive
                                           information to pass to the CSI driver to
                                           complete the CSI NodePublishVolume and NodeUnpublishVolume
@@ -5878,13 +6800,14 @@ spec:
                                             type: string
                                         type: object
                                       readOnly:
-                                        description: Specifies a read-only configuration
-                                          for the volume. Defaults to false (read/write).
+                                        description: readOnly specifies a read-only
+                                          configuration for the volume. Defaults to
+                                          false (read/write).
                                         type: boolean
                                       volumeAttributes:
                                         additionalProperties:
                                           type: string
-                                        description: VolumeAttributes stores driver-specific
+                                        description: volumeAttributes stores driver-specific
                                           properties that are passed to the CSI driver.
                                           Consult your driver's documentation for
                                           supported values.
@@ -5893,7 +6816,7 @@ spec:
                                     - driver
                                     type: object
                                   downwardAPI:
-                                    description: DownwardAPI represents downward API
+                                    description: downwardAPI represents downward API
                                       about the pod that should populate this volume
                                     properties:
                                       defaultMode:
@@ -5994,62 +6917,59 @@ spec:
                                         type: array
                                     type: object
                                   emptyDir:
-                                    description: 'EmptyDir represents a temporary
+                                    description: 'emptyDir represents a temporary
                                       directory that shares a pod''s lifetime. More
                                       info: https://kubernetes.io/docs/concepts/storage/volumes#emptydir'
                                     properties:
                                       medium:
-                                        description: 'What type of storage medium
-                                          should back this directory. The default
-                                          is "" which means to use the node''s default
-                                          medium. Must be an empty string (default)
-                                          or Memory. More info: https://kubernetes.io/docs/concepts/storage/volumes#emptydir'
+                                        description: 'medium represents what type
+                                          of storage medium should back this directory.
+                                          The default is "" which means to use the
+                                          node''s default medium. Must be an empty
+                                          string (default) or Memory. More info: https://kubernetes.io/docs/concepts/storage/volumes#emptydir'
                                         type: string
                                       sizeLimit:
                                         anyOf:
                                         - type: integer
                                         - type: string
-                                        description: 'Total amount of local storage
-                                          required for this EmptyDir volume. The size
-                                          limit is also applicable for memory medium.
-                                          The maximum usage on memory medium EmptyDir
-                                          would be the minimum value between the SizeLimit
-                                          specified here and the sum of memory limits
-                                          of all containers in a pod. The default
-                                          is nil which means that the limit is undefined.
-                                          More info: http://kubernetes.io/docs/user-guide/volumes#emptydir'
+                                        description: 'sizeLimit is the total amount
+                                          of local storage required for this EmptyDir
+                                          volume. The size limit is also applicable
+                                          for memory medium. The maximum usage on
+                                          memory medium EmptyDir would be the minimum
+                                          value between the SizeLimit specified here
+                                          and the sum of memory limits of all containers
+                                          in a pod. The default is nil which means
+                                          that the limit is undefined. More info:
+                                          http://kubernetes.io/docs/user-guide/volumes#emptydir'
                                         pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                         x-kubernetes-int-or-string: true
                                     type: object
                                   ephemeral:
-                                    description: "Ephemeral represents a volume that
-                                      is handled by a cluster storage driver (Alpha
-                                      feature). The volume's lifecycle is tied to
-                                      the pod that defines it - it will be created
-                                      before the pod starts, and deleted when the
-                                      pod is removed. \n Use this if: a) the volume
-                                      is only needed while the pod runs, b) features
-                                      of normal volumes like restoring from snapshot
-                                      or capacity    tracking are needed, c) the storage
-                                      driver is specified through a storage class,
-                                      and d) the storage driver supports dynamic volume
-                                      provisioning through    a PersistentVolumeClaim
-                                      (see EphemeralVolumeSource for more    information
-                                      on the connection between this volume type    and
-                                      PersistentVolumeClaim). \n Use PersistentVolumeClaim
-                                      or one of the vendor-specific APIs for volumes
-                                      that persist for longer than the lifecycle of
-                                      an individual pod. \n Use CSI for light-weight
-                                      local ephemeral volumes if the CSI driver is
-                                      meant to be used that way - see the documentation
-                                      of the driver for more information. \n A pod
-                                      can use both types of ephemeral volumes and
-                                      persistent volumes at the same time."
+                                    description: "ephemeral represents a volume that
+                                      is handled by a cluster storage driver. The
+                                      volume's lifecycle is tied to the pod that defines
+                                      it - it will be created before the pod starts,
+                                      and deleted when the pod is removed. \n Use
+                                      this if: a) the volume is only needed while
+                                      the pod runs, b) features of normal volumes
+                                      like restoring from snapshot or capacity    tracking
+                                      are needed, c) the storage driver is specified
+                                      through a storage class, and d) the storage
+                                      driver supports dynamic volume provisioning
+                                      through    a PersistentVolumeClaim (see EphemeralVolumeSource
+                                      for more    information on the connection between
+                                      this volume type    and PersistentVolumeClaim).
+                                      \n Use PersistentVolumeClaim or one of the vendor-specific
+                                      APIs for volumes that persist for longer than
+                                      the lifecycle of an individual pod. \n Use CSI
+                                      for light-weight local ephemeral volumes if
+                                      the CSI driver is meant to be used that way
+                                      - see the documentation of the driver for more
+                                      information. \n A pod can use both types of
+                                      ephemeral volumes and persistent volumes at
+                                      the same time."
                                     properties:
-                                      readOnly:
-                                        description: Specifies a read-only configuration
-                                          for the volume. Defaults to false (read/write).
-                                        type: boolean
                                       volumeClaimTemplate:
                                         description: "Will be used to create a stand-alone
                                           PVC to provision the volume. The pod in
@@ -6109,34 +7029,82 @@ spec:
                                               are also valid here.
                                             properties:
                                               accessModes:
-                                                description: 'AccessModes contains
+                                                description: 'accessModes contains
                                                   the desired access modes the volume
                                                   should have. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#access-modes-1'
                                                 items:
                                                   type: string
                                                 type: array
                                               dataSource:
-                                                description: 'This field can be used
-                                                  to specify either: * An existing
-                                                  VolumeSnapshot object (snapshot.storage.k8s.io/VolumeSnapshot
-                                                  - Beta) * An existing PVC (PersistentVolumeClaim)
-                                                  * An existing custom resource/object
-                                                  that implements data population
-                                                  (Alpha) In order to use VolumeSnapshot
-                                                  object types, the appropriate feature
-                                                  gate must be enabled (VolumeSnapshotDataSource
-                                                  or AnyVolumeDataSource) If the provisioner
-                                                  or an external controller can support
-                                                  the specified data source, it will
-                                                  create a new volume based on the
-                                                  contents of the specified data source.
-                                                  If the specified data source is
-                                                  not supported, the volume will not
-                                                  be created and the failure will
-                                                  be reported as an event. In the
-                                                  future, we plan to support more
-                                                  data source types and the behavior
-                                                  of the provisioner may change.'
+                                                description: 'dataSource field can
+                                                  be used to specify either: * An
+                                                  existing VolumeSnapshot object (snapshot.storage.k8s.io/VolumeSnapshot)
+                                                  * An existing PVC (PersistentVolumeClaim)
+                                                  If the provisioner or an external
+                                                  controller can support the specified
+                                                  data source, it will create a new
+                                                  volume based on the contents of
+                                                  the specified data source. If the
+                                                  AnyVolumeDataSource feature gate
+                                                  is enabled, this field will always
+                                                  have the same contents as the DataSourceRef
+                                                  field.'
+                                                properties:
+                                                  apiGroup:
+                                                    description: APIGroup is the group
+                                                      for the resource being referenced.
+                                                      If APIGroup is not specified,
+                                                      the specified Kind must be in
+                                                      the core API group. For any
+                                                      other third-party types, APIGroup
+                                                      is required.
+                                                    type: string
+                                                  kind:
+                                                    description: Kind is the type
+                                                      of resource being referenced
+                                                    type: string
+                                                  name:
+                                                    description: Name is the name
+                                                      of resource being referenced
+                                                    type: string
+                                                required:
+                                                - kind
+                                                - name
+                                                type: object
+                                              dataSourceRef:
+                                                description: 'dataSourceRef specifies
+                                                  the object from which to populate
+                                                  the volume with data, if a non-empty
+                                                  volume is desired. This may be any
+                                                  local object from a non-empty API
+                                                  group (non core object) or a PersistentVolumeClaim
+                                                  object. When this field is specified,
+                                                  volume binding will only succeed
+                                                  if the type of the specified object
+                                                  matches some installed volume populator
+                                                  or dynamic provisioner. This field
+                                                  will replace the functionality of
+                                                  the DataSource field and as such
+                                                  if both fields are non-empty, they
+                                                  must have the same value. For backwards
+                                                  compatibility, both fields (DataSource
+                                                  and DataSourceRef) will be set to
+                                                  the same value automatically if
+                                                  one of them is empty and the other
+                                                  is non-empty. There are two important
+                                                  differences between DataSource and
+                                                  DataSourceRef: * While DataSource
+                                                  only allows two specific types of
+                                                  objects, DataSourceRef   allows
+                                                  any non-core object, as well as
+                                                  PersistentVolumeClaim objects. *
+                                                  While DataSource ignores disallowed
+                                                  values (dropping them), DataSourceRef   preserves
+                                                  all values, and generates an error
+                                                  if a disallowed value is   specified.
+                                                  (Beta) Using this field requires
+                                                  the AnyVolumeDataSource feature
+                                                  gate to be enabled.'
                                                 properties:
                                                   apiGroup:
                                                     description: APIGroup is the group
@@ -6160,9 +7128,15 @@ spec:
                                                 - name
                                                 type: object
                                               resources:
-                                                description: 'Resources represents
+                                                description: 'resources represents
                                                   the minimum resources the volume
-                                                  should have. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#resources'
+                                                  should have. If RecoverVolumeExpansionFailure
+                                                  feature is enabled users are allowed
+                                                  to specify resource requirements
+                                                  that are lower than previous value
+                                                  but must still be higher than capacity
+                                                  recorded in the status field of
+                                                  the claim. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#resources'
                                                 properties:
                                                   limits:
                                                     additionalProperties:
@@ -6174,7 +7148,7 @@ spec:
                                                     description: 'Limits describes
                                                       the maximum amount of compute
                                                       resources allowed. More info:
-                                                      https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
+                                                      https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
                                                     type: object
                                                   requests:
                                                     additionalProperties:
@@ -6190,12 +7164,12 @@ spec:
                                                       it defaults to Limits if that
                                                       is explicitly specified, otherwise
                                                       to an implementation-defined
-                                                      value. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
+                                                      value. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
                                                     type: object
                                                 type: object
                                               selector:
-                                                description: A label query over volumes
-                                                  to consider for binding.
+                                                description: selector is a label query
+                                                  over volumes to consider for binding.
                                                 properties:
                                                   matchExpressions:
                                                     description: matchExpressions
@@ -6255,9 +7229,9 @@ spec:
                                                     type: object
                                                 type: object
                                               storageClassName:
-                                                description: 'Name of the StorageClass
-                                                  required by the claim. More info:
-                                                  https://kubernetes.io/docs/concepts/storage/persistent-volumes#class-1'
+                                                description: 'storageClassName is
+                                                  the name of the StorageClass required
+                                                  by the claim. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#class-1'
                                                 type: string
                                               volumeMode:
                                                 description: volumeMode defines what
@@ -6266,7 +7240,7 @@ spec:
                                                   when not included in claim spec.
                                                 type: string
                                               volumeName:
-                                                description: VolumeName is the binding
+                                                description: volumeName is the binding
                                                   reference to the PersistentVolume
                                                   backing this claim.
                                                 type: string
@@ -6276,77 +7250,79 @@ spec:
                                         type: object
                                     type: object
                                   fc:
-                                    description: FC represents a Fibre Channel resource
+                                    description: fc represents a Fibre Channel resource
                                       that is attached to a kubelet's host machine
                                       and then exposed to the pod.
                                     properties:
                                       fsType:
-                                        description: 'Filesystem type to mount. Must
-                                          be a filesystem type supported by the host
-                                          operating system. Ex. "ext4", "xfs", "ntfs".
-                                          Implicitly inferred to be "ext4" if unspecified.
-                                          TODO: how do we prevent errors in the filesystem
-                                          from compromising the machine'
+                                        description: 'fsType is the filesystem type
+                                          to mount. Must be a filesystem type supported
+                                          by the host operating system. Ex. "ext4",
+                                          "xfs", "ntfs". Implicitly inferred to be
+                                          "ext4" if unspecified. TODO: how do we prevent
+                                          errors in the filesystem from compromising
+                                          the machine'
                                         type: string
                                       lun:
-                                        description: 'Optional: FC target lun number'
+                                        description: 'lun is Optional: FC target lun
+                                          number'
                                         format: int32
                                         type: integer
                                       readOnly:
-                                        description: 'Optional: Defaults to false
-                                          (read/write). ReadOnly here will force the
-                                          ReadOnly setting in VolumeMounts.'
+                                        description: 'readOnly is Optional: Defaults
+                                          to false (read/write). ReadOnly here will
+                                          force the ReadOnly setting in VolumeMounts.'
                                         type: boolean
                                       targetWWNs:
-                                        description: 'Optional: FC target worldwide
-                                          names (WWNs)'
+                                        description: 'targetWWNs is Optional: FC target
+                                          worldwide names (WWNs)'
                                         items:
                                           type: string
                                         type: array
                                       wwids:
-                                        description: 'Optional: FC volume world wide
-                                          identifiers (wwids) Either wwids or combination
-                                          of targetWWNs and lun must be set, but not
-                                          both simultaneously.'
+                                        description: 'wwids Optional: FC volume world
+                                          wide identifiers (wwids) Either wwids or
+                                          combination of targetWWNs and lun must be
+                                          set, but not both simultaneously.'
                                         items:
                                           type: string
                                         type: array
                                     type: object
                                   flexVolume:
-                                    description: FlexVolume represents a generic volume
+                                    description: flexVolume represents a generic volume
                                       resource that is provisioned/attached using
                                       an exec based plugin.
                                     properties:
                                       driver:
-                                        description: Driver is the name of the driver
+                                        description: driver is the name of the driver
                                           to use for this volume.
                                         type: string
                                       fsType:
-                                        description: Filesystem type to mount. Must
-                                          be a filesystem type supported by the host
-                                          operating system. Ex. "ext4", "xfs", "ntfs".
-                                          The default filesystem depends on FlexVolume
-                                          script.
+                                        description: fsType is the filesystem type
+                                          to mount. Must be a filesystem type supported
+                                          by the host operating system. Ex. "ext4",
+                                          "xfs", "ntfs". The default filesystem depends
+                                          on FlexVolume script.
                                         type: string
                                       options:
                                         additionalProperties:
                                           type: string
-                                        description: 'Optional: Extra command options
-                                          if any.'
+                                        description: 'options is Optional: this field
+                                          holds extra command options if any.'
                                         type: object
                                       readOnly:
-                                        description: 'Optional: Defaults to false
-                                          (read/write). ReadOnly here will force the
-                                          ReadOnly setting in VolumeMounts.'
+                                        description: 'readOnly is Optional: defaults
+                                          to false (read/write). ReadOnly here will
+                                          force the ReadOnly setting in VolumeMounts.'
                                         type: boolean
                                       secretRef:
-                                        description: 'Optional: SecretRef is reference
-                                          to the secret object containing sensitive
-                                          information to pass to the plugin scripts.
-                                          This may be empty if no secret object is
-                                          specified. If the secret object contains
-                                          more than one secret, all secrets are passed
-                                          to the plugin scripts.'
+                                        description: 'secretRef is Optional: secretRef
+                                          is reference to the secret object containing
+                                          sensitive information to pass to the plugin
+                                          scripts. This may be empty if no secret
+                                          object is specified. If the secret object
+                                          contains more than one secret, all secrets
+                                          are passed to the plugin scripts.'
                                         properties:
                                           name:
                                             description: 'Name of the referent. More
@@ -6359,53 +7335,55 @@ spec:
                                     - driver
                                     type: object
                                   flocker:
-                                    description: Flocker represents a Flocker volume
+                                    description: flocker represents a Flocker volume
                                       attached to a kubelet's host machine. This depends
                                       on the Flocker control service being running
                                     properties:
                                       datasetName:
-                                        description: Name of the dataset stored as
-                                          metadata -> name on the dataset for Flocker
-                                          should be considered as deprecated
+                                        description: datasetName is Name of the dataset
+                                          stored as metadata -> name on the dataset
+                                          for Flocker should be considered as deprecated
                                         type: string
                                       datasetUUID:
-                                        description: UUID of the dataset. This is
-                                          unique identifier of a Flocker dataset
+                                        description: datasetUUID is the UUID of the
+                                          dataset. This is unique identifier of a
+                                          Flocker dataset
                                         type: string
                                     type: object
                                   gcePersistentDisk:
-                                    description: 'GCEPersistentDisk represents a GCE
+                                    description: 'gcePersistentDisk represents a GCE
                                       Disk resource that is attached to a kubelet''s
                                       host machine and then exposed to the pod. More
                                       info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk'
                                     properties:
                                       fsType:
-                                        description: 'Filesystem type of the volume
-                                          that you want to mount. Tip: Ensure that
-                                          the filesystem type is supported by the
-                                          host operating system. Examples: "ext4",
-                                          "xfs", "ntfs". Implicitly inferred to be
-                                          "ext4" if unspecified. More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk
+                                        description: 'fsType is filesystem type of
+                                          the volume that you want to mount. Tip:
+                                          Ensure that the filesystem type is supported
+                                          by the host operating system. Examples:
+                                          "ext4", "xfs", "ntfs". Implicitly inferred
+                                          to be "ext4" if unspecified. More info:
+                                          https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk
                                           TODO: how do we prevent errors in the filesystem
                                           from compromising the machine'
                                         type: string
                                       partition:
-                                        description: 'The partition in the volume
-                                          that you want to mount. If omitted, the
-                                          default is to mount by volume name. Examples:
-                                          For volume /dev/sda1, you specify the partition
-                                          as "1". Similarly, the volume partition
-                                          for /dev/sda is "0" (or you can leave the
-                                          property empty). More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk'
+                                        description: 'partition is the partition in
+                                          the volume that you want to mount. If omitted,
+                                          the default is to mount by volume name.
+                                          Examples: For volume /dev/sda1, you specify
+                                          the partition as "1". Similarly, the volume
+                                          partition for /dev/sda is "0" (or you can
+                                          leave the property empty). More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk'
                                         format: int32
                                         type: integer
                                       pdName:
-                                        description: 'Unique name of the PD resource
-                                          in GCE. Used to identify the disk in GCE.
-                                          More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk'
+                                        description: 'pdName is unique name of the
+                                          PD resource in GCE. Used to identify the
+                                          disk in GCE. More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk'
                                         type: string
                                       readOnly:
-                                        description: 'ReadOnly here will force the
+                                        description: 'readOnly here will force the
                                           ReadOnly setting in VolumeMounts. Defaults
                                           to false. More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk'
                                         type: boolean
@@ -6413,7 +7391,7 @@ spec:
                                     - pdName
                                     type: object
                                   gitRepo:
-                                    description: 'GitRepo represents a git repository
+                                    description: 'gitRepo represents a git repository
                                       at a particular revision. DEPRECATED: GitRepo
                                       is deprecated. To provision a container with
                                       a git repo, mount an EmptyDir into an InitContainer
@@ -6421,39 +7399,39 @@ spec:
                                       EmptyDir into the Pod''s container.'
                                     properties:
                                       directory:
-                                        description: Target directory name. Must not
-                                          contain or start with '..'.  If '.' is supplied,
-                                          the volume directory will be the git repository.  Otherwise,
-                                          if specified, the volume will contain the
-                                          git repository in the subdirectory with
-                                          the given name.
+                                        description: directory is the target directory
+                                          name. Must not contain or start with '..'.  If
+                                          '.' is supplied, the volume directory will
+                                          be the git repository.  Otherwise, if specified,
+                                          the volume will contain the git repository
+                                          in the subdirectory with the given name.
                                         type: string
                                       repository:
-                                        description: Repository URL
+                                        description: repository is the URL
                                         type: string
                                       revision:
-                                        description: Commit hash for the specified
-                                          revision.
+                                        description: revision is the commit hash for
+                                          the specified revision.
                                         type: string
                                     required:
                                     - repository
                                     type: object
                                   glusterfs:
-                                    description: 'Glusterfs represents a Glusterfs
+                                    description: 'glusterfs represents a Glusterfs
                                       mount on the host that shares a pod''s lifetime.
                                       More info: https://examples.k8s.io/volumes/glusterfs/README.md'
                                     properties:
                                       endpoints:
-                                        description: 'EndpointsName is the endpoint
-                                          name that details Glusterfs topology. More
-                                          info: https://examples.k8s.io/volumes/glusterfs/README.md#create-a-pod'
+                                        description: 'endpoints is the endpoint name
+                                          that details Glusterfs topology. More info:
+                                          https://examples.k8s.io/volumes/glusterfs/README.md#create-a-pod'
                                         type: string
                                       path:
-                                        description: 'Path is the Glusterfs volume
+                                        description: 'path is the Glusterfs volume
                                           path. More info: https://examples.k8s.io/volumes/glusterfs/README.md#create-a-pod'
                                         type: string
                                       readOnly:
-                                        description: 'ReadOnly here will force the
+                                        description: 'readOnly here will force the
                                           Glusterfs volume to be mounted with read-only
                                           permissions. Defaults to false. More info:
                                           https://examples.k8s.io/volumes/glusterfs/README.md#create-a-pod'
@@ -6463,7 +7441,7 @@ spec:
                                     - path
                                     type: object
                                   hostPath:
-                                    description: 'HostPath represents a pre-existing
+                                    description: 'hostPath represents a pre-existing
                                       file or directory on the host machine that is
                                       directly exposed to the container. This is generally
                                       used for system agents or other privileged things
@@ -6474,76 +7452,79 @@ spec:
                                       mount host directories as read/write.'
                                     properties:
                                       path:
-                                        description: 'Path of the directory on the
+                                        description: 'path of the directory on the
                                           host. If the path is a symlink, it will
                                           follow the link to the real path. More info:
                                           https://kubernetes.io/docs/concepts/storage/volumes#hostpath'
                                         type: string
                                       type:
-                                        description: 'Type for HostPath Volume Defaults
+                                        description: 'type for HostPath Volume Defaults
                                           to "" More info: https://kubernetes.io/docs/concepts/storage/volumes#hostpath'
                                         type: string
                                     required:
                                     - path
                                     type: object
                                   iscsi:
-                                    description: 'ISCSI represents an ISCSI Disk resource
+                                    description: 'iscsi represents an ISCSI Disk resource
                                       that is attached to a kubelet''s host machine
                                       and then exposed to the pod. More info: https://examples.k8s.io/volumes/iscsi/README.md'
                                     properties:
                                       chapAuthDiscovery:
-                                        description: whether support iSCSI Discovery
-                                          CHAP authentication
+                                        description: chapAuthDiscovery defines whether
+                                          support iSCSI Discovery CHAP authentication
                                         type: boolean
                                       chapAuthSession:
-                                        description: whether support iSCSI Session
-                                          CHAP authentication
+                                        description: chapAuthSession defines whether
+                                          support iSCSI Session CHAP authentication
                                         type: boolean
                                       fsType:
-                                        description: 'Filesystem type of the volume
-                                          that you want to mount. Tip: Ensure that
-                                          the filesystem type is supported by the
-                                          host operating system. Examples: "ext4",
-                                          "xfs", "ntfs". Implicitly inferred to be
-                                          "ext4" if unspecified. More info: https://kubernetes.io/docs/concepts/storage/volumes#iscsi
+                                        description: 'fsType is the filesystem type
+                                          of the volume that you want to mount. Tip:
+                                          Ensure that the filesystem type is supported
+                                          by the host operating system. Examples:
+                                          "ext4", "xfs", "ntfs". Implicitly inferred
+                                          to be "ext4" if unspecified. More info:
+                                          https://kubernetes.io/docs/concepts/storage/volumes#iscsi
                                           TODO: how do we prevent errors in the filesystem
                                           from compromising the machine'
                                         type: string
                                       initiatorName:
-                                        description: Custom iSCSI Initiator Name.
-                                          If initiatorName is specified with iscsiInterface
-                                          simultaneously, new iSCSI interface <target
-                                          portal>:<volume name> will be created for
-                                          the connection.
+                                        description: initiatorName is the custom iSCSI
+                                          Initiator Name. If initiatorName is specified
+                                          with iscsiInterface simultaneously, new
+                                          iSCSI interface <target portal>:<volume
+                                          name> will be created for the connection.
                                         type: string
                                       iqn:
-                                        description: Target iSCSI Qualified Name.
+                                        description: iqn is the target iSCSI Qualified
+                                          Name.
                                         type: string
                                       iscsiInterface:
-                                        description: iSCSI Interface Name that uses
-                                          an iSCSI transport. Defaults to 'default'
-                                          (tcp).
+                                        description: iscsiInterface is the interface
+                                          Name that uses an iSCSI transport. Defaults
+                                          to 'default' (tcp).
                                         type: string
                                       lun:
-                                        description: iSCSI Target Lun number.
+                                        description: lun represents iSCSI Target Lun
+                                          number.
                                         format: int32
                                         type: integer
                                       portals:
-                                        description: iSCSI Target Portal List. The
-                                          portal is either an IP or ip_addr:port if
-                                          the port is other than default (typically
+                                        description: portals is the iSCSI Target Portal
+                                          List. The portal is either an IP or ip_addr:port
+                                          if the port is other than default (typically
                                           TCP ports 860 and 3260).
                                         items:
                                           type: string
                                         type: array
                                       readOnly:
-                                        description: ReadOnly here will force the
+                                        description: readOnly here will force the
                                           ReadOnly setting in VolumeMounts. Defaults
                                           to false.
                                         type: boolean
                                       secretRef:
-                                        description: CHAP Secret for iSCSI target
-                                          and initiator authentication
+                                        description: secretRef is the CHAP Secret
+                                          for iSCSI target and initiator authentication
                                         properties:
                                           name:
                                             description: 'Name of the referent. More
@@ -6553,10 +7534,10 @@ spec:
                                             type: string
                                         type: object
                                       targetPortal:
-                                        description: iSCSI Target Portal. The Portal
-                                          is either an IP or ip_addr:port if the port
-                                          is other than default (typically TCP ports
-                                          860 and 3260).
+                                        description: targetPortal is iSCSI Target
+                                          Portal. The Portal is either an IP or ip_addr:port
+                                          if the port is other than default (typically
+                                          TCP ports 860 and 3260).
                                         type: string
                                     required:
                                     - iqn
@@ -6564,26 +7545,26 @@ spec:
                                     - targetPortal
                                     type: object
                                   name:
-                                    description: 'Volume''s name. Must be a DNS_LABEL
+                                    description: 'name of the volume. Must be a DNS_LABEL
                                       and unique within the pod. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
                                     type: string
                                   nfs:
-                                    description: 'NFS represents an NFS mount on the
+                                    description: 'nfs represents an NFS mount on the
                                       host that shares a pod''s lifetime More info:
                                       https://kubernetes.io/docs/concepts/storage/volumes#nfs'
                                     properties:
                                       path:
-                                        description: 'Path that is exported by the
+                                        description: 'path that is exported by the
                                           NFS server. More info: https://kubernetes.io/docs/concepts/storage/volumes#nfs'
                                         type: string
                                       readOnly:
-                                        description: 'ReadOnly here will force the
+                                        description: 'readOnly here will force the
                                           NFS export to be mounted with read-only
                                           permissions. Defaults to false. More info:
                                           https://kubernetes.io/docs/concepts/storage/volumes#nfs'
                                         type: boolean
                                       server:
-                                        description: 'Server is the hostname or IP
+                                        description: 'server is the hostname or IP
                                           address of the NFS server. More info: https://kubernetes.io/docs/concepts/storage/volumes#nfs'
                                         type: string
                                     required:
@@ -6591,99 +7572,101 @@ spec:
                                     - server
                                     type: object
                                   persistentVolumeClaim:
-                                    description: 'PersistentVolumeClaimVolumeSource
+                                    description: 'persistentVolumeClaimVolumeSource
                                       represents a reference to a PersistentVolumeClaim
                                       in the same namespace. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#persistentvolumeclaims'
                                     properties:
                                       claimName:
-                                        description: 'ClaimName is the name of a PersistentVolumeClaim
+                                        description: 'claimName is the name of a PersistentVolumeClaim
                                           in the same namespace as the pod using this
                                           volume. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#persistentvolumeclaims'
                                         type: string
                                       readOnly:
-                                        description: Will force the ReadOnly setting
-                                          in VolumeMounts. Default false.
+                                        description: readOnly Will force the ReadOnly
+                                          setting in VolumeMounts. Default false.
                                         type: boolean
                                     required:
                                     - claimName
                                     type: object
                                   photonPersistentDisk:
-                                    description: PhotonPersistentDisk represents a
+                                    description: photonPersistentDisk represents a
                                       PhotonController persistent disk attached and
                                       mounted on kubelets host machine
                                     properties:
                                       fsType:
-                                        description: Filesystem type to mount. Must
-                                          be a filesystem type supported by the host
-                                          operating system. Ex. "ext4", "xfs", "ntfs".
-                                          Implicitly inferred to be "ext4" if unspecified.
+                                        description: fsType is the filesystem type
+                                          to mount. Must be a filesystem type supported
+                                          by the host operating system. Ex. "ext4",
+                                          "xfs", "ntfs". Implicitly inferred to be
+                                          "ext4" if unspecified.
                                         type: string
                                       pdID:
-                                        description: ID that identifies Photon Controller
-                                          persistent disk
+                                        description: pdID is the ID that identifies
+                                          Photon Controller persistent disk
                                         type: string
                                     required:
                                     - pdID
                                     type: object
                                   portworxVolume:
-                                    description: PortworxVolume represents a portworx
+                                    description: portworxVolume represents a portworx
                                       volume attached and mounted on kubelets host
                                       machine
                                     properties:
                                       fsType:
-                                        description: FSType represents the filesystem
+                                        description: fSType represents the filesystem
                                           type to mount Must be a filesystem type
                                           supported by the host operating system.
                                           Ex. "ext4", "xfs". Implicitly inferred to
                                           be "ext4" if unspecified.
                                         type: string
                                       readOnly:
-                                        description: Defaults to false (read/write).
+                                        description: readOnly defaults to false (read/write).
                                           ReadOnly here will force the ReadOnly setting
                                           in VolumeMounts.
                                         type: boolean
                                       volumeID:
-                                        description: VolumeID uniquely identifies
+                                        description: volumeID uniquely identifies
                                           a Portworx volume
                                         type: string
                                     required:
                                     - volumeID
                                     type: object
                                   projected:
-                                    description: Items for all in one resources secrets,
-                                      configmaps, and downward API
+                                    description: projected items for all in one resources
+                                      secrets, configmaps, and downward API
                                     properties:
                                       defaultMode:
-                                        description: Mode bits used to set permissions
-                                          on created files by default. Must be an
-                                          octal value between 0000 and 0777 or a decimal
-                                          value between 0 and 511. YAML accepts both
-                                          octal and decimal values, JSON requires
-                                          decimal values for mode bits. Directories
-                                          within the path are not affected by this
-                                          setting. This might be in conflict with
-                                          other options that affect the file mode,
-                                          like fsGroup, and the result can be other
-                                          mode bits set.
+                                        description: defaultMode are the mode bits
+                                          used to set permissions on created files
+                                          by default. Must be an octal value between
+                                          0000 and 0777 or a decimal value between
+                                          0 and 511. YAML accepts both octal and decimal
+                                          values, JSON requires decimal values for
+                                          mode bits. Directories within the path are
+                                          not affected by this setting. This might
+                                          be in conflict with other options that affect
+                                          the file mode, like fsGroup, and the result
+                                          can be other mode bits set.
                                         format: int32
                                         type: integer
                                       sources:
-                                        description: list of volume projections
+                                        description: sources is the list of volume
+                                          projections
                                         items:
                                           description: Projection that may be projected
                                             along with other supported volume types
                                           properties:
                                             configMap:
-                                              description: information about the configMap
-                                                data to project
+                                              description: configMap information about
+                                                the configMap data to project
                                               properties:
                                                 items:
-                                                  description: If unspecified, each
-                                                    key-value pair in the Data field
-                                                    of the referenced ConfigMap will
-                                                    be projected into the volume as
-                                                    a file whose name is the key and
-                                                    content is the value. If specified,
+                                                  description: items if unspecified,
+                                                    each key-value pair in the Data
+                                                    field of the referenced ConfigMap
+                                                    will be projected into the volume
+                                                    as a file whose name is the key
+                                                    and content is the value. If specified,
                                                     the listed keys will be projected
                                                     into the specified paths, and
                                                     unlisted keys will not be present.
@@ -6698,11 +7681,12 @@ spec:
                                                       to a path within a volume.
                                                     properties:
                                                       key:
-                                                        description: The key to project.
+                                                        description: key is the key
+                                                          to project.
                                                         type: string
                                                       mode:
-                                                        description: 'Optional: mode
-                                                          bits used to set permissions
+                                                        description: 'mode is Optional:
+                                                          mode bits used to set permissions
                                                           on this file. Must be an
                                                           octal value between 0000
                                                           and 0777 or a decimal value
@@ -6720,7 +7704,7 @@ spec:
                                                         format: int32
                                                         type: integer
                                                       path:
-                                                        description: The relative
+                                                        description: path is the relative
                                                           path of the file to map
                                                           the key to. May not be an
                                                           absolute path. May not contain
@@ -6740,14 +7724,14 @@ spec:
                                                     apiVersion, kind, uid?'
                                                   type: string
                                                 optional:
-                                                  description: Specify whether the
-                                                    ConfigMap or its keys must be
-                                                    defined
+                                                  description: optional specify whether
+                                                    the ConfigMap or its keys must
+                                                    be defined
                                                   type: boolean
                                               type: object
                                             downwardAPI:
-                                              description: information about the downwardAPI
-                                                data to project
+                                              description: downwardAPI information
+                                                about the downwardAPI data to project
                                               properties:
                                                 items:
                                                   description: Items is a list of
@@ -6844,16 +7828,16 @@ spec:
                                                   type: array
                                               type: object
                                             secret:
-                                              description: information about the secret
-                                                data to project
+                                              description: secret information about
+                                                the secret data to project
                                               properties:
                                                 items:
-                                                  description: If unspecified, each
-                                                    key-value pair in the Data field
-                                                    of the referenced Secret will
-                                                    be projected into the volume as
-                                                    a file whose name is the key and
-                                                    content is the value. If specified,
+                                                  description: items if unspecified,
+                                                    each key-value pair in the Data
+                                                    field of the referenced Secret
+                                                    will be projected into the volume
+                                                    as a file whose name is the key
+                                                    and content is the value. If specified,
                                                     the listed keys will be projected
                                                     into the specified paths, and
                                                     unlisted keys will not be present.
@@ -6868,11 +7852,12 @@ spec:
                                                       to a path within a volume.
                                                     properties:
                                                       key:
-                                                        description: The key to project.
+                                                        description: key is the key
+                                                          to project.
                                                         type: string
                                                       mode:
-                                                        description: 'Optional: mode
-                                                          bits used to set permissions
+                                                        description: 'mode is Optional:
+                                                          mode bits used to set permissions
                                                           on this file. Must be an
                                                           octal value between 0000
                                                           and 0777 or a decimal value
@@ -6890,7 +7875,7 @@ spec:
                                                         format: int32
                                                         type: integer
                                                       path:
-                                                        description: The relative
+                                                        description: path is the relative
                                                           path of the file to map
                                                           the key to. May not be an
                                                           absolute path. May not contain
@@ -6910,16 +7895,18 @@ spec:
                                                     apiVersion, kind, uid?'
                                                   type: string
                                                 optional:
-                                                  description: Specify whether the
-                                                    Secret or its key must be defined
+                                                  description: optional field specify
+                                                    whether the Secret or its key
+                                                    must be defined
                                                   type: boolean
                                               type: object
                                             serviceAccountToken:
-                                              description: information about the serviceAccountToken
+                                              description: serviceAccountToken is
+                                                information about the serviceAccountToken
                                                 data to project
                                               properties:
                                                 audience:
-                                                  description: Audience is the intended
+                                                  description: audience is the intended
                                                     audience of the token. A recipient
                                                     of a token must identify itself
                                                     with an identifier specified in
@@ -6929,7 +7916,7 @@ spec:
                                                     of the apiserver.
                                                   type: string
                                                 expirationSeconds:
-                                                  description: ExpirationSeconds is
+                                                  description: expirationSeconds is
                                                     the requested duration of validity
                                                     of the service account token.
                                                     As the token approaches expiration,
@@ -6945,7 +7932,7 @@ spec:
                                                   format: int64
                                                   type: integer
                                                 path:
-                                                  description: Path is the path relative
+                                                  description: path is the path relative
                                                     to the mount point of the file
                                                     to project the token into.
                                                   type: string
@@ -6954,41 +7941,39 @@ spec:
                                               type: object
                                           type: object
                                         type: array
-                                    required:
-                                    - sources
                                     type: object
                                   quobyte:
-                                    description: Quobyte represents a Quobyte mount
+                                    description: quobyte represents a Quobyte mount
                                       on the host that shares a pod's lifetime
                                     properties:
                                       group:
-                                        description: Group to map volume access to
+                                        description: group to map volume access to
                                           Default is no group
                                         type: string
                                       readOnly:
-                                        description: ReadOnly here will force the
+                                        description: readOnly here will force the
                                           Quobyte volume to be mounted with read-only
                                           permissions. Defaults to false.
                                         type: boolean
                                       registry:
-                                        description: Registry represents a single
+                                        description: registry represents a single
                                           or multiple Quobyte Registry services specified
                                           as a string as host:port pair (multiple
                                           entries are separated with commas) which
                                           acts as the central registry for volumes
                                         type: string
                                       tenant:
-                                        description: Tenant owning the given Quobyte
+                                        description: tenant owning the given Quobyte
                                           volume in the Backend Used with dynamically
                                           provisioned Quobyte volumes, value is set
                                           by the plugin
                                         type: string
                                       user:
-                                        description: User to map volume access to
+                                        description: user to map volume access to
                                           Defaults to serivceaccount user
                                         type: string
                                       volume:
-                                        description: Volume is a string that references
+                                        description: volume is a string that references
                                           an already created Quobyte volume by name.
                                         type: string
                                     required:
@@ -6996,46 +7981,47 @@ spec:
                                     - volume
                                     type: object
                                   rbd:
-                                    description: 'RBD represents a Rados Block Device
+                                    description: 'rbd represents a Rados Block Device
                                       mount on the host that shares a pod''s lifetime.
                                       More info: https://examples.k8s.io/volumes/rbd/README.md'
                                     properties:
                                       fsType:
-                                        description: 'Filesystem type of the volume
-                                          that you want to mount. Tip: Ensure that
-                                          the filesystem type is supported by the
-                                          host operating system. Examples: "ext4",
-                                          "xfs", "ntfs". Implicitly inferred to be
-                                          "ext4" if unspecified. More info: https://kubernetes.io/docs/concepts/storage/volumes#rbd
+                                        description: 'fsType is the filesystem type
+                                          of the volume that you want to mount. Tip:
+                                          Ensure that the filesystem type is supported
+                                          by the host operating system. Examples:
+                                          "ext4", "xfs", "ntfs". Implicitly inferred
+                                          to be "ext4" if unspecified. More info:
+                                          https://kubernetes.io/docs/concepts/storage/volumes#rbd
                                           TODO: how do we prevent errors in the filesystem
                                           from compromising the machine'
                                         type: string
                                       image:
-                                        description: 'The rados image name. More info:
-                                          https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
+                                        description: 'image is the rados image name.
+                                          More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
                                         type: string
                                       keyring:
-                                        description: 'Keyring is the path to key ring
+                                        description: 'keyring is the path to key ring
                                           for RBDUser. Default is /etc/ceph/keyring.
                                           More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
                                         type: string
                                       monitors:
-                                        description: 'A collection of Ceph monitors.
-                                          More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
+                                        description: 'monitors is a collection of
+                                          Ceph monitors. More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
                                         items:
                                           type: string
                                         type: array
                                       pool:
-                                        description: 'The rados pool name. Default
-                                          is rbd. More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
+                                        description: 'pool is the rados pool name.
+                                          Default is rbd. More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
                                         type: string
                                       readOnly:
-                                        description: 'ReadOnly here will force the
+                                        description: 'readOnly here will force the
                                           ReadOnly setting in VolumeMounts. Defaults
                                           to false. More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
                                         type: boolean
                                       secretRef:
-                                        description: 'SecretRef is name of the authentication
+                                        description: 'secretRef is name of the authentication
                                           secret for RBDUser. If provided overrides
                                           keyring. Default is nil. More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
                                         properties:
@@ -7047,38 +8033,39 @@ spec:
                                             type: string
                                         type: object
                                       user:
-                                        description: 'The rados user name. Default
-                                          is admin. More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
+                                        description: 'user is the rados user name.
+                                          Default is admin. More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
                                         type: string
                                     required:
                                     - image
                                     - monitors
                                     type: object
                                   scaleIO:
-                                    description: ScaleIO represents a ScaleIO persistent
+                                    description: scaleIO represents a ScaleIO persistent
                                       volume attached and mounted on Kubernetes nodes.
                                     properties:
                                       fsType:
-                                        description: Filesystem type to mount. Must
-                                          be a filesystem type supported by the host
-                                          operating system. Ex. "ext4", "xfs", "ntfs".
-                                          Default is "xfs".
+                                        description: fsType is the filesystem type
+                                          to mount. Must be a filesystem type supported
+                                          by the host operating system. Ex. "ext4",
+                                          "xfs", "ntfs". Default is "xfs".
                                         type: string
                                       gateway:
-                                        description: The host address of the ScaleIO
-                                          API Gateway.
+                                        description: gateway is the host address of
+                                          the ScaleIO API Gateway.
                                         type: string
                                       protectionDomain:
-                                        description: The name of the ScaleIO Protection
-                                          Domain for the configured storage.
+                                        description: protectionDomain is the name
+                                          of the ScaleIO Protection Domain for the
+                                          configured storage.
                                         type: string
                                       readOnly:
-                                        description: Defaults to false (read/write).
+                                        description: readOnly Defaults to false (read/write).
                                           ReadOnly here will force the ReadOnly setting
                                           in VolumeMounts.
                                         type: boolean
                                       secretRef:
-                                        description: SecretRef references to the secret
+                                        description: secretRef references to the secret
                                           for ScaleIO user and other sensitive information.
                                           If this is not provided, Login operation
                                           will fail.
@@ -7091,26 +8078,27 @@ spec:
                                             type: string
                                         type: object
                                       sslEnabled:
-                                        description: Flag to enable/disable SSL communication
-                                          with Gateway, default false
+                                        description: sslEnabled Flag enable/disable
+                                          SSL communication with Gateway, default
+                                          false
                                         type: boolean
                                       storageMode:
-                                        description: Indicates whether the storage
-                                          for a volume should be ThickProvisioned
+                                        description: storageMode indicates whether
+                                          the storage for a volume should be ThickProvisioned
                                           or ThinProvisioned. Default is ThinProvisioned.
                                         type: string
                                       storagePool:
-                                        description: The ScaleIO Storage Pool associated
-                                          with the protection domain.
+                                        description: storagePool is the ScaleIO Storage
+                                          Pool associated with the protection domain.
                                         type: string
                                       system:
-                                        description: The name of the storage system
-                                          as configured in ScaleIO.
+                                        description: system is the name of the storage
+                                          system as configured in ScaleIO.
                                         type: string
                                       volumeName:
-                                        description: The name of a volume already
-                                          created in the ScaleIO system that is associated
-                                          with this volume source.
+                                        description: volumeName is the name of a volume
+                                          already created in the ScaleIO system that
+                                          is associated with this volume source.
                                         type: string
                                     required:
                                     - gateway
@@ -7118,25 +8106,26 @@ spec:
                                     - system
                                     type: object
                                   secret:
-                                    description: 'Secret represents a secret that
+                                    description: 'secret represents a secret that
                                       should populate this volume. More info: https://kubernetes.io/docs/concepts/storage/volumes#secret'
                                     properties:
                                       defaultMode:
-                                        description: 'Optional: mode bits used to
-                                          set permissions on created files by default.
-                                          Must be an octal value between 0000 and
-                                          0777 or a decimal value between 0 and 511.
-                                          YAML accepts both octal and decimal values,
-                                          JSON requires decimal values for mode bits.
-                                          Defaults to 0644. Directories within the
-                                          path are not affected by this setting. This
-                                          might be in conflict with other options
-                                          that affect the file mode, like fsGroup,
-                                          and the result can be other mode bits set.'
+                                        description: 'defaultMode is Optional: mode
+                                          bits used to set permissions on created
+                                          files by default. Must be an octal value
+                                          between 0000 and 0777 or a decimal value
+                                          between 0 and 511. YAML accepts both octal
+                                          and decimal values, JSON requires decimal
+                                          values for mode bits. Defaults to 0644.
+                                          Directories within the path are not affected
+                                          by this setting. This might be in conflict
+                                          with other options that affect the file
+                                          mode, like fsGroup, and the result can be
+                                          other mode bits set.'
                                         format: int32
                                         type: integer
                                       items:
-                                        description: If unspecified, each key-value
+                                        description: items If unspecified, each key-value
                                           pair in the Data field of the referenced
                                           Secret will be projected into the volume
                                           as a file whose name is the key and content
@@ -7153,27 +8142,27 @@ spec:
                                             within a volume.
                                           properties:
                                             key:
-                                              description: The key to project.
+                                              description: key is the key to project.
                                               type: string
                                             mode:
-                                              description: 'Optional: mode bits used
-                                                to set permissions on this file. Must
-                                                be an octal value between 0000 and
-                                                0777 or a decimal value between 0
-                                                and 511. YAML accepts both octal and
-                                                decimal values, JSON requires decimal
-                                                values for mode bits. If not specified,
-                                                the volume defaultMode will be used.
-                                                This might be in conflict with other
-                                                options that affect the file mode,
-                                                like fsGroup, and the result can be
-                                                other mode bits set.'
+                                              description: 'mode is Optional: mode
+                                                bits used to set permissions on this
+                                                file. Must be an octal value between
+                                                0000 and 0777 or a decimal value between
+                                                0 and 511. YAML accepts both octal
+                                                and decimal values, JSON requires
+                                                decimal values for mode bits. If not
+                                                specified, the volume defaultMode
+                                                will be used. This might be in conflict
+                                                with other options that affect the
+                                                file mode, like fsGroup, and the result
+                                                can be other mode bits set.'
                                               format: int32
                                               type: integer
                                             path:
-                                              description: The relative path of the
-                                                file to map the key to. May not be
-                                                an absolute path. May not contain
+                                              description: path is the relative path
+                                                of the file to map the key to. May
+                                                not be an absolute path. May not contain
                                                 the path element '..'. May not start
                                                 with the string '..'.
                                               type: string
@@ -7183,31 +8172,33 @@ spec:
                                           type: object
                                         type: array
                                       optional:
-                                        description: Specify whether the Secret or
-                                          its keys must be defined
+                                        description: optional field specify whether
+                                          the Secret or its keys must be defined
                                         type: boolean
                                       secretName:
-                                        description: 'Name of the secret in the pod''s
-                                          namespace to use. More info: https://kubernetes.io/docs/concepts/storage/volumes#secret'
+                                        description: 'secretName is the name of the
+                                          secret in the pod''s namespace to use. More
+                                          info: https://kubernetes.io/docs/concepts/storage/volumes#secret'
                                         type: string
                                     type: object
                                   storageos:
-                                    description: StorageOS represents a StorageOS
+                                    description: storageOS represents a StorageOS
                                       volume attached and mounted on Kubernetes nodes.
                                     properties:
                                       fsType:
-                                        description: Filesystem type to mount. Must
-                                          be a filesystem type supported by the host
-                                          operating system. Ex. "ext4", "xfs", "ntfs".
-                                          Implicitly inferred to be "ext4" if unspecified.
+                                        description: fsType is the filesystem type
+                                          to mount. Must be a filesystem type supported
+                                          by the host operating system. Ex. "ext4",
+                                          "xfs", "ntfs". Implicitly inferred to be
+                                          "ext4" if unspecified.
                                         type: string
                                       readOnly:
-                                        description: Defaults to false (read/write).
+                                        description: readOnly defaults to false (read/write).
                                           ReadOnly here will force the ReadOnly setting
                                           in VolumeMounts.
                                         type: boolean
                                       secretRef:
-                                        description: SecretRef specifies the secret
+                                        description: secretRef specifies the secret
                                           to use for obtaining the StorageOS API credentials.  If
                                           not specified, default values will be attempted.
                                         properties:
@@ -7219,12 +8210,12 @@ spec:
                                             type: string
                                         type: object
                                       volumeName:
-                                        description: VolumeName is the human-readable
+                                        description: volumeName is the human-readable
                                           name of the StorageOS volume.  Volume names
                                           are only unique within a namespace.
                                         type: string
                                       volumeNamespace:
-                                        description: VolumeNamespace specifies the
+                                        description: volumeNamespace specifies the
                                           scope of the volume within StorageOS.  If
                                           no namespace is specified then the Pod's
                                           namespace will be used.  This allows the
@@ -7237,27 +8228,29 @@ spec:
                                         type: string
                                     type: object
                                   vsphereVolume:
-                                    description: VsphereVolume represents a vSphere
+                                    description: vsphereVolume represents a vSphere
                                       volume attached and mounted on kubelets host
                                       machine
                                     properties:
                                       fsType:
-                                        description: Filesystem type to mount. Must
-                                          be a filesystem type supported by the host
-                                          operating system. Ex. "ext4", "xfs", "ntfs".
-                                          Implicitly inferred to be "ext4" if unspecified.
+                                        description: fsType is filesystem type to
+                                          mount. Must be a filesystem type supported
+                                          by the host operating system. Ex. "ext4",
+                                          "xfs", "ntfs". Implicitly inferred to be
+                                          "ext4" if unspecified.
                                         type: string
                                       storagePolicyID:
-                                        description: Storage Policy Based Management
-                                          (SPBM) profile ID associated with the StoragePolicyName.
+                                        description: storagePolicyID is the storage
+                                          Policy Based Management (SPBM) profile ID
+                                          associated with the StoragePolicyName.
                                         type: string
                                       storagePolicyName:
-                                        description: Storage Policy Based Management
-                                          (SPBM) profile name.
+                                        description: storagePolicyName is the storage
+                                          Policy Based Management (SPBM) profile name.
                                         type: string
                                       volumePath:
-                                        description: Path that identifies vSphere
-                                          volume vmdk
+                                        description: volumePath is the path that identifies
+                                          vSphere volume vmdk
                                         type: string
                                     required:
                                     - volumePath

--- a/apps/training-operator/upstream/base/crds/kubeflow.org_tfjobs.yaml
+++ b/apps/training-operator/upstream/base/crds/kubeflow.org_tfjobs.yaml
@@ -474,12 +474,85 @@ spec:
                                                       are ANDed.
                                                     type: object
                                                 type: object
+                                              namespaceSelector:
+                                                description: A label query over the
+                                                  set of namespaces that the term
+                                                  applies to. The term is applied
+                                                  to the union of the namespaces selected
+                                                  by this field and the ones listed
+                                                  in the namespaces field. null selector
+                                                  and null or empty namespaces list
+                                                  means "this pod's namespace". An
+                                                  empty selector ({}) matches all
+                                                  namespaces.
+                                                properties:
+                                                  matchExpressions:
+                                                    description: matchExpressions
+                                                      is a list of label selector
+                                                      requirements. The requirements
+                                                      are ANDed.
+                                                    items:
+                                                      description: A label selector
+                                                        requirement is a selector
+                                                        that contains values, a key,
+                                                        and an operator that relates
+                                                        the key and values.
+                                                      properties:
+                                                        key:
+                                                          description: key is the
+                                                            label key that the selector
+                                                            applies to.
+                                                          type: string
+                                                        operator:
+                                                          description: operator represents
+                                                            a key's relationship to
+                                                            a set of values. Valid
+                                                            operators are In, NotIn,
+                                                            Exists and DoesNotExist.
+                                                          type: string
+                                                        values:
+                                                          description: values is an
+                                                            array of string values.
+                                                            If the operator is In
+                                                            or NotIn, the values array
+                                                            must be non-empty. If
+                                                            the operator is Exists
+                                                            or DoesNotExist, the values
+                                                            array must be empty. This
+                                                            array is replaced during
+                                                            a strategic merge patch.
+                                                          items:
+                                                            type: string
+                                                          type: array
+                                                      required:
+                                                      - key
+                                                      - operator
+                                                      type: object
+                                                    type: array
+                                                  matchLabels:
+                                                    additionalProperties:
+                                                      type: string
+                                                    description: matchLabels is a
+                                                      map of {key,value} pairs. A
+                                                      single {key,value} in the matchLabels
+                                                      map is equivalent to an element
+                                                      of matchExpressions, whose key
+                                                      field is "key", the operator
+                                                      is "In", and the values array
+                                                      contains only "value". The requirements
+                                                      are ANDed.
+                                                    type: object
+                                                type: object
                                               namespaces:
                                                 description: namespaces specifies
-                                                  which namespaces the labelSelector
-                                                  applies to (matches against); null
-                                                  or empty list means "this pod's
-                                                  namespace"
+                                                  a static list of namespace names
+                                                  that the term applies to. The term
+                                                  is applied to the union of the namespaces
+                                                  listed in this field and the ones
+                                                  selected by namespaceSelector. null
+                                                  or empty namespaces list and null
+                                                  namespaceSelector means "this pod's
+                                                  namespace".
                                                 items:
                                                   type: string
                                                 type: array
@@ -589,11 +662,78 @@ spec:
                                                   ANDed.
                                                 type: object
                                             type: object
+                                          namespaceSelector:
+                                            description: A label query over the set
+                                              of namespaces that the term applies
+                                              to. The term is applied to the union
+                                              of the namespaces selected by this field
+                                              and the ones listed in the namespaces
+                                              field. null selector and null or empty
+                                              namespaces list means "this pod's namespace".
+                                              An empty selector ({}) matches all namespaces.
+                                            properties:
+                                              matchExpressions:
+                                                description: matchExpressions is a
+                                                  list of label selector requirements.
+                                                  The requirements are ANDed.
+                                                items:
+                                                  description: A label selector requirement
+                                                    is a selector that contains values,
+                                                    a key, and an operator that relates
+                                                    the key and values.
+                                                  properties:
+                                                    key:
+                                                      description: key is the label
+                                                        key that the selector applies
+                                                        to.
+                                                      type: string
+                                                    operator:
+                                                      description: operator represents
+                                                        a key's relationship to a
+                                                        set of values. Valid operators
+                                                        are In, NotIn, Exists and
+                                                        DoesNotExist.
+                                                      type: string
+                                                    values:
+                                                      description: values is an array
+                                                        of string values. If the operator
+                                                        is In or NotIn, the values
+                                                        array must be non-empty. If
+                                                        the operator is Exists or
+                                                        DoesNotExist, the values array
+                                                        must be empty. This array
+                                                        is replaced during a strategic
+                                                        merge patch.
+                                                      items:
+                                                        type: string
+                                                      type: array
+                                                  required:
+                                                  - key
+                                                  - operator
+                                                  type: object
+                                                type: array
+                                              matchLabels:
+                                                additionalProperties:
+                                                  type: string
+                                                description: matchLabels is a map
+                                                  of {key,value} pairs. A single {key,value}
+                                                  in the matchLabels map is equivalent
+                                                  to an element of matchExpressions,
+                                                  whose key field is "key", the operator
+                                                  is "In", and the values array contains
+                                                  only "value". The requirements are
+                                                  ANDed.
+                                                type: object
+                                            type: object
                                           namespaces:
-                                            description: namespaces specifies which
-                                              namespaces the labelSelector applies
-                                              to (matches against); null or empty
-                                              list means "this pod's namespace"
+                                            description: namespaces specifies a static
+                                              list of namespace names that the term
+                                              applies to. The term is applied to the
+                                              union of the namespaces listed in this
+                                              field and the ones selected by namespaceSelector.
+                                              null or empty namespaces list and null
+                                              namespaceSelector means "this pod's
+                                              namespace".
                                             items:
                                               type: string
                                             type: array
@@ -705,12 +845,85 @@ spec:
                                                       are ANDed.
                                                     type: object
                                                 type: object
+                                              namespaceSelector:
+                                                description: A label query over the
+                                                  set of namespaces that the term
+                                                  applies to. The term is applied
+                                                  to the union of the namespaces selected
+                                                  by this field and the ones listed
+                                                  in the namespaces field. null selector
+                                                  and null or empty namespaces list
+                                                  means "this pod's namespace". An
+                                                  empty selector ({}) matches all
+                                                  namespaces.
+                                                properties:
+                                                  matchExpressions:
+                                                    description: matchExpressions
+                                                      is a list of label selector
+                                                      requirements. The requirements
+                                                      are ANDed.
+                                                    items:
+                                                      description: A label selector
+                                                        requirement is a selector
+                                                        that contains values, a key,
+                                                        and an operator that relates
+                                                        the key and values.
+                                                      properties:
+                                                        key:
+                                                          description: key is the
+                                                            label key that the selector
+                                                            applies to.
+                                                          type: string
+                                                        operator:
+                                                          description: operator represents
+                                                            a key's relationship to
+                                                            a set of values. Valid
+                                                            operators are In, NotIn,
+                                                            Exists and DoesNotExist.
+                                                          type: string
+                                                        values:
+                                                          description: values is an
+                                                            array of string values.
+                                                            If the operator is In
+                                                            or NotIn, the values array
+                                                            must be non-empty. If
+                                                            the operator is Exists
+                                                            or DoesNotExist, the values
+                                                            array must be empty. This
+                                                            array is replaced during
+                                                            a strategic merge patch.
+                                                          items:
+                                                            type: string
+                                                          type: array
+                                                      required:
+                                                      - key
+                                                      - operator
+                                                      type: object
+                                                    type: array
+                                                  matchLabels:
+                                                    additionalProperties:
+                                                      type: string
+                                                    description: matchLabels is a
+                                                      map of {key,value} pairs. A
+                                                      single {key,value} in the matchLabels
+                                                      map is equivalent to an element
+                                                      of matchExpressions, whose key
+                                                      field is "key", the operator
+                                                      is "In", and the values array
+                                                      contains only "value". The requirements
+                                                      are ANDed.
+                                                    type: object
+                                                type: object
                                               namespaces:
                                                 description: namespaces specifies
-                                                  which namespaces the labelSelector
-                                                  applies to (matches against); null
-                                                  or empty list means "this pod's
-                                                  namespace"
+                                                  a static list of namespace names
+                                                  that the term applies to. The term
+                                                  is applied to the union of the namespaces
+                                                  listed in this field and the ones
+                                                  selected by namespaceSelector. null
+                                                  or empty namespaces list and null
+                                                  namespaceSelector means "this pod's
+                                                  namespace".
                                                 items:
                                                   type: string
                                                 type: array
@@ -820,11 +1033,78 @@ spec:
                                                   ANDed.
                                                 type: object
                                             type: object
+                                          namespaceSelector:
+                                            description: A label query over the set
+                                              of namespaces that the term applies
+                                              to. The term is applied to the union
+                                              of the namespaces selected by this field
+                                              and the ones listed in the namespaces
+                                              field. null selector and null or empty
+                                              namespaces list means "this pod's namespace".
+                                              An empty selector ({}) matches all namespaces.
+                                            properties:
+                                              matchExpressions:
+                                                description: matchExpressions is a
+                                                  list of label selector requirements.
+                                                  The requirements are ANDed.
+                                                items:
+                                                  description: A label selector requirement
+                                                    is a selector that contains values,
+                                                    a key, and an operator that relates
+                                                    the key and values.
+                                                  properties:
+                                                    key:
+                                                      description: key is the label
+                                                        key that the selector applies
+                                                        to.
+                                                      type: string
+                                                    operator:
+                                                      description: operator represents
+                                                        a key's relationship to a
+                                                        set of values. Valid operators
+                                                        are In, NotIn, Exists and
+                                                        DoesNotExist.
+                                                      type: string
+                                                    values:
+                                                      description: values is an array
+                                                        of string values. If the operator
+                                                        is In or NotIn, the values
+                                                        array must be non-empty. If
+                                                        the operator is Exists or
+                                                        DoesNotExist, the values array
+                                                        must be empty. This array
+                                                        is replaced during a strategic
+                                                        merge patch.
+                                                      items:
+                                                        type: string
+                                                      type: array
+                                                  required:
+                                                  - key
+                                                  - operator
+                                                  type: object
+                                                type: array
+                                              matchLabels:
+                                                additionalProperties:
+                                                  type: string
+                                                description: matchLabels is a map
+                                                  of {key,value} pairs. A single {key,value}
+                                                  in the matchLabels map is equivalent
+                                                  to an element of matchExpressions,
+                                                  whose key field is "key", the operator
+                                                  is "In", and the values array contains
+                                                  only "value". The requirements are
+                                                  ANDed.
+                                                type: object
+                                            type: object
                                           namespaces:
-                                            description: namespaces specifies which
-                                              namespaces the labelSelector applies
-                                              to (matches against); null or empty
-                                              list means "this pod's namespace"
+                                            description: namespaces specifies a static
+                                              list of namespace names that the term
+                                              applies to. The term is applied to the
+                                              union of the namespaces listed in this
+                                              field and the ones selected by namespaceSelector.
+                                              null or empty namespaces list and null
+                                              namespaceSelector means "this pod's
+                                              namespace".
                                             items:
                                               type: string
                                             type: array
@@ -861,12 +1141,14 @@ spec:
                                 properties:
                                   args:
                                     description: 'Arguments to the entrypoint. The
-                                      docker image''s CMD is used if this is not provided.
-                                      Variable references $(VAR_NAME) are expanded
-                                      using the container''s environment. If a variable
-                                      cannot be resolved, the reference in the input
-                                      string will be unchanged. The $(VAR_NAME) syntax
-                                      can be escaped with a double $$, ie: $$(VAR_NAME).
+                                      container image''s CMD is used if this is not
+                                      provided. Variable references $(VAR_NAME) are
+                                      expanded using the container''s environment.
+                                      If a variable cannot be resolved, the reference
+                                      in the input string will be unchanged. Double
+                                      $$ are reduced to a single $, which allows for
+                                      escaping the $(VAR_NAME) syntax: i.e. "$$(VAR_NAME)"
+                                      will produce the string literal "$(VAR_NAME)".
                                       Escaped references will never be expanded, regardless
                                       of whether the variable exists or not. Cannot
                                       be updated. More info: https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell'
@@ -875,16 +1157,17 @@ spec:
                                     type: array
                                   command:
                                     description: 'Entrypoint array. Not executed within
-                                      a shell. The docker image''s ENTRYPOINT is used
-                                      if this is not provided. Variable references
+                                      a shell. The container image''s ENTRYPOINT is
+                                      used if this is not provided. Variable references
                                       $(VAR_NAME) are expanded using the container''s
                                       environment. If a variable cannot be resolved,
                                       the reference in the input string will be unchanged.
-                                      The $(VAR_NAME) syntax can be escaped with a
-                                      double $$, ie: $$(VAR_NAME). Escaped references
-                                      will never be expanded, regardless of whether
-                                      the variable exists or not. Cannot be updated.
-                                      More info: https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell'
+                                      Double $$ are reduced to a single $, which allows
+                                      for escaping the $(VAR_NAME) syntax: i.e. "$$(VAR_NAME)"
+                                      will produce the string literal "$(VAR_NAME)".
+                                      Escaped references will never be expanded, regardless
+                                      of whether the variable exists or not. Cannot
+                                      be updated. More info: https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell'
                                     items:
                                       type: string
                                     type: array
@@ -901,13 +1184,15 @@ spec:
                                           type: string
                                         value:
                                           description: 'Variable references $(VAR_NAME)
-                                            are expanded using the previous defined
+                                            are expanded using the previously defined
                                             environment variables in the container
                                             and any service environment variables.
                                             If a variable cannot be resolved, the
                                             reference in the input string will be
-                                            unchanged. The $(VAR_NAME) syntax can
-                                            be escaped with a double $$, ie: $$(VAR_NAME).
+                                            unchanged. Double $$ are reduced to a
+                                            single $, which allows for escaping the
+                                            $(VAR_NAME) syntax: i.e. "$$(VAR_NAME)"
+                                            will produce the string literal "$(VAR_NAME)".
                                             Escaped references will never be expanded,
                                             regardless of whether the variable exists
                                             or not. Defaults to "".'
@@ -1061,7 +1346,8 @@ spec:
                                       type: object
                                     type: array
                                   image:
-                                    description: 'Docker image name. More info: https://kubernetes.io/docs/concepts/containers/images
+                                    description: 'Container image name. More info:
+                                      https://kubernetes.io/docs/concepts/containers/images
                                       This field is optional to allow higher level
                                       config management to default or override container
                                       images in workload controllers like Deployments
@@ -1087,9 +1373,8 @@ spec:
                                           More info: https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/#container-hooks'
                                         properties:
                                           exec:
-                                            description: One and only one of the following
-                                              should be specified. Exec specifies
-                                              the action to take.
+                                            description: Exec specifies the action
+                                              to take.
                                             properties:
                                               command:
                                                 description: Command is the command
@@ -1160,10 +1445,12 @@ spec:
                                             - port
                                             type: object
                                           tcpSocket:
-                                            description: 'TCPSocket specifies an action
-                                              involving a TCP port. TCP hooks not
-                                              yet supported TODO: implement a realistic
-                                              TCP lifecycle hook'
+                                            description: Deprecated. TCPSocket is
+                                              NOT supported as a LifecycleHandler
+                                              and kept for the backward compatibility.
+                                              There are no validation of this field
+                                              and lifecycle hooks will fail in runtime
+                                              when tcp handler is specified.
                                             properties:
                                               host:
                                                 description: 'Optional: Host name
@@ -1190,21 +1477,19 @@ spec:
                                           as liveness/startup probe failure, preemption,
                                           resource contention, etc. The handler is
                                           not called if the container crashes or exits.
-                                          The reason for termination is passed to
-                                          the handler. The Pod''s termination grace
-                                          period countdown begins before the PreStop
-                                          hooked is executed. Regardless of the outcome
-                                          of the handler, the container will eventually
-                                          terminate within the Pod''s termination
-                                          grace period. Other management of the container
-                                          blocks until the hook completes or until
-                                          the termination grace period is reached.
-                                          More info: https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/#container-hooks'
+                                          The Pod''s termination grace period countdown
+                                          begins before the PreStop hook is executed.
+                                          Regardless of the outcome of the handler,
+                                          the container will eventually terminate
+                                          within the Pod''s termination grace period
+                                          (unless delayed by finalizers). Other management
+                                          of the container blocks until the hook completes
+                                          or until the termination grace period is
+                                          reached. More info: https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/#container-hooks'
                                         properties:
                                           exec:
-                                            description: One and only one of the following
-                                              should be specified. Exec specifies
-                                              the action to take.
+                                            description: Exec specifies the action
+                                              to take.
                                             properties:
                                               command:
                                                 description: Command is the command
@@ -1275,10 +1560,12 @@ spec:
                                             - port
                                             type: object
                                           tcpSocket:
-                                            description: 'TCPSocket specifies an action
-                                              involving a TCP port. TCP hooks not
-                                              yet supported TODO: implement a realistic
-                                              TCP lifecycle hook'
+                                            description: Deprecated. TCPSocket is
+                                              NOT supported as a LifecycleHandler
+                                              and kept for the backward compatibility.
+                                              There are no validation of this field
+                                              and lifecycle hooks will fail in runtime
+                                              when tcp handler is specified.
                                             properties:
                                               host:
                                                 description: 'Optional: Host name
@@ -1305,9 +1592,8 @@ spec:
                                       Cannot be updated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
                                     properties:
                                       exec:
-                                        description: One and only one of the following
-                                          should be specified. Exec specifies the
-                                          action to take.
+                                        description: Exec specifies the action to
+                                          take.
                                         properties:
                                           command:
                                             description: Command is the command line
@@ -1332,6 +1618,26 @@ spec:
                                           value is 1.
                                         format: int32
                                         type: integer
+                                      grpc:
+                                        description: GRPC specifies an action involving
+                                          a GRPC port. This is a beta field and requires
+                                          enabling GRPCContainerProbe feature gate.
+                                        properties:
+                                          port:
+                                            description: Port number of the gRPC service.
+                                              Number must be in the range 1 to 65535.
+                                            format: int32
+                                            type: integer
+                                          service:
+                                            description: "Service is the name of the
+                                              service to place in the gRPC HealthCheckRequest
+                                              (see https://github.com/grpc/grpc/blob/master/doc/health-checking.md).
+                                              \n If this is not specified, the default
+                                              behavior is defined by gRPC."
+                                            type: string
+                                        required:
+                                        - port
+                                        type: object
                                       httpGet:
                                         description: HTTPGet specifies the http request
                                           to perform.
@@ -1400,10 +1706,8 @@ spec:
                                         format: int32
                                         type: integer
                                       tcpSocket:
-                                        description: 'TCPSocket specifies an action
-                                          involving a TCP port. TCP hooks not yet
-                                          supported TODO: implement a realistic TCP
-                                          lifecycle hook'
+                                        description: TCPSocket specifies an action
+                                          involving a TCP port.
                                         properties:
                                           host:
                                             description: 'Optional: Host name to connect
@@ -1421,6 +1725,28 @@ spec:
                                         required:
                                         - port
                                         type: object
+                                      terminationGracePeriodSeconds:
+                                        description: Optional duration in seconds
+                                          the pod needs to terminate gracefully upon
+                                          probe failure. The grace period is the duration
+                                          in seconds after the processes running in
+                                          the pod are sent a termination signal and
+                                          the time when the processes are forcibly
+                                          halted with a kill signal. Set this value
+                                          longer than the expected cleanup time for
+                                          your process. If this value is nil, the
+                                          pod's terminationGracePeriodSeconds will
+                                          be used. Otherwise, this value overrides
+                                          the value provided by the pod spec. Value
+                                          must be non-negative integer. The value
+                                          zero indicates stop immediately via the
+                                          kill signal (no opportunity to shut down).
+                                          This is a beta field and requires enabling
+                                          ProbeTerminationGracePeriod feature gate.
+                                          Minimum value is 1. spec.terminationGracePeriodSeconds
+                                          is used if unset.
+                                        format: int64
+                                        type: integer
                                       timeoutSeconds:
                                         description: 'Number of seconds after which
                                           the probe times out. Defaults to 1 second.
@@ -1492,9 +1818,8 @@ spec:
                                       More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
                                     properties:
                                       exec:
-                                        description: One and only one of the following
-                                          should be specified. Exec specifies the
-                                          action to take.
+                                        description: Exec specifies the action to
+                                          take.
                                         properties:
                                           command:
                                             description: Command is the command line
@@ -1519,6 +1844,26 @@ spec:
                                           value is 1.
                                         format: int32
                                         type: integer
+                                      grpc:
+                                        description: GRPC specifies an action involving
+                                          a GRPC port. This is a beta field and requires
+                                          enabling GRPCContainerProbe feature gate.
+                                        properties:
+                                          port:
+                                            description: Port number of the gRPC service.
+                                              Number must be in the range 1 to 65535.
+                                            format: int32
+                                            type: integer
+                                          service:
+                                            description: "Service is the name of the
+                                              service to place in the gRPC HealthCheckRequest
+                                              (see https://github.com/grpc/grpc/blob/master/doc/health-checking.md).
+                                              \n If this is not specified, the default
+                                              behavior is defined by gRPC."
+                                            type: string
+                                        required:
+                                        - port
+                                        type: object
                                       httpGet:
                                         description: HTTPGet specifies the http request
                                           to perform.
@@ -1587,10 +1932,8 @@ spec:
                                         format: int32
                                         type: integer
                                       tcpSocket:
-                                        description: 'TCPSocket specifies an action
-                                          involving a TCP port. TCP hooks not yet
-                                          supported TODO: implement a realistic TCP
-                                          lifecycle hook'
+                                        description: TCPSocket specifies an action
+                                          involving a TCP port.
                                         properties:
                                           host:
                                             description: 'Optional: Host name to connect
@@ -1608,6 +1951,28 @@ spec:
                                         required:
                                         - port
                                         type: object
+                                      terminationGracePeriodSeconds:
+                                        description: Optional duration in seconds
+                                          the pod needs to terminate gracefully upon
+                                          probe failure. The grace period is the duration
+                                          in seconds after the processes running in
+                                          the pod are sent a termination signal and
+                                          the time when the processes are forcibly
+                                          halted with a kill signal. Set this value
+                                          longer than the expected cleanup time for
+                                          your process. If this value is nil, the
+                                          pod's terminationGracePeriodSeconds will
+                                          be used. Otherwise, this value overrides
+                                          the value provided by the pod spec. Value
+                                          must be non-negative integer. The value
+                                          zero indicates stop immediately via the
+                                          kill signal (no opportunity to shut down).
+                                          This is a beta field and requires enabling
+                                          ProbeTerminationGracePeriod feature gate.
+                                          Minimum value is 1. spec.terminationGracePeriodSeconds
+                                          is used if unset.
+                                        format: int64
+                                        type: integer
                                       timeoutSeconds:
                                         description: 'Number of seconds after which
                                           the probe times out. Defaults to 1 second.
@@ -1617,7 +1982,7 @@ spec:
                                     type: object
                                   resources:
                                     description: 'Compute Resources required by this
-                                      container. Cannot be updated. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
+                                      container. Cannot be updated. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
                                     properties:
                                       limits:
                                         additionalProperties:
@@ -1628,7 +1993,7 @@ spec:
                                           x-kubernetes-int-or-string: true
                                         description: 'Limits describes the maximum
                                           amount of compute resources allowed. More
-                                          info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
+                                          info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
                                         type: object
                                       requests:
                                         additionalProperties:
@@ -1642,12 +2007,14 @@ spec:
                                           Requests is omitted for a container, it
                                           defaults to Limits if that is explicitly
                                           specified, otherwise to an implementation-defined
-                                          value. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
+                                          value. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
                                         type: object
                                     type: object
                                   securityContext:
-                                    description: 'Security options the pod should
-                                      run with. More info: https://kubernetes.io/docs/concepts/policy/security-context/
+                                    description: 'SecurityContext defines the security
+                                      options the container should be run with. If
+                                      set, the fields of SecurityContext override
+                                      the equivalent fields of PodSecurityContext.
                                       More info: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/'
                                     properties:
                                       allowPrivilegeEscalation:
@@ -1657,13 +2024,16 @@ spec:
                                           controls if the no_new_privs flag will be
                                           set on the container process. AllowPrivilegeEscalation
                                           is true always when the container is: 1)
-                                          run as Privileged 2) has CAP_SYS_ADMIN'
+                                          run as Privileged 2) has CAP_SYS_ADMIN Note
+                                          that this field cannot be set when spec.os.name
+                                          is windows.'
                                         type: boolean
                                       capabilities:
                                         description: The capabilities to add/drop
                                           when running containers. Defaults to the
                                           default set of capabilities granted by the
-                                          container runtime.
+                                          container runtime. Note that this field
+                                          cannot be set when spec.os.name is windows.
                                         properties:
                                           add:
                                             description: Added capabilities
@@ -1684,7 +2054,8 @@ spec:
                                         description: Run container in privileged mode.
                                           Processes in privileged containers are essentially
                                           equivalent to root on the host. Defaults
-                                          to false.
+                                          to false. Note that this field cannot be
+                                          set when spec.os.name is windows.
                                         type: boolean
                                       procMount:
                                         description: procMount denotes the type of
@@ -1693,10 +2064,14 @@ spec:
                                           container runtime defaults for readonly
                                           paths and masked paths. This requires the
                                           ProcMountType feature flag to be enabled.
+                                          Note that this field cannot be set when
+                                          spec.os.name is windows.
                                         type: string
                                       readOnlyRootFilesystem:
                                         description: Whether this container has a
                                           read-only root filesystem. Default is false.
+                                          Note that this field cannot be set when
+                                          spec.os.name is windows.
                                         type: boolean
                                       runAsGroup:
                                         description: The GID to run the entrypoint
@@ -1704,7 +2079,8 @@ spec:
                                           if unset. May also be set in PodSecurityContext.  If
                                           set in both SecurityContext and PodSecurityContext,
                                           the value specified in SecurityContext takes
-                                          precedence.
+                                          precedence. Note that this field cannot
+                                          be set when spec.os.name is windows.
                                         format: int64
                                         type: integer
                                       runAsNonRoot:
@@ -1726,7 +2102,8 @@ spec:
                                           May also be set in PodSecurityContext.  If
                                           set in both SecurityContext and PodSecurityContext,
                                           the value specified in SecurityContext takes
-                                          precedence.
+                                          precedence. Note that this field cannot
+                                          be set when spec.os.name is windows.
                                         format: int64
                                         type: integer
                                       seLinuxOptions:
@@ -1736,7 +2113,9 @@ spec:
                                           for each container.  May also be set in
                                           PodSecurityContext.  If set in both SecurityContext
                                           and PodSecurityContext, the value specified
-                                          in SecurityContext takes precedence.
+                                          in SecurityContext takes precedence. Note
+                                          that this field cannot be set when spec.os.name
+                                          is windows.
                                         properties:
                                           level:
                                             description: Level is SELinux level label
@@ -1759,7 +2138,9 @@ spec:
                                         description: The seccomp options to use by
                                           this container. If seccomp options are provided
                                           at both the pod & container level, the container
-                                          options override the pod options.
+                                          options override the pod options. Note that
+                                          this field cannot be set when spec.os.name
+                                          is windows.
                                         properties:
                                           localhostProfile:
                                             description: localhostProfile indicates
@@ -1790,7 +2171,9 @@ spec:
                                           the options from the PodSecurityContext
                                           will be used. If set in both SecurityContext
                                           and PodSecurityContext, the value specified
-                                          in SecurityContext takes precedence.
+                                          in SecurityContext takes precedence. Note
+                                          that this field cannot be set when spec.os.name
+                                          is linux.
                                         properties:
                                           gmsaCredentialSpec:
                                             description: GMSACredentialSpec is where
@@ -1804,6 +2187,22 @@ spec:
                                               the name of the GMSA credential spec
                                               to use.
                                             type: string
+                                          hostProcess:
+                                            description: HostProcess determines if
+                                              a container should be run as a 'Host
+                                              Process' container. This field is alpha-level
+                                              and will only be honored by components
+                                              that enable the WindowsHostProcessContainers
+                                              feature flag. Setting this field without
+                                              the feature flag will result in errors
+                                              when validating the Pod. All of a Pod's
+                                              containers must have the same effective
+                                              HostProcess value (it is not allowed
+                                              to have a mix of HostProcess containers
+                                              and non-HostProcess containers).  In
+                                              addition, if HostProcess is true then
+                                              HostNetwork must also be set to true.
+                                            type: boolean
                                           runAsUserName:
                                             description: The UserName in Windows to
                                               run the entrypoint of the container
@@ -1826,14 +2225,11 @@ spec:
                                       parameters at the beginning of a Pod''s lifecycle,
                                       when it might take a long time to load data
                                       or warm a cache, than during steady-state operation.
-                                      This cannot be updated. This is a beta feature
-                                      enabled by the StartupProbe feature flag. More
-                                      info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                                      This cannot be updated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
                                     properties:
                                       exec:
-                                        description: One and only one of the following
-                                          should be specified. Exec specifies the
-                                          action to take.
+                                        description: Exec specifies the action to
+                                          take.
                                         properties:
                                           command:
                                             description: Command is the command line
@@ -1858,6 +2254,26 @@ spec:
                                           value is 1.
                                         format: int32
                                         type: integer
+                                      grpc:
+                                        description: GRPC specifies an action involving
+                                          a GRPC port. This is a beta field and requires
+                                          enabling GRPCContainerProbe feature gate.
+                                        properties:
+                                          port:
+                                            description: Port number of the gRPC service.
+                                              Number must be in the range 1 to 65535.
+                                            format: int32
+                                            type: integer
+                                          service:
+                                            description: "Service is the name of the
+                                              service to place in the gRPC HealthCheckRequest
+                                              (see https://github.com/grpc/grpc/blob/master/doc/health-checking.md).
+                                              \n If this is not specified, the default
+                                              behavior is defined by gRPC."
+                                            type: string
+                                        required:
+                                        - port
+                                        type: object
                                       httpGet:
                                         description: HTTPGet specifies the http request
                                           to perform.
@@ -1926,10 +2342,8 @@ spec:
                                         format: int32
                                         type: integer
                                       tcpSocket:
-                                        description: 'TCPSocket specifies an action
-                                          involving a TCP port. TCP hooks not yet
-                                          supported TODO: implement a realistic TCP
-                                          lifecycle hook'
+                                        description: TCPSocket specifies an action
+                                          involving a TCP port.
                                         properties:
                                           host:
                                             description: 'Optional: Host name to connect
@@ -1947,6 +2361,28 @@ spec:
                                         required:
                                         - port
                                         type: object
+                                      terminationGracePeriodSeconds:
+                                        description: Optional duration in seconds
+                                          the pod needs to terminate gracefully upon
+                                          probe failure. The grace period is the duration
+                                          in seconds after the processes running in
+                                          the pod are sent a termination signal and
+                                          the time when the processes are forcibly
+                                          halted with a kill signal. Set this value
+                                          longer than the expected cleanup time for
+                                          your process. If this value is nil, the
+                                          pod's terminationGracePeriodSeconds will
+                                          be used. Otherwise, this value overrides
+                                          the value provided by the pod spec. Value
+                                          must be non-negative integer. The value
+                                          zero indicates stop immediately via the
+                                          kill signal (no opportunity to shut down).
+                                          This is a beta field and requires enabling
+                                          ProbeTerminationGracePeriod feature gate.
+                                          Minimum value is 1. spec.terminationGracePeriodSeconds
+                                          is used if unset.
+                                        format: int64
+                                        type: integer
                                       timeoutSeconds:
                                         description: 'Number of seconds after which
                                           the probe times out. Defaults to 1 second.
@@ -2144,33 +2580,35 @@ spec:
                                 and it cannot be modified by updating the pod spec.
                                 In order to add an ephemeral container to an existing
                                 pod, use the pod's ephemeralcontainers subresource.
-                                This field is alpha-level and is only honored by servers
-                                that enable the EphemeralContainers feature.
+                                This field is beta-level and available on clusters
+                                that haven't disabled the EphemeralContainers feature
+                                gate.
                               items:
-                                description: An EphemeralContainer is a container
-                                  that may be added temporarily to an existing pod
-                                  for user-initiated activities such as debugging.
-                                  Ephemeral containers have no resource or scheduling
-                                  guarantees, and they will not be restarted when
-                                  they exit or when a pod is removed or restarted.
-                                  If an ephemeral container causes a pod to exceed
-                                  its resource allocation, the pod may be evicted.
-                                  Ephemeral containers may not be added by directly
-                                  updating the pod spec. They must be added via the
-                                  pod's ephemeralcontainers subresource, and they
-                                  will appear in the pod spec once added. This is
-                                  an alpha feature enabled by the EphemeralContainers
-                                  feature flag.
+                                description: "An EphemeralContainer is a temporary
+                                  container that you may add to an existing Pod for
+                                  user-initiated activities such as debugging. Ephemeral
+                                  containers have no resource or scheduling guarantees,
+                                  and they will not be restarted when they exit or
+                                  when a Pod is removed or restarted. The kubelet
+                                  may evict a Pod if an ephemeral container causes
+                                  the Pod to exceed its resource allocation. \n To
+                                  add an ephemeral container, use the ephemeralcontainers
+                                  subresource of an existing Pod. Ephemeral containers
+                                  may not be removed or restarted. \n This is a beta
+                                  feature available on clusters that haven't disabled
+                                  the EphemeralContainers feature gate."
                                 properties:
                                   args:
                                     description: 'Arguments to the entrypoint. The
-                                      docker image''s CMD is used if this is not provided.
+                                      image''s CMD is used if this is not provided.
                                       Variable references $(VAR_NAME) are expanded
                                       using the container''s environment. If a variable
                                       cannot be resolved, the reference in the input
-                                      string will be unchanged. The $(VAR_NAME) syntax
-                                      can be escaped with a double $$, ie: $$(VAR_NAME).
-                                      Escaped references will never be expanded, regardless
+                                      string will be unchanged. Double $$ are reduced
+                                      to a single $, which allows for escaping the
+                                      $(VAR_NAME) syntax: i.e. "$$(VAR_NAME)" will
+                                      produce the string literal "$(VAR_NAME)". Escaped
+                                      references will never be expanded, regardless
                                       of whether the variable exists or not. Cannot
                                       be updated. More info: https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell'
                                     items:
@@ -2178,16 +2616,17 @@ spec:
                                     type: array
                                   command:
                                     description: 'Entrypoint array. Not executed within
-                                      a shell. The docker image''s ENTRYPOINT is used
-                                      if this is not provided. Variable references
-                                      $(VAR_NAME) are expanded using the container''s
-                                      environment. If a variable cannot be resolved,
-                                      the reference in the input string will be unchanged.
-                                      The $(VAR_NAME) syntax can be escaped with a
-                                      double $$, ie: $$(VAR_NAME). Escaped references
-                                      will never be expanded, regardless of whether
-                                      the variable exists or not. Cannot be updated.
-                                      More info: https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell'
+                                      a shell. The image''s ENTRYPOINT is used if
+                                      this is not provided. Variable references $(VAR_NAME)
+                                      are expanded using the container''s environment.
+                                      If a variable cannot be resolved, the reference
+                                      in the input string will be unchanged. Double
+                                      $$ are reduced to a single $, which allows for
+                                      escaping the $(VAR_NAME) syntax: i.e. "$$(VAR_NAME)"
+                                      will produce the string literal "$(VAR_NAME)".
+                                      Escaped references will never be expanded, regardless
+                                      of whether the variable exists or not. Cannot
+                                      be updated. More info: https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell'
                                     items:
                                       type: string
                                     type: array
@@ -2204,13 +2643,15 @@ spec:
                                           type: string
                                         value:
                                           description: 'Variable references $(VAR_NAME)
-                                            are expanded using the previous defined
+                                            are expanded using the previously defined
                                             environment variables in the container
                                             and any service environment variables.
                                             If a variable cannot be resolved, the
                                             reference in the input string will be
-                                            unchanged. The $(VAR_NAME) syntax can
-                                            be escaped with a double $$, ie: $$(VAR_NAME).
+                                            unchanged. Double $$ are reduced to a
+                                            single $, which allows for escaping the
+                                            $(VAR_NAME) syntax: i.e. "$$(VAR_NAME)"
+                                            will produce the string literal "$(VAR_NAME)".
                                             Escaped references will never be expanded,
                                             regardless of whether the variable exists
                                             or not. Defaults to "".'
@@ -2364,7 +2805,8 @@ spec:
                                       type: object
                                     type: array
                                   image:
-                                    description: 'Docker image name. More info: https://kubernetes.io/docs/concepts/containers/images'
+                                    description: 'Container image name. More info:
+                                      https://kubernetes.io/docs/concepts/containers/images'
                                     type: string
                                   imagePullPolicy:
                                     description: 'Image pull policy. One of Always,
@@ -2385,9 +2827,8 @@ spec:
                                           More info: https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/#container-hooks'
                                         properties:
                                           exec:
-                                            description: One and only one of the following
-                                              should be specified. Exec specifies
-                                              the action to take.
+                                            description: Exec specifies the action
+                                              to take.
                                             properties:
                                               command:
                                                 description: Command is the command
@@ -2458,10 +2899,12 @@ spec:
                                             - port
                                             type: object
                                           tcpSocket:
-                                            description: 'TCPSocket specifies an action
-                                              involving a TCP port. TCP hooks not
-                                              yet supported TODO: implement a realistic
-                                              TCP lifecycle hook'
+                                            description: Deprecated. TCPSocket is
+                                              NOT supported as a LifecycleHandler
+                                              and kept for the backward compatibility.
+                                              There are no validation of this field
+                                              and lifecycle hooks will fail in runtime
+                                              when tcp handler is specified.
                                             properties:
                                               host:
                                                 description: 'Optional: Host name
@@ -2488,21 +2931,19 @@ spec:
                                           as liveness/startup probe failure, preemption,
                                           resource contention, etc. The handler is
                                           not called if the container crashes or exits.
-                                          The reason for termination is passed to
-                                          the handler. The Pod''s termination grace
-                                          period countdown begins before the PreStop
-                                          hooked is executed. Regardless of the outcome
-                                          of the handler, the container will eventually
-                                          terminate within the Pod''s termination
-                                          grace period. Other management of the container
-                                          blocks until the hook completes or until
-                                          the termination grace period is reached.
-                                          More info: https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/#container-hooks'
+                                          The Pod''s termination grace period countdown
+                                          begins before the PreStop hook is executed.
+                                          Regardless of the outcome of the handler,
+                                          the container will eventually terminate
+                                          within the Pod''s termination grace period
+                                          (unless delayed by finalizers). Other management
+                                          of the container blocks until the hook completes
+                                          or until the termination grace period is
+                                          reached. More info: https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/#container-hooks'
                                         properties:
                                           exec:
-                                            description: One and only one of the following
-                                              should be specified. Exec specifies
-                                              the action to take.
+                                            description: Exec specifies the action
+                                              to take.
                                             properties:
                                               command:
                                                 description: Command is the command
@@ -2573,10 +3014,12 @@ spec:
                                             - port
                                             type: object
                                           tcpSocket:
-                                            description: 'TCPSocket specifies an action
-                                              involving a TCP port. TCP hooks not
-                                              yet supported TODO: implement a realistic
-                                              TCP lifecycle hook'
+                                            description: Deprecated. TCPSocket is
+                                              NOT supported as a LifecycleHandler
+                                              and kept for the backward compatibility.
+                                              There are no validation of this field
+                                              and lifecycle hooks will fail in runtime
+                                              when tcp handler is specified.
                                             properties:
                                               host:
                                                 description: 'Optional: Host name
@@ -2602,9 +3045,8 @@ spec:
                                       containers.
                                     properties:
                                       exec:
-                                        description: One and only one of the following
-                                          should be specified. Exec specifies the
-                                          action to take.
+                                        description: Exec specifies the action to
+                                          take.
                                         properties:
                                           command:
                                             description: Command is the command line
@@ -2629,6 +3071,26 @@ spec:
                                           value is 1.
                                         format: int32
                                         type: integer
+                                      grpc:
+                                        description: GRPC specifies an action involving
+                                          a GRPC port. This is a beta field and requires
+                                          enabling GRPCContainerProbe feature gate.
+                                        properties:
+                                          port:
+                                            description: Port number of the gRPC service.
+                                              Number must be in the range 1 to 65535.
+                                            format: int32
+                                            type: integer
+                                          service:
+                                            description: "Service is the name of the
+                                              service to place in the gRPC HealthCheckRequest
+                                              (see https://github.com/grpc/grpc/blob/master/doc/health-checking.md).
+                                              \n If this is not specified, the default
+                                              behavior is defined by gRPC."
+                                            type: string
+                                        required:
+                                        - port
+                                        type: object
                                       httpGet:
                                         description: HTTPGet specifies the http request
                                           to perform.
@@ -2697,10 +3159,8 @@ spec:
                                         format: int32
                                         type: integer
                                       tcpSocket:
-                                        description: 'TCPSocket specifies an action
-                                          involving a TCP port. TCP hooks not yet
-                                          supported TODO: implement a realistic TCP
-                                          lifecycle hook'
+                                        description: TCPSocket specifies an action
+                                          involving a TCP port.
                                         properties:
                                           host:
                                             description: 'Optional: Host name to connect
@@ -2718,6 +3178,28 @@ spec:
                                         required:
                                         - port
                                         type: object
+                                      terminationGracePeriodSeconds:
+                                        description: Optional duration in seconds
+                                          the pod needs to terminate gracefully upon
+                                          probe failure. The grace period is the duration
+                                          in seconds after the processes running in
+                                          the pod are sent a termination signal and
+                                          the time when the processes are forcibly
+                                          halted with a kill signal. Set this value
+                                          longer than the expected cleanup time for
+                                          your process. If this value is nil, the
+                                          pod's terminationGracePeriodSeconds will
+                                          be used. Otherwise, this value overrides
+                                          the value provided by the pod spec. Value
+                                          must be non-negative integer. The value
+                                          zero indicates stop immediately via the
+                                          kill signal (no opportunity to shut down).
+                                          This is a beta field and requires enabling
+                                          ProbeTerminationGracePeriod feature gate.
+                                          Minimum value is 1. spec.terminationGracePeriodSeconds
+                                          is used if unset.
+                                        format: int64
+                                        type: integer
                                       timeoutSeconds:
                                         description: 'Number of seconds after which
                                           the probe times out. Defaults to 1 second.
@@ -2772,14 +3254,17 @@ spec:
                                       - containerPort
                                       type: object
                                     type: array
+                                    x-kubernetes-list-map-keys:
+                                    - containerPort
+                                    - protocol
+                                    x-kubernetes-list-type: map
                                   readinessProbe:
                                     description: Probes are not allowed for ephemeral
                                       containers.
                                     properties:
                                       exec:
-                                        description: One and only one of the following
-                                          should be specified. Exec specifies the
-                                          action to take.
+                                        description: Exec specifies the action to
+                                          take.
                                         properties:
                                           command:
                                             description: Command is the command line
@@ -2804,6 +3289,26 @@ spec:
                                           value is 1.
                                         format: int32
                                         type: integer
+                                      grpc:
+                                        description: GRPC specifies an action involving
+                                          a GRPC port. This is a beta field and requires
+                                          enabling GRPCContainerProbe feature gate.
+                                        properties:
+                                          port:
+                                            description: Port number of the gRPC service.
+                                              Number must be in the range 1 to 65535.
+                                            format: int32
+                                            type: integer
+                                          service:
+                                            description: "Service is the name of the
+                                              service to place in the gRPC HealthCheckRequest
+                                              (see https://github.com/grpc/grpc/blob/master/doc/health-checking.md).
+                                              \n If this is not specified, the default
+                                              behavior is defined by gRPC."
+                                            type: string
+                                        required:
+                                        - port
+                                        type: object
                                       httpGet:
                                         description: HTTPGet specifies the http request
                                           to perform.
@@ -2872,10 +3377,8 @@ spec:
                                         format: int32
                                         type: integer
                                       tcpSocket:
-                                        description: 'TCPSocket specifies an action
-                                          involving a TCP port. TCP hooks not yet
-                                          supported TODO: implement a realistic TCP
-                                          lifecycle hook'
+                                        description: TCPSocket specifies an action
+                                          involving a TCP port.
                                         properties:
                                           host:
                                             description: 'Optional: Host name to connect
@@ -2893,6 +3396,28 @@ spec:
                                         required:
                                         - port
                                         type: object
+                                      terminationGracePeriodSeconds:
+                                        description: Optional duration in seconds
+                                          the pod needs to terminate gracefully upon
+                                          probe failure. The grace period is the duration
+                                          in seconds after the processes running in
+                                          the pod are sent a termination signal and
+                                          the time when the processes are forcibly
+                                          halted with a kill signal. Set this value
+                                          longer than the expected cleanup time for
+                                          your process. If this value is nil, the
+                                          pod's terminationGracePeriodSeconds will
+                                          be used. Otherwise, this value overrides
+                                          the value provided by the pod spec. Value
+                                          must be non-negative integer. The value
+                                          zero indicates stop immediately via the
+                                          kill signal (no opportunity to shut down).
+                                          This is a beta field and requires enabling
+                                          ProbeTerminationGracePeriod feature gate.
+                                          Minimum value is 1. spec.terminationGracePeriodSeconds
+                                          is used if unset.
+                                        format: int64
+                                        type: integer
                                       timeoutSeconds:
                                         description: 'Number of seconds after which
                                           the probe times out. Defaults to 1 second.
@@ -2914,7 +3439,7 @@ spec:
                                           x-kubernetes-int-or-string: true
                                         description: 'Limits describes the maximum
                                           amount of compute resources allowed. More
-                                          info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
+                                          info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
                                         type: object
                                       requests:
                                         additionalProperties:
@@ -2928,12 +3453,14 @@ spec:
                                           Requests is omitted for a container, it
                                           defaults to Limits if that is explicitly
                                           specified, otherwise to an implementation-defined
-                                          value. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
+                                          value. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
                                         type: object
                                     type: object
                                   securityContext:
-                                    description: SecurityContext is not allowed for
-                                      ephemeral containers.
+                                    description: 'Optional: SecurityContext defines
+                                      the security options the ephemeral container
+                                      should be run with. If set, the fields of SecurityContext
+                                      override the equivalent fields of PodSecurityContext.'
                                     properties:
                                       allowPrivilegeEscalation:
                                         description: 'AllowPrivilegeEscalation controls
@@ -2942,13 +3469,16 @@ spec:
                                           controls if the no_new_privs flag will be
                                           set on the container process. AllowPrivilegeEscalation
                                           is true always when the container is: 1)
-                                          run as Privileged 2) has CAP_SYS_ADMIN'
+                                          run as Privileged 2) has CAP_SYS_ADMIN Note
+                                          that this field cannot be set when spec.os.name
+                                          is windows.'
                                         type: boolean
                                       capabilities:
                                         description: The capabilities to add/drop
                                           when running containers. Defaults to the
                                           default set of capabilities granted by the
-                                          container runtime.
+                                          container runtime. Note that this field
+                                          cannot be set when spec.os.name is windows.
                                         properties:
                                           add:
                                             description: Added capabilities
@@ -2969,7 +3499,8 @@ spec:
                                         description: Run container in privileged mode.
                                           Processes in privileged containers are essentially
                                           equivalent to root on the host. Defaults
-                                          to false.
+                                          to false. Note that this field cannot be
+                                          set when spec.os.name is windows.
                                         type: boolean
                                       procMount:
                                         description: procMount denotes the type of
@@ -2978,10 +3509,14 @@ spec:
                                           container runtime defaults for readonly
                                           paths and masked paths. This requires the
                                           ProcMountType feature flag to be enabled.
+                                          Note that this field cannot be set when
+                                          spec.os.name is windows.
                                         type: string
                                       readOnlyRootFilesystem:
                                         description: Whether this container has a
                                           read-only root filesystem. Default is false.
+                                          Note that this field cannot be set when
+                                          spec.os.name is windows.
                                         type: boolean
                                       runAsGroup:
                                         description: The GID to run the entrypoint
@@ -2989,7 +3524,8 @@ spec:
                                           if unset. May also be set in PodSecurityContext.  If
                                           set in both SecurityContext and PodSecurityContext,
                                           the value specified in SecurityContext takes
-                                          precedence.
+                                          precedence. Note that this field cannot
+                                          be set when spec.os.name is windows.
                                         format: int64
                                         type: integer
                                       runAsNonRoot:
@@ -3011,7 +3547,8 @@ spec:
                                           May also be set in PodSecurityContext.  If
                                           set in both SecurityContext and PodSecurityContext,
                                           the value specified in SecurityContext takes
-                                          precedence.
+                                          precedence. Note that this field cannot
+                                          be set when spec.os.name is windows.
                                         format: int64
                                         type: integer
                                       seLinuxOptions:
@@ -3021,7 +3558,9 @@ spec:
                                           for each container.  May also be set in
                                           PodSecurityContext.  If set in both SecurityContext
                                           and PodSecurityContext, the value specified
-                                          in SecurityContext takes precedence.
+                                          in SecurityContext takes precedence. Note
+                                          that this field cannot be set when spec.os.name
+                                          is windows.
                                         properties:
                                           level:
                                             description: Level is SELinux level label
@@ -3044,7 +3583,9 @@ spec:
                                         description: The seccomp options to use by
                                           this container. If seccomp options are provided
                                           at both the pod & container level, the container
-                                          options override the pod options.
+                                          options override the pod options. Note that
+                                          this field cannot be set when spec.os.name
+                                          is windows.
                                         properties:
                                           localhostProfile:
                                             description: localhostProfile indicates
@@ -3075,7 +3616,9 @@ spec:
                                           the options from the PodSecurityContext
                                           will be used. If set in both SecurityContext
                                           and PodSecurityContext, the value specified
-                                          in SecurityContext takes precedence.
+                                          in SecurityContext takes precedence. Note
+                                          that this field cannot be set when spec.os.name
+                                          is linux.
                                         properties:
                                           gmsaCredentialSpec:
                                             description: GMSACredentialSpec is where
@@ -3089,6 +3632,22 @@ spec:
                                               the name of the GMSA credential spec
                                               to use.
                                             type: string
+                                          hostProcess:
+                                            description: HostProcess determines if
+                                              a container should be run as a 'Host
+                                              Process' container. This field is alpha-level
+                                              and will only be honored by components
+                                              that enable the WindowsHostProcessContainers
+                                              feature flag. Setting this field without
+                                              the feature flag will result in errors
+                                              when validating the Pod. All of a Pod's
+                                              containers must have the same effective
+                                              HostProcess value (it is not allowed
+                                              to have a mix of HostProcess containers
+                                              and non-HostProcess containers).  In
+                                              addition, if HostProcess is true then
+                                              HostNetwork must also be set to true.
+                                            type: boolean
                                           runAsUserName:
                                             description: The UserName in Windows to
                                               run the entrypoint of the container
@@ -3106,9 +3665,8 @@ spec:
                                       containers.
                                     properties:
                                       exec:
-                                        description: One and only one of the following
-                                          should be specified. Exec specifies the
-                                          action to take.
+                                        description: Exec specifies the action to
+                                          take.
                                         properties:
                                           command:
                                             description: Command is the command line
@@ -3133,6 +3691,26 @@ spec:
                                           value is 1.
                                         format: int32
                                         type: integer
+                                      grpc:
+                                        description: GRPC specifies an action involving
+                                          a GRPC port. This is a beta field and requires
+                                          enabling GRPCContainerProbe feature gate.
+                                        properties:
+                                          port:
+                                            description: Port number of the gRPC service.
+                                              Number must be in the range 1 to 65535.
+                                            format: int32
+                                            type: integer
+                                          service:
+                                            description: "Service is the name of the
+                                              service to place in the gRPC HealthCheckRequest
+                                              (see https://github.com/grpc/grpc/blob/master/doc/health-checking.md).
+                                              \n If this is not specified, the default
+                                              behavior is defined by gRPC."
+                                            type: string
+                                        required:
+                                        - port
+                                        type: object
                                       httpGet:
                                         description: HTTPGet specifies the http request
                                           to perform.
@@ -3201,10 +3779,8 @@ spec:
                                         format: int32
                                         type: integer
                                       tcpSocket:
-                                        description: 'TCPSocket specifies an action
-                                          involving a TCP port. TCP hooks not yet
-                                          supported TODO: implement a realistic TCP
-                                          lifecycle hook'
+                                        description: TCPSocket specifies an action
+                                          involving a TCP port.
                                         properties:
                                           host:
                                             description: 'Optional: Host name to connect
@@ -3222,6 +3798,28 @@ spec:
                                         required:
                                         - port
                                         type: object
+                                      terminationGracePeriodSeconds:
+                                        description: Optional duration in seconds
+                                          the pod needs to terminate gracefully upon
+                                          probe failure. The grace period is the duration
+                                          in seconds after the processes running in
+                                          the pod are sent a termination signal and
+                                          the time when the processes are forcibly
+                                          halted with a kill signal. Set this value
+                                          longer than the expected cleanup time for
+                                          your process. If this value is nil, the
+                                          pod's terminationGracePeriodSeconds will
+                                          be used. Otherwise, this value overrides
+                                          the value provided by the pod spec. Value
+                                          must be non-negative integer. The value
+                                          zero indicates stop immediately via the
+                                          kill signal (no opportunity to shut down).
+                                          This is a beta field and requires enabling
+                                          ProbeTerminationGracePeriod feature gate.
+                                          Minimum value is 1. spec.terminationGracePeriodSeconds
+                                          is used if unset.
+                                        format: int64
+                                        type: integer
                                       timeoutSeconds:
                                         description: 'Number of seconds after which
                                           the probe times out. Defaults to 1 second.
@@ -3252,13 +3850,15 @@ spec:
                                       EOF. Default is false
                                     type: boolean
                                   targetContainerName:
-                                    description: If set, the name of the container
+                                    description: "If set, the name of the container
                                       from PodSpec that this ephemeral container targets.
                                       The ephemeral container will be run in the namespaces
                                       (IPC, PID, etc) of this container. If not set
-                                      then the ephemeral container is run in whatever
-                                      namespaces are shared for the pod. Note that
-                                      the container runtime must support this feature.
+                                      then the ephemeral container uses the namespaces
+                                      configured in the Pod spec. \n The container
+                                      runtime must implement support for this feature.
+                                      If the runtime does not support namespace targeting
+                                      then the result of setting this field is undefined."
                                     type: string
                                   terminationMessagePath:
                                     description: 'Optional: Path at which the file
@@ -3311,7 +3911,8 @@ spec:
                                     type: array
                                   volumeMounts:
                                     description: Pod volumes to mount into the container's
-                                      filesystem. Cannot be updated.
+                                      filesystem. Subpath mounts are not allowed for
+                                      ephemeral containers. Cannot be updated.
                                     items:
                                       description: VolumeMount describes a mounting
                                         of a Volume within a container.
@@ -3410,9 +4011,8 @@ spec:
                                 references to secrets in the same namespace to use
                                 for pulling any of the images used by this PodSpec.
                                 If specified, these secrets will be passed to individual
-                                puller implementations for them to use. For example,
-                                in the case of docker, only DockerConfig type secrets
-                                are honored. More info: https://kubernetes.io/docs/concepts/containers/images#specifying-imagepullsecrets-on-a-pod'
+                                puller implementations for them to use. More info:
+                                https://kubernetes.io/docs/concepts/containers/images#specifying-imagepullsecrets-on-a-pod'
                               items:
                                 description: LocalObjectReference contains enough
                                   information to let you locate the referenced object
@@ -3449,12 +4049,14 @@ spec:
                                 properties:
                                   args:
                                     description: 'Arguments to the entrypoint. The
-                                      docker image''s CMD is used if this is not provided.
-                                      Variable references $(VAR_NAME) are expanded
-                                      using the container''s environment. If a variable
-                                      cannot be resolved, the reference in the input
-                                      string will be unchanged. The $(VAR_NAME) syntax
-                                      can be escaped with a double $$, ie: $$(VAR_NAME).
+                                      container image''s CMD is used if this is not
+                                      provided. Variable references $(VAR_NAME) are
+                                      expanded using the container''s environment.
+                                      If a variable cannot be resolved, the reference
+                                      in the input string will be unchanged. Double
+                                      $$ are reduced to a single $, which allows for
+                                      escaping the $(VAR_NAME) syntax: i.e. "$$(VAR_NAME)"
+                                      will produce the string literal "$(VAR_NAME)".
                                       Escaped references will never be expanded, regardless
                                       of whether the variable exists or not. Cannot
                                       be updated. More info: https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell'
@@ -3463,16 +4065,17 @@ spec:
                                     type: array
                                   command:
                                     description: 'Entrypoint array. Not executed within
-                                      a shell. The docker image''s ENTRYPOINT is used
-                                      if this is not provided. Variable references
+                                      a shell. The container image''s ENTRYPOINT is
+                                      used if this is not provided. Variable references
                                       $(VAR_NAME) are expanded using the container''s
                                       environment. If a variable cannot be resolved,
                                       the reference in the input string will be unchanged.
-                                      The $(VAR_NAME) syntax can be escaped with a
-                                      double $$, ie: $$(VAR_NAME). Escaped references
-                                      will never be expanded, regardless of whether
-                                      the variable exists or not. Cannot be updated.
-                                      More info: https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell'
+                                      Double $$ are reduced to a single $, which allows
+                                      for escaping the $(VAR_NAME) syntax: i.e. "$$(VAR_NAME)"
+                                      will produce the string literal "$(VAR_NAME)".
+                                      Escaped references will never be expanded, regardless
+                                      of whether the variable exists or not. Cannot
+                                      be updated. More info: https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell'
                                     items:
                                       type: string
                                     type: array
@@ -3489,13 +4092,15 @@ spec:
                                           type: string
                                         value:
                                           description: 'Variable references $(VAR_NAME)
-                                            are expanded using the previous defined
+                                            are expanded using the previously defined
                                             environment variables in the container
                                             and any service environment variables.
                                             If a variable cannot be resolved, the
                                             reference in the input string will be
-                                            unchanged. The $(VAR_NAME) syntax can
-                                            be escaped with a double $$, ie: $$(VAR_NAME).
+                                            unchanged. Double $$ are reduced to a
+                                            single $, which allows for escaping the
+                                            $(VAR_NAME) syntax: i.e. "$$(VAR_NAME)"
+                                            will produce the string literal "$(VAR_NAME)".
                                             Escaped references will never be expanded,
                                             regardless of whether the variable exists
                                             or not. Defaults to "".'
@@ -3649,7 +4254,8 @@ spec:
                                       type: object
                                     type: array
                                   image:
-                                    description: 'Docker image name. More info: https://kubernetes.io/docs/concepts/containers/images
+                                    description: 'Container image name. More info:
+                                      https://kubernetes.io/docs/concepts/containers/images
                                       This field is optional to allow higher level
                                       config management to default or override container
                                       images in workload controllers like Deployments
@@ -3675,9 +4281,8 @@ spec:
                                           More info: https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/#container-hooks'
                                         properties:
                                           exec:
-                                            description: One and only one of the following
-                                              should be specified. Exec specifies
-                                              the action to take.
+                                            description: Exec specifies the action
+                                              to take.
                                             properties:
                                               command:
                                                 description: Command is the command
@@ -3748,10 +4353,12 @@ spec:
                                             - port
                                             type: object
                                           tcpSocket:
-                                            description: 'TCPSocket specifies an action
-                                              involving a TCP port. TCP hooks not
-                                              yet supported TODO: implement a realistic
-                                              TCP lifecycle hook'
+                                            description: Deprecated. TCPSocket is
+                                              NOT supported as a LifecycleHandler
+                                              and kept for the backward compatibility.
+                                              There are no validation of this field
+                                              and lifecycle hooks will fail in runtime
+                                              when tcp handler is specified.
                                             properties:
                                               host:
                                                 description: 'Optional: Host name
@@ -3778,21 +4385,19 @@ spec:
                                           as liveness/startup probe failure, preemption,
                                           resource contention, etc. The handler is
                                           not called if the container crashes or exits.
-                                          The reason for termination is passed to
-                                          the handler. The Pod''s termination grace
-                                          period countdown begins before the PreStop
-                                          hooked is executed. Regardless of the outcome
-                                          of the handler, the container will eventually
-                                          terminate within the Pod''s termination
-                                          grace period. Other management of the container
-                                          blocks until the hook completes or until
-                                          the termination grace period is reached.
-                                          More info: https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/#container-hooks'
+                                          The Pod''s termination grace period countdown
+                                          begins before the PreStop hook is executed.
+                                          Regardless of the outcome of the handler,
+                                          the container will eventually terminate
+                                          within the Pod''s termination grace period
+                                          (unless delayed by finalizers). Other management
+                                          of the container blocks until the hook completes
+                                          or until the termination grace period is
+                                          reached. More info: https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/#container-hooks'
                                         properties:
                                           exec:
-                                            description: One and only one of the following
-                                              should be specified. Exec specifies
-                                              the action to take.
+                                            description: Exec specifies the action
+                                              to take.
                                             properties:
                                               command:
                                                 description: Command is the command
@@ -3863,10 +4468,12 @@ spec:
                                             - port
                                             type: object
                                           tcpSocket:
-                                            description: 'TCPSocket specifies an action
-                                              involving a TCP port. TCP hooks not
-                                              yet supported TODO: implement a realistic
-                                              TCP lifecycle hook'
+                                            description: Deprecated. TCPSocket is
+                                              NOT supported as a LifecycleHandler
+                                              and kept for the backward compatibility.
+                                              There are no validation of this field
+                                              and lifecycle hooks will fail in runtime
+                                              when tcp handler is specified.
                                             properties:
                                               host:
                                                 description: 'Optional: Host name
@@ -3893,9 +4500,8 @@ spec:
                                       Cannot be updated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
                                     properties:
                                       exec:
-                                        description: One and only one of the following
-                                          should be specified. Exec specifies the
-                                          action to take.
+                                        description: Exec specifies the action to
+                                          take.
                                         properties:
                                           command:
                                             description: Command is the command line
@@ -3920,6 +4526,26 @@ spec:
                                           value is 1.
                                         format: int32
                                         type: integer
+                                      grpc:
+                                        description: GRPC specifies an action involving
+                                          a GRPC port. This is a beta field and requires
+                                          enabling GRPCContainerProbe feature gate.
+                                        properties:
+                                          port:
+                                            description: Port number of the gRPC service.
+                                              Number must be in the range 1 to 65535.
+                                            format: int32
+                                            type: integer
+                                          service:
+                                            description: "Service is the name of the
+                                              service to place in the gRPC HealthCheckRequest
+                                              (see https://github.com/grpc/grpc/blob/master/doc/health-checking.md).
+                                              \n If this is not specified, the default
+                                              behavior is defined by gRPC."
+                                            type: string
+                                        required:
+                                        - port
+                                        type: object
                                       httpGet:
                                         description: HTTPGet specifies the http request
                                           to perform.
@@ -3988,10 +4614,8 @@ spec:
                                         format: int32
                                         type: integer
                                       tcpSocket:
-                                        description: 'TCPSocket specifies an action
-                                          involving a TCP port. TCP hooks not yet
-                                          supported TODO: implement a realistic TCP
-                                          lifecycle hook'
+                                        description: TCPSocket specifies an action
+                                          involving a TCP port.
                                         properties:
                                           host:
                                             description: 'Optional: Host name to connect
@@ -4009,6 +4633,28 @@ spec:
                                         required:
                                         - port
                                         type: object
+                                      terminationGracePeriodSeconds:
+                                        description: Optional duration in seconds
+                                          the pod needs to terminate gracefully upon
+                                          probe failure. The grace period is the duration
+                                          in seconds after the processes running in
+                                          the pod are sent a termination signal and
+                                          the time when the processes are forcibly
+                                          halted with a kill signal. Set this value
+                                          longer than the expected cleanup time for
+                                          your process. If this value is nil, the
+                                          pod's terminationGracePeriodSeconds will
+                                          be used. Otherwise, this value overrides
+                                          the value provided by the pod spec. Value
+                                          must be non-negative integer. The value
+                                          zero indicates stop immediately via the
+                                          kill signal (no opportunity to shut down).
+                                          This is a beta field and requires enabling
+                                          ProbeTerminationGracePeriod feature gate.
+                                          Minimum value is 1. spec.terminationGracePeriodSeconds
+                                          is used if unset.
+                                        format: int64
+                                        type: integer
                                       timeoutSeconds:
                                         description: 'Number of seconds after which
                                           the probe times out. Defaults to 1 second.
@@ -4080,9 +4726,8 @@ spec:
                                       More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
                                     properties:
                                       exec:
-                                        description: One and only one of the following
-                                          should be specified. Exec specifies the
-                                          action to take.
+                                        description: Exec specifies the action to
+                                          take.
                                         properties:
                                           command:
                                             description: Command is the command line
@@ -4107,6 +4752,26 @@ spec:
                                           value is 1.
                                         format: int32
                                         type: integer
+                                      grpc:
+                                        description: GRPC specifies an action involving
+                                          a GRPC port. This is a beta field and requires
+                                          enabling GRPCContainerProbe feature gate.
+                                        properties:
+                                          port:
+                                            description: Port number of the gRPC service.
+                                              Number must be in the range 1 to 65535.
+                                            format: int32
+                                            type: integer
+                                          service:
+                                            description: "Service is the name of the
+                                              service to place in the gRPC HealthCheckRequest
+                                              (see https://github.com/grpc/grpc/blob/master/doc/health-checking.md).
+                                              \n If this is not specified, the default
+                                              behavior is defined by gRPC."
+                                            type: string
+                                        required:
+                                        - port
+                                        type: object
                                       httpGet:
                                         description: HTTPGet specifies the http request
                                           to perform.
@@ -4175,10 +4840,8 @@ spec:
                                         format: int32
                                         type: integer
                                       tcpSocket:
-                                        description: 'TCPSocket specifies an action
-                                          involving a TCP port. TCP hooks not yet
-                                          supported TODO: implement a realistic TCP
-                                          lifecycle hook'
+                                        description: TCPSocket specifies an action
+                                          involving a TCP port.
                                         properties:
                                           host:
                                             description: 'Optional: Host name to connect
@@ -4196,6 +4859,28 @@ spec:
                                         required:
                                         - port
                                         type: object
+                                      terminationGracePeriodSeconds:
+                                        description: Optional duration in seconds
+                                          the pod needs to terminate gracefully upon
+                                          probe failure. The grace period is the duration
+                                          in seconds after the processes running in
+                                          the pod are sent a termination signal and
+                                          the time when the processes are forcibly
+                                          halted with a kill signal. Set this value
+                                          longer than the expected cleanup time for
+                                          your process. If this value is nil, the
+                                          pod's terminationGracePeriodSeconds will
+                                          be used. Otherwise, this value overrides
+                                          the value provided by the pod spec. Value
+                                          must be non-negative integer. The value
+                                          zero indicates stop immediately via the
+                                          kill signal (no opportunity to shut down).
+                                          This is a beta field and requires enabling
+                                          ProbeTerminationGracePeriod feature gate.
+                                          Minimum value is 1. spec.terminationGracePeriodSeconds
+                                          is used if unset.
+                                        format: int64
+                                        type: integer
                                       timeoutSeconds:
                                         description: 'Number of seconds after which
                                           the probe times out. Defaults to 1 second.
@@ -4205,7 +4890,7 @@ spec:
                                     type: object
                                   resources:
                                     description: 'Compute Resources required by this
-                                      container. Cannot be updated. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
+                                      container. Cannot be updated. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
                                     properties:
                                       limits:
                                         additionalProperties:
@@ -4216,7 +4901,7 @@ spec:
                                           x-kubernetes-int-or-string: true
                                         description: 'Limits describes the maximum
                                           amount of compute resources allowed. More
-                                          info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
+                                          info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
                                         type: object
                                       requests:
                                         additionalProperties:
@@ -4230,12 +4915,14 @@ spec:
                                           Requests is omitted for a container, it
                                           defaults to Limits if that is explicitly
                                           specified, otherwise to an implementation-defined
-                                          value. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
+                                          value. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
                                         type: object
                                     type: object
                                   securityContext:
-                                    description: 'Security options the pod should
-                                      run with. More info: https://kubernetes.io/docs/concepts/policy/security-context/
+                                    description: 'SecurityContext defines the security
+                                      options the container should be run with. If
+                                      set, the fields of SecurityContext override
+                                      the equivalent fields of PodSecurityContext.
                                       More info: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/'
                                     properties:
                                       allowPrivilegeEscalation:
@@ -4245,13 +4932,16 @@ spec:
                                           controls if the no_new_privs flag will be
                                           set on the container process. AllowPrivilegeEscalation
                                           is true always when the container is: 1)
-                                          run as Privileged 2) has CAP_SYS_ADMIN'
+                                          run as Privileged 2) has CAP_SYS_ADMIN Note
+                                          that this field cannot be set when spec.os.name
+                                          is windows.'
                                         type: boolean
                                       capabilities:
                                         description: The capabilities to add/drop
                                           when running containers. Defaults to the
                                           default set of capabilities granted by the
-                                          container runtime.
+                                          container runtime. Note that this field
+                                          cannot be set when spec.os.name is windows.
                                         properties:
                                           add:
                                             description: Added capabilities
@@ -4272,7 +4962,8 @@ spec:
                                         description: Run container in privileged mode.
                                           Processes in privileged containers are essentially
                                           equivalent to root on the host. Defaults
-                                          to false.
+                                          to false. Note that this field cannot be
+                                          set when spec.os.name is windows.
                                         type: boolean
                                       procMount:
                                         description: procMount denotes the type of
@@ -4281,10 +4972,14 @@ spec:
                                           container runtime defaults for readonly
                                           paths and masked paths. This requires the
                                           ProcMountType feature flag to be enabled.
+                                          Note that this field cannot be set when
+                                          spec.os.name is windows.
                                         type: string
                                       readOnlyRootFilesystem:
                                         description: Whether this container has a
                                           read-only root filesystem. Default is false.
+                                          Note that this field cannot be set when
+                                          spec.os.name is windows.
                                         type: boolean
                                       runAsGroup:
                                         description: The GID to run the entrypoint
@@ -4292,7 +4987,8 @@ spec:
                                           if unset. May also be set in PodSecurityContext.  If
                                           set in both SecurityContext and PodSecurityContext,
                                           the value specified in SecurityContext takes
-                                          precedence.
+                                          precedence. Note that this field cannot
+                                          be set when spec.os.name is windows.
                                         format: int64
                                         type: integer
                                       runAsNonRoot:
@@ -4314,7 +5010,8 @@ spec:
                                           May also be set in PodSecurityContext.  If
                                           set in both SecurityContext and PodSecurityContext,
                                           the value specified in SecurityContext takes
-                                          precedence.
+                                          precedence. Note that this field cannot
+                                          be set when spec.os.name is windows.
                                         format: int64
                                         type: integer
                                       seLinuxOptions:
@@ -4324,7 +5021,9 @@ spec:
                                           for each container.  May also be set in
                                           PodSecurityContext.  If set in both SecurityContext
                                           and PodSecurityContext, the value specified
-                                          in SecurityContext takes precedence.
+                                          in SecurityContext takes precedence. Note
+                                          that this field cannot be set when spec.os.name
+                                          is windows.
                                         properties:
                                           level:
                                             description: Level is SELinux level label
@@ -4347,7 +5046,9 @@ spec:
                                         description: The seccomp options to use by
                                           this container. If seccomp options are provided
                                           at both the pod & container level, the container
-                                          options override the pod options.
+                                          options override the pod options. Note that
+                                          this field cannot be set when spec.os.name
+                                          is windows.
                                         properties:
                                           localhostProfile:
                                             description: localhostProfile indicates
@@ -4378,7 +5079,9 @@ spec:
                                           the options from the PodSecurityContext
                                           will be used. If set in both SecurityContext
                                           and PodSecurityContext, the value specified
-                                          in SecurityContext takes precedence.
+                                          in SecurityContext takes precedence. Note
+                                          that this field cannot be set when spec.os.name
+                                          is linux.
                                         properties:
                                           gmsaCredentialSpec:
                                             description: GMSACredentialSpec is where
@@ -4392,6 +5095,22 @@ spec:
                                               the name of the GMSA credential spec
                                               to use.
                                             type: string
+                                          hostProcess:
+                                            description: HostProcess determines if
+                                              a container should be run as a 'Host
+                                              Process' container. This field is alpha-level
+                                              and will only be honored by components
+                                              that enable the WindowsHostProcessContainers
+                                              feature flag. Setting this field without
+                                              the feature flag will result in errors
+                                              when validating the Pod. All of a Pod's
+                                              containers must have the same effective
+                                              HostProcess value (it is not allowed
+                                              to have a mix of HostProcess containers
+                                              and non-HostProcess containers).  In
+                                              addition, if HostProcess is true then
+                                              HostNetwork must also be set to true.
+                                            type: boolean
                                           runAsUserName:
                                             description: The UserName in Windows to
                                               run the entrypoint of the container
@@ -4414,14 +5133,11 @@ spec:
                                       parameters at the beginning of a Pod''s lifecycle,
                                       when it might take a long time to load data
                                       or warm a cache, than during steady-state operation.
-                                      This cannot be updated. This is a beta feature
-                                      enabled by the StartupProbe feature flag. More
-                                      info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                                      This cannot be updated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
                                     properties:
                                       exec:
-                                        description: One and only one of the following
-                                          should be specified. Exec specifies the
-                                          action to take.
+                                        description: Exec specifies the action to
+                                          take.
                                         properties:
                                           command:
                                             description: Command is the command line
@@ -4446,6 +5162,26 @@ spec:
                                           value is 1.
                                         format: int32
                                         type: integer
+                                      grpc:
+                                        description: GRPC specifies an action involving
+                                          a GRPC port. This is a beta field and requires
+                                          enabling GRPCContainerProbe feature gate.
+                                        properties:
+                                          port:
+                                            description: Port number of the gRPC service.
+                                              Number must be in the range 1 to 65535.
+                                            format: int32
+                                            type: integer
+                                          service:
+                                            description: "Service is the name of the
+                                              service to place in the gRPC HealthCheckRequest
+                                              (see https://github.com/grpc/grpc/blob/master/doc/health-checking.md).
+                                              \n If this is not specified, the default
+                                              behavior is defined by gRPC."
+                                            type: string
+                                        required:
+                                        - port
+                                        type: object
                                       httpGet:
                                         description: HTTPGet specifies the http request
                                           to perform.
@@ -4514,10 +5250,8 @@ spec:
                                         format: int32
                                         type: integer
                                       tcpSocket:
-                                        description: 'TCPSocket specifies an action
-                                          involving a TCP port. TCP hooks not yet
-                                          supported TODO: implement a realistic TCP
-                                          lifecycle hook'
+                                        description: TCPSocket specifies an action
+                                          involving a TCP port.
                                         properties:
                                           host:
                                             description: 'Optional: Host name to connect
@@ -4535,6 +5269,28 @@ spec:
                                         required:
                                         - port
                                         type: object
+                                      terminationGracePeriodSeconds:
+                                        description: Optional duration in seconds
+                                          the pod needs to terminate gracefully upon
+                                          probe failure. The grace period is the duration
+                                          in seconds after the processes running in
+                                          the pod are sent a termination signal and
+                                          the time when the processes are forcibly
+                                          halted with a kill signal. Set this value
+                                          longer than the expected cleanup time for
+                                          your process. If this value is nil, the
+                                          pod's terminationGracePeriodSeconds will
+                                          be used. Otherwise, this value overrides
+                                          the value provided by the pod spec. Value
+                                          must be non-negative integer. The value
+                                          zero indicates stop immediately via the
+                                          kill signal (no opportunity to shut down).
+                                          This is a beta field and requires enabling
+                                          ProbeTerminationGracePeriod feature gate.
+                                          Minimum value is 1. spec.terminationGracePeriodSeconds
+                                          is used if unset.
+                                        format: int64
+                                        type: integer
                                       timeoutSeconds:
                                         description: 'Number of seconds after which
                                           the probe times out. Defaults to 1 second.
@@ -4684,6 +5440,40 @@ spec:
                                 must match a node''s labels for the pod to be scheduled
                                 on that node. More info: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/'
                               type: object
+                              x-kubernetes-map-type: atomic
+                            os:
+                              description: "Specifies the OS of the containers in
+                                the pod. Some pod and container fields are restricted
+                                if this is set. \n If the OS field is set to linux,
+                                the following fields must be unset: -securityContext.windowsOptions
+                                \n If the OS field is set to windows, following fields
+                                must be unset: - spec.hostPID - spec.hostIPC - spec.securityContext.seLinuxOptions
+                                - spec.securityContext.seccompProfile - spec.securityContext.fsGroup
+                                - spec.securityContext.fsGroupChangePolicy - spec.securityContext.sysctls
+                                - spec.shareProcessNamespace - spec.securityContext.runAsUser
+                                - spec.securityContext.runAsGroup - spec.securityContext.supplementalGroups
+                                - spec.containers[*].securityContext.seLinuxOptions
+                                - spec.containers[*].securityContext.seccompProfile
+                                - spec.containers[*].securityContext.capabilities
+                                - spec.containers[*].securityContext.readOnlyRootFilesystem
+                                - spec.containers[*].securityContext.privileged -
+                                spec.containers[*].securityContext.allowPrivilegeEscalation
+                                - spec.containers[*].securityContext.procMount - spec.containers[*].securityContext.runAsUser
+                                - spec.containers[*].securityContext.runAsGroup This
+                                is a beta field and requires the IdentifyPodOS feature"
+                              properties:
+                                name:
+                                  description: 'Name is the name of the operating
+                                    system. The currently supported values are linux
+                                    and windows. Additional value may be defined in
+                                    future and can be one of: https://github.com/opencontainers/runtime-spec/blob/master/config.md#platform-specific-configuration
+                                    Clients should expect to handle additional values
+                                    and treat unrecognized values in this field as
+                                    os: null'
+                                  type: string
+                              required:
+                              - name
+                              type: object
                             overhead:
                               additionalProperties:
                                 anyOf:
@@ -4702,17 +5492,12 @@ spec:
                                 and selected in the PodSpec, Overhead will be set
                                 to the value defined in the corresponding RuntimeClass,
                                 otherwise it will remain unset and treated as zero.
-                                More info: https://git.k8s.io/enhancements/keps/sig-node/20190226-pod-overhead.md
-                                This field is alpha-level as of Kubernetes v1.16,
-                                and is only honored by servers that enable the PodOverhead
-                                feature.'
+                                More info: https://git.k8s.io/enhancements/keps/sig-node/688-pod-overhead/README.md'
                               type: object
                             preemptionPolicy:
                               description: PreemptionPolicy is the Policy for preempting
                                 pods with lower priority. One of Never, PreemptLowerPriority.
-                                Defaults to PreemptLowerPriority if unset. This field
-                                is beta-level, gated by the NonPreemptingPriority
-                                feature-gate.
+                                Defaults to PreemptLowerPriority if unset.
                               type: string
                             priority:
                               description: The priority value. Various system components
@@ -4737,7 +5522,7 @@ spec:
                                 be evaluated for pod readiness. A pod is ready when
                                 all its containers are ready AND all conditions specified
                                 in the readiness gates have status equal to "True"
-                                More info: https://git.k8s.io/enhancements/keps/sig-network/0007-pod-ready%2B%2B.md'
+                                More info: https://git.k8s.io/enhancements/keps/sig-network/580-pod-readiness-gates'
                               items:
                                 description: PodReadinessGate contains the reference
                                   to a pod condition
@@ -4763,8 +5548,7 @@ spec:
                                 or empty, the "legacy" RuntimeClass will be used,
                                 which is an implicit class with an empty definition
                                 that uses the default runtime handler. More info:
-                                https://git.k8s.io/enhancements/keps/sig-node/runtime-class.md
-                                This is a beta feature as of Kubernetes v1.14.'
+                                https://git.k8s.io/enhancements/keps/sig-node/585-runtime-class'
                               type: string
                             schedulerName:
                               description: If specified, the pod will be dispatched
@@ -4786,7 +5570,9 @@ spec:
                                     is set (new files created in the volume will be
                                     owned by FSGroup) 3. The permission bits are OR'd
                                     with rw-rw---- \n If unset, the Kubelet will not
-                                    modify the ownership and permissions of any volume."
+                                    modify the ownership and permissions of any volume.
+                                    Note that this field cannot be set when spec.os.name
+                                    is windows."
                                   format: int64
                                   type: integer
                                 fsGroupChangePolicy:
@@ -4797,7 +5583,9 @@ spec:
                                     based ownership(and permissions). It will have
                                     no effect on ephemeral volume types such as: secret,
                                     configmaps and emptydir. Valid values are "OnRootMismatch"
-                                    and "Always". If not specified defaults to "Always".'
+                                    and "Always". If not specified, "Always" is used.
+                                    Note that this field cannot be set when spec.os.name
+                                    is windows.'
                                   type: string
                                 runAsGroup:
                                   description: The GID to run the entrypoint of the
@@ -4805,7 +5593,8 @@ spec:
                                     May also be set in SecurityContext.  If set in
                                     both SecurityContext and PodSecurityContext, the
                                     value specified in SecurityContext takes precedence
-                                    for that container.
+                                    for that container. Note that this field cannot
+                                    be set when spec.os.name is windows.
                                   format: int64
                                   type: integer
                                 runAsNonRoot:
@@ -4826,6 +5615,8 @@ spec:
                                     set in SecurityContext.  If set in both SecurityContext
                                     and PodSecurityContext, the value specified in
                                     SecurityContext takes precedence for that container.
+                                    Note that this field cannot be set when spec.os.name
+                                    is windows.
                                   format: int64
                                   type: integer
                                 seLinuxOptions:
@@ -4835,7 +5626,8 @@ spec:
                                     for each container.  May also be set in SecurityContext.  If
                                     set in both SecurityContext and PodSecurityContext,
                                     the value specified in SecurityContext takes precedence
-                                    for that container.
+                                    for that container. Note that this field cannot
+                                    be set when spec.os.name is windows.
                                   properties:
                                     level:
                                       description: Level is SELinux level label that
@@ -4856,7 +5648,8 @@ spec:
                                   type: object
                                 seccompProfile:
                                   description: The seccomp options to use by the containers
-                                    in this pod.
+                                    in this pod. Note that this field cannot be set
+                                    when spec.os.name is windows.
                                   properties:
                                     localhostProfile:
                                       description: localhostProfile indicates a profile
@@ -4882,7 +5675,9 @@ spec:
                                   description: A list of groups applied to the first
                                     process run in each container, in addition to
                                     the container's primary GID.  If unspecified,
-                                    no groups will be added to any container.
+                                    no groups will be added to any container. Note
+                                    that this field cannot be set when spec.os.name
+                                    is windows.
                                   items:
                                     format: int64
                                     type: integer
@@ -4891,6 +5686,8 @@ spec:
                                   description: Sysctls hold a list of namespaced sysctls
                                     used for the pod. Pods with unsupported sysctls
                                     (by the container runtime) might fail to launch.
+                                    Note that this field cannot be set when spec.os.name
+                                    is windows.
                                   items:
                                     description: Sysctl defines a kernel parameter
                                       to be set
@@ -4912,6 +5709,8 @@ spec:
                                     within a container's SecurityContext will be used.
                                     If set in both SecurityContext and PodSecurityContext,
                                     the value specified in SecurityContext takes precedence.
+                                    Note that this field cannot be set when spec.os.name
+                                    is linux.
                                   properties:
                                     gmsaCredentialSpec:
                                       description: GMSACredentialSpec is where the
@@ -4923,6 +5722,20 @@ spec:
                                       description: GMSACredentialSpecName is the name
                                         of the GMSA credential spec to use.
                                       type: string
+                                    hostProcess:
+                                      description: HostProcess determines if a container
+                                        should be run as a 'Host Process' container.
+                                        This field is alpha-level and will only be
+                                        honored by components that enable the WindowsHostProcessContainers
+                                        feature flag. Setting this field without the
+                                        feature flag will result in errors when validating
+                                        the Pod. All of a Pod's containers must have
+                                        the same effective HostProcess value (it is
+                                        not allowed to have a mix of HostProcess containers
+                                        and non-HostProcess containers).  In addition,
+                                        if HostProcess is true then HostNetwork must
+                                        also be set to true.
+                                      type: boolean
                                     runAsUserName:
                                       description: The UserName in Windows to run
                                         the entrypoint of the container process. Defaults
@@ -4974,10 +5787,11 @@ spec:
                               description: Optional duration in seconds the pod needs
                                 to terminate gracefully. May be decreased in delete
                                 request. Value must be non-negative integer. The value
-                                zero indicates delete immediately. If this value is
-                                nil, the default grace period will be used instead.
-                                The grace period is the duration in seconds after
-                                the processes running in the pod are sent a termination
+                                zero indicates stop immediately via the kill signal
+                                (no opportunity to shut down). If this value is nil,
+                                the default grace period will be used instead. The
+                                grace period is the duration in seconds after the
+                                processes running in the pod are sent a termination
                                 signal and the time when the processes are forcibly
                                 halted with a kill signal. Set this value longer than
                                 the expected cleanup time for your process. Defaults
@@ -5097,19 +5911,53 @@ spec:
                                       `whenUnsatisfiable=DoNotSchedule`, it is the
                                       maximum permitted difference between the number
                                       of matching pods in the target topology and
-                                      the global minimum. For example, in a 3-zone
+                                      the global minimum. The global minimum is the
+                                      minimum number of matching pods in an eligible
+                                      domain or zero if the number of eligible domains
+                                      is less than MinDomains. For example, in a 3-zone
                                       cluster, MaxSkew is set to 1, and pods with
-                                      the same labelSelector spread as 1/1/0: | zone1
-                                      | zone2 | zone3 | |   P   |   P   |       |
-                                      - if MaxSkew is 1, incoming pod can only be
-                                      scheduled to zone3 to become 1/1/1; scheduling
-                                      it onto zone1(zone2) would make the ActualSkew(2-0)
-                                      on zone1(zone2) violate MaxSkew(1). - if MaxSkew
-                                      is 2, incoming pod can be scheduled onto any
-                                      zone. When `whenUnsatisfiable=ScheduleAnyway`,
+                                      the same labelSelector spread as 2/2/1: In this
+                                      case, the global minimum is 1. | zone1 | zone2
+                                      | zone3 | |  P P  |  P P  |   P   | - if MaxSkew
+                                      is 1, incoming pod can only be scheduled to
+                                      zone3 to become 2/2/2; scheduling it onto zone1(zone2)
+                                      would make the ActualSkew(3-1) on zone1(zone2)
+                                      violate MaxSkew(1). - if MaxSkew is 2, incoming
+                                      pod can be scheduled onto any zone. When `whenUnsatisfiable=ScheduleAnyway`,
                                       it is used to give higher precedence to topologies
                                       that satisfy it. It''s a required field. Default
                                       value is 1 and 0 is not allowed.'
+                                    format: int32
+                                    type: integer
+                                  minDomains:
+                                    description: "MinDomains indicates a minimum number
+                                      of eligible domains. When the number of eligible
+                                      domains with matching topology keys is less
+                                      than minDomains, Pod Topology Spread treats
+                                      \"global minimum\" as 0, and then the calculation
+                                      of Skew is performed. And when the number of
+                                      eligible domains with matching topology keys
+                                      equals or greater than minDomains, this value
+                                      has no effect on scheduling. As a result, when
+                                      the number of eligible domains is less than
+                                      minDomains, scheduler won't schedule more than
+                                      maxSkew Pods to those domains. If value is nil,
+                                      the constraint behaves as if MinDomains is equal
+                                      to 1. Valid values are integers greater than
+                                      0. When value is not nil, WhenUnsatisfiable
+                                      must be DoNotSchedule. \n For example, in a
+                                      3-zone cluster, MaxSkew is set to 2, MinDomains
+                                      is set to 5 and pods with the same labelSelector
+                                      spread as 2/2/2: | zone1 | zone2 | zone3 | |
+                                      \ P P  |  P P  |  P P  | The number of domains
+                                      is less than 5(MinDomains), so \"global minimum\"
+                                      is treated as 0. In this situation, new pod
+                                      with the same labelSelector cannot be scheduled,
+                                      because computed skew will be 3(3 - 0) if new
+                                      Pod is scheduled to any of the three zones,
+                                      it will violate MaxSkew. \n This is an alpha
+                                      field and requires enabling MinDomainsInPodTopologySpread
+                                      feature gate."
                                     format: int32
                                     type: integer
                                   topologyKey:
@@ -5118,7 +5966,14 @@ spec:
                                       values are considered to be in the same topology.
                                       We consider each <key, value> as a "bucket",
                                       and try to put balanced number of pods into
-                                      each bucket. It's a required field.
+                                      each bucket. We define a domain as a particular
+                                      instance of a topology. Also, we define an eligible
+                                      domain as a domain whose nodes match the node
+                                      selector. e.g. If TopologyKey is "kubernetes.io/hostname",
+                                      each Node is a domain of that topology. And,
+                                      if TopologyKey is "topology.kubernetes.io/zone",
+                                      each zone is a domain of that topology. It's
+                                      a required field.
                                     type: string
                                   whenUnsatisfiable:
                                     description: 'WhenUnsatisfiable indicates how
@@ -5130,7 +5985,7 @@ spec:
                                       topologies that would help reduce the   skew.
                                       A constraint is considered "Unsatisfiable" for
                                       an incoming pod if and only if every possible
-                                      node assigment for that pod would violate "MaxSkew"
+                                      node assignment for that pod would violate "MaxSkew"
                                       on some topology. For example, in a 3-zone cluster,
                                       MaxSkew is set to 1, and pods with the same
                                       labelSelector spread as 3/1/1: | zone1 | zone2
@@ -5161,77 +6016,78 @@ spec:
                                   pod.
                                 properties:
                                   awsElasticBlockStore:
-                                    description: 'AWSElasticBlockStore represents
+                                    description: 'awsElasticBlockStore represents
                                       an AWS Disk resource that is attached to a kubelet''s
                                       host machine and then exposed to the pod. More
                                       info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore'
                                     properties:
                                       fsType:
-                                        description: 'Filesystem type of the volume
-                                          that you want to mount. Tip: Ensure that
-                                          the filesystem type is supported by the
-                                          host operating system. Examples: "ext4",
-                                          "xfs", "ntfs". Implicitly inferred to be
-                                          "ext4" if unspecified. More info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore
+                                        description: 'fsType is the filesystem type
+                                          of the volume that you want to mount. Tip:
+                                          Ensure that the filesystem type is supported
+                                          by the host operating system. Examples:
+                                          "ext4", "xfs", "ntfs". Implicitly inferred
+                                          to be "ext4" if unspecified. More info:
+                                          https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore
                                           TODO: how do we prevent errors in the filesystem
                                           from compromising the machine'
                                         type: string
                                       partition:
-                                        description: 'The partition in the volume
-                                          that you want to mount. If omitted, the
-                                          default is to mount by volume name. Examples:
-                                          For volume /dev/sda1, you specify the partition
-                                          as "1". Similarly, the volume partition
-                                          for /dev/sda is "0" (or you can leave the
-                                          property empty).'
+                                        description: 'partition is the partition in
+                                          the volume that you want to mount. If omitted,
+                                          the default is to mount by volume name.
+                                          Examples: For volume /dev/sda1, you specify
+                                          the partition as "1". Similarly, the volume
+                                          partition for /dev/sda is "0" (or you can
+                                          leave the property empty).'
                                         format: int32
                                         type: integer
                                       readOnly:
-                                        description: 'Specify "true" to force and
-                                          set the ReadOnly property in VolumeMounts
-                                          to "true". If omitted, the default is "false".
-                                          More info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore'
+                                        description: 'readOnly value true will force
+                                          the readOnly setting in VolumeMounts. More
+                                          info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore'
                                         type: boolean
                                       volumeID:
-                                        description: 'Unique ID of the persistent
-                                          disk resource in AWS (Amazon EBS volume).
-                                          More info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore'
+                                        description: 'volumeID is unique ID of the
+                                          persistent disk resource in AWS (Amazon
+                                          EBS volume). More info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore'
                                         type: string
                                     required:
                                     - volumeID
                                     type: object
                                   azureDisk:
-                                    description: AzureDisk represents an Azure Data
+                                    description: azureDisk represents an Azure Data
                                       Disk mount on the host and bind mount to the
                                       pod.
                                     properties:
                                       cachingMode:
-                                        description: 'Host Caching mode: None, Read
-                                          Only, Read Write.'
+                                        description: 'cachingMode is the Host Caching
+                                          mode: None, Read Only, Read Write.'
                                         type: string
                                       diskName:
-                                        description: The Name of the data disk in
-                                          the blob storage
+                                        description: diskName is the Name of the data
+                                          disk in the blob storage
                                         type: string
                                       diskURI:
-                                        description: The URI the data disk in the
-                                          blob storage
+                                        description: diskURI is the URI of data disk
+                                          in the blob storage
                                         type: string
                                       fsType:
-                                        description: Filesystem type to mount. Must
-                                          be a filesystem type supported by the host
-                                          operating system. Ex. "ext4", "xfs", "ntfs".
-                                          Implicitly inferred to be "ext4" if unspecified.
+                                        description: fsType is Filesystem type to
+                                          mount. Must be a filesystem type supported
+                                          by the host operating system. Ex. "ext4",
+                                          "xfs", "ntfs". Implicitly inferred to be
+                                          "ext4" if unspecified.
                                         type: string
                                       kind:
-                                        description: 'Expected values Shared: multiple
-                                          blob disks per storage account  Dedicated:
+                                        description: 'kind expected values are Shared:
+                                          multiple blob disks per storage account  Dedicated:
                                           single blob disk per storage account  Managed:
                                           azure managed data disk (only in managed
                                           availability set). defaults to shared'
                                         type: string
                                       readOnly:
-                                        description: Defaults to false (read/write).
+                                        description: readOnly Defaults to false (read/write).
                                           ReadOnly here will force the ReadOnly setting
                                           in VolumeMounts.
                                         type: boolean
@@ -5240,56 +6096,59 @@ spec:
                                     - diskURI
                                     type: object
                                   azureFile:
-                                    description: AzureFile represents an Azure File
+                                    description: azureFile represents an Azure File
                                       Service mount on the host and bind mount to
                                       the pod.
                                     properties:
                                       readOnly:
-                                        description: Defaults to false (read/write).
+                                        description: readOnly defaults to false (read/write).
                                           ReadOnly here will force the ReadOnly setting
                                           in VolumeMounts.
                                         type: boolean
                                       secretName:
-                                        description: the name of secret that contains
-                                          Azure Storage Account Name and Key
+                                        description: secretName is the  name of secret
+                                          that contains Azure Storage Account Name
+                                          and Key
                                         type: string
                                       shareName:
-                                        description: Share Name
+                                        description: shareName is the azure share
+                                          Name
                                         type: string
                                     required:
                                     - secretName
                                     - shareName
                                     type: object
                                   cephfs:
-                                    description: CephFS represents a Ceph FS mount
+                                    description: cephFS represents a Ceph FS mount
                                       on the host that shares a pod's lifetime
                                     properties:
                                       monitors:
-                                        description: 'Required: Monitors is a collection
-                                          of Ceph monitors More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it'
+                                        description: 'monitors is Required: Monitors
+                                          is a collection of Ceph monitors More info:
+                                          https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it'
                                         items:
                                           type: string
                                         type: array
                                       path:
-                                        description: 'Optional: Used as the mounted
-                                          root, rather than the full Ceph tree, default
-                                          is /'
+                                        description: 'path is Optional: Used as the
+                                          mounted root, rather than the full Ceph
+                                          tree, default is /'
                                         type: string
                                       readOnly:
-                                        description: 'Optional: Defaults to false
-                                          (read/write). ReadOnly here will force the
-                                          ReadOnly setting in VolumeMounts. More info:
-                                          https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it'
+                                        description: 'readOnly is Optional: Defaults
+                                          to false (read/write). ReadOnly here will
+                                          force the ReadOnly setting in VolumeMounts.
+                                          More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it'
                                         type: boolean
                                       secretFile:
-                                        description: 'Optional: SecretFile is the
-                                          path to key ring for User, default is /etc/ceph/user.secret
-                                          More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it'
+                                        description: 'secretFile is Optional: SecretFile
+                                          is the path to key ring for User, default
+                                          is /etc/ceph/user.secret More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it'
                                         type: string
                                       secretRef:
-                                        description: 'Optional: SecretRef is reference
-                                          to the authentication secret for User, default
-                                          is empty. More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it'
+                                        description: 'secretRef is Optional: SecretRef
+                                          is reference to the authentication secret
+                                          for User, default is empty. More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it'
                                         properties:
                                           name:
                                             description: 'Name of the referent. More
@@ -5299,34 +6158,35 @@ spec:
                                             type: string
                                         type: object
                                       user:
-                                        description: 'Optional: User is the rados
-                                          user name, default is admin More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it'
+                                        description: 'user is optional: User is the
+                                          rados user name, default is admin More info:
+                                          https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it'
                                         type: string
                                     required:
                                     - monitors
                                     type: object
                                   cinder:
-                                    description: 'Cinder represents a cinder volume
+                                    description: 'cinder represents a cinder volume
                                       attached and mounted on kubelets host machine.
                                       More info: https://examples.k8s.io/mysql-cinder-pd/README.md'
                                     properties:
                                       fsType:
-                                        description: 'Filesystem type to mount. Must
-                                          be a filesystem type supported by the host
-                                          operating system. Examples: "ext4", "xfs",
-                                          "ntfs". Implicitly inferred to be "ext4"
-                                          if unspecified. More info: https://examples.k8s.io/mysql-cinder-pd/README.md'
+                                        description: 'fsType is the filesystem type
+                                          to mount. Must be a filesystem type supported
+                                          by the host operating system. Examples:
+                                          "ext4", "xfs", "ntfs". Implicitly inferred
+                                          to be "ext4" if unspecified. More info:
+                                          https://examples.k8s.io/mysql-cinder-pd/README.md'
                                         type: string
                                       readOnly:
-                                        description: 'Optional: Defaults to false
-                                          (read/write). ReadOnly here will force the
-                                          ReadOnly setting in VolumeMounts. More info:
-                                          https://examples.k8s.io/mysql-cinder-pd/README.md'
+                                        description: 'readOnly defaults to false (read/write).
+                                          ReadOnly here will force the ReadOnly setting
+                                          in VolumeMounts. More info: https://examples.k8s.io/mysql-cinder-pd/README.md'
                                         type: boolean
                                       secretRef:
-                                        description: 'Optional: points to a secret
-                                          object containing parameters used to connect
-                                          to OpenStack.'
+                                        description: 'secretRef is optional: points
+                                          to a secret object containing parameters
+                                          used to connect to OpenStack.'
                                         properties:
                                           name:
                                             description: 'Name of the referent. More
@@ -5336,32 +6196,33 @@ spec:
                                             type: string
                                         type: object
                                       volumeID:
-                                        description: 'volume id used to identify the
+                                        description: 'volumeID used to identify the
                                           volume in cinder. More info: https://examples.k8s.io/mysql-cinder-pd/README.md'
                                         type: string
                                     required:
                                     - volumeID
                                     type: object
                                   configMap:
-                                    description: ConfigMap represents a configMap
+                                    description: configMap represents a configMap
                                       that should populate this volume
                                     properties:
                                       defaultMode:
-                                        description: 'Optional: mode bits used to
-                                          set permissions on created files by default.
-                                          Must be an octal value between 0000 and
-                                          0777 or a decimal value between 0 and 511.
-                                          YAML accepts both octal and decimal values,
-                                          JSON requires decimal values for mode bits.
-                                          Defaults to 0644. Directories within the
-                                          path are not affected by this setting. This
-                                          might be in conflict with other options
-                                          that affect the file mode, like fsGroup,
-                                          and the result can be other mode bits set.'
+                                        description: 'defaultMode is optional: mode
+                                          bits used to set permissions on created
+                                          files by default. Must be an octal value
+                                          between 0000 and 0777 or a decimal value
+                                          between 0 and 511. YAML accepts both octal
+                                          and decimal values, JSON requires decimal
+                                          values for mode bits. Defaults to 0644.
+                                          Directories within the path are not affected
+                                          by this setting. This might be in conflict
+                                          with other options that affect the file
+                                          mode, like fsGroup, and the result can be
+                                          other mode bits set.'
                                         format: int32
                                         type: integer
                                       items:
-                                        description: If unspecified, each key-value
+                                        description: items if unspecified, each key-value
                                           pair in the Data field of the referenced
                                           ConfigMap will be projected into the volume
                                           as a file whose name is the key and content
@@ -5378,27 +6239,27 @@ spec:
                                             within a volume.
                                           properties:
                                             key:
-                                              description: The key to project.
+                                              description: key is the key to project.
                                               type: string
                                             mode:
-                                              description: 'Optional: mode bits used
-                                                to set permissions on this file. Must
-                                                be an octal value between 0000 and
-                                                0777 or a decimal value between 0
-                                                and 511. YAML accepts both octal and
-                                                decimal values, JSON requires decimal
-                                                values for mode bits. If not specified,
-                                                the volume defaultMode will be used.
-                                                This might be in conflict with other
-                                                options that affect the file mode,
-                                                like fsGroup, and the result can be
-                                                other mode bits set.'
+                                              description: 'mode is Optional: mode
+                                                bits used to set permissions on this
+                                                file. Must be an octal value between
+                                                0000 and 0777 or a decimal value between
+                                                0 and 511. YAML accepts both octal
+                                                and decimal values, JSON requires
+                                                decimal values for mode bits. If not
+                                                specified, the volume defaultMode
+                                                will be used. This might be in conflict
+                                                with other options that affect the
+                                                file mode, like fsGroup, and the result
+                                                can be other mode bits set.'
                                               format: int32
                                               type: integer
                                             path:
-                                              description: The relative path of the
-                                                file to map the key to. May not be
-                                                an absolute path. May not contain
+                                              description: path is the relative path
+                                                of the file to map the key to. May
+                                                not be an absolute path. May not contain
                                                 the path element '..'. May not start
                                                 with the string '..'.
                                               type: string
@@ -5414,30 +6275,30 @@ spec:
                                           kind, uid?'
                                         type: string
                                       optional:
-                                        description: Specify whether the ConfigMap
-                                          or its keys must be defined
+                                        description: optional specify whether the
+                                          ConfigMap or its keys must be defined
                                         type: boolean
                                     type: object
                                   csi:
-                                    description: CSI (Container Storage Interface)
+                                    description: csi (Container Storage Interface)
                                       represents ephemeral storage that is handled
                                       by certain external CSI drivers (Beta feature).
                                     properties:
                                       driver:
-                                        description: Driver is the name of the CSI
+                                        description: driver is the name of the CSI
                                           driver that handles this volume. Consult
                                           with your admin for the correct name as
                                           registered in the cluster.
                                         type: string
                                       fsType:
-                                        description: Filesystem type to mount. Ex.
-                                          "ext4", "xfs", "ntfs". If not provided,
-                                          the empty value is passed to the associated
-                                          CSI driver which will determine the default
-                                          filesystem to apply.
+                                        description: fsType to mount. Ex. "ext4",
+                                          "xfs", "ntfs". If not provided, the empty
+                                          value is passed to the associated CSI driver
+                                          which will determine the default filesystem
+                                          to apply.
                                         type: string
                                       nodePublishSecretRef:
-                                        description: NodePublishSecretRef is a reference
+                                        description: nodePublishSecretRef is a reference
                                           to the secret object containing sensitive
                                           information to pass to the CSI driver to
                                           complete the CSI NodePublishVolume and NodeUnpublishVolume
@@ -5454,13 +6315,14 @@ spec:
                                             type: string
                                         type: object
                                       readOnly:
-                                        description: Specifies a read-only configuration
-                                          for the volume. Defaults to false (read/write).
+                                        description: readOnly specifies a read-only
+                                          configuration for the volume. Defaults to
+                                          false (read/write).
                                         type: boolean
                                       volumeAttributes:
                                         additionalProperties:
                                           type: string
-                                        description: VolumeAttributes stores driver-specific
+                                        description: volumeAttributes stores driver-specific
                                           properties that are passed to the CSI driver.
                                           Consult your driver's documentation for
                                           supported values.
@@ -5469,7 +6331,7 @@ spec:
                                     - driver
                                     type: object
                                   downwardAPI:
-                                    description: DownwardAPI represents downward API
+                                    description: downwardAPI represents downward API
                                       about the pod that should populate this volume
                                     properties:
                                       defaultMode:
@@ -5570,62 +6432,59 @@ spec:
                                         type: array
                                     type: object
                                   emptyDir:
-                                    description: 'EmptyDir represents a temporary
+                                    description: 'emptyDir represents a temporary
                                       directory that shares a pod''s lifetime. More
                                       info: https://kubernetes.io/docs/concepts/storage/volumes#emptydir'
                                     properties:
                                       medium:
-                                        description: 'What type of storage medium
-                                          should back this directory. The default
-                                          is "" which means to use the node''s default
-                                          medium. Must be an empty string (default)
-                                          or Memory. More info: https://kubernetes.io/docs/concepts/storage/volumes#emptydir'
+                                        description: 'medium represents what type
+                                          of storage medium should back this directory.
+                                          The default is "" which means to use the
+                                          node''s default medium. Must be an empty
+                                          string (default) or Memory. More info: https://kubernetes.io/docs/concepts/storage/volumes#emptydir'
                                         type: string
                                       sizeLimit:
                                         anyOf:
                                         - type: integer
                                         - type: string
-                                        description: 'Total amount of local storage
-                                          required for this EmptyDir volume. The size
-                                          limit is also applicable for memory medium.
-                                          The maximum usage on memory medium EmptyDir
-                                          would be the minimum value between the SizeLimit
-                                          specified here and the sum of memory limits
-                                          of all containers in a pod. The default
-                                          is nil which means that the limit is undefined.
-                                          More info: http://kubernetes.io/docs/user-guide/volumes#emptydir'
+                                        description: 'sizeLimit is the total amount
+                                          of local storage required for this EmptyDir
+                                          volume. The size limit is also applicable
+                                          for memory medium. The maximum usage on
+                                          memory medium EmptyDir would be the minimum
+                                          value between the SizeLimit specified here
+                                          and the sum of memory limits of all containers
+                                          in a pod. The default is nil which means
+                                          that the limit is undefined. More info:
+                                          http://kubernetes.io/docs/user-guide/volumes#emptydir'
                                         pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                         x-kubernetes-int-or-string: true
                                     type: object
                                   ephemeral:
-                                    description: "Ephemeral represents a volume that
-                                      is handled by a cluster storage driver (Alpha
-                                      feature). The volume's lifecycle is tied to
-                                      the pod that defines it - it will be created
-                                      before the pod starts, and deleted when the
-                                      pod is removed. \n Use this if: a) the volume
-                                      is only needed while the pod runs, b) features
-                                      of normal volumes like restoring from snapshot
-                                      or capacity    tracking are needed, c) the storage
-                                      driver is specified through a storage class,
-                                      and d) the storage driver supports dynamic volume
-                                      provisioning through    a PersistentVolumeClaim
-                                      (see EphemeralVolumeSource for more    information
-                                      on the connection between this volume type    and
-                                      PersistentVolumeClaim). \n Use PersistentVolumeClaim
-                                      or one of the vendor-specific APIs for volumes
-                                      that persist for longer than the lifecycle of
-                                      an individual pod. \n Use CSI for light-weight
-                                      local ephemeral volumes if the CSI driver is
-                                      meant to be used that way - see the documentation
-                                      of the driver for more information. \n A pod
-                                      can use both types of ephemeral volumes and
-                                      persistent volumes at the same time."
+                                    description: "ephemeral represents a volume that
+                                      is handled by a cluster storage driver. The
+                                      volume's lifecycle is tied to the pod that defines
+                                      it - it will be created before the pod starts,
+                                      and deleted when the pod is removed. \n Use
+                                      this if: a) the volume is only needed while
+                                      the pod runs, b) features of normal volumes
+                                      like restoring from snapshot or capacity    tracking
+                                      are needed, c) the storage driver is specified
+                                      through a storage class, and d) the storage
+                                      driver supports dynamic volume provisioning
+                                      through    a PersistentVolumeClaim (see EphemeralVolumeSource
+                                      for more    information on the connection between
+                                      this volume type    and PersistentVolumeClaim).
+                                      \n Use PersistentVolumeClaim or one of the vendor-specific
+                                      APIs for volumes that persist for longer than
+                                      the lifecycle of an individual pod. \n Use CSI
+                                      for light-weight local ephemeral volumes if
+                                      the CSI driver is meant to be used that way
+                                      - see the documentation of the driver for more
+                                      information. \n A pod can use both types of
+                                      ephemeral volumes and persistent volumes at
+                                      the same time."
                                     properties:
-                                      readOnly:
-                                        description: Specifies a read-only configuration
-                                          for the volume. Defaults to false (read/write).
-                                        type: boolean
                                       volumeClaimTemplate:
                                         description: "Will be used to create a stand-alone
                                           PVC to provision the volume. The pod in
@@ -5685,34 +6544,82 @@ spec:
                                               are also valid here.
                                             properties:
                                               accessModes:
-                                                description: 'AccessModes contains
+                                                description: 'accessModes contains
                                                   the desired access modes the volume
                                                   should have. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#access-modes-1'
                                                 items:
                                                   type: string
                                                 type: array
                                               dataSource:
-                                                description: 'This field can be used
-                                                  to specify either: * An existing
-                                                  VolumeSnapshot object (snapshot.storage.k8s.io/VolumeSnapshot
-                                                  - Beta) * An existing PVC (PersistentVolumeClaim)
-                                                  * An existing custom resource/object
-                                                  that implements data population
-                                                  (Alpha) In order to use VolumeSnapshot
-                                                  object types, the appropriate feature
-                                                  gate must be enabled (VolumeSnapshotDataSource
-                                                  or AnyVolumeDataSource) If the provisioner
-                                                  or an external controller can support
-                                                  the specified data source, it will
-                                                  create a new volume based on the
-                                                  contents of the specified data source.
-                                                  If the specified data source is
-                                                  not supported, the volume will not
-                                                  be created and the failure will
-                                                  be reported as an event. In the
-                                                  future, we plan to support more
-                                                  data source types and the behavior
-                                                  of the provisioner may change.'
+                                                description: 'dataSource field can
+                                                  be used to specify either: * An
+                                                  existing VolumeSnapshot object (snapshot.storage.k8s.io/VolumeSnapshot)
+                                                  * An existing PVC (PersistentVolumeClaim)
+                                                  If the provisioner or an external
+                                                  controller can support the specified
+                                                  data source, it will create a new
+                                                  volume based on the contents of
+                                                  the specified data source. If the
+                                                  AnyVolumeDataSource feature gate
+                                                  is enabled, this field will always
+                                                  have the same contents as the DataSourceRef
+                                                  field.'
+                                                properties:
+                                                  apiGroup:
+                                                    description: APIGroup is the group
+                                                      for the resource being referenced.
+                                                      If APIGroup is not specified,
+                                                      the specified Kind must be in
+                                                      the core API group. For any
+                                                      other third-party types, APIGroup
+                                                      is required.
+                                                    type: string
+                                                  kind:
+                                                    description: Kind is the type
+                                                      of resource being referenced
+                                                    type: string
+                                                  name:
+                                                    description: Name is the name
+                                                      of resource being referenced
+                                                    type: string
+                                                required:
+                                                - kind
+                                                - name
+                                                type: object
+                                              dataSourceRef:
+                                                description: 'dataSourceRef specifies
+                                                  the object from which to populate
+                                                  the volume with data, if a non-empty
+                                                  volume is desired. This may be any
+                                                  local object from a non-empty API
+                                                  group (non core object) or a PersistentVolumeClaim
+                                                  object. When this field is specified,
+                                                  volume binding will only succeed
+                                                  if the type of the specified object
+                                                  matches some installed volume populator
+                                                  or dynamic provisioner. This field
+                                                  will replace the functionality of
+                                                  the DataSource field and as such
+                                                  if both fields are non-empty, they
+                                                  must have the same value. For backwards
+                                                  compatibility, both fields (DataSource
+                                                  and DataSourceRef) will be set to
+                                                  the same value automatically if
+                                                  one of them is empty and the other
+                                                  is non-empty. There are two important
+                                                  differences between DataSource and
+                                                  DataSourceRef: * While DataSource
+                                                  only allows two specific types of
+                                                  objects, DataSourceRef   allows
+                                                  any non-core object, as well as
+                                                  PersistentVolumeClaim objects. *
+                                                  While DataSource ignores disallowed
+                                                  values (dropping them), DataSourceRef   preserves
+                                                  all values, and generates an error
+                                                  if a disallowed value is   specified.
+                                                  (Beta) Using this field requires
+                                                  the AnyVolumeDataSource feature
+                                                  gate to be enabled.'
                                                 properties:
                                                   apiGroup:
                                                     description: APIGroup is the group
@@ -5736,9 +6643,15 @@ spec:
                                                 - name
                                                 type: object
                                               resources:
-                                                description: 'Resources represents
+                                                description: 'resources represents
                                                   the minimum resources the volume
-                                                  should have. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#resources'
+                                                  should have. If RecoverVolumeExpansionFailure
+                                                  feature is enabled users are allowed
+                                                  to specify resource requirements
+                                                  that are lower than previous value
+                                                  but must still be higher than capacity
+                                                  recorded in the status field of
+                                                  the claim. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#resources'
                                                 properties:
                                                   limits:
                                                     additionalProperties:
@@ -5750,7 +6663,7 @@ spec:
                                                     description: 'Limits describes
                                                       the maximum amount of compute
                                                       resources allowed. More info:
-                                                      https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
+                                                      https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
                                                     type: object
                                                   requests:
                                                     additionalProperties:
@@ -5766,12 +6679,12 @@ spec:
                                                       it defaults to Limits if that
                                                       is explicitly specified, otherwise
                                                       to an implementation-defined
-                                                      value. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
+                                                      value. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
                                                     type: object
                                                 type: object
                                               selector:
-                                                description: A label query over volumes
-                                                  to consider for binding.
+                                                description: selector is a label query
+                                                  over volumes to consider for binding.
                                                 properties:
                                                   matchExpressions:
                                                     description: matchExpressions
@@ -5831,9 +6744,9 @@ spec:
                                                     type: object
                                                 type: object
                                               storageClassName:
-                                                description: 'Name of the StorageClass
-                                                  required by the claim. More info:
-                                                  https://kubernetes.io/docs/concepts/storage/persistent-volumes#class-1'
+                                                description: 'storageClassName is
+                                                  the name of the StorageClass required
+                                                  by the claim. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#class-1'
                                                 type: string
                                               volumeMode:
                                                 description: volumeMode defines what
@@ -5842,7 +6755,7 @@ spec:
                                                   when not included in claim spec.
                                                 type: string
                                               volumeName:
-                                                description: VolumeName is the binding
+                                                description: volumeName is the binding
                                                   reference to the PersistentVolume
                                                   backing this claim.
                                                 type: string
@@ -5852,77 +6765,79 @@ spec:
                                         type: object
                                     type: object
                                   fc:
-                                    description: FC represents a Fibre Channel resource
+                                    description: fc represents a Fibre Channel resource
                                       that is attached to a kubelet's host machine
                                       and then exposed to the pod.
                                     properties:
                                       fsType:
-                                        description: 'Filesystem type to mount. Must
-                                          be a filesystem type supported by the host
-                                          operating system. Ex. "ext4", "xfs", "ntfs".
-                                          Implicitly inferred to be "ext4" if unspecified.
-                                          TODO: how do we prevent errors in the filesystem
-                                          from compromising the machine'
+                                        description: 'fsType is the filesystem type
+                                          to mount. Must be a filesystem type supported
+                                          by the host operating system. Ex. "ext4",
+                                          "xfs", "ntfs". Implicitly inferred to be
+                                          "ext4" if unspecified. TODO: how do we prevent
+                                          errors in the filesystem from compromising
+                                          the machine'
                                         type: string
                                       lun:
-                                        description: 'Optional: FC target lun number'
+                                        description: 'lun is Optional: FC target lun
+                                          number'
                                         format: int32
                                         type: integer
                                       readOnly:
-                                        description: 'Optional: Defaults to false
-                                          (read/write). ReadOnly here will force the
-                                          ReadOnly setting in VolumeMounts.'
+                                        description: 'readOnly is Optional: Defaults
+                                          to false (read/write). ReadOnly here will
+                                          force the ReadOnly setting in VolumeMounts.'
                                         type: boolean
                                       targetWWNs:
-                                        description: 'Optional: FC target worldwide
-                                          names (WWNs)'
+                                        description: 'targetWWNs is Optional: FC target
+                                          worldwide names (WWNs)'
                                         items:
                                           type: string
                                         type: array
                                       wwids:
-                                        description: 'Optional: FC volume world wide
-                                          identifiers (wwids) Either wwids or combination
-                                          of targetWWNs and lun must be set, but not
-                                          both simultaneously.'
+                                        description: 'wwids Optional: FC volume world
+                                          wide identifiers (wwids) Either wwids or
+                                          combination of targetWWNs and lun must be
+                                          set, but not both simultaneously.'
                                         items:
                                           type: string
                                         type: array
                                     type: object
                                   flexVolume:
-                                    description: FlexVolume represents a generic volume
+                                    description: flexVolume represents a generic volume
                                       resource that is provisioned/attached using
                                       an exec based plugin.
                                     properties:
                                       driver:
-                                        description: Driver is the name of the driver
+                                        description: driver is the name of the driver
                                           to use for this volume.
                                         type: string
                                       fsType:
-                                        description: Filesystem type to mount. Must
-                                          be a filesystem type supported by the host
-                                          operating system. Ex. "ext4", "xfs", "ntfs".
-                                          The default filesystem depends on FlexVolume
-                                          script.
+                                        description: fsType is the filesystem type
+                                          to mount. Must be a filesystem type supported
+                                          by the host operating system. Ex. "ext4",
+                                          "xfs", "ntfs". The default filesystem depends
+                                          on FlexVolume script.
                                         type: string
                                       options:
                                         additionalProperties:
                                           type: string
-                                        description: 'Optional: Extra command options
-                                          if any.'
+                                        description: 'options is Optional: this field
+                                          holds extra command options if any.'
                                         type: object
                                       readOnly:
-                                        description: 'Optional: Defaults to false
-                                          (read/write). ReadOnly here will force the
-                                          ReadOnly setting in VolumeMounts.'
+                                        description: 'readOnly is Optional: defaults
+                                          to false (read/write). ReadOnly here will
+                                          force the ReadOnly setting in VolumeMounts.'
                                         type: boolean
                                       secretRef:
-                                        description: 'Optional: SecretRef is reference
-                                          to the secret object containing sensitive
-                                          information to pass to the plugin scripts.
-                                          This may be empty if no secret object is
-                                          specified. If the secret object contains
-                                          more than one secret, all secrets are passed
-                                          to the plugin scripts.'
+                                        description: 'secretRef is Optional: secretRef
+                                          is reference to the secret object containing
+                                          sensitive information to pass to the plugin
+                                          scripts. This may be empty if no secret
+                                          object is specified. If the secret object
+                                          contains more than one secret, all secrets
+                                          are passed to the plugin scripts.'
                                         properties:
                                           name:
                                             description: 'Name of the referent. More
@@ -5935,53 +6850,55 @@ spec:
                                     - driver
                                     type: object
                                   flocker:
-                                    description: Flocker represents a Flocker volume
+                                    description: flocker represents a Flocker volume
                                       attached to a kubelet's host machine. This depends
                                       on the Flocker control service being running
                                     properties:
                                       datasetName:
-                                        description: Name of the dataset stored as
-                                          metadata -> name on the dataset for Flocker
-                                          should be considered as deprecated
+                                        description: datasetName is Name of the dataset
+                                          stored as metadata -> name on the dataset
+                                          for Flocker should be considered as deprecated
                                         type: string
                                       datasetUUID:
-                                        description: UUID of the dataset. This is
-                                          unique identifier of a Flocker dataset
+                                        description: datasetUUID is the UUID of the
+                                          dataset. This is unique identifier of a
+                                          Flocker dataset
                                         type: string
                                     type: object
                                   gcePersistentDisk:
-                                    description: 'GCEPersistentDisk represents a GCE
+                                    description: 'gcePersistentDisk represents a GCE
                                       Disk resource that is attached to a kubelet''s
                                       host machine and then exposed to the pod. More
                                       info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk'
                                     properties:
                                       fsType:
-                                        description: 'Filesystem type of the volume
-                                          that you want to mount. Tip: Ensure that
-                                          the filesystem type is supported by the
-                                          host operating system. Examples: "ext4",
-                                          "xfs", "ntfs". Implicitly inferred to be
-                                          "ext4" if unspecified. More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk
+                                        description: 'fsType is filesystem type of
+                                          the volume that you want to mount. Tip:
+                                          Ensure that the filesystem type is supported
+                                          by the host operating system. Examples:
+                                          "ext4", "xfs", "ntfs". Implicitly inferred
+                                          to be "ext4" if unspecified. More info:
+                                          https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk
                                           TODO: how do we prevent errors in the filesystem
                                           from compromising the machine'
                                         type: string
                                       partition:
-                                        description: 'The partition in the volume
-                                          that you want to mount. If omitted, the
-                                          default is to mount by volume name. Examples:
-                                          For volume /dev/sda1, you specify the partition
-                                          as "1". Similarly, the volume partition
-                                          for /dev/sda is "0" (or you can leave the
-                                          property empty). More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk'
+                                        description: 'partition is the partition in
+                                          the volume that you want to mount. If omitted,
+                                          the default is to mount by volume name.
+                                          Examples: For volume /dev/sda1, you specify
+                                          the partition as "1". Similarly, the volume
+                                          partition for /dev/sda is "0" (or you can
+                                          leave the property empty). More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk'
                                         format: int32
                                         type: integer
                                       pdName:
-                                        description: 'Unique name of the PD resource
-                                          in GCE. Used to identify the disk in GCE.
-                                          More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk'
+                                        description: 'pdName is unique name of the
+                                          PD resource in GCE. Used to identify the
+                                          disk in GCE. More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk'
                                         type: string
                                       readOnly:
-                                        description: 'ReadOnly here will force the
+                                        description: 'readOnly here will force the
                                           ReadOnly setting in VolumeMounts. Defaults
                                           to false. More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk'
                                         type: boolean
@@ -5989,7 +6906,7 @@ spec:
                                     - pdName
                                     type: object
                                   gitRepo:
-                                    description: 'GitRepo represents a git repository
+                                    description: 'gitRepo represents a git repository
                                       at a particular revision. DEPRECATED: GitRepo
                                       is deprecated. To provision a container with
                                       a git repo, mount an EmptyDir into an InitContainer
@@ -5997,39 +6914,39 @@ spec:
                                       EmptyDir into the Pod''s container.'
                                     properties:
                                       directory:
-                                        description: Target directory name. Must not
-                                          contain or start with '..'.  If '.' is supplied,
-                                          the volume directory will be the git repository.  Otherwise,
-                                          if specified, the volume will contain the
-                                          git repository in the subdirectory with
-                                          the given name.
+                                        description: directory is the target directory
+                                          name. Must not contain or start with '..'.  If
+                                          '.' is supplied, the volume directory will
+                                          be the git repository.  Otherwise, if specified,
+                                          the volume will contain the git repository
+                                          in the subdirectory with the given name.
                                         type: string
                                       repository:
-                                        description: Repository URL
+                                        description: repository is the URL
                                         type: string
                                       revision:
-                                        description: Commit hash for the specified
-                                          revision.
+                                        description: revision is the commit hash for
+                                          the specified revision.
                                         type: string
                                     required:
                                     - repository
                                     type: object
                                   glusterfs:
-                                    description: 'Glusterfs represents a Glusterfs
+                                    description: 'glusterfs represents a Glusterfs
                                       mount on the host that shares a pod''s lifetime.
                                       More info: https://examples.k8s.io/volumes/glusterfs/README.md'
                                     properties:
                                       endpoints:
-                                        description: 'EndpointsName is the endpoint
-                                          name that details Glusterfs topology. More
-                                          info: https://examples.k8s.io/volumes/glusterfs/README.md#create-a-pod'
+                                        description: 'endpoints is the endpoint name
+                                          that details Glusterfs topology. More info:
+                                          https://examples.k8s.io/volumes/glusterfs/README.md#create-a-pod'
                                         type: string
                                       path:
-                                        description: 'Path is the Glusterfs volume
+                                        description: 'path is the Glusterfs volume
                                           path. More info: https://examples.k8s.io/volumes/glusterfs/README.md#create-a-pod'
                                         type: string
                                       readOnly:
-                                        description: 'ReadOnly here will force the
+                                        description: 'readOnly here will force the
                                           Glusterfs volume to be mounted with read-only
                                           permissions. Defaults to false. More info:
                                           https://examples.k8s.io/volumes/glusterfs/README.md#create-a-pod'
@@ -6039,7 +6956,7 @@ spec:
                                     - path
                                     type: object
                                   hostPath:
-                                    description: 'HostPath represents a pre-existing
+                                    description: 'hostPath represents a pre-existing
                                       file or directory on the host machine that is
                                       directly exposed to the container. This is generally
                                       used for system agents or other privileged things
@@ -6050,76 +6967,79 @@ spec:
                                       mount host directories as read/write.'
                                     properties:
                                       path:
-                                        description: 'Path of the directory on the
+                                        description: 'path of the directory on the
                                           host. If the path is a symlink, it will
                                           follow the link to the real path. More info:
                                           https://kubernetes.io/docs/concepts/storage/volumes#hostpath'
                                         type: string
                                       type:
-                                        description: 'Type for HostPath Volume Defaults
+                                        description: 'type for HostPath Volume Defaults
                                           to "" More info: https://kubernetes.io/docs/concepts/storage/volumes#hostpath'
                                         type: string
                                     required:
                                     - path
                                     type: object
                                   iscsi:
-                                    description: 'ISCSI represents an ISCSI Disk resource
+                                    description: 'iscsi represents an ISCSI Disk resource
                                       that is attached to a kubelet''s host machine
                                       and then exposed to the pod. More info: https://examples.k8s.io/volumes/iscsi/README.md'
                                     properties:
                                       chapAuthDiscovery:
-                                        description: whether support iSCSI Discovery
-                                          CHAP authentication
+                                        description: chapAuthDiscovery defines whether
+                                          support iSCSI Discovery CHAP authentication
                                         type: boolean
                                       chapAuthSession:
-                                        description: whether support iSCSI Session
-                                          CHAP authentication
+                                        description: chapAuthSession defines whether
+                                          support iSCSI Session CHAP authentication
                                         type: boolean
                                       fsType:
-                                        description: 'Filesystem type of the volume
-                                          that you want to mount. Tip: Ensure that
-                                          the filesystem type is supported by the
-                                          host operating system. Examples: "ext4",
-                                          "xfs", "ntfs". Implicitly inferred to be
-                                          "ext4" if unspecified. More info: https://kubernetes.io/docs/concepts/storage/volumes#iscsi
+                                        description: 'fsType is the filesystem type
+                                          of the volume that you want to mount. Tip:
+                                          Ensure that the filesystem type is supported
+                                          by the host operating system. Examples:
+                                          "ext4", "xfs", "ntfs". Implicitly inferred
+                                          to be "ext4" if unspecified. More info:
+                                          https://kubernetes.io/docs/concepts/storage/volumes#iscsi
                                           TODO: how do we prevent errors in the filesystem
                                           from compromising the machine'
                                         type: string
                                       initiatorName:
-                                        description: Custom iSCSI Initiator Name.
-                                          If initiatorName is specified with iscsiInterface
-                                          simultaneously, new iSCSI interface <target
-                                          portal>:<volume name> will be created for
-                                          the connection.
+                                        description: initiatorName is the custom iSCSI
+                                          Initiator Name. If initiatorName is specified
+                                          with iscsiInterface simultaneously, new
+                                          iSCSI interface <target portal>:<volume
+                                          name> will be created for the connection.
                                         type: string
                                       iqn:
-                                        description: Target iSCSI Qualified Name.
+                                        description: iqn is the target iSCSI Qualified
+                                          Name.
                                         type: string
                                       iscsiInterface:
-                                        description: iSCSI Interface Name that uses
-                                          an iSCSI transport. Defaults to 'default'
-                                          (tcp).
+                                        description: iscsiInterface is the interface
+                                          Name that uses an iSCSI transport. Defaults
+                                          to 'default' (tcp).
                                         type: string
                                       lun:
-                                        description: iSCSI Target Lun number.
+                                        description: lun represents iSCSI Target Lun
+                                          number.
                                         format: int32
                                         type: integer
                                       portals:
-                                        description: iSCSI Target Portal List. The
-                                          portal is either an IP or ip_addr:port if
-                                          the port is other than default (typically
+                                        description: portals is the iSCSI Target Portal
+                                          List. The portal is either an IP or ip_addr:port
+                                          if the port is other than default (typically
                                           TCP ports 860 and 3260).
                                         items:
                                           type: string
                                         type: array
                                       readOnly:
-                                        description: ReadOnly here will force the
+                                        description: readOnly here will force the
                                           ReadOnly setting in VolumeMounts. Defaults
                                           to false.
                                         type: boolean
                                       secretRef:
-                                        description: CHAP Secret for iSCSI target
-                                          and initiator authentication
+                                        description: secretRef is the CHAP Secret
+                                          for iSCSI target and initiator authentication
                                         properties:
                                           name:
                                             description: 'Name of the referent. More
@@ -6129,10 +7049,10 @@ spec:
                                             type: string
                                         type: object
                                       targetPortal:
-                                        description: iSCSI Target Portal. The Portal
-                                          is either an IP or ip_addr:port if the port
-                                          is other than default (typically TCP ports
-                                          860 and 3260).
+                                        description: targetPortal is iSCSI Target
+                                          Portal. The Portal is either an IP or ip_addr:port
+                                          if the port is other than default (typically
+                                          TCP ports 860 and 3260).
                                         type: string
                                     required:
                                     - iqn
@@ -6140,26 +7060,26 @@ spec:
                                     - targetPortal
                                     type: object
                                   name:
-                                    description: 'Volume''s name. Must be a DNS_LABEL
+                                    description: 'name of the volume. Must be a DNS_LABEL
                                       and unique within the pod. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
                                     type: string
                                   nfs:
-                                    description: 'NFS represents an NFS mount on the
+                                    description: 'nfs represents an NFS mount on the
                                       host that shares a pod''s lifetime More info:
                                       https://kubernetes.io/docs/concepts/storage/volumes#nfs'
                                     properties:
                                       path:
-                                        description: 'Path that is exported by the
+                                        description: 'path that is exported by the
                                           NFS server. More info: https://kubernetes.io/docs/concepts/storage/volumes#nfs'
                                         type: string
                                       readOnly:
-                                        description: 'ReadOnly here will force the
+                                        description: 'readOnly here will force the
                                           NFS export to be mounted with read-only
                                           permissions. Defaults to false. More info:
                                           https://kubernetes.io/docs/concepts/storage/volumes#nfs'
                                         type: boolean
                                       server:
-                                        description: 'Server is the hostname or IP
+                                        description: 'server is the hostname or IP
                                           address of the NFS server. More info: https://kubernetes.io/docs/concepts/storage/volumes#nfs'
                                         type: string
                                     required:
@@ -6167,99 +7087,101 @@ spec:
                                     - server
                                     type: object
                                   persistentVolumeClaim:
-                                    description: 'PersistentVolumeClaimVolumeSource
+                                    description: 'persistentVolumeClaimVolumeSource
                                       represents a reference to a PersistentVolumeClaim
                                       in the same namespace. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#persistentvolumeclaims'
                                     properties:
                                       claimName:
-                                        description: 'ClaimName is the name of a PersistentVolumeClaim
+                                        description: 'claimName is the name of a PersistentVolumeClaim
                                           in the same namespace as the pod using this
                                           volume. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#persistentvolumeclaims'
                                         type: string
                                       readOnly:
-                                        description: Will force the ReadOnly setting
-                                          in VolumeMounts. Default false.
+                                        description: readOnly Will force the ReadOnly
+                                          setting in VolumeMounts. Default false.
                                         type: boolean
                                     required:
                                     - claimName
                                     type: object
                                   photonPersistentDisk:
-                                    description: PhotonPersistentDisk represents a
+                                    description: photonPersistentDisk represents a
                                       PhotonController persistent disk attached and
                                       mounted on kubelets host machine
                                     properties:
                                       fsType:
-                                        description: Filesystem type to mount. Must
-                                          be a filesystem type supported by the host
-                                          operating system. Ex. "ext4", "xfs", "ntfs".
-                                          Implicitly inferred to be "ext4" if unspecified.
+                                        description: fsType is the filesystem type
+                                          to mount. Must be a filesystem type supported
+                                          by the host operating system. Ex. "ext4",
+                                          "xfs", "ntfs". Implicitly inferred to be
+                                          "ext4" if unspecified.
                                         type: string
                                       pdID:
-                                        description: ID that identifies Photon Controller
-                                          persistent disk
+                                        description: pdID is the ID that identifies
+                                          Photon Controller persistent disk
                                         type: string
                                     required:
                                     - pdID
                                     type: object
                                   portworxVolume:
-                                    description: PortworxVolume represents a portworx
+                                    description: portworxVolume represents a portworx
                                       volume attached and mounted on kubelets host
                                       machine
                                     properties:
                                       fsType:
-                                        description: FSType represents the filesystem
+                                        description: fSType represents the filesystem
                                           type to mount Must be a filesystem type
                                           supported by the host operating system.
                                           Ex. "ext4", "xfs". Implicitly inferred to
                                           be "ext4" if unspecified.
                                         type: string
                                       readOnly:
-                                        description: Defaults to false (read/write).
+                                        description: readOnly defaults to false (read/write).
                                           ReadOnly here will force the ReadOnly setting
                                           in VolumeMounts.
                                         type: boolean
                                       volumeID:
-                                        description: VolumeID uniquely identifies
+                                        description: volumeID uniquely identifies
                                           a Portworx volume
                                         type: string
                                     required:
                                     - volumeID
                                     type: object
                                   projected:
-                                    description: Items for all in one resources secrets,
-                                      configmaps, and downward API
+                                    description: projected items for all in one resources
+                                      secrets, configmaps, and downward API
                                     properties:
                                       defaultMode:
-                                        description: Mode bits used to set permissions
-                                          on created files by default. Must be an
-                                          octal value between 0000 and 0777 or a decimal
-                                          value between 0 and 511. YAML accepts both
-                                          octal and decimal values, JSON requires
-                                          decimal values for mode bits. Directories
-                                          within the path are not affected by this
-                                          setting. This might be in conflict with
-                                          other options that affect the file mode,
-                                          like fsGroup, and the result can be other
-                                          mode bits set.
+                                        description: defaultMode are the mode bits
+                                          used to set permissions on created files
+                                          by default. Must be an octal value between
+                                          0000 and 0777 or a decimal value between
+                                          0 and 511. YAML accepts both octal and decimal
+                                          values, JSON requires decimal values for
+                                          mode bits. Directories within the path are
+                                          not affected by this setting. This might
+                                          be in conflict with other options that affect
+                                          the file mode, like fsGroup, and the result
+                                          can be other mode bits set.
                                         format: int32
                                         type: integer
                                       sources:
-                                        description: list of volume projections
+                                        description: sources is the list of volume
+                                          projections
                                         items:
                                           description: Projection that may be projected
                                             along with other supported volume types
                                           properties:
                                             configMap:
-                                              description: information about the configMap
-                                                data to project
+                                              description: configMap information about
+                                                the configMap data to project
                                               properties:
                                                 items:
-                                                  description: If unspecified, each
-                                                    key-value pair in the Data field
-                                                    of the referenced ConfigMap will
-                                                    be projected into the volume as
-                                                    a file whose name is the key and
-                                                    content is the value. If specified,
+                                                  description: items if unspecified,
+                                                    each key-value pair in the Data
+                                                    field of the referenced ConfigMap
+                                                    will be projected into the volume
+                                                    as a file whose name is the key
+                                                    and content is the value. If specified,
                                                     the listed keys will be projected
                                                     into the specified paths, and
                                                     unlisted keys will not be present.
@@ -6274,11 +7196,12 @@ spec:
                                                       to a path within a volume.
                                                     properties:
                                                       key:
-                                                        description: The key to project.
+                                                        description: key is the key
+                                                          to project.
                                                         type: string
                                                       mode:
-                                                        description: 'Optional: mode
-                                                          bits used to set permissions
+                                                        description: 'mode is Optional:
+                                                          mode bits used to set permissions
                                                           on this file. Must be an
                                                           octal value between 0000
                                                           and 0777 or a decimal value
@@ -6296,7 +7219,7 @@ spec:
                                                         format: int32
                                                         type: integer
                                                       path:
-                                                        description: The relative
+                                                        description: path is the relative
                                                           path of the file to map
                                                           the key to. May not be an
                                                           absolute path. May not contain
@@ -6316,14 +7239,14 @@ spec:
                                                     apiVersion, kind, uid?'
                                                   type: string
                                                 optional:
-                                                  description: Specify whether the
-                                                    ConfigMap or its keys must be
-                                                    defined
+                                                  description: optional specify whether
+                                                    the ConfigMap or its keys must
+                                                    be defined
                                                   type: boolean
                                               type: object
                                             downwardAPI:
-                                              description: information about the downwardAPI
-                                                data to project
+                                              description: downwardAPI information
+                                                about the downwardAPI data to project
                                               properties:
                                                 items:
                                                   description: Items is a list of
@@ -6420,16 +7343,16 @@ spec:
                                                   type: array
                                               type: object
                                             secret:
-                                              description: information about the secret
-                                                data to project
+                                              description: secret information about
+                                                the secret data to project
                                               properties:
                                                 items:
-                                                  description: If unspecified, each
-                                                    key-value pair in the Data field
-                                                    of the referenced Secret will
-                                                    be projected into the volume as
-                                                    a file whose name is the key and
-                                                    content is the value. If specified,
+                                                  description: items if unspecified,
+                                                    each key-value pair in the Data
+                                                    field of the referenced Secret
+                                                    will be projected into the volume
+                                                    as a file whose name is the key
+                                                    and content is the value. If specified,
                                                     the listed keys will be projected
                                                     into the specified paths, and
                                                     unlisted keys will not be present.
@@ -6444,11 +7367,12 @@ spec:
                                                       to a path within a volume.
                                                     properties:
                                                       key:
-                                                        description: The key to project.
+                                                        description: key is the key
+                                                          to project.
                                                         type: string
                                                       mode:
-                                                        description: 'Optional: mode
-                                                          bits used to set permissions
+                                                        description: 'mode is Optional:
+                                                          mode bits used to set permissions
                                                           on this file. Must be an
                                                           octal value between 0000
                                                           and 0777 or a decimal value
@@ -6466,7 +7390,7 @@ spec:
                                                         format: int32
                                                         type: integer
                                                       path:
-                                                        description: The relative
+                                                        description: path is the relative
                                                           path of the file to map
                                                           the key to. May not be an
                                                           absolute path. May not contain
@@ -6486,16 +7410,18 @@ spec:
                                                     apiVersion, kind, uid?'
                                                   type: string
                                                 optional:
-                                                  description: Specify whether the
-                                                    Secret or its key must be defined
+                                                  description: optional field specify
+                                                    whether the Secret or its key
+                                                    must be defined
                                                   type: boolean
                                               type: object
                                             serviceAccountToken:
-                                              description: information about the serviceAccountToken
+                                              description: serviceAccountToken is
+                                                information about the serviceAccountToken
                                                 data to project
                                               properties:
                                                 audience:
-                                                  description: Audience is the intended
+                                                  description: audience is the intended
                                                     audience of the token. A recipient
                                                     of a token must identify itself
                                                     with an identifier specified in
@@ -6505,7 +7431,7 @@ spec:
                                                     of the apiserver.
                                                   type: string
                                                 expirationSeconds:
-                                                  description: ExpirationSeconds is
+                                                  description: expirationSeconds is
                                                     the requested duration of validity
                                                     of the service account token.
                                                     As the token approaches expiration,
@@ -6521,7 +7447,7 @@ spec:
                                                   format: int64
                                                   type: integer
                                                 path:
-                                                  description: Path is the path relative
+                                                  description: path is the path relative
                                                     to the mount point of the file
                                                     to project the token into.
                                                   type: string
@@ -6530,41 +7456,39 @@ spec:
                                               type: object
                                           type: object
                                         type: array
-                                    required:
-                                    - sources
                                     type: object
                                   quobyte:
-                                    description: Quobyte represents a Quobyte mount
+                                    description: quobyte represents a Quobyte mount
                                       on the host that shares a pod's lifetime
                                     properties:
                                       group:
-                                        description: Group to map volume access to
+                                        description: group to map volume access to
                                           Default is no group
                                         type: string
                                       readOnly:
-                                        description: ReadOnly here will force the
+                                        description: readOnly here will force the
                                           Quobyte volume to be mounted with read-only
                                           permissions. Defaults to false.
                                         type: boolean
                                       registry:
-                                        description: Registry represents a single
+                                        description: registry represents a single
                                           or multiple Quobyte Registry services specified
                                           as a string as host:port pair (multiple
                                           entries are separated with commas) which
                                           acts as the central registry for volumes
                                         type: string
                                       tenant:
-                                        description: Tenant owning the given Quobyte
+                                        description: tenant owning the given Quobyte
                                           volume in the Backend Used with dynamically
                                           provisioned Quobyte volumes, value is set
                                           by the plugin
                                         type: string
                                       user:
-                                        description: User to map volume access to
+                                        description: user to map volume access to
                                           Defaults to serivceaccount user
                                         type: string
                                       volume:
-                                        description: Volume is a string that references
+                                        description: volume is a string that references
                                           an already created Quobyte volume by name.
                                         type: string
                                     required:
@@ -6572,46 +7496,47 @@ spec:
                                     - volume
                                     type: object
                                   rbd:
-                                    description: 'RBD represents a Rados Block Device
+                                    description: 'rbd represents a Rados Block Device
                                       mount on the host that shares a pod''s lifetime.
                                       More info: https://examples.k8s.io/volumes/rbd/README.md'
                                     properties:
                                       fsType:
-                                        description: 'Filesystem type of the volume
-                                          that you want to mount. Tip: Ensure that
-                                          the filesystem type is supported by the
-                                          host operating system. Examples: "ext4",
-                                          "xfs", "ntfs". Implicitly inferred to be
-                                          "ext4" if unspecified. More info: https://kubernetes.io/docs/concepts/storage/volumes#rbd
+                                        description: 'fsType is the filesystem type
+                                          of the volume that you want to mount. Tip:
+                                          Ensure that the filesystem type is supported
+                                          by the host operating system. Examples:
+                                          "ext4", "xfs", "ntfs". Implicitly inferred
+                                          to be "ext4" if unspecified. More info:
+                                          https://kubernetes.io/docs/concepts/storage/volumes#rbd
                                           TODO: how do we prevent errors in the filesystem
                                           from compromising the machine'
                                         type: string
                                       image:
-                                        description: 'The rados image name. More info:
-                                          https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
+                                        description: 'image is the rados image name.
+                                          More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
                                         type: string
                                       keyring:
-                                        description: 'Keyring is the path to key ring
+                                        description: 'keyring is the path to key ring
                                           for RBDUser. Default is /etc/ceph/keyring.
                                           More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
                                         type: string
                                       monitors:
-                                        description: 'A collection of Ceph monitors.
-                                          More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
+                                        description: 'monitors is a collection of
+                                          Ceph monitors. More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
                                         items:
                                           type: string
                                         type: array
                                       pool:
-                                        description: 'The rados pool name. Default
-                                          is rbd. More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
+                                        description: 'pool is the rados pool name.
+                                          Default is rbd. More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
                                         type: string
                                       readOnly:
-                                        description: 'ReadOnly here will force the
+                                        description: 'readOnly here will force the
                                           ReadOnly setting in VolumeMounts. Defaults
                                           to false. More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
                                         type: boolean
                                       secretRef:
-                                        description: 'SecretRef is name of the authentication
+                                        description: 'secretRef is name of the authentication
                                           secret for RBDUser. If provided overrides
                                           keyring. Default is nil. More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
                                         properties:
@@ -6623,38 +7548,39 @@ spec:
                                             type: string
                                         type: object
                                       user:
-                                        description: 'The rados user name. Default
-                                          is admin. More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
+                                        description: 'user is the rados user name.
+                                          Default is admin. More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
                                         type: string
                                     required:
                                     - image
                                     - monitors
                                     type: object
                                   scaleIO:
-                                    description: ScaleIO represents a ScaleIO persistent
+                                    description: scaleIO represents a ScaleIO persistent
                                       volume attached and mounted on Kubernetes nodes.
                                     properties:
                                       fsType:
-                                        description: Filesystem type to mount. Must
-                                          be a filesystem type supported by the host
-                                          operating system. Ex. "ext4", "xfs", "ntfs".
-                                          Default is "xfs".
+                                        description: fsType is the filesystem type
+                                          to mount. Must be a filesystem type supported
+                                          by the host operating system. Ex. "ext4",
+                                          "xfs", "ntfs". Default is "xfs".
                                         type: string
                                       gateway:
-                                        description: The host address of the ScaleIO
-                                          API Gateway.
+                                        description: gateway is the host address of
+                                          the ScaleIO API Gateway.
                                         type: string
                                       protectionDomain:
-                                        description: The name of the ScaleIO Protection
-                                          Domain for the configured storage.
+                                        description: protectionDomain is the name
+                                          of the ScaleIO Protection Domain for the
+                                          configured storage.
                                         type: string
                                       readOnly:
-                                        description: Defaults to false (read/write).
+                                        description: readOnly Defaults to false (read/write).
                                           ReadOnly here will force the ReadOnly setting
                                           in VolumeMounts.
                                         type: boolean
                                       secretRef:
-                                        description: SecretRef references to the secret
+                                        description: secretRef references to the secret
                                           for ScaleIO user and other sensitive information.
                                           If this is not provided, Login operation
                                           will fail.
@@ -6667,26 +7593,27 @@ spec:
                                             type: string
                                         type: object
                                       sslEnabled:
-                                        description: Flag to enable/disable SSL communication
-                                          with Gateway, default false
+                                        description: sslEnabled Flag enable/disable
+                                          SSL communication with Gateway, default
+                                          false
                                         type: boolean
                                       storageMode:
-                                        description: Indicates whether the storage
-                                          for a volume should be ThickProvisioned
+                                        description: storageMode indicates whether
+                                          the storage for a volume should be ThickProvisioned
                                           or ThinProvisioned. Default is ThinProvisioned.
                                         type: string
                                       storagePool:
-                                        description: The ScaleIO Storage Pool associated
-                                          with the protection domain.
+                                        description: storagePool is the ScaleIO Storage
+                                          Pool associated with the protection domain.
                                         type: string
                                       system:
-                                        description: The name of the storage system
-                                          as configured in ScaleIO.
+                                        description: system is the name of the storage
+                                          system as configured in ScaleIO.
                                         type: string
                                       volumeName:
-                                        description: The name of a volume already
-                                          created in the ScaleIO system that is associated
-                                          with this volume source.
+                                        description: volumeName is the name of a volume
+                                          already created in the ScaleIO system that
+                                          is associated with this volume source.
                                         type: string
                                     required:
                                     - gateway
@@ -6694,25 +7621,26 @@ spec:
                                     - system
                                     type: object
                                   secret:
-                                    description: 'Secret represents a secret that
+                                    description: 'secret represents a secret that
                                       should populate this volume. More info: https://kubernetes.io/docs/concepts/storage/volumes#secret'
                                     properties:
                                       defaultMode:
-                                        description: 'Optional: mode bits used to
-                                          set permissions on created files by default.
-                                          Must be an octal value between 0000 and
-                                          0777 or a decimal value between 0 and 511.
-                                          YAML accepts both octal and decimal values,
-                                          JSON requires decimal values for mode bits.
-                                          Defaults to 0644. Directories within the
-                                          path are not affected by this setting. This
-                                          might be in conflict with other options
-                                          that affect the file mode, like fsGroup,
-                                          and the result can be other mode bits set.'
+                                        description: 'defaultMode is Optional: mode
+                                          bits used to set permissions on created
+                                          files by default. Must be an octal value
+                                          between 0000 and 0777 or a decimal value
+                                          between 0 and 511. YAML accepts both octal
+                                          and decimal values, JSON requires decimal
+                                          values for mode bits. Defaults to 0644.
+                                          Directories within the path are not affected
+                                          by this setting. This might be in conflict
+                                          with other options that affect the file
+                                          mode, like fsGroup, and the result can be
+                                          other mode bits set.'
                                         format: int32
                                         type: integer
                                       items:
-                                        description: If unspecified, each key-value
+                                        description: items If unspecified, each key-value
                                           pair in the Data field of the referenced
                                           Secret will be projected into the volume
                                           as a file whose name is the key and content
@@ -6729,27 +7657,27 @@ spec:
                                             within a volume.
                                           properties:
                                             key:
-                                              description: The key to project.
+                                              description: key is the key to project.
                                               type: string
                                             mode:
-                                              description: 'Optional: mode bits used
-                                                to set permissions on this file. Must
-                                                be an octal value between 0000 and
-                                                0777 or a decimal value between 0
-                                                and 511. YAML accepts both octal and
-                                                decimal values, JSON requires decimal
-                                                values for mode bits. If not specified,
-                                                the volume defaultMode will be used.
-                                                This might be in conflict with other
-                                                options that affect the file mode,
-                                                like fsGroup, and the result can be
-                                                other mode bits set.'
+                                              description: 'mode is Optional: mode
+                                                bits used to set permissions on this
+                                                file. Must be an octal value between
+                                                0000 and 0777 or a decimal value between
+                                                0 and 511. YAML accepts both octal
+                                                and decimal values, JSON requires
+                                                decimal values for mode bits. If not
+                                                specified, the volume defaultMode
+                                                will be used. This might be in conflict
+                                                with other options that affect the
+                                                file mode, like fsGroup, and the result
+                                                can be other mode bits set.'
                                               format: int32
                                               type: integer
                                             path:
-                                              description: The relative path of the
-                                                file to map the key to. May not be
-                                                an absolute path. May not contain
+                                              description: path is the relative path
+                                                of the file to map the key to. May
+                                                not be an absolute path. May not contain
                                                 the path element '..'. May not start
                                                 with the string '..'.
                                               type: string
@@ -6759,31 +7687,33 @@ spec:
                                           type: object
                                         type: array
                                       optional:
-                                        description: Specify whether the Secret or
-                                          its keys must be defined
+                                        description: optional field specify whether
+                                          the Secret or its keys must be defined
                                         type: boolean
                                       secretName:
-                                        description: 'Name of the secret in the pod''s
-                                          namespace to use. More info: https://kubernetes.io/docs/concepts/storage/volumes#secret'
+                                        description: 'secretName is the name of the
+                                          secret in the pod''s namespace to use. More
+                                          info: https://kubernetes.io/docs/concepts/storage/volumes#secret'
                                         type: string
                                     type: object
                                   storageos:
-                                    description: StorageOS represents a StorageOS
+                                    description: storageOS represents a StorageOS
                                       volume attached and mounted on Kubernetes nodes.
                                     properties:
                                       fsType:
-                                        description: Filesystem type to mount. Must
-                                          be a filesystem type supported by the host
-                                          operating system. Ex. "ext4", "xfs", "ntfs".
-                                          Implicitly inferred to be "ext4" if unspecified.
+                                        description: fsType is the filesystem type
+                                          to mount. Must be a filesystem type supported
+                                          by the host operating system. Ex. "ext4",
+                                          "xfs", "ntfs". Implicitly inferred to be
+                                          "ext4" if unspecified.
                                         type: string
                                       readOnly:
-                                        description: Defaults to false (read/write).
+                                        description: readOnly defaults to false (read/write).
                                           ReadOnly here will force the ReadOnly setting
                                           in VolumeMounts.
                                         type: boolean
                                       secretRef:
-                                        description: SecretRef specifies the secret
+                                        description: secretRef specifies the secret
                                           to use for obtaining the StorageOS API credentials.  If
                                           not specified, default values will be attempted.
                                         properties:
@@ -6795,12 +7725,12 @@ spec:
                                             type: string
                                         type: object
                                       volumeName:
-                                        description: VolumeName is the human-readable
+                                        description: volumeName is the human-readable
                                           name of the StorageOS volume.  Volume names
                                           are only unique within a namespace.
                                         type: string
                                       volumeNamespace:
-                                        description: VolumeNamespace specifies the
+                                        description: volumeNamespace specifies the
                                           scope of the volume within StorageOS.  If
                                           no namespace is specified then the Pod's
                                           namespace will be used.  This allows the
@@ -6813,27 +7743,29 @@ spec:
                                         type: string
                                     type: object
                                   vsphereVolume:
-                                    description: VsphereVolume represents a vSphere
+                                    description: vsphereVolume represents a vSphere
                                       volume attached and mounted on kubelets host
                                       machine
                                     properties:
                                       fsType:
-                                        description: Filesystem type to mount. Must
-                                          be a filesystem type supported by the host
-                                          operating system. Ex. "ext4", "xfs", "ntfs".
-                                          Implicitly inferred to be "ext4" if unspecified.
+                                        description: fsType is filesystem type to
+                                          mount. Must be a filesystem type supported
+                                          by the host operating system. Ex. "ext4",
+                                          "xfs", "ntfs". Implicitly inferred to be
+                                          "ext4" if unspecified.
                                         type: string
                                       storagePolicyID:
-                                        description: Storage Policy Based Management
-                                          (SPBM) profile ID associated with the StoragePolicyName.
+                                        description: storagePolicyID is the storage
+                                          Policy Based Management (SPBM) profile ID
+                                          associated with the StoragePolicyName.
                                         type: string
                                       storagePolicyName:
-                                        description: Storage Policy Based Management
-                                          (SPBM) profile name.
+                                        description: storagePolicyName is the storage
+                                          Policy Based Management (SPBM) profile name.
                                         type: string
                                       volumePath:
-                                        description: Path that identifies vSphere
-                                          volume vmdk
+                                        description: volumePath is the path that identifies
+                                          vSphere volume vmdk
                                         type: string
                                     required:
                                     - volumePath

--- a/apps/training-operator/upstream/base/crds/kubeflow.org_xgboostjobs.yaml
+++ b/apps/training-operator/upstream/base/crds/kubeflow.org_xgboostjobs.yaml
@@ -466,12 +466,85 @@ spec:
                                                       are ANDed.
                                                     type: object
                                                 type: object
+                                              namespaceSelector:
+                                                description: A label query over the
+                                                  set of namespaces that the term
+                                                  applies to. The term is applied
+                                                  to the union of the namespaces selected
+                                                  by this field and the ones listed
+                                                  in the namespaces field. null selector
+                                                  and null or empty namespaces list
+                                                  means "this pod's namespace". An
+                                                  empty selector ({}) matches all
+                                                  namespaces.
+                                                properties:
+                                                  matchExpressions:
+                                                    description: matchExpressions
+                                                      is a list of label selector
+                                                      requirements. The requirements
+                                                      are ANDed.
+                                                    items:
+                                                      description: A label selector
+                                                        requirement is a selector
+                                                        that contains values, a key,
+                                                        and an operator that relates
+                                                        the key and values.
+                                                      properties:
+                                                        key:
+                                                          description: key is the
+                                                            label key that the selector
+                                                            applies to.
+                                                          type: string
+                                                        operator:
+                                                          description: operator represents
+                                                            a key's relationship to
+                                                            a set of values. Valid
+                                                            operators are In, NotIn,
+                                                            Exists and DoesNotExist.
+                                                          type: string
+                                                        values:
+                                                          description: values is an
+                                                            array of string values.
+                                                            If the operator is In
+                                                            or NotIn, the values array
+                                                            must be non-empty. If
+                                                            the operator is Exists
+                                                            or DoesNotExist, the values
+                                                            array must be empty. This
+                                                            array is replaced during
+                                                            a strategic merge patch.
+                                                          items:
+                                                            type: string
+                                                          type: array
+                                                      required:
+                                                      - key
+                                                      - operator
+                                                      type: object
+                                                    type: array
+                                                  matchLabels:
+                                                    additionalProperties:
+                                                      type: string
+                                                    description: matchLabels is a
+                                                      map of {key,value} pairs. A
+                                                      single {key,value} in the matchLabels
+                                                      map is equivalent to an element
+                                                      of matchExpressions, whose key
+                                                      field is "key", the operator
+                                                      is "In", and the values array
+                                                      contains only "value". The requirements
+                                                      are ANDed.
+                                                    type: object
+                                                type: object
                                               namespaces:
                                                 description: namespaces specifies
-                                                  which namespaces the labelSelector
-                                                  applies to (matches against); null
-                                                  or empty list means "this pod's
-                                                  namespace"
+                                                  a static list of namespace names
+                                                  that the term applies to. The term
+                                                  is applied to the union of the namespaces
+                                                  listed in this field and the ones
+                                                  selected by namespaceSelector. null
+                                                  or empty namespaces list and null
+                                                  namespaceSelector means "this pod's
+                                                  namespace".
                                                 items:
                                                   type: string
                                                 type: array
@@ -581,11 +654,78 @@ spec:
                                                   ANDed.
                                                 type: object
                                             type: object
+                                          namespaceSelector:
+                                            description: A label query over the set
+                                              of namespaces that the term applies
+                                              to. The term is applied to the union
+                                              of the namespaces selected by this field
+                                              and the ones listed in the namespaces
+                                              field. null selector and null or empty
+                                              namespaces list means "this pod's namespace".
+                                              An empty selector ({}) matches all namespaces.
+                                            properties:
+                                              matchExpressions:
+                                                description: matchExpressions is a
+                                                  list of label selector requirements.
+                                                  The requirements are ANDed.
+                                                items:
+                                                  description: A label selector requirement
+                                                    is a selector that contains values,
+                                                    a key, and an operator that relates
+                                                    the key and values.
+                                                  properties:
+                                                    key:
+                                                      description: key is the label
+                                                        key that the selector applies
+                                                        to.
+                                                      type: string
+                                                    operator:
+                                                      description: operator represents
+                                                        a key's relationship to a
+                                                        set of values. Valid operators
+                                                        are In, NotIn, Exists and
+                                                        DoesNotExist.
+                                                      type: string
+                                                    values:
+                                                      description: values is an array
+                                                        of string values. If the operator
+                                                        is In or NotIn, the values
+                                                        array must be non-empty. If
+                                                        the operator is Exists or
+                                                        DoesNotExist, the values array
+                                                        must be empty. This array
+                                                        is replaced during a strategic
+                                                        merge patch.
+                                                      items:
+                                                        type: string
+                                                      type: array
+                                                  required:
+                                                  - key
+                                                  - operator
+                                                  type: object
+                                                type: array
+                                              matchLabels:
+                                                additionalProperties:
+                                                  type: string
+                                                description: matchLabels is a map
+                                                  of {key,value} pairs. A single {key,value}
+                                                  in the matchLabels map is equivalent
+                                                  to an element of matchExpressions,
+                                                  whose key field is "key", the operator
+                                                  is "In", and the values array contains
+                                                  only "value". The requirements are
+                                                  ANDed.
+                                                type: object
+                                            type: object
                                           namespaces:
-                                            description: namespaces specifies which
-                                              namespaces the labelSelector applies
-                                              to (matches against); null or empty
-                                              list means "this pod's namespace"
+                                            description: namespaces specifies a static
+                                              list of namespace names that the term
+                                              applies to. The term is applied to the
+                                              union of the namespaces listed in this
+                                              field and the ones selected by namespaceSelector.
+                                              null or empty namespaces list and null
+                                              namespaceSelector means "this pod's
+                                              namespace".
                                             items:
                                               type: string
                                             type: array
@@ -697,12 +837,85 @@ spec:
                                                       are ANDed.
                                                     type: object
                                                 type: object
+                                              namespaceSelector:
+                                                description: A label query over the
+                                                  set of namespaces that the term
+                                                  applies to. The term is applied
+                                                  to the union of the namespaces selected
+                                                  by this field and the ones listed
+                                                  in the namespaces field. null selector
+                                                  and null or empty namespaces list
+                                                  means "this pod's namespace". An
+                                                  empty selector ({}) matches all
+                                                  namespaces.
+                                                properties:
+                                                  matchExpressions:
+                                                    description: matchExpressions
+                                                      is a list of label selector
+                                                      requirements. The requirements
+                                                      are ANDed.
+                                                    items:
+                                                      description: A label selector
+                                                        requirement is a selector
+                                                        that contains values, a key,
+                                                        and an operator that relates
+                                                        the key and values.
+                                                      properties:
+                                                        key:
+                                                          description: key is the
+                                                            label key that the selector
+                                                            applies to.
+                                                          type: string
+                                                        operator:
+                                                          description: operator represents
+                                                            a key's relationship to
+                                                            a set of values. Valid
+                                                            operators are In, NotIn,
+                                                            Exists and DoesNotExist.
+                                                          type: string
+                                                        values:
+                                                          description: values is an
+                                                            array of string values.
+                                                            If the operator is In
+                                                            or NotIn, the values array
+                                                            must be non-empty. If
+                                                            the operator is Exists
+                                                            or DoesNotExist, the values
+                                                            array must be empty. This
+                                                            array is replaced during
+                                                            a strategic merge patch.
+                                                          items:
+                                                            type: string
+                                                          type: array
+                                                      required:
+                                                      - key
+                                                      - operator
+                                                      type: object
+                                                    type: array
+                                                  matchLabels:
+                                                    additionalProperties:
+                                                      type: string
+                                                    description: matchLabels is a
+                                                      map of {key,value} pairs. A
+                                                      single {key,value} in the matchLabels
+                                                      map is equivalent to an element
+                                                      of matchExpressions, whose key
+                                                      field is "key", the operator
+                                                      is "In", and the values array
+                                                      contains only "value". The requirements
+                                                      are ANDed.
+                                                    type: object
+                                                type: object
                                               namespaces:
                                                 description: namespaces specifies
-                                                  which namespaces the labelSelector
-                                                  applies to (matches against); null
-                                                  or empty list means "this pod's
-                                                  namespace"
+                                                  a static list of namespace names
+                                                  that the term applies to. The term
+                                                  is applied to the union of the namespaces
+                                                  listed in this field and the ones
+                                                  selected by namespaceSelector. null
+                                                  or empty namespaces list and null
+                                                  namespaceSelector means "this pod's
+                                                  namespace".
                                                 items:
                                                   type: string
                                                 type: array
@@ -812,11 +1025,78 @@ spec:
                                                   ANDed.
                                                 type: object
                                             type: object
+                                          namespaceSelector:
+                                            description: A label query over the set
+                                              of namespaces that the term applies
+                                              to. The term is applied to the union
+                                              of the namespaces selected by this field
+                                              and the ones listed in the namespaces
+                                              field. null selector and null or empty
+                                              namespaces list means "this pod's namespace".
+                                              An empty selector ({}) matches all namespaces.
+                                            properties:
+                                              matchExpressions:
+                                                description: matchExpressions is a
+                                                  list of label selector requirements.
+                                                  The requirements are ANDed.
+                                                items:
+                                                  description: A label selector requirement
+                                                    is a selector that contains values,
+                                                    a key, and an operator that relates
+                                                    the key and values.
+                                                  properties:
+                                                    key:
+                                                      description: key is the label
+                                                        key that the selector applies
+                                                        to.
+                                                      type: string
+                                                    operator:
+                                                      description: operator represents
+                                                        a key's relationship to a
+                                                        set of values. Valid operators
+                                                        are In, NotIn, Exists and
+                                                        DoesNotExist.
+                                                      type: string
+                                                    values:
+                                                      description: values is an array
+                                                        of string values. If the operator
+                                                        is In or NotIn, the values
+                                                        array must be non-empty. If
+                                                        the operator is Exists or
+                                                        DoesNotExist, the values array
+                                                        must be empty. This array
+                                                        is replaced during a strategic
+                                                        merge patch.
+                                                      items:
+                                                        type: string
+                                                      type: array
+                                                  required:
+                                                  - key
+                                                  - operator
+                                                  type: object
+                                                type: array
+                                              matchLabels:
+                                                additionalProperties:
+                                                  type: string
+                                                description: matchLabels is a map
+                                                  of {key,value} pairs. A single {key,value}
+                                                  in the matchLabels map is equivalent
+                                                  to an element of matchExpressions,
+                                                  whose key field is "key", the operator
+                                                  is "In", and the values array contains
+                                                  only "value". The requirements are
+                                                  ANDed.
+                                                type: object
+                                            type: object
                                           namespaces:
-                                            description: namespaces specifies which
-                                              namespaces the labelSelector applies
-                                              to (matches against); null or empty
-                                              list means "this pod's namespace"
+                                            description: namespaces specifies a static
+                                              list of namespace names that the term
+                                              applies to. The term is applied to the
+                                              union of the namespaces listed in this
+                                              field and the ones selected by namespaceSelector.
+                                              null or empty namespaces list and null
+                                              namespaceSelector means "this pod's
+                                              namespace".
                                             items:
                                               type: string
                                             type: array
@@ -853,12 +1133,14 @@ spec:
                                 properties:
                                   args:
                                     description: 'Arguments to the entrypoint. The
-                                      docker image''s CMD is used if this is not provided.
-                                      Variable references $(VAR_NAME) are expanded
-                                      using the container''s environment. If a variable
-                                      cannot be resolved, the reference in the input
-                                      string will be unchanged. The $(VAR_NAME) syntax
-                                      can be escaped with a double $$, ie: $$(VAR_NAME).
+                                      container image''s CMD is used if this is not
+                                      provided. Variable references $(VAR_NAME) are
+                                      expanded using the container''s environment.
+                                      If a variable cannot be resolved, the reference
+                                      in the input string will be unchanged. Double
+                                      $$ are reduced to a single $, which allows for
+                                      escaping the $(VAR_NAME) syntax: i.e. "$$(VAR_NAME)"
+                                      will produce the string literal "$(VAR_NAME)".
                                       Escaped references will never be expanded, regardless
                                       of whether the variable exists or not. Cannot
                                       be updated. More info: https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell'
@@ -867,16 +1149,17 @@ spec:
                                     type: array
                                   command:
                                     description: 'Entrypoint array. Not executed within
-                                      a shell. The docker image''s ENTRYPOINT is used
-                                      if this is not provided. Variable references
+                                      a shell. The container image''s ENTRYPOINT is
+                                      used if this is not provided. Variable references
                                       $(VAR_NAME) are expanded using the container''s
                                       environment. If a variable cannot be resolved,
                                       the reference in the input string will be unchanged.
-                                      The $(VAR_NAME) syntax can be escaped with a
-                                      double $$, ie: $$(VAR_NAME). Escaped references
-                                      will never be expanded, regardless of whether
-                                      the variable exists or not. Cannot be updated.
-                                      More info: https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell'
+                                      Double $$ are reduced to a single $, which allows
+                                      for escaping the $(VAR_NAME) syntax: i.e. "$$(VAR_NAME)"
+                                      will produce the string literal "$(VAR_NAME)".
+                                      Escaped references will never be expanded, regardless
+                                      of whether the variable exists or not. Cannot
+                                      be updated. More info: https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell'
                                     items:
                                       type: string
                                     type: array
@@ -893,13 +1176,15 @@ spec:
                                           type: string
                                         value:
                                           description: 'Variable references $(VAR_NAME)
-                                            are expanded using the previous defined
+                                            are expanded using the previously defined
                                             environment variables in the container
                                             and any service environment variables.
                                             If a variable cannot be resolved, the
                                             reference in the input string will be
-                                            unchanged. The $(VAR_NAME) syntax can
-                                            be escaped with a double $$, ie: $$(VAR_NAME).
+                                            unchanged. Double $$ are reduced to a
+                                            single $, which allows for escaping the
+                                            $(VAR_NAME) syntax: i.e. "$$(VAR_NAME)"
+                                            will produce the string literal "$(VAR_NAME)".
                                             Escaped references will never be expanded,
                                             regardless of whether the variable exists
                                             or not. Defaults to "".'
@@ -1053,7 +1338,8 @@ spec:
                                       type: object
                                     type: array
                                   image:
-                                    description: 'Docker image name. More info: https://kubernetes.io/docs/concepts/containers/images
+                                    description: 'Container image name. More info:
+                                      https://kubernetes.io/docs/concepts/containers/images
                                       This field is optional to allow higher level
                                       config management to default or override container
                                       images in workload controllers like Deployments
@@ -1079,9 +1365,8 @@ spec:
                                           More info: https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/#container-hooks'
                                         properties:
                                           exec:
-                                            description: One and only one of the following
-                                              should be specified. Exec specifies
-                                              the action to take.
+                                            description: Exec specifies the action
+                                              to take.
                                             properties:
                                               command:
                                                 description: Command is the command
@@ -1152,10 +1437,12 @@ spec:
                                             - port
                                             type: object
                                           tcpSocket:
-                                            description: 'TCPSocket specifies an action
-                                              involving a TCP port. TCP hooks not
-                                              yet supported TODO: implement a realistic
-                                              TCP lifecycle hook'
+                                            description: Deprecated. TCPSocket is
+                                              NOT supported as a LifecycleHandler
+                                              and kept for the backward compatibility.
+                                              There are no validation of this field
+                                              and lifecycle hooks will fail in runtime
+                                              when tcp handler is specified.
                                             properties:
                                               host:
                                                 description: 'Optional: Host name
@@ -1182,21 +1469,19 @@ spec:
                                           as liveness/startup probe failure, preemption,
                                           resource contention, etc. The handler is
                                           not called if the container crashes or exits.
-                                          The reason for termination is passed to
-                                          the handler. The Pod''s termination grace
-                                          period countdown begins before the PreStop
-                                          hooked is executed. Regardless of the outcome
-                                          of the handler, the container will eventually
-                                          terminate within the Pod''s termination
-                                          grace period. Other management of the container
-                                          blocks until the hook completes or until
-                                          the termination grace period is reached.
-                                          More info: https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/#container-hooks'
+                                          The Pod''s termination grace period countdown
+                                          begins before the PreStop hook is executed.
+                                          Regardless of the outcome of the handler,
+                                          the container will eventually terminate
+                                          within the Pod''s termination grace period
+                                          (unless delayed by finalizers). Other management
+                                          of the container blocks until the hook completes
+                                          or until the termination grace period is
+                                          reached. More info: https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/#container-hooks'
                                         properties:
                                           exec:
-                                            description: One and only one of the following
-                                              should be specified. Exec specifies
-                                              the action to take.
+                                            description: Exec specifies the action
+                                              to take.
                                             properties:
                                               command:
                                                 description: Command is the command
@@ -1267,10 +1552,12 @@ spec:
                                             - port
                                             type: object
                                           tcpSocket:
-                                            description: 'TCPSocket specifies an action
-                                              involving a TCP port. TCP hooks not
-                                              yet supported TODO: implement a realistic
-                                              TCP lifecycle hook'
+                                            description: Deprecated. TCPSocket is
+                                              NOT supported as a LifecycleHandler
+                                              and kept for the backward compatibility.
+                                              There are no validation of this field
+                                              and lifecycle hooks will fail in runtime
+                                              when tcp handler is specified.
                                             properties:
                                               host:
                                                 description: 'Optional: Host name
@@ -1297,9 +1584,8 @@ spec:
                                       Cannot be updated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
                                     properties:
                                       exec:
-                                        description: One and only one of the following
-                                          should be specified. Exec specifies the
-                                          action to take.
+                                        description: Exec specifies the action to
+                                          take.
                                         properties:
                                           command:
                                             description: Command is the command line
@@ -1324,6 +1610,26 @@ spec:
                                           value is 1.
                                         format: int32
                                         type: integer
+                                      grpc:
+                                        description: GRPC specifies an action involving
+                                          a GRPC port. This is a beta field and requires
+                                          enabling GRPCContainerProbe feature gate.
+                                        properties:
+                                          port:
+                                            description: Port number of the gRPC service.
+                                              Number must be in the range 1 to 65535.
+                                            format: int32
+                                            type: integer
+                                          service:
+                                            description: "Service is the name of the
+                                              service to place in the gRPC HealthCheckRequest
+                                              (see https://github.com/grpc/grpc/blob/master/doc/health-checking.md).
+                                              \n If this is not specified, the default
+                                              behavior is defined by gRPC."
+                                            type: string
+                                        required:
+                                        - port
+                                        type: object
                                       httpGet:
                                         description: HTTPGet specifies the http request
                                           to perform.
@@ -1392,10 +1698,8 @@ spec:
                                         format: int32
                                         type: integer
                                       tcpSocket:
-                                        description: 'TCPSocket specifies an action
-                                          involving a TCP port. TCP hooks not yet
-                                          supported TODO: implement a realistic TCP
-                                          lifecycle hook'
+                                        description: TCPSocket specifies an action
+                                          involving a TCP port.
                                         properties:
                                           host:
                                             description: 'Optional: Host name to connect
@@ -1413,6 +1717,28 @@ spec:
                                         required:
                                         - port
                                         type: object
+                                      terminationGracePeriodSeconds:
+                                        description: Optional duration in seconds
+                                          the pod needs to terminate gracefully upon
+                                          probe failure. The grace period is the duration
+                                          in seconds after the processes running in
+                                          the pod are sent a termination signal and
+                                          the time when the processes are forcibly
+                                          halted with a kill signal. Set this value
+                                          longer than the expected cleanup time for
+                                          your process. If this value is nil, the
+                                          pod's terminationGracePeriodSeconds will
+                                          be used. Otherwise, this value overrides
+                                          the value provided by the pod spec. Value
+                                          must be non-negative integer. The value
+                                          zero indicates stop immediately via the
+                                          kill signal (no opportunity to shut down).
+                                          This is a beta field and requires enabling
+                                          ProbeTerminationGracePeriod feature gate.
+                                          Minimum value is 1. spec.terminationGracePeriodSeconds
+                                          is used if unset.
+                                        format: int64
+                                        type: integer
                                       timeoutSeconds:
                                         description: 'Number of seconds after which
                                           the probe times out. Defaults to 1 second.
@@ -1484,9 +1810,8 @@ spec:
                                       More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
                                     properties:
                                       exec:
-                                        description: One and only one of the following
-                                          should be specified. Exec specifies the
-                                          action to take.
+                                        description: Exec specifies the action to
+                                          take.
                                         properties:
                                           command:
                                             description: Command is the command line
@@ -1511,6 +1836,26 @@ spec:
                                           value is 1.
                                         format: int32
                                         type: integer
+                                      grpc:
+                                        description: GRPC specifies an action involving
+                                          a GRPC port. This is a beta field and requires
+                                          enabling GRPCContainerProbe feature gate.
+                                        properties:
+                                          port:
+                                            description: Port number of the gRPC service.
+                                              Number must be in the range 1 to 65535.
+                                            format: int32
+                                            type: integer
+                                          service:
+                                            description: "Service is the name of the
+                                              service to place in the gRPC HealthCheckRequest
+                                              (see https://github.com/grpc/grpc/blob/master/doc/health-checking.md).
+                                              \n If this is not specified, the default
+                                              behavior is defined by gRPC."
+                                            type: string
+                                        required:
+                                        - port
+                                        type: object
                                       httpGet:
                                         description: HTTPGet specifies the http request
                                           to perform.
@@ -1579,10 +1924,8 @@ spec:
                                         format: int32
                                         type: integer
                                       tcpSocket:
-                                        description: 'TCPSocket specifies an action
-                                          involving a TCP port. TCP hooks not yet
-                                          supported TODO: implement a realistic TCP
-                                          lifecycle hook'
+                                        description: TCPSocket specifies an action
+                                          involving a TCP port.
                                         properties:
                                           host:
                                             description: 'Optional: Host name to connect
@@ -1600,6 +1943,28 @@ spec:
                                         required:
                                         - port
                                         type: object
+                                      terminationGracePeriodSeconds:
+                                        description: Optional duration in seconds
+                                          the pod needs to terminate gracefully upon
+                                          probe failure. The grace period is the duration
+                                          in seconds after the processes running in
+                                          the pod are sent a termination signal and
+                                          the time when the processes are forcibly
+                                          halted with a kill signal. Set this value
+                                          longer than the expected cleanup time for
+                                          your process. If this value is nil, the
+                                          pod's terminationGracePeriodSeconds will
+                                          be used. Otherwise, this value overrides
+                                          the value provided by the pod spec. Value
+                                          must be non-negative integer. The value
+                                          zero indicates stop immediately via the
+                                          kill signal (no opportunity to shut down).
+                                          This is a beta field and requires enabling
+                                          ProbeTerminationGracePeriod feature gate.
+                                          Minimum value is 1. spec.terminationGracePeriodSeconds
+                                          is used if unset.
+                                        format: int64
+                                        type: integer
                                       timeoutSeconds:
                                         description: 'Number of seconds after which
                                           the probe times out. Defaults to 1 second.
@@ -1609,7 +1974,7 @@ spec:
                                     type: object
                                   resources:
                                     description: 'Compute Resources required by this
-                                      container. Cannot be updated. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
+                                      container. Cannot be updated. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
                                     properties:
                                       limits:
                                         additionalProperties:
@@ -1620,7 +1985,7 @@ spec:
                                           x-kubernetes-int-or-string: true
                                         description: 'Limits describes the maximum
                                           amount of compute resources allowed. More
-                                          info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
+                                          info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
                                         type: object
                                       requests:
                                         additionalProperties:
@@ -1634,12 +1999,14 @@ spec:
                                           Requests is omitted for a container, it
                                           defaults to Limits if that is explicitly
                                           specified, otherwise to an implementation-defined
-                                          value. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
+                                          value. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
                                         type: object
                                     type: object
                                   securityContext:
-                                    description: 'Security options the pod should
-                                      run with. More info: https://kubernetes.io/docs/concepts/policy/security-context/
+                                    description: 'SecurityContext defines the security
+                                      options the container should be run with. If
+                                      set, the fields of SecurityContext override
+                                      the equivalent fields of PodSecurityContext.
                                       More info: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/'
                                     properties:
                                       allowPrivilegeEscalation:
@@ -1649,13 +2016,16 @@ spec:
                                           controls if the no_new_privs flag will be
                                           set on the container process. AllowPrivilegeEscalation
                                           is true always when the container is: 1)
-                                          run as Privileged 2) has CAP_SYS_ADMIN'
+                                          run as Privileged 2) has CAP_SYS_ADMIN Note
+                                          that this field cannot be set when spec.os.name
+                                          is windows.'
                                         type: boolean
                                       capabilities:
                                         description: The capabilities to add/drop
                                           when running containers. Defaults to the
                                           default set of capabilities granted by the
-                                          container runtime.
+                                          container runtime. Note that this field
+                                          cannot be set when spec.os.name is windows.
                                         properties:
                                           add:
                                             description: Added capabilities
@@ -1676,7 +2046,8 @@ spec:
                                         description: Run container in privileged mode.
                                           Processes in privileged containers are essentially
                                           equivalent to root on the host. Defaults
-                                          to false.
+                                          to false. Note that this field cannot be
+                                          set when spec.os.name is windows.
                                         type: boolean
                                       procMount:
                                         description: procMount denotes the type of
@@ -1685,10 +2056,14 @@ spec:
                                           container runtime defaults for readonly
                                           paths and masked paths. This requires the
                                           ProcMountType feature flag to be enabled.
+                                          Note that this field cannot be set when
+                                          spec.os.name is windows.
                                         type: string
                                       readOnlyRootFilesystem:
                                         description: Whether this container has a
                                           read-only root filesystem. Default is false.
+                                          Note that this field cannot be set when
+                                          spec.os.name is windows.
                                         type: boolean
                                       runAsGroup:
                                         description: The GID to run the entrypoint
@@ -1696,7 +2071,8 @@ spec:
                                           if unset. May also be set in PodSecurityContext.  If
                                           set in both SecurityContext and PodSecurityContext,
                                           the value specified in SecurityContext takes
-                                          precedence.
+                                          precedence. Note that this field cannot
+                                          be set when spec.os.name is windows.
                                         format: int64
                                         type: integer
                                       runAsNonRoot:
@@ -1718,7 +2094,8 @@ spec:
                                           May also be set in PodSecurityContext.  If
                                           set in both SecurityContext and PodSecurityContext,
                                           the value specified in SecurityContext takes
-                                          precedence.
+                                          precedence. Note that this field cannot
+                                          be set when spec.os.name is windows.
                                         format: int64
                                         type: integer
                                       seLinuxOptions:
@@ -1728,7 +2105,9 @@ spec:
                                           for each container.  May also be set in
                                           PodSecurityContext.  If set in both SecurityContext
                                           and PodSecurityContext, the value specified
-                                          in SecurityContext takes precedence.
+                                          in SecurityContext takes precedence. Note
+                                          that this field cannot be set when spec.os.name
+                                          is windows.
                                         properties:
                                           level:
                                             description: Level is SELinux level label
@@ -1751,7 +2130,9 @@ spec:
                                         description: The seccomp options to use by
                                           this container. If seccomp options are provided
                                           at both the pod & container level, the container
-                                          options override the pod options.
+                                          options override the pod options. Note that
+                                          this field cannot be set when spec.os.name
+                                          is windows.
                                         properties:
                                           localhostProfile:
                                             description: localhostProfile indicates
@@ -1782,7 +2163,9 @@ spec:
                                           the options from the PodSecurityContext
                                           will be used. If set in both SecurityContext
                                           and PodSecurityContext, the value specified
-                                          in SecurityContext takes precedence.
+                                          in SecurityContext takes precedence. Note
+                                          that this field cannot be set when spec.os.name
+                                          is linux.
                                         properties:
                                           gmsaCredentialSpec:
                                             description: GMSACredentialSpec is where
@@ -1796,6 +2179,22 @@ spec:
                                               the name of the GMSA credential spec
                                               to use.
                                             type: string
+                                          hostProcess:
+                                            description: HostProcess determines if
+                                              a container should be run as a 'Host
+                                              Process' container. This field is alpha-level
+                                              and will only be honored by components
+                                              that enable the WindowsHostProcessContainers
+                                              feature flag. Setting this field without
+                                              the feature flag will result in errors
+                                              when validating the Pod. All of a Pod's
+                                              containers must have the same effective
+                                              HostProcess value (it is not allowed
+                                              to have a mix of HostProcess containers
+                                              and non-HostProcess containers).  In
+                                              addition, if HostProcess is true then
+                                              HostNetwork must also be set to true.
+                                            type: boolean
                                           runAsUserName:
                                             description: The UserName in Windows to
                                               run the entrypoint of the container
@@ -1818,14 +2217,11 @@ spec:
                                       parameters at the beginning of a Pod''s lifecycle,
                                       when it might take a long time to load data
                                       or warm a cache, than during steady-state operation.
-                                      This cannot be updated. This is a beta feature
-                                      enabled by the StartupProbe feature flag. More
-                                      info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                                      This cannot be updated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
                                     properties:
                                       exec:
-                                        description: One and only one of the following
-                                          should be specified. Exec specifies the
-                                          action to take.
+                                        description: Exec specifies the action to
+                                          take.
                                         properties:
                                           command:
                                             description: Command is the command line
@@ -1850,6 +2246,26 @@ spec:
                                           value is 1.
                                         format: int32
                                         type: integer
+                                      grpc:
+                                        description: GRPC specifies an action involving
+                                          a GRPC port. This is a beta field and requires
+                                          enabling GRPCContainerProbe feature gate.
+                                        properties:
+                                          port:
+                                            description: Port number of the gRPC service.
+                                              Number must be in the range 1 to 65535.
+                                            format: int32
+                                            type: integer
+                                          service:
+                                            description: "Service is the name of the
+                                              service to place in the gRPC HealthCheckRequest
+                                              (see https://github.com/grpc/grpc/blob/master/doc/health-checking.md).
+                                              \n If this is not specified, the default
+                                              behavior is defined by gRPC."
+                                            type: string
+                                        required:
+                                        - port
+                                        type: object
                                       httpGet:
                                         description: HTTPGet specifies the http request
                                           to perform.
@@ -1918,10 +2334,8 @@ spec:
                                         format: int32
                                         type: integer
                                       tcpSocket:
-                                        description: 'TCPSocket specifies an action
-                                          involving a TCP port. TCP hooks not yet
-                                          supported TODO: implement a realistic TCP
-                                          lifecycle hook'
+                                        description: TCPSocket specifies an action
+                                          involving a TCP port.
                                         properties:
                                           host:
                                             description: 'Optional: Host name to connect
@@ -1939,6 +2353,28 @@ spec:
                                         required:
                                         - port
                                         type: object
+                                      terminationGracePeriodSeconds:
+                                        description: Optional duration in seconds
+                                          the pod needs to terminate gracefully upon
+                                          probe failure. The grace period is the duration
+                                          in seconds after the processes running in
+                                          the pod are sent a termination signal and
+                                          the time when the processes are forcibly
+                                          halted with a kill signal. Set this value
+                                          longer than the expected cleanup time for
+                                          your process. If this value is nil, the
+                                          pod's terminationGracePeriodSeconds will
+                                          be used. Otherwise, this value overrides
+                                          the value provided by the pod spec. Value
+                                          must be non-negative integer. The value
+                                          zero indicates stop immediately via the
+                                          kill signal (no opportunity to shut down).
+                                          This is a beta field and requires enabling
+                                          ProbeTerminationGracePeriod feature gate.
+                                          Minimum value is 1. spec.terminationGracePeriodSeconds
+                                          is used if unset.
+                                        format: int64
+                                        type: integer
                                       timeoutSeconds:
                                         description: 'Number of seconds after which
                                           the probe times out. Defaults to 1 second.
@@ -2136,33 +2572,35 @@ spec:
                                 and it cannot be modified by updating the pod spec.
                                 In order to add an ephemeral container to an existing
                                 pod, use the pod's ephemeralcontainers subresource.
-                                This field is alpha-level and is only honored by servers
-                                that enable the EphemeralContainers feature.
+                                This field is beta-level and available on clusters
+                                that haven't disabled the EphemeralContainers feature
+                                gate.
                               items:
-                                description: An EphemeralContainer is a container
-                                  that may be added temporarily to an existing pod
-                                  for user-initiated activities such as debugging.
-                                  Ephemeral containers have no resource or scheduling
-                                  guarantees, and they will not be restarted when
-                                  they exit or when a pod is removed or restarted.
-                                  If an ephemeral container causes a pod to exceed
-                                  its resource allocation, the pod may be evicted.
-                                  Ephemeral containers may not be added by directly
-                                  updating the pod spec. They must be added via the
-                                  pod's ephemeralcontainers subresource, and they
-                                  will appear in the pod spec once added. This is
-                                  an alpha feature enabled by the EphemeralContainers
-                                  feature flag.
+                                description: "An EphemeralContainer is a temporary
+                                  container that you may add to an existing Pod for
+                                  user-initiated activities such as debugging. Ephemeral
+                                  containers have no resource or scheduling guarantees,
+                                  and they will not be restarted when they exit or
+                                  when a Pod is removed or restarted. The kubelet
+                                  may evict a Pod if an ephemeral container causes
+                                  the Pod to exceed its resource allocation. \n To
+                                  add an ephemeral container, use the ephemeralcontainers
+                                  subresource of an existing Pod. Ephemeral containers
+                                  may not be removed or restarted. \n This is a beta
+                                  feature available on clusters that haven't disabled
+                                  the EphemeralContainers feature gate."
                                 properties:
                                   args:
                                     description: 'Arguments to the entrypoint. The
-                                      docker image''s CMD is used if this is not provided.
+                                      image''s CMD is used if this is not provided.
                                       Variable references $(VAR_NAME) are expanded
                                       using the container''s environment. If a variable
                                       cannot be resolved, the reference in the input
-                                      string will be unchanged. The $(VAR_NAME) syntax
-                                      can be escaped with a double $$, ie: $$(VAR_NAME).
-                                      Escaped references will never be expanded, regardless
+                                      string will be unchanged. Double $$ are reduced
+                                      to a single $, which allows for escaping the
+                                      $(VAR_NAME) syntax: i.e. "$$(VAR_NAME)" will
+                                      produce the string literal "$(VAR_NAME)". Escaped
+                                      references will never be expanded, regardless
                                       of whether the variable exists or not. Cannot
                                       be updated. More info: https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell'
                                     items:
@@ -2170,16 +2608,17 @@ spec:
                                     type: array
                                   command:
                                     description: 'Entrypoint array. Not executed within
-                                      a shell. The docker image''s ENTRYPOINT is used
-                                      if this is not provided. Variable references
-                                      $(VAR_NAME) are expanded using the container''s
-                                      environment. If a variable cannot be resolved,
-                                      the reference in the input string will be unchanged.
-                                      The $(VAR_NAME) syntax can be escaped with a
-                                      double $$, ie: $$(VAR_NAME). Escaped references
-                                      will never be expanded, regardless of whether
-                                      the variable exists or not. Cannot be updated.
-                                      More info: https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell'
+                                      a shell. The image''s ENTRYPOINT is used if
+                                      this is not provided. Variable references $(VAR_NAME)
+                                      are expanded using the container''s environment.
+                                      If a variable cannot be resolved, the reference
+                                      in the input string will be unchanged. Double
+                                      $$ are reduced to a single $, which allows for
+                                      escaping the $(VAR_NAME) syntax: i.e. "$$(VAR_NAME)"
+                                      will produce the string literal "$(VAR_NAME)".
+                                      Escaped references will never be expanded, regardless
+                                      of whether the variable exists or not. Cannot
+                                      be updated. More info: https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell'
                                     items:
                                       type: string
                                     type: array
@@ -2196,13 +2635,15 @@ spec:
                                           type: string
                                         value:
                                           description: 'Variable references $(VAR_NAME)
-                                            are expanded using the previous defined
+                                            are expanded using the previously defined
                                             environment variables in the container
                                             and any service environment variables.
                                             If a variable cannot be resolved, the
                                             reference in the input string will be
-                                            unchanged. The $(VAR_NAME) syntax can
-                                            be escaped with a double $$, ie: $$(VAR_NAME).
+                                            unchanged. Double $$ are reduced to a
+                                            single $, which allows for escaping the
+                                            $(VAR_NAME) syntax: i.e. "$$(VAR_NAME)"
+                                            will produce the string literal "$(VAR_NAME)".
                                             Escaped references will never be expanded,
                                             regardless of whether the variable exists
                                             or not. Defaults to "".'
@@ -2356,7 +2797,8 @@ spec:
                                       type: object
                                     type: array
                                   image:
-                                    description: 'Docker image name. More info: https://kubernetes.io/docs/concepts/containers/images'
+                                    description: 'Container image name. More info:
+                                      https://kubernetes.io/docs/concepts/containers/images'
                                     type: string
                                   imagePullPolicy:
                                     description: 'Image pull policy. One of Always,
@@ -2377,9 +2819,8 @@ spec:
                                           More info: https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/#container-hooks'
                                         properties:
                                           exec:
-                                            description: One and only one of the following
-                                              should be specified. Exec specifies
-                                              the action to take.
+                                            description: Exec specifies the action
+                                              to take.
                                             properties:
                                               command:
                                                 description: Command is the command
@@ -2450,10 +2891,12 @@ spec:
                                             - port
                                             type: object
                                           tcpSocket:
-                                            description: 'TCPSocket specifies an action
-                                              involving a TCP port. TCP hooks not
-                                              yet supported TODO: implement a realistic
-                                              TCP lifecycle hook'
+                                            description: Deprecated. TCPSocket is
+                                              NOT supported as a LifecycleHandler
+                                              and kept for the backward compatibility.
+                                              There are no validation of this field
+                                              and lifecycle hooks will fail in runtime
+                                              when tcp handler is specified.
                                             properties:
                                               host:
                                                 description: 'Optional: Host name
@@ -2480,21 +2923,19 @@ spec:
                                           as liveness/startup probe failure, preemption,
                                           resource contention, etc. The handler is
                                           not called if the container crashes or exits.
-                                          The reason for termination is passed to
-                                          the handler. The Pod''s termination grace
-                                          period countdown begins before the PreStop
-                                          hooked is executed. Regardless of the outcome
-                                          of the handler, the container will eventually
-                                          terminate within the Pod''s termination
-                                          grace period. Other management of the container
-                                          blocks until the hook completes or until
-                                          the termination grace period is reached.
-                                          More info: https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/#container-hooks'
+                                          The Pod''s termination grace period countdown
+                                          begins before the PreStop hook is executed.
+                                          Regardless of the outcome of the handler,
+                                          the container will eventually terminate
+                                          within the Pod''s termination grace period
+                                          (unless delayed by finalizers). Other management
+                                          of the container blocks until the hook completes
+                                          or until the termination grace period is
+                                          reached. More info: https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/#container-hooks'
                                         properties:
                                           exec:
-                                            description: One and only one of the following
-                                              should be specified. Exec specifies
-                                              the action to take.
+                                            description: Exec specifies the action
+                                              to take.
                                             properties:
                                               command:
                                                 description: Command is the command
@@ -2565,10 +3006,12 @@ spec:
                                             - port
                                             type: object
                                           tcpSocket:
-                                            description: 'TCPSocket specifies an action
-                                              involving a TCP port. TCP hooks not
-                                              yet supported TODO: implement a realistic
-                                              TCP lifecycle hook'
+                                            description: Deprecated. TCPSocket is
+                                              NOT supported as a LifecycleHandler
+                                              and kept for the backward compatibility.
+                                              There are no validation of this field
+                                              and lifecycle hooks will fail in runtime
+                                              when tcp handler is specified.
                                             properties:
                                               host:
                                                 description: 'Optional: Host name
@@ -2594,9 +3037,8 @@ spec:
                                       containers.
                                     properties:
                                       exec:
-                                        description: One and only one of the following
-                                          should be specified. Exec specifies the
-                                          action to take.
+                                        description: Exec specifies the action to
+                                          take.
                                         properties:
                                           command:
                                             description: Command is the command line
@@ -2621,6 +3063,26 @@ spec:
                                           value is 1.
                                         format: int32
                                         type: integer
+                                      grpc:
+                                        description: GRPC specifies an action involving
+                                          a GRPC port. This is a beta field and requires
+                                          enabling GRPCContainerProbe feature gate.
+                                        properties:
+                                          port:
+                                            description: Port number of the gRPC service.
+                                              Number must be in the range 1 to 65535.
+                                            format: int32
+                                            type: integer
+                                          service:
+                                            description: "Service is the name of the
+                                              service to place in the gRPC HealthCheckRequest
+                                              (see https://github.com/grpc/grpc/blob/master/doc/health-checking.md).
+                                              \n If this is not specified, the default
+                                              behavior is defined by gRPC."
+                                            type: string
+                                        required:
+                                        - port
+                                        type: object
                                       httpGet:
                                         description: HTTPGet specifies the http request
                                           to perform.
@@ -2689,10 +3151,8 @@ spec:
                                         format: int32
                                         type: integer
                                       tcpSocket:
-                                        description: 'TCPSocket specifies an action
-                                          involving a TCP port. TCP hooks not yet
-                                          supported TODO: implement a realistic TCP
-                                          lifecycle hook'
+                                        description: TCPSocket specifies an action
+                                          involving a TCP port.
                                         properties:
                                           host:
                                             description: 'Optional: Host name to connect
@@ -2710,6 +3170,28 @@ spec:
                                         required:
                                         - port
                                         type: object
+                                      terminationGracePeriodSeconds:
+                                        description: Optional duration in seconds
+                                          the pod needs to terminate gracefully upon
+                                          probe failure. The grace period is the duration
+                                          in seconds after the processes running in
+                                          the pod are sent a termination signal and
+                                          the time when the processes are forcibly
+                                          halted with a kill signal. Set this value
+                                          longer than the expected cleanup time for
+                                          your process. If this value is nil, the
+                                          pod's terminationGracePeriodSeconds will
+                                          be used. Otherwise, this value overrides
+                                          the value provided by the pod spec. Value
+                                          must be non-negative integer. The value
+                                          zero indicates stop immediately via the
+                                          kill signal (no opportunity to shut down).
+                                          This is a beta field and requires enabling
+                                          ProbeTerminationGracePeriod feature gate.
+                                          Minimum value is 1. spec.terminationGracePeriodSeconds
+                                          is used if unset.
+                                        format: int64
+                                        type: integer
                                       timeoutSeconds:
                                         description: 'Number of seconds after which
                                           the probe times out. Defaults to 1 second.
@@ -2764,14 +3246,17 @@ spec:
                                       - containerPort
                                       type: object
                                     type: array
+                                    x-kubernetes-list-map-keys:
+                                    - containerPort
+                                    - protocol
+                                    x-kubernetes-list-type: map
                                   readinessProbe:
                                     description: Probes are not allowed for ephemeral
                                       containers.
                                     properties:
                                       exec:
-                                        description: One and only one of the following
-                                          should be specified. Exec specifies the
-                                          action to take.
+                                        description: Exec specifies the action to
+                                          take.
                                         properties:
                                           command:
                                             description: Command is the command line
@@ -2796,6 +3281,26 @@ spec:
                                           value is 1.
                                         format: int32
                                         type: integer
+                                      grpc:
+                                        description: GRPC specifies an action involving
+                                          a GRPC port. This is a beta field and requires
+                                          enabling GRPCContainerProbe feature gate.
+                                        properties:
+                                          port:
+                                            description: Port number of the gRPC service.
+                                              Number must be in the range 1 to 65535.
+                                            format: int32
+                                            type: integer
+                                          service:
+                                            description: "Service is the name of the
+                                              service to place in the gRPC HealthCheckRequest
+                                              (see https://github.com/grpc/grpc/blob/master/doc/health-checking.md).
+                                              \n If this is not specified, the default
+                                              behavior is defined by gRPC."
+                                            type: string
+                                        required:
+                                        - port
+                                        type: object
                                       httpGet:
                                         description: HTTPGet specifies the http request
                                           to perform.
@@ -2864,10 +3369,8 @@ spec:
                                         format: int32
                                         type: integer
                                       tcpSocket:
-                                        description: 'TCPSocket specifies an action
-                                          involving a TCP port. TCP hooks not yet
-                                          supported TODO: implement a realistic TCP
-                                          lifecycle hook'
+                                        description: TCPSocket specifies an action
+                                          involving a TCP port.
                                         properties:
                                           host:
                                             description: 'Optional: Host name to connect
@@ -2885,6 +3388,28 @@ spec:
                                         required:
                                         - port
                                         type: object
+                                      terminationGracePeriodSeconds:
+                                        description: Optional duration in seconds
+                                          the pod needs to terminate gracefully upon
+                                          probe failure. The grace period is the duration
+                                          in seconds after the processes running in
+                                          the pod are sent a termination signal and
+                                          the time when the processes are forcibly
+                                          halted with a kill signal. Set this value
+                                          longer than the expected cleanup time for
+                                          your process. If this value is nil, the
+                                          pod's terminationGracePeriodSeconds will
+                                          be used. Otherwise, this value overrides
+                                          the value provided by the pod spec. Value
+                                          must be non-negative integer. The value
+                                          zero indicates stop immediately via the
+                                          kill signal (no opportunity to shut down).
+                                          This is a beta field and requires enabling
+                                          ProbeTerminationGracePeriod feature gate.
+                                          Minimum value is 1. spec.terminationGracePeriodSeconds
+                                          is used if unset.
+                                        format: int64
+                                        type: integer
                                       timeoutSeconds:
                                         description: 'Number of seconds after which
                                           the probe times out. Defaults to 1 second.
@@ -2906,7 +3431,7 @@ spec:
                                           x-kubernetes-int-or-string: true
                                         description: 'Limits describes the maximum
                                           amount of compute resources allowed. More
-                                          info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
+                                          info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
                                         type: object
                                       requests:
                                         additionalProperties:
@@ -2920,12 +3445,14 @@ spec:
                                           Requests is omitted for a container, it
                                           defaults to Limits if that is explicitly
                                           specified, otherwise to an implementation-defined
-                                          value. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
+                                          value. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
                                         type: object
                                     type: object
                                   securityContext:
-                                    description: SecurityContext is not allowed for
-                                      ephemeral containers.
+                                    description: 'Optional: SecurityContext defines
+                                      the security options the ephemeral container
+                                      should be run with. If set, the fields of SecurityContext
+                                      override the equivalent fields of PodSecurityContext.'
                                     properties:
                                       allowPrivilegeEscalation:
                                         description: 'AllowPrivilegeEscalation controls
@@ -2934,13 +3461,16 @@ spec:
                                           controls if the no_new_privs flag will be
                                           set on the container process. AllowPrivilegeEscalation
                                           is true always when the container is: 1)
-                                          run as Privileged 2) has CAP_SYS_ADMIN'
+                                          run as Privileged 2) has CAP_SYS_ADMIN Note
+                                          that this field cannot be set when spec.os.name
+                                          is windows.'
                                         type: boolean
                                       capabilities:
                                         description: The capabilities to add/drop
                                           when running containers. Defaults to the
                                           default set of capabilities granted by the
-                                          container runtime.
+                                          container runtime. Note that this field
+                                          cannot be set when spec.os.name is windows.
                                         properties:
                                           add:
                                             description: Added capabilities
@@ -2961,7 +3491,8 @@ spec:
                                         description: Run container in privileged mode.
                                           Processes in privileged containers are essentially
                                           equivalent to root on the host. Defaults
-                                          to false.
+                                          to false. Note that this field cannot be
+                                          set when spec.os.name is windows.
                                         type: boolean
                                       procMount:
                                         description: procMount denotes the type of
@@ -2970,10 +3501,14 @@ spec:
                                           container runtime defaults for readonly
                                           paths and masked paths. This requires the
                                           ProcMountType feature flag to be enabled.
+                                          Note that this field cannot be set when
+                                          spec.os.name is windows.
                                         type: string
                                       readOnlyRootFilesystem:
                                         description: Whether this container has a
                                           read-only root filesystem. Default is false.
+                                          Note that this field cannot be set when
+                                          spec.os.name is windows.
                                         type: boolean
                                       runAsGroup:
                                         description: The GID to run the entrypoint
@@ -2981,7 +3516,8 @@ spec:
                                           if unset. May also be set in PodSecurityContext.  If
                                           set in both SecurityContext and PodSecurityContext,
                                           the value specified in SecurityContext takes
-                                          precedence.
+                                          precedence. Note that this field cannot
+                                          be set when spec.os.name is windows.
                                         format: int64
                                         type: integer
                                       runAsNonRoot:
@@ -3003,7 +3539,8 @@ spec:
                                           May also be set in PodSecurityContext.  If
                                           set in both SecurityContext and PodSecurityContext,
                                           the value specified in SecurityContext takes
-                                          precedence.
+                                          precedence. Note that this field cannot
+                                          be set when spec.os.name is windows.
                                         format: int64
                                         type: integer
                                       seLinuxOptions:
@@ -3013,7 +3550,9 @@ spec:
                                           for each container.  May also be set in
                                           PodSecurityContext.  If set in both SecurityContext
                                           and PodSecurityContext, the value specified
-                                          in SecurityContext takes precedence.
+                                          in SecurityContext takes precedence. Note
+                                          that this field cannot be set when spec.os.name
+                                          is windows.
                                         properties:
                                           level:
                                             description: Level is SELinux level label
@@ -3036,7 +3575,9 @@ spec:
                                         description: The seccomp options to use by
                                           this container. If seccomp options are provided
                                           at both the pod & container level, the container
-                                          options override the pod options.
+                                          options override the pod options. Note that
+                                          this field cannot be set when spec.os.name
+                                          is windows.
                                         properties:
                                           localhostProfile:
                                             description: localhostProfile indicates
@@ -3067,7 +3608,9 @@ spec:
                                           the options from the PodSecurityContext
                                           will be used. If set in both SecurityContext
                                           and PodSecurityContext, the value specified
-                                          in SecurityContext takes precedence.
+                                          in SecurityContext takes precedence. Note
+                                          that this field cannot be set when spec.os.name
+                                          is linux.
                                         properties:
                                           gmsaCredentialSpec:
                                             description: GMSACredentialSpec is where
@@ -3081,6 +3624,22 @@ spec:
                                               the name of the GMSA credential spec
                                               to use.
                                             type: string
+                                          hostProcess:
+                                            description: HostProcess determines if
+                                              a container should be run as a 'Host
+                                              Process' container. This field is alpha-level
+                                              and will only be honored by components
+                                              that enable the WindowsHostProcessContainers
+                                              feature flag. Setting this field without
+                                              the feature flag will result in errors
+                                              when validating the Pod. All of a Pod's
+                                              containers must have the same effective
+                                              HostProcess value (it is not allowed
+                                              to have a mix of HostProcess containers
+                                              and non-HostProcess containers).  In
+                                              addition, if HostProcess is true then
+                                              HostNetwork must also be set to true.
+                                            type: boolean
                                           runAsUserName:
                                             description: The UserName in Windows to
                                               run the entrypoint of the container
@@ -3098,9 +3657,8 @@ spec:
                                       containers.
                                     properties:
                                       exec:
-                                        description: One and only one of the following
-                                          should be specified. Exec specifies the
-                                          action to take.
+                                        description: Exec specifies the action to
+                                          take.
                                         properties:
                                           command:
                                             description: Command is the command line
@@ -3125,6 +3683,26 @@ spec:
                                           value is 1.
                                         format: int32
                                         type: integer
+                                      grpc:
+                                        description: GRPC specifies an action involving
+                                          a GRPC port. This is a beta field and requires
+                                          enabling GRPCContainerProbe feature gate.
+                                        properties:
+                                          port:
+                                            description: Port number of the gRPC service.
+                                              Number must be in the range 1 to 65535.
+                                            format: int32
+                                            type: integer
+                                          service:
+                                            description: "Service is the name of the
+                                              service to place in the gRPC HealthCheckRequest
+                                              (see https://github.com/grpc/grpc/blob/master/doc/health-checking.md).
+                                              \n If this is not specified, the default
+                                              behavior is defined by gRPC."
+                                            type: string
+                                        required:
+                                        - port
+                                        type: object
                                       httpGet:
                                         description: HTTPGet specifies the http request
                                           to perform.
@@ -3193,10 +3771,8 @@ spec:
                                         format: int32
                                         type: integer
                                       tcpSocket:
-                                        description: 'TCPSocket specifies an action
-                                          involving a TCP port. TCP hooks not yet
-                                          supported TODO: implement a realistic TCP
-                                          lifecycle hook'
+                                        description: TCPSocket specifies an action
+                                          involving a TCP port.
                                         properties:
                                           host:
                                             description: 'Optional: Host name to connect
@@ -3214,6 +3790,28 @@ spec:
                                         required:
                                         - port
                                         type: object
+                                      terminationGracePeriodSeconds:
+                                        description: Optional duration in seconds
+                                          the pod needs to terminate gracefully upon
+                                          probe failure. The grace period is the duration
+                                          in seconds after the processes running in
+                                          the pod are sent a termination signal and
+                                          the time when the processes are forcibly
+                                          halted with a kill signal. Set this value
+                                          longer than the expected cleanup time for
+                                          your process. If this value is nil, the
+                                          pod's terminationGracePeriodSeconds will
+                                          be used. Otherwise, this value overrides
+                                          the value provided by the pod spec. Value
+                                          must be non-negative integer. The value
+                                          zero indicates stop immediately via the
+                                          kill signal (no opportunity to shut down).
+                                          This is a beta field and requires enabling
+                                          ProbeTerminationGracePeriod feature gate.
+                                          Minimum value is 1. spec.terminationGracePeriodSeconds
+                                          is used if unset.
+                                        format: int64
+                                        type: integer
                                       timeoutSeconds:
                                         description: 'Number of seconds after which
                                           the probe times out. Defaults to 1 second.
@@ -3244,13 +3842,15 @@ spec:
                                       EOF. Default is false
                                     type: boolean
                                   targetContainerName:
-                                    description: If set, the name of the container
+                                    description: "If set, the name of the container
                                       from PodSpec that this ephemeral container targets.
                                       The ephemeral container will be run in the namespaces
                                       (IPC, PID, etc) of this container. If not set
-                                      then the ephemeral container is run in whatever
-                                      namespaces are shared for the pod. Note that
-                                      the container runtime must support this feature.
+                                      then the ephemeral container uses the namespaces
+                                      configured in the Pod spec. \n The container
+                                      runtime must implement support for this feature.
+                                      If the runtime does not support namespace targeting
+                                      then the result of setting this field is undefined."
                                     type: string
                                   terminationMessagePath:
                                     description: 'Optional: Path at which the file
@@ -3303,7 +3903,8 @@ spec:
                                     type: array
                                   volumeMounts:
                                     description: Pod volumes to mount into the container's
-                                      filesystem. Cannot be updated.
+                                      filesystem. Subpath mounts are not allowed for
+                                      ephemeral containers. Cannot be updated.
                                     items:
                                       description: VolumeMount describes a mounting
                                         of a Volume within a container.
@@ -3402,9 +4003,8 @@ spec:
                                 references to secrets in the same namespace to use
                                 for pulling any of the images used by this PodSpec.
                                 If specified, these secrets will be passed to individual
-                                puller implementations for them to use. For example,
-                                in the case of docker, only DockerConfig type secrets
-                                are honored. More info: https://kubernetes.io/docs/concepts/containers/images#specifying-imagepullsecrets-on-a-pod'
+                                puller implementations for them to use. More info:
+                                https://kubernetes.io/docs/concepts/containers/images#specifying-imagepullsecrets-on-a-pod'
                               items:
                                 description: LocalObjectReference contains enough
                                   information to let you locate the referenced object
@@ -3441,12 +4041,14 @@ spec:
                                 properties:
                                   args:
                                     description: 'Arguments to the entrypoint. The
-                                      docker image''s CMD is used if this is not provided.
-                                      Variable references $(VAR_NAME) are expanded
-                                      using the container''s environment. If a variable
-                                      cannot be resolved, the reference in the input
-                                      string will be unchanged. The $(VAR_NAME) syntax
-                                      can be escaped with a double $$, ie: $$(VAR_NAME).
+                                      container image''s CMD is used if this is not
+                                      provided. Variable references $(VAR_NAME) are
+                                      expanded using the container''s environment.
+                                      If a variable cannot be resolved, the reference
+                                      in the input string will be unchanged. Double
+                                      $$ are reduced to a single $, which allows for
+                                      escaping the $(VAR_NAME) syntax: i.e. "$$(VAR_NAME)"
+                                      will produce the string literal "$(VAR_NAME)".
                                       Escaped references will never be expanded, regardless
                                       of whether the variable exists or not. Cannot
                                       be updated. More info: https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell'
@@ -3455,16 +4057,17 @@ spec:
                                     type: array
                                   command:
                                     description: 'Entrypoint array. Not executed within
-                                      a shell. The docker image''s ENTRYPOINT is used
-                                      if this is not provided. Variable references
+                                      a shell. The container image''s ENTRYPOINT is
+                                      used if this is not provided. Variable references
                                       $(VAR_NAME) are expanded using the container''s
                                       environment. If a variable cannot be resolved,
                                       the reference in the input string will be unchanged.
-                                      The $(VAR_NAME) syntax can be escaped with a
-                                      double $$, ie: $$(VAR_NAME). Escaped references
-                                      will never be expanded, regardless of whether
-                                      the variable exists or not. Cannot be updated.
-                                      More info: https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell'
+                                      Double $$ are reduced to a single $, which allows
+                                      for escaping the $(VAR_NAME) syntax: i.e. "$$(VAR_NAME)"
+                                      will produce the string literal "$(VAR_NAME)".
+                                      Escaped references will never be expanded, regardless
+                                      of whether the variable exists or not. Cannot
+                                      be updated. More info: https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell'
                                     items:
                                       type: string
                                     type: array
@@ -3481,13 +4084,15 @@ spec:
                                           type: string
                                         value:
                                           description: 'Variable references $(VAR_NAME)
-                                            are expanded using the previous defined
+                                            are expanded using the previously defined
                                             environment variables in the container
                                             and any service environment variables.
                                             If a variable cannot be resolved, the
                                             reference in the input string will be
-                                            unchanged. The $(VAR_NAME) syntax can
-                                            be escaped with a double $$, ie: $$(VAR_NAME).
+                                            unchanged. Double $$ are reduced to a
+                                            single $, which allows for escaping the
+                                            $(VAR_NAME) syntax: i.e. "$$(VAR_NAME)"
+                                            will produce the string literal "$(VAR_NAME)".
                                             Escaped references will never be expanded,
                                             regardless of whether the variable exists
                                             or not. Defaults to "".'
@@ -3641,7 +4246,8 @@ spec:
                                       type: object
                                     type: array
                                   image:
-                                    description: 'Docker image name. More info: https://kubernetes.io/docs/concepts/containers/images
+                                    description: 'Container image name. More info:
+                                      https://kubernetes.io/docs/concepts/containers/images
                                       This field is optional to allow higher level
                                       config management to default or override container
                                       images in workload controllers like Deployments
@@ -3667,9 +4273,8 @@ spec:
                                           More info: https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/#container-hooks'
                                         properties:
                                           exec:
-                                            description: One and only one of the following
-                                              should be specified. Exec specifies
-                                              the action to take.
+                                            description: Exec specifies the action
+                                              to take.
                                             properties:
                                               command:
                                                 description: Command is the command
@@ -3740,10 +4345,12 @@ spec:
                                             - port
                                             type: object
                                           tcpSocket:
-                                            description: 'TCPSocket specifies an action
-                                              involving a TCP port. TCP hooks not
-                                              yet supported TODO: implement a realistic
-                                              TCP lifecycle hook'
+                                            description: Deprecated. TCPSocket is
+                                              NOT supported as a LifecycleHandler
+                                              and kept for the backward compatibility.
+                                              There are no validation of this field
+                                              and lifecycle hooks will fail in runtime
+                                              when tcp handler is specified.
                                             properties:
                                               host:
                                                 description: 'Optional: Host name
@@ -3770,21 +4377,19 @@ spec:
                                           as liveness/startup probe failure, preemption,
                                           resource contention, etc. The handler is
                                           not called if the container crashes or exits.
-                                          The reason for termination is passed to
-                                          the handler. The Pod''s termination grace
-                                          period countdown begins before the PreStop
-                                          hooked is executed. Regardless of the outcome
-                                          of the handler, the container will eventually
-                                          terminate within the Pod''s termination
-                                          grace period. Other management of the container
-                                          blocks until the hook completes or until
-                                          the termination grace period is reached.
-                                          More info: https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/#container-hooks'
+                                          The Pod''s termination grace period countdown
+                                          begins before the PreStop hook is executed.
+                                          Regardless of the outcome of the handler,
+                                          the container will eventually terminate
+                                          within the Pod''s termination grace period
+                                          (unless delayed by finalizers). Other management
+                                          of the container blocks until the hook completes
+                                          or until the termination grace period is
+                                          reached. More info: https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/#container-hooks'
                                         properties:
                                           exec:
-                                            description: One and only one of the following
-                                              should be specified. Exec specifies
-                                              the action to take.
+                                            description: Exec specifies the action
+                                              to take.
                                             properties:
                                               command:
                                                 description: Command is the command
@@ -3855,10 +4460,12 @@ spec:
                                             - port
                                             type: object
                                           tcpSocket:
-                                            description: 'TCPSocket specifies an action
-                                              involving a TCP port. TCP hooks not
-                                              yet supported TODO: implement a realistic
-                                              TCP lifecycle hook'
+                                            description: Deprecated. TCPSocket is
+                                              NOT supported as a LifecycleHandler
+                                              and kept for the backward compatibility.
+                                              There are no validation of this field
+                                              and lifecycle hooks will fail in runtime
+                                              when tcp handler is specified.
                                             properties:
                                               host:
                                                 description: 'Optional: Host name
@@ -3885,9 +4492,8 @@ spec:
                                       Cannot be updated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
                                     properties:
                                       exec:
-                                        description: One and only one of the following
-                                          should be specified. Exec specifies the
-                                          action to take.
+                                        description: Exec specifies the action to
+                                          take.
                                         properties:
                                           command:
                                             description: Command is the command line
@@ -3912,6 +4518,26 @@ spec:
                                           value is 1.
                                         format: int32
                                         type: integer
+                                      grpc:
+                                        description: GRPC specifies an action involving
+                                          a GRPC port. This is a beta field and requires
+                                          enabling GRPCContainerProbe feature gate.
+                                        properties:
+                                          port:
+                                            description: Port number of the gRPC service.
+                                              Number must be in the range 1 to 65535.
+                                            format: int32
+                                            type: integer
+                                          service:
+                                            description: "Service is the name of the
+                                              service to place in the gRPC HealthCheckRequest
+                                              (see https://github.com/grpc/grpc/blob/master/doc/health-checking.md).
+                                              \n If this is not specified, the default
+                                              behavior is defined by gRPC."
+                                            type: string
+                                        required:
+                                        - port
+                                        type: object
                                       httpGet:
                                         description: HTTPGet specifies the http request
                                           to perform.
@@ -3980,10 +4606,8 @@ spec:
                                         format: int32
                                         type: integer
                                       tcpSocket:
-                                        description: 'TCPSocket specifies an action
-                                          involving a TCP port. TCP hooks not yet
-                                          supported TODO: implement a realistic TCP
-                                          lifecycle hook'
+                                        description: TCPSocket specifies an action
+                                          involving a TCP port.
                                         properties:
                                           host:
                                             description: 'Optional: Host name to connect
@@ -4001,6 +4625,28 @@ spec:
                                         required:
                                         - port
                                         type: object
+                                      terminationGracePeriodSeconds:
+                                        description: Optional duration in seconds
+                                          the pod needs to terminate gracefully upon
+                                          probe failure. The grace period is the duration
+                                          in seconds after the processes running in
+                                          the pod are sent a termination signal and
+                                          the time when the processes are forcibly
+                                          halted with a kill signal. Set this value
+                                          longer than the expected cleanup time for
+                                          your process. If this value is nil, the
+                                          pod's terminationGracePeriodSeconds will
+                                          be used. Otherwise, this value overrides
+                                          the value provided by the pod spec. Value
+                                          must be non-negative integer. The value
+                                          zero indicates stop immediately via the
+                                          kill signal (no opportunity to shut down).
+                                          This is a beta field and requires enabling
+                                          ProbeTerminationGracePeriod feature gate.
+                                          Minimum value is 1. spec.terminationGracePeriodSeconds
+                                          is used if unset.
+                                        format: int64
+                                        type: integer
                                       timeoutSeconds:
                                         description: 'Number of seconds after which
                                           the probe times out. Defaults to 1 second.
@@ -4072,9 +4718,8 @@ spec:
                                       More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
                                     properties:
                                       exec:
-                                        description: One and only one of the following
-                                          should be specified. Exec specifies the
-                                          action to take.
+                                        description: Exec specifies the action to
+                                          take.
                                         properties:
                                           command:
                                             description: Command is the command line
@@ -4099,6 +4744,26 @@ spec:
                                           value is 1.
                                         format: int32
                                         type: integer
+                                      grpc:
+                                        description: GRPC specifies an action involving
+                                          a GRPC port. This is a beta field and requires
+                                          enabling GRPCContainerProbe feature gate.
+                                        properties:
+                                          port:
+                                            description: Port number of the gRPC service.
+                                              Number must be in the range 1 to 65535.
+                                            format: int32
+                                            type: integer
+                                          service:
+                                            description: "Service is the name of the
+                                              service to place in the gRPC HealthCheckRequest
+                                              (see https://github.com/grpc/grpc/blob/master/doc/health-checking.md).
+                                              \n If this is not specified, the default
+                                              behavior is defined by gRPC."
+                                            type: string
+                                        required:
+                                        - port
+                                        type: object
                                       httpGet:
                                         description: HTTPGet specifies the http request
                                           to perform.
@@ -4167,10 +4832,8 @@ spec:
                                         format: int32
                                         type: integer
                                       tcpSocket:
-                                        description: 'TCPSocket specifies an action
-                                          involving a TCP port. TCP hooks not yet
-                                          supported TODO: implement a realistic TCP
-                                          lifecycle hook'
+                                        description: TCPSocket specifies an action
+                                          involving a TCP port.
                                         properties:
                                           host:
                                             description: 'Optional: Host name to connect
@@ -4188,6 +4851,28 @@ spec:
                                         required:
                                         - port
                                         type: object
+                                      terminationGracePeriodSeconds:
+                                        description: Optional duration in seconds
+                                          the pod needs to terminate gracefully upon
+                                          probe failure. The grace period is the duration
+                                          in seconds after the processes running in
+                                          the pod are sent a termination signal and
+                                          the time when the processes are forcibly
+                                          halted with a kill signal. Set this value
+                                          longer than the expected cleanup time for
+                                          your process. If this value is nil, the
+                                          pod's terminationGracePeriodSeconds will
+                                          be used. Otherwise, this value overrides
+                                          the value provided by the pod spec. Value
+                                          must be non-negative integer. The value
+                                          zero indicates stop immediately via the
+                                          kill signal (no opportunity to shut down).
+                                          This is a beta field and requires enabling
+                                          ProbeTerminationGracePeriod feature gate.
+                                          Minimum value is 1. spec.terminationGracePeriodSeconds
+                                          is used if unset.
+                                        format: int64
+                                        type: integer
                                       timeoutSeconds:
                                         description: 'Number of seconds after which
                                           the probe times out. Defaults to 1 second.
@@ -4197,7 +4882,7 @@ spec:
                                     type: object
                                   resources:
                                     description: 'Compute Resources required by this
-                                      container. Cannot be updated. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
+                                      container. Cannot be updated. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
                                     properties:
                                       limits:
                                         additionalProperties:
@@ -4208,7 +4893,7 @@ spec:
                                           x-kubernetes-int-or-string: true
                                         description: 'Limits describes the maximum
                                           amount of compute resources allowed. More
-                                          info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
+                                          info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
                                         type: object
                                       requests:
                                         additionalProperties:
@@ -4222,12 +4907,14 @@ spec:
                                           Requests is omitted for a container, it
                                           defaults to Limits if that is explicitly
                                           specified, otherwise to an implementation-defined
-                                          value. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
+                                          value. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
                                         type: object
                                     type: object
                                   securityContext:
-                                    description: 'Security options the pod should
-                                      run with. More info: https://kubernetes.io/docs/concepts/policy/security-context/
+                                    description: 'SecurityContext defines the security
+                                      options the container should be run with. If
+                                      set, the fields of SecurityContext override
+                                      the equivalent fields of PodSecurityContext.
                                       More info: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/'
                                     properties:
                                       allowPrivilegeEscalation:
@@ -4237,13 +4924,16 @@ spec:
                                           controls if the no_new_privs flag will be
                                           set on the container process. AllowPrivilegeEscalation
                                           is true always when the container is: 1)
-                                          run as Privileged 2) has CAP_SYS_ADMIN'
+                                          run as Privileged 2) has CAP_SYS_ADMIN Note
+                                          that this field cannot be set when spec.os.name
+                                          is windows.'
                                         type: boolean
                                       capabilities:
                                         description: The capabilities to add/drop
                                           when running containers. Defaults to the
                                           default set of capabilities granted by the
-                                          container runtime.
+                                          container runtime. Note that this field
+                                          cannot be set when spec.os.name is windows.
                                         properties:
                                           add:
                                             description: Added capabilities
@@ -4264,7 +4954,8 @@ spec:
                                         description: Run container in privileged mode.
                                           Processes in privileged containers are essentially
                                           equivalent to root on the host. Defaults
-                                          to false.
+                                          to false. Note that this field cannot be
+                                          set when spec.os.name is windows.
                                         type: boolean
                                       procMount:
                                         description: procMount denotes the type of
@@ -4273,10 +4964,14 @@ spec:
                                           container runtime defaults for readonly
                                           paths and masked paths. This requires the
                                           ProcMountType feature flag to be enabled.
+                                          Note that this field cannot be set when
+                                          spec.os.name is windows.
                                         type: string
                                       readOnlyRootFilesystem:
                                         description: Whether this container has a
                                           read-only root filesystem. Default is false.
+                                          Note that this field cannot be set when
+                                          spec.os.name is windows.
                                         type: boolean
                                       runAsGroup:
                                         description: The GID to run the entrypoint
@@ -4284,7 +4979,8 @@ spec:
                                           if unset. May also be set in PodSecurityContext.  If
                                           set in both SecurityContext and PodSecurityContext,
                                           the value specified in SecurityContext takes
-                                          precedence.
+                                          precedence. Note that this field cannot
+                                          be set when spec.os.name is windows.
                                         format: int64
                                         type: integer
                                       runAsNonRoot:
@@ -4306,7 +5002,8 @@ spec:
                                           May also be set in PodSecurityContext.  If
                                           set in both SecurityContext and PodSecurityContext,
                                           the value specified in SecurityContext takes
-                                          precedence.
+                                          precedence. Note that this field cannot
+                                          be set when spec.os.name is windows.
                                         format: int64
                                         type: integer
                                       seLinuxOptions:
@@ -4316,7 +5013,9 @@ spec:
                                           for each container.  May also be set in
                                           PodSecurityContext.  If set in both SecurityContext
                                           and PodSecurityContext, the value specified
-                                          in SecurityContext takes precedence.
+                                          in SecurityContext takes precedence. Note
+                                          that this field cannot be set when spec.os.name
+                                          is windows.
                                         properties:
                                           level:
                                             description: Level is SELinux level label
@@ -4339,7 +5038,9 @@ spec:
                                         description: The seccomp options to use by
                                           this container. If seccomp options are provided
                                           at both the pod & container level, the container
-                                          options override the pod options.
+                                          options override the pod options. Note that
+                                          this field cannot be set when spec.os.name
+                                          is windows.
                                         properties:
                                           localhostProfile:
                                             description: localhostProfile indicates
@@ -4370,7 +5071,9 @@ spec:
                                           the options from the PodSecurityContext
                                           will be used. If set in both SecurityContext
                                           and PodSecurityContext, the value specified
-                                          in SecurityContext takes precedence.
+                                          in SecurityContext takes precedence. Note
+                                          that this field cannot be set when spec.os.name
+                                          is linux.
                                         properties:
                                           gmsaCredentialSpec:
                                             description: GMSACredentialSpec is where
@@ -4384,6 +5087,22 @@ spec:
                                               the name of the GMSA credential spec
                                               to use.
                                             type: string
+                                          hostProcess:
+                                            description: HostProcess determines if
+                                              a container should be run as a 'Host
+                                              Process' container. This field is alpha-level
+                                              and will only be honored by components
+                                              that enable the WindowsHostProcessContainers
+                                              feature flag. Setting this field without
+                                              the feature flag will result in errors
+                                              when validating the Pod. All of a Pod's
+                                              containers must have the same effective
+                                              HostProcess value (it is not allowed
+                                              to have a mix of HostProcess containers
+                                              and non-HostProcess containers).  In
+                                              addition, if HostProcess is true then
+                                              HostNetwork must also be set to true.
+                                            type: boolean
                                           runAsUserName:
                                             description: The UserName in Windows to
                                               run the entrypoint of the container
@@ -4406,14 +5125,11 @@ spec:
                                       parameters at the beginning of a Pod''s lifecycle,
                                       when it might take a long time to load data
                                       or warm a cache, than during steady-state operation.
-                                      This cannot be updated. This is a beta feature
-                                      enabled by the StartupProbe feature flag. More
-                                      info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                                      This cannot be updated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
                                     properties:
                                       exec:
-                                        description: One and only one of the following
-                                          should be specified. Exec specifies the
-                                          action to take.
+                                        description: Exec specifies the action to
+                                          take.
                                         properties:
                                           command:
                                             description: Command is the command line
@@ -4438,6 +5154,26 @@ spec:
                                           value is 1.
                                         format: int32
                                         type: integer
+                                      grpc:
+                                        description: GRPC specifies an action involving
+                                          a GRPC port. This is a beta field and requires
+                                          enabling GRPCContainerProbe feature gate.
+                                        properties:
+                                          port:
+                                            description: Port number of the gRPC service.
+                                              Number must be in the range 1 to 65535.
+                                            format: int32
+                                            type: integer
+                                          service:
+                                            description: "Service is the name of the
+                                              service to place in the gRPC HealthCheckRequest
+                                              (see https://github.com/grpc/grpc/blob/master/doc/health-checking.md).
+                                              \n If this is not specified, the default
+                                              behavior is defined by gRPC."
+                                            type: string
+                                        required:
+                                        - port
+                                        type: object
                                       httpGet:
                                         description: HTTPGet specifies the http request
                                           to perform.
@@ -4506,10 +5242,8 @@ spec:
                                         format: int32
                                         type: integer
                                       tcpSocket:
-                                        description: 'TCPSocket specifies an action
-                                          involving a TCP port. TCP hooks not yet
-                                          supported TODO: implement a realistic TCP
-                                          lifecycle hook'
+                                        description: TCPSocket specifies an action
+                                          involving a TCP port.
                                         properties:
                                           host:
                                             description: 'Optional: Host name to connect
@@ -4527,6 +5261,28 @@ spec:
                                         required:
                                         - port
                                         type: object
+                                      terminationGracePeriodSeconds:
+                                        description: Optional duration in seconds
+                                          the pod needs to terminate gracefully upon
+                                          probe failure. The grace period is the duration
+                                          in seconds after the processes running in
+                                          the pod are sent a termination signal and
+                                          the time when the processes are forcibly
+                                          halted with a kill signal. Set this value
+                                          longer than the expected cleanup time for
+                                          your process. If this value is nil, the
+                                          pod's terminationGracePeriodSeconds will
+                                          be used. Otherwise, this value overrides
+                                          the value provided by the pod spec. Value
+                                          must be non-negative integer. The value
+                                          zero indicates stop immediately via the
+                                          kill signal (no opportunity to shut down).
+                                          This is a beta field and requires enabling
+                                          ProbeTerminationGracePeriod feature gate.
+                                          Minimum value is 1. spec.terminationGracePeriodSeconds
+                                          is used if unset.
+                                        format: int64
+                                        type: integer
                                       timeoutSeconds:
                                         description: 'Number of seconds after which
                                           the probe times out. Defaults to 1 second.
@@ -4676,6 +5432,40 @@ spec:
                                 must match a node''s labels for the pod to be scheduled
                                 on that node. More info: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/'
                               type: object
+                              x-kubernetes-map-type: atomic
+                            os:
+                              description: "Specifies the OS of the containers in
+                                the pod. Some pod and container fields are restricted
+                                if this is set. \n If the OS field is set to linux,
+                                the following fields must be unset: -securityContext.windowsOptions
+                                \n If the OS field is set to windows, following fields
+                                must be unset: - spec.hostPID - spec.hostIPC - spec.securityContext.seLinuxOptions
+                                - spec.securityContext.seccompProfile - spec.securityContext.fsGroup
+                                - spec.securityContext.fsGroupChangePolicy - spec.securityContext.sysctls
+                                - spec.shareProcessNamespace - spec.securityContext.runAsUser
+                                - spec.securityContext.runAsGroup - spec.securityContext.supplementalGroups
+                                - spec.containers[*].securityContext.seLinuxOptions
+                                - spec.containers[*].securityContext.seccompProfile
+                                - spec.containers[*].securityContext.capabilities
+                                - spec.containers[*].securityContext.readOnlyRootFilesystem
+                                - spec.containers[*].securityContext.privileged -
+                                spec.containers[*].securityContext.allowPrivilegeEscalation
+                                - spec.containers[*].securityContext.procMount - spec.containers[*].securityContext.runAsUser
+                                - spec.containers[*].securityContext.runAsGroup This
+                                is a beta field and requires the IdentifyPodOS feature"
+                              properties:
+                                name:
+                                  description: 'Name is the name of the operating
+                                    system. The currently supported values are linux
+                                    and windows. Additional value may be defined in
+                                    future and can be one of: https://github.com/opencontainers/runtime-spec/blob/master/config.md#platform-specific-configuration
+                                    Clients should expect to handle additional values
+                                    and treat unrecognized values in this field as
+                                    os: null'
+                                  type: string
+                              required:
+                              - name
+                              type: object
                             overhead:
                               additionalProperties:
                                 anyOf:
@@ -4694,17 +5484,12 @@ spec:
                                 and selected in the PodSpec, Overhead will be set
                                 to the value defined in the corresponding RuntimeClass,
                                 otherwise it will remain unset and treated as zero.
-                                More info: https://git.k8s.io/enhancements/keps/sig-node/20190226-pod-overhead.md
-                                This field is alpha-level as of Kubernetes v1.16,
-                                and is only honored by servers that enable the PodOverhead
-                                feature.'
+                                More info: https://git.k8s.io/enhancements/keps/sig-node/688-pod-overhead/README.md'
                               type: object
                             preemptionPolicy:
                               description: PreemptionPolicy is the Policy for preempting
                                 pods with lower priority. One of Never, PreemptLowerPriority.
-                                Defaults to PreemptLowerPriority if unset. This field
-                                is beta-level, gated by the NonPreemptingPriority
-                                feature-gate.
+                                Defaults to PreemptLowerPriority if unset.
                               type: string
                             priority:
                               description: The priority value. Various system components
@@ -4729,7 +5514,7 @@ spec:
                                 be evaluated for pod readiness. A pod is ready when
                                 all its containers are ready AND all conditions specified
                                 in the readiness gates have status equal to "True"
-                                More info: https://git.k8s.io/enhancements/keps/sig-network/0007-pod-ready%2B%2B.md'
+                                More info: https://git.k8s.io/enhancements/keps/sig-network/580-pod-readiness-gates'
                               items:
                                 description: PodReadinessGate contains the reference
                                   to a pod condition
@@ -4755,8 +5540,7 @@ spec:
                                 or empty, the "legacy" RuntimeClass will be used,
                                 which is an implicit class with an empty definition
                                 that uses the default runtime handler. More info:
-                                https://git.k8s.io/enhancements/keps/sig-node/runtime-class.md
-                                This is a beta feature as of Kubernetes v1.14.'
+                                https://git.k8s.io/enhancements/keps/sig-node/585-runtime-class'
                               type: string
                             schedulerName:
                               description: If specified, the pod will be dispatched
@@ -4778,7 +5562,9 @@ spec:
                                     is set (new files created in the volume will be
                                     owned by FSGroup) 3. The permission bits are OR'd
                                     with rw-rw---- \n If unset, the Kubelet will not
-                                    modify the ownership and permissions of any volume."
+                                    modify the ownership and permissions of any volume.
+                                    Note that this field cannot be set when spec.os.name
+                                    is windows."
                                   format: int64
                                   type: integer
                                 fsGroupChangePolicy:
@@ -4789,7 +5575,9 @@ spec:
                                     based ownership(and permissions). It will have
                                     no effect on ephemeral volume types such as: secret,
                                     configmaps and emptydir. Valid values are "OnRootMismatch"
-                                    and "Always". If not specified defaults to "Always".'
+                                    and "Always". If not specified, "Always" is used.
+                                    Note that this field cannot be set when spec.os.name
+                                    is windows.'
                                   type: string
                                 runAsGroup:
                                   description: The GID to run the entrypoint of the
@@ -4797,7 +5585,8 @@ spec:
                                     May also be set in SecurityContext.  If set in
                                     both SecurityContext and PodSecurityContext, the
                                     value specified in SecurityContext takes precedence
-                                    for that container.
+                                    for that container. Note that this field cannot
+                                    be set when spec.os.name is windows.
                                   format: int64
                                   type: integer
                                 runAsNonRoot:
@@ -4818,6 +5607,8 @@ spec:
                                     set in SecurityContext.  If set in both SecurityContext
                                     and PodSecurityContext, the value specified in
                                     SecurityContext takes precedence for that container.
+                                    Note that this field cannot be set when spec.os.name
+                                    is windows.
                                   format: int64
                                   type: integer
                                 seLinuxOptions:
@@ -4827,7 +5618,8 @@ spec:
                                     for each container.  May also be set in SecurityContext.  If
                                     set in both SecurityContext and PodSecurityContext,
                                     the value specified in SecurityContext takes precedence
-                                    for that container.
+                                    for that container. Note that this field cannot
+                                    be set when spec.os.name is windows.
                                   properties:
                                     level:
                                       description: Level is SELinux level label that
@@ -4848,7 +5640,8 @@ spec:
                                   type: object
                                 seccompProfile:
                                   description: The seccomp options to use by the containers
-                                    in this pod.
+                                    in this pod. Note that this field cannot be set
+                                    when spec.os.name is windows.
                                   properties:
                                     localhostProfile:
                                       description: localhostProfile indicates a profile
@@ -4874,7 +5667,9 @@ spec:
                                   description: A list of groups applied to the first
                                     process run in each container, in addition to
                                     the container's primary GID.  If unspecified,
-                                    no groups will be added to any container.
+                                    no groups will be added to any container. Note
+                                    that this field cannot be set when spec.os.name
+                                    is windows.
                                   items:
                                     format: int64
                                     type: integer
@@ -4883,6 +5678,8 @@ spec:
                                   description: Sysctls hold a list of namespaced sysctls
                                     used for the pod. Pods with unsupported sysctls
                                     (by the container runtime) might fail to launch.
+                                    Note that this field cannot be set when spec.os.name
+                                    is windows.
                                   items:
                                     description: Sysctl defines a kernel parameter
                                       to be set
@@ -4904,6 +5701,8 @@ spec:
                                     within a container's SecurityContext will be used.
                                     If set in both SecurityContext and PodSecurityContext,
                                     the value specified in SecurityContext takes precedence.
+                                    Note that this field cannot be set when spec.os.name
+                                    is linux.
                                   properties:
                                     gmsaCredentialSpec:
                                       description: GMSACredentialSpec is where the
@@ -4915,6 +5714,20 @@ spec:
                                       description: GMSACredentialSpecName is the name
                                         of the GMSA credential spec to use.
                                       type: string
+                                    hostProcess:
+                                      description: HostProcess determines if a container
+                                        should be run as a 'Host Process' container.
+                                        This field is alpha-level and will only be
+                                        honored by components that enable the WindowsHostProcessContainers
+                                        feature flag. Setting this field without the
+                                        feature flag will result in errors when validating
+                                        the Pod. All of a Pod's containers must have
+                                        the same effective HostProcess value (it is
+                                        not allowed to have a mix of HostProcess containers
+                                        and non-HostProcess containers).  In addition,
+                                        if HostProcess is true then HostNetwork must
+                                        also be set to true.
+                                      type: boolean
                                     runAsUserName:
                                       description: The UserName in Windows to run
                                         the entrypoint of the container process. Defaults
@@ -4966,10 +5779,11 @@ spec:
                               description: Optional duration in seconds the pod needs
                                 to terminate gracefully. May be decreased in delete
                                 request. Value must be non-negative integer. The value
-                                zero indicates delete immediately. If this value is
-                                nil, the default grace period will be used instead.
-                                The grace period is the duration in seconds after
-                                the processes running in the pod are sent a termination
+                                zero indicates stop immediately via the kill signal
+                                (no opportunity to shut down). If this value is nil,
+                                the default grace period will be used instead. The
+                                grace period is the duration in seconds after the
+                                processes running in the pod are sent a termination
                                 signal and the time when the processes are forcibly
                                 halted with a kill signal. Set this value longer than
                                 the expected cleanup time for your process. Defaults
@@ -5089,19 +5903,53 @@ spec:
                                       `whenUnsatisfiable=DoNotSchedule`, it is the
                                       maximum permitted difference between the number
                                       of matching pods in the target topology and
-                                      the global minimum. For example, in a 3-zone
+                                      the global minimum. The global minimum is the
+                                      minimum number of matching pods in an eligible
+                                      domain or zero if the number of eligible domains
+                                      is less than MinDomains. For example, in a 3-zone
                                       cluster, MaxSkew is set to 1, and pods with
-                                      the same labelSelector spread as 1/1/0: | zone1
-                                      | zone2 | zone3 | |   P   |   P   |       |
-                                      - if MaxSkew is 1, incoming pod can only be
-                                      scheduled to zone3 to become 1/1/1; scheduling
-                                      it onto zone1(zone2) would make the ActualSkew(2-0)
-                                      on zone1(zone2) violate MaxSkew(1). - if MaxSkew
-                                      is 2, incoming pod can be scheduled onto any
-                                      zone. When `whenUnsatisfiable=ScheduleAnyway`,
+                                      the same labelSelector spread as 2/2/1: In this
+                                      case, the global minimum is 1. | zone1 | zone2
+                                      | zone3 | |  P P  |  P P  |   P   | - if MaxSkew
+                                      is 1, incoming pod can only be scheduled to
+                                      zone3 to become 2/2/2; scheduling it onto zone1(zone2)
+                                      would make the ActualSkew(3-1) on zone1(zone2)
+                                      violate MaxSkew(1). - if MaxSkew is 2, incoming
+                                      pod can be scheduled onto any zone. When `whenUnsatisfiable=ScheduleAnyway`,
                                       it is used to give higher precedence to topologies
                                       that satisfy it. It''s a required field. Default
                                       value is 1 and 0 is not allowed.'
+                                    format: int32
+                                    type: integer
+                                  minDomains:
+                                    description: "MinDomains indicates a minimum number
+                                      of eligible domains. When the number of eligible
+                                      domains with matching topology keys is less
+                                      than minDomains, Pod Topology Spread treats
+                                      \"global minimum\" as 0, and then the calculation
+                                      of Skew is performed. And when the number of
+                                      eligible domains with matching topology keys
+                                      equals or greater than minDomains, this value
+                                      has no effect on scheduling. As a result, when
+                                      the number of eligible domains is less than
+                                      minDomains, scheduler won't schedule more than
+                                      maxSkew Pods to those domains. If value is nil,
+                                      the constraint behaves as if MinDomains is equal
+                                      to 1. Valid values are integers greater than
+                                      0. When value is not nil, WhenUnsatisfiable
+                                      must be DoNotSchedule. \n For example, in a
+                                      3-zone cluster, MaxSkew is set to 2, MinDomains
+                                      is set to 5 and pods with the same labelSelector
+                                      spread as 2/2/2: | zone1 | zone2 | zone3 | |
+                                      \ P P  |  P P  |  P P  | The number of domains
+                                      is less than 5(MinDomains), so \"global minimum\"
+                                      is treated as 0. In this situation, new pod
+                                      with the same labelSelector cannot be scheduled,
+                                      because computed skew will be 3(3 - 0) if new
+                                      Pod is scheduled to any of the three zones,
+                                      it will violate MaxSkew. \n This is an alpha
+                                      field and requires enabling MinDomainsInPodTopologySpread
+                                      feature gate."
                                     format: int32
                                     type: integer
                                   topologyKey:
@@ -5110,7 +5958,14 @@ spec:
                                       values are considered to be in the same topology.
                                       We consider each <key, value> as a "bucket",
                                       and try to put balanced number of pods into
-                                      each bucket. It's a required field.
+                                      each bucket. We define a domain as a particular
+                                      instance of a topology. Also, we define an eligible
+                                      domain as a domain whose nodes match the node
+                                      selector. e.g. If TopologyKey is "kubernetes.io/hostname",
+                                      each Node is a domain of that topology. And,
+                                      if TopologyKey is "topology.kubernetes.io/zone",
+                                      each zone is a domain of that topology. It's
+                                      a required field.
                                     type: string
                                   whenUnsatisfiable:
                                     description: 'WhenUnsatisfiable indicates how
@@ -5122,7 +5977,7 @@ spec:
                                       topologies that would help reduce the   skew.
                                       A constraint is considered "Unsatisfiable" for
                                       an incoming pod if and only if every possible
-                                      node assigment for that pod would violate "MaxSkew"
+                                      node assignment for that pod would violate "MaxSkew"
                                       on some topology. For example, in a 3-zone cluster,
                                       MaxSkew is set to 1, and pods with the same
                                       labelSelector spread as 3/1/1: | zone1 | zone2
@@ -5153,77 +6008,78 @@ spec:
                                   pod.
                                 properties:
                                   awsElasticBlockStore:
-                                    description: 'AWSElasticBlockStore represents
+                                    description: 'awsElasticBlockStore represents
                                       an AWS Disk resource that is attached to a kubelet''s
                                       host machine and then exposed to the pod. More
                                       info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore'
                                     properties:
                                       fsType:
-                                        description: 'Filesystem type of the volume
-                                          that you want to mount. Tip: Ensure that
-                                          the filesystem type is supported by the
-                                          host operating system. Examples: "ext4",
-                                          "xfs", "ntfs". Implicitly inferred to be
-                                          "ext4" if unspecified. More info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore
+                                        description: 'fsType is the filesystem type
+                                          of the volume that you want to mount. Tip:
+                                          Ensure that the filesystem type is supported
+                                          by the host operating system. Examples:
+                                          "ext4", "xfs", "ntfs". Implicitly inferred
+                                          to be "ext4" if unspecified. More info:
+                                          https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore
                                           TODO: how do we prevent errors in the filesystem
                                           from compromising the machine'
                                         type: string
                                       partition:
-                                        description: 'The partition in the volume
-                                          that you want to mount. If omitted, the
-                                          default is to mount by volume name. Examples:
-                                          For volume /dev/sda1, you specify the partition
-                                          as "1". Similarly, the volume partition
-                                          for /dev/sda is "0" (or you can leave the
-                                          property empty).'
+                                        description: 'partition is the partition in
+                                          the volume that you want to mount. If omitted,
+                                          the default is to mount by volume name.
+                                          Examples: For volume /dev/sda1, you specify
+                                          the partition as "1". Similarly, the volume
+                                          partition for /dev/sda is "0" (or you can
+                                          leave the property empty).'
                                         format: int32
                                         type: integer
                                       readOnly:
-                                        description: 'Specify "true" to force and
-                                          set the ReadOnly property in VolumeMounts
-                                          to "true". If omitted, the default is "false".
-                                          More info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore'
+                                        description: 'readOnly value true will force
+                                          the readOnly setting in VolumeMounts. More
+                                          info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore'
                                         type: boolean
                                       volumeID:
-                                        description: 'Unique ID of the persistent
-                                          disk resource in AWS (Amazon EBS volume).
-                                          More info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore'
+                                        description: 'volumeID is unique ID of the
+                                          persistent disk resource in AWS (Amazon
+                                          EBS volume). More info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore'
                                         type: string
                                     required:
                                     - volumeID
                                     type: object
                                   azureDisk:
-                                    description: AzureDisk represents an Azure Data
+                                    description: azureDisk represents an Azure Data
                                       Disk mount on the host and bind mount to the
                                       pod.
                                     properties:
                                       cachingMode:
-                                        description: 'Host Caching mode: None, Read
-                                          Only, Read Write.'
+                                        description: 'cachingMode is the Host Caching
+                                          mode: None, Read Only, Read Write.'
                                         type: string
                                       diskName:
-                                        description: The Name of the data disk in
-                                          the blob storage
+                                        description: diskName is the Name of the data
+                                          disk in the blob storage
                                         type: string
                                       diskURI:
-                                        description: The URI the data disk in the
-                                          blob storage
+                                        description: diskURI is the URI of data disk
+                                          in the blob storage
                                         type: string
                                       fsType:
-                                        description: Filesystem type to mount. Must
-                                          be a filesystem type supported by the host
-                                          operating system. Ex. "ext4", "xfs", "ntfs".
-                                          Implicitly inferred to be "ext4" if unspecified.
+                                        description: fsType is Filesystem type to
+                                          mount. Must be a filesystem type supported
+                                          by the host operating system. Ex. "ext4",
+                                          "xfs", "ntfs". Implicitly inferred to be
+                                          "ext4" if unspecified.
                                         type: string
                                       kind:
-                                        description: 'Expected values Shared: multiple
-                                          blob disks per storage account  Dedicated:
+                                        description: 'kind expected values are Shared:
+                                          multiple blob disks per storage account  Dedicated:
                                           single blob disk per storage account  Managed:
                                           azure managed data disk (only in managed
                                           availability set). defaults to shared'
                                         type: string
                                       readOnly:
-                                        description: Defaults to false (read/write).
+                                        description: readOnly Defaults to false (read/write).
                                           ReadOnly here will force the ReadOnly setting
                                           in VolumeMounts.
                                         type: boolean
@@ -5232,56 +6088,59 @@ spec:
                                     - diskURI
                                     type: object
                                   azureFile:
-                                    description: AzureFile represents an Azure File
+                                    description: azureFile represents an Azure File
                                       Service mount on the host and bind mount to
                                       the pod.
                                     properties:
                                       readOnly:
-                                        description: Defaults to false (read/write).
+                                        description: readOnly defaults to false (read/write).
                                           ReadOnly here will force the ReadOnly setting
                                           in VolumeMounts.
                                         type: boolean
                                       secretName:
-                                        description: the name of secret that contains
-                                          Azure Storage Account Name and Key
+                                        description: secretName is the  name of secret
+                                          that contains Azure Storage Account Name
+                                          and Key
                                         type: string
                                       shareName:
-                                        description: Share Name
+                                        description: shareName is the azure share
+                                          Name
                                         type: string
                                     required:
                                     - secretName
                                     - shareName
                                     type: object
                                   cephfs:
-                                    description: CephFS represents a Ceph FS mount
+                                    description: cephFS represents a Ceph FS mount
                                       on the host that shares a pod's lifetime
                                     properties:
                                       monitors:
-                                        description: 'Required: Monitors is a collection
-                                          of Ceph monitors More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it'
+                                        description: 'monitors is Required: Monitors
+                                          is a collection of Ceph monitors More info:
+                                          https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it'
                                         items:
                                           type: string
                                         type: array
                                       path:
-                                        description: 'Optional: Used as the mounted
-                                          root, rather than the full Ceph tree, default
-                                          is /'
+                                        description: 'path is Optional: Used as the
+                                          mounted root, rather than the full Ceph
+                                          tree, default is /'
                                         type: string
                                       readOnly:
-                                        description: 'Optional: Defaults to false
-                                          (read/write). ReadOnly here will force the
-                                          ReadOnly setting in VolumeMounts. More info:
-                                          https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it'
+                                        description: 'readOnly is Optional: Defaults
+                                          to false (read/write). ReadOnly here will
+                                          force the ReadOnly setting in VolumeMounts.
+                                          More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it'
                                         type: boolean
                                       secretFile:
-                                        description: 'Optional: SecretFile is the
-                                          path to key ring for User, default is /etc/ceph/user.secret
-                                          More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it'
+                                        description: 'secretFile is Optional: SecretFile
+                                          is the path to key ring for User, default
+                                          is /etc/ceph/user.secret More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it'
                                         type: string
                                       secretRef:
-                                        description: 'Optional: SecretRef is reference
-                                          to the authentication secret for User, default
-                                          is empty. More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it'
+                                        description: 'secretRef is Optional: SecretRef
+                                          is reference to the authentication secret
+                                          for User, default is empty. More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it'
                                         properties:
                                           name:
                                             description: 'Name of the referent. More
@@ -5291,34 +6150,35 @@ spec:
                                             type: string
                                         type: object
                                       user:
-                                        description: 'Optional: User is the rados
-                                          user name, default is admin More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it'
+                                        description: 'user is optional: User is the
+                                          rados user name, default is admin More info:
+                                          https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it'
                                         type: string
                                     required:
                                     - monitors
                                     type: object
                                   cinder:
-                                    description: 'Cinder represents a cinder volume
+                                    description: 'cinder represents a cinder volume
                                       attached and mounted on kubelets host machine.
                                       More info: https://examples.k8s.io/mysql-cinder-pd/README.md'
                                     properties:
                                       fsType:
-                                        description: 'Filesystem type to mount. Must
-                                          be a filesystem type supported by the host
-                                          operating system. Examples: "ext4", "xfs",
-                                          "ntfs". Implicitly inferred to be "ext4"
-                                          if unspecified. More info: https://examples.k8s.io/mysql-cinder-pd/README.md'
+                                        description: 'fsType is the filesystem type
+                                          to mount. Must be a filesystem type supported
+                                          by the host operating system. Examples:
+                                          "ext4", "xfs", "ntfs". Implicitly inferred
+                                          to be "ext4" if unspecified. More info:
+                                          https://examples.k8s.io/mysql-cinder-pd/README.md'
                                         type: string
                                       readOnly:
-                                        description: 'Optional: Defaults to false
-                                          (read/write). ReadOnly here will force the
-                                          ReadOnly setting in VolumeMounts. More info:
-                                          https://examples.k8s.io/mysql-cinder-pd/README.md'
+                                        description: 'readOnly defaults to false (read/write).
+                                          ReadOnly here will force the ReadOnly setting
+                                          in VolumeMounts. More info: https://examples.k8s.io/mysql-cinder-pd/README.md'
                                         type: boolean
                                       secretRef:
-                                        description: 'Optional: points to a secret
-                                          object containing parameters used to connect
-                                          to OpenStack.'
+                                        description: 'secretRef is optional: points
+                                          to a secret object containing parameters
+                                          used to connect to OpenStack.'
                                         properties:
                                           name:
                                             description: 'Name of the referent. More
@@ -5328,32 +6188,33 @@ spec:
                                             type: string
                                         type: object
                                       volumeID:
-                                        description: 'volume id used to identify the
+                                        description: 'volumeID used to identify the
                                           volume in cinder. More info: https://examples.k8s.io/mysql-cinder-pd/README.md'
                                         type: string
                                     required:
                                     - volumeID
                                     type: object
                                   configMap:
-                                    description: ConfigMap represents a configMap
+                                    description: configMap represents a configMap
                                       that should populate this volume
                                     properties:
                                       defaultMode:
-                                        description: 'Optional: mode bits used to
-                                          set permissions on created files by default.
-                                          Must be an octal value between 0000 and
-                                          0777 or a decimal value between 0 and 511.
-                                          YAML accepts both octal and decimal values,
-                                          JSON requires decimal values for mode bits.
-                                          Defaults to 0644. Directories within the
-                                          path are not affected by this setting. This
-                                          might be in conflict with other options
-                                          that affect the file mode, like fsGroup,
-                                          and the result can be other mode bits set.'
+                                        description: 'defaultMode is optional: mode
+                                          bits used to set permissions on created
+                                          files by default. Must be an octal value
+                                          between 0000 and 0777 or a decimal value
+                                          between 0 and 511. YAML accepts both octal
+                                          and decimal values, JSON requires decimal
+                                          values for mode bits. Defaults to 0644.
+                                          Directories within the path are not affected
+                                          by this setting. This might be in conflict
+                                          with other options that affect the file
+                                          mode, like fsGroup, and the result can be
+                                          other mode bits set.'
                                         format: int32
                                         type: integer
                                       items:
-                                        description: If unspecified, each key-value
+                                        description: items if unspecified, each key-value
                                           pair in the Data field of the referenced
                                           ConfigMap will be projected into the volume
                                           as a file whose name is the key and content
@@ -5370,27 +6231,27 @@ spec:
                                             within a volume.
                                           properties:
                                             key:
-                                              description: The key to project.
+                                              description: key is the key to project.
                                               type: string
                                             mode:
-                                              description: 'Optional: mode bits used
-                                                to set permissions on this file. Must
-                                                be an octal value between 0000 and
-                                                0777 or a decimal value between 0
-                                                and 511. YAML accepts both octal and
-                                                decimal values, JSON requires decimal
-                                                values for mode bits. If not specified,
-                                                the volume defaultMode will be used.
-                                                This might be in conflict with other
-                                                options that affect the file mode,
-                                                like fsGroup, and the result can be
-                                                other mode bits set.'
+                                              description: 'mode is Optional: mode
+                                                bits used to set permissions on this
+                                                file. Must be an octal value between
+                                                0000 and 0777 or a decimal value between
+                                                0 and 511. YAML accepts both octal
+                                                and decimal values, JSON requires
+                                                decimal values for mode bits. If not
+                                                specified, the volume defaultMode
+                                                will be used. This might be in conflict
+                                                with other options that affect the
+                                                file mode, like fsGroup, and the result
+                                                can be other mode bits set.'
                                               format: int32
                                               type: integer
                                             path:
-                                              description: The relative path of the
-                                                file to map the key to. May not be
-                                                an absolute path. May not contain
+                                              description: path is the relative path
+                                                of the file to map the key to. May
+                                                not be an absolute path. May not contain
                                                 the path element '..'. May not start
                                                 with the string '..'.
                                               type: string
@@ -5406,30 +6267,30 @@ spec:
                                           kind, uid?'
                                         type: string
                                       optional:
-                                        description: Specify whether the ConfigMap
-                                          or its keys must be defined
+                                        description: optional specify whether the
+                                          ConfigMap or its keys must be defined
                                         type: boolean
                                     type: object
                                   csi:
-                                    description: CSI (Container Storage Interface)
+                                    description: csi (Container Storage Interface)
                                       represents ephemeral storage that is handled
                                       by certain external CSI drivers (Beta feature).
                                     properties:
                                       driver:
-                                        description: Driver is the name of the CSI
+                                        description: driver is the name of the CSI
                                           driver that handles this volume. Consult
                                           with your admin for the correct name as
                                           registered in the cluster.
                                         type: string
                                       fsType:
-                                        description: Filesystem type to mount. Ex.
-                                          "ext4", "xfs", "ntfs". If not provided,
-                                          the empty value is passed to the associated
-                                          CSI driver which will determine the default
-                                          filesystem to apply.
+                                        description: fsType to mount. Ex. "ext4",
+                                          "xfs", "ntfs". If not provided, the empty
+                                          value is passed to the associated CSI driver
+                                          which will determine the default filesystem
+                                          to apply.
                                         type: string
                                       nodePublishSecretRef:
-                                        description: NodePublishSecretRef is a reference
+                                        description: nodePublishSecretRef is a reference
                                           to the secret object containing sensitive
                                           information to pass to the CSI driver to
                                           complete the CSI NodePublishVolume and NodeUnpublishVolume
@@ -5446,13 +6307,14 @@ spec:
                                             type: string
                                         type: object
                                       readOnly:
-                                        description: Specifies a read-only configuration
-                                          for the volume. Defaults to false (read/write).
+                                        description: readOnly specifies a read-only
+                                          configuration for the volume. Defaults to
+                                          false (read/write).
                                         type: boolean
                                       volumeAttributes:
                                         additionalProperties:
                                           type: string
-                                        description: VolumeAttributes stores driver-specific
+                                        description: volumeAttributes stores driver-specific
                                           properties that are passed to the CSI driver.
                                           Consult your driver's documentation for
                                           supported values.
@@ -5461,7 +6323,7 @@ spec:
                                     - driver
                                     type: object
                                   downwardAPI:
-                                    description: DownwardAPI represents downward API
+                                    description: downwardAPI represents downward API
                                       about the pod that should populate this volume
                                     properties:
                                       defaultMode:
@@ -5562,62 +6424,59 @@ spec:
                                         type: array
                                     type: object
                                   emptyDir:
-                                    description: 'EmptyDir represents a temporary
+                                    description: 'emptyDir represents a temporary
                                       directory that shares a pod''s lifetime. More
                                       info: https://kubernetes.io/docs/concepts/storage/volumes#emptydir'
                                     properties:
                                       medium:
-                                        description: 'What type of storage medium
-                                          should back this directory. The default
-                                          is "" which means to use the node''s default
-                                          medium. Must be an empty string (default)
-                                          or Memory. More info: https://kubernetes.io/docs/concepts/storage/volumes#emptydir'
+                                        description: 'medium represents what type
+                                          of storage medium should back this directory.
+                                          The default is "" which means to use the
+                                          node''s default medium. Must be an empty
+                                          string (default) or Memory. More info: https://kubernetes.io/docs/concepts/storage/volumes#emptydir'
                                         type: string
                                       sizeLimit:
                                         anyOf:
                                         - type: integer
                                         - type: string
-                                        description: 'Total amount of local storage
-                                          required for this EmptyDir volume. The size
-                                          limit is also applicable for memory medium.
-                                          The maximum usage on memory medium EmptyDir
-                                          would be the minimum value between the SizeLimit
-                                          specified here and the sum of memory limits
-                                          of all containers in a pod. The default
-                                          is nil which means that the limit is undefined.
-                                          More info: http://kubernetes.io/docs/user-guide/volumes#emptydir'
+                                        description: 'sizeLimit is the total amount
+                                          of local storage required for this EmptyDir
+                                          volume. The size limit is also applicable
+                                          for memory medium. The maximum usage on
+                                          memory medium EmptyDir would be the minimum
+                                          value between the SizeLimit specified here
+                                          and the sum of memory limits of all containers
+                                          in a pod. The default is nil which means
+                                          that the limit is undefined. More info:
+                                          http://kubernetes.io/docs/user-guide/volumes#emptydir'
                                         pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                         x-kubernetes-int-or-string: true
                                     type: object
                                   ephemeral:
-                                    description: "Ephemeral represents a volume that
-                                      is handled by a cluster storage driver (Alpha
-                                      feature). The volume's lifecycle is tied to
-                                      the pod that defines it - it will be created
-                                      before the pod starts, and deleted when the
-                                      pod is removed. \n Use this if: a) the volume
-                                      is only needed while the pod runs, b) features
-                                      of normal volumes like restoring from snapshot
-                                      or capacity    tracking are needed, c) the storage
-                                      driver is specified through a storage class,
-                                      and d) the storage driver supports dynamic volume
-                                      provisioning through    a PersistentVolumeClaim
-                                      (see EphemeralVolumeSource for more    information
-                                      on the connection between this volume type    and
-                                      PersistentVolumeClaim). \n Use PersistentVolumeClaim
-                                      or one of the vendor-specific APIs for volumes
-                                      that persist for longer than the lifecycle of
-                                      an individual pod. \n Use CSI for light-weight
-                                      local ephemeral volumes if the CSI driver is
-                                      meant to be used that way - see the documentation
-                                      of the driver for more information. \n A pod
-                                      can use both types of ephemeral volumes and
-                                      persistent volumes at the same time."
+                                    description: "ephemeral represents a volume that
+                                      is handled by a cluster storage driver. The
+                                      volume's lifecycle is tied to the pod that defines
+                                      it - it will be created before the pod starts,
+                                      and deleted when the pod is removed. \n Use
+                                      this if: a) the volume is only needed while
+                                      the pod runs, b) features of normal volumes
+                                      like restoring from snapshot or capacity    tracking
+                                      are needed, c) the storage driver is specified
+                                      through a storage class, and d) the storage
+                                      driver supports dynamic volume provisioning
+                                      through    a PersistentVolumeClaim (see EphemeralVolumeSource
+                                      for more    information on the connection between
+                                      this volume type    and PersistentVolumeClaim).
+                                      \n Use PersistentVolumeClaim or one of the vendor-specific
+                                      APIs for volumes that persist for longer than
+                                      the lifecycle of an individual pod. \n Use CSI
+                                      for light-weight local ephemeral volumes if
+                                      the CSI driver is meant to be used that way
+                                      - see the documentation of the driver for more
+                                      information. \n A pod can use both types of
+                                      ephemeral volumes and persistent volumes at
+                                      the same time."
                                     properties:
-                                      readOnly:
-                                        description: Specifies a read-only configuration
-                                          for the volume. Defaults to false (read/write).
-                                        type: boolean
                                       volumeClaimTemplate:
                                         description: "Will be used to create a stand-alone
                                           PVC to provision the volume. The pod in
@@ -5677,34 +6536,82 @@ spec:
                                               are also valid here.
                                             properties:
                                               accessModes:
-                                                description: 'AccessModes contains
+                                                description: 'accessModes contains
                                                   the desired access modes the volume
                                                   should have. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#access-modes-1'
                                                 items:
                                                   type: string
                                                 type: array
                                               dataSource:
-                                                description: 'This field can be used
-                                                  to specify either: * An existing
-                                                  VolumeSnapshot object (snapshot.storage.k8s.io/VolumeSnapshot
-                                                  - Beta) * An existing PVC (PersistentVolumeClaim)
-                                                  * An existing custom resource/object
-                                                  that implements data population
-                                                  (Alpha) In order to use VolumeSnapshot
-                                                  object types, the appropriate feature
-                                                  gate must be enabled (VolumeSnapshotDataSource
-                                                  or AnyVolumeDataSource) If the provisioner
-                                                  or an external controller can support
-                                                  the specified data source, it will
-                                                  create a new volume based on the
-                                                  contents of the specified data source.
-                                                  If the specified data source is
-                                                  not supported, the volume will not
-                                                  be created and the failure will
-                                                  be reported as an event. In the
-                                                  future, we plan to support more
-                                                  data source types and the behavior
-                                                  of the provisioner may change.'
+                                                description: 'dataSource field can
+                                                  be used to specify either: * An
+                                                  existing VolumeSnapshot object (snapshot.storage.k8s.io/VolumeSnapshot)
+                                                  * An existing PVC (PersistentVolumeClaim)
+                                                  If the provisioner or an external
+                                                  controller can support the specified
+                                                  data source, it will create a new
+                                                  volume based on the contents of
+                                                  the specified data source. If the
+                                                  AnyVolumeDataSource feature gate
+                                                  is enabled, this field will always
+                                                  have the same contents as the DataSourceRef
+                                                  field.'
+                                                properties:
+                                                  apiGroup:
+                                                    description: APIGroup is the group
+                                                      for the resource being referenced.
+                                                      If APIGroup is not specified,
+                                                      the specified Kind must be in
+                                                      the core API group. For any
+                                                      other third-party types, APIGroup
+                                                      is required.
+                                                    type: string
+                                                  kind:
+                                                    description: Kind is the type
+                                                      of resource being referenced
+                                                    type: string
+                                                  name:
+                                                    description: Name is the name
+                                                      of resource being referenced
+                                                    type: string
+                                                required:
+                                                - kind
+                                                - name
+                                                type: object
+                                              dataSourceRef:
+                                                description: 'dataSourceRef specifies
+                                                  the object from which to populate
+                                                  the volume with data, if a non-empty
+                                                  volume is desired. This may be any
+                                                  local object from a non-empty API
+                                                  group (non core object) or a PersistentVolumeClaim
+                                                  object. When this field is specified,
+                                                  volume binding will only succeed
+                                                  if the type of the specified object
+                                                  matches some installed volume populator
+                                                  or dynamic provisioner. This field
+                                                  will replace the functionality of
+                                                  the DataSource field and as such
+                                                  if both fields are non-empty, they
+                                                  must have the same value. For backwards
+                                                  compatibility, both fields (DataSource
+                                                  and DataSourceRef) will be set to
+                                                  the same value automatically if
+                                                  one of them is empty and the other
+                                                  is non-empty. There are two important
+                                                  differences between DataSource and
+                                                  DataSourceRef: * While DataSource
+                                                  only allows two specific types of
+                                                  objects, DataSourceRef   allows
+                                                  any non-core object, as well as
+                                                  PersistentVolumeClaim objects. *
+                                                  While DataSource ignores disallowed
+                                                  values (dropping them), DataSourceRef   preserves
+                                                  all values, and generates an error
+                                                  if a disallowed value is   specified.
+                                                  (Beta) Using this field requires
+                                                  the AnyVolumeDataSource feature
+                                                  gate to be enabled.'
                                                 properties:
                                                   apiGroup:
                                                     description: APIGroup is the group
@@ -5728,9 +6635,15 @@ spec:
                                                 - name
                                                 type: object
                                               resources:
-                                                description: 'Resources represents
+                                                description: 'resources represents
                                                   the minimum resources the volume
-                                                  should have. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#resources'
+                                                  should have. If RecoverVolumeExpansionFailure
+                                                  feature is enabled users are allowed
+                                                  to specify resource requirements
+                                                  that are lower than previous value
+                                                  but must still be higher than capacity
+                                                  recorded in the status field of
+                                                  the claim. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#resources'
                                                 properties:
                                                   limits:
                                                     additionalProperties:
@@ -5742,7 +6655,7 @@ spec:
                                                     description: 'Limits describes
                                                       the maximum amount of compute
                                                       resources allowed. More info:
-                                                      https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
+                                                      https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
                                                     type: object
                                                   requests:
                                                     additionalProperties:
@@ -5758,12 +6671,12 @@ spec:
                                                       it defaults to Limits if that
                                                       is explicitly specified, otherwise
                                                       to an implementation-defined
-                                                      value. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
+                                                      value. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
                                                     type: object
                                                 type: object
                                               selector:
-                                                description: A label query over volumes
-                                                  to consider for binding.
+                                                description: selector is a label query
+                                                  over volumes to consider for binding.
                                                 properties:
                                                   matchExpressions:
                                                     description: matchExpressions
@@ -5823,9 +6736,9 @@ spec:
                                                     type: object
                                                 type: object
                                               storageClassName:
-                                                description: 'Name of the StorageClass
-                                                  required by the claim. More info:
-                                                  https://kubernetes.io/docs/concepts/storage/persistent-volumes#class-1'
+                                                description: 'storageClassName is
+                                                  the name of the StorageClass required
+                                                  by the claim. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#class-1'
                                                 type: string
                                               volumeMode:
                                                 description: volumeMode defines what
@@ -5834,7 +6747,7 @@ spec:
                                                   when not included in claim spec.
                                                 type: string
                                               volumeName:
-                                                description: VolumeName is the binding
+                                                description: volumeName is the binding
                                                   reference to the PersistentVolume
                                                   backing this claim.
                                                 type: string
@@ -5844,77 +6757,79 @@ spec:
                                         type: object
                                     type: object
                                   fc:
-                                    description: FC represents a Fibre Channel resource
+                                    description: fc represents a Fibre Channel resource
                                       that is attached to a kubelet's host machine
                                       and then exposed to the pod.
                                     properties:
                                       fsType:
-                                        description: 'Filesystem type to mount. Must
-                                          be a filesystem type supported by the host
-                                          operating system. Ex. "ext4", "xfs", "ntfs".
-                                          Implicitly inferred to be "ext4" if unspecified.
-                                          TODO: how do we prevent errors in the filesystem
-                                          from compromising the machine'
+                                        description: 'fsType is the filesystem type
+                                          to mount. Must be a filesystem type supported
+                                          by the host operating system. Ex. "ext4",
+                                          "xfs", "ntfs". Implicitly inferred to be
+                                          "ext4" if unspecified. TODO: how do we prevent
+                                          errors in the filesystem from compromising
+                                          the machine'
                                         type: string
                                       lun:
-                                        description: 'Optional: FC target lun number'
+                                        description: 'lun is Optional: FC target lun
+                                          number'
                                         format: int32
                                         type: integer
                                       readOnly:
-                                        description: 'Optional: Defaults to false
-                                          (read/write). ReadOnly here will force the
-                                          ReadOnly setting in VolumeMounts.'
+                                        description: 'readOnly is Optional: Defaults
+                                          to false (read/write). ReadOnly here will
+                                          force the ReadOnly setting in VolumeMounts.'
                                         type: boolean
                                       targetWWNs:
-                                        description: 'Optional: FC target worldwide
-                                          names (WWNs)'
+                                        description: 'targetWWNs is Optional: FC target
+                                          worldwide names (WWNs)'
                                         items:
                                           type: string
                                         type: array
                                       wwids:
-                                        description: 'Optional: FC volume world wide
-                                          identifiers (wwids) Either wwids or combination
-                                          of targetWWNs and lun must be set, but not
-                                          both simultaneously.'
+                                        description: 'wwids Optional: FC volume world
+                                          wide identifiers (wwids) Either wwids or
+                                          combination of targetWWNs and lun must be
+                                          set, but not both simultaneously.'
                                         items:
                                           type: string
                                         type: array
                                     type: object
                                   flexVolume:
-                                    description: FlexVolume represents a generic volume
+                                    description: flexVolume represents a generic volume
                                       resource that is provisioned/attached using
                                       an exec based plugin.
                                     properties:
                                       driver:
-                                        description: Driver is the name of the driver
+                                        description: driver is the name of the driver
                                           to use for this volume.
                                         type: string
                                       fsType:
-                                        description: Filesystem type to mount. Must
-                                          be a filesystem type supported by the host
-                                          operating system. Ex. "ext4", "xfs", "ntfs".
-                                          The default filesystem depends on FlexVolume
-                                          script.
+                                        description: fsType is the filesystem type
+                                          to mount. Must be a filesystem type supported
+                                          by the host operating system. Ex. "ext4",
+                                          "xfs", "ntfs". The default filesystem depends
+                                          on FlexVolume script.
                                         type: string
                                       options:
                                         additionalProperties:
                                           type: string
-                                        description: 'Optional: Extra command options
-                                          if any.'
+                                        description: 'options is Optional: this field
+                                          holds extra command options if any.'
                                         type: object
                                       readOnly:
-                                        description: 'Optional: Defaults to false
-                                          (read/write). ReadOnly here will force the
-                                          ReadOnly setting in VolumeMounts.'
+                                        description: 'readOnly is Optional: defaults
+                                          to false (read/write). ReadOnly here will
+                                          force the ReadOnly setting in VolumeMounts.'
                                         type: boolean
                                       secretRef:
-                                        description: 'Optional: SecretRef is reference
-                                          to the secret object containing sensitive
-                                          information to pass to the plugin scripts.
-                                          This may be empty if no secret object is
-                                          specified. If the secret object contains
-                                          more than one secret, all secrets are passed
-                                          to the plugin scripts.'
+                                        description: 'secretRef is Optional: secretRef
+                                          is reference to the secret object containing
+                                          sensitive information to pass to the plugin
+                                          scripts. This may be empty if no secret
+                                          object is specified. If the secret object
+                                          contains more than one secret, all secrets
+                                          are passed to the plugin scripts.'
                                         properties:
                                           name:
                                             description: 'Name of the referent. More
@@ -5927,53 +6842,55 @@ spec:
                                     - driver
                                     type: object
                                   flocker:
-                                    description: Flocker represents a Flocker volume
+                                    description: flocker represents a Flocker volume
                                       attached to a kubelet's host machine. This depends
                                       on the Flocker control service being running
                                     properties:
                                       datasetName:
-                                        description: Name of the dataset stored as
-                                          metadata -> name on the dataset for Flocker
-                                          should be considered as deprecated
+                                        description: datasetName is Name of the dataset
+                                          stored as metadata -> name on the dataset
+                                          for Flocker should be considered as deprecated
                                         type: string
                                       datasetUUID:
-                                        description: UUID of the dataset. This is
-                                          unique identifier of a Flocker dataset
+                                        description: datasetUUID is the UUID of the
+                                          dataset. This is unique identifier of a
+                                          Flocker dataset
                                         type: string
                                     type: object
                                   gcePersistentDisk:
-                                    description: 'GCEPersistentDisk represents a GCE
+                                    description: 'gcePersistentDisk represents a GCE
                                       Disk resource that is attached to a kubelet''s
                                       host machine and then exposed to the pod. More
                                       info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk'
                                     properties:
                                       fsType:
-                                        description: 'Filesystem type of the volume
-                                          that you want to mount. Tip: Ensure that
-                                          the filesystem type is supported by the
-                                          host operating system. Examples: "ext4",
-                                          "xfs", "ntfs". Implicitly inferred to be
-                                          "ext4" if unspecified. More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk
+                                        description: 'fsType is filesystem type of
+                                          the volume that you want to mount. Tip:
+                                          Ensure that the filesystem type is supported
+                                          by the host operating system. Examples:
+                                          "ext4", "xfs", "ntfs". Implicitly inferred
+                                          to be "ext4" if unspecified. More info:
+                                          https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk
                                           TODO: how do we prevent errors in the filesystem
                                           from compromising the machine'
                                         type: string
                                       partition:
-                                        description: 'The partition in the volume
-                                          that you want to mount. If omitted, the
-                                          default is to mount by volume name. Examples:
-                                          For volume /dev/sda1, you specify the partition
-                                          as "1". Similarly, the volume partition
-                                          for /dev/sda is "0" (or you can leave the
-                                          property empty). More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk'
+                                        description: 'partition is the partition in
+                                          the volume that you want to mount. If omitted,
+                                          the default is to mount by volume name.
+                                          Examples: For volume /dev/sda1, you specify
+                                          the partition as "1". Similarly, the volume
+                                          partition for /dev/sda is "0" (or you can
+                                          leave the property empty). More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk'
                                         format: int32
                                         type: integer
                                       pdName:
-                                        description: 'Unique name of the PD resource
-                                          in GCE. Used to identify the disk in GCE.
-                                          More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk'
+                                        description: 'pdName is unique name of the
+                                          PD resource in GCE. Used to identify the
+                                          disk in GCE. More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk'
                                         type: string
                                       readOnly:
-                                        description: 'ReadOnly here will force the
+                                        description: 'readOnly here will force the
                                           ReadOnly setting in VolumeMounts. Defaults
                                           to false. More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk'
                                         type: boolean
@@ -5981,7 +6898,7 @@ spec:
                                     - pdName
                                     type: object
                                   gitRepo:
-                                    description: 'GitRepo represents a git repository
+                                    description: 'gitRepo represents a git repository
                                       at a particular revision. DEPRECATED: GitRepo
                                       is deprecated. To provision a container with
                                       a git repo, mount an EmptyDir into an InitContainer
@@ -5989,39 +6906,39 @@ spec:
                                       EmptyDir into the Pod''s container.'
                                     properties:
                                       directory:
-                                        description: Target directory name. Must not
-                                          contain or start with '..'.  If '.' is supplied,
-                                          the volume directory will be the git repository.  Otherwise,
-                                          if specified, the volume will contain the
-                                          git repository in the subdirectory with
-                                          the given name.
+                                        description: directory is the target directory
+                                          name. Must not contain or start with '..'.  If
+                                          '.' is supplied, the volume directory will
+                                          be the git repository.  Otherwise, if specified,
+                                          the volume will contain the git repository
+                                          in the subdirectory with the given name.
                                         type: string
                                       repository:
-                                        description: Repository URL
+                                        description: repository is the URL
                                         type: string
                                       revision:
-                                        description: Commit hash for the specified
-                                          revision.
+                                        description: revision is the commit hash for
+                                          the specified revision.
                                         type: string
                                     required:
                                     - repository
                                     type: object
                                   glusterfs:
-                                    description: 'Glusterfs represents a Glusterfs
+                                    description: 'glusterfs represents a Glusterfs
                                       mount on the host that shares a pod''s lifetime.
                                       More info: https://examples.k8s.io/volumes/glusterfs/README.md'
                                     properties:
                                       endpoints:
-                                        description: 'EndpointsName is the endpoint
-                                          name that details Glusterfs topology. More
-                                          info: https://examples.k8s.io/volumes/glusterfs/README.md#create-a-pod'
+                                        description: 'endpoints is the endpoint name
+                                          that details Glusterfs topology. More info:
+                                          https://examples.k8s.io/volumes/glusterfs/README.md#create-a-pod'
                                         type: string
                                       path:
-                                        description: 'Path is the Glusterfs volume
+                                        description: 'path is the Glusterfs volume
                                           path. More info: https://examples.k8s.io/volumes/glusterfs/README.md#create-a-pod'
                                         type: string
                                       readOnly:
-                                        description: 'ReadOnly here will force the
+                                        description: 'readOnly here will force the
                                           Glusterfs volume to be mounted with read-only
                                           permissions. Defaults to false. More info:
                                           https://examples.k8s.io/volumes/glusterfs/README.md#create-a-pod'
@@ -6031,7 +6948,7 @@ spec:
                                     - path
                                     type: object
                                   hostPath:
-                                    description: 'HostPath represents a pre-existing
+                                    description: 'hostPath represents a pre-existing
                                       file or directory on the host machine that is
                                       directly exposed to the container. This is generally
                                       used for system agents or other privileged things
@@ -6042,76 +6959,79 @@ spec:
                                       mount host directories as read/write.'
                                     properties:
                                       path:
-                                        description: 'Path of the directory on the
+                                        description: 'path of the directory on the
                                           host. If the path is a symlink, it will
                                           follow the link to the real path. More info:
                                           https://kubernetes.io/docs/concepts/storage/volumes#hostpath'
                                         type: string
                                       type:
-                                        description: 'Type for HostPath Volume Defaults
+                                        description: 'type for HostPath Volume Defaults
                                           to "" More info: https://kubernetes.io/docs/concepts/storage/volumes#hostpath'
                                         type: string
                                     required:
                                     - path
                                     type: object
                                   iscsi:
-                                    description: 'ISCSI represents an ISCSI Disk resource
+                                    description: 'iscsi represents an ISCSI Disk resource
                                       that is attached to a kubelet''s host machine
                                       and then exposed to the pod. More info: https://examples.k8s.io/volumes/iscsi/README.md'
                                     properties:
                                       chapAuthDiscovery:
-                                        description: whether support iSCSI Discovery
-                                          CHAP authentication
+                                        description: chapAuthDiscovery defines whether
+                                          support iSCSI Discovery CHAP authentication
                                         type: boolean
                                       chapAuthSession:
-                                        description: whether support iSCSI Session
-                                          CHAP authentication
+                                        description: chapAuthSession defines whether
+                                          support iSCSI Session CHAP authentication
                                         type: boolean
                                       fsType:
-                                        description: 'Filesystem type of the volume
-                                          that you want to mount. Tip: Ensure that
-                                          the filesystem type is supported by the
-                                          host operating system. Examples: "ext4",
-                                          "xfs", "ntfs". Implicitly inferred to be
-                                          "ext4" if unspecified. More info: https://kubernetes.io/docs/concepts/storage/volumes#iscsi
+                                        description: 'fsType is the filesystem type
+                                          of the volume that you want to mount. Tip:
+                                          Ensure that the filesystem type is supported
+                                          by the host operating system. Examples:
+                                          "ext4", "xfs", "ntfs". Implicitly inferred
+                                          to be "ext4" if unspecified. More info:
+                                          https://kubernetes.io/docs/concepts/storage/volumes#iscsi
                                           TODO: how do we prevent errors in the filesystem
                                           from compromising the machine'
                                         type: string
                                       initiatorName:
-                                        description: Custom iSCSI Initiator Name.
-                                          If initiatorName is specified with iscsiInterface
-                                          simultaneously, new iSCSI interface <target
-                                          portal>:<volume name> will be created for
-                                          the connection.
+                                        description: initiatorName is the custom iSCSI
+                                          Initiator Name. If initiatorName is specified
+                                          with iscsiInterface simultaneously, new
+                                          iSCSI interface <target portal>:<volume
+                                          name> will be created for the connection.
                                         type: string
                                       iqn:
-                                        description: Target iSCSI Qualified Name.
+                                        description: iqn is the target iSCSI Qualified
+                                          Name.
                                         type: string
                                       iscsiInterface:
-                                        description: iSCSI Interface Name that uses
-                                          an iSCSI transport. Defaults to 'default'
-                                          (tcp).
+                                        description: iscsiInterface is the interface
+                                          Name that uses an iSCSI transport. Defaults
+                                          to 'default' (tcp).
                                         type: string
                                       lun:
-                                        description: iSCSI Target Lun number.
+                                        description: lun represents iSCSI Target Lun
+                                          number.
                                         format: int32
                                         type: integer
                                       portals:
-                                        description: iSCSI Target Portal List. The
-                                          portal is either an IP or ip_addr:port if
-                                          the port is other than default (typically
+                                        description: portals is the iSCSI Target Portal
+                                          List. The portal is either an IP or ip_addr:port
+                                          if the port is other than default (typically
                                           TCP ports 860 and 3260).
                                         items:
                                           type: string
                                         type: array
                                       readOnly:
-                                        description: ReadOnly here will force the
+                                        description: readOnly here will force the
                                           ReadOnly setting in VolumeMounts. Defaults
                                           to false.
                                         type: boolean
                                       secretRef:
-                                        description: CHAP Secret for iSCSI target
-                                          and initiator authentication
+                                        description: secretRef is the CHAP Secret
+                                          for iSCSI target and initiator authentication
                                         properties:
                                           name:
                                             description: 'Name of the referent. More
@@ -6121,10 +7041,10 @@ spec:
                                             type: string
                                         type: object
                                       targetPortal:
-                                        description: iSCSI Target Portal. The Portal
-                                          is either an IP or ip_addr:port if the port
-                                          is other than default (typically TCP ports
-                                          860 and 3260).
+                                        description: targetPortal is iSCSI Target
+                                          Portal. The Portal is either an IP or ip_addr:port
+                                          if the port is other than default (typically
+                                          TCP ports 860 and 3260).
                                         type: string
                                     required:
                                     - iqn
@@ -6132,26 +7052,26 @@ spec:
                                     - targetPortal
                                     type: object
                                   name:
-                                    description: 'Volume''s name. Must be a DNS_LABEL
+                                    description: 'name of the volume. Must be a DNS_LABEL
                                       and unique within the pod. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
                                     type: string
                                   nfs:
-                                    description: 'NFS represents an NFS mount on the
+                                    description: 'nfs represents an NFS mount on the
                                       host that shares a pod''s lifetime More info:
                                       https://kubernetes.io/docs/concepts/storage/volumes#nfs'
                                     properties:
                                       path:
-                                        description: 'Path that is exported by the
+                                        description: 'path that is exported by the
                                           NFS server. More info: https://kubernetes.io/docs/concepts/storage/volumes#nfs'
                                         type: string
                                       readOnly:
-                                        description: 'ReadOnly here will force the
+                                        description: 'readOnly here will force the
                                           NFS export to be mounted with read-only
                                           permissions. Defaults to false. More info:
                                           https://kubernetes.io/docs/concepts/storage/volumes#nfs'
                                         type: boolean
                                       server:
-                                        description: 'Server is the hostname or IP
+                                        description: 'server is the hostname or IP
                                           address of the NFS server. More info: https://kubernetes.io/docs/concepts/storage/volumes#nfs'
                                         type: string
                                     required:
@@ -6159,99 +7079,101 @@ spec:
                                     - server
                                     type: object
                                   persistentVolumeClaim:
-                                    description: 'PersistentVolumeClaimVolumeSource
+                                    description: 'persistentVolumeClaimVolumeSource
                                       represents a reference to a PersistentVolumeClaim
                                       in the same namespace. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#persistentvolumeclaims'
                                     properties:
                                       claimName:
-                                        description: 'ClaimName is the name of a PersistentVolumeClaim
+                                        description: 'claimName is the name of a PersistentVolumeClaim
                                           in the same namespace as the pod using this
                                           volume. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#persistentvolumeclaims'
                                         type: string
                                       readOnly:
-                                        description: Will force the ReadOnly setting
-                                          in VolumeMounts. Default false.
+                                        description: readOnly Will force the ReadOnly
+                                          setting in VolumeMounts. Default false.
                                         type: boolean
                                     required:
                                     - claimName
                                     type: object
                                   photonPersistentDisk:
-                                    description: PhotonPersistentDisk represents a
+                                    description: photonPersistentDisk represents a
                                       PhotonController persistent disk attached and
                                       mounted on kubelets host machine
                                     properties:
                                       fsType:
-                                        description: Filesystem type to mount. Must
-                                          be a filesystem type supported by the host
-                                          operating system. Ex. "ext4", "xfs", "ntfs".
-                                          Implicitly inferred to be "ext4" if unspecified.
+                                        description: fsType is the filesystem type
+                                          to mount. Must be a filesystem type supported
+                                          by the host operating system. Ex. "ext4",
+                                          "xfs", "ntfs". Implicitly inferred to be
+                                          "ext4" if unspecified.
                                         type: string
                                       pdID:
-                                        description: ID that identifies Photon Controller
-                                          persistent disk
+                                        description: pdID is the ID that identifies
+                                          Photon Controller persistent disk
                                         type: string
                                     required:
                                     - pdID
                                     type: object
                                   portworxVolume:
-                                    description: PortworxVolume represents a portworx
+                                    description: portworxVolume represents a portworx
                                       volume attached and mounted on kubelets host
                                       machine
                                     properties:
                                       fsType:
-                                        description: FSType represents the filesystem
+                                        description: fSType represents the filesystem
                                           type to mount Must be a filesystem type
                                           supported by the host operating system.
                                           Ex. "ext4", "xfs". Implicitly inferred to
                                           be "ext4" if unspecified.
                                         type: string
                                       readOnly:
-                                        description: Defaults to false (read/write).
+                                        description: readOnly defaults to false (read/write).
                                           ReadOnly here will force the ReadOnly setting
                                           in VolumeMounts.
                                         type: boolean
                                       volumeID:
-                                        description: VolumeID uniquely identifies
+                                        description: volumeID uniquely identifies
                                           a Portworx volume
                                         type: string
                                     required:
                                     - volumeID
                                     type: object
                                   projected:
-                                    description: Items for all in one resources secrets,
-                                      configmaps, and downward API
+                                    description: projected items for all in one resources
+                                      secrets, configmaps, and downward API
                                     properties:
                                       defaultMode:
-                                        description: Mode bits used to set permissions
-                                          on created files by default. Must be an
-                                          octal value between 0000 and 0777 or a decimal
-                                          value between 0 and 511. YAML accepts both
-                                          octal and decimal values, JSON requires
-                                          decimal values for mode bits. Directories
-                                          within the path are not affected by this
-                                          setting. This might be in conflict with
-                                          other options that affect the file mode,
-                                          like fsGroup, and the result can be other
-                                          mode bits set.
+                                        description: defaultMode are the mode bits
+                                          used to set permissions on created files
+                                          by default. Must be an octal value between
+                                          0000 and 0777 or a decimal value between
+                                          0 and 511. YAML accepts both octal and decimal
+                                          values, JSON requires decimal values for
+                                          mode bits. Directories within the path are
+                                          not affected by this setting. This might
+                                          be in conflict with other options that affect
+                                          the file mode, like fsGroup, and the result
+                                          can be other mode bits set.
                                         format: int32
                                         type: integer
                                       sources:
-                                        description: list of volume projections
+                                        description: sources is the list of volume
+                                          projections
                                         items:
                                           description: Projection that may be projected
                                             along with other supported volume types
                                           properties:
                                             configMap:
-                                              description: information about the configMap
-                                                data to project
+                                              description: configMap information about
+                                                the configMap data to project
                                               properties:
                                                 items:
-                                                  description: If unspecified, each
-                                                    key-value pair in the Data field
-                                                    of the referenced ConfigMap will
-                                                    be projected into the volume as
-                                                    a file whose name is the key and
-                                                    content is the value. If specified,
+                                                  description: items if unspecified,
+                                                    each key-value pair in the Data
+                                                    field of the referenced ConfigMap
+                                                    will be projected into the volume
+                                                    as a file whose name is the key
+                                                    and content is the value. If specified,
                                                     the listed keys will be projected
                                                     into the specified paths, and
                                                     unlisted keys will not be present.
@@ -6266,11 +7188,12 @@ spec:
                                                       to a path within a volume.
                                                     properties:
                                                       key:
-                                                        description: The key to project.
+                                                        description: key is the key
+                                                          to project.
                                                         type: string
                                                       mode:
-                                                        description: 'Optional: mode
-                                                          bits used to set permissions
+                                                        description: 'mode is Optional:
+                                                          mode bits used to set permissions
                                                           on this file. Must be an
                                                           octal value between 0000
                                                           and 0777 or a decimal value
@@ -6288,7 +7211,7 @@ spec:
                                                         format: int32
                                                         type: integer
                                                       path:
-                                                        description: The relative
+                                                        description: path is the relative
                                                           path of the file to map
                                                           the key to. May not be an
                                                           absolute path. May not contain
@@ -6308,14 +7231,14 @@ spec:
                                                     apiVersion, kind, uid?'
                                                   type: string
                                                 optional:
-                                                  description: Specify whether the
-                                                    ConfigMap or its keys must be
-                                                    defined
+                                                  description: optional specify whether
+                                                    the ConfigMap or its keys must
+                                                    be defined
                                                   type: boolean
                                               type: object
                                             downwardAPI:
-                                              description: information about the downwardAPI
-                                                data to project
+                                              description: downwardAPI information
+                                                about the downwardAPI data to project
                                               properties:
                                                 items:
                                                   description: Items is a list of
@@ -6412,16 +7335,16 @@ spec:
                                                   type: array
                                               type: object
                                             secret:
-                                              description: information about the secret
-                                                data to project
+                                              description: secret information about
+                                                the secret data to project
                                               properties:
                                                 items:
-                                                  description: If unspecified, each
-                                                    key-value pair in the Data field
-                                                    of the referenced Secret will
-                                                    be projected into the volume as
-                                                    a file whose name is the key and
-                                                    content is the value. If specified,
+                                                  description: items if unspecified,
+                                                    each key-value pair in the Data
+                                                    field of the referenced Secret
+                                                    will be projected into the volume
+                                                    as a file whose name is the key
+                                                    and content is the value. If specified,
                                                     the listed keys will be projected
                                                     into the specified paths, and
                                                     unlisted keys will not be present.
@@ -6436,11 +7359,12 @@ spec:
                                                       to a path within a volume.
                                                     properties:
                                                       key:
-                                                        description: The key to project.
+                                                        description: key is the key
+                                                          to project.
                                                         type: string
                                                       mode:
-                                                        description: 'Optional: mode
-                                                          bits used to set permissions
+                                                        description: 'mode is Optional:
+                                                          mode bits used to set permissions
                                                           on this file. Must be an
                                                           octal value between 0000
                                                           and 0777 or a decimal value
@@ -6458,7 +7382,7 @@ spec:
                                                         format: int32
                                                         type: integer
                                                       path:
-                                                        description: The relative
+                                                        description: path is the relative
                                                           path of the file to map
                                                           the key to. May not be an
                                                           absolute path. May not contain
@@ -6478,16 +7402,18 @@ spec:
                                                     apiVersion, kind, uid?'
                                                   type: string
                                                 optional:
-                                                  description: Specify whether the
-                                                    Secret or its key must be defined
+                                                  description: optional field specify
+                                                    whether the Secret or its key
+                                                    must be defined
                                                   type: boolean
                                               type: object
                                             serviceAccountToken:
-                                              description: information about the serviceAccountToken
+                                              description: serviceAccountToken is
+                                                information about the serviceAccountToken
                                                 data to project
                                               properties:
                                                 audience:
-                                                  description: Audience is the intended
+                                                  description: audience is the intended
                                                     audience of the token. A recipient
                                                     of a token must identify itself
                                                     with an identifier specified in
@@ -6497,7 +7423,7 @@ spec:
                                                     of the apiserver.
                                                   type: string
                                                 expirationSeconds:
-                                                  description: ExpirationSeconds is
+                                                  description: expirationSeconds is
                                                     the requested duration of validity
                                                     of the service account token.
                                                     As the token approaches expiration,
@@ -6513,7 +7439,7 @@ spec:
                                                   format: int64
                                                   type: integer
                                                 path:
-                                                  description: Path is the path relative
+                                                  description: path is the path relative
                                                     to the mount point of the file
                                                     to project the token into.
                                                   type: string
@@ -6522,41 +7448,39 @@ spec:
                                               type: object
                                           type: object
                                         type: array
-                                    required:
-                                    - sources
                                     type: object
                                   quobyte:
-                                    description: Quobyte represents a Quobyte mount
+                                    description: quobyte represents a Quobyte mount
                                       on the host that shares a pod's lifetime
                                     properties:
                                       group:
-                                        description: Group to map volume access to
+                                        description: group to map volume access to
                                           Default is no group
                                         type: string
                                       readOnly:
-                                        description: ReadOnly here will force the
+                                        description: readOnly here will force the
                                           Quobyte volume to be mounted with read-only
                                           permissions. Defaults to false.
                                         type: boolean
                                       registry:
-                                        description: Registry represents a single
+                                        description: registry represents a single
                                           or multiple Quobyte Registry services specified
                                           as a string as host:port pair (multiple
                                           entries are separated with commas) which
                                           acts as the central registry for volumes
                                         type: string
                                       tenant:
-                                        description: Tenant owning the given Quobyte
+                                        description: tenant owning the given Quobyte
                                           volume in the Backend Used with dynamically
                                           provisioned Quobyte volumes, value is set
                                           by the plugin
                                         type: string
                                       user:
-                                        description: User to map volume access to
+                                        description: user to map volume access to
                                           Defaults to serivceaccount user
                                         type: string
                                       volume:
-                                        description: Volume is a string that references
+                                        description: volume is a string that references
                                           an already created Quobyte volume by name.
                                         type: string
                                     required:
@@ -6564,46 +7488,47 @@ spec:
                                     - volume
                                     type: object
                                   rbd:
-                                    description: 'RBD represents a Rados Block Device
+                                    description: 'rbd represents a Rados Block Device
                                       mount on the host that shares a pod''s lifetime.
                                       More info: https://examples.k8s.io/volumes/rbd/README.md'
                                     properties:
                                       fsType:
-                                        description: 'Filesystem type of the volume
-                                          that you want to mount. Tip: Ensure that
-                                          the filesystem type is supported by the
-                                          host operating system. Examples: "ext4",
-                                          "xfs", "ntfs". Implicitly inferred to be
-                                          "ext4" if unspecified. More info: https://kubernetes.io/docs/concepts/storage/volumes#rbd
+                                        description: 'fsType is the filesystem type
+                                          of the volume that you want to mount. Tip:
+                                          Ensure that the filesystem type is supported
+                                          by the host operating system. Examples:
+                                          "ext4", "xfs", "ntfs". Implicitly inferred
+                                          to be "ext4" if unspecified. More info:
+                                          https://kubernetes.io/docs/concepts/storage/volumes#rbd
                                           TODO: how do we prevent errors in the filesystem
                                           from compromising the machine'
                                         type: string
                                       image:
-                                        description: 'The rados image name. More info:
-                                          https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
+                                        description: 'image is the rados image name.
+                                          More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
                                         type: string
                                       keyring:
-                                        description: 'Keyring is the path to key ring
+                                        description: 'keyring is the path to key ring
                                           for RBDUser. Default is /etc/ceph/keyring.
                                           More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
                                         type: string
                                       monitors:
-                                        description: 'A collection of Ceph monitors.
-                                          More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
+                                        description: 'monitors is a collection of
+                                          Ceph monitors. More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
                                         items:
                                           type: string
                                         type: array
                                       pool:
-                                        description: 'The rados pool name. Default
-                                          is rbd. More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
+                                        description: 'pool is the rados pool name.
+                                          Default is rbd. More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
                                         type: string
                                       readOnly:
-                                        description: 'ReadOnly here will force the
+                                        description: 'readOnly here will force the
                                           ReadOnly setting in VolumeMounts. Defaults
                                           to false. More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
                                         type: boolean
                                       secretRef:
-                                        description: 'SecretRef is name of the authentication
+                                        description: 'secretRef is name of the authentication
                                           secret for RBDUser. If provided overrides
                                           keyring. Default is nil. More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
                                         properties:
@@ -6615,38 +7540,39 @@ spec:
                                             type: string
                                         type: object
                                       user:
-                                        description: 'The rados user name. Default
-                                          is admin. More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
+                                        description: 'user is the rados user name.
+                                          Default is admin. More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
                                         type: string
                                     required:
                                     - image
                                     - monitors
                                     type: object
                                   scaleIO:
-                                    description: ScaleIO represents a ScaleIO persistent
+                                    description: scaleIO represents a ScaleIO persistent
                                       volume attached and mounted on Kubernetes nodes.
                                     properties:
                                       fsType:
-                                        description: Filesystem type to mount. Must
-                                          be a filesystem type supported by the host
-                                          operating system. Ex. "ext4", "xfs", "ntfs".
-                                          Default is "xfs".
+                                        description: fsType is the filesystem type
+                                          to mount. Must be a filesystem type supported
+                                          by the host operating system. Ex. "ext4",
+                                          "xfs", "ntfs". Default is "xfs".
                                         type: string
                                       gateway:
-                                        description: The host address of the ScaleIO
-                                          API Gateway.
+                                        description: gateway is the host address of
+                                          the ScaleIO API Gateway.
                                         type: string
                                       protectionDomain:
-                                        description: The name of the ScaleIO Protection
-                                          Domain for the configured storage.
+                                        description: protectionDomain is the name
+                                          of the ScaleIO Protection Domain for the
+                                          configured storage.
                                         type: string
                                       readOnly:
-                                        description: Defaults to false (read/write).
+                                        description: readOnly Defaults to false (read/write).
                                           ReadOnly here will force the ReadOnly setting
                                           in VolumeMounts.
                                         type: boolean
                                       secretRef:
-                                        description: SecretRef references to the secret
+                                        description: secretRef references to the secret
                                           for ScaleIO user and other sensitive information.
                                           If this is not provided, Login operation
                                           will fail.
@@ -6659,26 +7585,27 @@ spec:
                                             type: string
                                         type: object
                                       sslEnabled:
-                                        description: Flag to enable/disable SSL communication
-                                          with Gateway, default false
+                                        description: sslEnabled Flag enable/disable
+                                          SSL communication with Gateway, default
+                                          false
                                         type: boolean
                                       storageMode:
-                                        description: Indicates whether the storage
-                                          for a volume should be ThickProvisioned
+                                        description: storageMode indicates whether
+                                          the storage for a volume should be ThickProvisioned
                                           or ThinProvisioned. Default is ThinProvisioned.
                                         type: string
                                       storagePool:
-                                        description: The ScaleIO Storage Pool associated
-                                          with the protection domain.
+                                        description: storagePool is the ScaleIO Storage
+                                          Pool associated with the protection domain.
                                         type: string
                                       system:
-                                        description: The name of the storage system
-                                          as configured in ScaleIO.
+                                        description: system is the name of the storage
+                                          system as configured in ScaleIO.
                                         type: string
                                       volumeName:
-                                        description: The name of a volume already
-                                          created in the ScaleIO system that is associated
-                                          with this volume source.
+                                        description: volumeName is the name of a volume
+                                          already created in the ScaleIO system that
+                                          is associated with this volume source.
                                         type: string
                                     required:
                                     - gateway
@@ -6686,25 +7613,26 @@ spec:
                                     - system
                                     type: object
                                   secret:
-                                    description: 'Secret represents a secret that
+                                    description: 'secret represents a secret that
                                       should populate this volume. More info: https://kubernetes.io/docs/concepts/storage/volumes#secret'
                                     properties:
                                       defaultMode:
-                                        description: 'Optional: mode bits used to
-                                          set permissions on created files by default.
-                                          Must be an octal value between 0000 and
-                                          0777 or a decimal value between 0 and 511.
-                                          YAML accepts both octal and decimal values,
-                                          JSON requires decimal values for mode bits.
-                                          Defaults to 0644. Directories within the
-                                          path are not affected by this setting. This
-                                          might be in conflict with other options
-                                          that affect the file mode, like fsGroup,
-                                          and the result can be other mode bits set.'
+                                        description: 'defaultMode is Optional: mode
+                                          bits used to set permissions on created
+                                          files by default. Must be an octal value
+                                          between 0000 and 0777 or a decimal value
+                                          between 0 and 511. YAML accepts both octal
+                                          and decimal values, JSON requires decimal
+                                          values for mode bits. Defaults to 0644.
+                                          Directories within the path are not affected
+                                          by this setting. This might be in conflict
+                                          with other options that affect the file
+                                          mode, like fsGroup, and the result can be
+                                          other mode bits set.'
                                         format: int32
                                         type: integer
                                       items:
-                                        description: If unspecified, each key-value
+                                        description: items If unspecified, each key-value
                                           pair in the Data field of the referenced
                                           Secret will be projected into the volume
                                           as a file whose name is the key and content
@@ -6721,27 +7649,27 @@ spec:
                                             within a volume.
                                           properties:
                                             key:
-                                              description: The key to project.
+                                              description: key is the key to project.
                                               type: string
                                             mode:
-                                              description: 'Optional: mode bits used
-                                                to set permissions on this file. Must
-                                                be an octal value between 0000 and
-                                                0777 or a decimal value between 0
-                                                and 511. YAML accepts both octal and
-                                                decimal values, JSON requires decimal
-                                                values for mode bits. If not specified,
-                                                the volume defaultMode will be used.
-                                                This might be in conflict with other
-                                                options that affect the file mode,
-                                                like fsGroup, and the result can be
-                                                other mode bits set.'
+                                              description: 'mode is Optional: mode
+                                                bits used to set permissions on this
+                                                file. Must be an octal value between
+                                                0000 and 0777 or a decimal value between
+                                                0 and 511. YAML accepts both octal
+                                                and decimal values, JSON requires
+                                                decimal values for mode bits. If not
+                                                specified, the volume defaultMode
+                                                will be used. This might be in conflict
+                                                with other options that affect the
+                                                file mode, like fsGroup, and the result
+                                                can be other mode bits set.'
                                               format: int32
                                               type: integer
                                             path:
-                                              description: The relative path of the
-                                                file to map the key to. May not be
-                                                an absolute path. May not contain
+                                              description: path is the relative path
+                                                of the file to map the key to. May
+                                                not be an absolute path. May not contain
                                                 the path element '..'. May not start
                                                 with the string '..'.
                                               type: string
@@ -6751,31 +7679,33 @@ spec:
                                           type: object
                                         type: array
                                       optional:
-                                        description: Specify whether the Secret or
-                                          its keys must be defined
+                                        description: optional field specify whether
+                                          the Secret or its keys must be defined
                                         type: boolean
                                       secretName:
-                                        description: 'Name of the secret in the pod''s
-                                          namespace to use. More info: https://kubernetes.io/docs/concepts/storage/volumes#secret'
+                                        description: 'secretName is the name of the
+                                          secret in the pod''s namespace to use. More
+                                          info: https://kubernetes.io/docs/concepts/storage/volumes#secret'
                                         type: string
                                     type: object
                                   storageos:
-                                    description: StorageOS represents a StorageOS
+                                    description: storageOS represents a StorageOS
                                       volume attached and mounted on Kubernetes nodes.
                                     properties:
                                       fsType:
-                                        description: Filesystem type to mount. Must
-                                          be a filesystem type supported by the host
-                                          operating system. Ex. "ext4", "xfs", "ntfs".
-                                          Implicitly inferred to be "ext4" if unspecified.
+                                        description: fsType is the filesystem type
+                                          to mount. Must be a filesystem type supported
+                                          by the host operating system. Ex. "ext4",
+                                          "xfs", "ntfs". Implicitly inferred to be
+                                          "ext4" if unspecified.
                                         type: string
                                       readOnly:
-                                        description: Defaults to false (read/write).
+                                        description: readOnly defaults to false (read/write).
                                           ReadOnly here will force the ReadOnly setting
                                           in VolumeMounts.
                                         type: boolean
                                       secretRef:
-                                        description: SecretRef specifies the secret
+                                        description: secretRef specifies the secret
                                           to use for obtaining the StorageOS API credentials.  If
                                           not specified, default values will be attempted.
                                         properties:
@@ -6787,12 +7717,12 @@ spec:
                                             type: string
                                         type: object
                                       volumeName:
-                                        description: VolumeName is the human-readable
+                                        description: volumeName is the human-readable
                                           name of the StorageOS volume.  Volume names
                                           are only unique within a namespace.
                                         type: string
                                       volumeNamespace:
-                                        description: VolumeNamespace specifies the
+                                        description: volumeNamespace specifies the
                                           scope of the volume within StorageOS.  If
                                           no namespace is specified then the Pod's
                                           namespace will be used.  This allows the
@@ -6805,27 +7735,29 @@ spec:
                                         type: string
                                     type: object
                                   vsphereVolume:
-                                    description: VsphereVolume represents a vSphere
+                                    description: vsphereVolume represents a vSphere
                                       volume attached and mounted on kubelets host
                                       machine
                                     properties:
                                       fsType:
-                                        description: Filesystem type to mount. Must
-                                          be a filesystem type supported by the host
-                                          operating system. Ex. "ext4", "xfs", "ntfs".
-                                          Implicitly inferred to be "ext4" if unspecified.
+                                        description: fsType is filesystem type to
+                                          mount. Must be a filesystem type supported
+                                          by the host operating system. Ex. "ext4",
+                                          "xfs", "ntfs". Implicitly inferred to be
+                                          "ext4" if unspecified.
                                         type: string
                                       storagePolicyID:
-                                        description: Storage Policy Based Management
-                                          (SPBM) profile ID associated with the StoragePolicyName.
+                                        description: storagePolicyID is the storage
+                                          Policy Based Management (SPBM) profile ID
+                                          associated with the StoragePolicyName.
                                         type: string
                                       storagePolicyName:
-                                        description: Storage Policy Based Management
-                                          (SPBM) profile name.
+                                        description: storagePolicyName is the storage
+                                          Policy Based Management (SPBM) profile name.
                                         type: string
                                       volumePath:
-                                        description: Path that identifies vSphere
-                                          volume vmdk
+                                        description: volumePath is the path that identifies
+                                          vSphere volume vmdk
                                         type: string
                                     required:
                                     - volumePath

--- a/apps/training-operator/upstream/base/deployment.yaml
+++ b/apps/training-operator/upstream/base/deployment.yaml
@@ -40,12 +40,14 @@ spec:
               port: 8081
             initialDelaySeconds: 15
             periodSeconds: 20
+            timeoutSeconds: 3
           readinessProbe:
             httpGet:
               path: /readyz
               port: 8081
-            initialDelaySeconds: 5
-            periodSeconds: 10
+            initialDelaySeconds: 10
+            periodSeconds: 15
+            timeoutSeconds: 3
           resources:
             limits:
               cpu: 100m

--- a/apps/training-operator/upstream/overlays/kubeflow/kubeflow-training-roles.yaml
+++ b/apps/training-operator/upstream/overlays/kubeflow/kubeflow-training-roles.yaml
@@ -22,6 +22,7 @@ rules:
   - apiGroups:
       - kubeflow.org
     resources:
+      - mpijobs
       - tfjobs
       - pytorchjobs
       - mxjobs
@@ -37,6 +38,7 @@ rules:
   - apiGroups:
       - kubeflow.org
     resources:
+      - mpijobs/status
       - tfjobs/status
       - pytorchjobs/status
       - mxjobs/status
@@ -55,6 +57,7 @@ rules:
   - apiGroups:
       - kubeflow.org
     resources:
+      - mpijobs
       - tfjobs
       - pytorchjobs
       - mxjobs
@@ -66,6 +69,7 @@ rules:
   - apiGroups:
       - kubeflow.org
     resources:
+      - mpijobs/status
       - tfjobs/status
       - pytorchjobs/status
       - mxjobs/status

--- a/apps/training-operator/upstream/overlays/kubeflow/kustomization.yaml
+++ b/apps/training-operator/upstream/overlays/kubeflow/kustomization.yaml
@@ -6,5 +6,4 @@ resources:
   - kubeflow-training-roles.yaml
 images:
   - name: kubeflow/training-operator
-    newName: public.ecr.aws/j1r0q0g6/training/training-operator
-    newTag: "174e8813666951ded505daf334a37f60fd50c18d"
+    newTag: "v1-e1434f6"

--- a/apps/training-operator/upstream/overlays/standalone/kustomization.yaml
+++ b/apps/training-operator/upstream/overlays/standalone/kustomization.yaml
@@ -6,5 +6,4 @@ resources:
   - namespace.yaml
 images:
   - name: kubeflow/training-operator
-    newName: public.ecr.aws/j1r0q0g6/training/training-operator
-    newTag: "174e8813666951ded505daf334a37f60fd50c18d"
+    newTag: "v1-e1434f6"

--- a/hack/sync-training-operator-manifests.sh
+++ b/hack/sync-training-operator-manifests.sh
@@ -55,8 +55,15 @@ cp $SRC_DIR/manifests $DST_DIR -r
 
 echo "Successfully copied all manifests."
 
+echo "Updating README..."
+SRC_TXT="\[.*\](https://github.com/kubeflow/training-operator/tree/.*/manifests)"
+DST_TXT="\[$COMMIT\](https://github.com/kubeflow/training-operator/tree/$COMMIT/manifests)"
+
+sed -i "s|$SRC_TXT|$DST_TXT|g" ${MANIFESTS_DIR}/README.md
+
 # DEV: Comment out these commands when local testing
 echo "Committing the changes..."
 cd $MANIFESTS_DIR
 git add apps
+git add README.md
 git commit -m "Update kubeflow/training-operator manifests from ${COMMIT}"


### PR DESCRIPTION
Used the sync script in `hack`.

I also updated the README to use the `training-operator` GH link, instead of the `tf-operator` one. Lastly I updated the sync script to automatically fix the README as well.

cc @johnugeorge 
