### PR TITLE
Update Istio version references to v1.16

### DIFF
--- a/.github/workflows/jwa_kind_test.yaml
+++ b/.github/workflows/jwa_kind_test.yaml
@@ -3,11 +3,8 @@ on:
   pull_request:
     paths:
       - apps/jupyter/jupyter-web-app/upstream/**
-<<<<<<< HEAD
       - tests/gh-actions/kind-cluster.yaml
-=======
       - tests/gh-actions/install_istio.sh
->>>>>>> tests: Update GH Action workflows
 
 jobs:
   build:

--- a/.github/workflows/twa_kind_test.yaml
+++ b/.github/workflows/twa_kind_test.yaml
@@ -3,11 +3,8 @@ on:
   pull_request:
     paths:
       - apps/tensorboard/tensorboards-web-app/upstream/**
-<<<<<<< HEAD
       - tests/gh-actions/kind-cluster.yaml
-=======
       - tests/gh-actions/install_istio.sh
->>>>>>> tests: Update GH Action workflows
 
 jobs:
   build:

--- a/README.md
+++ b/README.md
@@ -136,9 +136,9 @@ network authorization and implement routing policies.
 Install Istio:
 
 ```sh
-kustomize build common/istio-1-14/istio-crds/base | kubectl apply -f -
-kustomize build common/istio-1-14/istio-namespace/base | kubectl apply -f -
-kustomize build common/istio-1-14/istio-install/base | kubectl apply -f -
+kustomize build common/istio-1-16/istio-crds/base | kubectl apply -f -
+kustomize build common/istio-1-16/istio-namespace/base | kubectl apply -f -
+kustomize build common/istio-1-16/istio-install/base | kubectl apply -f -
 ```
 
 #### Dex
@@ -167,7 +167,7 @@ Install Knative Serving:
 
 ```sh
 kustomize build common/knative/knative-serving/overlays/gateways | kubectl apply -f -
-kustomize build common/istio-1-14/cluster-local-gateway/base | kubectl apply -f -
+kustomize build common/istio-1-16/cluster-local-gateway/base | kubectl apply -f -
 ```
 
 Optionally, you can install Knative Eventing which can be used for inference request logging:
@@ -209,7 +209,7 @@ well.
 Install istio resources:
 
 ```sh
-kustomize build common/istio-1-14/kubeflow-istio-resources/base | kubectl apply -f -
+kustomize build common/istio-1-16/kubeflow-istio-resources/base | kubectl apply -f -
 ```
 
 #### Kubeflow Pipelines

--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ used from the different projects of Kubeflow:
 
 | Component | Local Manifests Path | Upstream Revision |
 | - | - | - |
-| Istio | common/istio-1-14 | [1.14.1](https://github.com/istio/istio/releases/tag/1.14.1) |
+| Istio | common/istio-1-16 | [1.16.0](https://github.com/istio/istio/releases/tag/1.16.0) |
 | Knative | common/knative | [0.22.1](https://github.com/knative/serving/releases/tag/v0.22.1) |
 
 ## Installation

--- a/common/istio-1-16/README.md
+++ b/common/istio-1-16/README.md
@@ -64,8 +64,7 @@ old version is `X1.Y1.Z1`:
     `--cluster-specific` is a flag that determines if a current K8s cluster context will be used to dynamically 
     detect default settings. Ensure you have a target cluster ready before running the above commands. 
     We set this flag because `istioctl manifest generate` generates manifest files with resources that are no 
-    longer supported in Kubernetes 1.25 (`policy/v1beta1`). See: 
-    - https://github.com/istio/istio/issues/41220
+    longer supported in Kubernetes 1.25 (`policy/v1beta1`). See: https://github.com/istio/istio/issues/41220
 
     ---
 

--- a/hack/setup-kubeflow-light.sh
+++ b/hack/setup-kubeflow-light.sh
@@ -30,9 +30,9 @@ sleep 5
 kubectl wait --timeout=${TIMEOUT} -n cert-manager --all --for=condition=Ready pod
 
 echo "Deploying Istio."
-kustomize build common/istio-1-14/istio-crds/base | kubectl apply -f -
-kustomize build common/istio-1-14/istio-namespace/base | kubectl apply -f -
-kustomize build common/istio-1-14/istio-install/base | kubectl apply -f -
+kustomize build common/istio-1-16/istio-crds/base | kubectl apply -f -
+kustomize build common/istio-1-16/istio-namespace/base | kubectl apply -f -
+kustomize build common/istio-1-16/istio-install/base | kubectl apply -f -
 
 echo "Waiting for istio-system Pods to become ready..."
 sleep 5
@@ -50,7 +50,7 @@ do
 done
 
 kustomize build common/knative/knative-eventing/base | kubectl apply -f -
-kustomize build common/istio-1-14/cluster-local-gateway/base | kubectl apply -f -
+kustomize build common/istio-1-16/cluster-local-gateway/base | kubectl apply -f -
 
 echo "Waiting for knative-serving Pods to become ready..."
 sleep 5

--- a/tests/gh-actions/install_knative.sh
+++ b/tests/gh-actions/install_knative.sh
@@ -6,4 +6,4 @@ kustomize build common/knative/knative-serving/overlays/gateways | kubectl apply
 set -e
 kustomize build common/knative/knative-serving/overlays/gateways | kubectl apply -f -
 kustomize build common/knative/knative-eventing/base | kubectl apply -f -
-kustomize build common/istio-1-14/kubeflow-istio-resources/base | kubectl apply -f -
+kustomize build common/istio-1-16/kubeflow-istio-resources/base | kubectl apply -f -


### PR DESCRIPTION
Follow-up PR from: https://github.com/kubeflow/manifests/pull/2327

- Update Istio version reference in main README file
- Replace all references of `istio-1-14` with `istio-1-16`
  - installation instructions in README
  - helper scripts
- Minor fixes for GH Action workflows

Refs: https://github.com/kubeflow/manifests/issues/2325

cc. @kimwnasptd 
Signed-off-by: Apostolos Gerakaris <apoger@arrikto.com>