### PR TITLE
Extend KServe GH action to also apply an inference service and assert it becomes ready

### DIFF
--- a/.github/workflows/kserve_kind_test.yaml
+++ b/.github/workflows/kserve_kind_test.yaml
@@ -29,7 +29,8 @@ jobs:
     - name: Build & Apply manifests
       run: ./tests/gh-actions/install_kserve.sh
 
-     - name: Create kserve experiment
+    - name: Create kserve experiment
       run: |
-        kubectl apply -f tests/gh-actions/kserve_test.yaml
-        kubectl wait --for=condition=Ready inferenceservices.serving.kubeflow.org -n kubeflow-user --all --timeout 300s
+        ./tests/gh-actions/install_knative.sh
+        kubectl apply -f tests/gh-actions/kf-objects/kserve_test.yaml
+        kubectl wait --for=condition=ready inferenceservices.serving.kserve.io --all-namespaces --all --timeout 300s

--- a/.github/workflows/kserve_kind_test.yaml
+++ b/.github/workflows/kserve_kind_test.yaml
@@ -28,3 +28,8 @@ jobs:
 
     - name: Build & Apply manifests
       run: ./tests/gh-actions/install_kserve.sh
+
+     - name: Create kserve experiment
+      run: |
+        kubectl apply -f tests/gh-actions/kserve_test.yaml
+        kubectl wait --for=condition=Ready inferenceservices.serving.kubeflow.org -n kubeflow-user --all --timeout 300s

--- a/tests/gh-actions/install_knative.sh
+++ b/tests/gh-actions/install_knative.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+set -euo pipefail
+echo "Installing KNative ..."
+set +e
+kustomize build common/knative/knative-serving/overlays/gateways | kubectl apply -f -
+set -e
+kustomize build common/knative/knative-serving/overlays/gateways | kubectl apply -f -
+kustomize build common/knative/knative-eventing/base | kubectl apply -f -
+kustomize build common/istio-1-14/kubeflow-istio-resources/base | kubectl apply -f -

--- a/tests/gh-actions/kf-objects/kserve_test.yaml
+++ b/tests/gh-actions/kf-objects/kserve_test.yaml
@@ -1,0 +1,8 @@
+apiVersion: "serving.kserve.io/v1beta1"
+kind: "InferenceService"
+metadata:
+  name: "sklearn-iris"
+spec:
+  predictor:
+    sklearn:
+      storageUri: "gs://kfserving-examples/models/sklearn/1.0/model"

--- a/tests/gh-actions/kf-objects/kserve_test.yaml
+++ b/tests/gh-actions/kf-objects/kserve_test.yaml
@@ -5,4 +5,11 @@ metadata:
 spec:
   predictor:
     sklearn:
+      resources:
+          limits:
+            cpu: "1"
+            memory: 2Gi
+          requests:
+            cpu: "0.1"
+            memory: 200M 
       storageUri: "gs://kfserving-examples/models/sklearn/1.0/model"


### PR DESCRIPTION
Refs https://github.com/kubeflow/manifests/issues/2248