### PR TITLE
Change images of KinD configuration files to be compatible with v0.14.0

### DIFF
--- a/.github/workflows/centraldb_kind_test.yaml
+++ b/.github/workflows/centraldb_kind_test.yaml
@@ -15,7 +15,7 @@ jobs:
       run: ./tests/gh-actions/install_kind.sh
 
     - name: Create KinD Cluster
-      run: kind create cluster --config tests/gh-actions/kind-1-22.yaml
+      run: kind create cluster --config tests/gh-actions/kind-cluster-1-22.yaml
 
     - name: Install kustomize
       run: ./tests/gh-actions/install_kustomize.sh

--- a/.github/workflows/jwa_kind_test.yaml
+++ b/.github/workflows/jwa_kind_test.yaml
@@ -15,7 +15,7 @@ jobs:
       run: ./tests/gh-actions/install_kind.sh
 
     - name: Create KinD Cluster
-      run: kind create cluster --config tests/gh-actions/kind-1-22.yaml
+      run: kind create cluster --config tests/gh-actions/kind-cluster-1-22.yaml
 
     - name: Install kustomize
       run: ./tests/gh-actions/install_kustomize.sh

--- a/.github/workflows/katib_kind_test.yaml
+++ b/.github/workflows/katib_kind_test.yaml
@@ -15,7 +15,7 @@ jobs:
       run: ./tests/gh-actions/install_kind.sh
 
     - name: Create KinD Cluster
-      run: kind create cluster --config tests/gh-actions/kind-1-22.yaml
+      run: kind create cluster --config tests/gh-actions/kind-cluster-1-22.yaml
 
     - name: Install kustomize
       run: ./tests/gh-actions/install_kustomize.sh

--- a/.github/workflows/kserve_kind_test.yaml
+++ b/.github/workflows/kserve_kind_test.yaml
@@ -15,7 +15,7 @@ jobs:
       run: ./tests/gh-actions/install_kind.sh
 
     - name: Create KinD Cluster
-      run: kind create cluster --config tests/gh-actions/kind-1-22.yaml
+      run: kind create cluster --config tests/gh-actions/kind-cluster-1-22.yaml
 
     - name: Install kustomize
       run: ./tests/gh-actions/install_kustomize.sh

--- a/.github/workflows/nb_controller_kind_test.yaml
+++ b/.github/workflows/nb_controller_kind_test.yaml
@@ -15,7 +15,7 @@ jobs:
       run: ./tests/gh-actions/install_kind.sh
 
     - name: Create KinD Cluster
-      run: kind create cluster --config tests/gh-actions/kind-1-22.yaml
+      run: kind create cluster --config tests/gh-actions/kind-cluster-1-22.yaml
 
     - name: Install kustomize
       run: ./tests/gh-actions/install_kustomize.sh

--- a/.github/workflows/pipeline_kind_test.yaml
+++ b/.github/workflows/pipeline_kind_test.yaml
@@ -15,7 +15,7 @@ jobs:
       run: ./tests/gh-actions/install_kind.sh
 
     - name: Create KinD Cluster
-      run: kind create cluster --config tests/gh-actions/kind-1-22.yaml
+      run: kind create cluster --config tests/gh-actions/kind-cluster-1-22.yaml
 
     - name: Install kustomize
       run: ./tests/gh-actions/install_kustomize.sh

--- a/.github/workflows/poddefaults_kind_test.yaml
+++ b/.github/workflows/poddefaults_kind_test.yaml
@@ -15,7 +15,7 @@ jobs:
       run: ./tests/gh-actions/install_kind.sh
 
     - name: Create KinD Cluster
-      run: kind create cluster --config tests/gh-actions/kind-1-22.yaml
+      run: kind create cluster --config tests/gh-actions/kind-cluster-1-22.yaml
 
     - name: Install kustomize
       run: ./tests/gh-actions/install_kustomize.sh

--- a/.github/workflows/profiles_kind_test.yaml
+++ b/.github/workflows/profiles_kind_test.yaml
@@ -15,7 +15,7 @@ jobs:
       run: ./tests/gh-actions/install_kind.sh
 
     - name: Create KinD Cluster
-      run: kind create cluster --config tests/gh-actions/kind-1-22.yaml
+      run: kind create cluster --config tests/gh-actions/kind-cluster-1-22.yaml
 
     - name: Install kustomize
       run: ./tests/gh-actions/install_kustomize.sh

--- a/.github/workflows/tb_controller_kind_test.yaml
+++ b/.github/workflows/tb_controller_kind_test.yaml
@@ -15,7 +15,7 @@ jobs:
       run: ./tests/gh-actions/install_kind.sh
 
     - name: Create KinD Cluster
-      run: kind create cluster --config tests/gh-actions/kind-1-22.yaml
+      run: kind create cluster --config tests/gh-actions/kind-cluster-1-22.yaml
 
     - name: Install kustomize
       run: ./tests/gh-actions/install_kustomize.sh

--- a/.github/workflows/train_operator_kind_test.yaml
+++ b/.github/workflows/train_operator_kind_test.yaml
@@ -15,7 +15,7 @@ jobs:
       run: ./tests/gh-actions/install_kind.sh
 
     - name: Create KinD Cluster
-      run: kind create cluster --config tests/gh-actions/kind-1-22.yaml
+      run: kind create cluster --config tests/gh-actions/kind-cluster-1-22.yaml
 
     - name: Install kustomize
       run: ./tests/gh-actions/install_kustomize.sh

--- a/.github/workflows/twa_kind_test.yaml
+++ b/.github/workflows/twa_kind_test.yaml
@@ -15,7 +15,7 @@ jobs:
       run: ./tests/gh-actions/install_kind.sh
 
     - name: Create KinD Cluster
-      run: kind create cluster --config tests/gh-actions/kind-1-22.yaml
+      run: kind create cluster --config tests/gh-actions/kind-cluster-1-22.yaml
 
     - name: Install kustomize
       run: ./tests/gh-actions/install_kustomize.sh

--- a/.github/workflows/vwa_kind_test.yaml
+++ b/.github/workflows/vwa_kind_test.yaml
@@ -15,7 +15,7 @@ jobs:
       run: ./tests/gh-actions/install_kind.sh
 
     - name: Create KinD Cluster
-      run: kind create cluster --config tests/gh-actions/kind-1-22.yaml
+      run: kind create cluster --config tests/gh-actions/kind-cluster-1-22.yaml
 
     - name: Install kustomize
       run: ./tests/gh-actions/install_kustomize.sh

--- a/tests/gh-actions/kind-cluster-1-20.yaml
+++ b/tests/gh-actions/kind-cluster-1-20.yaml
@@ -1,16 +1,17 @@
 # https://github.com/kubernetes-sigs/kind/issues/1954#issuecomment-737775492
 # https://github.com/istio/istio/blob/e02690fbfb8bda564582b27d22d9e8e6e00422a5/prow/config/trustworthy-jwt.yaml#L1-L13
 # This configs KinD to spin up a k8s cluster with trustworthy jwt (Service Account Token Volume Projection) feature.
+# This configuration file should work with KinD v0.14.0
 kind: Cluster
 apiVersion: kind.x-k8s.io/v1alpha4
-name: manifests-1-21
+name: manifests-1-20
 nodes:
 - role: control-plane
-  image: kindest/node:1.21.2@sha256:19c2315068fd5951aa478ef7b9d1771572c8ea58fbfbf7bc81f7b153679d7a6c
+  image: kindest/node:v1.20.15@sha256:6f2d011dffe182bad80b85f6c00e8ca9d86b5b8922cdf433d53575c4c5212248
 - role: worker
-  image: kindest/node:1.21.2@sha256:19c2315068fd5951aa478ef7b9d1771572c8ea58fbfbf7bc81f7b153679d7a6c
+  image: kindest/node:v1.20.15@sha256:6f2d011dffe182bad80b85f6c00e8ca9d86b5b8922cdf433d53575c4c5212248
 - role: worker
-  image: kindest/node:1.21.2@sha256:19c2315068fd5951aa478ef7b9d1771572c8ea58fbfbf7bc81f7b153679d7a6c
+  image: kindest/node:v1.20.15@sha256:6f2d011dffe182bad80b85f6c00e8ca9d86b5b8922cdf433d53575c4c5212248
 kubeadmConfigPatches:
   - |
     apiVersion: kubeadm.k8s.io/v1beta2

--- a/tests/gh-actions/kind-cluster-1-21.yaml
+++ b/tests/gh-actions/kind-cluster-1-21.yaml
@@ -1,16 +1,17 @@
 # https://github.com/kubernetes-sigs/kind/issues/1954#issuecomment-737775492
 # https://github.com/istio/istio/blob/e02690fbfb8bda564582b27d22d9e8e6e00422a5/prow/config/trustworthy-jwt.yaml#L1-L13
 # This configs KinD to spin up a k8s cluster with trustworthy jwt (Service Account Token Volume Projection) feature.
+# This configuration file should work with KinD v0.14.0
 kind: Cluster
 apiVersion: kind.x-k8s.io/v1alpha4
-name: manifests-1-20
+name: manifests-1-21
 nodes:
 - role: control-plane
-  image: kindest/node:1.20.7@sha256:688fba5ce6b825be62a7c7fe1415b35da2bdfbb5a69227c499ea4cc0008661ca
+  image: kindest/node:v1.21.12@sha256:f316b33dd88f8196379f38feb80545ef3ed44d9197dca1bfd48bcb1583210207
 - role: worker
-  image: kindest/node:1.20.7@sha256:688fba5ce6b825be62a7c7fe1415b35da2bdfbb5a69227c499ea4cc0008661ca
+  image: kindest/node:v1.21.12@sha256:f316b33dd88f8196379f38feb80545ef3ed44d9197dca1bfd48bcb1583210207
 - role: worker
-  image: kindest/node:1.20.7@sha256:688fba5ce6b825be62a7c7fe1415b35da2bdfbb5a69227c499ea4cc0008661ca
+  image: kindest/node:v1.21.12@sha256:f316b33dd88f8196379f38feb80545ef3ed44d9197dca1bfd48bcb1583210207
 kubeadmConfigPatches:
   - |
     apiVersion: kubeadm.k8s.io/v1beta2

--- a/tests/gh-actions/kind-cluster-1-22.yaml
+++ b/tests/gh-actions/kind-cluster-1-22.yaml
@@ -1,3 +1,4 @@
+# This configuration file should work with KinD v0.14.0
 apiVersion: kind.x-k8s.io/v1alpha4
 kind: Cluster
 # Configure registry for KinD.
@@ -19,6 +20,6 @@ kubeadmConfigPatches:
         "service-account-signing-key-file": "/etc/kubernetes/pki/sa.key"
 nodes:
 - role: control-plane
-  image: kindest/node:1.22.9@sha256:ad5b8404c4052781365a4e70bb7d17c5331e4177bd4a7cd214339316cd6193b6
+  image: kindest/node:v1.22.9@sha256:8135260b959dfe320206eb36b3aeda9cffcb262f4b44cda6b33f7bb73f453105
 - role: worker
-  image: kindest/node:1.22.9@sha256:ad5b8404c4052781365a4e70bb7d17c5331e4177bd4a7cd214339316cd6193b6
+  image: kindest/node:v1.22.9@sha256:8135260b959dfe320206eb36b3aeda9cffcb262f4b44cda6b33f7bb73f453105


### PR DESCRIPTION
As requested here https://github.com/kubeflow/manifests/pull/2237#issuecomment-1171430252 we're moving all the KinD configuration files in one place and make sure that they all use the images from v0.14.0.