### PR TITLE
Update kubeflow/kubeflow manifests from v1.6.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,14 +42,14 @@ This repo periodically syncs all official Kubeflow components from their respect
 | Component | Local Manifests Path | Upstream Revision |
 | - | - | - |
 | Training Operator | apps/training-operator/upstream | [v1.5.0](https://github.com/kubeflow/training-operator/tree/v1.5.0/manifests) |
-| Notebook Controller | apps/jupyter/notebook-controller/upstream | [v1.6.1-rc.0](https://github.com/kubeflow/kubeflow/tree/v1.6.1-rc.0/components/notebook-controller/config) |
-| Tensorboard Controller | apps/tensorboard/tensorboard-controller/upstream | [v1.6.1-rc.0](https://github.com/kubeflow/kubeflow/tree/v1.6.1-rc.0/components/tensorboard-controller/config) |
-| Central Dashboard | apps/centraldashboard/upstream | [v1.6.1-rc.0](https://github.com/kubeflow/kubeflow/tree/v1.6.1-rc.0/components/centraldashboard/manifests) |
-| Profiles + KFAM | apps/profiles/upstream | [v1.6.1-rc.0](https://github.com/kubeflow/kubeflow/tree/v1.6.1-rc.0/components/profile-controller/config) |
-| PodDefaults Webhook | apps/admission-webhook/upstream | [v1.6.1-rc.0](https://github.com/kubeflow/kubeflow/tree/v1.6.1-rc.0/components/admission-webhook/manifests) |
-| Jupyter Web App | apps/jupyter/jupyter-web-app/upstream | [v1.6.1-rc.0](https://github.com/kubeflow/kubeflow/tree/v1.6.1-rc.0/components/crud-web-apps/jupyter/manifests) |
-| Tensorboards Web App | apps/tensorboard/tensorboards-web-app/upstream | [v1.6.1-rc.0](https://github.com/kubeflow/kubeflow/tree/v1.6.1-rc.0/components/crud-web-apps/tensorboards/manifests) |
-| Volumes Web App | apps/volumes-web-app/upstream | [v1.6.1-rc.0](https://github.com/kubeflow/kubeflow/tree/v1.6.1-rc.0/components/crud-web-apps/volumes/manifests) |
+| Notebook Controller | apps/jupyter/notebook-controller/upstream | [v1.6.1](https://github.com/kubeflow/kubeflow/tree/v1.6.1/components/notebook-controller/config) |
+| Tensorboard Controller | apps/tensorboard/tensorboard-controller/upstream | [v1.6.1](https://github.com/kubeflow/kubeflow/tree/v1.6.1/components/tensorboard-controller/config) |
+| Central Dashboard | apps/centraldashboard/upstream | [v1.6.1](https://github.com/kubeflow/kubeflow/tree/v1.6.1/components/centraldashboard/manifests) |
+| Profiles + KFAM | apps/profiles/upstream | [v1.6.1](https://github.com/kubeflow/kubeflow/tree/v1.6.1/components/profile-controller/config) |
+| PodDefaults Webhook | apps/admission-webhook/upstream | [v1.6.1](https://github.com/kubeflow/kubeflow/tree/v1.6.1/components/admission-webhook/manifests) |
+| Jupyter Web App | apps/jupyter/jupyter-web-app/upstream | [v1.6.1](https://github.com/kubeflow/kubeflow/tree/v1.6.1/components/crud-web-apps/jupyter/manifests) |
+| Tensorboards Web App | apps/tensorboard/tensorboards-web-app/upstream | [v1.6.1](https://github.com/kubeflow/kubeflow/tree/v1.6.1/components/crud-web-apps/tensorboards/manifests) |
+| Volumes Web App | apps/volumes-web-app/upstream | [v1.6.1](https://github.com/kubeflow/kubeflow/tree/v1.6.1/components/crud-web-apps/volumes/manifests) |
 | Katib | apps/katib/upstream | [v0.14.0-rc.0](https://github.com/kubeflow/katib/tree/v0.14.0-rc.0/manifests/v1beta1) |
 | KServe | contrib/kserve/kserve | [release-0.8](https://github.com/kserve/kserve/tree/8079f375cbcedc4d45a1b4aade2e2308ea6f9ae8/install/v0.8.0) |
 | KServe Models Web App | contrib/kserve/models-web-app | [v0.8.1](https://github.com/kserve/models-web-app/tree/v0.8.1/config) |

--- a/apps/admission-webhook/upstream/base/kustomization.yaml
+++ b/apps/admission-webhook/upstream/base/kustomization.yaml
@@ -15,7 +15,7 @@ commonLabels:
   app.kubernetes.io/name: poddefaults
 images:
 - name: docker.io/kubeflownotebookswg/poddefaults-webhook
-  newTag: v1.6.1-rc.0
+  newTag: v1.6.1
 namespace: kubeflow
 generatorOptions:
   disableNameSuffixHash: true

--- a/apps/centraldashboard/upstream/base/kustomization.yaml
+++ b/apps/centraldashboard/upstream/base/kustomization.yaml
@@ -17,7 +17,7 @@ commonLabels:
   app.kubernetes.io/name: centraldashboard
 images:
 - name: docker.io/kubeflownotebookswg/centraldashboard
-  newTag: v1.6.1-rc.0
+  newTag: v1.6.1
 configMapGenerator:
 - envs:
   - params.env

--- a/apps/jupyter/jupyter-web-app/upstream/base/configs/spawner_ui_config.yaml
+++ b/apps/jupyter/jupyter-web-app/upstream/base/configs/spawner_ui_config.yaml
@@ -17,23 +17,23 @@
 spawnerFormDefaults:
   image:
     # The container Image for the user's Jupyter Notebook
-    value: kubeflownotebookswg/jupyter-scipy:v1.6.1-rc.0
+    value: kubeflownotebookswg/jupyter-scipy:v1.6.1
     # The list of available standard container Images
     options:
-    - kubeflownotebookswg/jupyter-scipy:v1.6.1-rc.0
-    - kubeflownotebookswg/jupyter-pytorch-full:v1.6.1-rc.0
-    - kubeflownotebookswg/jupyter-pytorch-cuda-full:v1.6.1-rc.0
-    - kubeflownotebookswg/jupyter-tensorflow-full:v1.6.1-rc.0
-    - kubeflownotebookswg/jupyter-tensorflow-cuda-full:v1.6.1-rc.0
+    - kubeflownotebookswg/jupyter-scipy:v1.6.1
+    - kubeflownotebookswg/jupyter-pytorch-full:v1.6.1
+    - kubeflownotebookswg/jupyter-pytorch-cuda-full:v1.6.1
+    - kubeflownotebookswg/jupyter-tensorflow-full:v1.6.1
+    - kubeflownotebookswg/jupyter-tensorflow-cuda-full:v1.6.1
   imageGroupOne:
     # The container Image for the user's Group One Server
     # The annotation `notebooks.kubeflow.org/http-rewrite-uri: /`
     # is applied to notebook in this group, configuring
     # the Istio rewrite for containers that host their web UI at `/`
-    value: kubeflownotebookswg/codeserver-python:v1.6.1-rc.0
+    value: kubeflownotebookswg/codeserver-python:v1.6.1
     # The list of available standard container Images
     options:
-    - kubeflownotebookswg/codeserver-python:v1.6.1-rc.0
+    - kubeflownotebookswg/codeserver-python:v1.6.1
   imageGroupTwo:
     # The container Image for the user's Group Two Server
     # The annotation `notebooks.kubeflow.org/http-rewrite-uri: /`
@@ -42,10 +42,10 @@ spawnerFormDefaults:
     # The annotation `notebooks.kubeflow.org/http-headers-request-set`
     # is applied to notebook in this group, configuring Istio
     # to add the `X-RStudio-Root-Path` header to requests
-    value: kubeflownotebookswg/rstudio-tidyverse:v1.6.1-rc.0
+    value: kubeflownotebookswg/rstudio-tidyverse:v1.6.1
     # The list of available standard container Images
     options:
-    - kubeflownotebookswg/rstudio-tidyverse:v1.6.1-rc.0
+    - kubeflownotebookswg/rstudio-tidyverse:v1.6.1
   # If true, hide registry and/or tag name in the image selection dropdown
   hideRegistry: true
   hideTag: false

--- a/apps/jupyter/jupyter-web-app/upstream/base/kustomization.yaml
+++ b/apps/jupyter/jupyter-web-app/upstream/base/kustomization.yaml
@@ -22,7 +22,7 @@ commonLabels:
   kustomize.component: jupyter-web-app
 images:
 - name: docker.io/kubeflownotebookswg/jupyter-web-app
-  newTag: v1.6.1-rc.0
+  newTag: v1.6.1
 # We need the name to be unique without the suffix because the original name is what
 # gets used with patches
 configMapGenerator:

--- a/apps/jupyter/notebook-controller/upstream/base/kustomization.yaml
+++ b/apps/jupyter/notebook-controller/upstream/base/kustomization.yaml
@@ -4,4 +4,4 @@ resources:
 - ../default
 images:
 - name: docker.io/kubeflownotebookswg/notebook-controller
-  newTag: v1.6.1-rc.0
+  newTag: v1.6.1

--- a/apps/profiles/upstream/base/kustomization.yaml
+++ b/apps/profiles/upstream/base/kustomization.yaml
@@ -11,7 +11,7 @@ patchesStrategicMerge:
 
 images:
 - name: docker.io/kubeflownotebookswg/profile-controller
-  newTag: v1.6.1-rc.0
+  newTag: v1.6.1
 
 configMapGenerator:
 - name: namespace-labels-data

--- a/apps/profiles/upstream/overlays/kubeflow/kustomization.yaml
+++ b/apps/profiles/upstream/overlays/kubeflow/kustomization.yaml
@@ -28,4 +28,4 @@ vars:
 
 images:
 - name: docker.io/kubeflownotebookswg/kfam
-  newTag: v1.6.1-rc.0
+  newTag: v1.6.1

--- a/apps/tensorboard/tensorboard-controller/upstream/base/kustomization.yaml
+++ b/apps/tensorboard/tensorboard-controller/upstream/base/kustomization.yaml
@@ -12,4 +12,4 @@ patchesStrategicMerge:
 - patches/add_controller_config.yaml
 images:
 - name: docker.io/kubeflownotebookswg/tensorboard-controller
-  newTag: v1.6.1-rc.0
+  newTag: v1.6.1

--- a/apps/tensorboard/tensorboards-web-app/upstream/base/kustomization.yaml
+++ b/apps/tensorboard/tensorboards-web-app/upstream/base/kustomization.yaml
@@ -13,7 +13,7 @@ commonLabels:
   kustomize.component: tensorboards-web-app
 images:
 - name: docker.io/kubeflownotebookswg/tensorboards-web-app
-  newTag: v1.6.1-rc.0
+  newTag: v1.6.1
 # We need the name to be unique without the suffix because the original name is what
 # gets used with patches
 configMapGenerator:

--- a/apps/volumes-web-app/upstream/base/kustomization.yaml
+++ b/apps/volumes-web-app/upstream/base/kustomization.yaml
@@ -13,7 +13,7 @@ commonLabels:
   kustomize.component: volumes-web-app
 images:
 - name: docker.io/kubeflownotebookswg/volumes-web-app
-  newTag: v1.6.1-rc.0
+  newTag: v1.6.1
 # We need the name to be unique without the suffix because the original name is what
 # gets used with patches
 configMapGenerator:


### PR DESCRIPTION
Syncing manifests with the latest `v1.6.1` tag of the kubeflow/kubeflow repo

/cc @annajung 
