### PR TITLE
Add unmaintained notice to contrib spark

### DIFF
--- a/contrib/README.md
+++ b/contrib/README.md
@@ -1,0 +1,7 @@
+Please note: This component is **unmaintained and out-of-date**.
+
+If the component fails to meet the [contrib requirements](https://github.com/kubeflow/manifests/blob/master/proposals/20220926-contrib-component-guidelines.md#component-requirements)
+ by the next Kubeflow release ([1.7](https://github.com/kubeflow/community/tree/master/releases/release-1.7#timeline)),
+ it will be removed from the [`manifest`](https://github.com/kubeflow/manifests) repository.
+
+Updates to the `/contrib` components can be found in the [tracking issue](https://github.com/kubeflow/manifests/issues/2311).


### PR DESCRIPTION
Signed-off-by: Anna Jung (VMware) <antheaj@vmware.com>

**Which issue is resolved by this Pull Request:**
Part of https://github.com/kubeflow/manifests/issues/2311

**Description of your changes:**
Add README to `/contrib/spark` to mark the directory as unmaintained and out of date

**Note:**
Tagging spark component [owners](https://github.com/kubeflow/manifests/blob/master/contrib/spark/OWNERS) @Jeffwan @holdenk to ensure awareness of the out-of-date label on the component.

To remove the unmaintained label, check out the missing requirements https://github.com/kubeflow/manifests/issues/2311 and leave a comment on the issue to indicate that you'll take action to provide the missing requirements and are willing to keep the component up to date.

cc @kimwnasptd @kubeflow/wg-manifests-leads 