### PR TITLE
change docker pull policy from always to ifNotPresent

### DIFF
--- a/apps/jupyter/notebook-controller/upstream/manager/manager.yaml
+++ b/apps/jupyter/notebook-controller/upstream/manager/manager.yaml
@@ -32,7 +32,7 @@ spec:
               configMapKeyRef:
                 name: config
                 key: ISTIO_GATEWAY
-        imagePullPolicy: Always
+        imagePullPolicy: IfNotPresent
         livenessProbe:
           httpGet:
             path: /healthz

--- a/apps/profiles/upstream/manager/manager.yaml
+++ b/apps/profiles/upstream/manager/manager.yaml
@@ -29,7 +29,7 @@ spec:
           - configMapRef:
               name: config
         image: docker.io/kubeflownotebookswg/profile-controller
-        imagePullPolicy: Always
+        imagePullPolicy: IfNotPresent
         name: manager
         livenessProbe:
           httpGet:

--- a/apps/profiles/upstream/overlays/kubeflow/patches/kfam.yaml
+++ b/apps/profiles/upstream/overlays/kubeflow/patches/kfam.yaml
@@ -21,7 +21,7 @@ spec:
           - configMapRef:
               name: config
         image: docker.io/kubeflownotebookswg/kfam
-        imagePullPolicy: Always
+        imagePullPolicy: IfNotPresent
         name: kfam
         livenessProbe:
           httpGet:


### PR DESCRIPTION
Address issue https://github.com/kubeflow/kubeflow/issues/6704
-change docker image pull policy to IfNotPresent so images can be cached to avoid [docker pull rate limit](https://aws.amazon.com/premiumsupport/knowledge-center/ecs-pull-container-error-rate-limit/#:~:text=Docker%20Hub%20uses%20IP%20addresses,pulls%20per%206%2Dhour%20period)