### PR TITLE
Update metacontroller

### DIFF
--- a/contrib/metacontroller/Kptfile
+++ b/contrib/metacontroller/Kptfile
@@ -1,0 +1,18 @@
+apiVersion: kpt.dev/v1
+kind: Kptfile
+metadata:
+  name: metacontroller
+upstream:
+  type: git
+  git:
+    repo: https://github.com/kubeflow/pipelines
+    directory: /manifests/kustomize/third-party/metacontroller
+    ref: 2.0.0-alpha.3
+  updateStrategy: resource-merge
+upstreamLock:
+  type: git
+  git:
+    repo: https://github.com/kubeflow/pipelines
+    directory: /manifests/kustomize/third-party/metacontroller
+    ref: 2.0.0-alpha.3
+    commit: fe333d49fc08f66ec867d3dd7dbd756927bf390c

--- a/contrib/metacontroller/README.md
+++ b/contrib/metacontroller/README.md
@@ -5,5 +5,12 @@
 
 ## Upgrade
 
-To update this component pull the latest content from [Kubeflow Pipelines third-party folder](https://github.com/kubeflow/pipelines/tree/master/manifests/kustomize/third-party/metacontroller).
+Metacontroller is pulled from [Kubeflow Pipelines third-party folder](https://github.com/kubeflow/pipelines/tree/master/manifests/kustomize/third-party/metacontroller). To update this component specify the desired KFP version and run the following command in console from the root directory **/**:
+
+```bash
+export KFP_VERSION=2.0.0-alpha.3   # specify KFP version
+kpt pkg update ./contrib/metacontroller@${KFP_VERSION}
+```
+
+Alternatively, you can copy the content from [Kubeflow Pipelines third-party folder](https://github.com/kubeflow/pipelines/tree/master/manifests/kustomize/third-party/metacontroller) by choosing the appropriate `TAG` in that repository.
 

--- a/contrib/metacontroller/README.md
+++ b/contrib/metacontroller/README.md
@@ -1,8 +1,9 @@
 # Metacontroller
 
-- [Official documentation] (https://metacontroller.github.io/metacontroller/)
+- [Official documentation](https://metacontroller.github.io/metacontroller/)
 - [Official repoitory](https://github.com/metacontroller/metacontroller)
 
 ## Upgrade
 
 To update this component pull the latest content from [Kubeflow Pipelines third-party folder](https://github.com/kubeflow/pipelines/tree/master/manifests/kustomize/third-party/metacontroller).
+

--- a/contrib/metacontroller/README.md
+++ b/contrib/metacontroller/README.md
@@ -1,0 +1,8 @@
+# Metacontroller
+
+- [Official documentation] (https://metacontroller.github.io/metacontroller/)
+- [Official repoitory](https://github.com/metacontroller/metacontroller)
+
+## Upgrade
+
+To update this component pull the latest content from [Kubeflow Pipelines third-party folder](https://github.com/kubeflow/pipelines/tree/master/manifests/kustomize/third-party/metacontroller).

--- a/contrib/metacontroller/base/cluster-role-binding.yaml
+++ b/contrib/metacontroller/base/cluster-role-binding.yaml
@@ -1,6 +1,6 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
-metadata:
+metadata: # kpt-merge: /meta-controller-cluster-role-binding
   name: meta-controller-cluster-role-binding
 roleRef:
   apiGroup: rbac.authorization.k8s.io

--- a/contrib/metacontroller/base/crd.yaml
+++ b/contrib/metacontroller/base/crd.yaml
@@ -1,45 +1,533 @@
 ---
-apiVersion: apiextensions.k8s.io/v1beta1
+apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
+  annotations:
+    "api-approved.kubernetes.io": "unapproved, request not yet submitted"
   name: compositecontrollers.metacontroller.k8s.io
 spec:
   group: metacontroller.k8s.io
   names:
     kind: CompositeController
+    listKind: CompositeControllerList
     plural: compositecontrollers
     shortNames:
     - cc
     - cctl
     singular: compositecontroller
   scope: Cluster
-  version: v1alpha1
+  versions:
+  - name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            properties:
+              childResources:
+                items:
+                  properties:
+                    apiVersion:
+                      type: string
+                    resource:
+                      type: string
+                    updateStrategy:
+                      properties:
+                        method:
+                          type: string
+                        statusChecks:
+                          properties:
+                            conditions:
+                              items:
+                                properties:
+                                  reason:
+                                    type: string
+                                  status:
+                                    type: string
+                                  type:
+                                    type: string
+                                required:
+                                - type
+                                type: object
+                              type: array
+                          type: object
+                      type: object
+                  required:
+                  - apiVersion
+                  - resource
+                  type: object
+                type: array
+              generateSelector:
+                type: boolean
+              hooks:
+                properties:
+                  customize:
+                    properties:
+                      webhook:
+                        properties:
+                          path:
+                            type: string
+                          service:
+                            properties:
+                              name:
+                                type: string
+                              namespace:
+                                type: string
+                              port:
+                                format: int32
+                                type: integer
+                              protocol:
+                                type: string
+                            required:
+                            - name
+                            - namespace
+                            type: object
+                          timeout:
+                            type: string
+                          url:
+                            type: string
+                        type: object
+                    type: object
+                  finalize:
+                    properties:
+                      webhook:
+                        properties:
+                          path:
+                            type: string
+                          service:
+                            properties:
+                              name:
+                                type: string
+                              namespace:
+                                type: string
+                              port:
+                                format: int32
+                                type: integer
+                              protocol:
+                                type: string
+                            required:
+                            - name
+                            - namespace
+                            type: object
+                          timeout:
+                            type: string
+                          url:
+                            type: string
+                        type: object
+                    type: object
+                  postUpdateChild:
+                    properties:
+                      webhook:
+                        properties:
+                          path:
+                            type: string
+                          service:
+                            properties:
+                              name:
+                                type: string
+                              namespace:
+                                type: string
+                              port:
+                                format: int32
+                                type: integer
+                              protocol:
+                                type: string
+                            required:
+                            - name
+                            - namespace
+                            type: object
+                          timeout:
+                            type: string
+                          url:
+                            type: string
+                        type: object
+                    type: object
+                  preUpdateChild:
+                    properties:
+                      webhook:
+                        properties:
+                          path:
+                            type: string
+                          service:
+                            properties:
+                              name:
+                                type: string
+                              namespace:
+                                type: string
+                              port:
+                                format: int32
+                                type: integer
+                              protocol:
+                                type: string
+                            required:
+                            - name
+                            - namespace
+                            type: object
+                          timeout:
+                            type: string
+                          url:
+                            type: string
+                        type: object
+                    type: object
+                  sync:
+                    properties:
+                      webhook:
+                        properties:
+                          path:
+                            type: string
+                          service:
+                            properties:
+                              name:
+                                type: string
+                              namespace:
+                                type: string
+                              port:
+                                format: int32
+                                type: integer
+                              protocol:
+                                type: string
+                            required:
+                            - name
+                            - namespace
+                            type: object
+                          timeout:
+                            type: string
+                          url:
+                            type: string
+                        type: object
+                    type: object
+                type: object
+              parentResource:
+                properties:
+                  apiVersion:
+                    type: string
+                  resource:
+                    type: string
+                  revisionHistory:
+                    properties:
+                      fieldPaths:
+                        items:
+                          type: string
+                        type: array
+                    type: object
+                required:
+                - apiVersion
+                - resource
+                type: object
+              resyncPeriodSeconds:
+                format: int32
+                type: integer
+            required:
+            - parentResource
+            type: object
+          status:
+            type: object
+        required:
+        - metadata
+        - spec
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: []
+  storedVersions: []
+
 ---
-apiVersion: apiextensions.k8s.io/v1beta1
+apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
+  annotations:
+    "api-approved.kubernetes.io": "unapproved, request not yet submitted"
   name: controllerrevisions.metacontroller.k8s.io
 spec:
   group: metacontroller.k8s.io
   names:
     kind: ControllerRevision
+    listKind: ControllerRevisionList
     plural: controllerrevisions
     singular: controllerrevision
   scope: Namespaced
-  version: v1alpha1
+  versions:
+  - name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          children:
+            items:
+              properties:
+                apiGroup:
+                  type: string
+                kind:
+                  type: string
+                names:
+                  items:
+                    type: string
+                  type: array
+              required:
+              - apiGroup
+              - kind
+              - names
+              type: object
+            type: array
+          kind:
+            description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          parentPatch:
+            type: object
+        required:
+        - metadata
+        - parentPatch
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: []
+  storedVersions: []
+
 ---
-apiVersion: apiextensions.k8s.io/v1beta1
+apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
+  annotations:
+    "api-approved.kubernetes.io": "unapproved, request not yet submitted"
   name: decoratorcontrollers.metacontroller.k8s.io
 spec:
   group: metacontroller.k8s.io
   names:
     kind: DecoratorController
+    listKind: DecoratorControllerList
     plural: decoratorcontrollers
     shortNames:
     - dec
     - decorators
     singular: decoratorcontroller
   scope: Cluster
-  version: v1alpha1
+  versions:
+  - name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            properties:
+              attachments:
+                items:
+                  properties:
+                    apiVersion:
+                      type: string
+                    resource:
+                      type: string
+                    updateStrategy:
+                      properties:
+                        method:
+                          type: string
+                      type: object
+                  required:
+                  - apiVersion
+                  - resource
+                  type: object
+                type: array
+              hooks:
+                properties:
+                  customize:
+                    properties:
+                      webhook:
+                        properties:
+                          path:
+                            type: string
+                          service:
+                            properties:
+                              name:
+                                type: string
+                              namespace:
+                                type: string
+                              port:
+                                format: int32
+                                type: integer
+                              protocol:
+                                type: string
+                            required:
+                            - name
+                            - namespace
+                            type: object
+                          timeout:
+                            type: string
+                          url:
+                            type: string
+                        type: object
+                    type: object
+                  finalize:
+                    properties:
+                      webhook:
+                        properties:
+                          path:
+                            type: string
+                          service:
+                            properties:
+                              name:
+                                type: string
+                              namespace:
+                                type: string
+                              port:
+                                format: int32
+                                type: integer
+                              protocol:
+                                type: string
+                            required:
+                            - name
+                            - namespace
+                            type: object
+                          timeout:
+                            type: string
+                          url:
+                            type: string
+                        type: object
+                    type: object
+                  sync:
+                    properties:
+                      webhook:
+                        properties:
+                          path:
+                            type: string
+                          service:
+                            properties:
+                              name:
+                                type: string
+                              namespace:
+                                type: string
+                              port:
+                                format: int32
+                                type: integer
+                              protocol:
+                                type: string
+                            required:
+                            - name
+                            - namespace
+                            type: object
+                          timeout:
+                            type: string
+                          url:
+                            type: string
+                        type: object
+                    type: object
+                type: object
+              resources:
+                items:
+                  properties:
+                    annotationSelector:
+                      properties:
+                        matchAnnotations:
+                          additionalProperties:
+                            type: string
+                          type: object
+                        matchExpressions:
+                          items:
+                            description: A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                            properties:
+                              key:
+                                description: key is the label key that the selector applies to.
+                                type: string
+                              operator:
+                                description: operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.
+                                type: string
+                              values:
+                                description: values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.
+                                items:
+                                  type: string
+                                type: array
+                            required:
+                            - key
+                            - operator
+                            type: object
+                          type: array
+                      type: object
+                    apiVersion:
+                      type: string
+                    labelSelector:
+                      description: A label selector is a label query over a set of resources. The result of matchLabels and matchExpressions are ANDed. An empty label selector matches all objects. A null label selector matches no objects.
+                      properties:
+                        matchExpressions:
+                          description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
+                          items:
+                            description: A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                            properties:
+                              key:
+                                description: key is the label key that the selector applies to.
+                                type: string
+                              operator:
+                                description: operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.
+                                type: string
+                              values:
+                                description: values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.
+                                items:
+                                  type: string
+                                type: array
+                            required:
+                            - key
+                            - operator
+                            type: object
+                          type: array
+                        matchLabels:
+                          additionalProperties:
+                            type: string
+                          description: matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
+                          type: object
+                      type: object
+                    resource:
+                      type: string
+                  required:
+                  - apiVersion
+                  - resource
+                  type: object
+                type: array
+              resyncPeriodSeconds:
+                format: int32
+                type: integer
+            required:
+            - resources
+            type: object
+          status:
+            type: object
+        required:
+        - metadata
+        - spec
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: []
+  storedVersions: []

--- a/contrib/metacontroller/base/crd.yaml
+++ b/contrib/metacontroller/base/crd.yaml
@@ -1,7 +1,6 @@
----
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
-metadata:
+metadata: # kpt-merge: /compositecontrollers.metacontroller.k8s.io
   annotations:
     "api-approved.kubernetes.io": "unapproved, request not yet submitted"
   name: compositecontrollers.metacontroller.k8s.io
@@ -243,11 +242,10 @@ status:
     plural: ""
   conditions: []
   storedVersions: []
-
 ---
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
-metadata:
+metadata: # kpt-merge: /controllerrevisions.metacontroller.k8s.io
   annotations:
     "api-approved.kubernetes.io": "unapproved, request not yet submitted"
   name: controllerrevisions.metacontroller.k8s.io
@@ -305,11 +303,10 @@ status:
     plural: ""
   conditions: []
   storedVersions: []
-
 ---
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
-metadata:
+metadata: # kpt-merge: /decoratorcontrollers.metacontroller.k8s.io
   annotations:
     "api-approved.kubernetes.io": "unapproved, request not yet submitted"
   name: decoratorcontrollers.metacontroller.k8s.io

--- a/contrib/metacontroller/base/kustomization.yaml
+++ b/contrib/metacontroller/base/kustomization.yaml
@@ -8,7 +8,7 @@ resources:
 - stateful-set.yaml
 commonLabels:
   kustomize.component: metacontroller
-images:
-- name: metacontroller/metacontroller
-  newName: metacontroller/metacontroller
-  newTag: v0.3.0
+
+# Update metacontroller CRD:
+# Copy the upstream file to crd.yaml in this folder.
+# Upstream file: https://github.com/metacontroller/metacontroller/blob/master/manifests/production/metacontroller-crds-v1.yaml

--- a/contrib/metacontroller/base/service-account.yaml
+++ b/contrib/metacontroller/base/service-account.yaml
@@ -1,4 +1,4 @@
 apiVersion: v1
 kind: ServiceAccount
-metadata:
+metadata: # kpt-merge: /meta-controller-service
   name: meta-controller-service

--- a/contrib/metacontroller/base/stateful-set.yaml
+++ b/contrib/metacontroller/base/stateful-set.yaml
@@ -18,26 +18,28 @@ spec:
         sidecar.istio.io/inject: "false"
     spec:
       containers:
-      - command:
-        - /usr/bin/metacontroller
-        - --logtostderr
-        - -v=4
-        - --discovery-interval=20s
-        image: metacontroller/metacontroller:v0.3.0
-        imagePullPolicy: Always
-        name: metacontroller
-        ports:
-        - containerPort: 2345
-        resources:
-          limits:
-            cpu: "4"
-            memory: 4Gi
-          requests:
-            cpu: 500m
-            memory: 1Gi
-        securityContext:
-          allowPrivilegeEscalation: true
-          privileged: true
+        - resources:
+            limits:
+              cpu: '1'
+              memory: 1Gi
+            requests:
+              cpu: 100m
+              memory: 256Mi
+          command:
+            - /usr/bin/metacontroller
+            - --zap-log-level=4
+            - '--discovery-interval=3600s' # less insane than 10 seconds
+          securityContext:
+            capabilities:
+              drop:
+              - ALL
+            readOnlyRootFilesystem: true
+            runAsNonRoot: true
+            runAsUser: 1000
+            privileged: false
+            allowPrivilegeEscalation: false
+          name: metacontroller
+          image: 'docker.io/metacontrollerio/metacontroller:v2.0.4'
       serviceAccountName: meta-controller-service
   # Workaround for https://github.com/kubernetes-sigs/kustomize/issues/677
   volumeClaimTemplates: []

--- a/contrib/metacontroller/base/stateful-set.yaml
+++ b/contrib/metacontroller/base/stateful-set.yaml
@@ -1,6 +1,6 @@
 apiVersion: apps/v1
 kind: StatefulSet
-metadata:
+metadata: # kpt-merge: /metacontroller
   labels:
     app: metacontroller
   name: metacontroller


### PR DESCRIPTION
**Which issue is resolved by this Pull Request:**


- KF 1.6 release target k8s v 1.22: #2194
- apiextensions.k8s.io/v1beta1 has been removed in k8s 1.22.

**Description of your changes:**

- Upgraded metacontroller to stay in sync for Kubeflow Pipelines.
- Added README with short instructions on how to manually upgrade it in the future.

**Checklist:**
- [ ] Unit tests pass:
  **Make sure you have installed kustomize == 3.2.1**
    1. `make generate-changed-only`
    2. `make test`
