### PR TITLE
fix Duplicate keys in profiles manager.yaml

### DIFF
--- a/apps/profiles/upstream/manager/manager.yaml
+++ b/apps/profiles/upstream/manager/manager.yaml
@@ -31,16 +31,11 @@ spec:
         image: docker.io/kubeflownotebookswg/profile-controller
         imagePullPolicy: Always
         name: manager
-        livenessProbe:
-          httpGet:
-            path: /metrics
-            port: 8080
-          initialDelaySeconds: 30
-          periodSeconds: 30
         ports:
         - containerPort: 8080
           name: manager-http
           protocol: TCP
+        - containerPort: 9876
         livenessProbe:
           httpGet:
             path: /healthz
@@ -53,6 +48,4 @@ spec:
             port: 9876
           initialDelaySeconds: 5
           periodSeconds: 10
-        ports:
-        - containerPort: 9876
       serviceAccountName: controller-manager


### PR DESCRIPTION
**Which issue is resolved by this Pull Request:**
Resolves #2261

**Description of your changes:**
remove duplicate livenessProbe and container pord

**Checklist:**
- [x] Unit tests pass:
  **Make sure you have installed kustomize == 3.2.1**
    1. `make generate-changed-only`
    2. `make test`
