### PR TITLE
Solve the problem relating to Kubeflow authservice-0 permission denied

### DIFF
--- a/common/oidc-authservice/base/statefulset.yaml
+++ b/common/oidc-authservice/base/statefulset.yaml
@@ -15,6 +15,14 @@ spec:
       labels:
         app: authservice
     spec:
+      initContainers:
+      - name: fix-permission
+        image: busybox
+        command: ['sh', '-c']
+        args: ['chmod -R 777 /var/lib/authservice;']
+        volumeMounts:
+        - mountPath: /var/lib/authservice
+          name: data
       containers:
       - name: authservice
         image: gcr.io/arrikto/kubeflow/oidc-authservice:6ac9400


### PR DESCRIPTION
**Which issue is resolved by this Pull Request:**
Resolves #

**Description of your changes:**

Add the `initContainers` in `spec.template.spec` at `common/oidc-authservice/base/statefulset.yaml`

**Checklist:**
- [ ] Unit tests pass:
  **Make sure you have installed kustomize == 3.2.1**
    1. `make generate-changed-only`
    2. `make test`
