### PR TITLE
Add unmaintained notice to contrib basic-auth

### DIFF
--- a/contrib/basic-auth/README.md
+++ b/contrib/basic-auth/README.md
@@ -1,0 +1,7 @@
+Please note: This component is **unmaintained and out-of-date**.
+
+If the component fails to meet the [contrib requirements](https://github.com/kubeflow/manifests/blob/master/proposals/20220926-contrib-component-guidelines.md#component-requirements)
+ by the next Kubeflow release ([1.7](https://github.com/kubeflow/community/tree/master/releases/release-1.7#timeline)),
+ it will be removed from the [`manifest`](https://github.com/kubeflow/manifests) repository.
+
+Updates to the `/contrib` components can be found in the [tracking issue](https://github.com/kubeflow/manifests/issues/2311).


### PR DESCRIPTION
Signed-off-by: Anna Jung (VMware) <antheaj@vmware.com>

**Which issue is resolved by this Pull Request:**
Part of https://github.com/kubeflow/manifests/issues/2311

**Description of your changes:**
Add README to `/contrib/basic-auth` to mark the directory as unmaintained and out of date

**Note:**
The OWNERS file is not available for this component, therefore, am not sure who the original owners are. Tagging @yanniszark (last commit) to ensure the component OWNER(s) are aware of the out-of-date label put on the component.

To remove the unmaintained label, check out the missing requirements https://github.com/kubeflow/manifests/issues/2311 and leave a comment on the issue to indicate that you'll take action to provide the missing requirements and are willing to keep the component up to date.

cc @kimwnasptd @kubeflow/wg-manifests-leads 