### PR TITLE
Fix typo in Katib GH action

### DIFF
--- a/.github/workflows/katib_kind_test.yaml
+++ b/.github/workflows/katib_kind_test.yaml
@@ -35,6 +35,6 @@ jobs:
 
     - name: Create katib experiment
       run: |
-        kubectl apply -f tests/gh-actions/katib_test.yaml
+        kubectl apply -f tests/gh-actions/kf-objects/katib_test.yaml
         kubectl wait --for=condition=Succeeded trials.kubeflow.org -n kubeflow-user --all --timeout 300s
         kubectl wait --for=condition=Succeeded experiments.kubeflow.org -n kubeflow-user --all --timeout 300s


### PR DESCRIPTION
This is a follow up PR to this (https://github.com/kubeflow/manifests/pull/2249) to fix the path of the katib test.

Refs https://github.com/kubeflow/manifests/issues/2248