### PR TITLE
Update Dex for K8s 1.22

### DIFF
--- a/.github/workflows/dex_kind_test.yaml
+++ b/.github/workflows/dex_kind_test.yaml
@@ -1,0 +1,30 @@
+name: Build & Apply Dex manifests in KinD
+on:
+  pull_request:
+    paths:
+      - common/dex/base/**
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v3
+
+    - name: Install KinD
+      run: ./tests/gh-actions/install_kind.sh
+
+    - name: Create KinD Cluster
+      run: kind create cluster --config tests/gh-actions/kind-cluster-1-22.yaml
+
+    - name: Install kustomize
+      run: ./tests/gh-actions/install_kustomize.sh
+
+    - name: Install Istio
+      run: ./tests/gh-actions/install_istio.sh
+
+    - name: Build & Apply manifests
+      run: |
+        cd common/dex
+        kustomize build overlays/istio | kubectl apply -f -
+        kubectl wait --for=condition=Ready pods --all --all-namespaces --timeout 180s

--- a/common/dex/base/crds.yaml
+++ b/common/dex/base/crds.yaml
@@ -1,5 +1,5 @@
 ---
-apiVersion: apiextensions.k8s.io/v1beta1
+apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   name: authcodes.dex.coreos.com
@@ -11,9 +11,16 @@ spec:
     plural: authcodes
     singular: authcode
   scope: Namespaced
-  version: v1
+  versions:
+  - name: v1
+    served: true
+    storage: true
+    schema:
+      openAPIV3Schema:
+        type: object
+        x-kubernetes-preserve-unknown-fields: true
 ---
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   name: dex
@@ -25,7 +32,7 @@ rules:
   resources: ["customresourcedefinitions"]
   verbs: ["create"] # To manage its own resources identity must be able to create customresourcedefinitions.
 ---
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   name: dex

--- a/common/dex/base/deployment.yaml
+++ b/common/dex/base/deployment.yaml
@@ -16,7 +16,7 @@ spec:
     spec:
       serviceAccountName: dex
       containers:
-      - image: quay.io/dexidp/dex:v2.22.0
+      - image: ghcr.io/dexidp/dex:v2.31.2
         name: dex
         command: ["dex", "serve", "/etc/dex/cfg/config.yaml"]
         ports:


### PR DESCRIPTION
Refs #2200

Dex had some `CRD`, `ClusterRole` and `ClusterRoleBinding` resources that were using the deprecated `apiextensions.k8s.io/v1` API.

This PR:
1. Updates these APIs
2. Add a GH Action for testing the Dex manifests as well