### PR TITLE
Sync kserve web app manifests v0.8.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ This repo periodically syncs all official Kubeflow components from their respect
 | Volumes Web App | apps/volumes-web-app/upstream | [v1.6.0-rc.0](https://github.com/kubeflow/kubeflow/tree/v1.6.0-rc.0/components/crud-web-apps/volumes/manifests) |
 | Katib | apps/katib/upstream | [v0.14.0-rc.0](https://github.com/kubeflow/katib/tree/v0.14.0-rc.0/manifests/v1beta1) |
 | KServe | contrib/kserve/kserve | [release-0.8](https://github.com/kserve/kserve/tree/8079f375cbcedc4d45a1b4aade2e2308ea6f9ae8/install/v0.8.0) |
-| KServe Models Web App | contrib/kserve/models-web-app | [v0.8.0](https://github.com/kserve/models-web-app/tree/v0.8.0/config) |
+| KServe Models Web App | contrib/kserve/models-web-app | [v0.8.1](https://github.com/kserve/models-web-app/tree/v0.8.1/config) |
 | Kubeflow Pipelines | apps/pipeline/upstream | [2.0.0-alpha.3](https://github.com/kubeflow/pipelines/tree/2.0.0-alpha.3/manifests/kustomize) |
 | Kubeflow Tekton Pipelines | apps/kfp-tekton/upstream | [v1.2.1](https://github.com/kubeflow/kfp-tekton/tree/v1.2.1/manifests/kustomize) |
 

--- a/contrib/kserve/models-web-app/base/istio.yaml
+++ b/contrib/kserve/models-web-app/base/istio.yaml
@@ -11,7 +11,7 @@ spec:
   http:
   - match:
     - uri:
-        prefix: /models/
+        prefix: /kserve-endpoints/
     rewrite:
       uri: /
     route:

--- a/contrib/kserve/models-web-app/base/kustomization.yaml
+++ b/contrib/kserve/models-web-app/base/kustomization.yaml
@@ -13,7 +13,7 @@ commonLabels:
 images:
 - name: kserve/models-web-app
   newName: kserve/models-web-app
-  newTag: v0.7.0
+  newTag: v0.8.0
 configMapGenerator:
   - name: kserve-models-web-app-config
     literals:

--- a/contrib/kserve/models-web-app/overlays/kubeflow/kustomization.yaml
+++ b/contrib/kserve/models-web-app/overlays/kubeflow/kustomization.yaml
@@ -36,6 +36,7 @@ configMapGenerator:
     behavior: replace
     literals:
     - USERID_HEADER=kubeflow-userid
+    - APP_PREFIX=/kserve-endpoints
 
 configurations:
 - params.yaml

--- a/contrib/kserve/models-web-app/overlays/kubeflow/patches/web-app-vsvc.yaml
+++ b/contrib/kserve/models-web-app/overlays/kubeflow/patches/web-app-vsvc.yaml
@@ -1,4 +1,8 @@
 - op: replace
+  path: /spec/gateways
+  value:
+    - kubeflow/kubeflow-gateway
+- op: replace
   path: /spec/http/0/route/0/destination
   value:
     host: kserve-models-web-app.kubeflow.svc.cluster.local

--- a/hack/sync-kserve-kserve-manifests.sh
+++ b/hack/sync-kserve-kserve-manifests.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 
 # This script aims at helping create a PR to update the manifests of the
-# kserve/kserve and kserve/models-web-app repo.
+# kserve/kserve repo.
 # This script:
 # 1. Checks out a new branch
 # 2. Copies files to the correct places
@@ -19,11 +19,9 @@ IFS=$'\n\t'
 
 CLONE_DIR=${CLONE_DIR:=/tmp}
 KSERVE_DIR="${CLONE_DIR?}/kserve"
-WEBAPP_DIR="${CLONE_DIR?}/models-web-app"
 BRANCH=${BRANCH:=sync-kserve-manifests-${KSERVE_COMMIT?}}
 # *_VERSION vars are required only if COMMIT does not match a tag
 KSERVE_VERSION=${KSERVE_VERSION:=${KSERVE_COMMIT?}}
-WEBAPP_VERSION=${WEBAPP_VERSION:=${WEBAPP_COMMIT?}}
 
 SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
 MANIFESTS_DIR=$(dirname "${SCRIPT_DIR}")
@@ -81,41 +79,9 @@ DST_TXT="\[$KSERVE_COMMIT\](https://github.com/kserve/kserve/tree/$KSERVE_COMMIT
 
 sed -i "s|$SRC_TXT|$DST_TXT|g" "${MANIFESTS_DIR}"/README.md
 
-echo "Checking out in $WEBAPP_DIR to $WEBAPP_COMMIT..."
-pushd $CLONE_DIR
-    if [ ! -d "$WEBAPP_DIR" ]
-    then
-        git clone https://github.com/kserve/models-web-app.git && cd models-web-app
-        git checkout "${WEBAPP_COMMIT}"
-    else
-        echo "WARNING: ${WEBAPP_DIR} directory already exists. Exiting..."
-        exit 1
-    fi
-popd
-
-echo "Copying kserve models web app manifests..."
-SRC_MANIFEST_PATH="$WEBAPP_DIR"/config
-if [ ! -d "$SRC_MANIFEST_PATH" ]
-then
-    echo "Directory $SRC_MANIFEST_PATH DOES NOT exists."
-    exit 1
-fi
-
-DST_DIR=$MANIFESTS_DIR/contrib/kserve/models-web-app
-rm -r "$DST_DIR"
-cp "$SRC_MANIFEST_PATH" "$DST_DIR" -r
-
-echo "Successfully copied kserve models web app manifests."
-
-echo "Updating README..."
-SRC_TXT="\[.*\](https://github.com/kserve/models-web-app/tree/.*)"
-DST_TXT="\[$WEBAPP_COMMIT\](https://github.com/kserve/models-web-app/tree/$WEBAPP_COMMIT/config)"
-
-sed -i "s|$SRC_TXT|$DST_TXT|g" "${MANIFESTS_DIR}"/README.md
-
 # DEV: Comment out these commands when local testing
 echo "Committing the changes..."
 cd "$MANIFESTS_DIR"
 git add contrib/kserve
 git add README.md
-git commit -m "Update kserve manifests from ${KSERVE_VERSION}" -m "Update kserve/kserve manifests from ${KSERVE_COMMIT}" -m "Update kserve/models-web-app manifests from ${WEBAPP_COMMIT}"
+git commit -m "Update kserve manifests from ${KSERVE_VERSION}" -m "Update kserve/kserve manifests from ${KSERVE_COMMIT}"

--- a/hack/sync-kserve-web-app-manifests.sh
+++ b/hack/sync-kserve-web-app-manifests.sh
@@ -1,0 +1,68 @@
+#!/usr/bin/env bash
+
+# This script aims at helping create a PR to update the manifests of the
+# kserve/models-web-app repo.
+# This script:
+# 1. Checks out a new branch
+# 2. Copies files to the correct places
+# 3. Commits the changes
+#
+# Afterwards the developers can submit the PR to the kubeflow/manifests
+# repo, based on that local branch
+
+# strict mode http://redsymbol.net/articles/unofficial-bash-strict-mode/
+set -euo pipefail
+IFS=$'\n\t'
+
+SRC_DIR=${SRC_DIR:=/tmp/kserve-models-web-app}
+BRANCH=${BRANCH:=sync-kserve-web-app-manifests-${COMMIT?}}
+
+SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
+MANIFESTS_DIR=$(dirname $SCRIPT_DIR)
+
+echo "Creating branch: ${BRANCH}"
+
+# DEV: Comment out this if when local testing
+if [ -n "$(git status --porcelain)" ]; then
+  # Uncommitted changes
+  echo "WARNING: You have uncommitted changes, exiting..."
+  exit 1
+fi
+
+if [ `git branch --list $BRANCH` ]
+then
+   echo "WARNING: Branch $BRANCH already exists. Exiting..."
+   exit 1
+fi
+
+# DEV: Comment out this checkout command when local testing
+git checkout -b $BRANCH
+
+echo "Checking out in $SRC_DIR to $COMMIT..."
+cd $SRC_DIR
+if [ -n "$(git status --porcelain)" ]; then
+  # Uncommitted changes
+  echo "WARNING: You have uncommitted changes, exiting..."
+  exit 1
+fi
+git checkout $COMMIT
+
+echo "Copying admission-webhook manifests..."
+DST_DIR=$MANIFESTS_DIR/contrib/kserve/models-web-app
+rm -r $DST_DIR
+cp $SRC_DIR/config $DST_DIR -r
+
+echo "Successfully copied kserve models web app manifests."
+
+echo "Updating README..."
+SRC_TXT="\[.*\](https://github.com/kserve/models-web-app/tree/.*)"
+DST_TXT="\[$COMMIT\](https://github.com/kserve/models-web-app/tree/$COMMIT/config)"
+
+sed -i "s|$SRC_TXT|$DST_TXT|g" "${MANIFESTS_DIR}"/README.md
+
+# DEV: Comment out these commands when local testing
+echo "Committing the changes..."
+cd "$MANIFESTS_DIR"
+git add contrib/kserve/models-web-app
+git add README.md
+git commit -m "Update kserve web app manifests from ${COMMIT}"

--- a/tests/e2e/hack/cleanup_yamls.sh
+++ b/tests/e2e/hack/cleanup_yamls.sh
@@ -13,4 +13,4 @@ kubectl delete experiments.kubeflow.org -n kubeflow-user-example-com mnist-e2e
 
 kubectl delete tfjobs.kubeflow.org -n kubeflow-user-example-com mnist-e2e
 
-kubectl delete inferenceservices.serving.kubeflow.org -n kubeflow-user-example-com mnist-e2e
+kubectl delete inferenceservices.serving.kserve.io -n kubeflow-user-example-com mnist-e2e

--- a/tests/e2e/settings.py
+++ b/tests/e2e/settings.py
@@ -1,5 +1,5 @@
 NAMESPACE = "kubeflow-user-example-com"
-TIMEOUT = 300
+TIMEOUT = 600
 
 PIPELINE_NAME = "mnist-e2e"
 EXPERIMENT_NAME = "mnist-e2e"


### PR DESCRIPTION
Did a couple of changes to wrap up the work around the web app in this PR and testing. Specifically:
1. I created a new patch release for the MWA https://github.com/kserve/models-web-app/tree/v0.8.1/config
2. Created a distinct script for the MWA, for syncing the manifests, and decoupled it from a single one for doing both the app and kserve
3. Doubled the timeout in the e2e test script. I noticed that sometimes even when everything would run as expected 5mins wasn't enough for some steps
4. Update the cleanup script, in the e2e test script, to use `kserve.io` and not `kubeflow.org` (we had missed this place)

cc @annajung @surajkota 