### PR TITLE
Add unmaintained notice to contrib components

### DIFF
--- a/contrib/application/README.md
+++ b/contrib/application/README.md
@@ -1,0 +1,7 @@
+Please note: This component is **unmaintained and out-of-date**.
+
+If the component fails to meet the [contrib requirements](https://github.com/kubeflow/manifests/blob/master/proposals/20220926-contrib-component-guidelines.md#component-requirements)
+ by the next Kubeflow release ([1.7](https://github.com/kubeflow/community/tree/master/releases/release-1.7#timeline)),
+ it will be removed from the [`manifest`](https://github.com/kubeflow/manifests) repository.
+
+Updates to the `/contrib` components can be found in the [tracking issue](https://github.com/kubeflow/manifests/issues/2311).

--- a/contrib/basic-auth/README.md
+++ b/contrib/basic-auth/README.md
@@ -1,0 +1,7 @@
+Please note: This component is **unmaintained and out-of-date**.
+
+If the component fails to meet the [contrib requirements](https://github.com/kubeflow/manifests/blob/master/proposals/20220926-contrib-component-guidelines.md#component-requirements)
+ by the next Kubeflow release ([1.7](https://github.com/kubeflow/community/tree/master/releases/release-1.7#timeline)),
+ it will be removed from the [`manifest`](https://github.com/kubeflow/manifests) repository.
+
+Updates to the `/contrib` components can be found in the [tracking issue](https://github.com/kubeflow/manifests/issues/2311).

--- a/contrib/experimental/README.md
+++ b/contrib/experimental/README.md
@@ -1,0 +1,7 @@
+Please note: This component is **unmaintained and out-of-date**.
+
+If the component fails to meet the [contrib requirements](https://github.com/kubeflow/manifests/blob/master/proposals/20220926-contrib-component-guidelines.md#component-requirements)
+ by the next Kubeflow release ([1.7](https://github.com/kubeflow/community/tree/master/releases/release-1.7#timeline)),
+ it will be removed from the [`manifest`](https://github.com/kubeflow/manifests) repository.
+
+Updates to the `/contrib` components can be found in the [tracking issue](https://github.com/kubeflow/manifests/issues/2311).

--- a/contrib/gatekeeper/README.md
+++ b/contrib/gatekeeper/README.md
@@ -1,3 +1,12 @@
+Please note: This component is **unmaintained and out-of-date**.
+
+If the component fails to meet the [contrib requirements](https://github.com/kubeflow/manifests/blob/master/proposals/20220926-contrib-component-guidelines.md#component-requirements)
+ by the next Kubeflow release ([1.7](https://github.com/kubeflow/community/tree/master/releases/release-1.7#timeline)),
+ it will be removed from the [`manifest`](https://github.com/kubeflow/manifests) repository.
+
+Updates to the `/contrib` components can be found in the [tracking issue](https://github.com/kubeflow/manifests/issues/2311).
+
+
 # Gatekeeper and Kubeflow
 
 [Gatekeeper](https://github.com/open-policy-agent/gatekeeper) is a validating webhook for Kubernetes that enforces CRD-based access control policies.

--- a/contrib/modeldb/README.md
+++ b/contrib/modeldb/README.md
@@ -1,0 +1,7 @@
+Please note: This component is **unmaintained and out-of-date**.
+
+If the component fails to meet the [contrib requirements](https://github.com/kubeflow/manifests/blob/master/proposals/20220926-contrib-component-guidelines.md#component-requirements)
+ by the next Kubeflow release ([1.7](https://github.com/kubeflow/community/tree/master/releases/release-1.7#timeline)),
+ it will be removed from the [`manifest`](https://github.com/kubeflow/manifests) repository.
+
+Updates to the `/contrib` components can be found in the [tracking issue](https://github.com/kubeflow/manifests/issues/2311).

--- a/contrib/spartakus/README.md
+++ b/contrib/spartakus/README.md
@@ -1,0 +1,7 @@
+Please note: This component is **unmaintained and out-of-date**.
+
+If the component fails to meet the [contrib requirements](https://github.com/kubeflow/manifests/blob/master/proposals/20220926-contrib-component-guidelines.md#component-requirements)
+ by the next Kubeflow release ([1.7](https://github.com/kubeflow/community/tree/master/releases/release-1.7#timeline)),
+ it will be removed from the [`manifest`](https://github.com/kubeflow/manifests) repository.
+
+Updates to the `/contrib` components can be found in the [tracking issue](https://github.com/kubeflow/manifests/issues/2311).


### PR DESCRIPTION
Signed-off-by: Anna Jung (VMware) <antheaj@vmware.com>

**Which issue is resolved by this Pull Request:**
Part of https://github.com/kubeflow/manifests/issues/2311

**Description of your changes:**
- Add README to the following components to mark the directory as unmaintained and out of date
  - `/contrib/application`
  - `/contrib/basic-auth`
  - `/contrib/experimental`
  - `/contrib/gatekeeper`
  - `/contrib/modeldb`
  - `/contrib/spartakus`

cc @kimwnasptd @kubeflow/wg-manifests-leads 