### PR TITLE
knative: Updrade Knative to version 1.2

### DIFF
--- a/common/knative/README.md
+++ b/common/knative/README.md
@@ -4,8 +4,8 @@
 
 The manifests for Knative Serving are based off the following:
 
-  - [Knative serving (v1.4.0)](https://github.com/knative/serving/releases/download/v0.22.1/serving-core.yaml)
-  - [Knative ingress controller for Istio (v1.4.0)](https://github.com/knative-sandbox/net-istio/releases/download/v0.22.1/net-istio.yaml)
+  - [Knative serving (v1.2.5)](https://github.com/knative/serving/releases/download/knative-v1.2.5/serving-core.yaml)
+  - [Knative ingress controller for Istio (v1.2.0)](https://github.com/knative-sandbox/net-istio/releases/download/knative-v1.2.0/net-istio.yaml)
 
 
 1. Download the knative-serving manifests with the following commands:
@@ -13,9 +13,9 @@ The manifests for Knative Serving are based off the following:
     ```sh
     # No need to install serving-crds.
     # See: https://github.com/knative/serving/issues/9945
-    wget -O knative-serving/base/upstream/serving-core.yaml 'https://github.com/knative/serving/releases/download/knative-v1.4.0/serving-core.yaml'
-    wget -O knative-serving/base/upstream/net-istio.yaml 'https://github.com/knative-sandbox/net-istio/releases/download/knative-v1.4.0/net-istio.yaml'
-    wget -O knative-serving-post-install-jobs/base/serving-post-install-jobs.yaml https://github.com/knative/serving/releases/download/knative-v1.4.0/serving-post-install-jobs.yaml
+    wget -O knative-serving/base/upstream/serving-core.yaml 'https://github.com/knative/serving/releases/download/knative-v1.2.5/serving-core.yaml'
+    wget -O knative-serving/base/upstream/net-istio.yaml 'https://github.com/knative-sandbox/net-istio/releases/download/knative-v1.2.0/net-istio.yaml'
+    wget -O knative-serving-post-install-jobs/base/serving-post-install-jobs.yaml https://github.com/knative/serving/releases/download/knative-v1.2.5/serving-post-install-jobs.yaml
     ```
 
 1. Remove all comments, since `yq` does not handle them correctly. See:
@@ -57,6 +57,10 @@ The manifests for Knative Serving are based off the following:
     yq eval -i 'select(.kind == "Job" and .metadata.generateName == "storage-version-migration-serving-") | .metadata.name = "storage-version-migration-serving"' knative-serving-post-install-jobs/base/serving-post-install-jobs.yaml
     ```
 
+
+NOTE: You'll need to remove a redundant `{}` at the end of the `knative-serving/base/upstream/net-istio.yaml` and 
+`knative-serving/base/upstream/serving-core.yaml` files.
+
 ### Changes from upstream
 
 - In `knative-serving/base/upstream/net-istio.yaml`, the `knative-ingress-gateway` Gateway is removed since we use the Kubeflow gateway.
@@ -69,20 +73,20 @@ The manifests for Knative Serving are based off the following:
 
 ## Knative-Eventing
 
-The manifests for Knative Eventing are based off the the [v1.4.0 release](https://github.com/knative/eventing/releases/tag/v0.22.1).
+The manifests for Knative Eventing are based off the the [v1.2.4 release](https://github.com/knative/eventing/releases/tag/knative-v1.2.4).
 
-  - [Eventing Core](https://github.com/knative/eventing/releases/download/v1.4.0/eventing-core.yaml)
-  - [In-Memory Channel](https://github.com/knative/eventing/releases/download/v1.4.0/in-memory-channel.yaml)
-  - [MT Channel Broker](https://github.com/knative/eventing/releases/download/v1.4.0/mt-channel-broker.yaml)
+  - [Eventing Core](https://github.com/knative/eventing/releases/download/knative-v1.2.4/eventing-core.yaml)
+  - [In-Memory Channel](https://github.com/knative/eventing/releases/download/knative-v1.2.4/in-memory-channel.yaml)
+  - [MT Channel Broker](https://github.com/knative/eventing/releases/download/knative-v1.2.4/mt-channel-broker.yaml)
 
 
 1. Download the knative-eventing manifests with the following commands:
 
     ```sh
-    wget -O knative-eventing/base/upstream/eventing-core.yaml 'https://github.com/knative/eventing/releases/download/knative-v1.4.0/eventing-core.yaml'
-    wget -O knative-eventing/base/upstream/in-memory-channel.yaml 'https://github.com/knative/eventing/releases/download/knative-v1.4.0/in-memory-channel.yaml'
-    wget -O knative-eventing/base/upstream/mt-channel-broker.yaml 'https://github.com/knative/eventing/releases/download/knative-v1.4.0/mt-channel-broker.yaml'
-    wget -O knative-eventing-post-install-jobs/base/eventing-post-install-jobs.yaml https://github.com/knative/eventing/releases/download/knative-v1.4.0/eventing-post-install-jobs.yaml
+    wget -O knative-eventing/base/upstream/eventing-core.yaml 'https://github.com/knative/eventing/releases/download/knative-v1.2.4/eventing-core.yaml'
+    wget -O knative-eventing/base/upstream/in-memory-channel.yaml 'https://github.com/knative/eventing/releases/download/knative-v1.2.4/in-memory-channel.yaml'
+    wget -O knative-eventing/base/upstream/mt-channel-broker.yaml 'https://github.com/knative/eventing/releases/download/knative-v1.2.4/mt-channel-broker.yaml'
+    wget -O knative-eventing-post-install-jobs/base/eventing-post-install-jobs.yaml https://github.com/knative/eventing/releases/download/knative-v1.2.4/eventing-post-install.yaml
     ```
 
 1. Remove all comments, since `yq` does not handle them correctly. See:

--- a/common/knative/knative-eventing-post-install-jobs/base/eventing-post-install-jobs.yaml
+++ b/common/knative/knative-eventing-post-install-jobs/base/eventing-post-install-jobs.yaml
@@ -1,1 +1,171 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: knative-eventing-post-install-job-role
+  labels:
+    eventing.knative.dev/release: "v1.2.4"
+rules:
+  - apiGroups:
+      - "apiextensions.k8s.io"
+    resources:
+      - "customresourcedefinitions"
+      - "customresourcedefinitions/status"
+    verbs:
+      - "get"
+      - "list"
+      - "update"
+      - "patch"
+      - "watch"
+  - apiGroups:
+      - "sources.knative.dev"
+    resources:
+      - "apiserversources"
+      - "apiserversources/finalizers"
+      - "apiserversources/status"
+      - "containersources"
+      - "containersources/finalizers"
+      - "containersources/status"
+      - "pingsources"
+      - "pingsources/finalizers"
+      - "pingsources/status"
+      - "sinkbindings"
+      - "sinkbindings/finalizers"
+      - "sinkbindings/status"
+    verbs:
+      - "get"
+      - "list"
+      - "create"
+      - "update"
+      - "patch"
+      - "watch"
+  - apiGroups:
+      - "eventing.knative.dev"
+    resources:
+      - "brokers"
+      - "brokers/finalizers"
+      - "brokers/status"
+      - "eventtypes"
+      - "eventtypes/finalizers"
+      - "eventtypes/status"
+      - "triggers"
+      - "triggers/finalizers"
+      - "triggers/status"
+    verbs:
+      - "get"
+      - "list"
+      - "create"
+      - "update"
+      - "patch"
+      - "watch"
+  - apiGroups:
+      - "messaging.knative.dev"
+    resources:
+      - "channels"
+      - "channels/finalizers"
+      - "channels/status"
+      - "inmemorychannels"
+      - "inmemorychannels/finalizers"
+      - "inmemorychannels/status"
+      - "subscriptions"
+      - "subscriptions/finalizers"
+      - "subscriptions/status"
+    verbs:
+      - "get"
+      - "list"
+      - "create"
+      - "update"
+      - "patch"
+      - "watch"
+  - apiGroups:
+      - "flows.knative.dev"
+    resources:
+      - "parallels"
+      - "parallels/finalizers"
+      - "parallels/status"
+      - "sequences"
+      - "sequences/finalizers"
+      - "sequences/status"
+    verbs:
+      - "get"
+      - "list"
+      - "create"
+      - "update"
+      - "patch"
+      - "watch"
+  - apiGroups:
+      - ""
+    resources:
+      - "namespaces"
+    verbs:
+      - "get"
+      - "list"
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: knative-eventing-post-install-job
+  namespace: knative-eventing
+  labels:
+    eventing.knative.dev/release: "v1.2.4"
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: knative-eventing-post-install-job-role-binding
+  labels:
+    eventing.knative.dev/release: "v1.2.4"
+subjects:
+  - kind: ServiceAccount
+    name: knative-eventing-post-install-job
+    namespace: knative-eventing
+roleRef:
+  kind: ClusterRole
+  name: knative-eventing-post-install-job-role
+  apiGroup: rbac.authorization.k8s.io
+---
+apiVersion: batch/v1
+kind: Job
+metadata:
+  generateName: storage-version-migration-eventing-
+  namespace: knative-eventing
+  labels:
+    app: "storage-version-migration-eventing"
+    eventing.knative.dev/release: "v1.2.4"
+spec:
+  ttlSecondsAfterFinished: 600
+  backoffLimit: 10
+  template:
+    metadata:
+      labels:
+        app: "storage-version-migration-eventing"
+        eventing.knative.dev/release: "v1.2.4"
+      annotations:
+        sidecar.istio.io/inject: "false"
+    spec:
+      serviceAccountName: knative-eventing-post-install-job
+      restartPolicy: OnFailure
+      containers:
+        - name: migrate
+          image: gcr.io/knative-releases/knative.dev/eventing/vendor/knative.dev/pkg/apiextensions/storageversion/cmd/migrate@sha256:ce1cf40c3e58fb437bac1731aa4dd3bda63bcedeaaf303b928963071192f82bf
+          args:
+            - "apiserversources.sources.knative.dev"
+            - "brokers.eventing.knative.dev"
+            - "channels.messaging.knative.dev"
+            - "containersources.sources.knative.dev"
+            - "eventtypes.eventing.knative.dev"
+            - "inmemorychannels.messaging.knative.dev"
+            - "parallels.flows.knative.dev"
+            - "pingsources.sources.knative.dev"
+            - "sequences.flows.knative.dev"
+            - "sinkbindings.sources.knative.dev"
+            - "subscriptions.messaging.knative.dev"
+            - "triggers.eventing.knative.dev"
+          securityContext:
+            allowPrivilegeEscalation: false
+            readOnlyRootFilesystem: true
+            runAsNonRoot: true
+            capabilities:
+              drop:
+                - all
+---
 

--- a/common/knative/knative-eventing/base/kustomization.yaml
+++ b/common/knative/knative-eventing/base/kustomization.yaml
@@ -3,8 +3,8 @@ kind: Kustomization
 namespace: knative-eventing
 resources:
 - upstream/eventing-core.yaml
-#- upstream/in-memory-channel.yaml
-#- upstream/mt-channel-broker.yaml
+# - upstream/in-memory-channel.yaml
+# - upstream/mt-channel-broker.yaml
 patchesStrategicMerge:
 - patches/clusterrole-patch.yaml
 commonLabels:

--- a/common/knative/knative-eventing/base/upstream/eventing-core.yaml
+++ b/common/knative/knative-eventing/base/upstream/eventing-core.yaml
@@ -3,22 +3,9 @@ kind: Namespace
 metadata:
   name: knative-eventing
   labels:
-    eventing.knative.dev/release: "v1.4.0"
-    app.kubernetes.io/version: "1.4.0"
+    eventing.knative.dev/release: "v1.2.4"
+    app.kubernetes.io/version: "1.2.4"
     app.kubernetes.io/name: knative-eventing
-# Copyright 2018 The Knative Authors
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#     http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
 ---
 apiVersion: v1
 kind: ServiceAccount
@@ -26,8 +13,8 @@ metadata:
   name: eventing-controller
   namespace: knative-eventing
   labels:
-    eventing.knative.dev/release: "v1.4.0"
-    app.kubernetes.io/version: "1.4.0"
+    eventing.knative.dev/release: "v1.2.4"
+    app.kubernetes.io/version: "1.2.4"
     app.kubernetes.io/name: knative-eventing
 ---
 apiVersion: rbac.authorization.k8s.io/v1
@@ -35,8 +22,8 @@ kind: ClusterRoleBinding
 metadata:
   name: eventing-controller
   labels:
-    eventing.knative.dev/release: "v1.4.0"
-    app.kubernetes.io/version: "1.4.0"
+    eventing.knative.dev/release: "v1.2.4"
+    app.kubernetes.io/version: "1.2.4"
     app.kubernetes.io/name: knative-eventing
 subjects:
   - kind: ServiceAccount
@@ -52,8 +39,8 @@ kind: ClusterRoleBinding
 metadata:
   name: eventing-controller-resolver
   labels:
-    eventing.knative.dev/release: "v1.4.0"
-    app.kubernetes.io/version: "1.4.0"
+    eventing.knative.dev/release: "v1.2.4"
+    app.kubernetes.io/version: "1.2.4"
     app.kubernetes.io/name: knative-eventing
 subjects:
   - kind: ServiceAccount
@@ -69,8 +56,8 @@ kind: ClusterRoleBinding
 metadata:
   name: eventing-controller-source-observer
   labels:
-    eventing.knative.dev/release: "v1.4.0"
-    app.kubernetes.io/version: "1.4.0"
+    eventing.knative.dev/release: "v1.2.4"
+    app.kubernetes.io/version: "1.2.4"
     app.kubernetes.io/name: knative-eventing
 subjects:
   - kind: ServiceAccount
@@ -86,8 +73,8 @@ kind: ClusterRoleBinding
 metadata:
   name: eventing-controller-sources-controller
   labels:
-    eventing.knative.dev/release: "v1.4.0"
-    app.kubernetes.io/version: "1.4.0"
+    eventing.knative.dev/release: "v1.2.4"
+    app.kubernetes.io/version: "1.2.4"
     app.kubernetes.io/name: knative-eventing
 subjects:
   - kind: ServiceAccount
@@ -103,8 +90,8 @@ kind: ClusterRoleBinding
 metadata:
   name: eventing-controller-manipulator
   labels:
-    eventing.knative.dev/release: "v1.4.0"
-    app.kubernetes.io/version: "1.4.0"
+    eventing.knative.dev/release: "v1.2.4"
+    app.kubernetes.io/version: "1.2.4"
     app.kubernetes.io/name: knative-eventing
 subjects:
   - kind: ServiceAccount
@@ -114,19 +101,6 @@ roleRef:
   kind: ClusterRole
   name: channelable-manipulator
   apiGroup: rbac.authorization.k8s.io
-# Copyright 2020 The Knative Authors
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#     http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
 ---
 apiVersion: v1
 kind: ServiceAccount
@@ -134,8 +108,8 @@ metadata:
   name: pingsource-mt-adapter
   namespace: knative-eventing
   labels:
-    eventing.knative.dev/release: "v1.4.0"
-    app.kubernetes.io/version: "1.4.0"
+    eventing.knative.dev/release: "v1.2.4"
+    app.kubernetes.io/version: "1.2.4"
     app.kubernetes.io/name: knative-eventing
 ---
 apiVersion: rbac.authorization.k8s.io/v1
@@ -143,8 +117,8 @@ kind: ClusterRoleBinding
 metadata:
   name: knative-eventing-pingsource-mt-adapter
   labels:
-    eventing.knative.dev/release: "v1.4.0"
-    app.kubernetes.io/version: "1.4.0"
+    eventing.knative.dev/release: "v1.2.4"
+    app.kubernetes.io/version: "1.2.4"
     app.kubernetes.io/name: knative-eventing
 subjects:
   - kind: ServiceAccount
@@ -154,19 +128,6 @@ roleRef:
   kind: ClusterRole
   name: knative-eventing-pingsource-mt-adapter
   apiGroup: rbac.authorization.k8s.io
-# Copyright 2018 The Knative Authors
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#     http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
 ---
 apiVersion: v1
 kind: ServiceAccount
@@ -174,8 +135,8 @@ metadata:
   name: eventing-webhook
   namespace: knative-eventing
   labels:
-    eventing.knative.dev/release: "v1.4.0"
-    app.kubernetes.io/version: "1.4.0"
+    eventing.knative.dev/release: "v1.2.4"
+    app.kubernetes.io/version: "1.2.4"
     app.kubernetes.io/name: knative-eventing
 ---
 apiVersion: rbac.authorization.k8s.io/v1
@@ -183,8 +144,8 @@ kind: ClusterRoleBinding
 metadata:
   name: eventing-webhook
   labels:
-    eventing.knative.dev/release: "v1.4.0"
-    app.kubernetes.io/version: "1.4.0"
+    eventing.knative.dev/release: "v1.2.4"
+    app.kubernetes.io/version: "1.2.4"
     app.kubernetes.io/name: knative-eventing
 subjects:
   - kind: ServiceAccount
@@ -201,8 +162,8 @@ metadata:
   namespace: knative-eventing
   name: eventing-webhook
   labels:
-    eventing.knative.dev/release: "v1.4.0"
-    app.kubernetes.io/version: "1.4.0"
+    eventing.knative.dev/release: "v1.2.4"
+    app.kubernetes.io/version: "1.2.4"
     app.kubernetes.io/name: knative-eventing
 subjects:
   - kind: ServiceAccount
@@ -218,8 +179,8 @@ kind: ClusterRoleBinding
 metadata:
   name: eventing-webhook-resolver
   labels:
-    eventing.knative.dev/release: "v1.4.0"
-    app.kubernetes.io/version: "1.4.0"
+    eventing.knative.dev/release: "v1.2.4"
+    app.kubernetes.io/version: "1.2.4"
     app.kubernetes.io/name: knative-eventing
 subjects:
   - kind: ServiceAccount
@@ -235,8 +196,8 @@ kind: ClusterRoleBinding
 metadata:
   name: eventing-webhook-podspecable-binding
   labels:
-    eventing.knative.dev/release: "v1.4.0"
-    app.kubernetes.io/version: "1.4.0"
+    eventing.knative.dev/release: "v1.2.4"
+    app.kubernetes.io/version: "1.2.4"
     app.kubernetes.io/name: knative-eventing
 subjects:
   - kind: ServiceAccount
@@ -246,19 +207,6 @@ roleRef:
   kind: ClusterRole
   name: podspecable-binding
   apiGroup: rbac.authorization.k8s.io
-# Copyright 2020 The Knative Authors
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#     https://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
 ---
 apiVersion: v1
 kind: ConfigMap
@@ -266,26 +214,13 @@ metadata:
   name: config-br-default-channel
   namespace: knative-eventing
   labels:
-    eventing.knative.dev/release: "v1.4.0"
-    app.kubernetes.io/version: "1.4.0"
+    eventing.knative.dev/release: "v1.2.4"
+    app.kubernetes.io/version: "1.2.4"
     app.kubernetes.io/name: knative-eventing
 data:
   channel-template-spec: |
     apiVersion: messaging.knative.dev/v1
     kind: InMemoryChannel
-# Copyright 2021 The Knative Authors
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#     https://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
 ---
 apiVersion: v1
 kind: ConfigMap
@@ -293,8 +228,8 @@ metadata:
   name: config-br-defaults
   namespace: knative-eventing
   labels:
-    eventing.knative.dev/release: "v1.4.0"
-    app.kubernetes.io/version: "1.4.0"
+    eventing.knative.dev/release: "v1.2.4"
+    app.kubernetes.io/version: "1.2.4"
     app.kubernetes.io/name: knative-eventing
 data:
   default-br-config: |
@@ -308,19 +243,6 @@ data:
         retry: 10
         backoffPolicy: exponential
         backoffDelay: PT0.2S
-# Copyright 2018 The Knative Authors
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#     https://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
 ---
 apiVersion: v1
 kind: ConfigMap
@@ -328,8 +250,8 @@ metadata:
   name: default-ch-webhook
   namespace: knative-eventing
   labels:
-    eventing.knative.dev/release: "v1.4.0"
-    app.kubernetes.io/version: "1.4.0"
+    eventing.knative.dev/release: "v1.2.4"
+    app.kubernetes.io/version: "1.2.4"
     app.kubernetes.io/name: knative-eventing
 data:
   default-ch-config: |
@@ -340,19 +262,6 @@ data:
       some-namespace:
         apiVersion: messaging.knative.dev/v1
         kind: InMemoryChannel
-# Copyright 2020 The Knative Authors
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#     https://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
 ---
 apiVersion: v1
 kind: ConfigMap
@@ -360,10 +269,10 @@ metadata:
   name: config-ping-defaults
   namespace: knative-eventing
   labels:
-    eventing.knative.dev/release: "v1.4.0"
+    eventing.knative.dev/release: "v1.2.4"
   annotations:
     knative.dev/example-checksum: "9185c153"
-    app.kubernetes.io/version: "1.4.0"
+    app.kubernetes.io/version: "1.2.4"
     app.kubernetes.io/name: knative-eventing
 data:
   _example: |
@@ -385,19 +294,6 @@ data:
     # Max number of bytes allowed to be sent for message excluding any
     # base64 decoding. Default is no limit set for data
     data-max-size: -1
-# Copyright 2021 The Knative Authors
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#     https://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
 ---
 apiVersion: v1
 kind: ConfigMap
@@ -405,10 +301,10 @@ metadata:
   name: config-features
   namespace: knative-eventing
   labels:
-    eventing.knative.dev/release: "v1.4.0"
+    eventing.knative.dev/release: "v1.2.4"
     knative.dev/config-propagation: original
     knative.dev/config-category: eventing
-    app.kubernetes.io/version: "1.4.0"
+    app.kubernetes.io/version: "1.2.4"
     app.kubernetes.io/name: knative-eventing
 data:
   kreference-group: "disabled"
@@ -417,19 +313,6 @@ data:
   kreference-mapping: "disabled"
   strict-subscriber: "disabled"
   new-trigger-filters: "disabled"
-# Copyright 2021 The Knative Authors
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#     https://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
 ---
 apiVersion: v1
 kind: ConfigMap
@@ -437,7 +320,7 @@ metadata:
   name: config-kreference-mapping
   namespace: knative-eventing
   labels:
-    eventing.knative.dev/release: "v1.4.0"
+    eventing.knative.dev/release: "v1.2.4"
     knative.dev/config-propagation: original
     knative.dev/config-category: eventing
   annotations:
@@ -464,19 +347,6 @@ data:
     # - UID: reference UID
     #
     # Pod.v1: https://addressable-pod.{{ .SystemNamespace }}.svc.cluster.local/{{ .Name }}
-# Copyright 2018 The Knative Authors
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#     https://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
 ---
 apiVersion: v1
 kind: ConfigMap
@@ -484,8 +354,8 @@ metadata:
   name: config-leader-election
   namespace: knative-eventing
   labels:
-    eventing.knative.dev/release: "v1.4.0"
-    app.kubernetes.io/version: "1.4.0"
+    eventing.knative.dev/release: "v1.2.4"
+    app.kubernetes.io/version: "1.2.4"
     app.kubernetes.io/name: knative-eventing
   annotations:
     knative.dev/example-checksum: "f7948630"
@@ -524,19 +394,6 @@ data:
     # bucket will take care of the reconciling for the keys partitioned into
     # that bucket.
     buckets: "1"
-# Copyright 2018 The Knative Authors
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#     https://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
 ---
 apiVersion: v1
 kind: ConfigMap
@@ -544,10 +401,10 @@ metadata:
   name: config-logging
   namespace: knative-eventing
   labels:
-    eventing.knative.dev/release: "v1.4.0"
+    eventing.knative.dev/release: "v1.2.4"
     knative.dev/config-propagation: original
     knative.dev/config-category: eventing
-    app.kubernetes.io/version: "1.4.0"
+    app.kubernetes.io/version: "1.2.4"
     app.kubernetes.io/name: knative-eventing
 data:
   zap-logger-config: |
@@ -573,19 +430,6 @@ data:
     }
   loglevel.controller: "info"
   loglevel.webhook: "info"
-# Copyright 2019 The Knative Authors
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#     https://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
 ---
 apiVersion: v1
 kind: ConfigMap
@@ -593,10 +437,10 @@ metadata:
   name: config-observability
   namespace: knative-eventing
   labels:
-    eventing.knative.dev/release: "v1.4.0"
+    eventing.knative.dev/release: "v1.2.4"
     knative.dev/config-propagation: original
     knative.dev/config-category: eventing
-    app.kubernetes.io/version: "1.4.0"
+    app.kubernetes.io/version: "1.2.4"
     app.kubernetes.io/name: knative-eventing
   annotations:
     knative.dev/example-checksum: "f46cf09d"
@@ -648,75 +492,6 @@ data:
     # sink-event-error-reporting.enable whether the adapter reports a kube event to the CRD indicating
     # a failure to send a cloud event to the sink.
     sink-event-error-reporting.enable: "false"
-# Copyright 2022 The Knative Authors
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#     https://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
----
-apiVersion: v1
-kind: ConfigMap
-metadata:
-  name: config-sugar
-  namespace: knative-eventing
-  labels:
-    eventing.knative.dev/release: "v1.4.0"
-    app.kubernetes.io/version: "1.4.0"
-    app.kubernetes.io/name: knative-eventing
-  annotations:
-    knative.dev/example-checksum: "b05e6e70"
-data:
-  _example: |
-    ################################
-    #                              #
-    #    EXAMPLE CONFIGURATION     #
-    #                              #
-    ################################
-    # This block is not actually functional configuration,
-    # but serves to illustrate the available configuration
-    # options and document them in a way that is accessible
-    # to users that `kubectl edit` this config map.
-    #
-    # These sample configuration options may be copied out of
-    # this example block and unindented to be in the data block
-    # to actually change the configuration.
-
-    # namespace-selector specifies a LabelSelector which
-    # determines which namespaces the Sugar Controller should operate upon
-    # Use an empty value to disable the feature (this is the default):
-    namespace-selector: ""
-
-    # Use an empty object to enable for all namespaces
-    namespace-selector: {}
-
-    # trigger-selector specifies a LabelSelector which
-    # determines which triggers the Sugar Controller should operate upon
-    # Use an empty value to disable the feature (this is the default):
-    trigger-selector: ""
-
-    # Use an empty object to enable for all triggers
-    trigger-selector: {}
-# Copyright 2019 The Knative Authors
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#     https://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
 ---
 apiVersion: v1
 kind: ConfigMap
@@ -724,10 +499,10 @@ metadata:
   name: config-tracing
   namespace: knative-eventing
   labels:
-    eventing.knative.dev/release: "v1.4.0"
+    eventing.knative.dev/release: "v1.2.4"
     knative.dev/config-propagation: original
     knative.dev/config-category: eventing
-    app.kubernetes.io/version: "1.4.0"
+    app.kubernetes.io/version: "1.2.4"
     app.kubernetes.io/name: knative-eventing
   annotations:
     knative.dev/example-checksum: "0492ceb0"
@@ -760,19 +535,6 @@ data:
 
     # Percentage (0-1) of requests to trace
     sample-rate: "0.1"
-# Copyright 2018 The Knative Authors
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#     http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
 ---
 apiVersion: apps/v1
 kind: Deployment
@@ -780,10 +542,10 @@ metadata:
   name: eventing-controller
   namespace: knative-eventing
   labels:
-    eventing.knative.dev/release: "v1.4.0"
+    eventing.knative.dev/release: "v1.2.4"
     knative.dev/high-availability: "true"
     app.kubernetes.io/component: eventing-controller
-    app.kubernetes.io/version: "1.4.0"
+    app.kubernetes.io/version: "1.2.4"
     app.kubernetes.io/name: knative-eventing
 spec:
   selector:
@@ -793,9 +555,9 @@ spec:
     metadata:
       labels:
         app: eventing-controller
-        eventing.knative.dev/release: "v1.4.0"
-        app.kubernetes.io/component: eventing-controller
-        app.kubernetes.io/version: "1.4.0"
+        eventing.knative.dev/release: "v1.2.4"
+        app.kubernetes.io/component: eventing-autoscaler
+        app.kubernetes.io/version: "1.2.4"
         app.kubernetes.io/name: knative-eventing
     spec:
       affinity:
@@ -812,7 +574,7 @@ spec:
       containers:
         - name: eventing-controller
           terminationMessagePolicy: FallbackToLogsOnError
-          image: gcr.io/knative-releases/knative.dev/eventing/cmd/controller@sha256:ed8e55c792c8e1203b14c8b886d38c8aabe6e565b6ab5d17fdf56234a8a174ca
+          image: gcr.io/knative-releases/knative.dev/eventing/cmd/controller@sha256:dc0ac2d8f235edb04ec1290721f389d2bc719ab8b6222ee86f17af8d7d2a160f
           resources:
             requests:
               cpu: 100m
@@ -829,7 +591,7 @@ spec:
             - name: METRICS_DOMAIN
               value: knative.dev/eventing
             - name: APISERVER_RA_IMAGE
-              value: gcr.io/knative-releases/knative.dev/eventing/cmd/apiserver_receive_adapter@sha256:908675367940cb9a46ca7d30d92ce85540d9143b8253ba443eb8a32e86d33bec
+              value: gcr.io/knative-releases/knative.dev/eventing/cmd/apiserver_receive_adapter@sha256:5b672eedd343bcf9496c2070479f9d8f29231069148bf2aa7991bd5ca5a7562a
             - name: POD_NAME
               valueFrom:
                 fieldRef:
@@ -846,19 +608,6 @@ spec:
               containerPort: 9090
             - name: profiling
               containerPort: 8008
-# Copyright 2018 The Knative Authors
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#     http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
 ---
 apiVersion: apps/v1
 kind: Deployment
@@ -866,9 +615,9 @@ metadata:
   name: pingsource-mt-adapter
   namespace: knative-eventing
   labels:
-    eventing.knative.dev/release: "v1.4.0"
+    eventing.knative.dev/release: "v1.2.4"
     app.kubernetes.io/component: pingsource-mt-adapter
-    app.kubernetes.io/version: "1.4.0"
+    app.kubernetes.io/version: "1.2.4"
     app.kubernetes.io/name: knative-eventing
 spec:
   replicas: 0
@@ -881,9 +630,9 @@ spec:
       labels:
         eventing.knative.dev/source: ping-source-controller
         sources.knative.dev/role: adapter
-        eventing.knative.dev/release: "v1.4.0"
+        eventing.knative.dev/release: "v1.2.4"
         app.kubernetes.io/component: pingsource-mt-adapter
-        app.kubernetes.io/version: "1.4.0"
+        app.kubernetes.io/version: "1.2.4"
         app.kubernetes.io/name: knative-eventing
     spec:
       affinity:
@@ -899,7 +648,7 @@ spec:
       enableServiceLinks: false
       containers:
         - name: dispatcher
-          image: gcr.io/knative-releases/knative.dev/eventing/cmd/mtping@sha256:f561f45c932a9dc4c5a4aacb4326388262c95929a68be596f7a99e3a9e2c5a7f
+          image: gcr.io/knative-releases/knative.dev/eventing/cmd/mtping@sha256:632d9d710d070efed2563f6125a87993e825e8e36562ec3da0366e2a897406c0
           env:
             - name: SYSTEM_NAMESPACE
               value: ''
@@ -940,19 +689,6 @@ spec:
               drop:
                 - all
       serviceAccountName: pingsource-mt-adapter
-# Copyright 2021 The Knative Authors
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#     https://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
 ---
 apiVersion: autoscaling/v2beta2
 kind: HorizontalPodAutoscaler
@@ -960,9 +696,9 @@ metadata:
   name: eventing-webhook
   namespace: knative-eventing
   labels:
-    eventing.knative.dev/release: "v1.4.0"
+    eventing.knative.dev/release: "v1.2.4"
     app.kubernetes.io/component: eventing-webhook
-    app.kubernetes.io/version: "1.4.0"
+    app.kubernetes.io/version: "1.2.4"
     app.kubernetes.io/name: knative-eventing
 spec:
   scaleTargetRef:
@@ -985,28 +721,15 @@ metadata:
   name: eventing-webhook
   namespace: knative-eventing
   labels:
-    eventing.knative.dev/release: "v1.4.0"
+    eventing.knative.dev/release: "v1.2.4"
     app.kubernetes.io/component: eventing-webhook
-    app.kubernetes.io/version: "1.4.0"
+    app.kubernetes.io/version: "1.2.4"
     app.kubernetes.io/name: knative-eventing
 spec:
   minAvailable: 80%
   selector:
     matchLabels:
       app: eventing-webhook
-# Copyright 2018 The Knative Authors
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#     https://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
 ---
 apiVersion: apps/v1
 kind: Deployment
@@ -1014,9 +737,9 @@ metadata:
   name: eventing-webhook
   namespace: knative-eventing
   labels:
-    eventing.knative.dev/release: "v1.4.0"
+    eventing.knative.dev/release: "v1.2.4"
     app.kubernetes.io/component: eventing-webhook
-    app.kubernetes.io/version: "1.4.0"
+    app.kubernetes.io/version: "1.2.4"
     app.kubernetes.io/name: knative-eventing
 spec:
   selector:
@@ -1028,9 +751,9 @@ spec:
       labels:
         app: eventing-webhook
         role: eventing-webhook
-        eventing.knative.dev/release: "v1.4.0"
+        eventing.knative.dev/release: "v1.2.4"
         app.kubernetes.io/component: eventing-webhook
-        app.kubernetes.io/version: "1.4.0"
+        app.kubernetes.io/version: "1.2.4"
         app.kubernetes.io/name: knative-eventing
     spec:
       affinity:
@@ -1047,7 +770,7 @@ spec:
       containers:
         - name: eventing-webhook
           terminationMessagePolicy: FallbackToLogsOnError
-          image: gcr.io/knative-releases/knative.dev/eventing/cmd/webhook@sha256:cbc6ee9181614a76bedd67b8f10250566a4e448e07f25da888dde3ed4f7670fb
+          image: gcr.io/knative-releases/knative.dev/eventing/cmd/webhook@sha256:b7faf7d253bd256dbe08f1cac084469128989cf39abbe256ecb4e1d4eb085a31
           resources:
             requests:
               cpu: 100m
@@ -1111,10 +834,10 @@ apiVersion: v1
 kind: Service
 metadata:
   labels:
-    eventing.knative.dev/release: "v1.4.0"
+    eventing.knative.dev/release: "v1.2.4"
     role: eventing-webhook
     app.kubernetes.io/component: eventing-webhook
-    app.kubernetes.io/version: "1.4.0"
+    app.kubernetes.io/version: "1.2.4"
     app.kubernetes.io/name: knative-eventing
   name: eventing-webhook
   namespace: knative-eventing
@@ -1125,30 +848,17 @@ spec:
       targetPort: 8443
   selector:
     role: eventing-webhook
-# Copyright 2020 The Knative Authors
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#     http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
 ---
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   creationTimestamp: null
   labels:
-    eventing.knative.dev/release: "v1.4.0"
+    eventing.knative.dev/release: "v1.2.4"
     eventing.knative.dev/source: "true"
     duck.knative.dev/source: "true"
     knative.dev/crd-install: "true"
-    app.kubernetes.io/version: "1.4.0"
+    app.kubernetes.io/version: "1.2.4"
     app.kubernetes.io/name: knative-eventing
   annotations:
     registry.knative.dev/eventTypes: |
@@ -1338,29 +1048,16 @@ spec:
     plural: apiserversources
     singular: apiserversource
   scope: Namespaced
-# Copyright 2020 The Knative Authors
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#     http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
 ---
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   name: brokers.eventing.knative.dev
   labels:
-    eventing.knative.dev/release: "v1.4.0"
+    eventing.knative.dev/release: "v1.2.4"
     knative.dev/crd-install: "true"
     duck.knative.dev/addressable: "true"
-    app.kubernetes.io/version: "1.4.0"
+    app.kubernetes.io/version: "1.2.4"
     app.kubernetes.io/name: knative-eventing
 spec:
   group: eventing.knative.dev
@@ -1503,30 +1200,17 @@ spec:
       - knative
       - eventing
   scope: Namespaced
-# Copyright 2020 The Knative Authors
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#     http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
 ---
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   name: channels.messaging.knative.dev
   labels:
-    eventing.knative.dev/release: "v1.4.0"
+    eventing.knative.dev/release: "v1.2.4"
     knative.dev/crd-install: "true"
     messaging.knative.dev/subscribable: "true"
     duck.knative.dev/addressable: "true"
-    app.kubernetes.io/version: "1.4.0"
+    app.kubernetes.io/version: "1.2.4"
     app.kubernetes.io/name: knative-eventing
 spec:
   group: messaging.knative.dev
@@ -1777,29 +1461,16 @@ spec:
     shortNames:
       - ch
   scope: Namespaced
-# Copyright 2020 The Knative Authors
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#     http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
 ---
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   labels:
-    eventing.knative.dev/release: "v1.4.0"
+    eventing.knative.dev/release: "v1.2.4"
     eventing.knative.dev/source: "true"
     duck.knative.dev/source: "true"
     knative.dev/crd-install: "true"
-    app.kubernetes.io/version: "1.4.0"
+    app.kubernetes.io/version: "1.2.4"
     app.kubernetes.io/name: knative-eventing
   name: containersources.sources.knative.dev
 spec:
@@ -1934,9 +1605,9 @@ kind: CustomResourceDefinition
 metadata:
   name: eventtypes.eventing.knative.dev
   labels:
-    eventing.knative.dev/release: "v1.4.0"
+    eventing.knative.dev/release: "v1.2.4"
     knative.dev/crd-install: "true"
-    app.kubernetes.io/version: "1.4.0"
+    app.kubernetes.io/version: "1.2.4"
     app.kubernetes.io/name: knative-eventing
 spec:
   group: eventing.knative.dev
@@ -2048,10 +1719,10 @@ kind: CustomResourceDefinition
 metadata:
   name: parallels.flows.knative.dev
   labels:
-    eventing.knative.dev/release: "v1.4.0"
+    eventing.knative.dev/release: "v1.2.4"
     knative.dev/crd-install: "true"
     duck.knative.dev/addressable: "true"
-    app.kubernetes.io/version: "1.4.0"
+    app.kubernetes.io/version: "1.2.4"
     app.kubernetes.io/name: knative-eventing
 spec:
   group: flows.knative.dev
@@ -2481,29 +2152,16 @@ spec:
       - knative
       - flows
   scope: Namespaced
-# Copyright 2020 The Knative Authors
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#     http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
 ---
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   labels:
-    eventing.knative.dev/release: "v1.4.0"
+    eventing.knative.dev/release: "v1.2.4"
     eventing.knative.dev/source: "true"
     duck.knative.dev/source: "true"
     knative.dev/crd-install: "true"
-    app.kubernetes.io/version: "1.4.0"
+    app.kubernetes.io/version: "1.2.4"
     app.kubernetes.io/name: knative-eventing
   annotations:
     registry.knative.dev/eventTypes: |
@@ -2801,10 +2459,10 @@ kind: CustomResourceDefinition
 metadata:
   name: sequences.flows.knative.dev
   labels:
-    eventing.knative.dev/release: "v1.4.0"
+    eventing.knative.dev/release: "v1.2.4"
     knative.dev/crd-install: "true"
     duck.knative.dev/addressable: "true"
-    app.kubernetes.io/version: "1.4.0"
+    app.kubernetes.io/version: "1.2.4"
     app.kubernetes.io/name: knative-eventing
 spec:
   group: flows.knative.dev
@@ -3101,30 +2759,17 @@ spec:
       - knative
       - flows
   scope: Namespaced
-# Copyright 2020 The Knative Authors
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#     http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
 ---
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   labels:
-    eventing.knative.dev/release: "v1.4.0"
+    eventing.knative.dev/release: "v1.2.4"
     eventing.knative.dev/source: "true"
     duck.knative.dev/source: "true"
     duck.knative.dev/binding: "true"
     knative.dev/crd-install: "true"
-    app.kubernetes.io/version: "1.4.0"
+    app.kubernetes.io/version: "1.2.4"
     app.kubernetes.io/name: knative-eventing
   name: sinkbindings.sources.knative.dev
 spec:
@@ -3297,9 +2942,9 @@ kind: CustomResourceDefinition
 metadata:
   name: subscriptions.messaging.knative.dev
   labels:
-    eventing.knative.dev/release: "v1.4.0"
+    eventing.knative.dev/release: "v1.2.4"
     knative.dev/crd-install: "true"
-    app.kubernetes.io/version: "1.4.0"
+    app.kubernetes.io/version: "1.2.4"
     app.kubernetes.io/name: knative-eventing
 spec:
   group: messaging.knative.dev
@@ -3488,28 +3133,15 @@ spec:
     shortNames:
       - sub
   scope: Namespaced
-# Copyright 2020 The Knative Authors
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#     http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
 ---
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   name: triggers.eventing.knative.dev
   labels:
-    eventing.knative.dev/release: "v1.4.0"
+    eventing.knative.dev/release: "v1.2.4"
     knative.dev/crd-install: "true"
-    app.kubernetes.io/version: "1.4.0"
+    app.kubernetes.io/version: "1.2.4"
     app.kubernetes.io/name: knative-eventing
 spec:
   group: eventing.knative.dev
@@ -3671,27 +3303,14 @@ spec:
       - knative
       - eventing
   scope: Namespaced
-# Copyright 2019 The Knative Authors
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#     http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   name: addressable-resolver
   labels:
-    eventing.knative.dev/release: "v1.4.0"
-    app.kubernetes.io/version: "1.4.0"
+    eventing.knative.dev/release: "v1.2.4"
+    app.kubernetes.io/version: "1.2.4"
     app.kubernetes.io/name: knative-eventing
 aggregationRule:
   clusterRoleSelectors:
@@ -3704,9 +3323,9 @@ apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: service-addressable-resolver
   labels:
-    eventing.knative.dev/release: "v1.4.0"
+    eventing.knative.dev/release: "v1.2.4"
     duck.knative.dev/addressable: "true"
-    app.kubernetes.io/version: "1.4.0"
+    app.kubernetes.io/version: "1.2.4"
     app.kubernetes.io/name: knative-eventing
 rules:
   - apiGroups:
@@ -3723,9 +3342,9 @@ apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: serving-addressable-resolver
   labels:
-    eventing.knative.dev/release: "v1.4.0"
+    eventing.knative.dev/release: "v1.2.4"
     duck.knative.dev/addressable: "true"
-    app.kubernetes.io/version: "1.4.0"
+    app.kubernetes.io/version: "1.2.4"
     app.kubernetes.io/name: knative-eventing
 rules:
   - apiGroups:
@@ -3745,9 +3364,9 @@ apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: channel-addressable-resolver
   labels:
-    eventing.knative.dev/release: "v1.4.0"
+    eventing.knative.dev/release: "v1.2.4"
     duck.knative.dev/addressable: "true"
-    app.kubernetes.io/version: "1.4.0"
+    app.kubernetes.io/version: "1.2.4"
     app.kubernetes.io/name: knative-eventing
 rules:
   - apiGroups:
@@ -3771,9 +3390,9 @@ apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: broker-addressable-resolver
   labels:
-    eventing.knative.dev/release: "v1.4.0"
+    eventing.knative.dev/release: "v1.2.4"
     duck.knative.dev/addressable: "true"
-    app.kubernetes.io/version: "1.4.0"
+    app.kubernetes.io/version: "1.2.4"
     app.kubernetes.io/name: knative-eventing
 rules:
   - apiGroups:
@@ -3791,9 +3410,9 @@ apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: flows-addressable-resolver
   labels:
-    eventing.knative.dev/release: "v1.4.0"
+    eventing.knative.dev/release: "v1.2.4"
     duck.knative.dev/addressable: "true"
-    app.kubernetes.io/version: "1.4.0"
+    app.kubernetes.io/version: "1.2.4"
     app.kubernetes.io/name: knative-eventing
 rules:
   - apiGroups:
@@ -3807,27 +3426,14 @@ rules:
       - get
       - list
       - watch
-# Copyright 2019 The Knative Authors
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#     http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   name: eventing-broker-filter
   labels:
-    eventing.knative.dev/release: "v1.4.0"
-    app.kubernetes.io/version: "1.4.0"
+    eventing.knative.dev/release: "v1.2.4"
+    app.kubernetes.io/version: "1.2.4"
     app.kubernetes.io/name: knative-eventing
 rules:
   - apiGroups:
@@ -3853,8 +3459,8 @@ kind: ClusterRole
 metadata:
   name: eventing-broker-ingress
   labels:
-    eventing.knative.dev/release: "v1.4.0"
-    app.kubernetes.io/version: "1.4.0"
+    eventing.knative.dev/release: "v1.2.4"
+    app.kubernetes.io/version: "1.2.4"
     app.kubernetes.io/name: knative-eventing
 rules:
   - apiGroups:
@@ -3871,8 +3477,8 @@ kind: ClusterRole
 metadata:
   name: eventing-config-reader
   labels:
-    eventing.knative.dev/release: "v1.4.0"
-    app.kubernetes.io/version: "1.4.0"
+    eventing.knative.dev/release: "v1.2.4"
+    app.kubernetes.io/version: "1.2.4"
     app.kubernetes.io/name: knative-eventing
 rules:
   - apiGroups:
@@ -3883,27 +3489,14 @@ rules:
       - "get"
       - "list"
       - "watch"
-# Copyright 2019 The Knative Authors
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#     http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   name: channelable-manipulator
   labels:
-    eventing.knative.dev/release: "v1.4.0"
-    app.kubernetes.io/version: "1.4.0"
+    eventing.knative.dev/release: "v1.2.4"
+    app.kubernetes.io/version: "1.2.4"
     app.kubernetes.io/name: knative-eventing
 aggregationRule:
   clusterRoleSelectors:
@@ -3916,9 +3509,9 @@ kind: ClusterRole
 metadata:
   name: meta-channelable-manipulator
   labels:
-    eventing.knative.dev/release: "v1.4.0"
+    eventing.knative.dev/release: "v1.2.4"
     duck.knative.dev/channelable: "true"
-    app.kubernetes.io/version: "1.4.0"
+    app.kubernetes.io/version: "1.2.4"
     app.kubernetes.io/name: knative-eventing
 rules:
   - apiGroups:
@@ -3934,28 +3527,15 @@ rules:
       - update
       - patch
       - delete
-# Copyright 2019 The Knative Authors
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#     http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
 ---
 kind: ClusterRole
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: knative-eventing-namespaced-admin
   labels:
-    eventing.knative.dev/release: "v1.4.0"
+    eventing.knative.dev/release: "v1.2.4"
     rbac.authorization.k8s.io/aggregate-to-admin: "true"
-    app.kubernetes.io/version: "1.4.0"
+    app.kubernetes.io/version: "1.2.4"
     app.kubernetes.io/name: knative-eventing
 rules:
   - apiGroups: ["eventing.knative.dev"]
@@ -3967,9 +3547,9 @@ apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: knative-messaging-namespaced-admin
   labels:
-    eventing.knative.dev/release: "v1.4.0"
+    eventing.knative.dev/release: "v1.2.4"
     rbac.authorization.k8s.io/aggregate-to-admin: "true"
-    app.kubernetes.io/version: "1.4.0"
+    app.kubernetes.io/version: "1.2.4"
     app.kubernetes.io/name: knative-eventing
 rules:
   - apiGroups: ["messaging.knative.dev"]
@@ -3981,9 +3561,9 @@ apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: knative-flows-namespaced-admin
   labels:
-    eventing.knative.dev/release: "v1.4.0"
+    eventing.knative.dev/release: "v1.2.4"
     rbac.authorization.k8s.io/aggregate-to-admin: "true"
-    app.kubernetes.io/version: "1.4.0"
+    app.kubernetes.io/version: "1.2.4"
     app.kubernetes.io/name: knative-eventing
 rules:
   - apiGroups: ["flows.knative.dev"]
@@ -3995,9 +3575,9 @@ apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: knative-sources-namespaced-admin
   labels:
-    eventing.knative.dev/release: "v1.4.0"
+    eventing.knative.dev/release: "v1.2.4"
     rbac.authorization.k8s.io/aggregate-to-admin: "true"
-    app.kubernetes.io/version: "1.4.0"
+    app.kubernetes.io/version: "1.2.4"
     app.kubernetes.io/name: knative-eventing
 rules:
   - apiGroups: ["sources.knative.dev"]
@@ -4009,9 +3589,9 @@ apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: knative-bindings-namespaced-admin
   labels:
-    eventing.knative.dev/release: "v1.4.0"
+    eventing.knative.dev/release: "v1.2.4"
     rbac.authorization.k8s.io/aggregate-to-admin: "true"
-    app.kubernetes.io/version: "1.4.0"
+    app.kubernetes.io/version: "1.2.4"
     app.kubernetes.io/name: knative-eventing
 rules:
   - apiGroups: ["bindings.knative.dev"]
@@ -4024,8 +3604,8 @@ metadata:
   name: knative-eventing-namespaced-edit
   labels:
     rbac.authorization.k8s.io/aggregate-to-edit: "true"
-    eventing.knative.dev/release: "v1.4.0"
-    app.kubernetes.io/version: "1.4.0"
+    eventing.knative.dev/release: "v1.2.4"
+    app.kubernetes.io/version: "1.2.4"
     app.kubernetes.io/name: knative-eventing
 rules:
   - apiGroups: ["eventing.knative.dev", "messaging.knative.dev", "sources.knative.dev", "flows.knative.dev", "bindings.knative.dev"]
@@ -4038,34 +3618,21 @@ metadata:
   name: knative-eventing-namespaced-view
   labels:
     rbac.authorization.k8s.io/aggregate-to-view: "true"
-    eventing.knative.dev/release: "v1.4.0"
-    app.kubernetes.io/version: "1.4.0"
+    eventing.knative.dev/release: "v1.2.4"
+    app.kubernetes.io/version: "1.2.4"
     app.kubernetes.io/name: knative-eventing
 rules:
   - apiGroups: ["eventing.knative.dev", "messaging.knative.dev", "sources.knative.dev", "flows.knative.dev", "bindings.knative.dev"]
     resources: ["*"]
     verbs: ["get", "list", "watch"]
-# Copyright 2019 The Knative Authors
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#     http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   name: knative-eventing-controller
   labels:
-    eventing.knative.dev/release: "v1.4.0"
-    app.kubernetes.io/version: "1.4.0"
+    eventing.knative.dev/release: "v1.2.4"
+    app.kubernetes.io/version: "1.2.4"
     app.kubernetes.io/name: knative-eventing
 rules:
   - apiGroups:
@@ -4210,27 +3777,14 @@ rules:
       - "delete"
       - "patch"
       - "watch"
-# Copyright 2020 The Knative Authors
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#     http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   name: knative-eventing-pingsource-mt-adapter
   labels:
-    eventing.knative.dev/release: "v1.4.0"
-    app.kubernetes.io/version: "1.4.0"
+    eventing.knative.dev/release: "v1.2.4"
+    app.kubernetes.io/version: "1.2.4"
     app.kubernetes.io/name: knative-eventing
 rules:
   - apiGroups:
@@ -4275,27 +3829,14 @@ rules:
       - create
       - update
       - patch
-# Copyright 2019 The Knative Authors
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#     http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   name: podspecable-binding
   labels:
-    eventing.knative.dev/release: "v1.4.0"
-    app.kubernetes.io/version: "1.4.0"
+    eventing.knative.dev/release: "v1.2.4"
+    app.kubernetes.io/version: "1.2.4"
     app.kubernetes.io/name: knative-eventing
 aggregationRule:
   clusterRoleSelectors:
@@ -4308,9 +3849,9 @@ apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: builtin-podspecable-binding
   labels:
-    eventing.knative.dev/release: "v1.4.0"
+    eventing.knative.dev/release: "v1.2.4"
     duck.knative.dev/podspecable: "true"
-    app.kubernetes.io/version: "1.4.0"
+    app.kubernetes.io/version: "1.2.4"
     app.kubernetes.io/name: knative-eventing
 rules:
   - apiGroups:
@@ -4332,27 +3873,14 @@ rules:
       - "list"
       - "watch"
       - "patch"
-# Copyright 2019 The Knative Authors
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#     http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   name: source-observer
   labels:
-    eventing.knative.dev/release: "v1.4.0"
-    app.kubernetes.io/version: "1.4.0"
+    eventing.knative.dev/release: "v1.2.4"
+    app.kubernetes.io/version: "1.2.4"
     app.kubernetes.io/name: knative-eventing
 aggregationRule:
   clusterRoleSelectors:
@@ -4365,9 +3893,9 @@ apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: eventing-sources-source-observer
   labels:
-    eventing.knative.dev/release: "v1.4.0"
+    eventing.knative.dev/release: "v1.2.4"
     duck.knative.dev/source: "true"
-    app.kubernetes.io/version: "1.4.0"
+    app.kubernetes.io/version: "1.2.4"
     app.kubernetes.io/name: knative-eventing
 rules:
   - apiGroups:
@@ -4381,27 +3909,14 @@ rules:
       - get
       - list
       - watch
-# Copyright 2019 The Knative Authors
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#     http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   name: knative-eventing-sources-controller
   labels:
-    eventing.knative.dev/release: "v1.4.0"
-    app.kubernetes.io/version: "1.4.0"
+    eventing.knative.dev/release: "v1.2.4"
+    app.kubernetes.io/version: "1.2.4"
     app.kubernetes.io/name: knative-eventing
 rules:
   - apiGroups:
@@ -4495,27 +4010,14 @@ rules:
       - subjectaccessreviews
     verbs:
       - create
-# Copyright 2019 The Knative Authors
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#     http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   name: knative-eventing-webhook
   labels:
-    eventing.knative.dev/release: "v1.4.0"
-    app.kubernetes.io/version: "1.4.0"
+    eventing.knative.dev/release: "v1.2.4"
+    app.kubernetes.io/version: "1.2.4"
     app.kubernetes.io/name: knative-eventing
 rules:
   - apiGroups:
@@ -4597,19 +4099,6 @@ rules:
   - apiGroups: ["apiextensions.k8s.io"]
     resources: ["customresourcedefinitions"]
     verbs: ["get", "list", "create", "update", "delete", "patch", "watch"]
-# Copyright 2020 The Knative Authors
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#     http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
@@ -4617,8 +4106,8 @@ metadata:
   namespace: knative-eventing
   name: knative-eventing-webhook
   labels:
-    eventing.knative.dev/release: "v1.4.0"
-    app.kubernetes.io/version: "1.4.0"
+    eventing.knative.dev/release: "v1.2.4"
+    app.kubernetes.io/version: "1.2.4"
     app.kubernetes.io/name: knative-eventing
 rules:
   - apiGroups:
@@ -4632,27 +4121,14 @@ rules:
       - "list"
       - "watch"
       - "patch"
-# Copyright 2018 The Knative Authors
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#     https://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
 ---
 apiVersion: admissionregistration.k8s.io/v1
 kind: ValidatingWebhookConfiguration
 metadata:
   name: config.webhook.eventing.knative.dev
   labels:
-    eventing.knative.dev/release: "v1.4.0"
-    app.kubernetes.io/version: "1.4.0"
+    eventing.knative.dev/release: "v1.2.4"
+    app.kubernetes.io/version: "1.2.4"
     app.kubernetes.io/name: knative-eventing
 webhooks:
   - admissionReviewVersions: ["v1", "v1beta1"]
@@ -4668,27 +4144,14 @@ webhooks:
         - key: eventing.knative.dev/release
           operator: Exists
     timeoutSeconds: 10
-# Copyright 2018 The Knative Authors
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#     https://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
 ---
 apiVersion: admissionregistration.k8s.io/v1
 kind: MutatingWebhookConfiguration
 metadata:
   name: webhook.eventing.knative.dev
   labels:
-    eventing.knative.dev/release: "v1.4.0"
-    app.kubernetes.io/version: "1.4.0"
+    eventing.knative.dev/release: "v1.2.4"
+    app.kubernetes.io/version: "1.2.4"
     app.kubernetes.io/name: knative-eventing
 webhooks:
   - admissionReviewVersions: ["v1", "v1beta1"]
@@ -4700,27 +4163,14 @@ webhooks:
     failurePolicy: Fail
     name: webhook.eventing.knative.dev
     timeoutSeconds: 10
-# Copyright 2018 The Knative Authors
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#     https://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
 ---
 apiVersion: admissionregistration.k8s.io/v1
 kind: ValidatingWebhookConfiguration
 metadata:
   name: validation.webhook.eventing.knative.dev
   labels:
-    eventing.knative.dev/release: "v1.4.0"
-    app.kubernetes.io/version: "1.4.0"
+    eventing.knative.dev/release: "v1.2.4"
+    app.kubernetes.io/version: "1.2.4"
     app.kubernetes.io/name: knative-eventing
 webhooks:
   - admissionReviewVersions: ["v1", "v1beta1"]
@@ -4732,19 +4182,6 @@ webhooks:
     failurePolicy: Fail
     name: validation.webhook.eventing.knative.dev
     timeoutSeconds: 10
-# Copyright 2018 The Knative Authors
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#     https://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
 ---
 apiVersion: v1
 kind: Secret
@@ -4752,30 +4189,17 @@ metadata:
   name: eventing-webhook-certs
   namespace: knative-eventing
   labels:
-    eventing.knative.dev/release: "v1.4.0"
-    app.kubernetes.io/version: "1.4.0"
+    eventing.knative.dev/release: "v1.2.4"
+    app.kubernetes.io/version: "1.2.4"
     app.kubernetes.io/name: knative-eventing
-# Copyright 2018 The Knative Authors
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#     https://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
 ---
 apiVersion: admissionregistration.k8s.io/v1
 kind: MutatingWebhookConfiguration
 metadata:
   name: sinkbindings.webhook.sources.knative.dev
   labels:
-    eventing.knative.dev/release: "v1.4.0"
-    app.kubernetes.io/version: "1.4.0"
+    eventing.knative.dev/release: "v1.2.4"
+    app.kubernetes.io/version: "1.2.4"
     app.kubernetes.io/name: knative-eventing
 webhooks:
   - admissionReviewVersions: ["v1", "v1beta1"]

--- a/common/knative/knative-eventing/base/upstream/in-memory-channel.yaml
+++ b/common/knative/knative-eventing/base/upstream/in-memory-channel.yaml
@@ -3,22 +3,9 @@ kind: Namespace
 metadata:
   name: knative-eventing
   labels:
-    eventing.knative.dev/release: "v1.4.0"
-    app.kubernetes.io/version: "1.4.0"
+    eventing.knative.dev/release: "v1.2.4"
+    app.kubernetes.io/version: "1.2.4"
     app.kubernetes.io/name: knative-eventing
-# Copyright 2021 The Knative Authors
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#     http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
 ---
 apiVersion: v1
 kind: ServiceAccount
@@ -26,8 +13,8 @@ metadata:
   name: imc-controller
   namespace: knative-eventing
   labels:
-    eventing.knative.dev/release: "v1.4.0"
-    app.kubernetes.io/version: "1.4.0"
+    eventing.knative.dev/release: "v1.2.4"
+    app.kubernetes.io/version: "1.2.4"
     app.kubernetes.io/name: knative-eventing
 ---
 apiVersion: rbac.authorization.k8s.io/v1
@@ -35,8 +22,8 @@ kind: ClusterRoleBinding
 metadata:
   name: imc-controller
   labels:
-    eventing.knative.dev/release: "v1.4.0"
-    app.kubernetes.io/version: "1.4.0"
+    eventing.knative.dev/release: "v1.2.4"
+    app.kubernetes.io/version: "1.2.4"
     app.kubernetes.io/name: knative-eventing
 subjects:
   - kind: ServiceAccount
@@ -53,8 +40,8 @@ metadata:
   namespace: knative-eventing
   name: imc-controller
   labels:
-    eventing.knative.dev/release: "v1.4.0"
-    app.kubernetes.io/version: "1.4.0"
+    eventing.knative.dev/release: "v1.2.4"
+    app.kubernetes.io/version: "1.2.4"
     app.kubernetes.io/name: knative-eventing
 subjects:
   - kind: ServiceAccount
@@ -70,8 +57,8 @@ kind: ClusterRoleBinding
 metadata:
   name: imc-controller-resolver
   labels:
-    eventing.knative.dev/release: "v1.4.0"
-    app.kubernetes.io/version: "1.4.0"
+    eventing.knative.dev/release: "v1.2.4"
+    app.kubernetes.io/version: "1.2.4"
     app.kubernetes.io/name: knative-eventing
 subjects:
   - kind: ServiceAccount
@@ -81,19 +68,6 @@ roleRef:
   kind: ClusterRole
   name: addressable-resolver
   apiGroup: rbac.authorization.k8s.io
-# Copyright 2021 The Knative Authors
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#     http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
 ---
 apiVersion: v1
 kind: ServiceAccount
@@ -101,8 +75,8 @@ metadata:
   name: imc-dispatcher
   namespace: knative-eventing
   labels:
-    eventing.knative.dev/release: "v1.4.0"
-    app.kubernetes.io/version: "1.4.0"
+    eventing.knative.dev/release: "v1.2.4"
+    app.kubernetes.io/version: "1.2.4"
     app.kubernetes.io/name: knative-eventing
 ---
 apiVersion: rbac.authorization.k8s.io/v1
@@ -110,8 +84,8 @@ kind: ClusterRoleBinding
 metadata:
   name: imc-dispatcher
   labels:
-    eventing.knative.dev/release: "v1.4.0"
-    app.kubernetes.io/version: "1.4.0"
+    eventing.knative.dev/release: "v1.2.4"
+    app.kubernetes.io/version: "1.2.4"
     app.kubernetes.io/name: knative-eventing
 subjects:
   - kind: ServiceAccount
@@ -121,19 +95,6 @@ roleRef:
   kind: ClusterRole
   name: imc-dispatcher
   apiGroup: rbac.authorization.k8s.io
-# Copyright 2020 The Knative Authors
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#     https://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
 ---
 apiVersion: v1
 kind: ConfigMap
@@ -141,26 +102,13 @@ metadata:
   name: config-imc-event-dispatcher
   namespace: knative-eventing
   labels:
-    eventing.knative.dev/release: "v1.4.0"
+    eventing.knative.dev/release: "v1.2.4"
     app.kubernetes.io/component: imc-controller
-    app.kubernetes.io/version: "1.4.0"
+    app.kubernetes.io/version: "1.2.4"
     app.kubernetes.io/name: knative-eventing
 data:
   MaxIdleConnections: "1000"
   MaxIdleConnectionsPerHost: "100"
-# Copyright 2019 The Knative Authors
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#     https://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
 ---
 apiVersion: v1
 kind: ConfigMap
@@ -168,10 +116,10 @@ metadata:
   name: config-observability
   namespace: knative-eventing
   labels:
-    eventing.knative.dev/release: "v1.4.0"
+    eventing.knative.dev/release: "v1.2.4"
     knative.dev/config-propagation: original
     knative.dev/config-category: eventing
-    app.kubernetes.io/version: "1.4.0"
+    app.kubernetes.io/version: "1.2.4"
     app.kubernetes.io/name: knative-eventing
   annotations:
     knative.dev/example-checksum: "f46cf09d"
@@ -223,19 +171,6 @@ data:
     # sink-event-error-reporting.enable whether the adapter reports a kube event to the CRD indicating
     # a failure to send a cloud event to the sink.
     sink-event-error-reporting.enable: "false"
-# Copyright 2019 The Knative Authors
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#     https://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
 ---
 apiVersion: v1
 kind: ConfigMap
@@ -243,13 +178,13 @@ metadata:
   name: config-tracing
   namespace: knative-eventing
   labels:
-    eventing.knative.dev/release: "v1.4.0"
+    eventing.knative.dev/release: "v1.2.4"
     knative.dev/config-propagation: original
     knative.dev/config-category: eventing
-    app.kubernetes.io/version: "1.4.0"
+    app.kubernetes.io/version: "1.2.4"
     app.kubernetes.io/name: knative-eventing
   annotations:
-    knative.dev/example-checksum: "0492ceb0"
+    knative.dev/example-checksum: "c8f8c47b"
 data:
   _example: |
     ################################
@@ -266,7 +201,7 @@ data:
     # this example block and unindented to be in the data block
     # to actually change the configuration.
     #
-    # This may be "zipkin" or "none". the default is "none"
+    # This may be "zipkin" or "none", the default is "none"
     backend: "none"
 
     # URL to zipkin collector where traces are sent.
@@ -279,19 +214,6 @@ data:
 
     # Percentage (0-1) of requests to trace
     sample-rate: "0.1"
-# Copyright 2019 The Knative Authors
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#     http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
 ---
 apiVersion: apps/v1
 kind: Deployment
@@ -299,10 +221,10 @@ metadata:
   name: imc-controller
   namespace: knative-eventing
   labels:
-    eventing.knative.dev/release: "v1.4.0"
+    eventing.knative.dev/release: "v1.2.4"
     knative.dev/high-availability: "true"
     app.kubernetes.io/component: imc-controller
-    app.kubernetes.io/version: "1.4.0"
+    app.kubernetes.io/version: "1.2.4"
     app.kubernetes.io/name: knative-eventing
 spec:
   selector:
@@ -315,7 +237,7 @@ spec:
         messaging.knative.dev/channel: in-memory-channel
         messaging.knative.dev/role: controller
         app.kubernetes.io/component: imc-controller
-        app.kubernetes.io/version: "1.4.0"
+        app.kubernetes.io/version: "1.2.4"
         app.kubernetes.io/name: knative-eventing
     spec:
       affinity:
@@ -332,7 +254,7 @@ spec:
       enableServiceLinks: false
       containers:
         - name: controller
-          image: gcr.io/knative-releases/knative.dev/eventing/cmd/in_memory/channel_controller@sha256:bcf585877a32db79b651d2560f9ae9378de26ee5ac3a6d3e63b3159b3fec32d2
+          image: gcr.io/knative-releases/knative.dev/eventing/cmd/in_memory/channel_controller@sha256:a602de59eab2140a9a7639e221b777aa1bd5b9b4203e09dacdc32850f4414e4f
           env:
             - name: WEBHOOK_NAME
               value: inmemorychannel-webhook
@@ -349,7 +271,7 @@ spec:
                 fieldRef:
                   fieldPath: metadata.namespace
             - name: DISPATCHER_IMAGE
-              value: gcr.io/knative-releases/knative.dev/eventing/cmd/in_memory/channel_dispatcher@sha256:1bfe4a8b168449a65d87191a45b68ccece87cc73d5f8c3728dc07ab83fe71240
+              value: gcr.io/knative-releases/knative.dev/eventing/cmd/in_memory/channel_dispatcher@sha256:cd4502677aedc0779be980c5e7186cdc8e7557a036048480f8a3431ec1b3b873
             - name: POD_NAME
               valueFrom:
                 fieldRef:
@@ -392,9 +314,9 @@ kind: Service
 metadata:
   labels:
     app.kubernetes.io/component: imc-controller
-    app.kubernetes.io/version: "1.4.0"
+    app.kubernetes.io/version: "1.2.4"
     app.kubernetes.io/name: knative-eventing
-    eventing.knative.dev/release: "v1.4.0"
+    eventing.knative.dev/release: "v1.2.4"
   name: inmemorychannel-webhook
   namespace: knative-eventing
 spec:
@@ -418,11 +340,11 @@ metadata:
   name: imc-dispatcher
   namespace: knative-eventing
   labels:
-    eventing.knative.dev/release: "v1.4.0"
+    eventing.knative.dev/release: "v1.2.4"
     messaging.knative.dev/channel: in-memory-channel
     messaging.knative.dev/role: dispatcher
     app.kubernetes.io/component: imc-dispatcher
-    app.kubernetes.io/version: "1.4.0"
+    app.kubernetes.io/version: "1.2.4"
     app.kubernetes.io/name: knative-eventing
 spec:
   selector:
@@ -436,19 +358,6 @@ spec:
     - name: http-metrics
       port: 9090
       targetPort: 9090
-# Copyright 2019 The Knative Authors
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#     http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
 ---
 apiVersion: apps/v1
 kind: Deployment
@@ -456,10 +365,10 @@ metadata:
   name: imc-dispatcher
   namespace: knative-eventing
   labels:
-    eventing.knative.dev/release: "v1.4.0"
+    eventing.knative.dev/release: "v1.2.4"
     knative.dev/high-availability: "true"
     app.kubernetes.io/component: imc-dispatcher
-    app.kubernetes.io/version: "1.4.0"
+    app.kubernetes.io/version: "1.2.4"
     app.kubernetes.io/name: knative-eventing
 spec:
   selector:
@@ -472,7 +381,7 @@ spec:
         messaging.knative.dev/channel: in-memory-channel
         messaging.knative.dev/role: dispatcher
         app.kubernetes.io/component: imc-dispatcher
-        app.kubernetes.io/version: "1.4.0"
+        app.kubernetes.io/version: "1.2.4"
         app.kubernetes.io/name: knative-eventing
     spec:
       affinity:
@@ -489,7 +398,7 @@ spec:
       enableServiceLinks: false
       containers:
         - name: dispatcher
-          image: gcr.io/knative-releases/knative.dev/eventing/cmd/in_memory/channel_dispatcher@sha256:1bfe4a8b168449a65d87191a45b68ccece87cc73d5f8c3728dc07ab83fe71240
+          image: gcr.io/knative-releases/knative.dev/eventing/cmd/in_memory/channel_dispatcher@sha256:cd4502677aedc0779be980c5e7186cdc8e7557a036048480f8a3431ec1b3b873
           readinessProbe:
             failureThreshold: 3
             httpGet:
@@ -549,11 +458,11 @@ kind: CustomResourceDefinition
 metadata:
   name: inmemorychannels.messaging.knative.dev
   labels:
-    eventing.knative.dev/release: "v1.4.0"
+    eventing.knative.dev/release: "v1.2.4"
     knative.dev/crd-install: "true"
     messaging.knative.dev/subscribable: "true"
     duck.knative.dev/addressable: "true"
-    app.kubernetes.io/version: "1.4.0"
+    app.kubernetes.io/version: "1.2.4"
     app.kubernetes.io/name: knative-eventing
 spec:
   group: messaging.knative.dev
@@ -774,28 +683,15 @@ spec:
     shortNames:
       - imc
   scope: Namespaced
-# Copyright 2019 The Knative Authors
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#     http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   name: imc-addressable-resolver
   labels:
-    eventing.knative.dev/release: "v1.4.0"
+    eventing.knative.dev/release: "v1.2.4"
     duck.knative.dev/addressable: "true"
-    app.kubernetes.io/version: "1.4.0"
+    app.kubernetes.io/version: "1.2.4"
     app.kubernetes.io/name: knative-eventing
 rules:
   - apiGroups:
@@ -807,28 +703,15 @@ rules:
       - get
       - list
       - watch
-# Copyright 2019 The Knative Authors
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#     http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   name: imc-channelable-manipulator
   labels:
-    eventing.knative.dev/release: "v1.4.0"
+    eventing.knative.dev/release: "v1.2.4"
     duck.knative.dev/channelable: "true"
-    app.kubernetes.io/version: "1.4.0"
+    app.kubernetes.io/version: "1.2.4"
     app.kubernetes.io/name: knative-eventing
 rules:
   - apiGroups:
@@ -844,27 +727,14 @@ rules:
       - update
       - patch
       - delete
-# Copyright 2019 The Knative Authors
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#     http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   name: imc-controller
   labels:
-    eventing.knative.dev/release: "v1.4.0"
-    app.kubernetes.io/version: "1.4.0"
+    eventing.knative.dev/release: "v1.2.4"
+    app.kubernetes.io/version: "1.2.4"
     app.kubernetes.io/name: knative-eventing
 rules:
   - apiGroups:
@@ -1003,8 +873,8 @@ kind: ClusterRole
 metadata:
   name: imc-dispatcher
   labels:
-    eventing.knative.dev/release: "v1.4.0"
-    app.kubernetes.io/version: "1.4.0"
+    eventing.knative.dev/release: "v1.2.4"
+    app.kubernetes.io/version: "1.2.4"
     app.kubernetes.io/name: knative-eventing
 rules:
   - apiGroups:
@@ -1050,19 +920,6 @@ rules:
       - create
       - update
       - patch
-# Copyright 2020 The Knative Authors
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#     http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
@@ -1070,8 +927,8 @@ metadata:
   namespace: knative-eventing
   name: knative-inmemorychannel-webhook
   labels:
-    eventing.knative.dev/release: "v1.4.0"
-    app.kubernetes.io/version: "1.4.0"
+    eventing.knative.dev/release: "v1.2.4"
+    app.kubernetes.io/version: "1.2.4"
     app.kubernetes.io/name: knative-eventing
 rules:
   - apiGroups:
@@ -1085,27 +942,14 @@ rules:
       - "list"
       - "watch"
       - "patch"
-# Copyright 2021 The Knative Authors
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#     https://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
 ---
 apiVersion: admissionregistration.k8s.io/v1
 kind: MutatingWebhookConfiguration
 metadata:
   name: inmemorychannel.eventing.knative.dev
   labels:
-    eventing.knative.dev/release: "v1.4.0"
-    app.kubernetes.io/version: "1.4.0"
+    eventing.knative.dev/release: "v1.2.4"
+    app.kubernetes.io/version: "1.2.4"
     app.kubernetes.io/name: knative-eventing
 webhooks:
   - admissionReviewVersions: ["v1"]
@@ -1117,27 +961,14 @@ webhooks:
     failurePolicy: Fail
     name: inmemorychannel.eventing.knative.dev
     timeoutSeconds: 10
-# Copyright 2021 The Knative Authors
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#     https://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
 ---
 apiVersion: admissionregistration.k8s.io/v1
 kind: ValidatingWebhookConfiguration
 metadata:
   name: validation.inmemorychannel.eventing.knative.dev
   labels:
-    eventing.knative.dev/release: "v1.4.0"
-    app.kubernetes.io/version: "1.4.0"
+    eventing.knative.dev/release: "v1.2.4"
+    app.kubernetes.io/version: "1.2.4"
     app.kubernetes.io/name: knative-eventing
 webhooks:
   - admissionReviewVersions: ["v1"]
@@ -1149,19 +980,6 @@ webhooks:
     failurePolicy: Fail
     name: validation.inmemorychannel.eventing.knative.dev
     timeoutSeconds: 10
-# Copyright 2021 The Knative Authors
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#     https://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
 ---
 apiVersion: v1
 kind: Secret
@@ -1169,8 +987,8 @@ metadata:
   name: inmemorychannel-webhook-certs
   namespace: knative-eventing
   labels:
-    eventing.knative.dev/release: "v1.4.0"
-    app.kubernetes.io/version: "1.4.0"
+    eventing.knative.dev/release: "v1.2.4"
+    app.kubernetes.io/version: "1.2.4"
     app.kubernetes.io/name: knative-eventing
 ---
 

--- a/common/knative/knative-eventing/base/upstream/mt-channel-broker.yaml
+++ b/common/knative/knative-eventing/base/upstream/mt-channel-broker.yaml
@@ -3,8 +3,8 @@ kind: ClusterRole
 metadata:
   name: knative-eventing-mt-channel-broker-controller
   labels:
-    eventing.knative.dev/release: "v1.4.0"
-    app.kubernetes.io/version: "1.4.0"
+    eventing.knative.dev/release: "v1.2.4"
+    app.kubernetes.io/version: "1.2.4"
     app.kubernetes.io/name: knative-eventing
 rules:
   - apiGroups:
@@ -31,8 +31,8 @@ kind: ClusterRole
 metadata:
   name: knative-eventing-mt-broker-filter
   labels:
-    eventing.knative.dev/release: "v1.4.0"
-    app.kubernetes.io/version: "1.4.0"
+    eventing.knative.dev/release: "v1.2.4"
+    app.kubernetes.io/version: "1.2.4"
     app.kubernetes.io/name: knative-eventing
 rules:
   - apiGroups:
@@ -59,8 +59,8 @@ metadata:
   name: mt-broker-filter
   namespace: knative-eventing
   labels:
-    eventing.knative.dev/release: "v1.4.0"
-    app.kubernetes.io/version: "1.4.0"
+    eventing.knative.dev/release: "v1.2.4"
+    app.kubernetes.io/version: "1.2.4"
     app.kubernetes.io/name: knative-eventing
 ---
 apiVersion: rbac.authorization.k8s.io/v1
@@ -68,8 +68,8 @@ kind: ClusterRole
 metadata:
   name: knative-eventing-mt-broker-ingress
   labels:
-    eventing.knative.dev/release: "v1.4.0"
-    app.kubernetes.io/version: "1.4.0"
+    eventing.knative.dev/release: "v1.2.4"
+    app.kubernetes.io/version: "1.2.4"
     app.kubernetes.io/name: knative-eventing
 rules:
   - apiGroups:
@@ -95,30 +95,17 @@ metadata:
   name: mt-broker-ingress
   namespace: knative-eventing
   labels:
-    eventing.knative.dev/release: "v1.4.0"
-    app.kubernetes.io/version: "1.4.0"
+    eventing.knative.dev/release: "v1.2.4"
+    app.kubernetes.io/version: "1.2.4"
     app.kubernetes.io/name: knative-eventing
-# Copyright 2020 The Knative Authors
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#     http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   name: eventing-mt-channel-broker-controller
   labels:
-    eventing.knative.dev/release: "v1.4.0"
-    app.kubernetes.io/version: "1.4.0"
+    eventing.knative.dev/release: "v1.2.4"
+    app.kubernetes.io/version: "1.2.4"
     app.kubernetes.io/name: knative-eventing
 subjects:
   - kind: ServiceAccount
@@ -128,27 +115,14 @@ roleRef:
   kind: ClusterRole
   name: knative-eventing-mt-channel-broker-controller
   apiGroup: rbac.authorization.k8s.io
-# Copyright 2020 The Knative Authors
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#     http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   name: knative-eventing-mt-broker-filter
   labels:
-    eventing.knative.dev/release: "v1.4.0"
-    app.kubernetes.io/version: "1.4.0"
+    eventing.knative.dev/release: "v1.2.4"
+    app.kubernetes.io/version: "1.2.4"
     app.kubernetes.io/name: knative-eventing
 subjects:
   - kind: ServiceAccount
@@ -158,27 +132,14 @@ roleRef:
   kind: ClusterRole
   name: knative-eventing-mt-broker-filter
   apiGroup: rbac.authorization.k8s.io
-# Copyright 2020 The Knative Authors
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#     http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   name: knative-eventing-mt-broker-ingress
   labels:
-    eventing.knative.dev/release: "v1.4.0"
-    app.kubernetes.io/version: "1.4.0"
+    eventing.knative.dev/release: "v1.2.4"
+    app.kubernetes.io/version: "1.2.4"
     app.kubernetes.io/name: knative-eventing
 subjects:
   - kind: ServiceAccount
@@ -188,19 +149,6 @@ roleRef:
   kind: ClusterRole
   name: knative-eventing-mt-broker-ingress
   apiGroup: rbac.authorization.k8s.io
-# Copyright 2020 The Knative Authors
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#     http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
 ---
 apiVersion: apps/v1
 kind: Deployment
@@ -208,9 +156,9 @@ metadata:
   name: mt-broker-filter
   namespace: knative-eventing
   labels:
-    eventing.knative.dev/release: "v1.4.0"
+    eventing.knative.dev/release: "v1.2.4"
     app.kubernetes.io/component: broker-filter
-    app.kubernetes.io/version: "1.4.0"
+    app.kubernetes.io/version: "1.2.4"
     app.kubernetes.io/name: knative-eventing
 spec:
   selector:
@@ -220,9 +168,9 @@ spec:
     metadata:
       labels:
         eventing.knative.dev/brokerRole: filter
-        eventing.knative.dev/release: "v1.4.0"
+        eventing.knative.dev/release: "v1.2.4"
         app.kubernetes.io/component: broker-filter
-        app.kubernetes.io/version: "1.4.0"
+        app.kubernetes.io/version: "1.2.4"
         app.kubernetes.io/name: knative-eventing
     spec:
       serviceAccountName: mt-broker-filter
@@ -230,7 +178,7 @@ spec:
       containers:
         - name: filter
           terminationMessagePolicy: FallbackToLogsOnError
-          image: gcr.io/knative-releases/knative.dev/eventing/cmd/broker/filter@sha256:426797eae80ce0b759701ed5aa70571bf10a8fd1d459b6d1da3b6ea7bd320280
+          image: gcr.io/knative-releases/knative.dev/eventing/cmd/broker/filter@sha256:f4bda104202557a75fce024329fc1f0e2d4ac43f4362007ed4201290f79c1d82
           readinessProbe:
             failureThreshold: 3
             httpGet:
@@ -300,9 +248,9 @@ kind: Service
 metadata:
   labels:
     eventing.knative.dev/brokerRole: filter
-    eventing.knative.dev/release: "v1.4.0"
+    eventing.knative.dev/release: "v1.2.4"
     app.kubernetes.io/component: broker-filter
-    app.kubernetes.io/version: "1.4.0"
+    app.kubernetes.io/version: "1.2.4"
     app.kubernetes.io/name: knative-eventing
   name: broker-filter
   namespace: knative-eventing
@@ -318,19 +266,6 @@ spec:
       targetPort: 9092
   selector:
     eventing.knative.dev/brokerRole: filter
-# Copyright 2020 The Knative Authors
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#     http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
 ---
 apiVersion: apps/v1
 kind: Deployment
@@ -338,9 +273,9 @@ metadata:
   name: mt-broker-ingress
   namespace: knative-eventing
   labels:
-    eventing.knative.dev/release: "v1.4.0"
+    eventing.knative.dev/release: "v1.2.4"
     app.kubernetes.io/component: broker-ingress
-    app.kubernetes.io/version: "1.4.0"
+    app.kubernetes.io/version: "1.2.4"
     app.kubernetes.io/name: knative-eventing
 spec:
   selector:
@@ -350,9 +285,9 @@ spec:
     metadata:
       labels:
         eventing.knative.dev/brokerRole: ingress
-        eventing.knative.dev/release: "v1.4.0"
+        eventing.knative.dev/release: "v1.2.4"
         app.kubernetes.io/component: broker-ingress
-        app.kubernetes.io/version: "1.4.0"
+        app.kubernetes.io/version: "1.2.4"
         app.kubernetes.io/name: knative-eventing
     spec:
       serviceAccountName: mt-broker-ingress
@@ -360,7 +295,7 @@ spec:
       containers:
         - name: ingress
           terminationMessagePolicy: FallbackToLogsOnError
-          image: gcr.io/knative-releases/knative.dev/eventing/cmd/broker/ingress@sha256:e53c0774a9f95506566c2cee91437df5c69effa314afcd699610a34e12bd9595
+          image: gcr.io/knative-releases/knative.dev/eventing/cmd/broker/ingress@sha256:1bbbdea02b6fc01f316addefe56fa33f583cd332d7213cbc2e4937234bfc3d1b
           readinessProbe:
             failureThreshold: 3
             httpGet:
@@ -430,9 +365,9 @@ kind: Service
 metadata:
   labels:
     eventing.knative.dev/brokerRole: ingress
-    eventing.knative.dev/release: "v1.4.0"
+    eventing.knative.dev/release: "v1.2.4"
     app.kubernetes.io/component: broker-ingress
-    app.kubernetes.io/version: "1.4.0"
+    app.kubernetes.io/version: "1.2.4"
     app.kubernetes.io/name: knative-eventing
   name: broker-ingress
   namespace: knative-eventing
@@ -448,19 +383,6 @@ spec:
       targetPort: 9092
   selector:
     eventing.knative.dev/brokerRole: ingress
-# Copyright 2020 The Knative Authors
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#     http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
 ---
 apiVersion: apps/v1
 kind: Deployment
@@ -468,9 +390,9 @@ metadata:
   name: mt-broker-controller
   namespace: knative-eventing
   labels:
-    eventing.knative.dev/release: "v1.4.0"
+    eventing.knative.dev/release: "v1.2.4"
     app.kubernetes.io/component: mt-broker-controller
-    app.kubernetes.io/version: "1.4.0"
+    app.kubernetes.io/version: "1.2.4"
     app.kubernetes.io/name: knative-eventing
 spec:
   selector:
@@ -480,9 +402,9 @@ spec:
     metadata:
       labels:
         app: mt-broker-controller
-        eventing.knative.dev/release: "v1.4.0"
+        eventing.knative.dev/release: "v1.2.4"
         app.kubernetes.io/component: broker-controller
-        app.kubernetes.io/version: "1.4.0"
+        app.kubernetes.io/version: "1.2.4"
         app.kubernetes.io/name: knative-eventing
     spec:
       affinity:
@@ -499,7 +421,7 @@ spec:
       containers:
         - name: mt-broker-controller
           terminationMessagePolicy: FallbackToLogsOnError
-          image: gcr.io/knative-releases/knative.dev/eventing/cmd/mtchannel_broker@sha256:c0b3b21bdf2694d68e5eeaf20d2052a901173e929055a78815aa03c08f0c386f
+          image: gcr.io/knative-releases/knative.dev/eventing/cmd/mtchannel_broker@sha256:90e2b9413519d0634508ff848180fb50a341da09e53ac0408848f0663c7c8c3b
           resources:
             requests:
               cpu: 100m
@@ -515,6 +437,8 @@ spec:
               value: config-observability
             - name: METRICS_DOMAIN
               value: knative.dev/eventing
+            - name: BROKER_INJECTION_DEFAULT
+              value: "false"
             - name: POD_NAME
               valueFrom:
                 fieldRef:
@@ -531,19 +455,6 @@ spec:
               containerPort: 9090
             - name: profiling
               containerPort: 8008
-# Copyright 2020 The Knative Authors
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#     http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
 ---
 apiVersion: autoscaling/v2beta2
 kind: HorizontalPodAutoscaler
@@ -551,9 +462,9 @@ metadata:
   name: broker-ingress-hpa
   namespace: knative-eventing
   labels:
-    eventing.knative.dev/release: "v1.4.0"
+    eventing.knative.dev/release: "v1.2.4"
     app.kubernetes.io/component: broker-ingress
-    app.kubernetes.io/version: "1.4.0"
+    app.kubernetes.io/version: "1.2.4"
     app.kubernetes.io/name: knative-eventing
 spec:
   scaleTargetRef:
@@ -576,9 +487,9 @@ metadata:
   name: broker-filter-hpa
   namespace: knative-eventing
   labels:
-    eventing.knative.dev/release: "v1.4.0"
+    eventing.knative.dev/release: "v1.2.4"
     app.kubernetes.io/component: broker-filter
-    app.kubernetes.io/version: "1.4.0"
+    app.kubernetes.io/version: "1.2.4"
     app.kubernetes.io/name: knative-eventing
 spec:
   scaleTargetRef:

--- a/common/knative/knative-serving-post-install-jobs/base/serving-post-install-jobs.yaml
+++ b/common/knative/knative-serving-post-install-jobs/base/serving-post-install-jobs.yaml
@@ -7,7 +7,8 @@ metadata:
     app: storage-version-migration-serving
     app.kubernetes.io/name: knative-serving
     app.kubernetes.io/component: storage-version-migration-job
-    app.kubernetes.io/version: "1.4.0"
+    app.kubernetes.io/version: "1.2.5"
+    serving.knative.dev/release: "v1.2.5"
   name: storage-version-migration-serving
 spec:
   ttlSecondsAfterFinished: 600
@@ -20,13 +21,13 @@ spec:
         app: storage-version-migration-serving
         app.kubernetes.io/name: knative-serving
         app.kubernetes.io/component: storage-version-migration-job
-        app.kubernetes.io/version: "1.4.0"
+        app.kubernetes.io/version: "1.2.5"
     spec:
       serviceAccountName: controller
       restartPolicy: OnFailure
       containers:
         - name: migrate
-          image: gcr.io/knative-releases/knative.dev/pkg/apiextensions/storageversion/cmd/migrate@sha256:a53b272ad6937f2fa785e9e42b059aaa9f93dd100d1fabae8e63c7acb7a4f711
+          image: gcr.io/knative-releases/knative.dev/pkg/apiextensions/storageversion/cmd/migrate@sha256:bf8ef91c3caccfcde8aa59d15f9fe9a06053134a0172cc7c18c4787fdcfbc77e
           args:
             - "services.serving.knative.dev"
             - "configurations.serving.knative.dev"

--- a/common/knative/knative-serving/base/istio-authorization-policy.yaml
+++ b/common/knative/knative-serving/base/istio-authorization-policy.yaml
@@ -60,7 +60,7 @@ spec:
   action: ALLOW
   selector:
     matchLabels:
-      app: istio-webhook
+      app: net-istio-webhook
   rules:
   - {}
 ---

--- a/common/knative/knative-serving/base/upstream/net-istio.yaml
+++ b/common/knative/knative-serving/base/upstream/net-istio.yaml
@@ -5,26 +5,14 @@ metadata:
   labels:
     app.kubernetes.io/component: net-istio
     app.kubernetes.io/name: knative-serving
-    app.kubernetes.io/version: "1.4.0"
+    app.kubernetes.io/version: "1.2.0"
+    serving.knative.dev/release: "v1.2.0"
     serving.knative.dev/controller: "true"
     networking.knative.dev/ingress-provider: istio
 rules:
   - apiGroups: ["networking.istio.io"]
     resources: ["virtualservices", "gateways", "destinationrules"]
     verbs: ["get", "list", "create", "update", "delete", "patch", "watch"]
-# Copyright 2019 The Knative Authors
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#     https://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
 ---
 apiVersion: networking.istio.io/v1alpha3
 kind: Gateway
@@ -34,7 +22,8 @@ metadata:
   labels:
     app.kubernetes.io/component: net-istio
     app.kubernetes.io/name: knative-serving
-    app.kubernetes.io/version: "1.4.0"
+    app.kubernetes.io/version: "1.2.0"
+    serving.knative.dev/release: "v1.2.0"
     networking.knative.dev/ingress-provider: istio
 spec:
   selector:
@@ -55,7 +44,8 @@ metadata:
   labels:
     app.kubernetes.io/component: net-istio
     app.kubernetes.io/name: knative-serving
-    app.kubernetes.io/version: "1.4.0"
+    app.kubernetes.io/version: "1.2.0"
+    serving.knative.dev/release: "v1.2.0"
     networking.knative.dev/ingress-provider: istio
     experimental.istio.io/disable-gateway-port-translation: "true"
 spec:
@@ -66,19 +56,6 @@ spec:
     - name: http2
       port: 80
       targetPort: 8081
-# Copyright 2018 The Knative Authors
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#     https://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
 ---
 apiVersion: v1
 kind: ConfigMap
@@ -88,7 +65,8 @@ metadata:
   labels:
     app.kubernetes.io/component: net-istio
     app.kubernetes.io/name: knative-serving
-    app.kubernetes.io/version: "1.4.0"
+    app.kubernetes.io/version: "1.2.0"
+    serving.knative.dev/release: "v1.2.0"
     networking.knative.dev/ingress-provider: istio
 data:
   _example: |
@@ -150,7 +128,8 @@ metadata:
   labels:
     app.kubernetes.io/component: net-istio
     app.kubernetes.io/name: knative-serving
-    app.kubernetes.io/version: "1.4.0"
+    app.kubernetes.io/version: "1.2.0"
+    serving.knative.dev/release: "v1.2.0"
     networking.knative.dev/ingress-provider: istio
 spec:
   selector:
@@ -168,7 +147,8 @@ metadata:
   labels:
     app.kubernetes.io/component: net-istio
     app.kubernetes.io/name: knative-serving
-    app.kubernetes.io/version: "1.4.0"
+    app.kubernetes.io/version: "1.2.0"
+    serving.knative.dev/release: "v1.2.0"
     networking.knative.dev/ingress-provider: istio
 spec:
   selector:
@@ -186,7 +166,8 @@ metadata:
   labels:
     app.kubernetes.io/component: net-istio
     app.kubernetes.io/name: knative-serving
-    app.kubernetes.io/version: "1.4.0"
+    app.kubernetes.io/version: "1.2.0"
+    serving.knative.dev/release: "v1.2.0"
     networking.knative.dev/ingress-provider: istio
 spec:
   selector:
@@ -195,19 +176,6 @@ spec:
   portLevelMtls:
     "8443":
       mode: PERMISSIVE
-# Copyright 2019 The Knative Authors
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#     https://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
 ---
 apiVersion: apps/v1
 kind: Deployment
@@ -217,7 +185,8 @@ metadata:
   labels:
     app.kubernetes.io/component: net-istio
     app.kubernetes.io/name: knative-serving
-    app.kubernetes.io/version: "1.4.0"
+    app.kubernetes.io/version: "1.2.0"
+    serving.knative.dev/release: "v1.2.0"
     networking.knative.dev/ingress-provider: istio
 spec:
   selector:
@@ -232,12 +201,13 @@ spec:
         app: net-istio-controller
         app.kubernetes.io/component: net-istio
         app.kubernetes.io/name: knative-serving
-        app.kubernetes.io/version: "1.4.0"
+        app.kubernetes.io/version: "1.2.0"
+        serving.knative.dev/release: "v1.2.0"
     spec:
       serviceAccountName: controller
       containers:
         - name: controller
-          image: gcr.io/knative-releases/knative.dev/net-istio/cmd/controller@sha256:3b3e93366ec18b0af7d1ea071f0917e5d853e49b48b687e9893336844917aec8
+          image: gcr.io/knative-releases/knative.dev/net-istio/cmd/controller@sha256:f253b82941c2220181cee80d7488fe1cefce9d49ab30bdb54bcb8c76515f7a26
           resources:
             requests:
               cpu: 30m
@@ -268,19 +238,6 @@ spec:
               containerPort: 9090
             - name: profiling
               containerPort: 8008
-# Copyright 2020 The Knative Authors
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#     https://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
 ---
 apiVersion: apps/v1
 kind: Deployment
@@ -290,7 +247,8 @@ metadata:
   labels:
     app.kubernetes.io/component: net-istio
     app.kubernetes.io/name: knative-serving
-    app.kubernetes.io/version: "1.4.0"
+    app.kubernetes.io/version: "1.2.0"
+    serving.knative.dev/release: "v1.2.0"
     networking.knative.dev/ingress-provider: istio
 spec:
   selector:
@@ -306,12 +264,13 @@ spec:
         role: net-istio-webhook
         app.kubernetes.io/component: net-istio
         app.kubernetes.io/name: knative-serving
-        app.kubernetes.io/version: "1.4.0"
+        app.kubernetes.io/version: "1.2.0"
+        serving.knative.dev/release: "v1.2.0"
     spec:
       serviceAccountName: controller
       containers:
         - name: webhook
-          image: gcr.io/knative-releases/knative.dev/net-istio/cmd/webhook@sha256:d80d32bc8f27ef05cc834ea54383f74cad6c6d83fe96f4e685bfb86562787e53
+          image: gcr.io/knative-releases/knative.dev/net-istio/cmd/webhook@sha256:a705c1ea8e9e556f860314fe055082fbe3cde6a924c29291955f98d979f8185e
           resources:
             requests:
               cpu: 20m
@@ -341,19 +300,6 @@ spec:
               containerPort: 8008
             - name: https-webhook
               containerPort: 8443
-# Copyright 2020 The Knative Authors
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#     https://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
 ---
 apiVersion: v1
 kind: Secret
@@ -363,21 +309,9 @@ metadata:
   labels:
     app.kubernetes.io/component: net-istio
     app.kubernetes.io/name: knative-serving
-    app.kubernetes.io/version: "1.4.0"
+    app.kubernetes.io/version: "1.2.0"
+    serving.knative.dev/release: "v1.2.0"
     networking.knative.dev/ingress-provider: istio
-# Copyright 2020 The Knative Authors
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#     https://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
 ---
 apiVersion: v1
 kind: Service
@@ -388,7 +322,8 @@ metadata:
     role: net-istio-webhook
     app.kubernetes.io/component: net-istio
     app.kubernetes.io/name: knative-serving
-    app.kubernetes.io/version: "1.4.0"
+    app.kubernetes.io/version: "1.2.0"
+    serving.knative.dev/release: "v1.2.0"
     networking.knative.dev/ingress-provider: istio
 spec:
   ports:
@@ -403,19 +338,6 @@ spec:
       targetPort: 8443
   selector:
     app: net-istio-webhook
-# Copyright 2020 The Knative Authors
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#     https://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
 ---
 apiVersion: admissionregistration.k8s.io/v1
 kind: MutatingWebhookConfiguration
@@ -424,7 +346,8 @@ metadata:
   labels:
     app.kubernetes.io/component: net-istio
     app.kubernetes.io/name: knative-serving
-    app.kubernetes.io/version: "1.4.0"
+    app.kubernetes.io/version: "1.2.0"
+    serving.knative.dev/release: "v1.2.0"
     networking.knative.dev/ingress-provider: istio
 webhooks:
   - admissionReviewVersions:
@@ -440,19 +363,6 @@ webhooks:
       matchExpressions:
         - {key: "serving.knative.dev/configuration", operator: Exists}
     name: webhook.istio.networking.internal.knative.dev
-# Copyright 2020 The Knative Authors
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#     https://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
 ---
 apiVersion: admissionregistration.k8s.io/v1
 kind: ValidatingWebhookConfiguration
@@ -461,7 +371,8 @@ metadata:
   labels:
     app.kubernetes.io/component: net-istio
     app.kubernetes.io/name: knative-serving
-    app.kubernetes.io/version: "1.4.0"
+    app.kubernetes.io/version: "1.2.0"
+    serving.knative.dev/release: "v1.2.0"
     networking.knative.dev/ingress-provider: istio
 webhooks:
   - admissionReviewVersions:
@@ -474,8 +385,8 @@ webhooks:
     failurePolicy: Fail
     sideEffects: None
     name: config.webhook.istio.networking.internal.knative.dev
-    objectSelector:
-      matchLabels:
-        app.kubernetes.io/name: knative-serving
-        app.kubernetes.io/component: net-istio
+    namespaceSelector:
+      matchExpressions:
+        - key: serving.knative.dev/release
+          operator: Exists
 ---

--- a/common/knative/knative-serving/base/upstream/serving-core.yaml
+++ b/common/knative/knative-serving/base/upstream/serving-core.yaml
@@ -4,27 +4,16 @@ metadata:
   name: knative-serving
   labels:
     app.kubernetes.io/name: knative-serving
-    app.kubernetes.io/version: "1.4.0"
-# Copyright 2019 The Knative Authors
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#     https://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
+    app.kubernetes.io/version: "1.2.5"
+    serving.knative.dev/release: "v1.2.5"
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   name: knative-serving-aggregated-addressable-resolver
   labels:
-    app.kubernetes.io/version: "1.4.0"
+    serving.knative.dev/release: "v1.2.5"
+    app.kubernetes.io/version: "1.2.5"
     app.kubernetes.io/name: knative-serving
 aggregationRule:
   clusterRoleSelectors:
@@ -36,7 +25,8 @@ apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: knative-serving-addressable-resolver
   labels:
-    app.kubernetes.io/version: "1.4.0"
+    serving.knative.dev/release: "v1.2.5"
+    app.kubernetes.io/version: "1.2.5"
     app.kubernetes.io/name: knative-serving
     duck.knative.dev/addressable: "true"
 rules:
@@ -51,19 +41,6 @@ rules:
       - get
       - list
       - watch
-# Copyright 2019 The Knative Authors
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#     https://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
 ---
 kind: ClusterRole
 apiVersion: rbac.authorization.k8s.io/v1
@@ -71,7 +48,8 @@ metadata:
   name: knative-serving-namespaced-admin
   labels:
     rbac.authorization.k8s.io/aggregate-to-admin: "true"
-    app.kubernetes.io/version: "1.4.0"
+    serving.knative.dev/release: "v1.2.5"
+    app.kubernetes.io/version: "1.2.5"
     app.kubernetes.io/name: knative-serving
 rules:
   - apiGroups: ["serving.knative.dev"]
@@ -87,7 +65,8 @@ metadata:
   name: knative-serving-namespaced-edit
   labels:
     rbac.authorization.k8s.io/aggregate-to-edit: "true"
-    app.kubernetes.io/version: "1.4.0"
+    serving.knative.dev/release: "v1.2.5"
+    app.kubernetes.io/version: "1.2.5"
     app.kubernetes.io/name: knative-serving
 rules:
   - apiGroups: ["serving.knative.dev"]
@@ -103,25 +82,13 @@ metadata:
   name: knative-serving-namespaced-view
   labels:
     rbac.authorization.k8s.io/aggregate-to-view: "true"
-    app.kubernetes.io/version: "1.4.0"
+    serving.knative.dev/release: "v1.2.5"
+    app.kubernetes.io/version: "1.2.5"
     app.kubernetes.io/name: knative-serving
 rules:
   - apiGroups: ["serving.knative.dev", "networking.internal.knative.dev", "autoscaling.internal.knative.dev", "caching.internal.knative.dev"]
     resources: ["*"]
     verbs: ["get", "list", "watch"]
-# Copyright 2019 The Knative Authors
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#     https://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
 ---
 kind: ClusterRole
 apiVersion: rbac.authorization.k8s.io/v1
@@ -129,7 +96,8 @@ metadata:
   name: knative-serving-core
   labels:
     serving.knative.dev/controller: "true"
-    app.kubernetes.io/version: "1.4.0"
+    serving.knative.dev/release: "v1.2.5"
+    app.kubernetes.io/version: "1.2.5"
     app.kubernetes.io/name: knative-serving
 rules:
   - apiGroups: [""]
@@ -162,26 +130,14 @@ rules:
   - apiGroups: ["caching.internal.knative.dev"]
     resources: ["images"]
     verbs: ["get", "list", "create", "update", "delete", "patch", "watch"]
-# Copyright 2019 The Knative Authors
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#     https://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
 ---
 kind: ClusterRole
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: knative-serving-podspecable-binding
   labels:
-    app.kubernetes.io/version: "1.4.0"
+    serving.knative.dev/release: "v1.2.5"
+    app.kubernetes.io/version: "1.2.5"
     app.kubernetes.io/name: knative-serving
     duck.knative.dev/podspecable: "true"
 rules:
@@ -194,19 +150,6 @@ rules:
       - list
       - watch
       - patch
-# Copyright 2018 The Knative Authors
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#     https://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
 ---
 apiVersion: v1
 kind: ServiceAccount
@@ -216,7 +159,8 @@ metadata:
   labels:
     app.kubernetes.io/component: controller
     app.kubernetes.io/name: knative-serving
-    app.kubernetes.io/version: "1.4.0"
+    app.kubernetes.io/version: "1.2.5"
+    serving.knative.dev/release: "v1.2.5"
 ---
 kind: ClusterRole
 apiVersion: rbac.authorization.k8s.io/v1
@@ -224,7 +168,8 @@ metadata:
   name: knative-serving-admin
   labels:
     app.kubernetes.io/name: knative-serving
-    app.kubernetes.io/version: "1.4.0"
+    app.kubernetes.io/version: "1.2.5"
+    serving.knative.dev/release: "v1.2.5"
 aggregationRule:
   clusterRoleSelectors:
     - matchLabels:
@@ -237,7 +182,8 @@ metadata:
   labels:
     app.kubernetes.io/component: controller
     app.kubernetes.io/name: knative-serving
-    app.kubernetes.io/version: "1.4.0"
+    app.kubernetes.io/version: "1.2.5"
+    serving.knative.dev/release: "v1.2.5"
 subjects:
   - kind: ServiceAccount
     name: controller
@@ -254,7 +200,8 @@ metadata:
   labels:
     app.kubernetes.io/component: controller
     app.kubernetes.io/name: knative-serving
-    app.kubernetes.io/version: "1.4.0"
+    app.kubernetes.io/version: "1.2.5"
+    serving.knative.dev/release: "v1.2.5"
 subjects:
   - kind: ServiceAccount
     name: controller
@@ -263,19 +210,6 @@ roleRef:
   kind: ClusterRole
   name: knative-serving-aggregated-addressable-resolver
   apiGroup: rbac.authorization.k8s.io
-# Copyright 2018 The Knative Authors
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#     https://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
 ---
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
@@ -283,7 +217,7 @@ metadata:
   name: images.caching.internal.knative.dev
   labels:
     app.kubernetes.io/name: knative-serving
-    app.kubernetes.io/version: "1.4.0"
+    app.kubernetes.io/version: "1.2.5"
     knative.dev/crd-install: "true"
 spec:
   group: caching.internal.knative.dev
@@ -294,6 +228,8 @@ spec:
     categories:
       - knative-internal
       - caching
+    shortNames:
+      - img
   scope: Namespaced
   versions:
     - name: v1alpha1
@@ -309,19 +245,6 @@ spec:
         - name: Image
           type: string
           jsonPath: .spec.image
-# Copyright 2020 The Knative Authors
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#     https://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
 ---
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
@@ -329,8 +252,8 @@ metadata:
   name: certificates.networking.internal.knative.dev
   labels:
     app.kubernetes.io/name: knative-serving
-    app.kubernetes.io/component: networking
-    app.kubernetes.io/version: "1.4.0"
+    app.kubernetes.io/version: "1.2.5"
+    serving.knative.dev/release: "v1.2.5"
     knative.dev/crd-install: "true"
 spec:
   group: networking.internal.knative.dev
@@ -361,19 +284,6 @@ spec:
     shortNames:
       - kcert
   scope: Namespaced
-# Copyright 2019 The Knative Authors
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#     https://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
 ---
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
@@ -381,7 +291,8 @@ metadata:
   name: configurations.serving.knative.dev
   labels:
     app.kubernetes.io/name: knative-serving
-    app.kubernetes.io/version: "1.4.0"
+    app.kubernetes.io/version: "1.2.5"
+    serving.knative.dev/release: "v1.2.5"
     knative.dev/crd-install: "true"
     duck.knative.dev/podspecable: "true"
 spec:
@@ -579,7 +490,7 @@ spec:
                                 type: object
                                 properties:
                                   exec:
-                                    description: Exec specifies the action to take.
+                                    description: One and only one of the following should be specified. Exec specifies the action to take.
                                     type: object
                                     properties:
                                       command:
@@ -634,7 +545,7 @@ spec:
                                     type: integer
                                     format: int32
                                   tcpSocket:
-                                    description: TCPSocket specifies an action involving a TCP port.
+                                    description: 'TCPSocket specifies an action involving a TCP port. TCP hooks not yet supported TODO: implement a realistic TCP lifecycle hook'
                                     type: object
                                     properties:
                                       host:
@@ -678,7 +589,7 @@ spec:
                                 type: object
                                 properties:
                                   exec:
-                                    description: Exec specifies the action to take.
+                                    description: One and only one of the following should be specified. Exec specifies the action to take.
                                     type: object
                                     properties:
                                       command:
@@ -733,7 +644,7 @@ spec:
                                     type: integer
                                     format: int32
                                   tcpSocket:
-                                    description: TCPSocket specifies an action involving a TCP port.
+                                    description: 'TCPSocket specifies an action involving a TCP port. TCP hooks not yet supported TODO: implement a realistic TCP lifecycle hook'
                                     type: object
                                     properties:
                                       host:
@@ -771,7 +682,7 @@ spec:
                                 type: object
                                 properties:
                                   capabilities:
-                                    description: The capabilities to add/drop when running containers. Defaults to the default set of capabilities granted by the container runtime. Note that this field cannot be set when spec.os.name is windows.
+                                    description: The capabilities to add/drop when running containers. Defaults to the default set of capabilities granted by the container runtime.
                                     type: object
                                     properties:
                                       drop:
@@ -782,10 +693,10 @@ spec:
                                           type: string
                                     x-kubernetes-preserve-unknown-fields: true
                                   readOnlyRootFilesystem:
-                                    description: Whether this container has a read-only root filesystem. Default is false. Note that this field cannot be set when spec.os.name is windows.
+                                    description: Whether this container has a read-only root filesystem. Default is false.
                                     type: boolean
                                   runAsUser:
-                                    description: The UID to run the entrypoint of the container process. Defaults to user specified in image metadata if unspecified. May also be set in PodSecurityContext.  If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence. Note that this field cannot be set when spec.os.name is windows.
+                                    description: The UID to run the entrypoint of the container process. Defaults to user specified in image metadata if unspecified. May also be set in PodSecurityContext.  If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence.
                                     type: integer
                                     format: int64
                                 x-kubernetes-preserve-unknown-fields: true
@@ -1062,19 +973,6 @@ spec:
                   description: ObservedGeneration is the 'Generation' of the Service that was last processed by the controller.
                   type: integer
                   format: int64
-# Copyright 2020 The Knative Authors
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#     https://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
 ---
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
@@ -1082,8 +980,8 @@ metadata:
   name: clusterdomainclaims.networking.internal.knative.dev
   labels:
     app.kubernetes.io/name: knative-serving
-    app.kubernetes.io/component: networking
-    app.kubernetes.io/version: "1.4.0"
+    app.kubernetes.io/version: "1.2.5"
+    serving.knative.dev/release: "v1.2.5"
     knative.dev/crd-install: "true"
 spec:
   group: networking.internal.knative.dev
@@ -1107,19 +1005,6 @@ spec:
     shortNames:
       - cdc
   scope: Cluster
-# Copyright 2020 The Knative Authors
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#     https://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
 ---
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
@@ -1127,7 +1012,8 @@ metadata:
   name: domainmappings.serving.knative.dev
   labels:
     app.kubernetes.io/name: knative-serving
-    app.kubernetes.io/version: "1.4.0"
+    app.kubernetes.io/version: "1.2.5"
+    serving.knative.dev/release: "v1.2.5"
     knative.dev/crd-install: "true"
 spec:
   group: serving.knative.dev
@@ -1375,19 +1261,6 @@ spec:
     shortNames:
       - dm
   scope: Namespaced
-# Copyright 2020 The Knative Authors
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#     https://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
 ---
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
@@ -1395,8 +1268,8 @@ metadata:
   name: ingresses.networking.internal.knative.dev
   labels:
     app.kubernetes.io/name: knative-serving
-    app.kubernetes.io/component: networking
-    app.kubernetes.io/version: "1.4.0"
+    app.kubernetes.io/version: "1.2.5"
+    serving.knative.dev/release: "v1.2.5"
     knative.dev/crd-install: "true"
 spec:
   group: networking.internal.knative.dev
@@ -1428,19 +1301,6 @@ spec:
       - kingress
       - king
   scope: Namespaced
-# Copyright 2019 The Knative Authors
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#     https://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
 ---
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
@@ -1448,7 +1308,8 @@ metadata:
   name: metrics.autoscaling.internal.knative.dev
   labels:
     app.kubernetes.io/name: knative-serving
-    app.kubernetes.io/version: "1.4.0"
+    app.kubernetes.io/version: "1.2.5"
+    serving.knative.dev/release: "v1.2.5"
     knative.dev/crd-install: "true"
 spec:
   group: autoscaling.internal.knative.dev
@@ -1547,19 +1408,6 @@ spec:
                   description: ObservedGeneration is the 'Generation' of the Service that was last processed by the controller.
                   type: integer
                   format: int64
-# Copyright 2018 The Knative Authors
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#     https://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
 ---
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
@@ -1567,7 +1415,8 @@ metadata:
   name: podautoscalers.autoscaling.internal.knative.dev
   labels:
     app.kubernetes.io/name: knative-serving
-    app.kubernetes.io/version: "1.4.0"
+    app.kubernetes.io/version: "1.2.5"
+    serving.knative.dev/release: "v1.2.5"
     knative.dev/crd-install: "true"
 spec:
   group: autoscaling.internal.knative.dev
@@ -1703,19 +1552,6 @@ spec:
                 serviceName:
                   description: ServiceName is the K8s Service name that serves the revision, scaled by this PA. The service is created and owned by the ServerlessService object owned by this PA.
                   type: string
-# Copyright 2019 The Knative Authors
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#     https://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
 ---
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
@@ -1723,7 +1559,8 @@ metadata:
   name: revisions.serving.knative.dev
   labels:
     app.kubernetes.io/name: knative-serving
-    app.kubernetes.io/version: "1.4.0"
+    app.kubernetes.io/version: "1.2.5"
+    serving.knative.dev/release: "v1.2.5"
     knative.dev/crd-install: "true"
 spec:
   group: serving.knative.dev
@@ -1900,7 +1737,7 @@ spec:
                         type: object
                         properties:
                           exec:
-                            description: Exec specifies the action to take.
+                            description: One and only one of the following should be specified. Exec specifies the action to take.
                             type: object
                             properties:
                               command:
@@ -1955,7 +1792,7 @@ spec:
                             type: integer
                             format: int32
                           tcpSocket:
-                            description: TCPSocket specifies an action involving a TCP port.
+                            description: 'TCPSocket specifies an action involving a TCP port. TCP hooks not yet supported TODO: implement a realistic TCP lifecycle hook'
                             type: object
                             properties:
                               host:
@@ -1999,7 +1836,7 @@ spec:
                         type: object
                         properties:
                           exec:
-                            description: Exec specifies the action to take.
+                            description: One and only one of the following should be specified. Exec specifies the action to take.
                             type: object
                             properties:
                               command:
@@ -2054,7 +1891,7 @@ spec:
                             type: integer
                             format: int32
                           tcpSocket:
-                            description: TCPSocket specifies an action involving a TCP port.
+                            description: 'TCPSocket specifies an action involving a TCP port. TCP hooks not yet supported TODO: implement a realistic TCP lifecycle hook'
                             type: object
                             properties:
                               host:
@@ -2092,7 +1929,7 @@ spec:
                         type: object
                         properties:
                           capabilities:
-                            description: The capabilities to add/drop when running containers. Defaults to the default set of capabilities granted by the container runtime. Note that this field cannot be set when spec.os.name is windows.
+                            description: The capabilities to add/drop when running containers. Defaults to the default set of capabilities granted by the container runtime.
                             type: object
                             properties:
                               drop:
@@ -2103,10 +1940,10 @@ spec:
                                   type: string
                             x-kubernetes-preserve-unknown-fields: true
                           readOnlyRootFilesystem:
-                            description: Whether this container has a read-only root filesystem. Default is false. Note that this field cannot be set when spec.os.name is windows.
+                            description: Whether this container has a read-only root filesystem. Default is false.
                             type: boolean
                           runAsUser:
-                            description: The UID to run the entrypoint of the container process. Defaults to user specified in image metadata if unspecified. May also be set in PodSecurityContext.  If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence. Note that this field cannot be set when spec.os.name is windows.
+                            description: The UID to run the entrypoint of the container process. Defaults to user specified in image metadata if unspecified. May also be set in PodSecurityContext.  If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence.
                             type: integer
                             format: int64
                         x-kubernetes-preserve-unknown-fields: true
@@ -2410,19 +2247,6 @@ spec:
                   description: ObservedGeneration is the 'Generation' of the Service that was last processed by the controller.
                   type: integer
                   format: int64
-# Copyright 2019 The Knative Authors
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#     https://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
 ---
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
@@ -2430,7 +2254,8 @@ metadata:
   name: routes.serving.knative.dev
   labels:
     app.kubernetes.io/name: knative-serving
-    app.kubernetes.io/version: "1.4.0"
+    app.kubernetes.io/version: "1.2.5"
+    serving.knative.dev/release: "v1.2.5"
     knative.dev/crd-install: "true"
     duck.knative.dev/addressable: "true"
 spec:
@@ -2582,19 +2407,6 @@ spec:
                 url:
                   description: URL holds the url that will distribute traffic over the provided traffic targets. It generally has the form http[s]://{route-name}.{route-namespace}.{cluster-level-suffix}
                   type: string
-# Copyright 2019 The Knative Authors
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#     https://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
 ---
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
@@ -2602,8 +2414,8 @@ metadata:
   name: serverlessservices.networking.internal.knative.dev
   labels:
     app.kubernetes.io/name: knative-serving
-    app.kubernetes.io/component: networking
-    app.kubernetes.io/version: "1.4.0"
+    app.kubernetes.io/version: "1.2.5"
+    serving.knative.dev/release: "v1.2.5"
     knative.dev/crd-install: "true"
 spec:
   group: networking.internal.knative.dev
@@ -2646,19 +2458,6 @@ spec:
     shortNames:
       - sks
   scope: Namespaced
-# Copyright 2019 The Knative Authors
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#     https://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
 ---
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
@@ -2666,7 +2465,8 @@ metadata:
   name: services.serving.knative.dev
   labels:
     app.kubernetes.io/name: knative-serving
-    app.kubernetes.io/version: "1.4.0"
+    app.kubernetes.io/version: "1.2.5"
+    serving.knative.dev/release: "v1.2.5"
     knative.dev/crd-install: "true"
     duck.knative.dev/addressable: "true"
     duck.knative.dev/podspecable: "true"
@@ -2868,7 +2668,7 @@ spec:
                                 type: object
                                 properties:
                                   exec:
-                                    description: Exec specifies the action to take.
+                                    description: One and only one of the following should be specified. Exec specifies the action to take.
                                     type: object
                                     properties:
                                       command:
@@ -2923,7 +2723,7 @@ spec:
                                     type: integer
                                     format: int32
                                   tcpSocket:
-                                    description: TCPSocket specifies an action involving a TCP port.
+                                    description: 'TCPSocket specifies an action involving a TCP port. TCP hooks not yet supported TODO: implement a realistic TCP lifecycle hook'
                                     type: object
                                     properties:
                                       host:
@@ -2967,7 +2767,7 @@ spec:
                                 type: object
                                 properties:
                                   exec:
-                                    description: Exec specifies the action to take.
+                                    description: One and only one of the following should be specified. Exec specifies the action to take.
                                     type: object
                                     properties:
                                       command:
@@ -3022,7 +2822,7 @@ spec:
                                     type: integer
                                     format: int32
                                   tcpSocket:
-                                    description: TCPSocket specifies an action involving a TCP port.
+                                    description: 'TCPSocket specifies an action involving a TCP port. TCP hooks not yet supported TODO: implement a realistic TCP lifecycle hook'
                                     type: object
                                     properties:
                                       host:
@@ -3060,7 +2860,7 @@ spec:
                                 type: object
                                 properties:
                                   capabilities:
-                                    description: The capabilities to add/drop when running containers. Defaults to the default set of capabilities granted by the container runtime. Note that this field cannot be set when spec.os.name is windows.
+                                    description: The capabilities to add/drop when running containers. Defaults to the default set of capabilities granted by the container runtime.
                                     type: object
                                     properties:
                                       drop:
@@ -3071,10 +2871,10 @@ spec:
                                           type: string
                                     x-kubernetes-preserve-unknown-fields: true
                                   readOnlyRootFilesystem:
-                                    description: Whether this container has a read-only root filesystem. Default is false. Note that this field cannot be set when spec.os.name is windows.
+                                    description: Whether this container has a read-only root filesystem. Default is false.
                                     type: boolean
                                   runAsUser:
-                                    description: The UID to run the entrypoint of the container process. Defaults to user specified in image metadata if unspecified. May also be set in PodSecurityContext.  If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence. Note that this field cannot be set when spec.os.name is windows.
+                                    description: The UID to run the entrypoint of the container process. Defaults to user specified in image metadata if unspecified. May also be set in PodSecurityContext.  If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence.
                                     type: integer
                                     format: int64
                                 x-kubernetes-preserve-unknown-fields: true
@@ -3412,19 +3212,6 @@ spec:
                 url:
                   description: URL holds the url that will distribute traffic over the provided traffic targets. It generally has the form http[s]://{route-name}.{route-namespace}.{cluster-level-suffix}
                   type: string
-# Copyright 2018 The Knative Authors
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#     https://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
 ---
 apiVersion: caching.internal.knative.dev/v1alpha1
 kind: Image
@@ -3434,22 +3221,10 @@ metadata:
   labels:
     app.kubernetes.io/component: queue-proxy
     app.kubernetes.io/name: knative-serving
-    app.kubernetes.io/version: "1.4.0"
+    app.kubernetes.io/version: "1.2.5"
+    serving.knative.dev/release: "v1.2.5"
 spec:
-  image: gcr.io/knative-releases/knative.dev/serving/cmd/queue@sha256:a40f6e84de1a0d145d27084a94cc7fa221159e75cafde7d332ac8f4f0aed58fb
-# Copyright 2018 The Knative Authors
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#     https://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
+  image: gcr.io/knative-releases/knative.dev/serving/cmd/queue@sha256:14415b204ea8d0567235143a6c3377f49cbd35f18dc84dfa4baa7695c2a9b53d
 ---
 apiVersion: v1
 kind: ConfigMap
@@ -3459,9 +3234,10 @@ metadata:
   labels:
     app.kubernetes.io/component: autoscaler
     app.kubernetes.io/name: knative-serving
-    app.kubernetes.io/version: "1.4.0"
+    app.kubernetes.io/version: "1.2.5"
+    serving.knative.dev/release: "v1.2.5"
   annotations:
-    knative.dev/example-checksum: "47c2487f"
+    knative.dev/example-checksum: "16af78ce"
 data:
   _example: |
     ################################
@@ -3536,7 +3312,7 @@ data:
     # -1 denotes unlimited target-burst-capacity and activator will always
     # be in the request path.
     # Other negative values are invalid.
-    target-burst-capacity: "211"
+    target-burst-capacity: "200"
 
     # When operating in a stable mode, the autoscaler operates on the
     # average concurrency over the stable window.
@@ -3646,19 +3422,6 @@ data:
     # (including a maxScale of "0" = unlimited) is disallowed.
     # A value of zero (the default) allows any limit, including unlimited.
     max-scale-limit: "0"
-# Copyright 2019 The Knative Authors
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#     https://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
 ---
 apiVersion: v1
 kind: ConfigMap
@@ -3668,7 +3431,8 @@ metadata:
   labels:
     app.kubernetes.io/name: knative-serving
     app.kubernetes.io/component: controller
-    app.kubernetes.io/version: "1.4.0"
+    app.kubernetes.io/version: "1.2.5"
+    serving.knative.dev/release: "v1.2.5"
   annotations:
     knative.dev/example-checksum: "a0feb4c6"
 data:
@@ -3787,19 +3551,6 @@ data:
     # to set this value to `false`.
     # See https://github.com/knative/serving/issues/8498.
     enable-service-links: "false"
-# Copyright 2019 The Knative Authors
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#     https://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
 ---
 apiVersion: v1
 kind: ConfigMap
@@ -3809,11 +3560,12 @@ metadata:
   labels:
     app.kubernetes.io/name: knative-serving
     app.kubernetes.io/component: controller
-    app.kubernetes.io/version: "1.4.0"
+    app.kubernetes.io/version: "1.2.5"
+    serving.knative.dev/release: "v1.2.5"
   annotations:
     knative.dev/example-checksum: "dd7ee769"
 data:
-  queueSidecarImage: gcr.io/knative-releases/knative.dev/serving/cmd/queue@sha256:a40f6e84de1a0d145d27084a94cc7fa221159e75cafde7d332ac8f4f0aed58fb
+  queueSidecarImage: gcr.io/knative-releases/knative.dev/serving/cmd/queue@sha256:14415b204ea8d0567235143a6c3377f49cbd35f18dc84dfa4baa7695c2a9b53d
   _example: |-
     ################################
     #                              #
@@ -3885,19 +3637,6 @@ data:
     #
     # NOTE THAT THIS IS AN EXPERIMENTAL / ALPHA FEATURE
     concurrency-state-endpoint: ""
-# Copyright 2018 The Knative Authors
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#     https://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
 ---
 apiVersion: v1
 kind: ConfigMap
@@ -3907,7 +3646,8 @@ metadata:
   labels:
     app.kubernetes.io/name: knative-serving
     app.kubernetes.io/component: controller
-    app.kubernetes.io/version: "1.4.0"
+    app.kubernetes.io/version: "1.2.5"
+    serving.knative.dev/release: "v1.2.5"
   annotations:
     knative.dev/example-checksum: "81552d0b"
 data:
@@ -3948,19 +3688,6 @@ data:
     svc.cluster.local: |
       selector:
         app: secret
-# Copyright 2020 The Knative Authors
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#     https://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
 ---
 apiVersion: v1
 kind: ConfigMap
@@ -3970,9 +3697,10 @@ metadata:
   labels:
     app.kubernetes.io/name: knative-serving
     app.kubernetes.io/component: controller
-    app.kubernetes.io/version: "1.4.0"
+    app.kubernetes.io/version: "1.2.5"
+    serving.knative.dev/release: "v1.2.5"
   annotations:
-    knative.dev/example-checksum: "e1c6e542"
+    knative.dev/example-checksum: "d9e300ba"
 data:
   _example: |-
     ################################
@@ -4001,12 +3729,6 @@ data:
     # WARNING: Cannot safely be disabled once enabled.
     # See: https://knative.dev/docs/serving/feature-flags/#kubernetes-node-affinity
     kubernetes.podspec-affinity: "disabled"
-
-    # Indicates whether Kubernetes topologySpreadConstraints support is enabled
-    #
-    # WARNING: Cannot safely be disabled once enabled.
-    # See: https://knative.dev/docs/serving/feature-flags/#kubernetes-topology-spread-constraints
-    kubernetes.podspec-topologyspreadconstraints: "disabled"
 
     # Indicates whether Kubernetes hostAliases support is enabled
     #
@@ -4114,19 +3836,6 @@ data:
     # 1. Enabled: enabling write access for persistent volumes
     # 2. Disabled: disabling write access for persistent volumes
     kubernetes.podspec-persistent-volume-write: "disabled"
-# Copyright 2018 The Knative Authors
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#     https://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
 ---
 apiVersion: v1
 kind: ConfigMap
@@ -4136,9 +3845,10 @@ metadata:
   labels:
     app.kubernetes.io/name: knative-serving
     app.kubernetes.io/component: controller
-    app.kubernetes.io/version: "1.4.0"
+    app.kubernetes.io/version: "1.2.5"
+    serving.knative.dev/release: "v1.2.5"
   annotations:
-    knative.dev/example-checksum: "45463e45"
+    knative.dev/example-checksum: "51b4d68a"
 data:
   _example: |
     ################################
@@ -4179,7 +3889,6 @@ data:
     #
     # Example config to immediately collect any inactive revision:
     #    min-non-active-revisions: "0"
-    #    max-non-active-revisions: "0"
     #    retain-since-create-time: "disabled"
     #    retain-since-last-active-time: "disabled"
     #
@@ -4213,19 +3922,6 @@ data:
     # Maximum number of non-active revisions to retain
     # or "disabled" to disable any maximum limit.
     max-non-active-revisions: "1000"
-# Copyright 2020 The Knative Authors
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#     https://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
 ---
 apiVersion: v1
 kind: ConfigMap
@@ -4235,7 +3931,8 @@ metadata:
   labels:
     app.kubernetes.io/name: knative-serving
     app.kubernetes.io/component: controller
-    app.kubernetes.io/version: "1.4.0"
+    app.kubernetes.io/version: "1.2.5"
+    serving.knative.dev/release: "v1.2.5"
   annotations:
     knative.dev/example-checksum: "f4b71f57"
 data:
@@ -4273,19 +3970,6 @@ data:
     # bucket will take care of the reconciling for the keys partitioned into
     # that bucket.
     buckets: "1"
-# Copyright 2018 The Knative Authors
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#     https://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
 ---
 apiVersion: v1
 kind: ConfigMap
@@ -4293,11 +3977,11 @@ metadata:
   name: config-logging
   namespace: knative-serving
   labels:
-    app.kubernetes.io/version: "1.4.0"
-    app.kubernetes.io/component: logging
+    serving.knative.dev/release: "v1.2.5"
+    app.kubernetes.io/version: "1.2.5"
     app.kubernetes.io/name: knative-serving
   annotations:
-    knative.dev/example-checksum: "b0f3c6f2"
+    knative.dev/example-checksum: "be93ff10"
 data:
   _example: |
     ################################
@@ -4350,20 +4034,6 @@ data:
     loglevel.hpaautoscaler: "info"
     loglevel.net-certmanager-controller: "info"
     loglevel.net-istio-controller: "info"
-    loglevel.net-contour-controller: "info"
-# Copyright 2018 The Knative Authors
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#     https://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
 ---
 apiVersion: v1
 kind: ConfigMap
@@ -4372,10 +4042,10 @@ metadata:
   namespace: knative-serving
   labels:
     app.kubernetes.io/name: knative-serving
-    app.kubernetes.io/component: networking
-    app.kubernetes.io/version: "1.4.0"
+    app.kubernetes.io/version: "1.2.5"
+    serving.knative.dev/release: "v1.2.5"
   annotations:
-    knative.dev/example-checksum: "d0b91f80"
+    knative.dev/example-checksum: "6e2033e0"
 data:
   _example: |
     ################################
@@ -4525,67 +4195,6 @@ data:
     # fronting Knative with an external loadbalancer that deals with TLS termination and
     # Knative doesn't know about that otherwise.
     default-external-scheme: "http"
-
-    # The CA public certificate used to sign the activator TLS certificate.
-    # It is specified by the secret name, which has the "ca.crt" data field.
-    # Use an empty value to disable the feature (default).
-    #
-    # NOTE: This flag is in an alpha state and is mostly here to enable internal testing
-    #       for now. Use with caution.
-    activator-ca: ""
-
-    # The SAN (Subject Alt Name) used to validate the activator TLS certificate.
-    # It must be set when "activator-ca" is specified.
-    # Use an empty value to disable the feature (default).
-    #
-    # NOTE: This flag is in an alpha state and is mostly here to enable internal testing
-    #       for now. Use with caution.
-    activator-san: ""
-
-    # The server certificates to serve the TLS traffic from ingress to activator.
-    # It is specified by the secret name, which has the "tls.crt" and "tls.key" data field.
-    # Use an empty value to disable the feature (default).
-    #
-    # NOTE: This flag is in an alpha state and is mostly here to enable internal testing
-    #       for now. Use with caution.
-    activator-cert-secret: ""
-
-    # The CA public certificate used to sign the queue-proxy TLS certificate.
-    # It is specified by the secret name, which has the "ca.crt" data field.
-    # Use an empty value to disable the feature (default).
-    #
-    # NOTE: This flag is in an alpha state and is mostly here to enable internal testing
-    #       for now. Use with caution.
-    queue-proxy-ca: ""
-
-    # The SAN (Subject Alt Name) used to validate the activator TLS certificate.
-    # It must be set when "queue-proxy-ca" is specified.
-    # Use an empty value to disable the feature (default).
-    #
-    # NOTE: This flag is in an alpha state and is mostly here to enable internal testing
-    #       for now. Use with caution.
-    queue-proxy-san: ""
-
-    # The server certificates to serve the TLS traffic from activator to queue-proxy.
-    # It is specified by the secret name, which has the "tls.crt" and "tls.key" data field.
-    # Use an empty value to disable the feature (default).
-    #
-    # NOTE: This flag is in an alpha state and is mostly here to enable internal testing
-    #       for now. Use with caution.
-    queue-proxy-cert-secret: ""
-# Copyright 2018 The Knative Authors
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#     https://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
 ---
 apiVersion: v1
 kind: ConfigMap
@@ -4594,8 +4203,8 @@ metadata:
   namespace: knative-serving
   labels:
     app.kubernetes.io/name: knative-serving
-    app.kubernetes.io/component: observability
-    app.kubernetes.io/version: "1.4.0"
+    app.kubernetes.io/version: "1.2.5"
+    serving.knative.dev/release: "v1.2.5"
   annotations:
     knative.dev/example-checksum: "fed4756e"
 data:
@@ -4680,19 +4289,6 @@ data:
     # enabled, the Knative Serving pods expose the profiling data on an alternate HTTP port 8008.
     # The HTTP context root for profiling is then /debug/pprof/.
     profiling.enable: "false"
-# Copyright 2019 The Knative Authors
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#     https://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
 ---
 apiVersion: v1
 kind: ConfigMap
@@ -4701,8 +4297,8 @@ metadata:
   namespace: knative-serving
   labels:
     app.kubernetes.io/name: knative-serving
-    app.kubernetes.io/component: tracing
-    app.kubernetes.io/version: "1.4.0"
+    app.kubernetes.io/version: "1.2.5"
+    serving.knative.dev/release: "v1.2.5"
   annotations:
     knative.dev/example-checksum: "26614636"
 data:
@@ -4735,19 +4331,6 @@ data:
 
     # Percentage (0-1) of requests to trace
     sample-rate: "0.1"
-# Copyright 2020 The Knative Authors
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#     https://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
 ---
 apiVersion: autoscaling/v2beta2
 kind: HorizontalPodAutoscaler
@@ -4757,7 +4340,8 @@ metadata:
   labels:
     app.kubernetes.io/component: activator
     app.kubernetes.io/name: knative-serving
-    app.kubernetes.io/version: "1.4.0"
+    app.kubernetes.io/version: "1.2.5"
+    serving.knative.dev/release: "v1.2.5"
 spec:
   minReplicas: 1
   maxReplicas: 20
@@ -4781,25 +4365,13 @@ metadata:
   labels:
     app.kubernetes.io/component: activator
     app.kubernetes.io/name: knative-serving
-    app.kubernetes.io/version: "1.4.0"
+    app.kubernetes.io/version: "1.2.5"
+    serving.knative.dev/release: "v1.2.5"
 spec:
   minAvailable: 80%
   selector:
     matchLabels:
       app: activator
-# Copyright 2018 The Knative Authors
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#     https://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
 ---
 apiVersion: apps/v1
 kind: Deployment
@@ -4808,8 +4380,9 @@ metadata:
   namespace: knative-serving
   labels:
     app.kubernetes.io/component: activator
-    app.kubernetes.io/version: "1.4.0"
+    app.kubernetes.io/version: "1.2.5"
     app.kubernetes.io/name: knative-serving
+    serving.knative.dev/release: "v1.2.5"
 spec:
   selector:
     matchLabels:
@@ -4824,12 +4397,13 @@ spec:
         role: activator
         app.kubernetes.io/component: activator
         app.kubernetes.io/name: knative-serving
-        app.kubernetes.io/version: "1.4.0"
+        app.kubernetes.io/version: "1.2.5"
+        serving.knative.dev/release: "v1.2.5"
     spec:
       serviceAccountName: controller
       containers:
         - name: activator
-          image: gcr.io/knative-releases/knative.dev/serving/cmd/activator@sha256:7d664e052ec0e78961dbb7b5acb62c70ba106ba1fdd46f2177ab56e1d0d360fb
+          image: gcr.io/knative-releases/knative.dev/serving/cmd/activator@sha256:93ff6e69357785ff97806945b284cbd1d37e50402b876a320645be8877c0d7b7
           resources:
             requests:
               cpu: 300m
@@ -4901,8 +4475,9 @@ metadata:
   labels:
     app: activator
     app.kubernetes.io/component: activator
-    app.kubernetes.io/version: "1.4.0"
+    app.kubernetes.io/version: "1.2.5"
     app.kubernetes.io/name: knative-serving
+    serving.knative.dev/release: "v1.2.5"
 spec:
   selector:
     app: activator
@@ -4919,23 +4494,7 @@ spec:
     - name: http2
       port: 81
       targetPort: 8013
-    - name: https
-      port: 443
-      targetPort: 8112
   type: ClusterIP
-# Copyright 2018 The Knative Authors
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#     https://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
 ---
 apiVersion: apps/v1
 kind: Deployment
@@ -4945,7 +4504,8 @@ metadata:
   labels:
     app.kubernetes.io/component: autoscaler
     app.kubernetes.io/name: knative-serving
-    app.kubernetes.io/version: "1.4.0"
+    app.kubernetes.io/version: "1.2.5"
+    serving.knative.dev/release: "v1.2.5"
 spec:
   replicas: 1
   selector:
@@ -4963,7 +4523,8 @@ spec:
         app: autoscaler
         app.kubernetes.io/component: autoscaler
         app.kubernetes.io/name: knative-serving
-        app.kubernetes.io/version: "1.4.0"
+        app.kubernetes.io/version: "1.2.5"
+        serving.knative.dev/release: "v1.2.5"
     spec:
       affinity:
         podAntiAffinity:
@@ -4977,7 +4538,7 @@ spec:
       serviceAccountName: controller
       containers:
         - name: autoscaler
-          image: gcr.io/knative-releases/knative.dev/serving/cmd/autoscaler@sha256:02f187b21cc00bc91c45db85571299f338fcbd58aa5c9193f0833782a7710dea
+          image: gcr.io/knative-releases/knative.dev/serving/cmd/autoscaler@sha256:007820fdb75b60e6fd5a25e65fd6ad9744082a6bf195d72795561c91b425d016
           resources:
             requests:
               cpu: 100m
@@ -5039,7 +4600,8 @@ metadata:
     app: autoscaler
     app.kubernetes.io/component: autoscaler
     app.kubernetes.io/name: knative-serving
-    app.kubernetes.io/version: "1.4.0"
+    app.kubernetes.io/version: "1.2.5"
+    serving.knative.dev/release: "v1.2.5"
   name: autoscaler
   namespace: knative-serving
 spec:
@@ -5055,19 +4617,6 @@ spec:
       targetPort: 8080
   selector:
     app: autoscaler
-# Copyright 2018 The Knative Authors
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#     https://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
 ---
 apiVersion: apps/v1
 kind: Deployment
@@ -5077,7 +4626,8 @@ metadata:
   labels:
     app.kubernetes.io/component: controller
     app.kubernetes.io/name: knative-serving
-    app.kubernetes.io/version: "1.4.0"
+    app.kubernetes.io/version: "1.2.5"
+    serving.knative.dev/release: "v1.2.5"
 spec:
   selector:
     matchLabels:
@@ -5090,7 +4640,8 @@ spec:
         app: controller
         app.kubernetes.io/component: controller
         app.kubernetes.io/name: knative-serving
-        app.kubernetes.io/version: "1.4.0"
+        app.kubernetes.io/version: "1.2.5"
+        serving.knative.dev/release: "v1.2.5"
     spec:
       affinity:
         podAntiAffinity:
@@ -5104,7 +4655,7 @@ spec:
       serviceAccountName: controller
       containers:
         - name: controller
-          image: gcr.io/knative-releases/knative.dev/serving/cmd/controller@sha256:8d84706d53adcf89c49687b4fade06261769b9f99257cb64d1758398f085b062
+          image: gcr.io/knative-releases/knative.dev/serving/cmd/controller@sha256:75cfdcfa050af9522e798e820ba5483b9093de1ce520207a3fedf112d73a4686
           resources:
             requests:
               cpu: 100m
@@ -5147,7 +4698,8 @@ metadata:
     app: controller
     app.kubernetes.io/component: controller
     app.kubernetes.io/name: knative-serving
-    app.kubernetes.io/version: "1.4.0"
+    app.kubernetes.io/version: "1.2.5"
+    serving.knative.dev/release: "v1.2.5"
   name: controller
   namespace: knative-serving
 spec:
@@ -5160,19 +4712,6 @@ spec:
       targetPort: 8008
   selector:
     app: controller
-# Copyright 2020 The Knative Authors
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#     https://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
 ---
 apiVersion: apps/v1
 kind: Deployment
@@ -5182,7 +4721,8 @@ metadata:
   labels:
     app.kubernetes.io/component: domain-mapping
     app.kubernetes.io/name: knative-serving
-    app.kubernetes.io/version: "1.4.0"
+    app.kubernetes.io/version: "1.2.5"
+    serving.knative.dev/release: "v1.2.5"
 spec:
   selector:
     matchLabels:
@@ -5195,7 +4735,8 @@ spec:
         app: domain-mapping
         app.kubernetes.io/component: domain-mapping
         app.kubernetes.io/name: knative-serving
-        app.kubernetes.io/version: "1.4.0"
+        app.kubernetes.io/version: "1.2.5"
+        serving.knative.dev/release: "v1.2.5"
     spec:
       affinity:
         podAntiAffinity:
@@ -5209,7 +4750,7 @@ spec:
       serviceAccountName: controller
       containers:
         - name: domain-mapping
-          image: gcr.io/knative-releases/knative.dev/serving/cmd/domain-mapping@sha256:43d9ef8ef868aa8fd72a1f1f69ba07da99cfa0a73014636ff7ece9bc614b1f8f
+          image: gcr.io/knative-releases/knative.dev/serving/cmd/domain-mapping@sha256:23baa19322320f25a462568eded1276601ef67194883db9211e1ea24f21a0beb
           resources:
             requests:
               cpu: 30m
@@ -5240,19 +4781,6 @@ spec:
               containerPort: 9090
             - name: profiling
               containerPort: 8008
-# Copyright 2020 The Knative Authors
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#     https://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
 ---
 apiVersion: apps/v1
 kind: Deployment
@@ -5262,7 +4790,8 @@ metadata:
   labels:
     app.kubernetes.io/component: domain-mapping
     app.kubernetes.io/name: knative-serving
-    app.kubernetes.io/version: "1.4.0"
+    app.kubernetes.io/version: "1.2.5"
+    serving.knative.dev/release: "v1.2.5"
 spec:
   selector:
     matchLabels:
@@ -5277,7 +4806,8 @@ spec:
         role: domainmapping-webhook
         app.kubernetes.io/component: domain-mapping
         app.kubernetes.io/name: knative-serving
-        app.kubernetes.io/version: "1.4.0"
+        app.kubernetes.io/version: "1.2.5"
+        serving.knative.dev/release: "v1.2.5"
     spec:
       affinity:
         podAntiAffinity:
@@ -5291,7 +4821,7 @@ spec:
       serviceAccountName: controller
       containers:
         - name: domainmapping-webhook
-          image: gcr.io/knative-releases/knative.dev/serving/cmd/domain-mapping-webhook@sha256:b0039cd8d749608e4ab04544d36026556be04fe6ac39041223372b1c9031d8d6
+          image: gcr.io/knative-releases/knative.dev/serving/cmd/domain-mapping-webhook@sha256:847bb97e38440c71cb4bcc3e430743e18b328ad1e168b6fca35b10353b9a2c22
           resources:
             requests:
               cpu: 100m
@@ -5357,7 +4887,8 @@ metadata:
     role: domainmapping-webhook
     app.kubernetes.io/component: domain-mapping
     app.kubernetes.io/name: knative-serving
-    app.kubernetes.io/version: "1.4.0"
+    app.kubernetes.io/version: "1.2.5"
+    serving.knative.dev/release: "v1.2.5"
   name: domainmapping-webhook
   namespace: knative-serving
 spec:
@@ -5373,19 +4904,6 @@ spec:
       targetPort: 8443
   selector:
     role: domainmapping-webhook
-# Copyright 2020 The Knative Authors
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#     https://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
 ---
 apiVersion: autoscaling/v2beta2
 kind: HorizontalPodAutoscaler
@@ -5395,7 +4913,8 @@ metadata:
   labels:
     app.kubernetes.io/component: webhook
     app.kubernetes.io/name: knative-serving
-    app.kubernetes.io/version: "1.4.0"
+    app.kubernetes.io/version: "1.2.5"
+    serving.knative.dev/release: "v1.2.5"
 spec:
   minReplicas: 1
   maxReplicas: 5
@@ -5419,25 +4938,13 @@ metadata:
   labels:
     app.kubernetes.io/component: webhook
     app.kubernetes.io/name: knative-serving
-    app.kubernetes.io/version: "1.4.0"
+    app.kubernetes.io/version: "1.2.5"
+    serving.knative.dev/release: "v1.2.5"
 spec:
   minAvailable: 80%
   selector:
     matchLabels:
       app: webhook
-# Copyright 2018 The Knative Authors
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#     https://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
 ---
 apiVersion: apps/v1
 kind: Deployment
@@ -5445,8 +4952,9 @@ metadata:
   name: webhook
   namespace: knative-serving
   labels:
+    serving.knative.dev/release: "v1.2.5"
     app.kubernetes.io/component: webhook
-    app.kubernetes.io/version: "1.4.0"
+    app.kubernetes.io/version: "1.2.5"
     app.kubernetes.io/name: knative-serving
 spec:
   selector:
@@ -5460,7 +4968,9 @@ spec:
       labels:
         app: webhook
         role: webhook
-        app.kubernetes.io/version: "1.4.0"
+        serving.knative.dev/release: "v1.2.5"
+        app.kubernetes.io/component: webhook
+        app.kubernetes.io/version: "1.2.5"
         app.kubernetes.io/name: knative-serving
     spec:
       affinity:
@@ -5475,7 +4985,7 @@ spec:
       serviceAccountName: controller
       containers:
         - name: webhook
-          image: gcr.io/knative-releases/knative.dev/serving/cmd/webhook@sha256:bf58bf8d3790440aa7fb700b45e52ae9678e1ea6dc1135b10ff4b9b1087ee016
+          image: gcr.io/knative-releases/knative.dev/serving/cmd/webhook@sha256:9084ea8498eae3c6c4364a397d66516a25e48488f4a9871ef765fa554ba483f0
           resources:
             requests:
               cpu: 100m
@@ -5541,8 +5051,9 @@ kind: Service
 metadata:
   labels:
     role: webhook
+    serving.knative.dev/release: "v1.2.5"
     app.kubernetes.io/component: webhook
-    app.kubernetes.io/version: "1.4.0"
+    app.kubernetes.io/version: "1.2.5"
     app.kubernetes.io/name: knative-serving
   name: webhook
   namespace: knative-serving
@@ -5559,19 +5070,6 @@ spec:
       targetPort: 8443
   selector:
     role: webhook
-# Copyright 2020 The Knative Authors
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#     https://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
 ---
 apiVersion: admissionregistration.k8s.io/v1
 kind: ValidatingWebhookConfiguration
@@ -5580,7 +5078,8 @@ metadata:
   labels:
     app.kubernetes.io/component: webhook
     app.kubernetes.io/name: knative-serving
-    app.kubernetes.io/version: "1.4.0"
+    app.kubernetes.io/version: "1.2.5"
+    serving.knative.dev/release: "v1.2.5"
 webhooks:
   - admissionReviewVersions: ["v1", "v1beta1"]
     clientConfig:
@@ -5590,28 +5089,11 @@ webhooks:
     failurePolicy: Fail
     sideEffects: None
     name: config.webhook.serving.knative.dev
-    objectSelector:
+    namespaceSelector:
       matchExpressions:
-        - key: app.kubernetes.io/name
-          operator: In
-          values: ["knative-serving"]
-        - key: app.kubernetes.io/component
-          operator: In
-          values: ["autoscaler", "controller", "logging", "networking", "observability", "tracing"]
+        - key: serving.knative.dev/release
+          operator: Exists
     timeoutSeconds: 10
-# Copyright 2020 The Knative Authors
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#     https://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
 ---
 apiVersion: admissionregistration.k8s.io/v1
 kind: MutatingWebhookConfiguration
@@ -5620,7 +5102,8 @@ metadata:
   labels:
     app.kubernetes.io/component: webhook
     app.kubernetes.io/name: knative-serving
-    app.kubernetes.io/version: "1.4.0"
+    app.kubernetes.io/version: "1.2.5"
+    serving.knative.dev/release: "v1.2.5"
 webhooks:
   - admissionReviewVersions: ["v1", "v1beta1"]
     clientConfig:
@@ -5652,19 +5135,6 @@ webhooks:
           - revisions
           - routes
           - services
-# Copyright 2020 The Knative Authors
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#     https://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
 ---
 apiVersion: admissionregistration.k8s.io/v1
 kind: MutatingWebhookConfiguration
@@ -5673,7 +5143,8 @@ metadata:
   labels:
     app.kubernetes.io/component: domain-mapping
     app.kubernetes.io/name: knative-serving
-    app.kubernetes.io/version: "1.4.0"
+    app.kubernetes.io/version: "1.2.5"
+    serving.knative.dev/release: "v1.2.5"
 webhooks:
   - admissionReviewVersions: ["v1", "v1beta1"]
     clientConfig:
@@ -5696,19 +5167,6 @@ webhooks:
         scope: "*"
         resources:
           - domainmappings
-# Copyright 2020 The Knative Authors
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#     https://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
 ---
 apiVersion: v1
 kind: Secret
@@ -5718,20 +5176,8 @@ metadata:
   labels:
     app.kubernetes.io/component: domain-mapping
     app.kubernetes.io/name: knative-serving
-    app.kubernetes.io/version: "1.4.0"
-# Copyright 2020 The Knative Authors
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#     https://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
+    app.kubernetes.io/version: "1.2.5"
+    serving.knative.dev/release: "v1.2.5"
 ---
 apiVersion: admissionregistration.k8s.io/v1
 kind: ValidatingWebhookConfiguration
@@ -5740,7 +5186,8 @@ metadata:
   labels:
     app.kubernetes.io/component: domain-mapping
     app.kubernetes.io/name: knative-serving
-    app.kubernetes.io/version: "1.4.0"
+    app.kubernetes.io/version: "1.2.5"
+    serving.knative.dev/release: "v1.2.5"
 webhooks:
   - admissionReviewVersions: ["v1", "v1beta1"]
     clientConfig:
@@ -5764,19 +5211,6 @@ webhooks:
         scope: "*"
         resources:
           - domainmappings
-# Copyright 2020 The Knative Authors
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#     https://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
 ---
 apiVersion: admissionregistration.k8s.io/v1
 kind: ValidatingWebhookConfiguration
@@ -5785,7 +5219,8 @@ metadata:
   labels:
     app.kubernetes.io/component: webhook
     app.kubernetes.io/name: knative-serving
-    app.kubernetes.io/version: "1.4.0"
+    app.kubernetes.io/version: "1.2.5"
+    serving.knative.dev/release: "v1.2.5"
 webhooks:
   - admissionReviewVersions: ["v1", "v1beta1"]
     clientConfig:
@@ -5818,19 +5253,6 @@ webhooks:
           - revisions
           - routes
           - services
-# Copyright 2020 The Knative Authors
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#     https://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
 ---
 apiVersion: v1
 kind: Secret
@@ -5840,6 +5262,6 @@ metadata:
   labels:
     app.kubernetes.io/component: webhook
     app.kubernetes.io/name: knative-serving
-    app.kubernetes.io/version: "1.4.0"
+    app.kubernetes.io/version: "1.2.5"
+    serving.knative.dev/release: "v1.2.5"
 ---
-


### PR DESCRIPTION
* Update the README file
* Fetch the manifests for Knative serving 1.2.5
* Fetch the manifests for Knative eventing 1.2.4
* Remove comments, anchors and aliases

Signed-off-by: Dimitris Poulopoulos <dimpo@arrikto.com>