### PR TITLE
common: Upgrade Knative Eventing manifests to version 1.8.1

### DIFF
--- a/.github/workflows/kserve_kind_test.yaml
+++ b/.github/workflows/kserve_kind_test.yaml
@@ -3,6 +3,7 @@ on:
   pull_request:
     paths:
       - contrib/kserve/**
+      - common/knative/**
 
 jobs:
   build:

--- a/common/knative/README.md
+++ b/common/knative/README.md
@@ -107,6 +107,24 @@ The manifests for Knative Eventing are based off the the [v1.2.4 release](https:
     yq eval -i 'explode(.)' knative-eventing-post-install-jobs/base/eventing-post-install-jobs.yaml
     ```
 
+1. Set `metadata.name` in the eventing post-install job, to be deploy-able with
+   `kustomize` and `kubectl apply`:
+
+    ```sh
+    # We are not using the '|=' operator because it generates an empty object
+    # ({}) which crashes kustomize.
+    yq eval -i 'select(.kind == "Job" and .metadata.generateName == "storage-version-migration-eventing-") | .metadata.name = "storage-version-migration-serving"' knative-eventing-post-install-jobs/base/eventing-post-install.yaml
+    ```
+
+1. Remove the `config-observability` and `config-tracing` ConfigMaps resource definitions from the In-Memory Channel, as they are already defined in eventing core. 
+
+   ```sh
+   yq eval -i 'select((.kind == "ConfigMap" and .metadata.name == "config-observability") | not)' knative-eventing/base/upstream/in-memory-channel.yaml 
+   yq eval -i 'select((.kind == "ConfigMap" and .metadata.name == "config-tracing") | not)' knative-eventing/base/upstream/in-memory-channel.yaml 
+   ``` 
+
+   NOTE: Make sure to remove a redundant `{}` at the end of the `knative-eventing/base/upstream/in-memory-channel.yaml` file after running the above commands.
+
 ## Copyright
 
 The files under the folders `knative-serving/base/upstream` and

--- a/common/knative/README.md
+++ b/common/knative/README.md
@@ -70,20 +70,20 @@ NOTE: You'll need to remove a redundant `{}` at the end of the `knative-serving/
 
 ## Knative-Eventing
 
-The manifests for Knative Eventing are based off the the [v1.2.4 release](https://github.com/knative/eventing/releases/tag/knative-v1.2.4).
+The manifests for Knative Eventing are based off the the [v1.8.1 release](https://github.com/knative/eventing/releases/tag/knative-v1.8.1).
 
-  - [Eventing Core](https://github.com/knative/eventing/releases/download/knative-v1.2.4/eventing-core.yaml)
-  - [In-Memory Channel](https://github.com/knative/eventing/releases/download/knative-v1.2.4/in-memory-channel.yaml)
-  - [MT Channel Broker](https://github.com/knative/eventing/releases/download/knative-v1.2.4/mt-channel-broker.yaml)
+  - [Eventing Core](https://github.com/knative/eventing/releases/download/knative-v1.8.1/eventing-core.yaml)
+  - [In-Memory Channel](https://github.com/knative/eventing/releases/download/knative-v1.8.1/in-memory-channel.yaml)
+  - [MT Channel Broker](https://github.com/knative/eventing/releases/download/knative-v1.8.1/mt-channel-broker.yaml)
 
 
 1. Download the knative-eventing manifests with the following commands:
 
     ```sh
-    wget -O knative-eventing/base/upstream/eventing-core.yaml 'https://github.com/knative/eventing/releases/download/knative-v1.2.4/eventing-core.yaml'
-    wget -O knative-eventing/base/upstream/in-memory-channel.yaml 'https://github.com/knative/eventing/releases/download/knative-v1.2.4/in-memory-channel.yaml'
-    wget -O knative-eventing/base/upstream/mt-channel-broker.yaml 'https://github.com/knative/eventing/releases/download/knative-v1.2.4/mt-channel-broker.yaml'
-    wget -O knative-eventing-post-install-jobs/base/eventing-post-install-jobs.yaml https://github.com/knative/eventing/releases/download/knative-v1.2.4/eventing-post-install.yaml
+    wget -O knative-eventing/base/upstream/eventing-core.yaml 'https://github.com/knative/eventing/releases/download/knative-v1.8.1/eventing-core.yaml'
+    wget -O knative-eventing/base/upstream/in-memory-channel.yaml 'https://github.com/knative/eventing/releases/download/knative-v1.8.1/in-memory-channel.yaml'
+    wget -O knative-eventing/base/upstream/mt-channel-broker.yaml 'https://github.com/knative/eventing/releases/download/knative-v1.8.1/mt-channel-broker.yaml'
+    wget -O knative-eventing-post-install-jobs/base/eventing-post-install.yaml 'https://github.com/knative/eventing/releases/download/knative-v1.8.1/eventing-post-install.yaml'
     ```
 
 1. Remove all comments, since `yq` does not handle them correctly. See:
@@ -93,7 +93,7 @@ The manifests for Knative Eventing are based off the the [v1.2.4 release](https:
     yq eval -i '... comments=""' knative-eventing/base/upstream/eventing-core.yaml
     yq eval -i '... comments=""' knative-eventing/base/upstream/in-memory-channel.yaml
     yq eval -i '... comments=""' knative-eventing/base/upstream/mt-channel-broker.yaml
-    yq eval -i '... comments=""' knative-eventing-post-install-jobs/base/eventing-post-install-jobs.yaml
+    yq eval -i '... comments=""' knative-eventing-post-install-jobs/base/eventing-post-install.yaml
     ```
 
 1. Remove all YAML anchors and aliases, as kustomize does not support them. See:
@@ -104,7 +104,7 @@ The manifests for Knative Eventing are based off the the [v1.2.4 release](https:
     yq eval -i 'explode(.)' knative-eventing/base/upstream/eventing-core.yaml
     yq eval -i 'explode(.)' knative-eventing/base/upstream/in-memory-channel.yaml
     yq eval -i 'explode(.)' knative-eventing/base/upstream/mt-channel-broker.yaml
-    yq eval -i 'explode(.)' knative-eventing-post-install-jobs/base/eventing-post-install-jobs.yaml
+    yq eval -i 'explode(.)' knative-eventing-post-install-jobs/base/eventing-post-install.yaml
     ```
 
 1. Set `metadata.name` in the eventing post-install job, to be deploy-able with
@@ -113,7 +113,7 @@ The manifests for Knative Eventing are based off the the [v1.2.4 release](https:
     ```sh
     # We are not using the '|=' operator because it generates an empty object
     # ({}) which crashes kustomize.
-    yq eval -i 'select(.kind == "Job" and .metadata.generateName == "storage-version-migration-eventing-") | .metadata.name = "storage-version-migration-serving"' knative-eventing-post-install-jobs/base/eventing-post-install.yaml
+    yq eval -i 'select(.kind == "Job" and .metadata.generateName == "storage-version-migration-eventing-") | .metadata.name = "storage-version-migration-eventing"' knative-eventing-post-install-jobs/base/eventing-post-install.yaml
     ```
 
 1. Remove the `config-observability` and `config-tracing` ConfigMaps resource definitions from the In-Memory Channel, as they are already defined in eventing core. 

--- a/common/knative/knative-eventing-post-install-jobs/base/eventing-post-install.yaml
+++ b/common/knative/knative-eventing-post-install-jobs/base/eventing-post-install.yaml
@@ -3,7 +3,9 @@ kind: ClusterRole
 metadata:
   name: knative-eventing-post-install-job-role
   labels:
-    eventing.knative.dev/release: "v1.2.4"
+    app.kubernetes.io/version: "1.8.1"
+    app.kubernetes.io/name: knative-eventing
+    eventing.knative.dev/release: "v1.8.1"
 rules:
   - apiGroups:
       - "apiextensions.k8s.io"
@@ -106,14 +108,18 @@ metadata:
   name: knative-eventing-post-install-job
   namespace: knative-eventing
   labels:
-    eventing.knative.dev/release: "v1.2.4"
+    eventing.knative.dev/release: "v1.8.1"
+    app.kubernetes.io/version: "1.8.1"
+    app.kubernetes.io/name: knative-eventing
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   name: knative-eventing-post-install-job-role-binding
   labels:
-    eventing.knative.dev/release: "v1.2.4"
+    eventing.knative.dev/release: "v1.8.1"
+    app.kubernetes.io/version: "1.8.1"
+    app.kubernetes.io/name: knative-eventing
 subjects:
   - kind: ServiceAccount
     name: knative-eventing-post-install-job
@@ -126,11 +132,14 @@ roleRef:
 apiVersion: batch/v1
 kind: Job
 metadata:
-  generateName: storage-version-migration-eventing-
+  name: storage-version-migration-eventing
   namespace: knative-eventing
   labels:
     app: "storage-version-migration-eventing"
-    eventing.knative.dev/release: "v1.2.4"
+    app.kubernetes.io/name: knative-eventing
+    app.kubernetes.io/component: storage-version-migration-job
+    app.kubernetes.io/version: "1.8.1"
+    eventing.knative.dev/release: "v1.8.1"
 spec:
   ttlSecondsAfterFinished: 600
   backoffLimit: 10
@@ -138,7 +147,10 @@ spec:
     metadata:
       labels:
         app: "storage-version-migration-eventing"
-        eventing.knative.dev/release: "v1.2.4"
+        app.kubernetes.io/name: knative-eventing
+        app.kubernetes.io/component: storage-version-migration-job
+        app.kubernetes.io/version: "1.8.1"
+        eventing.knative.dev/release: "v1.8.1"
       annotations:
         sidecar.istio.io/inject: "false"
     spec:
@@ -146,7 +158,7 @@ spec:
       restartPolicy: OnFailure
       containers:
         - name: migrate
-          image: gcr.io/knative-releases/knative.dev/eventing/vendor/knative.dev/pkg/apiextensions/storageversion/cmd/migrate@sha256:ce1cf40c3e58fb437bac1731aa4dd3bda63bcedeaaf303b928963071192f82bf
+          image: gcr.io/knative-releases/knative.dev/pkg/apiextensions/storageversion/cmd/migrate@sha256:bb95337552b07e1a52d6205a95342317b1b081b6b57ef7764c0d59c466978b6f
           args:
             - "apiserversources.sources.knative.dev"
             - "brokers.eventing.knative.dev"
@@ -166,6 +178,8 @@ spec:
             runAsNonRoot: true
             capabilities:
               drop:
-                - all
+                - ALL
+            seccompProfile:
+              type: RuntimeDefault
 ---
 

--- a/common/knative/knative-eventing-post-install-jobs/base/kustomization.yaml
+++ b/common/knative/knative-eventing-post-install-jobs/base/kustomization.yaml
@@ -1,4 +1,4 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
-- eventing-post-install-jobs.yaml
+- eventing-post-install.yaml

--- a/common/knative/knative-eventing/base/kustomization.yaml
+++ b/common/knative/knative-eventing/base/kustomization.yaml
@@ -2,8 +2,10 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 namespace: knative-eventing
 resources:
-- upstream/eventing-core.yaml
+- upstream/eventing-core.yaml 
+# Uncomment to install In-Memory Channels as messaging layer: 
 # - upstream/in-memory-channel.yaml
+# Uncomment to install MT-channel-based Broker layer
 # - upstream/mt-channel-broker.yaml
 patchesStrategicMerge:
 - patches/clusterrole-patch.yaml

--- a/common/knative/knative-eventing/base/upstream/eventing-core.yaml
+++ b/common/knative/knative-eventing/base/upstream/eventing-core.yaml
@@ -3,8 +3,8 @@ kind: Namespace
 metadata:
   name: knative-eventing
   labels:
-    eventing.knative.dev/release: "v1.2.4"
-    app.kubernetes.io/version: "1.2.4"
+    eventing.knative.dev/release: "v1.8.1"
+    app.kubernetes.io/version: "1.8.1"
     app.kubernetes.io/name: knative-eventing
 ---
 apiVersion: v1
@@ -13,8 +13,8 @@ metadata:
   name: eventing-controller
   namespace: knative-eventing
   labels:
-    eventing.knative.dev/release: "v1.2.4"
-    app.kubernetes.io/version: "1.2.4"
+    eventing.knative.dev/release: "v1.8.1"
+    app.kubernetes.io/version: "1.8.1"
     app.kubernetes.io/name: knative-eventing
 ---
 apiVersion: rbac.authorization.k8s.io/v1
@@ -22,8 +22,8 @@ kind: ClusterRoleBinding
 metadata:
   name: eventing-controller
   labels:
-    eventing.knative.dev/release: "v1.2.4"
-    app.kubernetes.io/version: "1.2.4"
+    eventing.knative.dev/release: "v1.8.1"
+    app.kubernetes.io/version: "1.8.1"
     app.kubernetes.io/name: knative-eventing
 subjects:
   - kind: ServiceAccount
@@ -39,8 +39,8 @@ kind: ClusterRoleBinding
 metadata:
   name: eventing-controller-resolver
   labels:
-    eventing.knative.dev/release: "v1.2.4"
-    app.kubernetes.io/version: "1.2.4"
+    eventing.knative.dev/release: "v1.8.1"
+    app.kubernetes.io/version: "1.8.1"
     app.kubernetes.io/name: knative-eventing
 subjects:
   - kind: ServiceAccount
@@ -56,8 +56,8 @@ kind: ClusterRoleBinding
 metadata:
   name: eventing-controller-source-observer
   labels:
-    eventing.knative.dev/release: "v1.2.4"
-    app.kubernetes.io/version: "1.2.4"
+    eventing.knative.dev/release: "v1.8.1"
+    app.kubernetes.io/version: "1.8.1"
     app.kubernetes.io/name: knative-eventing
 subjects:
   - kind: ServiceAccount
@@ -73,8 +73,8 @@ kind: ClusterRoleBinding
 metadata:
   name: eventing-controller-sources-controller
   labels:
-    eventing.knative.dev/release: "v1.2.4"
-    app.kubernetes.io/version: "1.2.4"
+    eventing.knative.dev/release: "v1.8.1"
+    app.kubernetes.io/version: "1.8.1"
     app.kubernetes.io/name: knative-eventing
 subjects:
   - kind: ServiceAccount
@@ -90,8 +90,8 @@ kind: ClusterRoleBinding
 metadata:
   name: eventing-controller-manipulator
   labels:
-    eventing.knative.dev/release: "v1.2.4"
-    app.kubernetes.io/version: "1.2.4"
+    eventing.knative.dev/release: "v1.8.1"
+    app.kubernetes.io/version: "1.8.1"
     app.kubernetes.io/name: knative-eventing
 subjects:
   - kind: ServiceAccount
@@ -108,8 +108,8 @@ metadata:
   name: pingsource-mt-adapter
   namespace: knative-eventing
   labels:
-    eventing.knative.dev/release: "v1.2.4"
-    app.kubernetes.io/version: "1.2.4"
+    eventing.knative.dev/release: "v1.8.1"
+    app.kubernetes.io/version: "1.8.1"
     app.kubernetes.io/name: knative-eventing
 ---
 apiVersion: rbac.authorization.k8s.io/v1
@@ -117,8 +117,8 @@ kind: ClusterRoleBinding
 metadata:
   name: knative-eventing-pingsource-mt-adapter
   labels:
-    eventing.knative.dev/release: "v1.2.4"
-    app.kubernetes.io/version: "1.2.4"
+    eventing.knative.dev/release: "v1.8.1"
+    app.kubernetes.io/version: "1.8.1"
     app.kubernetes.io/name: knative-eventing
 subjects:
   - kind: ServiceAccount
@@ -135,8 +135,8 @@ metadata:
   name: eventing-webhook
   namespace: knative-eventing
   labels:
-    eventing.knative.dev/release: "v1.2.4"
-    app.kubernetes.io/version: "1.2.4"
+    eventing.knative.dev/release: "v1.8.1"
+    app.kubernetes.io/version: "1.8.1"
     app.kubernetes.io/name: knative-eventing
 ---
 apiVersion: rbac.authorization.k8s.io/v1
@@ -144,8 +144,8 @@ kind: ClusterRoleBinding
 metadata:
   name: eventing-webhook
   labels:
-    eventing.knative.dev/release: "v1.2.4"
-    app.kubernetes.io/version: "1.2.4"
+    eventing.knative.dev/release: "v1.8.1"
+    app.kubernetes.io/version: "1.8.1"
     app.kubernetes.io/name: knative-eventing
 subjects:
   - kind: ServiceAccount
@@ -162,8 +162,8 @@ metadata:
   namespace: knative-eventing
   name: eventing-webhook
   labels:
-    eventing.knative.dev/release: "v1.2.4"
-    app.kubernetes.io/version: "1.2.4"
+    eventing.knative.dev/release: "v1.8.1"
+    app.kubernetes.io/version: "1.8.1"
     app.kubernetes.io/name: knative-eventing
 subjects:
   - kind: ServiceAccount
@@ -179,8 +179,8 @@ kind: ClusterRoleBinding
 metadata:
   name: eventing-webhook-resolver
   labels:
-    eventing.knative.dev/release: "v1.2.4"
-    app.kubernetes.io/version: "1.2.4"
+    eventing.knative.dev/release: "v1.8.1"
+    app.kubernetes.io/version: "1.8.1"
     app.kubernetes.io/name: knative-eventing
 subjects:
   - kind: ServiceAccount
@@ -196,8 +196,8 @@ kind: ClusterRoleBinding
 metadata:
   name: eventing-webhook-podspecable-binding
   labels:
-    eventing.knative.dev/release: "v1.2.4"
-    app.kubernetes.io/version: "1.2.4"
+    eventing.knative.dev/release: "v1.8.1"
+    app.kubernetes.io/version: "1.8.1"
     app.kubernetes.io/name: knative-eventing
 subjects:
   - kind: ServiceAccount
@@ -214,8 +214,8 @@ metadata:
   name: config-br-default-channel
   namespace: knative-eventing
   labels:
-    eventing.knative.dev/release: "v1.2.4"
-    app.kubernetes.io/version: "1.2.4"
+    eventing.knative.dev/release: "v1.8.1"
+    app.kubernetes.io/version: "1.8.1"
     app.kubernetes.io/name: knative-eventing
 data:
   channel-template-spec: |
@@ -228,8 +228,8 @@ metadata:
   name: config-br-defaults
   namespace: knative-eventing
   labels:
-    eventing.knative.dev/release: "v1.2.4"
-    app.kubernetes.io/version: "1.2.4"
+    eventing.knative.dev/release: "v1.8.1"
+    app.kubernetes.io/version: "1.8.1"
     app.kubernetes.io/name: knative-eventing
 data:
   default-br-config: |
@@ -250,8 +250,8 @@ metadata:
   name: default-ch-webhook
   namespace: knative-eventing
   labels:
-    eventing.knative.dev/release: "v1.2.4"
-    app.kubernetes.io/version: "1.2.4"
+    eventing.knative.dev/release: "v1.8.1"
+    app.kubernetes.io/version: "1.8.1"
     app.kubernetes.io/name: knative-eventing
 data:
   default-ch-config: |
@@ -269,10 +269,10 @@ metadata:
   name: config-ping-defaults
   namespace: knative-eventing
   labels:
-    eventing.knative.dev/release: "v1.2.4"
+    eventing.knative.dev/release: "v1.8.1"
   annotations:
     knative.dev/example-checksum: "9185c153"
-    app.kubernetes.io/version: "1.2.4"
+    app.kubernetes.io/version: "1.8.1"
     app.kubernetes.io/name: knative-eventing
 data:
   _example: |
@@ -301,17 +301,17 @@ metadata:
   name: config-features
   namespace: knative-eventing
   labels:
-    eventing.knative.dev/release: "v1.2.4"
+    eventing.knative.dev/release: "v1.8.1"
     knative.dev/config-propagation: original
     knative.dev/config-category: eventing
-    app.kubernetes.io/version: "1.2.4"
+    app.kubernetes.io/version: "1.8.1"
     app.kubernetes.io/name: knative-eventing
 data:
   kreference-group: "disabled"
   delivery-retryafter: "disabled"
-  delivery-timeout: "disabled"
+  delivery-timeout: "enabled"
   kreference-mapping: "disabled"
-  strict-subscriber: "disabled"
+  strict-subscriber: "enabled"
   new-trigger-filters: "disabled"
 ---
 apiVersion: v1
@@ -320,7 +320,7 @@ metadata:
   name: config-kreference-mapping
   namespace: knative-eventing
   labels:
-    eventing.knative.dev/release: "v1.2.4"
+    eventing.knative.dev/release: "v1.8.1"
     knative.dev/config-propagation: original
     knative.dev/config-category: eventing
   annotations:
@@ -354,8 +354,8 @@ metadata:
   name: config-leader-election
   namespace: knative-eventing
   labels:
-    eventing.knative.dev/release: "v1.2.4"
-    app.kubernetes.io/version: "1.2.4"
+    eventing.knative.dev/release: "v1.8.1"
+    app.kubernetes.io/version: "1.8.1"
     app.kubernetes.io/name: knative-eventing
   annotations:
     knative.dev/example-checksum: "f7948630"
@@ -401,10 +401,10 @@ metadata:
   name: config-logging
   namespace: knative-eventing
   labels:
-    eventing.knative.dev/release: "v1.2.4"
+    eventing.knative.dev/release: "v1.8.1"
     knative.dev/config-propagation: original
     knative.dev/config-category: eventing
-    app.kubernetes.io/version: "1.2.4"
+    app.kubernetes.io/version: "1.8.1"
     app.kubernetes.io/name: knative-eventing
 data:
   zap-logger-config: |
@@ -437,10 +437,10 @@ metadata:
   name: config-observability
   namespace: knative-eventing
   labels:
-    eventing.knative.dev/release: "v1.2.4"
+    eventing.knative.dev/release: "v1.8.1"
     knative.dev/config-propagation: original
     knative.dev/config-category: eventing
-    app.kubernetes.io/version: "1.2.4"
+    app.kubernetes.io/version: "1.8.1"
     app.kubernetes.io/name: knative-eventing
   annotations:
     knative.dev/example-checksum: "f46cf09d"
@@ -496,13 +496,56 @@ data:
 apiVersion: v1
 kind: ConfigMap
 metadata:
+  name: config-sugar
+  namespace: knative-eventing
+  labels:
+    eventing.knative.dev/release: "v1.8.1"
+    app.kubernetes.io/version: "1.8.1"
+    app.kubernetes.io/name: knative-eventing
+  annotations:
+    knative.dev/example-checksum: "62dfac6f"
+data:
+  _example: |
+    ################################
+    #                              #
+    #    EXAMPLE CONFIGURATION     #
+    #                              #
+    ################################
+    # This block is not actually functional configuration,
+    # but serves to illustrate the available configuration
+    # options and document them in a way that is accessible
+    # to users that `kubectl edit` this config map.
+    #
+    # These sample configuration options may be copied out of
+    # this example block and unindented to be in the data block
+    # to actually change the configuration.
+
+    # namespace-selector specifies a LabelSelector which
+    # determines which namespaces the Sugar Controller should operate upon
+    # Use an empty value to disable the feature (this is the default):
+    namespace-selector: ""
+
+    # Use an empty object as a string to enable for all namespaces
+    namespace-selector: "{}"
+
+    # trigger-selector specifies a LabelSelector which
+    # determines which triggers the Sugar Controller should operate upon
+    # Use an empty value to disable the feature (this is the default):
+    trigger-selector: ""
+
+    # Use an empty object as string to enable for all triggers
+    trigger-selector: "{}"
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
   name: config-tracing
   namespace: knative-eventing
   labels:
-    eventing.knative.dev/release: "v1.2.4"
+    eventing.knative.dev/release: "v1.8.1"
     knative.dev/config-propagation: original
     knative.dev/config-category: eventing
-    app.kubernetes.io/version: "1.2.4"
+    app.kubernetes.io/version: "1.8.1"
     app.kubernetes.io/name: knative-eventing
   annotations:
     knative.dev/example-checksum: "0492ceb0"
@@ -542,10 +585,10 @@ metadata:
   name: eventing-controller
   namespace: knative-eventing
   labels:
-    eventing.knative.dev/release: "v1.2.4"
+    eventing.knative.dev/release: "v1.8.1"
     knative.dev/high-availability: "true"
     app.kubernetes.io/component: eventing-controller
-    app.kubernetes.io/version: "1.2.4"
+    app.kubernetes.io/version: "1.8.1"
     app.kubernetes.io/name: knative-eventing
 spec:
   selector:
@@ -555,9 +598,9 @@ spec:
     metadata:
       labels:
         app: eventing-controller
-        eventing.knative.dev/release: "v1.2.4"
-        app.kubernetes.io/component: eventing-autoscaler
-        app.kubernetes.io/version: "1.2.4"
+        eventing.knative.dev/release: "v1.8.1"
+        app.kubernetes.io/component: eventing-controller
+        app.kubernetes.io/version: "1.8.1"
         app.kubernetes.io/name: knative-eventing
     spec:
       affinity:
@@ -574,7 +617,7 @@ spec:
       containers:
         - name: eventing-controller
           terminationMessagePolicy: FallbackToLogsOnError
-          image: gcr.io/knative-releases/knative.dev/eventing/cmd/controller@sha256:dc0ac2d8f235edb04ec1290721f389d2bc719ab8b6222ee86f17af8d7d2a160f
+          image: gcr.io/knative-releases/knative.dev/eventing/cmd/controller@sha256:33d78536e9b38dbb2ec2952207b48ff8e05acb48e7d28c2305bd0a0f7156198f
           resources:
             requests:
               cpu: 100m
@@ -591,7 +634,7 @@ spec:
             - name: METRICS_DOMAIN
               value: knative.dev/eventing
             - name: APISERVER_RA_IMAGE
-              value: gcr.io/knative-releases/knative.dev/eventing/cmd/apiserver_receive_adapter@sha256:5b672eedd343bcf9496c2070479f9d8f29231069148bf2aa7991bd5ca5a7562a
+              value: gcr.io/knative-releases/knative.dev/eventing/cmd/apiserver_receive_adapter@sha256:2fd38788ae96abd96e63bf8b7ef3e1b37370513a84a86cd153dfb1cd9442a095
             - name: POD_NAME
               valueFrom:
                 fieldRef:
@@ -602,12 +645,32 @@ spec:
             runAsNonRoot: true
             capabilities:
               drop:
-                - all
+                - ALL
+            seccompProfile:
+              type: RuntimeDefault
+          livenessProbe:
+            httpGet:
+              path: /health
+              port: probes
+              scheme: HTTP
+            initialDelaySeconds: 20
+            periodSeconds: 10
+            timeoutSeconds: 5
+          readinessProbe:
+            httpGet:
+              path: /readiness
+              port: probes
+              scheme: HTTP
+            initialDelaySeconds: 20
+            periodSeconds: 10
+            timeoutSeconds: 5
           ports:
             - name: metrics
               containerPort: 9090
             - name: profiling
               containerPort: 8008
+            - name: probes
+              containerPort: 8080
 ---
 apiVersion: apps/v1
 kind: Deployment
@@ -615,9 +678,9 @@ metadata:
   name: pingsource-mt-adapter
   namespace: knative-eventing
   labels:
-    eventing.knative.dev/release: "v1.2.4"
+    eventing.knative.dev/release: "v1.8.1"
     app.kubernetes.io/component: pingsource-mt-adapter
-    app.kubernetes.io/version: "1.2.4"
+    app.kubernetes.io/version: "1.8.1"
     app.kubernetes.io/name: knative-eventing
 spec:
   replicas: 0
@@ -630,9 +693,9 @@ spec:
       labels:
         eventing.knative.dev/source: ping-source-controller
         sources.knative.dev/role: adapter
-        eventing.knative.dev/release: "v1.2.4"
+        eventing.knative.dev/release: "v1.8.1"
         app.kubernetes.io/component: pingsource-mt-adapter
-        app.kubernetes.io/version: "1.2.4"
+        app.kubernetes.io/version: "1.8.1"
         app.kubernetes.io/name: knative-eventing
     spec:
       affinity:
@@ -648,9 +711,15 @@ spec:
       enableServiceLinks: false
       containers:
         - name: dispatcher
-          image: gcr.io/knative-releases/knative.dev/eventing/cmd/mtping@sha256:632d9d710d070efed2563f6125a87993e825e8e36562ec3da0366e2a897406c0
+          image: gcr.io/knative-releases/knative.dev/eventing/cmd/mtping@sha256:282b5265e1ef26309b3343038c9b4f172654e06cbee46f6ddffd23ea9ad9a3be
           env:
             - name: SYSTEM_NAMESPACE
+              value: ''
+              valueFrom:
+                fieldRef:
+                  apiVersion: v1
+                  fieldPath: metadata.namespace
+            - name: NAMESPACE
               value: ''
               valueFrom:
                 fieldRef:
@@ -687,18 +756,20 @@ spec:
             runAsNonRoot: true
             capabilities:
               drop:
-                - all
+                - ALL
+            seccompProfile:
+              type: RuntimeDefault
       serviceAccountName: pingsource-mt-adapter
 ---
-apiVersion: autoscaling/v2beta2
+apiVersion: autoscaling/v2
 kind: HorizontalPodAutoscaler
 metadata:
   name: eventing-webhook
   namespace: knative-eventing
   labels:
-    eventing.knative.dev/release: "v1.2.4"
+    eventing.knative.dev/release: "v1.8.1"
     app.kubernetes.io/component: eventing-webhook
-    app.kubernetes.io/version: "1.2.4"
+    app.kubernetes.io/version: "1.8.1"
     app.kubernetes.io/name: knative-eventing
 spec:
   scaleTargetRef:
@@ -715,15 +786,15 @@ spec:
           type: Utilization
           averageUtilization: 100
 ---
-apiVersion: policy/v1beta1
+apiVersion: policy/v1
 kind: PodDisruptionBudget
 metadata:
   name: eventing-webhook
   namespace: knative-eventing
   labels:
-    eventing.knative.dev/release: "v1.2.4"
+    eventing.knative.dev/release: "v1.8.1"
     app.kubernetes.io/component: eventing-webhook
-    app.kubernetes.io/version: "1.2.4"
+    app.kubernetes.io/version: "1.8.1"
     app.kubernetes.io/name: knative-eventing
 spec:
   minAvailable: 80%
@@ -737,9 +808,9 @@ metadata:
   name: eventing-webhook
   namespace: knative-eventing
   labels:
-    eventing.knative.dev/release: "v1.2.4"
+    eventing.knative.dev/release: "v1.8.1"
     app.kubernetes.io/component: eventing-webhook
-    app.kubernetes.io/version: "1.2.4"
+    app.kubernetes.io/version: "1.8.1"
     app.kubernetes.io/name: knative-eventing
 spec:
   selector:
@@ -751,9 +822,9 @@ spec:
       labels:
         app: eventing-webhook
         role: eventing-webhook
-        eventing.knative.dev/release: "v1.2.4"
+        eventing.knative.dev/release: "v1.8.1"
         app.kubernetes.io/component: eventing-webhook
-        app.kubernetes.io/version: "1.2.4"
+        app.kubernetes.io/version: "1.8.1"
         app.kubernetes.io/name: knative-eventing
     spec:
       affinity:
@@ -770,7 +841,7 @@ spec:
       containers:
         - name: eventing-webhook
           terminationMessagePolicy: FallbackToLogsOnError
-          image: gcr.io/knative-releases/knative.dev/eventing/cmd/webhook@sha256:b7faf7d253bd256dbe08f1cac084469128989cf39abbe256ecb4e1d4eb085a31
+          image: gcr.io/knative-releases/knative.dev/eventing/cmd/webhook@sha256:d217ab7e3452a87f8cbb3b45df65c98b18b8be39551e3e960cd49ea44bb415ba
           resources:
             requests:
               cpu: 100m
@@ -803,7 +874,9 @@ spec:
             runAsNonRoot: true
             capabilities:
               drop:
-                - all
+                - ALL
+            seccompProfile:
+              type: RuntimeDefault
           ports:
             - name: https-webhook
               containerPort: 8443
@@ -827,17 +900,17 @@ spec:
               httpHeaders:
                 - name: k-kubelet-probe
                   value: "webhook"
-            initialDelaySeconds: 20
+            initialDelaySeconds: 120
       terminationGracePeriodSeconds: 300
 ---
 apiVersion: v1
 kind: Service
 metadata:
   labels:
-    eventing.knative.dev/release: "v1.2.4"
+    eventing.knative.dev/release: "v1.8.1"
     role: eventing-webhook
     app.kubernetes.io/component: eventing-webhook
-    app.kubernetes.io/version: "1.2.4"
+    app.kubernetes.io/version: "1.8.1"
     app.kubernetes.io/name: knative-eventing
   name: eventing-webhook
   namespace: knative-eventing
@@ -854,11 +927,11 @@ kind: CustomResourceDefinition
 metadata:
   creationTimestamp: null
   labels:
-    eventing.knative.dev/release: "v1.2.4"
+    eventing.knative.dev/release: "v1.8.1"
     eventing.knative.dev/source: "true"
     duck.knative.dev/source: "true"
     knative.dev/crd-install: "true"
-    app.kubernetes.io/version: "1.2.4"
+    app.kubernetes.io/version: "1.8.1"
     app.kubernetes.io/name: knative-eventing
   annotations:
     registry.knative.dev/eventTypes: |
@@ -1054,10 +1127,10 @@ kind: CustomResourceDefinition
 metadata:
   name: brokers.eventing.knative.dev
   labels:
-    eventing.knative.dev/release: "v1.2.4"
+    eventing.knative.dev/release: "v1.8.1"
     knative.dev/crd-install: "true"
     duck.knative.dev/addressable: "true"
-    app.kubernetes.io/version: "1.2.4"
+    app.kubernetes.io/version: "1.8.1"
     app.kubernetes.io/name: knative-eventing
 spec:
   group: eventing.knative.dev
@@ -1206,11 +1279,11 @@ kind: CustomResourceDefinition
 metadata:
   name: channels.messaging.knative.dev
   labels:
-    eventing.knative.dev/release: "v1.2.4"
+    eventing.knative.dev/release: "v1.8.1"
     knative.dev/crd-install: "true"
     messaging.knative.dev/subscribable: "true"
     duck.knative.dev/addressable: "true"
-    app.kubernetes.io/version: "1.2.4"
+    app.kubernetes.io/version: "1.8.1"
     app.kubernetes.io/name: knative-eventing
 spec:
   group: messaging.knative.dev
@@ -1466,11 +1539,11 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   labels:
-    eventing.knative.dev/release: "v1.2.4"
+    eventing.knative.dev/release: "v1.8.1"
     eventing.knative.dev/source: "true"
     duck.knative.dev/source: "true"
     knative.dev/crd-install: "true"
-    app.kubernetes.io/version: "1.2.4"
+    app.kubernetes.io/version: "1.8.1"
     app.kubernetes.io/name: knative-eventing
   name: containersources.sources.knative.dev
 spec:
@@ -1605,9 +1678,9 @@ kind: CustomResourceDefinition
 metadata:
   name: eventtypes.eventing.knative.dev
   labels:
-    eventing.knative.dev/release: "v1.2.4"
+    eventing.knative.dev/release: "v1.8.1"
     knative.dev/crd-install: "true"
-    app.kubernetes.io/version: "1.2.4"
+    app.kubernetes.io/version: "1.8.1"
     app.kubernetes.io/name: knative-eventing
 spec:
   group: eventing.knative.dev
@@ -1719,10 +1792,10 @@ kind: CustomResourceDefinition
 metadata:
   name: parallels.flows.knative.dev
   labels:
-    eventing.knative.dev/release: "v1.2.4"
+    eventing.knative.dev/release: "v1.8.1"
     knative.dev/crd-install: "true"
     duck.knative.dev/addressable: "true"
-    app.kubernetes.io/version: "1.2.4"
+    app.kubernetes.io/version: "1.8.1"
     app.kubernetes.io/name: knative-eventing
 spec:
   group: flows.knative.dev
@@ -2157,11 +2230,11 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   labels:
-    eventing.knative.dev/release: "v1.2.4"
+    eventing.knative.dev/release: "v1.8.1"
     eventing.knative.dev/source: "true"
     duck.knative.dev/source: "true"
     knative.dev/crd-install: "true"
-    app.kubernetes.io/version: "1.2.4"
+    app.kubernetes.io/version: "1.8.1"
     app.kubernetes.io/name: knative-eventing
   annotations:
     registry.knative.dev/eventTypes: |
@@ -2459,10 +2532,10 @@ kind: CustomResourceDefinition
 metadata:
   name: sequences.flows.knative.dev
   labels:
-    eventing.knative.dev/release: "v1.2.4"
+    eventing.knative.dev/release: "v1.8.1"
     knative.dev/crd-install: "true"
     duck.knative.dev/addressable: "true"
-    app.kubernetes.io/version: "1.2.4"
+    app.kubernetes.io/version: "1.8.1"
     app.kubernetes.io/name: knative-eventing
 spec:
   group: flows.knative.dev
@@ -2764,12 +2837,12 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   labels:
-    eventing.knative.dev/release: "v1.2.4"
+    eventing.knative.dev/release: "v1.8.1"
     eventing.knative.dev/source: "true"
     duck.knative.dev/source: "true"
     duck.knative.dev/binding: "true"
     knative.dev/crd-install: "true"
-    app.kubernetes.io/version: "1.2.4"
+    app.kubernetes.io/version: "1.8.1"
     app.kubernetes.io/name: knative-eventing
   name: sinkbindings.sources.knative.dev
 spec:
@@ -2942,9 +3015,9 @@ kind: CustomResourceDefinition
 metadata:
   name: subscriptions.messaging.knative.dev
   labels:
-    eventing.knative.dev/release: "v1.2.4"
+    eventing.knative.dev/release: "v1.8.1"
     knative.dev/crd-install: "true"
-    app.kubernetes.io/version: "1.2.4"
+    app.kubernetes.io/version: "1.8.1"
     app.kubernetes.io/name: knative-eventing
 spec:
   group: messaging.knative.dev
@@ -3139,9 +3212,9 @@ kind: CustomResourceDefinition
 metadata:
   name: triggers.eventing.knative.dev
   labels:
-    eventing.knative.dev/release: "v1.2.4"
+    eventing.knative.dev/release: "v1.8.1"
     knative.dev/crd-install: "true"
-    app.kubernetes.io/version: "1.2.4"
+    app.kubernetes.io/version: "1.8.1"
     app.kubernetes.io/name: knative-eventing
 spec:
   group: eventing.knative.dev
@@ -3309,8 +3382,8 @@ kind: ClusterRole
 metadata:
   name: addressable-resolver
   labels:
-    eventing.knative.dev/release: "v1.2.4"
-    app.kubernetes.io/version: "1.2.4"
+    eventing.knative.dev/release: "v1.8.1"
+    app.kubernetes.io/version: "1.8.1"
     app.kubernetes.io/name: knative-eventing
 aggregationRule:
   clusterRoleSelectors:
@@ -3323,9 +3396,9 @@ apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: service-addressable-resolver
   labels:
-    eventing.knative.dev/release: "v1.2.4"
+    eventing.knative.dev/release: "v1.8.1"
     duck.knative.dev/addressable: "true"
-    app.kubernetes.io/version: "1.2.4"
+    app.kubernetes.io/version: "1.8.1"
     app.kubernetes.io/name: knative-eventing
 rules:
   - apiGroups:
@@ -3342,9 +3415,9 @@ apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: serving-addressable-resolver
   labels:
-    eventing.knative.dev/release: "v1.2.4"
+    eventing.knative.dev/release: "v1.8.1"
     duck.knative.dev/addressable: "true"
-    app.kubernetes.io/version: "1.2.4"
+    app.kubernetes.io/version: "1.8.1"
     app.kubernetes.io/name: knative-eventing
 rules:
   - apiGroups:
@@ -3364,9 +3437,9 @@ apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: channel-addressable-resolver
   labels:
-    eventing.knative.dev/release: "v1.2.4"
+    eventing.knative.dev/release: "v1.8.1"
     duck.knative.dev/addressable: "true"
-    app.kubernetes.io/version: "1.2.4"
+    app.kubernetes.io/version: "1.8.1"
     app.kubernetes.io/name: knative-eventing
 rules:
   - apiGroups:
@@ -3390,9 +3463,9 @@ apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: broker-addressable-resolver
   labels:
-    eventing.knative.dev/release: "v1.2.4"
+    eventing.knative.dev/release: "v1.8.1"
     duck.knative.dev/addressable: "true"
-    app.kubernetes.io/version: "1.2.4"
+    app.kubernetes.io/version: "1.8.1"
     app.kubernetes.io/name: knative-eventing
 rules:
   - apiGroups:
@@ -3410,9 +3483,9 @@ apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: flows-addressable-resolver
   labels:
-    eventing.knative.dev/release: "v1.2.4"
+    eventing.knative.dev/release: "v1.8.1"
     duck.knative.dev/addressable: "true"
-    app.kubernetes.io/version: "1.2.4"
+    app.kubernetes.io/version: "1.8.1"
     app.kubernetes.io/name: knative-eventing
 rules:
   - apiGroups:
@@ -3432,8 +3505,8 @@ kind: ClusterRole
 metadata:
   name: eventing-broker-filter
   labels:
-    eventing.knative.dev/release: "v1.2.4"
-    app.kubernetes.io/version: "1.2.4"
+    eventing.knative.dev/release: "v1.8.1"
+    app.kubernetes.io/version: "1.8.1"
     app.kubernetes.io/name: knative-eventing
 rules:
   - apiGroups:
@@ -3459,8 +3532,8 @@ kind: ClusterRole
 metadata:
   name: eventing-broker-ingress
   labels:
-    eventing.knative.dev/release: "v1.2.4"
-    app.kubernetes.io/version: "1.2.4"
+    eventing.knative.dev/release: "v1.8.1"
+    app.kubernetes.io/version: "1.8.1"
     app.kubernetes.io/name: knative-eventing
 rules:
   - apiGroups:
@@ -3477,8 +3550,8 @@ kind: ClusterRole
 metadata:
   name: eventing-config-reader
   labels:
-    eventing.knative.dev/release: "v1.2.4"
-    app.kubernetes.io/version: "1.2.4"
+    eventing.knative.dev/release: "v1.8.1"
+    app.kubernetes.io/version: "1.8.1"
     app.kubernetes.io/name: knative-eventing
 rules:
   - apiGroups:
@@ -3495,8 +3568,8 @@ kind: ClusterRole
 metadata:
   name: channelable-manipulator
   labels:
-    eventing.knative.dev/release: "v1.2.4"
-    app.kubernetes.io/version: "1.2.4"
+    eventing.knative.dev/release: "v1.8.1"
+    app.kubernetes.io/version: "1.8.1"
     app.kubernetes.io/name: knative-eventing
 aggregationRule:
   clusterRoleSelectors:
@@ -3509,9 +3582,9 @@ kind: ClusterRole
 metadata:
   name: meta-channelable-manipulator
   labels:
-    eventing.knative.dev/release: "v1.2.4"
+    eventing.knative.dev/release: "v1.8.1"
     duck.knative.dev/channelable: "true"
-    app.kubernetes.io/version: "1.2.4"
+    app.kubernetes.io/version: "1.8.1"
     app.kubernetes.io/name: knative-eventing
 rules:
   - apiGroups:
@@ -3533,9 +3606,9 @@ apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: knative-eventing-namespaced-admin
   labels:
-    eventing.knative.dev/release: "v1.2.4"
+    eventing.knative.dev/release: "v1.8.1"
     rbac.authorization.k8s.io/aggregate-to-admin: "true"
-    app.kubernetes.io/version: "1.2.4"
+    app.kubernetes.io/version: "1.8.1"
     app.kubernetes.io/name: knative-eventing
 rules:
   - apiGroups: ["eventing.knative.dev"]
@@ -3547,9 +3620,9 @@ apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: knative-messaging-namespaced-admin
   labels:
-    eventing.knative.dev/release: "v1.2.4"
+    eventing.knative.dev/release: "v1.8.1"
     rbac.authorization.k8s.io/aggregate-to-admin: "true"
-    app.kubernetes.io/version: "1.2.4"
+    app.kubernetes.io/version: "1.8.1"
     app.kubernetes.io/name: knative-eventing
 rules:
   - apiGroups: ["messaging.knative.dev"]
@@ -3561,9 +3634,9 @@ apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: knative-flows-namespaced-admin
   labels:
-    eventing.knative.dev/release: "v1.2.4"
+    eventing.knative.dev/release: "v1.8.1"
     rbac.authorization.k8s.io/aggregate-to-admin: "true"
-    app.kubernetes.io/version: "1.2.4"
+    app.kubernetes.io/version: "1.8.1"
     app.kubernetes.io/name: knative-eventing
 rules:
   - apiGroups: ["flows.knative.dev"]
@@ -3575,9 +3648,9 @@ apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: knative-sources-namespaced-admin
   labels:
-    eventing.knative.dev/release: "v1.2.4"
+    eventing.knative.dev/release: "v1.8.1"
     rbac.authorization.k8s.io/aggregate-to-admin: "true"
-    app.kubernetes.io/version: "1.2.4"
+    app.kubernetes.io/version: "1.8.1"
     app.kubernetes.io/name: knative-eventing
 rules:
   - apiGroups: ["sources.knative.dev"]
@@ -3589,9 +3662,9 @@ apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: knative-bindings-namespaced-admin
   labels:
-    eventing.knative.dev/release: "v1.2.4"
+    eventing.knative.dev/release: "v1.8.1"
     rbac.authorization.k8s.io/aggregate-to-admin: "true"
-    app.kubernetes.io/version: "1.2.4"
+    app.kubernetes.io/version: "1.8.1"
     app.kubernetes.io/name: knative-eventing
 rules:
   - apiGroups: ["bindings.knative.dev"]
@@ -3604,8 +3677,8 @@ metadata:
   name: knative-eventing-namespaced-edit
   labels:
     rbac.authorization.k8s.io/aggregate-to-edit: "true"
-    eventing.knative.dev/release: "v1.2.4"
-    app.kubernetes.io/version: "1.2.4"
+    eventing.knative.dev/release: "v1.8.1"
+    app.kubernetes.io/version: "1.8.1"
     app.kubernetes.io/name: knative-eventing
 rules:
   - apiGroups: ["eventing.knative.dev", "messaging.knative.dev", "sources.knative.dev", "flows.knative.dev", "bindings.knative.dev"]
@@ -3618,8 +3691,8 @@ metadata:
   name: knative-eventing-namespaced-view
   labels:
     rbac.authorization.k8s.io/aggregate-to-view: "true"
-    eventing.knative.dev/release: "v1.2.4"
-    app.kubernetes.io/version: "1.2.4"
+    eventing.knative.dev/release: "v1.8.1"
+    app.kubernetes.io/version: "1.8.1"
     app.kubernetes.io/name: knative-eventing
 rules:
   - apiGroups: ["eventing.knative.dev", "messaging.knative.dev", "sources.knative.dev", "flows.knative.dev", "bindings.knative.dev"]
@@ -3631,8 +3704,8 @@ kind: ClusterRole
 metadata:
   name: knative-eventing-controller
   labels:
-    eventing.knative.dev/release: "v1.2.4"
-    app.kubernetes.io/version: "1.2.4"
+    eventing.knative.dev/release: "v1.8.1"
+    app.kubernetes.io/version: "1.8.1"
     app.kubernetes.io/name: knative-eventing
 rules:
   - apiGroups:
@@ -3783,8 +3856,8 @@ kind: ClusterRole
 metadata:
   name: knative-eventing-pingsource-mt-adapter
   labels:
-    eventing.knative.dev/release: "v1.2.4"
-    app.kubernetes.io/version: "1.2.4"
+    eventing.knative.dev/release: "v1.8.1"
+    app.kubernetes.io/version: "1.8.1"
     app.kubernetes.io/name: knative-eventing
 rules:
   - apiGroups:
@@ -3835,8 +3908,8 @@ kind: ClusterRole
 metadata:
   name: podspecable-binding
   labels:
-    eventing.knative.dev/release: "v1.2.4"
-    app.kubernetes.io/version: "1.2.4"
+    eventing.knative.dev/release: "v1.8.1"
+    app.kubernetes.io/version: "1.8.1"
     app.kubernetes.io/name: knative-eventing
 aggregationRule:
   clusterRoleSelectors:
@@ -3849,9 +3922,9 @@ apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: builtin-podspecable-binding
   labels:
-    eventing.knative.dev/release: "v1.2.4"
+    eventing.knative.dev/release: "v1.8.1"
     duck.knative.dev/podspecable: "true"
-    app.kubernetes.io/version: "1.2.4"
+    app.kubernetes.io/version: "1.8.1"
     app.kubernetes.io/name: knative-eventing
 rules:
   - apiGroups:
@@ -3879,8 +3952,8 @@ kind: ClusterRole
 metadata:
   name: source-observer
   labels:
-    eventing.knative.dev/release: "v1.2.4"
-    app.kubernetes.io/version: "1.2.4"
+    eventing.knative.dev/release: "v1.8.1"
+    app.kubernetes.io/version: "1.8.1"
     app.kubernetes.io/name: knative-eventing
 aggregationRule:
   clusterRoleSelectors:
@@ -3893,9 +3966,9 @@ apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: eventing-sources-source-observer
   labels:
-    eventing.knative.dev/release: "v1.2.4"
+    eventing.knative.dev/release: "v1.8.1"
     duck.knative.dev/source: "true"
-    app.kubernetes.io/version: "1.2.4"
+    app.kubernetes.io/version: "1.8.1"
     app.kubernetes.io/name: knative-eventing
 rules:
   - apiGroups:
@@ -3915,8 +3988,8 @@ kind: ClusterRole
 metadata:
   name: knative-eventing-sources-controller
   labels:
-    eventing.knative.dev/release: "v1.2.4"
-    app.kubernetes.io/version: "1.2.4"
+    eventing.knative.dev/release: "v1.8.1"
+    app.kubernetes.io/version: "1.8.1"
     app.kubernetes.io/name: knative-eventing
 rules:
   - apiGroups:
@@ -4016,8 +4089,8 @@ kind: ClusterRole
 metadata:
   name: knative-eventing-webhook
   labels:
-    eventing.knative.dev/release: "v1.2.4"
-    app.kubernetes.io/version: "1.2.4"
+    eventing.knative.dev/release: "v1.8.1"
+    app.kubernetes.io/version: "1.8.1"
     app.kubernetes.io/name: knative-eventing
 rules:
   - apiGroups:
@@ -4106,8 +4179,8 @@ metadata:
   namespace: knative-eventing
   name: knative-eventing-webhook
   labels:
-    eventing.knative.dev/release: "v1.2.4"
-    app.kubernetes.io/version: "1.2.4"
+    eventing.knative.dev/release: "v1.8.1"
+    app.kubernetes.io/version: "1.8.1"
     app.kubernetes.io/name: knative-eventing
 rules:
   - apiGroups:
@@ -4127,8 +4200,8 @@ kind: ValidatingWebhookConfiguration
 metadata:
   name: config.webhook.eventing.knative.dev
   labels:
-    eventing.knative.dev/release: "v1.2.4"
-    app.kubernetes.io/version: "1.2.4"
+    eventing.knative.dev/release: "v1.8.1"
+    app.kubernetes.io/version: "1.8.1"
     app.kubernetes.io/name: knative-eventing
 webhooks:
   - admissionReviewVersions: ["v1", "v1beta1"]
@@ -4150,8 +4223,8 @@ kind: MutatingWebhookConfiguration
 metadata:
   name: webhook.eventing.knative.dev
   labels:
-    eventing.knative.dev/release: "v1.2.4"
-    app.kubernetes.io/version: "1.2.4"
+    eventing.knative.dev/release: "v1.8.1"
+    app.kubernetes.io/version: "1.8.1"
     app.kubernetes.io/name: knative-eventing
 webhooks:
   - admissionReviewVersions: ["v1", "v1beta1"]
@@ -4169,8 +4242,8 @@ kind: ValidatingWebhookConfiguration
 metadata:
   name: validation.webhook.eventing.knative.dev
   labels:
-    eventing.knative.dev/release: "v1.2.4"
-    app.kubernetes.io/version: "1.2.4"
+    eventing.knative.dev/release: "v1.8.1"
+    app.kubernetes.io/version: "1.8.1"
     app.kubernetes.io/name: knative-eventing
 webhooks:
   - admissionReviewVersions: ["v1", "v1beta1"]
@@ -4189,8 +4262,8 @@ metadata:
   name: eventing-webhook-certs
   namespace: knative-eventing
   labels:
-    eventing.knative.dev/release: "v1.2.4"
-    app.kubernetes.io/version: "1.2.4"
+    eventing.knative.dev/release: "v1.8.1"
+    app.kubernetes.io/version: "1.8.1"
     app.kubernetes.io/name: knative-eventing
 ---
 apiVersion: admissionregistration.k8s.io/v1
@@ -4198,8 +4271,8 @@ kind: MutatingWebhookConfiguration
 metadata:
   name: sinkbindings.webhook.sources.knative.dev
   labels:
-    eventing.knative.dev/release: "v1.2.4"
-    app.kubernetes.io/version: "1.2.4"
+    eventing.knative.dev/release: "v1.8.1"
+    app.kubernetes.io/version: "1.8.1"
     app.kubernetes.io/name: knative-eventing
 webhooks:
   - admissionReviewVersions: ["v1", "v1beta1"]

--- a/common/knative/knative-eventing/base/upstream/in-memory-channel.yaml
+++ b/common/knative/knative-eventing/base/upstream/in-memory-channel.yaml
@@ -1,20 +1,11 @@
 apiVersion: v1
-kind: Namespace
-metadata:
-  name: knative-eventing
-  labels:
-    eventing.knative.dev/release: "v1.2.4"
-    app.kubernetes.io/version: "1.2.4"
-    app.kubernetes.io/name: knative-eventing
----
-apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: imc-controller
   namespace: knative-eventing
   labels:
-    eventing.knative.dev/release: "v1.2.4"
-    app.kubernetes.io/version: "1.2.4"
+    eventing.knative.dev/release: "v1.8.1"
+    app.kubernetes.io/version: "1.8.1"
     app.kubernetes.io/name: knative-eventing
 ---
 apiVersion: rbac.authorization.k8s.io/v1
@@ -22,8 +13,8 @@ kind: ClusterRoleBinding
 metadata:
   name: imc-controller
   labels:
-    eventing.knative.dev/release: "v1.2.4"
-    app.kubernetes.io/version: "1.2.4"
+    eventing.knative.dev/release: "v1.8.1"
+    app.kubernetes.io/version: "1.8.1"
     app.kubernetes.io/name: knative-eventing
 subjects:
   - kind: ServiceAccount
@@ -40,8 +31,8 @@ metadata:
   namespace: knative-eventing
   name: imc-controller
   labels:
-    eventing.knative.dev/release: "v1.2.4"
-    app.kubernetes.io/version: "1.2.4"
+    eventing.knative.dev/release: "v1.8.1"
+    app.kubernetes.io/version: "1.8.1"
     app.kubernetes.io/name: knative-eventing
 subjects:
   - kind: ServiceAccount
@@ -57,8 +48,8 @@ kind: ClusterRoleBinding
 metadata:
   name: imc-controller-resolver
   labels:
-    eventing.knative.dev/release: "v1.2.4"
-    app.kubernetes.io/version: "1.2.4"
+    eventing.knative.dev/release: "v1.8.1"
+    app.kubernetes.io/version: "1.8.1"
     app.kubernetes.io/name: knative-eventing
 subjects:
   - kind: ServiceAccount
@@ -75,8 +66,8 @@ metadata:
   name: imc-dispatcher
   namespace: knative-eventing
   labels:
-    eventing.knative.dev/release: "v1.2.4"
-    app.kubernetes.io/version: "1.2.4"
+    eventing.knative.dev/release: "v1.8.1"
+    app.kubernetes.io/version: "1.8.1"
     app.kubernetes.io/name: knative-eventing
 ---
 apiVersion: rbac.authorization.k8s.io/v1
@@ -84,8 +75,8 @@ kind: ClusterRoleBinding
 metadata:
   name: imc-dispatcher
   labels:
-    eventing.knative.dev/release: "v1.2.4"
-    app.kubernetes.io/version: "1.2.4"
+    eventing.knative.dev/release: "v1.8.1"
+    app.kubernetes.io/version: "1.8.1"
     app.kubernetes.io/name: knative-eventing
 subjects:
   - kind: ServiceAccount
@@ -102,118 +93,13 @@ metadata:
   name: config-imc-event-dispatcher
   namespace: knative-eventing
   labels:
-    eventing.knative.dev/release: "v1.2.4"
+    eventing.knative.dev/release: "v1.8.1"
     app.kubernetes.io/component: imc-controller
-    app.kubernetes.io/version: "1.2.4"
+    app.kubernetes.io/version: "1.8.1"
     app.kubernetes.io/name: knative-eventing
 data:
   MaxIdleConnections: "1000"
   MaxIdleConnectionsPerHost: "100"
----
-apiVersion: v1
-kind: ConfigMap
-metadata:
-  name: config-observability
-  namespace: knative-eventing
-  labels:
-    eventing.knative.dev/release: "v1.2.4"
-    knative.dev/config-propagation: original
-    knative.dev/config-category: eventing
-    app.kubernetes.io/version: "1.2.4"
-    app.kubernetes.io/name: knative-eventing
-  annotations:
-    knative.dev/example-checksum: "f46cf09d"
-data:
-  _example: |
-    ################################
-    #                              #
-    #    EXAMPLE CONFIGURATION     #
-    #                              #
-    ################################
-
-    # This block is not actually functional configuration,
-    # but serves to illustrate the available configuration
-    # options and document them in a way that is accessible
-    # to users that `kubectl edit` this config map.
-    #
-    # These sample configuration options may be copied out of
-    # this example block and unindented to be in the data block
-    # to actually change the configuration.
-
-    # metrics.backend-destination field specifies the system metrics destination.
-    # It supports either prometheus (the default) or stackdriver.
-    # Note: Using stackdriver will incur additional charges
-    metrics.backend-destination: prometheus
-
-    # metrics.request-metrics-backend-destination specifies the request metrics
-    # destination. If non-empty, it enables queue proxy to send request metrics.
-    # Currently supported values: prometheus, stackdriver.
-    metrics.request-metrics-backend-destination: prometheus
-
-    # metrics.stackdriver-project-id field specifies the stackdriver project ID. This
-    # field is optional. When running on GCE, application default credentials will be
-    # used if this field is not provided.
-    metrics.stackdriver-project-id: "<your stackdriver project id>"
-
-    # metrics.allow-stackdriver-custom-metrics indicates whether it is allowed to send metrics to
-    # Stackdriver using "global" resource type and custom metric type if the
-    # metrics are not supported by "knative_broker", "knative_trigger", and "knative_source" resource types.
-    # Setting this flag to "true" could cause extra Stackdriver charge.
-    # If metrics.backend-destination is not Stackdriver, this is ignored.
-    metrics.allow-stackdriver-custom-metrics: "false"
-
-    # profiling.enable indicates whether it is allowed to retrieve runtime profiling data from
-    # the pods via an HTTP server in the format expected by the pprof visualization tool. When
-    # enabled, the Knative Eventing pods expose the profiling data on an alternate HTTP port 8008.
-    # The HTTP context root for profiling is then /debug/pprof/.
-    profiling.enable: "false"
-
-    # sink-event-error-reporting.enable whether the adapter reports a kube event to the CRD indicating
-    # a failure to send a cloud event to the sink.
-    sink-event-error-reporting.enable: "false"
----
-apiVersion: v1
-kind: ConfigMap
-metadata:
-  name: config-tracing
-  namespace: knative-eventing
-  labels:
-    eventing.knative.dev/release: "v1.2.4"
-    knative.dev/config-propagation: original
-    knative.dev/config-category: eventing
-    app.kubernetes.io/version: "1.2.4"
-    app.kubernetes.io/name: knative-eventing
-  annotations:
-    knative.dev/example-checksum: "c8f8c47b"
-data:
-  _example: |
-    ################################
-    #                              #
-    #    EXAMPLE CONFIGURATION     #
-    #                              #
-    ################################
-    # This block is not actually functional configuration,
-    # but serves to illustrate the available configuration
-    # options and document them in a way that is accessible
-    # to users that `kubectl edit` this config map.
-    #
-    # These sample configuration options may be copied out of
-    # this example block and unindented to be in the data block
-    # to actually change the configuration.
-    #
-    # This may be "zipkin" or "none", the default is "none"
-    backend: "none"
-
-    # URL to zipkin collector where traces are sent.
-    # This must be specified when backend is "zipkin"
-    zipkin-endpoint: "http://zipkin.istio-system.svc.cluster.local:9411/api/v2/spans"
-
-    # Enable zipkin debug mode. This allows all spans to be sent to the server
-    # bypassing sampling.
-    debug: "false"
-
-    # Percentage (0-1) of requests to trace
-    sample-rate: "0.1"
 ---
 apiVersion: apps/v1
 kind: Deployment
@@ -221,10 +107,10 @@ metadata:
   name: imc-controller
   namespace: knative-eventing
   labels:
-    eventing.knative.dev/release: "v1.2.4"
+    eventing.knative.dev/release: "v1.8.1"
     knative.dev/high-availability: "true"
     app.kubernetes.io/component: imc-controller
-    app.kubernetes.io/version: "1.2.4"
+    app.kubernetes.io/version: "1.8.1"
     app.kubernetes.io/name: knative-eventing
 spec:
   selector:
@@ -237,7 +123,7 @@ spec:
         messaging.knative.dev/channel: in-memory-channel
         messaging.knative.dev/role: controller
         app.kubernetes.io/component: imc-controller
-        app.kubernetes.io/version: "1.2.4"
+        app.kubernetes.io/version: "1.8.1"
         app.kubernetes.io/name: knative-eventing
     spec:
       affinity:
@@ -254,7 +140,7 @@ spec:
       enableServiceLinks: false
       containers:
         - name: controller
-          image: gcr.io/knative-releases/knative.dev/eventing/cmd/in_memory/channel_controller@sha256:a602de59eab2140a9a7639e221b777aa1bd5b9b4203e09dacdc32850f4414e4f
+          image: gcr.io/knative-releases/knative.dev/eventing/cmd/in_memory/channel_controller@sha256:f40825f7b4384ba8baac90018c42e4fd8aa2e37ad7a9e1c00c8858b73ed8d987
           env:
             - name: WEBHOOK_NAME
               value: inmemorychannel-webhook
@@ -271,7 +157,7 @@ spec:
                 fieldRef:
                   fieldPath: metadata.namespace
             - name: DISPATCHER_IMAGE
-              value: gcr.io/knative-releases/knative.dev/eventing/cmd/in_memory/channel_dispatcher@sha256:cd4502677aedc0779be980c5e7186cdc8e7557a036048480f8a3431ec1b3b873
+              value: gcr.io/knative-releases/knative.dev/eventing/cmd/in_memory/channel_dispatcher@sha256:eef625176c57aab4c3061428b787f844529dfd19b82cf50ccaffc909072d568f
             - name: POD_NAME
               valueFrom:
                 fieldRef:
@@ -282,7 +168,9 @@ spec:
             runAsNonRoot: true
             capabilities:
               drop:
-                - all
+                - ALL
+            seccompProfile:
+              type: RuntimeDefault
           ports:
             - name: metrics
               containerPort: 9090
@@ -306,7 +194,7 @@ spec:
               httpHeaders:
                 - name: k-kubelet-probe
                   value: "webhook"
-            initialDelaySeconds: 20
+            initialDelaySeconds: 120
       terminationGracePeriodSeconds: 300
 ---
 apiVersion: v1
@@ -314,9 +202,9 @@ kind: Service
 metadata:
   labels:
     app.kubernetes.io/component: imc-controller
-    app.kubernetes.io/version: "1.2.4"
+    app.kubernetes.io/version: "1.8.1"
     app.kubernetes.io/name: knative-eventing
-    eventing.knative.dev/release: "v1.2.4"
+    eventing.knative.dev/release: "v1.8.1"
   name: inmemorychannel-webhook
   namespace: knative-eventing
 spec:
@@ -340,11 +228,11 @@ metadata:
   name: imc-dispatcher
   namespace: knative-eventing
   labels:
-    eventing.knative.dev/release: "v1.2.4"
+    eventing.knative.dev/release: "v1.8.1"
     messaging.knative.dev/channel: in-memory-channel
     messaging.knative.dev/role: dispatcher
     app.kubernetes.io/component: imc-dispatcher
-    app.kubernetes.io/version: "1.2.4"
+    app.kubernetes.io/version: "1.8.1"
     app.kubernetes.io/name: knative-eventing
 spec:
   selector:
@@ -365,10 +253,10 @@ metadata:
   name: imc-dispatcher
   namespace: knative-eventing
   labels:
-    eventing.knative.dev/release: "v1.2.4"
+    eventing.knative.dev/release: "v1.8.1"
     knative.dev/high-availability: "true"
     app.kubernetes.io/component: imc-dispatcher
-    app.kubernetes.io/version: "1.2.4"
+    app.kubernetes.io/version: "1.8.1"
     app.kubernetes.io/name: knative-eventing
 spec:
   selector:
@@ -381,7 +269,7 @@ spec:
         messaging.knative.dev/channel: in-memory-channel
         messaging.knative.dev/role: dispatcher
         app.kubernetes.io/component: imc-dispatcher
-        app.kubernetes.io/version: "1.2.4"
+        app.kubernetes.io/version: "1.8.1"
         app.kubernetes.io/name: knative-eventing
     spec:
       affinity:
@@ -398,7 +286,7 @@ spec:
       enableServiceLinks: false
       containers:
         - name: dispatcher
-          image: gcr.io/knative-releases/knative.dev/eventing/cmd/in_memory/channel_dispatcher@sha256:cd4502677aedc0779be980c5e7186cdc8e7557a036048480f8a3431ec1b3b873
+          image: gcr.io/knative-releases/knative.dev/eventing/cmd/in_memory/channel_dispatcher@sha256:eef625176c57aab4c3061428b787f844529dfd19b82cf50ccaffc909072d568f
           readinessProbe:
             failureThreshold: 3
             httpGet:
@@ -451,18 +339,20 @@ spec:
             runAsNonRoot: true
             capabilities:
               drop:
-                - all
+                - ALL
+            seccompProfile:
+              type: RuntimeDefault
 ---
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   name: inmemorychannels.messaging.knative.dev
   labels:
-    eventing.knative.dev/release: "v1.2.4"
+    eventing.knative.dev/release: "v1.8.1"
     knative.dev/crd-install: "true"
     messaging.knative.dev/subscribable: "true"
     duck.knative.dev/addressable: "true"
-    app.kubernetes.io/version: "1.2.4"
+    app.kubernetes.io/version: "1.8.1"
     app.kubernetes.io/name: knative-eventing
 spec:
   group: messaging.knative.dev
@@ -689,9 +579,9 @@ kind: ClusterRole
 metadata:
   name: imc-addressable-resolver
   labels:
-    eventing.knative.dev/release: "v1.2.4"
+    eventing.knative.dev/release: "v1.8.1"
     duck.knative.dev/addressable: "true"
-    app.kubernetes.io/version: "1.2.4"
+    app.kubernetes.io/version: "1.8.1"
     app.kubernetes.io/name: knative-eventing
 rules:
   - apiGroups:
@@ -709,9 +599,9 @@ kind: ClusterRole
 metadata:
   name: imc-channelable-manipulator
   labels:
-    eventing.knative.dev/release: "v1.2.4"
+    eventing.knative.dev/release: "v1.8.1"
     duck.knative.dev/channelable: "true"
-    app.kubernetes.io/version: "1.2.4"
+    app.kubernetes.io/version: "1.8.1"
     app.kubernetes.io/name: knative-eventing
 rules:
   - apiGroups:
@@ -733,8 +623,8 @@ kind: ClusterRole
 metadata:
   name: imc-controller
   labels:
-    eventing.knative.dev/release: "v1.2.4"
-    app.kubernetes.io/version: "1.2.4"
+    eventing.knative.dev/release: "v1.8.1"
+    app.kubernetes.io/version: "1.8.1"
     app.kubernetes.io/name: knative-eventing
 rules:
   - apiGroups:
@@ -873,8 +763,8 @@ kind: ClusterRole
 metadata:
   name: imc-dispatcher
   labels:
-    eventing.knative.dev/release: "v1.2.4"
-    app.kubernetes.io/version: "1.2.4"
+    eventing.knative.dev/release: "v1.8.1"
+    app.kubernetes.io/version: "1.8.1"
     app.kubernetes.io/name: knative-eventing
 rules:
   - apiGroups:
@@ -927,8 +817,8 @@ metadata:
   namespace: knative-eventing
   name: knative-inmemorychannel-webhook
   labels:
-    eventing.knative.dev/release: "v1.2.4"
-    app.kubernetes.io/version: "1.2.4"
+    eventing.knative.dev/release: "v1.8.1"
+    app.kubernetes.io/version: "1.8.1"
     app.kubernetes.io/name: knative-eventing
 rules:
   - apiGroups:
@@ -948,8 +838,8 @@ kind: MutatingWebhookConfiguration
 metadata:
   name: inmemorychannel.eventing.knative.dev
   labels:
-    eventing.knative.dev/release: "v1.2.4"
-    app.kubernetes.io/version: "1.2.4"
+    eventing.knative.dev/release: "v1.8.1"
+    app.kubernetes.io/version: "1.8.1"
     app.kubernetes.io/name: knative-eventing
 webhooks:
   - admissionReviewVersions: ["v1"]
@@ -967,8 +857,8 @@ kind: ValidatingWebhookConfiguration
 metadata:
   name: validation.inmemorychannel.eventing.knative.dev
   labels:
-    eventing.knative.dev/release: "v1.2.4"
-    app.kubernetes.io/version: "1.2.4"
+    eventing.knative.dev/release: "v1.8.1"
+    app.kubernetes.io/version: "1.8.1"
     app.kubernetes.io/name: knative-eventing
 webhooks:
   - admissionReviewVersions: ["v1"]
@@ -987,8 +877,8 @@ metadata:
   name: inmemorychannel-webhook-certs
   namespace: knative-eventing
   labels:
-    eventing.knative.dev/release: "v1.2.4"
-    app.kubernetes.io/version: "1.2.4"
+    eventing.knative.dev/release: "v1.8.1"
+    app.kubernetes.io/version: "1.8.1"
     app.kubernetes.io/name: knative-eventing
 ---
 

--- a/common/knative/knative-eventing/base/upstream/mt-channel-broker.yaml
+++ b/common/knative/knative-eventing/base/upstream/mt-channel-broker.yaml
@@ -3,8 +3,8 @@ kind: ClusterRole
 metadata:
   name: knative-eventing-mt-channel-broker-controller
   labels:
-    eventing.knative.dev/release: "v1.2.4"
-    app.kubernetes.io/version: "1.2.4"
+    eventing.knative.dev/release: "v1.8.1"
+    app.kubernetes.io/version: "1.8.1"
     app.kubernetes.io/name: knative-eventing
 rules:
   - apiGroups:
@@ -31,8 +31,8 @@ kind: ClusterRole
 metadata:
   name: knative-eventing-mt-broker-filter
   labels:
-    eventing.knative.dev/release: "v1.2.4"
-    app.kubernetes.io/version: "1.2.4"
+    eventing.knative.dev/release: "v1.8.1"
+    app.kubernetes.io/version: "1.8.1"
     app.kubernetes.io/name: knative-eventing
 rules:
   - apiGroups:
@@ -59,8 +59,8 @@ metadata:
   name: mt-broker-filter
   namespace: knative-eventing
   labels:
-    eventing.knative.dev/release: "v1.2.4"
-    app.kubernetes.io/version: "1.2.4"
+    eventing.knative.dev/release: "v1.8.1"
+    app.kubernetes.io/version: "1.8.1"
     app.kubernetes.io/name: knative-eventing
 ---
 apiVersion: rbac.authorization.k8s.io/v1
@@ -68,8 +68,8 @@ kind: ClusterRole
 metadata:
   name: knative-eventing-mt-broker-ingress
   labels:
-    eventing.knative.dev/release: "v1.2.4"
-    app.kubernetes.io/version: "1.2.4"
+    eventing.knative.dev/release: "v1.8.1"
+    app.kubernetes.io/version: "1.8.1"
     app.kubernetes.io/name: knative-eventing
 rules:
   - apiGroups:
@@ -95,8 +95,8 @@ metadata:
   name: mt-broker-ingress
   namespace: knative-eventing
   labels:
-    eventing.knative.dev/release: "v1.2.4"
-    app.kubernetes.io/version: "1.2.4"
+    eventing.knative.dev/release: "v1.8.1"
+    app.kubernetes.io/version: "1.8.1"
     app.kubernetes.io/name: knative-eventing
 ---
 apiVersion: rbac.authorization.k8s.io/v1
@@ -104,8 +104,8 @@ kind: ClusterRoleBinding
 metadata:
   name: eventing-mt-channel-broker-controller
   labels:
-    eventing.knative.dev/release: "v1.2.4"
-    app.kubernetes.io/version: "1.2.4"
+    eventing.knative.dev/release: "v1.8.1"
+    app.kubernetes.io/version: "1.8.1"
     app.kubernetes.io/name: knative-eventing
 subjects:
   - kind: ServiceAccount
@@ -121,8 +121,8 @@ kind: ClusterRoleBinding
 metadata:
   name: knative-eventing-mt-broker-filter
   labels:
-    eventing.knative.dev/release: "v1.2.4"
-    app.kubernetes.io/version: "1.2.4"
+    eventing.knative.dev/release: "v1.8.1"
+    app.kubernetes.io/version: "1.8.1"
     app.kubernetes.io/name: knative-eventing
 subjects:
   - kind: ServiceAccount
@@ -138,8 +138,8 @@ kind: ClusterRoleBinding
 metadata:
   name: knative-eventing-mt-broker-ingress
   labels:
-    eventing.knative.dev/release: "v1.2.4"
-    app.kubernetes.io/version: "1.2.4"
+    eventing.knative.dev/release: "v1.8.1"
+    app.kubernetes.io/version: "1.8.1"
     app.kubernetes.io/name: knative-eventing
 subjects:
   - kind: ServiceAccount
@@ -156,9 +156,9 @@ metadata:
   name: mt-broker-filter
   namespace: knative-eventing
   labels:
-    eventing.knative.dev/release: "v1.2.4"
+    eventing.knative.dev/release: "v1.8.1"
     app.kubernetes.io/component: broker-filter
-    app.kubernetes.io/version: "1.2.4"
+    app.kubernetes.io/version: "1.8.1"
     app.kubernetes.io/name: knative-eventing
 spec:
   selector:
@@ -168,9 +168,9 @@ spec:
     metadata:
       labels:
         eventing.knative.dev/brokerRole: filter
-        eventing.knative.dev/release: "v1.2.4"
+        eventing.knative.dev/release: "v1.8.1"
         app.kubernetes.io/component: broker-filter
-        app.kubernetes.io/version: "1.2.4"
+        app.kubernetes.io/version: "1.8.1"
         app.kubernetes.io/name: knative-eventing
     spec:
       serviceAccountName: mt-broker-filter
@@ -178,7 +178,7 @@ spec:
       containers:
         - name: filter
           terminationMessagePolicy: FallbackToLogsOnError
-          image: gcr.io/knative-releases/knative.dev/eventing/cmd/broker/filter@sha256:f4bda104202557a75fce024329fc1f0e2d4ac43f4362007ed4201290f79c1d82
+          image: gcr.io/knative-releases/knative.dev/eventing/cmd/broker/filter@sha256:1155e66059a84b83d21e3360e03dcc28e933566e8a049c8882e75b541862b0cc
           readinessProbe:
             failureThreshold: 3
             httpGet:
@@ -241,16 +241,18 @@ spec:
             runAsNonRoot: true
             capabilities:
               drop:
-                - all
+                - ALL
+            seccompProfile:
+              type: RuntimeDefault
 ---
 apiVersion: v1
 kind: Service
 metadata:
   labels:
     eventing.knative.dev/brokerRole: filter
-    eventing.knative.dev/release: "v1.2.4"
+    eventing.knative.dev/release: "v1.8.1"
     app.kubernetes.io/component: broker-filter
-    app.kubernetes.io/version: "1.2.4"
+    app.kubernetes.io/version: "1.8.1"
     app.kubernetes.io/name: knative-eventing
   name: broker-filter
   namespace: knative-eventing
@@ -273,9 +275,9 @@ metadata:
   name: mt-broker-ingress
   namespace: knative-eventing
   labels:
-    eventing.knative.dev/release: "v1.2.4"
+    eventing.knative.dev/release: "v1.8.1"
     app.kubernetes.io/component: broker-ingress
-    app.kubernetes.io/version: "1.2.4"
+    app.kubernetes.io/version: "1.8.1"
     app.kubernetes.io/name: knative-eventing
 spec:
   selector:
@@ -285,9 +287,9 @@ spec:
     metadata:
       labels:
         eventing.knative.dev/brokerRole: ingress
-        eventing.knative.dev/release: "v1.2.4"
+        eventing.knative.dev/release: "v1.8.1"
         app.kubernetes.io/component: broker-ingress
-        app.kubernetes.io/version: "1.2.4"
+        app.kubernetes.io/version: "1.8.1"
         app.kubernetes.io/name: knative-eventing
     spec:
       serviceAccountName: mt-broker-ingress
@@ -295,7 +297,7 @@ spec:
       containers:
         - name: ingress
           terminationMessagePolicy: FallbackToLogsOnError
-          image: gcr.io/knative-releases/knative.dev/eventing/cmd/broker/ingress@sha256:1bbbdea02b6fc01f316addefe56fa33f583cd332d7213cbc2e4937234bfc3d1b
+          image: gcr.io/knative-releases/knative.dev/eventing/cmd/broker/ingress@sha256:5529e577c6262d78530531b26b3e940da5dec071304e9c639d00400f644463f8
           readinessProbe:
             failureThreshold: 3
             httpGet:
@@ -358,16 +360,18 @@ spec:
             runAsNonRoot: true
             capabilities:
               drop:
-                - all
+                - ALL
+            seccompProfile:
+              type: RuntimeDefault
 ---
 apiVersion: v1
 kind: Service
 metadata:
   labels:
     eventing.knative.dev/brokerRole: ingress
-    eventing.knative.dev/release: "v1.2.4"
+    eventing.knative.dev/release: "v1.8.1"
     app.kubernetes.io/component: broker-ingress
-    app.kubernetes.io/version: "1.2.4"
+    app.kubernetes.io/version: "1.8.1"
     app.kubernetes.io/name: knative-eventing
   name: broker-ingress
   namespace: knative-eventing
@@ -390,9 +394,9 @@ metadata:
   name: mt-broker-controller
   namespace: knative-eventing
   labels:
-    eventing.knative.dev/release: "v1.2.4"
+    eventing.knative.dev/release: "v1.8.1"
     app.kubernetes.io/component: mt-broker-controller
-    app.kubernetes.io/version: "1.2.4"
+    app.kubernetes.io/version: "1.8.1"
     app.kubernetes.io/name: knative-eventing
 spec:
   selector:
@@ -402,9 +406,9 @@ spec:
     metadata:
       labels:
         app: mt-broker-controller
-        eventing.knative.dev/release: "v1.2.4"
+        eventing.knative.dev/release: "v1.8.1"
         app.kubernetes.io/component: broker-controller
-        app.kubernetes.io/version: "1.2.4"
+        app.kubernetes.io/version: "1.8.1"
         app.kubernetes.io/name: knative-eventing
     spec:
       affinity:
@@ -421,7 +425,7 @@ spec:
       containers:
         - name: mt-broker-controller
           terminationMessagePolicy: FallbackToLogsOnError
-          image: gcr.io/knative-releases/knative.dev/eventing/cmd/mtchannel_broker@sha256:90e2b9413519d0634508ff848180fb50a341da09e53ac0408848f0663c7c8c3b
+          image: gcr.io/knative-releases/knative.dev/eventing/cmd/mtchannel_broker@sha256:1f2783738c0ba4e8f72cbbdd4bf5cef8a1dd7bfa57d0297f288c64f853ed58ef
           resources:
             requests:
               cpu: 100m
@@ -437,8 +441,6 @@ spec:
               value: config-observability
             - name: METRICS_DOMAIN
               value: knative.dev/eventing
-            - name: BROKER_INJECTION_DEFAULT
-              value: "false"
             - name: POD_NAME
               valueFrom:
                 fieldRef:
@@ -449,22 +451,24 @@ spec:
             runAsNonRoot: true
             capabilities:
               drop:
-                - all
+                - ALL
+            seccompProfile:
+              type: RuntimeDefault
           ports:
             - name: metrics
               containerPort: 9090
             - name: profiling
               containerPort: 8008
 ---
-apiVersion: autoscaling/v2beta2
+apiVersion: autoscaling/v2
 kind: HorizontalPodAutoscaler
 metadata:
   name: broker-ingress-hpa
   namespace: knative-eventing
   labels:
-    eventing.knative.dev/release: "v1.2.4"
+    eventing.knative.dev/release: "v1.8.1"
     app.kubernetes.io/component: broker-ingress
-    app.kubernetes.io/version: "1.2.4"
+    app.kubernetes.io/version: "1.8.1"
     app.kubernetes.io/name: knative-eventing
 spec:
   scaleTargetRef:
@@ -481,15 +485,15 @@ spec:
           type: Utilization
           averageUtilization: 70
 ---
-apiVersion: autoscaling/v2beta2
+apiVersion: autoscaling/v2
 kind: HorizontalPodAutoscaler
 metadata:
   name: broker-filter-hpa
   namespace: knative-eventing
   labels:
-    eventing.knative.dev/release: "v1.2.4"
+    eventing.knative.dev/release: "v1.8.1"
     app.kubernetes.io/component: broker-filter
-    app.kubernetes.io/version: "1.2.4"
+    app.kubernetes.io/version: "1.8.1"
     app.kubernetes.io/name: knative-eventing
 spec:
   scaleTargetRef:


### PR DESCRIPTION
Changes:

- Update knative eventing manifests to v1.8.1 to support K8s-v1.25
- Update README files (version references, instructions etc)
- Trigger the test workflow of each component, that uses Knative, when Knative-serving/eventing manifests are changed

Refs: https://github.com/kubeflow/manifests/issues/2325
