### PR TITLE
istio: Include patches and resources in Istio install kustomization

### DIFF
--- a/common/istio-1-14/istio-install/base/kustomization.yaml
+++ b/common/istio-1-14/istio-install/base/kustomization.yaml
@@ -2,5 +2,14 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
 - install.yaml
+- gateway_authorizationpolicy.yaml
+- deny_all_authorizationpolicy.yaml
+- gateway.yaml
+- x-forwarded-host.yaml
 
 namespace: istio-system
+
+patchesStrategicMerge:
+- patches/service.yaml
+- patches/remove-pdb.yaml
+- patches/istio-configmap-disable-tracing.yaml


### PR DESCRIPTION
Include the resources and patches in Istio install kustomization. Specifically, include:

* 'service.yaml' patch
* 'remove-pdb.yaml' patch
* 'istio-configmap-disable-tracing.yaml' patch

and:

* 'gateway_authorizationpolicy.yaml' resource
* 'deny_all_authorizationpolicy.yaml' resource
* 'gateway.yaml' resource
* 'x-forwarded-host.yaml' resource

Signed-off-by: Dimitris Poulopoulos <dimpo@arrikto.com>
