### PR TITLE
Update kubeflow/katib manifests from v0.14.0-rc.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ This repo periodically syncs all official Kubeflow components from their respect
 | Jupyter Web App | apps/jupyter/jupyter-web-app/upstream | [v1.5.0](https://github.com/kubeflow/kubeflow/tree/v1.5.0/components/crud-web-apps/jupyter/manifests) |
 | Tensorboards Web App | apps/tensorboard/tensorboards-web-app/upstream | [v1.5.0](https://github.com/kubeflow/kubeflow/tree/v1.5.0/components/crud-web-apps/tensorboards/manifests) |
 | Volumes Web App | apps/volumes-web-app/upstream | [v1.5.0](https://github.com/kubeflow/kubeflow/tree/v1.5.0/components/crud-web-apps/volumes/manifests) |
-| Katib | apps/katib/upstream | [v0.13.0](https://github.com/kubeflow/katib/tree/v0.13.0/manifests/v1beta1) |
+| Katib | apps/katib/upstream | [v0.14.0-rc.0](https://github.com/kubeflow/katib/tree/v0.14.0-rc.0/manifests/v1beta1) |
 | KFServing | apps/kfserving/upstream | [v0.6.1](https://github.com/kubeflow/kfserving/releases/tag/v0.6.1) |
 | KServe | contrib/kserve/upstream | [v0.7.0](https://github.com/kserve/kserve/tree/v0.7.0) |
 | Kubeflow Pipelines | apps/pipeline/upstream | [1.8.2](https://github.com/kubeflow/pipelines/tree/1.8.2/manifests/kustomize) |

--- a/apps/katib/upstream/components/cert-generator/cert-generator.yaml
+++ b/apps/katib/upstream/components/cert-generator/cert-generator.yaml
@@ -1,3 +1,4 @@
+---
 apiVersion: batch/v1
 kind: Job
 metadata:
@@ -15,7 +16,6 @@ spec:
       containers:
         - name: cert-generator
           image: docker.io/kubeflowkatib/cert-generator
-          imagePullPolicy: Always
           command: ["./katib-cert-generator"]
           args: ["generate", "--namespace=$(KATIB_CORE_NAMESPACE)"]
           env:

--- a/apps/katib/upstream/components/cert-generator/kustomization.yaml
+++ b/apps/katib/upstream/components/cert-generator/kustomization.yaml
@@ -1,3 +1,4 @@
+---
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 

--- a/apps/katib/upstream/components/cert-generator/rbac.yaml
+++ b/apps/katib/upstream/components/cert-generator/rbac.yaml
@@ -1,3 +1,4 @@
+---
 kind: ClusterRole
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
@@ -7,6 +8,7 @@ rules:
       - ""
     resources:
       - secrets
+      - services
     verbs:
       - get
       - create

--- a/apps/katib/upstream/components/controller/controller.yaml
+++ b/apps/katib/upstream/components/controller/controller.yaml
@@ -1,3 +1,4 @@
+---
 apiVersion: apps/v1
 kind: Deployment
 metadata:

--- a/apps/katib/upstream/components/controller/katib-config.yaml
+++ b/apps/katib/upstream/components/controller/katib-config.yaml
@@ -1,3 +1,4 @@
+---
 apiVersion: v1
 kind: ConfigMap
 metadata:
@@ -7,13 +8,13 @@ data:
   metrics-collector-sidecar: |-
     {
       "StdOut": {
-        "image": "docker.io/kubeflowkatib/file-metrics-collector:v0.13.0"
+        "image": "docker.io/kubeflowkatib/file-metrics-collector:v0.14.0-rc.0"
       },
       "File": {
-        "image": "docker.io/kubeflowkatib/file-metrics-collector:v0.13.0"
+        "image": "docker.io/kubeflowkatib/file-metrics-collector:v0.14.0-rc.0"
       },
       "TensorFlowEvent": {
-        "image": "docker.io/kubeflowkatib/tfevent-metrics-collector:v0.13.0",
+        "image": "docker.io/kubeflowkatib/tfevent-metrics-collector:v0.14.0-rc.0",
         "resources": {
           "limits": {
             "memory": "1Gi"
@@ -24,31 +25,31 @@ data:
   suggestion: |-
     {
       "random": {
-        "image": "docker.io/kubeflowkatib/suggestion-hyperopt:v0.13.0"
+        "image": "docker.io/kubeflowkatib/suggestion-hyperopt:v0.14.0-rc.0"
       },
       "tpe": {
-        "image": "docker.io/kubeflowkatib/suggestion-hyperopt:v0.13.0"
+        "image": "docker.io/kubeflowkatib/suggestion-hyperopt:v0.14.0-rc.0"
       },
       "grid": {
-        "image": "docker.io/kubeflowkatib/suggestion-chocolate:v0.13.0"
+        "image": "docker.io/kubeflowkatib/suggestion-chocolate:v0.14.0-rc.0"
       },
       "hyperband": {
-        "image": "docker.io/kubeflowkatib/suggestion-hyperband:v0.13.0"
+        "image": "docker.io/kubeflowkatib/suggestion-hyperband:v0.14.0-rc.0"
       },
       "bayesianoptimization": {
-        "image": "docker.io/kubeflowkatib/suggestion-skopt:v0.13.0"
+        "image": "docker.io/kubeflowkatib/suggestion-skopt:v0.14.0-rc.0"
       },
       "cmaes": {
-        "image": "docker.io/kubeflowkatib/suggestion-goptuna:v0.13.0"
+        "image": "docker.io/kubeflowkatib/suggestion-goptuna:v0.14.0-rc.0"
       },
       "sobol": {
-        "image": "docker.io/kubeflowkatib/suggestion-goptuna:v0.13.0"
+        "image": "docker.io/kubeflowkatib/suggestion-goptuna:v0.14.0-rc.0"
       },
       "multivariate-tpe": {
-        "image": "docker.io/kubeflowkatib/suggestion-optuna:v0.13.0"
+        "image": "docker.io/kubeflowkatib/suggestion-optuna:v0.14.0-rc.0"
       },
       "enas": {
-        "image": "docker.io/kubeflowkatib/suggestion-enas:v0.13.0",
+        "image": "docker.io/kubeflowkatib/suggestion-enas:v0.14.0-rc.0",
         "resources": {
           "limits": {
             "memory": "200Mi"
@@ -56,12 +57,25 @@ data:
         }
       },
       "darts": {
-        "image": "docker.io/kubeflowkatib/suggestion-darts:v0.13.0"
+        "image": "docker.io/kubeflowkatib/suggestion-darts:v0.14.0-rc.0"
+      },
+      "pbt": {
+        "image": "docker.io/kubeflowkatib/suggestion-pbt:v0.14.0-rc.0",
+        "persistentVolumeClaimSpec": {
+          "accessModes": [
+            "ReadWriteMany"
+          ],
+          "resources": {
+            "requests": {
+              "storage": "5Gi"
+            }
+          }
+        }
       }
     }
   early-stopping: |-
     {
       "medianstop": {
-        "image": "docker.io/kubeflowkatib/earlystopping-medianstop:v0.13.0"
+        "image": "docker.io/kubeflowkatib/earlystopping-medianstop:v0.14.0-rc.0"
       }
     }

--- a/apps/katib/upstream/components/controller/kustomization.yaml
+++ b/apps/katib/upstream/components/controller/kustomization.yaml
@@ -1,3 +1,4 @@
+---
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 

--- a/apps/katib/upstream/components/controller/rbac.yaml
+++ b/apps/katib/upstream/components/controller/rbac.yaml
@@ -1,3 +1,4 @@
+---
 kind: ClusterRole
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:

--- a/apps/katib/upstream/components/controller/service.yaml
+++ b/apps/katib/upstream/components/controller/service.yaml
@@ -1,3 +1,4 @@
+---
 apiVersion: v1
 kind: Service
 metadata:

--- a/apps/katib/upstream/components/controller/trial-templates.yaml
+++ b/apps/katib/upstream/components/controller/trial-templates.yaml
@@ -1,3 +1,4 @@
+---
 apiVersion: v1
 kind: ConfigMap
 metadata:
@@ -14,7 +15,7 @@ data:
         spec:
           containers:
             - name: training-container
-              image: docker.io/kubeflowkatib/mxnet-mnist:v0.13.0
+              image: docker.io/kubeflowkatib/mxnet-mnist:v0.14.0-rc.0
               command:
                 - "python3"
                 - "/opt/mxnet-mnist/mnist.py"
@@ -32,7 +33,7 @@ data:
         spec:
           containers:
             - name: training-container
-              image: docker.io/kubeflowkatib/enas-cnn-cifar10-cpu:v0.13.0
+              image: docker.io/kubeflowkatib/enas-cnn-cifar10-cpu:v0.14.0-rc.0
               command:
                 - python3
                 - -u
@@ -53,8 +54,7 @@ data:
             spec:
               containers:
                 - name: pytorch
-                  image: docker.io/kubeflowkatib/pytorch-mnist:v0.13.0
-                  imagePullPolicy: Always
+                  image: docker.io/kubeflowkatib/pytorch-mnist:v0.14.0-rc.0
                   command:
                     - "python3"
                     - "/opt/pytorch-mnist/mnist.py"
@@ -68,8 +68,7 @@ data:
             spec:
               containers:
                 - name: pytorch
-                  image: docker.io/kubeflowkatib/pytorch-mnist:v0.13.0
-                  imagePullPolicy: Always
+                  image: docker.io/kubeflowkatib/pytorch-mnist:v0.14.0-rc.0
                   command:
                     - "python3"
                     - "/opt/pytorch-mnist/mnist.py"

--- a/apps/katib/upstream/components/crd/experiment.yaml
+++ b/apps/katib/upstream/components/crd/experiment.yaml
@@ -1,3 +1,4 @@
+---
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:

--- a/apps/katib/upstream/components/crd/kustomization.yaml
+++ b/apps/katib/upstream/components/crd/kustomization.yaml
@@ -1,3 +1,4 @@
+---
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 

--- a/apps/katib/upstream/components/crd/suggestion.yaml
+++ b/apps/katib/upstream/components/crd/suggestion.yaml
@@ -1,3 +1,4 @@
+---
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:

--- a/apps/katib/upstream/components/crd/trial.yaml
+++ b/apps/katib/upstream/components/crd/trial.yaml
@@ -1,3 +1,4 @@
+---
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:

--- a/apps/katib/upstream/components/db-manager/db-manager.yaml
+++ b/apps/katib/upstream/components/db-manager/db-manager.yaml
@@ -1,3 +1,4 @@
+---
 apiVersion: apps/v1
 kind: Deployment
 metadata:

--- a/apps/katib/upstream/components/db-manager/kustomization.yaml
+++ b/apps/katib/upstream/components/db-manager/kustomization.yaml
@@ -1,3 +1,4 @@
+---
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 

--- a/apps/katib/upstream/components/db-manager/service.yaml
+++ b/apps/katib/upstream/components/db-manager/service.yaml
@@ -1,3 +1,4 @@
+---
 apiVersion: v1
 kind: Service
 metadata:

--- a/apps/katib/upstream/components/mysql/kustomization.yaml
+++ b/apps/katib/upstream/components/mysql/kustomization.yaml
@@ -1,3 +1,4 @@
+---
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 

--- a/apps/katib/upstream/components/mysql/mysql.yaml
+++ b/apps/katib/upstream/components/mysql/mysql.yaml
@@ -1,3 +1,4 @@
+---
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -21,7 +22,7 @@ spec:
     spec:
       containers:
         - name: katib-mysql
-          image: mysql:8.0.26
+          image: mysql:8.0.29
           args:
             - --datadir
             - /var/lib/mysql/datadir
@@ -44,7 +45,8 @@ spec:
                 - "/bin/bash"
                 - "-c"
                 - "mysql -D ${MYSQL_DATABASE} -u root -p${MYSQL_ROOT_PASSWORD} -e 'SELECT 1'"
-            periodSeconds: 2
+            initialDelaySeconds: 10
+            periodSeconds: 5
             failureThreshold: 10
           livenessProbe:
             exec:
@@ -52,7 +54,8 @@ spec:
                 - "/bin/bash"
                 - "-c"
                 - "mysqladmin ping -u root -p${MYSQL_ROOT_PASSWORD}"
-            periodSeconds: 2
+            initialDelaySeconds: 10
+            periodSeconds: 5
             failureThreshold: 10
           startupProbe:
             exec:

--- a/apps/katib/upstream/components/mysql/pvc.yaml
+++ b/apps/katib/upstream/components/mysql/pvc.yaml
@@ -1,3 +1,4 @@
+---
 apiVersion: v1
 kind: PersistentVolumeClaim
 metadata:

--- a/apps/katib/upstream/components/mysql/secret.yaml
+++ b/apps/katib/upstream/components/mysql/secret.yaml
@@ -1,7 +1,8 @@
+---
 apiVersion: v1
 kind: Secret
 type: Opaque
 metadata:
   name: katib-mysql-secrets
 data:
-  MYSQL_ROOT_PASSWORD: dGVzdA== # "test"
+  MYSQL_ROOT_PASSWORD: dGVzdA==  # "test"

--- a/apps/katib/upstream/components/mysql/service.yaml
+++ b/apps/katib/upstream/components/mysql/service.yaml
@@ -1,3 +1,4 @@
+---
 apiVersion: v1
 kind: Service
 metadata:

--- a/apps/katib/upstream/components/namespace/kustomization.yaml
+++ b/apps/katib/upstream/components/namespace/kustomization.yaml
@@ -1,3 +1,4 @@
+---
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 namespace: kubeflow

--- a/apps/katib/upstream/components/namespace/namespace.yaml
+++ b/apps/katib/upstream/components/namespace/namespace.yaml
@@ -1,3 +1,4 @@
+---
 apiVersion: v1
 kind: Namespace
 metadata:

--- a/apps/katib/upstream/components/ui/kustomization.yaml
+++ b/apps/katib/upstream/components/ui/kustomization.yaml
@@ -1,3 +1,4 @@
+---
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 

--- a/apps/katib/upstream/components/ui/rbac.yaml
+++ b/apps/katib/upstream/components/ui/rbac.yaml
@@ -1,3 +1,4 @@
+---
 kind: ClusterRole
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:

--- a/apps/katib/upstream/components/ui/service.yaml
+++ b/apps/katib/upstream/components/ui/service.yaml
@@ -1,3 +1,4 @@
+---
 apiVersion: v1
 kind: Service
 metadata:

--- a/apps/katib/upstream/components/ui/ui.yaml
+++ b/apps/katib/upstream/components/ui/ui.yaml
@@ -1,3 +1,4 @@
+---
 apiVersion: apps/v1
 kind: Deployment
 metadata:

--- a/apps/katib/upstream/components/webhook/kustomization.yaml
+++ b/apps/katib/upstream/components/webhook/kustomization.yaml
@@ -1,3 +1,4 @@
+---
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 

--- a/apps/katib/upstream/components/webhook/webhooks.yaml
+++ b/apps/katib/upstream/components/webhook/webhooks.yaml
@@ -1,3 +1,4 @@
+---
 apiVersion: admissionregistration.k8s.io/v1
 kind: ValidatingWebhookConfiguration
 metadata:

--- a/apps/katib/upstream/installs/katib-cert-manager/certificate.yaml
+++ b/apps/katib/upstream/installs/katib-cert-manager/certificate.yaml
@@ -1,3 +1,4 @@
+---
 apiVersion: cert-manager.io/v1
 kind: Certificate
 metadata:

--- a/apps/katib/upstream/installs/katib-cert-manager/kustomization.yaml
+++ b/apps/katib/upstream/installs/katib-cert-manager/kustomization.yaml
@@ -1,3 +1,4 @@
+---
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 namespace: kubeflow
@@ -21,13 +22,13 @@ resources:
 images:
   - name: docker.io/kubeflowkatib/katib-controller
     newName: docker.io/kubeflowkatib/katib-controller
-    newTag: v0.13.0
+    newTag: v0.14.0-rc.0
   - name: docker.io/kubeflowkatib/katib-db-manager
     newName: docker.io/kubeflowkatib/katib-db-manager
-    newTag: v0.13.0
+    newTag: v0.14.0-rc.0
   - name: docker.io/kubeflowkatib/katib-ui
     newName: docker.io/kubeflowkatib/katib-ui
-    newTag: v0.13.0
+    newTag: v0.14.0-rc.0
 
 patchesStrategicMerge:
   - patches/katib-cert-injection.yaml

--- a/apps/katib/upstream/installs/katib-cert-manager/params.yaml
+++ b/apps/katib/upstream/installs/katib-cert-manager/params.yaml
@@ -1,3 +1,4 @@
+---
 varReference:
   - path: spec/commonName
     kind: Certificate

--- a/apps/katib/upstream/installs/katib-cert-manager/patches/katib-cert-injection.yaml
+++ b/apps/katib/upstream/installs/katib-cert-manager/patches/katib-cert-injection.yaml
@@ -1,3 +1,4 @@
+---
 apiVersion: admissionregistration.k8s.io/v1
 kind: ValidatingWebhookConfiguration
 metadata:

--- a/apps/katib/upstream/installs/katib-external-db/kustomization.yaml
+++ b/apps/katib/upstream/installs/katib-external-db/kustomization.yaml
@@ -1,3 +1,4 @@
+---
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 namespace: kubeflow
@@ -19,16 +20,16 @@ resources:
 images:
   - name: docker.io/kubeflowkatib/katib-controller
     newName: docker.io/kubeflowkatib/katib-controller
-    newTag: v0.13.0
+    newTag: v0.14.0-rc.0
   - name: docker.io/kubeflowkatib/katib-db-manager
     newName: docker.io/kubeflowkatib/katib-db-manager
-    newTag: v0.13.0
+    newTag: v0.14.0-rc.0
   - name: docker.io/kubeflowkatib/katib-ui
     newName: docker.io/kubeflowkatib/katib-ui
-    newTag: v0.13.0
+    newTag: v0.14.0-rc.0
   - name: docker.io/kubeflowkatib/cert-generator
     newName: docker.io/kubeflowkatib/cert-generator
-    newTag: v0.13.0
+    newTag: v0.14.0-rc.0
 patchesStrategicMerge:
   - patches/db-manager.yaml
 # Modify katib-mysql-secrets with parameters for the DB.

--- a/apps/katib/upstream/installs/katib-external-db/patches/db-manager.yaml
+++ b/apps/katib/upstream/installs/katib-external-db/patches/db-manager.yaml
@@ -1,3 +1,4 @@
+---
 apiVersion: apps/v1
 kind: Deployment
 metadata:

--- a/apps/katib/upstream/installs/katib-leader-election/kustomization.yaml
+++ b/apps/katib/upstream/installs/katib-leader-election/kustomization.yaml
@@ -1,3 +1,4 @@
+---
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 namespace: kubeflow

--- a/apps/katib/upstream/installs/katib-leader-election/leader-election-rbac.yaml
+++ b/apps/katib/upstream/installs/katib-leader-election/leader-election-rbac.yaml
@@ -1,3 +1,4 @@
+---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:

--- a/apps/katib/upstream/installs/katib-leader-election/patches/controller.yaml
+++ b/apps/katib/upstream/installs/katib-leader-election/patches/controller.yaml
@@ -1,3 +1,4 @@
+---
 - op: add
   path: /spec/template/spec/containers/0/args/-
   value: "--enable-leader-election"

--- a/apps/katib/upstream/installs/katib-openshift/kustomization.yaml
+++ b/apps/katib/upstream/installs/katib-openshift/kustomization.yaml
@@ -30,13 +30,13 @@ resources:
 images:
   - name: docker.io/kubeflowkatib/katib-controller
     newName: docker.io/kubeflowkatib/katib-controller
-    newTag: v0.13.0
+    newTag: v0.14.0-rc.0
   - name: docker.io/kubeflowkatib/katib-db-manager
     newName: docker.io/kubeflowkatib/katib-db-manager
-    newTag: v0.13.0
+    newTag: v0.14.0-rc.0
   - name: docker.io/kubeflowkatib/katib-ui
     newName: docker.io/kubeflowkatib/katib-ui
-    newTag: v0.13.0
+    newTag: v0.14.0-rc.0
 
 patchesJson6902:
   # Annotate Service to delegate TLS-secret generation to OpenShift service controller

--- a/apps/katib/upstream/installs/katib-openshift/patches/service-serving-cert.yaml
+++ b/apps/katib/upstream/installs/katib-openshift/patches/service-serving-cert.yaml
@@ -1,3 +1,4 @@
+---
 - op: "add"
   path: "/metadata/annotations/service.beta.openshift.io~1serving-cert-secret-name"
   value: katib-webhook-cert

--- a/apps/katib/upstream/installs/katib-openshift/patches/webhook-inject-cabundle.yaml
+++ b/apps/katib/upstream/installs/katib-openshift/patches/webhook-inject-cabundle.yaml
@@ -1,3 +1,4 @@
+---
 - op: "add"
   path: "/metadata/annotations"
   value:

--- a/apps/katib/upstream/installs/katib-standalone/kustomization.yaml
+++ b/apps/katib/upstream/installs/katib-standalone/kustomization.yaml
@@ -1,3 +1,4 @@
+---
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 namespace: kubeflow
@@ -21,13 +22,13 @@ resources:
 images:
   - name: docker.io/kubeflowkatib/katib-controller
     newName: docker.io/kubeflowkatib/katib-controller
-    newTag: v0.13.0
+    newTag: v0.14.0-rc.0
   - name: docker.io/kubeflowkatib/katib-db-manager
     newName: docker.io/kubeflowkatib/katib-db-manager
-    newTag: v0.13.0
+    newTag: v0.14.0-rc.0
   - name: docker.io/kubeflowkatib/katib-ui
     newName: docker.io/kubeflowkatib/katib-ui
-    newTag: v0.13.0
+    newTag: v0.14.0-rc.0
   - name: docker.io/kubeflowkatib/cert-generator
     newName: docker.io/kubeflowkatib/cert-generator
-    newTag: v0.13.0
+    newTag: v0.14.0-rc.0

--- a/apps/katib/upstream/installs/katib-with-kubeflow/kubeflow-katib-roles.yaml
+++ b/apps/katib/upstream/installs/katib-with-kubeflow/kubeflow-katib-roles.yaml
@@ -1,3 +1,4 @@
+---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:

--- a/apps/katib/upstream/installs/katib-with-kubeflow/kustomization.yaml
+++ b/apps/katib/upstream/installs/katib-with-kubeflow/kustomization.yaml
@@ -1,3 +1,4 @@
+---
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 namespace: kubeflow
@@ -9,13 +10,13 @@ resources:
 images:
   - name: docker.io/kubeflowkatib/katib-controller
     newName: docker.io/kubeflowkatib/katib-controller
-    newTag: v0.13.0
+    newTag: v0.14.0-rc.0
   - name: docker.io/kubeflowkatib/katib-db-manager
     newName: docker.io/kubeflowkatib/katib-db-manager
-    newTag: v0.13.0
+    newTag: v0.14.0-rc.0
   - name: docker.io/kubeflowkatib/katib-ui
     newName: docker.io/kubeflowkatib/katib-ui
-    newTag: v0.13.0
+    newTag: v0.14.0-rc.0
 
 patchesStrategicMerge:
   - patches/remove-namespace.yaml

--- a/apps/katib/upstream/installs/katib-with-kubeflow/params.yaml
+++ b/apps/katib/upstream/installs/katib-with-kubeflow/params.yaml
@@ -1,3 +1,4 @@
+---
 varReference:
   - path: spec/http/route/destination/host
     kind: VirtualService

--- a/apps/katib/upstream/installs/katib-with-kubeflow/patches/remove-namespace.yaml
+++ b/apps/katib/upstream/installs/katib-with-kubeflow/patches/remove-namespace.yaml
@@ -1,3 +1,4 @@
+---
 $patch: delete
 apiVersion: v1
 kind: Namespace

--- a/apps/katib/upstream/installs/katib-with-kubeflow/ui-virtual-service.yaml
+++ b/apps/katib/upstream/installs/katib-with-kubeflow/ui-virtual-service.yaml
@@ -1,3 +1,4 @@
+---
 apiVersion: networking.istio.io/v1alpha3
 kind: VirtualService
 metadata:


### PR DESCRIPTION
Updates Katib for commit `v0.14.0-rc.0`. Just used the sync script for this, which was up to date.

cc @johnugeorge 