### PR TITLE
Harden the istio configuration

### DIFF
--- a/common/dex/base/service.yaml
+++ b/common/dex/base/service.yaml
@@ -3,12 +3,11 @@ kind: Service
 metadata:
   name: dex
 spec:
-  type: NodePort
+  type: ClusterIP
   ports:
   - name: dex
     port: 5556
     protocol: TCP
     targetPort: 5556
-    nodePort: 32000
   selector:
     app: dex

--- a/common/istio-1-14/istio-install/base/kustomization.yaml
+++ b/common/istio-1-14/istio-install/base/kustomization.yaml
@@ -13,3 +13,4 @@ patchesStrategicMerge:
 - patches/service.yaml
 - patches/remove-pdb.yaml
 - patches/istio-configmap-disable-tracing.yaml
+- patches/disable-debugging.yaml

--- a/common/istio-1-14/istio-install/base/patches/disable-debugging.yaml
+++ b/common/istio-1-14/istio-install/base/patches/disable-debugging.yaml
@@ -1,0 +1,18 @@
+# Pentest enahncement: check port 15010 & 8080 in istiod: According to https://istio.io/latest/docs/ops/best-practices/security/#control-plane port 15010
+# is not that problematic (only resource discovery). Other parts of the documentation also say| 15010 | GRPC | XDS and CA services (Plaintext, only for secure networks) | 
+# We have a secure network layer and only XDS is served. 
+# Port 8080 is not listed in the service and even if it would be somehow reachable by IP it only "offers read access". 
+# Nevertheless we set ENABLE_DEBUG_ON_HTTP=false do disable it entirely.
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: istiod
+  namespace: istio-system
+spec:
+  template:
+    spec:
+      containers:
+      - name: discovery
+        env:
+        - name: ENABLE_DEBUG_ON_HTTP
+          value: 'false'

--- a/common/istio-1-14/istio-install/base/patches/service.yaml
+++ b/common/istio-1-14/istio-install/base/patches/service.yaml
@@ -4,4 +4,4 @@ metadata:
   name: istio-ingressgateway
   namespace: istio-system
 spec:
-  type: NodePort
+  type: ClusterIP


### PR DESCRIPTION
The istio nodeport (loadbalancer)instead of a proper ClusterIP seems dangerous to me https://oteemo.com/think-nodeport-kubernetes/
Fixes #2285
@kimwnasptd 

**Which issue is resolved by this Pull Request:**
Resolves #

**Description of your changes:**


**Checklist:**
- [ ] Unit tests pass:
  **Make sure you have installed kustomize == 3.2.1**
    1. `make generate-changed-only`
    2. `make test`
