### PR TITLE
oidc-authservice: fix unknown port error

### DIFF
--- a/common/oidc-authservice/base/params.env
+++ b/common/oidc-authservice/base/params.env
@@ -6,5 +6,5 @@ SKIP_AUTH_URI=/dex
 USERID_HEADER=kubeflow-userid
 USERID_PREFIX=
 USERID_CLAIM=email
-PORT="8080"
+PORT=8080
 STORE_PATH=/var/lib/authservice/data.db


### PR DESCRIPTION
<img width="945" alt="image" src="https://user-images.githubusercontent.com/13548195/180358372-945d9cee-e001-42c0-bb29-391473788f85.png">


**Which issue is resolved by this Pull Request:**
Resolves #

**Description of your changes:**

remove extra double quotes

**Checklist:**
- [x] Unit tests pass:
  **Make sure you have installed kustomize == 3.2.1**
    1. `make generate-changed-only`
    2. `make test`
