### PR TITLE
istio: Remove Istio 1.14 overlays

### DIFF
--- a/common/istio-1-14/kubeflow-istio-resources/overlays/deploy/kustomization.yaml
+++ b/common/istio-1-14/kubeflow-istio-resources/overlays/deploy/kustomization.yaml
@@ -1,5 +1,0 @@
-apiVersion: kustomize.config.k8s.io/v1beta1
-kind: Kustomization
-resources:
-- ../ekf
-namespace: kubeflow

--- a/common/istio-1-14/kubeflow-istio-resources/overlays/ekf/kustomization.yaml
+++ b/common/istio-1-14/kubeflow-istio-resources/overlays/ekf/kustomization.yaml
@@ -1,7 +1,0 @@
-apiVersion: kustomize.config.k8s.io/v1beta1
-kind: Kustomization
-
-resources:
-- ../../base
-
-namespace: kubeflow

--- a/common/istio-1-14/kubeflow-istio-resources/overlays/minikf/kustomization.yaml
+++ b/common/istio-1-14/kubeflow-istio-resources/overlays/minikf/kustomization.yaml
@@ -1,5 +1,0 @@
-apiVersion: kustomize.config.k8s.io/v1beta1
-kind: Kustomization
-resources:
-- ../ekf
-namespace: kubeflow


### PR DESCRIPTION
Remove overlays in 'kubeflow-istio-resources' for version 1.14.

Signed-off-by: Dimitris Poulopoulos <dimpo@arrikto.com>