### PR TITLE
common: Upgrade Knative Serving manifests to version 1.8.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ used from the different projects of Kubeflow:
 | Component | Local Manifests Path | Upstream Revision |
 | - | - | - |
 | Istio | common/istio-1-16 | [1.16.0](https://github.com/istio/istio/releases/tag/1.16.0) |
-| Knative | common/knative | [0.22.1](https://github.com/knative/serving/releases/tag/v0.22.1) |
+| Knative | common/knative/knative-serving <br /> common/knative/knative-eventing | [1.8.1](https://github.com/knative/serving/releases/tag/knative-v1.8.1) <br /> [1.8.1](https://github.com/knative/eventing/releases/tag/knative-v1.8.1) |
 | Cert Manager | common/cert-manager | [1.10.1](https://github.com/cert-manager/cert-manager/releases/tag/v1.10.1) |
 
 ## Installation

--- a/common/knative/README.md
+++ b/common/knative/README.md
@@ -4,8 +4,8 @@
 
 The manifests for Knative Serving are based off the following:
 
-  - [Knative serving (v1.2.5)](https://github.com/knative/serving/releases/download/knative-v1.2.5/serving-core.yaml)
-  - [Knative ingress controller for Istio (v1.2.0)](https://github.com/knative-sandbox/net-istio/releases/download/knative-v1.2.0/net-istio.yaml)
+  - [Knative serving (v1.8.1)](https://github.com/knative/serving/releases/tag/knative-v1.8.1)
+  - [Knative ingress controller for Istio (v1.8.0)](https://github.com/knative-sandbox/net-istio/releases/tag/knative-v1.8.0)
 
 
 1. Download the knative-serving manifests with the following commands:
@@ -13,9 +13,9 @@ The manifests for Knative Serving are based off the following:
     ```sh
     # No need to install serving-crds.
     # See: https://github.com/knative/serving/issues/9945
-    wget -O knative-serving/base/upstream/serving-core.yaml 'https://github.com/knative/serving/releases/download/knative-v1.2.5/serving-core.yaml'
-    wget -O knative-serving/base/upstream/net-istio.yaml 'https://github.com/knative-sandbox/net-istio/releases/download/knative-v1.2.0/net-istio.yaml'
-    wget -O knative-serving-post-install-jobs/base/serving-post-install-jobs.yaml https://github.com/knative/serving/releases/download/knative-v1.2.5/serving-post-install-jobs.yaml
+    wget -O knative-serving/base/upstream/serving-core.yaml 'https://github.com/knative/serving/releases/download/knative-v1.8.1/serving-core.yaml'
+    wget -O knative-serving/base/upstream/net-istio.yaml 'https://github.com/knative-sandbox/net-istio/releases/download/knative-v1.8.0/net-istio.yaml'
+    wget -O knative-serving-post-install-jobs/base/serving-post-install-jobs.yaml 'https://github.com/knative/serving/releases/download/knative-v1.8.1/serving-post-install-jobs.yaml'
     ```
 
 1. Remove all comments, since `yq` does not handle them correctly. See:
@@ -67,9 +67,6 @@ NOTE: You'll need to remove a redundant `{}` at the end of the `knative-serving/
 - In `config-istio`, the Knative gateway is set to use `gateway.kubeflow.kubeflow-gateway`.
 - In `config-deployment`, `progressDeadline` is set to `600s` as sometimes large models need longer than
   the default of `120s` to start the containers.
-- In `knative-serving/base/upstream/net-istio.yaml` we explicitly changed the
-  `portLevelMtls.8443` keys to be string. This was necessary to make these
-  manifests work with kustomize 4.2 https://github.com/kubernetes-sigs/kustomize/issues/3446
 
 ## Knative-Eventing
 

--- a/common/knative/knative-serving-post-install-jobs/base/serving-post-install-jobs.yaml
+++ b/common/knative/knative-serving-post-install-jobs/base/serving-post-install-jobs.yaml
@@ -7,8 +7,7 @@ metadata:
     app: storage-version-migration-serving
     app.kubernetes.io/name: knative-serving
     app.kubernetes.io/component: storage-version-migration-job
-    app.kubernetes.io/version: "1.2.5"
-    serving.knative.dev/release: "v1.2.5"
+    app.kubernetes.io/version: "1.8.1"
   name: storage-version-migration-serving
 spec:
   ttlSecondsAfterFinished: 600
@@ -21,13 +20,13 @@ spec:
         app: storage-version-migration-serving
         app.kubernetes.io/name: knative-serving
         app.kubernetes.io/component: storage-version-migration-job
-        app.kubernetes.io/version: "1.2.5"
+        app.kubernetes.io/version: "1.8.1"
     spec:
       serviceAccountName: controller
       restartPolicy: OnFailure
       containers:
         - name: migrate
-          image: gcr.io/knative-releases/knative.dev/pkg/apiextensions/storageversion/cmd/migrate@sha256:bf8ef91c3caccfcde8aa59d15f9fe9a06053134a0172cc7c18c4787fdcfbc77e
+          image: gcr.io/knative-releases/knative.dev/pkg/apiextensions/storageversion/cmd/migrate@sha256:b6a9bb1c500669410d1ec2fef88af0de011375e619c335973a2894f109135858
           args:
             - "services.serving.knative.dev"
             - "configurations.serving.knative.dev"
@@ -44,3 +43,8 @@ spec:
             allowPrivilegeEscalation: false
             readOnlyRootFilesystem: true
             runAsNonRoot: true
+            capabilities:
+              drop:
+                - ALL
+            seccompProfile:
+              type: RuntimeDefault

--- a/common/knative/knative-serving/base/upstream/net-istio.yaml
+++ b/common/knative/knative-serving/base/upstream/net-istio.yaml
@@ -5,8 +5,7 @@ metadata:
   labels:
     app.kubernetes.io/component: net-istio
     app.kubernetes.io/name: knative-serving
-    app.kubernetes.io/version: "1.2.0"
-    serving.knative.dev/release: "v1.2.0"
+    app.kubernetes.io/version: "1.8.0"
     serving.knative.dev/controller: "true"
     networking.knative.dev/ingress-provider: istio
 rules:
@@ -22,8 +21,7 @@ metadata:
   labels:
     app.kubernetes.io/component: net-istio
     app.kubernetes.io/name: knative-serving
-    app.kubernetes.io/version: "1.2.0"
-    serving.knative.dev/release: "v1.2.0"
+    app.kubernetes.io/version: "1.8.0"
     networking.knative.dev/ingress-provider: istio
 spec:
   selector:
@@ -44,8 +42,7 @@ metadata:
   labels:
     app.kubernetes.io/component: net-istio
     app.kubernetes.io/name: knative-serving
-    app.kubernetes.io/version: "1.2.0"
-    serving.knative.dev/release: "v1.2.0"
+    app.kubernetes.io/version: "1.8.0"
     networking.knative.dev/ingress-provider: istio
     experimental.istio.io/disable-gateway-port-translation: "true"
 spec:
@@ -65,8 +62,7 @@ metadata:
   labels:
     app.kubernetes.io/component: net-istio
     app.kubernetes.io/name: knative-serving
-    app.kubernetes.io/version: "1.2.0"
-    serving.knative.dev/release: "v1.2.0"
+    app.kubernetes.io/version: "1.8.0"
     networking.knative.dev/ingress-provider: istio
 data:
   _example: |
@@ -108,13 +104,6 @@ data:
     # `knative-serving`
     local-gateway.knative-serving.knative-local-gateway: "knative-local-gateway.istio-system.svc.cluster.local"
 
-    # DEPRECATED: local-gateway.mesh is deprecated.
-    # See: https://github.com/knative/serving/issues/11523
-    #
-    # To use only Istio service mesh and no knative-local-gateway, replace
-    # all local-gateway.* entries by the following entry.
-    local-gateway.mesh: "mesh"
-
     # If true, knative will use the Istio VirtualService's status to determine
     # endpoint readiness. Otherwise, probe as usual.
     # NOTE: This feature is currently experimental and should not be used in production.
@@ -128,8 +117,7 @@ metadata:
   labels:
     app.kubernetes.io/component: net-istio
     app.kubernetes.io/name: knative-serving
-    app.kubernetes.io/version: "1.2.0"
-    serving.knative.dev/release: "v1.2.0"
+    app.kubernetes.io/version: "1.8.0"
     networking.knative.dev/ingress-provider: istio
 spec:
   selector:
@@ -147,8 +135,7 @@ metadata:
   labels:
     app.kubernetes.io/component: net-istio
     app.kubernetes.io/name: knative-serving
-    app.kubernetes.io/version: "1.2.0"
-    serving.knative.dev/release: "v1.2.0"
+    app.kubernetes.io/version: "1.8.0"
     networking.knative.dev/ingress-provider: istio
 spec:
   selector:
@@ -166,8 +153,7 @@ metadata:
   labels:
     app.kubernetes.io/component: net-istio
     app.kubernetes.io/name: knative-serving
-    app.kubernetes.io/version: "1.2.0"
-    serving.knative.dev/release: "v1.2.0"
+    app.kubernetes.io/version: "1.8.0"
     networking.knative.dev/ingress-provider: istio
 spec:
   selector:
@@ -185,8 +171,7 @@ metadata:
   labels:
     app.kubernetes.io/component: net-istio
     app.kubernetes.io/name: knative-serving
-    app.kubernetes.io/version: "1.2.0"
-    serving.knative.dev/release: "v1.2.0"
+    app.kubernetes.io/version: "1.8.0"
     networking.knative.dev/ingress-provider: istio
 spec:
   selector:
@@ -201,13 +186,12 @@ spec:
         app: net-istio-controller
         app.kubernetes.io/component: net-istio
         app.kubernetes.io/name: knative-serving
-        app.kubernetes.io/version: "1.2.0"
-        serving.knative.dev/release: "v1.2.0"
+        app.kubernetes.io/version: "1.8.0"
     spec:
       serviceAccountName: controller
       containers:
         - name: controller
-          image: gcr.io/knative-releases/knative.dev/net-istio/cmd/controller@sha256:f253b82941c2220181cee80d7488fe1cefce9d49ab30bdb54bcb8c76515f7a26
+          image: gcr.io/knative-releases/knative.dev/net-istio/cmd/controller@sha256:2b484d982ef1a5d6ff93c46d3e45f51c2605c2e3ed766e20247d1727eb5ce918
           resources:
             requests:
               cpu: 30m
@@ -224,6 +208,8 @@ spec:
               value: config-logging
             - name: CONFIG_OBSERVABILITY_NAME
               value: config-observability
+            - name: ENABLE_SECRET_INFORMER_FILTERING_BY_CERT_UID
+              value: "false"
             - name: METRICS_DOMAIN
               value: knative.dev/net-istio
           securityContext:
@@ -232,7 +218,9 @@ spec:
             runAsNonRoot: true
             capabilities:
               drop:
-                - all
+                - ALL
+            seccompProfile:
+              type: RuntimeDefault
           ports:
             - name: metrics
               containerPort: 9090
@@ -247,8 +235,7 @@ metadata:
   labels:
     app.kubernetes.io/component: net-istio
     app.kubernetes.io/name: knative-serving
-    app.kubernetes.io/version: "1.2.0"
-    serving.knative.dev/release: "v1.2.0"
+    app.kubernetes.io/version: "1.8.0"
     networking.knative.dev/ingress-provider: istio
 spec:
   selector:
@@ -264,13 +251,12 @@ spec:
         role: net-istio-webhook
         app.kubernetes.io/component: net-istio
         app.kubernetes.io/name: knative-serving
-        app.kubernetes.io/version: "1.2.0"
-        serving.knative.dev/release: "v1.2.0"
+        app.kubernetes.io/version: "1.8.0"
     spec:
       serviceAccountName: controller
       containers:
         - name: webhook
-          image: gcr.io/knative-releases/knative.dev/net-istio/cmd/webhook@sha256:a705c1ea8e9e556f860314fe055082fbe3cde6a924c29291955f98d979f8185e
+          image: gcr.io/knative-releases/knative.dev/net-istio/cmd/webhook@sha256:59b6a46d3b55a03507c76a3afe8a4ee5f1a38f1130fd3d65c9fe57fff583fa8d
           resources:
             requests:
               cpu: 20m
@@ -292,7 +278,13 @@ spec:
             - name: WEBHOOK_NAME
               value: net-istio-webhook
           securityContext:
+            runAsNonRoot: true
             allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+                - ALL
+            seccompProfile:
+              type: RuntimeDefault
           ports:
             - name: metrics
               containerPort: 9090
@@ -309,8 +301,7 @@ metadata:
   labels:
     app.kubernetes.io/component: net-istio
     app.kubernetes.io/name: knative-serving
-    app.kubernetes.io/version: "1.2.0"
-    serving.knative.dev/release: "v1.2.0"
+    app.kubernetes.io/version: "1.8.0"
     networking.knative.dev/ingress-provider: istio
 ---
 apiVersion: v1
@@ -322,8 +313,7 @@ metadata:
     role: net-istio-webhook
     app.kubernetes.io/component: net-istio
     app.kubernetes.io/name: knative-serving
-    app.kubernetes.io/version: "1.2.0"
-    serving.knative.dev/release: "v1.2.0"
+    app.kubernetes.io/version: "1.8.0"
     networking.knative.dev/ingress-provider: istio
 spec:
   ports:
@@ -346,8 +336,7 @@ metadata:
   labels:
     app.kubernetes.io/component: net-istio
     app.kubernetes.io/name: knative-serving
-    app.kubernetes.io/version: "1.2.0"
-    serving.knative.dev/release: "v1.2.0"
+    app.kubernetes.io/version: "1.8.0"
     networking.knative.dev/ingress-provider: istio
 webhooks:
   - admissionReviewVersions:
@@ -371,8 +360,7 @@ metadata:
   labels:
     app.kubernetes.io/component: net-istio
     app.kubernetes.io/name: knative-serving
-    app.kubernetes.io/version: "1.2.0"
-    serving.knative.dev/release: "v1.2.0"
+    app.kubernetes.io/version: "1.8.0"
     networking.knative.dev/ingress-provider: istio
 webhooks:
   - admissionReviewVersions:
@@ -385,8 +373,8 @@ webhooks:
     failurePolicy: Fail
     sideEffects: None
     name: config.webhook.istio.networking.internal.knative.dev
-    namespaceSelector:
-      matchExpressions:
-        - key: serving.knative.dev/release
-          operator: Exists
+    objectSelector:
+      matchLabels:
+        app.kubernetes.io/name: knative-serving
+        app.kubernetes.io/component: net-istio
 ---

--- a/common/knative/knative-serving/base/upstream/serving-core.yaml
+++ b/common/knative/knative-serving/base/upstream/serving-core.yaml
@@ -4,16 +4,14 @@ metadata:
   name: knative-serving
   labels:
     app.kubernetes.io/name: knative-serving
-    app.kubernetes.io/version: "1.2.5"
-    serving.knative.dev/release: "v1.2.5"
+    app.kubernetes.io/version: "1.8.0"
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   name: knative-serving-aggregated-addressable-resolver
   labels:
-    serving.knative.dev/release: "v1.2.5"
-    app.kubernetes.io/version: "1.2.5"
+    app.kubernetes.io/version: "1.8.0"
     app.kubernetes.io/name: knative-serving
 aggregationRule:
   clusterRoleSelectors:
@@ -25,8 +23,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: knative-serving-addressable-resolver
   labels:
-    serving.knative.dev/release: "v1.2.5"
-    app.kubernetes.io/version: "1.2.5"
+    app.kubernetes.io/version: "1.8.0"
     app.kubernetes.io/name: knative-serving
     duck.knative.dev/addressable: "true"
 rules:
@@ -48,8 +45,7 @@ metadata:
   name: knative-serving-namespaced-admin
   labels:
     rbac.authorization.k8s.io/aggregate-to-admin: "true"
-    serving.knative.dev/release: "v1.2.5"
-    app.kubernetes.io/version: "1.2.5"
+    app.kubernetes.io/version: "1.8.0"
     app.kubernetes.io/name: knative-serving
 rules:
   - apiGroups: ["serving.knative.dev"]
@@ -65,8 +61,7 @@ metadata:
   name: knative-serving-namespaced-edit
   labels:
     rbac.authorization.k8s.io/aggregate-to-edit: "true"
-    serving.knative.dev/release: "v1.2.5"
-    app.kubernetes.io/version: "1.2.5"
+    app.kubernetes.io/version: "1.8.0"
     app.kubernetes.io/name: knative-serving
 rules:
   - apiGroups: ["serving.knative.dev"]
@@ -82,8 +77,7 @@ metadata:
   name: knative-serving-namespaced-view
   labels:
     rbac.authorization.k8s.io/aggregate-to-view: "true"
-    serving.knative.dev/release: "v1.2.5"
-    app.kubernetes.io/version: "1.2.5"
+    app.kubernetes.io/version: "1.8.0"
     app.kubernetes.io/name: knative-serving
 rules:
   - apiGroups: ["serving.knative.dev", "networking.internal.knative.dev", "autoscaling.internal.knative.dev", "caching.internal.knative.dev"]
@@ -96,8 +90,7 @@ metadata:
   name: knative-serving-core
   labels:
     serving.knative.dev/controller: "true"
-    serving.knative.dev/release: "v1.2.5"
-    app.kubernetes.io/version: "1.2.5"
+    app.kubernetes.io/version: "1.8.0"
     app.kubernetes.io/name: knative-serving
 rules:
   - apiGroups: [""]
@@ -136,8 +129,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: knative-serving-podspecable-binding
   labels:
-    serving.knative.dev/release: "v1.2.5"
-    app.kubernetes.io/version: "1.2.5"
+    app.kubernetes.io/version: "1.8.0"
     app.kubernetes.io/name: knative-serving
     duck.knative.dev/podspecable: "true"
 rules:
@@ -159,8 +151,7 @@ metadata:
   labels:
     app.kubernetes.io/component: controller
     app.kubernetes.io/name: knative-serving
-    app.kubernetes.io/version: "1.2.5"
-    serving.knative.dev/release: "v1.2.5"
+    app.kubernetes.io/version: "1.8.0"
 ---
 kind: ClusterRole
 apiVersion: rbac.authorization.k8s.io/v1
@@ -168,8 +159,7 @@ metadata:
   name: knative-serving-admin
   labels:
     app.kubernetes.io/name: knative-serving
-    app.kubernetes.io/version: "1.2.5"
-    serving.knative.dev/release: "v1.2.5"
+    app.kubernetes.io/version: "1.8.0"
 aggregationRule:
   clusterRoleSelectors:
     - matchLabels:
@@ -182,8 +172,7 @@ metadata:
   labels:
     app.kubernetes.io/component: controller
     app.kubernetes.io/name: knative-serving
-    app.kubernetes.io/version: "1.2.5"
-    serving.knative.dev/release: "v1.2.5"
+    app.kubernetes.io/version: "1.8.0"
 subjects:
   - kind: ServiceAccount
     name: controller
@@ -200,8 +189,7 @@ metadata:
   labels:
     app.kubernetes.io/component: controller
     app.kubernetes.io/name: knative-serving
-    app.kubernetes.io/version: "1.2.5"
-    serving.knative.dev/release: "v1.2.5"
+    app.kubernetes.io/version: "1.8.0"
 subjects:
   - kind: ServiceAccount
     name: controller
@@ -217,7 +205,7 @@ metadata:
   name: images.caching.internal.knative.dev
   labels:
     app.kubernetes.io/name: knative-serving
-    app.kubernetes.io/version: "1.2.5"
+    app.kubernetes.io/version: "1.8.0"
     knative.dev/crd-install: "true"
 spec:
   group: caching.internal.knative.dev
@@ -228,8 +216,6 @@ spec:
     categories:
       - knative-internal
       - caching
-    shortNames:
-      - img
   scope: Namespaced
   versions:
     - name: v1alpha1
@@ -239,8 +225,81 @@ spec:
         status: {}
       schema:
         openAPIV3Schema:
+          description: Image is a Knative abstraction that encapsulates the interface by which Knative components express a desire to have a particular image cached.
           type: object
-          x-kubernetes-preserve-unknown-fields: true
+          properties:
+            apiVersion:
+              description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+              type: string
+            kind:
+              description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+              type: string
+            metadata:
+              type: object
+            spec:
+              description: Spec holds the desired state of the Image (from the client).
+              type: object
+              required:
+                - image
+              properties:
+                image:
+                  description: Image is the name of the container image url to cache across the cluster.
+                  type: string
+                imagePullSecrets:
+                  description: ImagePullSecrets contains the names of the Kubernetes Secrets containing login information used by the Pods which will run this container.
+                  type: array
+                  items:
+                    description: LocalObjectReference contains enough information to let you locate the referenced object inside the same namespace.
+                    type: object
+                    properties:
+                      name:
+                        description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?'
+                        type: string
+                    x-kubernetes-map-type: atomic
+                serviceAccountName:
+                  description: 'ServiceAccountName is the name of the Kubernetes ServiceAccount as which the Pods will run this container.  This is potentially used to authenticate the image pull if the service account has attached pull secrets.  For more information: https://kubernetes.io/docs/tasks/configure-pod-container/configure-service-account/#add-imagepullsecrets-to-a-service-account'
+                  type: string
+            status:
+              description: Status communicates the observed state of the Image (from the controller).
+              type: object
+              properties:
+                annotations:
+                  description: Annotations is additional Status fields for the Resource to save some additional State as well as convey more information to the user. This is roughly akin to Annotations on any k8s resource, just the reconciler conveying richer information outwards.
+                  type: object
+                  additionalProperties:
+                    type: string
+                conditions:
+                  description: Conditions the latest available observations of a resource's current state.
+                  type: array
+                  items:
+                    description: 'Condition defines a readiness condition for a Knative resource. See: https://github.com/kubernetes/community/blob/master/contributors/devel/sig-architecture/api-conventions.md#typical-status-properties'
+                    type: object
+                    required:
+                      - status
+                      - type
+                    properties:
+                      lastTransitionTime:
+                        description: LastTransitionTime is the last time the condition transitioned from one status to another. We use VolatileTime in place of metav1.Time to exclude this from creating equality.Semantic differences (all other things held constant).
+                        type: string
+                      message:
+                        description: A human readable message indicating details about the transition.
+                        type: string
+                      reason:
+                        description: The reason for the condition's last transition.
+                        type: string
+                      severity:
+                        description: Severity with which to treat failures of this type of condition. When this is not specified, it defaults to Error.
+                        type: string
+                      status:
+                        description: Status of the condition, one of True, False, Unknown.
+                        type: string
+                      type:
+                        description: Type of condition.
+                        type: string
+                observedGeneration:
+                  description: ObservedGeneration is the 'Generation' of the Service that was last processed by the controller.
+                  type: integer
+                  format: int64
       additionalPrinterColumns:
         - name: Image
           type: string
@@ -252,8 +311,8 @@ metadata:
   name: certificates.networking.internal.knative.dev
   labels:
     app.kubernetes.io/name: knative-serving
-    app.kubernetes.io/version: "1.2.5"
-    serving.knative.dev/release: "v1.2.5"
+    app.kubernetes.io/component: networking
+    app.kubernetes.io/version: "1.8.0"
     knative.dev/crd-install: "true"
 spec:
   group: networking.internal.knative.dev
@@ -265,8 +324,99 @@ spec:
         status: {}
       schema:
         openAPIV3Schema:
+          description: Certificate is responsible for provisioning a SSL certificate for the given hosts. It is a Knative abstraction for various SSL certificate provisioning solutions (such as cert-manager or self-signed SSL certificate).
           type: object
-          x-kubernetes-preserve-unknown-fields: true
+          properties:
+            apiVersion:
+              description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+              type: string
+            kind:
+              description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+              type: string
+            metadata:
+              type: object
+            spec:
+              description: 'Spec is the desired state of the Certificate. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status'
+              type: object
+              required:
+                - dnsNames
+                - secretName
+              properties:
+                dnsNames:
+                  description: DNSNames is a list of DNS names the Certificate could support. The wildcard format of DNSNames (e.g. *.default.example.com) is supported.
+                  type: array
+                  items:
+                    type: string
+                secretName:
+                  description: SecretName is the name of the secret resource to store the SSL certificate in.
+                  type: string
+            status:
+              description: 'Status is the current state of the Certificate. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status'
+              type: object
+              properties:
+                annotations:
+                  description: Annotations is additional Status fields for the Resource to save some additional State as well as convey more information to the user. This is roughly akin to Annotations on any k8s resource, just the reconciler conveying richer information outwards.
+                  type: object
+                  additionalProperties:
+                    type: string
+                conditions:
+                  description: Conditions the latest available observations of a resource's current state.
+                  type: array
+                  items:
+                    description: 'Condition defines a readiness condition for a Knative resource. See: https://github.com/kubernetes/community/blob/master/contributors/devel/sig-architecture/api-conventions.md#typical-status-properties'
+                    type: object
+                    required:
+                      - status
+                      - type
+                    properties:
+                      lastTransitionTime:
+                        description: LastTransitionTime is the last time the condition transitioned from one status to another. We use VolatileTime in place of metav1.Time to exclude this from creating equality.Semantic differences (all other things held constant).
+                        type: string
+                      message:
+                        description: A human readable message indicating details about the transition.
+                        type: string
+                      reason:
+                        description: The reason for the condition's last transition.
+                        type: string
+                      severity:
+                        description: Severity with which to treat failures of this type of condition. When this is not specified, it defaults to Error.
+                        type: string
+                      status:
+                        description: Status of the condition, one of True, False, Unknown.
+                        type: string
+                      type:
+                        description: Type of condition.
+                        type: string
+                http01Challenges:
+                  description: HTTP01Challenges is a list of HTTP01 challenges that need to be fulfilled in order to get the TLS certificate..
+                  type: array
+                  items:
+                    description: HTTP01Challenge defines the status of a HTTP01 challenge that a certificate needs to fulfill.
+                    type: object
+                    properties:
+                      serviceName:
+                        description: ServiceName is the name of the service to serve HTTP01 challenge requests.
+                        type: string
+                      serviceNamespace:
+                        description: ServiceNamespace is the namespace of the service to serve HTTP01 challenge requests.
+                        type: string
+                      servicePort:
+                        description: ServicePort is the port of the service to serve HTTP01 challenge requests.
+                        anyOf:
+                          - type: integer
+                          - type: string
+                        x-kubernetes-int-or-string: true
+                      url:
+                        description: URL is the URL that the HTTP01 challenge is expected to serve on.
+                        type: string
+                notAfter:
+                  description: The expiration time of the TLS certificate stored in the secret named by this resource in spec.secretName.
+                  type: string
+                  format: date-time
+                observedGeneration:
+                  description: ObservedGeneration is the 'Generation' of the Service that was last processed by the controller.
+                  type: integer
+                  format: int64
       additionalPrinterColumns:
         - name: Ready
           type: string
@@ -291,8 +441,7 @@ metadata:
   name: configurations.serving.knative.dev
   labels:
     app.kubernetes.io/name: knative-serving
-    app.kubernetes.io/version: "1.2.5"
-    serving.knative.dev/release: "v1.2.5"
+    app.kubernetes.io/version: "1.8.0"
     knative.dev/crd-install: "true"
     duck.knative.dev/podspecable: "true"
 spec:
@@ -375,6 +524,10 @@ spec:
                       required:
                         - containers
                       properties:
+                        affinity:
+                          description: This is accessible behind a feature flag - kubernetes.podspec-affinity
+                          type: object
+                          x-kubernetes-preserve-unknown-fields: true
                         automountServiceAccountToken:
                           description: AutomountServiceAccountToken indicates whether a service account token should be automatically mounted.
                           type: boolean
@@ -390,12 +543,12 @@ spec:
                             type: object
                             properties:
                               args:
-                                description: 'Arguments to the entrypoint. The docker image''s CMD is used if this is not provided. Variable references $(VAR_NAME) are expanded using the container''s environment. If a variable cannot be resolved, the reference in the input string will be unchanged. Double $$ are reduced to a single $, which allows for escaping the $(VAR_NAME) syntax: i.e. "$$(VAR_NAME)" will produce the string literal "$(VAR_NAME)". Escaped references will never be expanded, regardless of whether the variable exists or not. Cannot be updated. More info: https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell'
+                                description: 'Arguments to the entrypoint. The container image''s CMD is used if this is not provided. Variable references $(VAR_NAME) are expanded using the container''s environment. If a variable cannot be resolved, the reference in the input string will be unchanged. Double $$ are reduced to a single $, which allows for escaping the $(VAR_NAME) syntax: i.e. "$$(VAR_NAME)" will produce the string literal "$(VAR_NAME)". Escaped references will never be expanded, regardless of whether the variable exists or not. Cannot be updated. More info: https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell'
                                 type: array
                                 items:
                                   type: string
                               command:
-                                description: 'Entrypoint array. Not executed within a shell. The docker image''s ENTRYPOINT is used if this is not provided. Variable references $(VAR_NAME) are expanded using the container''s environment. If a variable cannot be resolved, the reference in the input string will be unchanged. Double $$ are reduced to a single $, which allows for escaping the $(VAR_NAME) syntax: i.e. "$$(VAR_NAME)" will produce the string literal "$(VAR_NAME)". Escaped references will never be expanded, regardless of whether the variable exists or not. Cannot be updated. More info: https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell'
+                                description: 'Entrypoint array. Not executed within a shell. The container image''s ENTRYPOINT is used if this is not provided. Variable references $(VAR_NAME) are expanded using the container''s environment. If a variable cannot be resolved, the reference in the input string will be unchanged. Double $$ are reduced to a single $, which allows for escaping the $(VAR_NAME) syntax: i.e. "$$(VAR_NAME)" will produce the string literal "$(VAR_NAME)". Escaped references will never be expanded, regardless of whether the variable exists or not. Cannot be updated. More info: https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell'
                                 type: array
                                 items:
                                   type: string
@@ -433,6 +586,17 @@ spec:
                                             optional:
                                               description: Specify whether the ConfigMap or its key must be defined
                                               type: boolean
+                                          x-kubernetes-map-type: atomic
+                                        fieldRef:
+                                          description: This is accessible behind a feature flag - kubernetes.podspec-fieldref
+                                          type: object
+                                          x-kubernetes-preserve-unknown-fields: true
+                                          x-kubernetes-map-type: atomic
+                                        resourceFieldRef:
+                                          description: This is accessible behind a feature flag - kubernetes.podspec-fieldref
+                                          type: object
+                                          x-kubernetes-preserve-unknown-fields: true
+                                          x-kubernetes-map-type: atomic
                                         secretKeyRef:
                                           description: Selects a key of a secret in the pod's namespace
                                           type: object
@@ -448,7 +612,7 @@ spec:
                                             optional:
                                               description: Specify whether the Secret or its key must be defined
                                               type: boolean
-                                      x-kubernetes-preserve-unknown-fields: true
+                                          x-kubernetes-map-type: atomic
                               envFrom:
                                 description: List of sources to populate environment variables in the container. The keys defined within a source must be a C_IDENTIFIER. All invalid keys will be reported as an event when the container is starting. When a key exists in multiple sources, the value associated with the last source will take precedence. Values defined by an Env with a duplicate key will take precedence. Cannot be updated.
                                 type: array
@@ -466,6 +630,7 @@ spec:
                                         optional:
                                           description: Specify whether the ConfigMap must be defined
                                           type: boolean
+                                      x-kubernetes-map-type: atomic
                                     prefix:
                                       description: An optional identifier to prepend to each key in the ConfigMap. Must be a C_IDENTIFIER.
                                       type: string
@@ -479,8 +644,9 @@ spec:
                                         optional:
                                           description: Specify whether the Secret must be defined
                                           type: boolean
+                                      x-kubernetes-map-type: atomic
                               image:
-                                description: 'Docker image name. More info: https://kubernetes.io/docs/concepts/containers/images This field is optional to allow higher level config management to default or override container images in workload controllers like Deployments and StatefulSets.'
+                                description: 'Container image name. More info: https://kubernetes.io/docs/concepts/containers/images This field is optional to allow higher level config management to default or override container images in workload controllers like Deployments and StatefulSets.'
                                 type: string
                               imagePullPolicy:
                                 description: 'Image pull policy. One of Always, Never, IfNotPresent. Defaults to Always if :latest tag is specified, or IfNotPresent otherwise. Cannot be updated. More info: https://kubernetes.io/docs/concepts/containers/images#updating-images'
@@ -490,7 +656,7 @@ spec:
                                 type: object
                                 properties:
                                   exec:
-                                    description: One and only one of the following should be specified. Exec specifies the action to take.
+                                    description: Exec specifies the action to take.
                                     type: object
                                     properties:
                                       command:
@@ -528,10 +694,15 @@ spec:
                                       path:
                                         description: Path to access on the HTTP server.
                                         type: string
+                                      port:
+                                        description: Name or number of the port to access on the container. Number must be in the range 1 to 65535. Name must be an IANA_SVC_NAME.
+                                        anyOf:
+                                          - type: integer
+                                          - type: string
+                                        x-kubernetes-int-or-string: true
                                       scheme:
                                         description: Scheme to use for connecting to the host. Defaults to HTTP.
                                         type: string
-                                    x-kubernetes-preserve-unknown-fields: true
                                   initialDelaySeconds:
                                     description: 'Number of seconds after the container has started before liveness probes are initiated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
                                     type: integer
@@ -545,13 +716,18 @@ spec:
                                     type: integer
                                     format: int32
                                   tcpSocket:
-                                    description: 'TCPSocket specifies an action involving a TCP port. TCP hooks not yet supported TODO: implement a realistic TCP lifecycle hook'
+                                    description: TCPSocket specifies an action involving a TCP port.
                                     type: object
                                     properties:
                                       host:
                                         description: 'Optional: Host name to connect to, defaults to the pod IP.'
                                         type: string
-                                    x-kubernetes-preserve-unknown-fields: true
+                                      port:
+                                        description: Number or name of the port to access on the container. Number must be in the range 1 to 65535. Name must be an IANA_SVC_NAME.
+                                        anyOf:
+                                          - type: integer
+                                          - type: string
+                                        x-kubernetes-int-or-string: true
                                   timeoutSeconds:
                                     description: 'Number of seconds after which the probe times out. Defaults to 1 second. Minimum value is 1. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
                                     type: integer
@@ -560,7 +736,7 @@ spec:
                                 description: Name of the container specified as a DNS_LABEL. Each container in a pod must have a unique name (DNS_LABEL). Cannot be updated.
                                 type: string
                               ports:
-                                description: List of ports to expose from the container. Exposing a port here gives the system additional information about the network connections a container uses, but is primarily informational. Not specifying a port here DOES NOT prevent that port from being exposed. Any port which is listening on the default "0.0.0.0" address inside a container will be accessible from the network. Cannot be updated.
+                                description: List of ports to expose from the container. Not specifying a port here DOES NOT prevent that port from being exposed. Any port which is listening on the default "0.0.0.0" address inside a container will be accessible from the network. Modifying this array with strategic merge patch may corrupt the data. For more information See https://github.com/kubernetes/kubernetes/issues/108255. Cannot be updated.
                                 type: array
                                 items:
                                   description: ContainerPort represents a network port in a single container.
@@ -579,7 +755,6 @@ spec:
                                       description: Protocol for port. Must be UDP, TCP, or SCTP. Defaults to "TCP".
                                       type: string
                                       default: TCP
-                                  x-kubernetes-preserve-unknown-fields: true
                                 x-kubernetes-list-map-keys:
                                   - containerPort
                                   - protocol
@@ -589,7 +764,7 @@ spec:
                                 type: object
                                 properties:
                                   exec:
-                                    description: One and only one of the following should be specified. Exec specifies the action to take.
+                                    description: Exec specifies the action to take.
                                     type: object
                                     properties:
                                       command:
@@ -627,10 +802,15 @@ spec:
                                       path:
                                         description: Path to access on the HTTP server.
                                         type: string
+                                      port:
+                                        description: Name or number of the port to access on the container. Number must be in the range 1 to 65535. Name must be an IANA_SVC_NAME.
+                                        anyOf:
+                                          - type: integer
+                                          - type: string
+                                        x-kubernetes-int-or-string: true
                                       scheme:
                                         description: Scheme to use for connecting to the host. Defaults to HTTP.
                                         type: string
-                                    x-kubernetes-preserve-unknown-fields: true
                                   initialDelaySeconds:
                                     description: 'Number of seconds after the container has started before liveness probes are initiated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
                                     type: integer
@@ -644,13 +824,18 @@ spec:
                                     type: integer
                                     format: int32
                                   tcpSocket:
-                                    description: 'TCPSocket specifies an action involving a TCP port. TCP hooks not yet supported TODO: implement a realistic TCP lifecycle hook'
+                                    description: TCPSocket specifies an action involving a TCP port.
                                     type: object
                                     properties:
                                       host:
                                         description: 'Optional: Host name to connect to, defaults to the pod IP.'
                                         type: string
-                                    x-kubernetes-preserve-unknown-fields: true
+                                      port:
+                                        description: Number or name of the port to access on the container. Number must be in the range 1 to 65535. Name must be an IANA_SVC_NAME.
+                                        anyOf:
+                                          - type: integer
+                                          - type: string
+                                        x-kubernetes-int-or-string: true
                                   timeoutSeconds:
                                     description: 'Number of seconds after which the probe times out. Defaults to 1 second. Minimum value is 1. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
                                     type: integer
@@ -681,25 +866,39 @@ spec:
                                 description: 'SecurityContext defines the security options the container should be run with. If set, the fields of SecurityContext override the equivalent fields of PodSecurityContext. More info: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/'
                                 type: object
                                 properties:
+                                  allowPrivilegeEscalation:
+                                    description: 'AllowPrivilegeEscalation controls whether a process can gain more privileges than its parent process. This bool directly controls if the no_new_privs flag will be set on the container process. AllowPrivilegeEscalation is true always when the container is: 1) run as Privileged 2) has CAP_SYS_ADMIN Note that this field cannot be set when spec.os.name is windows.'
+                                    type: boolean
                                   capabilities:
-                                    description: The capabilities to add/drop when running containers. Defaults to the default set of capabilities granted by the container runtime.
+                                    description: The capabilities to add/drop when running containers. Defaults to the default set of capabilities granted by the container runtime. Note that this field cannot be set when spec.os.name is windows.
                                     type: object
                                     properties:
+                                      add:
+                                        description: This is accessible behind a feature flag - kubernetes.containerspec-addcapabilities
+                                        type: array
+                                        items:
+                                          description: Capability represent POSIX capabilities type
+                                          type: string
                                       drop:
                                         description: Removed capabilities
                                         type: array
                                         items:
                                           description: Capability represent POSIX capabilities type
                                           type: string
-                                    x-kubernetes-preserve-unknown-fields: true
                                   readOnlyRootFilesystem:
-                                    description: Whether this container has a read-only root filesystem. Default is false.
+                                    description: Whether this container has a read-only root filesystem. Default is false. Note that this field cannot be set when spec.os.name is windows.
                                     type: boolean
-                                  runAsUser:
-                                    description: The UID to run the entrypoint of the container process. Defaults to user specified in image metadata if unspecified. May also be set in PodSecurityContext.  If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence.
+                                  runAsGroup:
+                                    description: The GID to run the entrypoint of the container process. Uses runtime default if unset. May also be set in PodSecurityContext.  If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence. Note that this field cannot be set when spec.os.name is windows.
                                     type: integer
                                     format: int64
-                                x-kubernetes-preserve-unknown-fields: true
+                                  runAsNonRoot:
+                                    description: Indicates that the container must run as a non-root user. If true, the Kubelet will validate the image at runtime to ensure that it does not run as UID 0 (root) and fail to start the container if it does. If unset or false, no such validation will be performed. May also be set in PodSecurityContext.  If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence.
+                                    type: boolean
+                                  runAsUser:
+                                    description: The UID to run the entrypoint of the container process. Defaults to user specified in image metadata if unspecified. May also be set in PodSecurityContext.  If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence. Note that this field cannot be set when spec.os.name is windows.
+                                    type: integer
+                                    format: int64
                               terminationMessagePath:
                                 description: 'Optional: Path at which the file to which the container''s termination message will be written is mounted into the container''s filesystem. Message written is intended to be brief final status, such as an assertion failure message. Will be truncated by the node if greater than 4096 bytes. The total message length across all containers will be limited to 12kb. Defaults to /dev/termination-log. Cannot be updated.'
                                 type: string
@@ -731,12 +930,29 @@ spec:
                               workingDir:
                                 description: Container's working directory. If not specified, the container runtime's default will be used, which might be configured in the container image. Cannot be updated.
                                 type: string
-                            x-kubernetes-preserve-unknown-fields: true
+                        dnsConfig:
+                          description: This is accessible behind a feature flag - kubernetes.podspec-dnsconfig
+                          type: object
+                          x-kubernetes-preserve-unknown-fields: true
+                        dnsPolicy:
+                          description: This is accessible behind a feature flag - kubernetes.podspec-dnspolicy
+                          type: string
                         enableServiceLinks:
-                          description: 'EnableServiceLinks indicates whether information about services should be injected into pod''s environment variables, matching the syntax of Docker links. Optional: Defaults to true.'
+                          description: 'EnableServiceLinks indicates whether information about services should be injected into pod''s environment variables, matching the syntax of Docker links. Optional: Knative defaults this to false.'
                           type: boolean
+                        hostAliases:
+                          description: This is accessible behind a feature flag - kubernetes.podspec-hostaliases
+                          type: array
+                          items:
+                            description: This is accessible behind a feature flag - kubernetes.podspec-hostaliases
+                            type: object
+                            x-kubernetes-preserve-unknown-fields: true
+                        idleTimeoutSeconds:
+                          description: IdleTimeoutSeconds is the maximum duration in seconds a request will be allowed to stay open while not receiving any bytes from the user's application. If unspecified, a system default will be provided.
+                          type: integer
+                          format: int64
                         imagePullSecrets:
-                          description: 'ImagePullSecrets is an optional list of references to secrets in the same namespace to use for pulling any of the images used by this PodSpec. If specified, these secrets will be passed to individual puller implementations for them to use. For example, in the case of docker, only DockerConfig type secrets are honored. More info: https://kubernetes.io/docs/concepts/containers/images#specifying-imagepullsecrets-on-a-pod'
+                          description: 'ImagePullSecrets is an optional list of references to secrets in the same namespace to use for pulling any of the images used by this PodSpec. If specified, these secrets will be passed to individual puller implementations for them to use. More info: https://kubernetes.io/docs/concepts/containers/images#specifying-imagepullsecrets-on-a-pod'
                           type: array
                           items:
                             description: LocalObjectReference contains enough information to let you locate the referenced object inside the same namespace.
@@ -745,13 +961,60 @@ spec:
                               name:
                                 description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?'
                                 type: string
+                            x-kubernetes-map-type: atomic
+                        initContainers:
+                          description: 'List of initialization containers belonging to the pod. Init containers are executed in order prior to containers being started. If any init container fails, the pod is considered to have failed and is handled according to its restartPolicy. The name for an init container or normal container must be unique among all containers. Init containers may not have Lifecycle actions, Readiness probes, Liveness probes, or Startup probes. The resourceRequirements of an init container are taken into account during scheduling by finding the highest request/limit for each resource type, and then using the max of of that value or the sum of the normal containers. Limits are applied to init containers in a similar fashion. Init containers cannot currently be added or removed. Cannot be updated. More info: https://kubernetes.io/docs/concepts/workloads/pods/init-containers/'
+                          type: array
+                          items:
+                            description: This is accessible behind a feature flag - kubernetes.podspec-init-containers
+                            type: object
+                            x-kubernetes-preserve-unknown-fields: true
+                        nodeSelector:
+                          description: This is accessible behind a feature flag - kubernetes.podspec-nodeselector
+                          type: object
+                          x-kubernetes-preserve-unknown-fields: true
+                          x-kubernetes-map-type: atomic
+                        priorityClassName:
+                          description: This is accessible behind a feature flag - kubernetes.podspec-priorityclassname
+                          type: string
+                          x-kubernetes-preserve-unknown-fields: true
+                        responseStartTimeoutSeconds:
+                          description: ResponseStartTimeoutSeconds is the maximum duration in seconds that the request routing layer will wait for a request delivered to a container to begin sending any network traffic.
+                          type: integer
+                          format: int64
+                        runtimeClassName:
+                          description: This is accessible behind a feature flag - kubernetes.podspec-runtimeclassname
+                          type: string
+                          x-kubernetes-preserve-unknown-fields: true
+                        schedulerName:
+                          description: This is accessible behind a feature flag - kubernetes.podspec-schedulername
+                          type: string
+                          x-kubernetes-preserve-unknown-fields: true
+                        securityContext:
+                          description: This is accessible behind a feature flag - kubernetes.podspec-securitycontext
+                          type: object
+                          x-kubernetes-preserve-unknown-fields: true
                         serviceAccountName:
                           description: 'ServiceAccountName is the name of the ServiceAccount to use to run this pod. More info: https://kubernetes.io/docs/tasks/configure-pod-container/configure-service-account/'
                           type: string
                         timeoutSeconds:
-                          description: TimeoutSeconds is the maximum duration in seconds that the request routing layer will wait for a request delivered to a container to begin replying (send network traffic). If unspecified, a system default will be provided.
+                          description: TimeoutSeconds is the maximum duration in seconds that the request instance is allowed to respond to a request. If unspecified, a system default will be provided.
                           type: integer
                           format: int64
+                        tolerations:
+                          description: This is accessible behind a feature flag - kubernetes.podspec-tolerations
+                          type: array
+                          items:
+                            description: This is accessible behind a feature flag - kubernetes.podspec-tolerations
+                            type: object
+                            x-kubernetes-preserve-unknown-fields: true
+                        topologySpreadConstraints:
+                          description: This is accessible behind a feature flag - kubernetes.podspec-topologyspreadconstraints
+                          type: array
+                          items:
+                            description: This is accessible behind a feature flag - kubernetes.podspec-topologyspreadconstraints
+                            type: object
+                            x-kubernetes-preserve-unknown-fields: true
                         volumes:
                           description: 'List of volumes that can be mounted by containers belonging to the pod. More info: https://kubernetes.io/docs/concepts/storage/volumes'
                           type: array
@@ -762,15 +1025,15 @@ spec:
                               - name
                             properties:
                               configMap:
-                                description: ConfigMap represents a configMap that should populate this volume
+                                description: configMap represents a configMap that should populate this volume
                                 type: object
                                 properties:
                                   defaultMode:
-                                    description: 'Optional: mode bits used to set permissions on created files by default. Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511. YAML accepts both octal and decimal values, JSON requires decimal values for mode bits. Defaults to 0644. Directories within the path are not affected by this setting. This might be in conflict with other options that affect the file mode, like fsGroup, and the result can be other mode bits set.'
+                                    description: 'defaultMode is optional: mode bits used to set permissions on created files by default. Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511. YAML accepts both octal and decimal values, JSON requires decimal values for mode bits. Defaults to 0644. Directories within the path are not affected by this setting. This might be in conflict with other options that affect the file mode, like fsGroup, and the result can be other mode bits set.'
                                     type: integer
                                     format: int32
                                   items:
-                                    description: If unspecified, each key-value pair in the Data field of the referenced ConfigMap will be projected into the volume as a file whose name is the key and content is the value. If specified, the listed keys will be projected into the specified paths, and unlisted keys will not be present. If a key is specified which is not present in the ConfigMap, the volume setup will error unless it is marked optional. Paths must be relative and may not contain the '..' path or start with '..'.
+                                    description: items if unspecified, each key-value pair in the Data field of the referenced ConfigMap will be projected into the volume as a file whose name is the key and content is the value. If specified, the listed keys will be projected into the specified paths, and unlisted keys will not be present. If a key is specified which is not present in the ConfigMap, the volume setup will error unless it is marked optional. Paths must be relative and may not contain the '..' path or start with '..'.
                                     type: array
                                     items:
                                       description: Maps a string key to a path within a volume.
@@ -780,45 +1043,54 @@ spec:
                                         - path
                                       properties:
                                         key:
-                                          description: The key to project.
+                                          description: key is the key to project.
                                           type: string
                                         mode:
-                                          description: 'Optional: mode bits used to set permissions on this file. Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511. YAML accepts both octal and decimal values, JSON requires decimal values for mode bits. If not specified, the volume defaultMode will be used. This might be in conflict with other options that affect the file mode, like fsGroup, and the result can be other mode bits set.'
+                                          description: 'mode is Optional: mode bits used to set permissions on this file. Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511. YAML accepts both octal and decimal values, JSON requires decimal values for mode bits. If not specified, the volume defaultMode will be used. This might be in conflict with other options that affect the file mode, like fsGroup, and the result can be other mode bits set.'
                                           type: integer
                                           format: int32
                                         path:
-                                          description: The relative path of the file to map the key to. May not be an absolute path. May not contain the path element '..'. May not start with the string '..'.
+                                          description: path is the relative path of the file to map the key to. May not be an absolute path. May not contain the path element '..'. May not start with the string '..'.
                                           type: string
                                   name:
                                     description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?'
                                     type: string
                                   optional:
-                                    description: Specify whether the ConfigMap or its keys must be defined
+                                    description: optional specify whether the ConfigMap or its keys must be defined
                                     type: boolean
+                                x-kubernetes-map-type: atomic
+                              emptyDir:
+                                description: This is accessible behind a feature flag - kubernetes.podspec-emptydir
+                                type: object
+                                x-kubernetes-preserve-unknown-fields: true
                               name:
-                                description: 'Volume''s name. Must be a DNS_LABEL and unique within the pod. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                                description: 'name of the volume. Must be a DNS_LABEL and unique within the pod. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
                                 type: string
+                              persistentVolumeClaim:
+                                description: This is accessible behind a feature flag - kubernetes.podspec-persistent-volume-claim
+                                type: object
+                                x-kubernetes-preserve-unknown-fields: true
                               projected:
-                                description: Items for all in one resources secrets, configmaps, and downward API
+                                description: projected items for all in one resources secrets, configmaps, and downward API
                                 type: object
                                 properties:
                                   defaultMode:
-                                    description: Mode bits used to set permissions on created files by default. Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511. YAML accepts both octal and decimal values, JSON requires decimal values for mode bits. Directories within the path are not affected by this setting. This might be in conflict with other options that affect the file mode, like fsGroup, and the result can be other mode bits set.
+                                    description: defaultMode are the mode bits used to set permissions on created files by default. Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511. YAML accepts both octal and decimal values, JSON requires decimal values for mode bits. Directories within the path are not affected by this setting. This might be in conflict with other options that affect the file mode, like fsGroup, and the result can be other mode bits set.
                                     type: integer
                                     format: int32
                                   sources:
-                                    description: list of volume projections
+                                    description: sources is the list of volume projections
                                     type: array
                                     items:
                                       description: Projection that may be projected along with other supported volume types
                                       type: object
                                       properties:
                                         configMap:
-                                          description: information about the configMap data to project
+                                          description: configMap information about the configMap data to project
                                           type: object
                                           properties:
                                             items:
-                                              description: If unspecified, each key-value pair in the Data field of the referenced ConfigMap will be projected into the volume as a file whose name is the key and content is the value. If specified, the listed keys will be projected into the specified paths, and unlisted keys will not be present. If a key is specified which is not present in the ConfigMap, the volume setup will error unless it is marked optional. Paths must be relative and may not contain the '..' path or start with '..'.
+                                              description: items if unspecified, each key-value pair in the Data field of the referenced ConfigMap will be projected into the volume as a file whose name is the key and content is the value. If specified, the listed keys will be projected into the specified paths, and unlisted keys will not be present. If a key is specified which is not present in the ConfigMap, the volume setup will error unless it is marked optional. Paths must be relative and may not contain the '..' path or start with '..'.
                                               type: array
                                               items:
                                                 description: Maps a string key to a path within a volume.
@@ -828,27 +1100,28 @@ spec:
                                                   - path
                                                 properties:
                                                   key:
-                                                    description: The key to project.
+                                                    description: key is the key to project.
                                                     type: string
                                                   mode:
-                                                    description: 'Optional: mode bits used to set permissions on this file. Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511. YAML accepts both octal and decimal values, JSON requires decimal values for mode bits. If not specified, the volume defaultMode will be used. This might be in conflict with other options that affect the file mode, like fsGroup, and the result can be other mode bits set.'
+                                                    description: 'mode is Optional: mode bits used to set permissions on this file. Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511. YAML accepts both octal and decimal values, JSON requires decimal values for mode bits. If not specified, the volume defaultMode will be used. This might be in conflict with other options that affect the file mode, like fsGroup, and the result can be other mode bits set.'
                                                     type: integer
                                                     format: int32
                                                   path:
-                                                    description: The relative path of the file to map the key to. May not be an absolute path. May not contain the path element '..'. May not start with the string '..'.
+                                                    description: path is the relative path of the file to map the key to. May not be an absolute path. May not contain the path element '..'. May not start with the string '..'.
                                                     type: string
                                             name:
                                               description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?'
                                               type: string
                                             optional:
-                                              description: Specify whether the ConfigMap or its keys must be defined
+                                              description: optional specify whether the ConfigMap or its keys must be defined
                                               type: boolean
+                                          x-kubernetes-map-type: atomic
                                         secret:
-                                          description: information about the secret data to project
+                                          description: secret information about the secret data to project
                                           type: object
                                           properties:
                                             items:
-                                              description: If unspecified, each key-value pair in the Data field of the referenced Secret will be projected into the volume as a file whose name is the key and content is the value. If specified, the listed keys will be projected into the specified paths, and unlisted keys will not be present. If a key is specified which is not present in the Secret, the volume setup will error unless it is marked optional. Paths must be relative and may not contain the '..' path or start with '..'.
+                                              description: items if unspecified, each key-value pair in the Data field of the referenced Secret will be projected into the volume as a file whose name is the key and content is the value. If specified, the listed keys will be projected into the specified paths, and unlisted keys will not be present. If a key is specified which is not present in the Secret, the volume setup will error unless it is marked optional. Paths must be relative and may not contain the '..' path or start with '..'.
                                               type: array
                                               items:
                                                 description: Maps a string key to a path within a volume.
@@ -858,47 +1131,48 @@ spec:
                                                   - path
                                                 properties:
                                                   key:
-                                                    description: The key to project.
+                                                    description: key is the key to project.
                                                     type: string
                                                   mode:
-                                                    description: 'Optional: mode bits used to set permissions on this file. Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511. YAML accepts both octal and decimal values, JSON requires decimal values for mode bits. If not specified, the volume defaultMode will be used. This might be in conflict with other options that affect the file mode, like fsGroup, and the result can be other mode bits set.'
+                                                    description: 'mode is Optional: mode bits used to set permissions on this file. Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511. YAML accepts both octal and decimal values, JSON requires decimal values for mode bits. If not specified, the volume defaultMode will be used. This might be in conflict with other options that affect the file mode, like fsGroup, and the result can be other mode bits set.'
                                                     type: integer
                                                     format: int32
                                                   path:
-                                                    description: The relative path of the file to map the key to. May not be an absolute path. May not contain the path element '..'. May not start with the string '..'.
+                                                    description: path is the relative path of the file to map the key to. May not be an absolute path. May not contain the path element '..'. May not start with the string '..'.
                                                     type: string
                                             name:
                                               description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?'
                                               type: string
                                             optional:
-                                              description: Specify whether the Secret or its key must be defined
+                                              description: optional field specify whether the Secret or its key must be defined
                                               type: boolean
+                                          x-kubernetes-map-type: atomic
                                         serviceAccountToken:
-                                          description: information about the serviceAccountToken data to project
+                                          description: serviceAccountToken is information about the serviceAccountToken data to project
                                           type: object
                                           required:
                                             - path
                                           properties:
                                             audience:
-                                              description: Audience is the intended audience of the token. A recipient of a token must identify itself with an identifier specified in the audience of the token, and otherwise should reject the token. The audience defaults to the identifier of the apiserver.
+                                              description: audience is the intended audience of the token. A recipient of a token must identify itself with an identifier specified in the audience of the token, and otherwise should reject the token. The audience defaults to the identifier of the apiserver.
                                               type: string
                                             expirationSeconds:
-                                              description: ExpirationSeconds is the requested duration of validity of the service account token. As the token approaches expiration, the kubelet volume plugin will proactively rotate the service account token. The kubelet will start trying to rotate the token if the token is older than 80 percent of its time to live or if the token is older than 24 hours.Defaults to 1 hour and must be at least 10 minutes.
+                                              description: expirationSeconds is the requested duration of validity of the service account token. As the token approaches expiration, the kubelet volume plugin will proactively rotate the service account token. The kubelet will start trying to rotate the token if the token is older than 80 percent of its time to live or if the token is older than 24 hours.Defaults to 1 hour and must be at least 10 minutes.
                                               type: integer
                                               format: int64
                                             path:
-                                              description: Path is the path relative to the mount point of the file to project the token into.
+                                              description: path is the path relative to the mount point of the file to project the token into.
                                               type: string
                               secret:
-                                description: 'Secret represents a secret that should populate this volume. More info: https://kubernetes.io/docs/concepts/storage/volumes#secret'
+                                description: 'secret represents a secret that should populate this volume. More info: https://kubernetes.io/docs/concepts/storage/volumes#secret'
                                 type: object
                                 properties:
                                   defaultMode:
-                                    description: 'Optional: mode bits used to set permissions on created files by default. Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511. YAML accepts both octal and decimal values, JSON requires decimal values for mode bits. Defaults to 0644. Directories within the path are not affected by this setting. This might be in conflict with other options that affect the file mode, like fsGroup, and the result can be other mode bits set.'
+                                    description: 'defaultMode is Optional: mode bits used to set permissions on created files by default. Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511. YAML accepts both octal and decimal values, JSON requires decimal values for mode bits. Defaults to 0644. Directories within the path are not affected by this setting. This might be in conflict with other options that affect the file mode, like fsGroup, and the result can be other mode bits set.'
                                     type: integer
                                     format: int32
                                   items:
-                                    description: If unspecified, each key-value pair in the Data field of the referenced Secret will be projected into the volume as a file whose name is the key and content is the value. If specified, the listed keys will be projected into the specified paths, and unlisted keys will not be present. If a key is specified which is not present in the Secret, the volume setup will error unless it is marked optional. Paths must be relative and may not contain the '..' path or start with '..'.
+                                    description: items If unspecified, each key-value pair in the Data field of the referenced Secret will be projected into the volume as a file whose name is the key and content is the value. If specified, the listed keys will be projected into the specified paths, and unlisted keys will not be present. If a key is specified which is not present in the Secret, the volume setup will error unless it is marked optional. Paths must be relative and may not contain the '..' path or start with '..'.
                                     type: array
                                     items:
                                       description: Maps a string key to a path within a volume.
@@ -908,23 +1182,21 @@ spec:
                                         - path
                                       properties:
                                         key:
-                                          description: The key to project.
+                                          description: key is the key to project.
                                           type: string
                                         mode:
-                                          description: 'Optional: mode bits used to set permissions on this file. Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511. YAML accepts both octal and decimal values, JSON requires decimal values for mode bits. If not specified, the volume defaultMode will be used. This might be in conflict with other options that affect the file mode, like fsGroup, and the result can be other mode bits set.'
+                                          description: 'mode is Optional: mode bits used to set permissions on this file. Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511. YAML accepts both octal and decimal values, JSON requires decimal values for mode bits. If not specified, the volume defaultMode will be used. This might be in conflict with other options that affect the file mode, like fsGroup, and the result can be other mode bits set.'
                                           type: integer
                                           format: int32
                                         path:
-                                          description: The relative path of the file to map the key to. May not be an absolute path. May not contain the path element '..'. May not start with the string '..'.
+                                          description: path is the relative path of the file to map the key to. May not be an absolute path. May not contain the path element '..'. May not start with the string '..'.
                                           type: string
                                   optional:
-                                    description: Specify whether the Secret or its keys must be defined
+                                    description: optional field specify whether the Secret or its keys must be defined
                                     type: boolean
                                   secretName:
-                                    description: 'Name of the secret in the pod''s namespace to use. More info: https://kubernetes.io/docs/concepts/storage/volumes#secret'
+                                    description: 'secretName is the name of the secret in the pod''s namespace to use. More info: https://kubernetes.io/docs/concepts/storage/volumes#secret'
                                     type: string
-                            x-kubernetes-preserve-unknown-fields: true
-                      x-kubernetes-preserve-unknown-fields: true
             status:
               description: ConfigurationStatus communicates the observed state of the Configuration (from the controller).
               type: object
@@ -947,7 +1219,6 @@ spec:
                       lastTransitionTime:
                         description: LastTransitionTime is the last time the condition transitioned from one status to another. We use VolatileTime in place of metav1.Time to exclude this from creating equality.Semantic differences (all other things held constant).
                         type: string
-                        format: date-time
                       message:
                         description: A human readable message indicating details about the transition.
                         type: string
@@ -980,8 +1251,8 @@ metadata:
   name: clusterdomainclaims.networking.internal.knative.dev
   labels:
     app.kubernetes.io/name: knative-serving
-    app.kubernetes.io/version: "1.2.5"
-    serving.knative.dev/release: "v1.2.5"
+    app.kubernetes.io/component: networking
+    app.kubernetes.io/version: "1.8.0"
     knative.dev/crd-install: "true"
 spec:
   group: networking.internal.knative.dev
@@ -993,8 +1264,26 @@ spec:
         status: {}
       schema:
         openAPIV3Schema:
+          description: ClusterDomainClaim is a cluster-wide reservation for a particular domain name.
           type: object
-          x-kubernetes-preserve-unknown-fields: true
+          properties:
+            apiVersion:
+              description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+              type: string
+            kind:
+              description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+              type: string
+            metadata:
+              type: object
+            spec:
+              description: 'Spec is the desired state of the ClusterDomainClaim. More info: https://github.com/kubernetes/community/blob/master/contributors/devel/sig-architecture/api-conventions.md#spec-and-status'
+              type: object
+              required:
+                - namespace
+              properties:
+                namespace:
+                  description: Namespace is the namespace which is allowed to create a DomainMapping using this ClusterDomainClaim's name.
+                  type: string
   names:
     kind: ClusterDomainClaim
     plural: clusterdomainclaims
@@ -1012,8 +1301,7 @@ metadata:
   name: domainmappings.serving.knative.dev
   labels:
     app.kubernetes.io/name: knative-serving
-    app.kubernetes.io/version: "1.2.5"
-    serving.knative.dev/release: "v1.2.5"
+    app.kubernetes.io/version: "1.8.0"
     knative.dev/crd-install: "true"
 spec:
   group: serving.knative.dev
@@ -1111,7 +1399,6 @@ spec:
                       lastTransitionTime:
                         description: LastTransitionTime is the last time the condition transitioned from one status to another. We use VolatileTime in place of metav1.Time to exclude this from creating equality.Semantic differences (all other things held constant).
                         type: string
-                        format: date-time
                       message:
                         description: A human readable message indicating details about the transition.
                         type: string
@@ -1217,7 +1504,6 @@ spec:
                       lastTransitionTime:
                         description: LastTransitionTime is the last time the condition transitioned from one status to another. We use VolatileTime in place of metav1.Time to exclude this from creating equality.Semantic differences (all other things held constant).
                         type: string
-                        format: date-time
                       message:
                         description: A human readable message indicating details about the transition.
                         type: string
@@ -1268,8 +1554,8 @@ metadata:
   name: ingresses.networking.internal.knative.dev
   labels:
     app.kubernetes.io/name: knative-serving
-    app.kubernetes.io/version: "1.2.5"
-    serving.knative.dev/release: "v1.2.5"
+    app.kubernetes.io/component: networking
+    app.kubernetes.io/version: "1.8.0"
     knative.dev/crd-install: "true"
 spec:
   group: networking.internal.knative.dev
@@ -1281,8 +1567,212 @@ spec:
         status: {}
       schema:
         openAPIV3Schema:
+          description: "Ingress is a collection of rules that allow inbound connections to reach the endpoints defined by a backend. An Ingress can be configured to give services externally-reachable URLs, load balance traffic, offer name based virtual hosting, etc. \n This is heavily based on K8s Ingress https://godoc.org/k8s.io/api/networking/v1beta1#Ingress which some highlighted modifications."
           type: object
-          x-kubernetes-preserve-unknown-fields: true
+          properties:
+            apiVersion:
+              description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+              type: string
+            kind:
+              description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+              type: string
+            metadata:
+              type: object
+            spec:
+              description: 'Spec is the desired state of the Ingress. More info: https://github.com/kubernetes/community/blob/master/contributors/devel/sig-architecture/api-conventions.md#spec-and-status'
+              type: object
+              properties:
+                httpOption:
+                  description: 'HTTPOption is the option of HTTP. It has the following two values: `HTTPOptionEnabled`, `HTTPOptionRedirected`'
+                  type: string
+                rules:
+                  description: A list of host rules used to configure the Ingress.
+                  type: array
+                  items:
+                    description: IngressRule represents the rules mapping the paths under a specified host to the related backend services. Incoming requests are first evaluated for a host match, then routed to the backend associated with the matching IngressRuleValue.
+                    type: object
+                    properties:
+                      hosts:
+                        description: 'Host is the fully qualified domain name of a network host, as defined by RFC 3986. Note the following deviations from the "host" part of the URI as defined in the RFC: 1. IPs are not allowed. Currently a rule value can only apply to the IP in the Spec of the parent . 2. The `:` delimiter is not respected because ports are not allowed. Currently the port of an Ingress is implicitly :80 for http and :443 for https. Both these may change in the future. If the host is unspecified, the Ingress routes all traffic based on the specified IngressRuleValue. If multiple matching Hosts were provided, the first rule will take precedent.'
+                        type: array
+                        items:
+                          type: string
+                      http:
+                        description: HTTP represents a rule to apply against incoming requests. If the rule is satisfied, the request is routed to the specified backend.
+                        type: object
+                        required:
+                          - paths
+                        properties:
+                          paths:
+                            description: "A collection of paths that map requests to backends. \n If they are multiple matching paths, the first match takes precedence."
+                            type: array
+                            items:
+                              description: HTTPIngressPath associates a path regex with a backend. Incoming URLs matching the path are forwarded to the backend.
+                              type: object
+                              required:
+                                - splits
+                              properties:
+                                appendHeaders:
+                                  description: "AppendHeaders allow specifying additional HTTP headers to add before forwarding a request to the destination service. \n NOTE: This differs from K8s Ingress which doesn't allow header appending."
+                                  type: object
+                                  additionalProperties:
+                                    type: string
+                                headers:
+                                  description: Headers defines header matching rules which is a map from a header name to HeaderMatch which specify a matching condition. When a request matched with all the header matching rules, the request is routed by the corresponding ingress rule. If it is empty, the headers are not used for matching
+                                  type: object
+                                  additionalProperties:
+                                    description: HeaderMatch represents a matching value of Headers in HTTPIngressPath. Currently, only the exact matching is supported.
+                                    type: object
+                                    required:
+                                      - exact
+                                    properties:
+                                      exact:
+                                        type: string
+                                path:
+                                  description: Path represents a literal prefix to which this rule should apply. Currently it can contain characters disallowed from the conventional "path" part of a URL as defined by RFC 3986. Paths must begin with a '/'. If unspecified, the path defaults to a catch all sending traffic to the backend.
+                                  type: string
+                                rewriteHost:
+                                  description: "RewriteHost rewrites the incoming request's host header. \n This field is currently experimental and not supported by all Ingress implementations."
+                                  type: string
+                                splits:
+                                  description: Splits defines the referenced service endpoints to which the traffic will be forwarded to.
+                                  type: array
+                                  items:
+                                    description: IngressBackendSplit describes all endpoints for a given service and port.
+                                    type: object
+                                    required:
+                                      - serviceName
+                                      - serviceNamespace
+                                      - servicePort
+                                    properties:
+                                      appendHeaders:
+                                        description: "AppendHeaders allow specifying additional HTTP headers to add before forwarding a request to the destination service. \n NOTE: This differs from K8s Ingress which doesn't allow header appending."
+                                        type: object
+                                        additionalProperties:
+                                          type: string
+                                      percent:
+                                        description: "Specifies the split percentage, a number between 0 and 100.  If only one split is specified, we default to 100. \n NOTE: This differs from K8s Ingress to allow percentage split."
+                                        type: integer
+                                      serviceName:
+                                        description: Specifies the name of the referenced service.
+                                        type: string
+                                      serviceNamespace:
+                                        description: "Specifies the namespace of the referenced service. \n NOTE: This differs from K8s Ingress to allow routing to different namespaces."
+                                        type: string
+                                      servicePort:
+                                        description: Specifies the port of the referenced service.
+                                        anyOf:
+                                          - type: integer
+                                          - type: string
+                                        x-kubernetes-int-or-string: true
+                      visibility:
+                        description: Visibility signifies whether this rule should `ClusterLocal`. If it's not specified then it defaults to `ExternalIP`.
+                        type: string
+                tls:
+                  description: 'TLS configuration. Currently Ingress only supports a single TLS port: 443. If multiple members of this list specify different hosts, they will be multiplexed on the same port according to the hostname specified through the SNI TLS extension, if the ingress controller fulfilling the ingress supports SNI.'
+                  type: array
+                  items:
+                    description: IngressTLS describes the transport layer security associated with an Ingress.
+                    type: object
+                    properties:
+                      hosts:
+                        description: Hosts is a list of hosts included in the TLS certificate. The values in this list must match the name/s used in the tlsSecret. Defaults to the wildcard host setting for the loadbalancer controller fulfilling this Ingress, if left unspecified.
+                        type: array
+                        items:
+                          type: string
+                      secretName:
+                        description: SecretName is the name of the secret used to terminate SSL traffic.
+                        type: string
+                      secretNamespace:
+                        description: SecretNamespace is the namespace of the secret used to terminate SSL traffic. If not set the namespace should be assumed to be the same as the Ingress. If set the secret should have the same namespace as the Ingress otherwise the behaviour is undefined and not supported.
+                        type: string
+            status:
+              description: 'Status is the current state of the Ingress. More info: https://github.com/kubernetes/community/blob/master/contributors/devel/sig-architecture/api-conventions.md#spec-and-status'
+              type: object
+              properties:
+                annotations:
+                  description: Annotations is additional Status fields for the Resource to save some additional State as well as convey more information to the user. This is roughly akin to Annotations on any k8s resource, just the reconciler conveying richer information outwards.
+                  type: object
+                  additionalProperties:
+                    type: string
+                conditions:
+                  description: Conditions the latest available observations of a resource's current state.
+                  type: array
+                  items:
+                    description: 'Condition defines a readiness condition for a Knative resource. See: https://github.com/kubernetes/community/blob/master/contributors/devel/sig-architecture/api-conventions.md#typical-status-properties'
+                    type: object
+                    required:
+                      - status
+                      - type
+                    properties:
+                      lastTransitionTime:
+                        description: LastTransitionTime is the last time the condition transitioned from one status to another. We use VolatileTime in place of metav1.Time to exclude this from creating equality.Semantic differences (all other things held constant).
+                        type: string
+                      message:
+                        description: A human readable message indicating details about the transition.
+                        type: string
+                      reason:
+                        description: The reason for the condition's last transition.
+                        type: string
+                      severity:
+                        description: Severity with which to treat failures of this type of condition. When this is not specified, it defaults to Error.
+                        type: string
+                      status:
+                        description: Status of the condition, one of True, False, Unknown.
+                        type: string
+                      type:
+                        description: Type of condition.
+                        type: string
+                observedGeneration:
+                  description: ObservedGeneration is the 'Generation' of the Service that was last processed by the controller.
+                  type: integer
+                  format: int64
+                privateLoadBalancer:
+                  description: PrivateLoadBalancer contains the current status of the load-balancer.
+                  type: object
+                  properties:
+                    ingress:
+                      description: Ingress is a list containing ingress points for the load-balancer. Traffic intended for the service should be sent to these ingress points.
+                      type: array
+                      items:
+                        description: 'LoadBalancerIngressStatus represents the status of a load-balancer ingress point: traffic intended for the service should be sent to an ingress point.'
+                        type: object
+                        properties:
+                          domain:
+                            description: Domain is set for load-balancer ingress points that are DNS based (typically AWS load-balancers)
+                            type: string
+                          domainInternal:
+                            description: "DomainInternal is set if there is a cluster-local DNS name to access the Ingress. \n NOTE: This differs from K8s Ingress, since we also desire to have a cluster-local DNS name to allow routing in case of not having a mesh."
+                            type: string
+                          ip:
+                            description: IP is set for load-balancer ingress points that are IP based (typically GCE or OpenStack load-balancers)
+                            type: string
+                          meshOnly:
+                            description: MeshOnly is set if the Ingress is only load-balanced through a Service mesh.
+                            type: boolean
+                publicLoadBalancer:
+                  description: PublicLoadBalancer contains the current status of the load-balancer.
+                  type: object
+                  properties:
+                    ingress:
+                      description: Ingress is a list containing ingress points for the load-balancer. Traffic intended for the service should be sent to these ingress points.
+                      type: array
+                      items:
+                        description: 'LoadBalancerIngressStatus represents the status of a load-balancer ingress point: traffic intended for the service should be sent to an ingress point.'
+                        type: object
+                        properties:
+                          domain:
+                            description: Domain is set for load-balancer ingress points that are DNS based (typically AWS load-balancers)
+                            type: string
+                          domainInternal:
+                            description: "DomainInternal is set if there is a cluster-local DNS name to access the Ingress. \n NOTE: This differs from K8s Ingress, since we also desire to have a cluster-local DNS name to allow routing in case of not having a mesh."
+                            type: string
+                          ip:
+                            description: IP is set for load-balancer ingress points that are IP based (typically GCE or OpenStack load-balancers)
+                            type: string
+                          meshOnly:
+                            description: MeshOnly is set if the Ingress is only load-balanced through a Service mesh.
+                            type: boolean
       additionalPrinterColumns:
         - name: Ready
           type: string
@@ -1308,8 +1798,7 @@ metadata:
   name: metrics.autoscaling.internal.knative.dev
   labels:
     app.kubernetes.io/name: knative-serving
-    app.kubernetes.io/version: "1.2.5"
-    serving.knative.dev/release: "v1.2.5"
+    app.kubernetes.io/version: "1.8.0"
     knative.dev/crd-install: "true"
 spec:
   group: autoscaling.internal.knative.dev
@@ -1388,7 +1877,6 @@ spec:
                       lastTransitionTime:
                         description: LastTransitionTime is the last time the condition transitioned from one status to another. We use VolatileTime in place of metav1.Time to exclude this from creating equality.Semantic differences (all other things held constant).
                         type: string
-                        format: date-time
                       message:
                         description: A human readable message indicating details about the transition.
                         type: string
@@ -1415,8 +1903,7 @@ metadata:
   name: podautoscalers.autoscaling.internal.knative.dev
   labels:
     app.kubernetes.io/name: knative-serving
-    app.kubernetes.io/version: "1.2.5"
-    serving.knative.dev/release: "v1.2.5"
+    app.kubernetes.io/version: "1.8.0"
     knative.dev/crd-install: "true"
 spec:
   group: autoscaling.internal.knative.dev
@@ -1452,7 +1939,7 @@ spec:
           jsonPath: ".status.conditions[?(@.type=='Ready')].reason"
       schema:
         openAPIV3Schema:
-          description: 'PodAutoscaler is a Knative abstraction that encapsulates the interface by which Knative components instantiate autoscalers.  This definition is an abstraction that may be backed by multiple definitions.  For more information, see the Knative Pluggability presentation: https://docs.google.com/presentation/d/10KWynvAJYuOEWy69VBa6bHJVCqIsz1TNdEKosNvcpPY/edit'
+          description: 'PodAutoscaler is a Knative abstraction that encapsulates the interface by which Knative components instantiate autoscalers.  This definition is an abstraction that may be backed by multiple definitions.  For more information, see the Knative Pluggability presentation: https://docs.google.com/presentation/d/19vW9HFZ6Puxt31biNZF3uLRejDmu82rxJIk1cWmxF7w/edit'
           type: object
           properties:
             apiVersion:
@@ -1493,6 +1980,7 @@ spec:
                     name:
                       description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
                       type: string
+                  x-kubernetes-map-type: atomic
             status:
               description: Status communicates the observed state of the PodAutoscaler (from the controller).
               type: object
@@ -1522,7 +2010,6 @@ spec:
                       lastTransitionTime:
                         description: LastTransitionTime is the last time the condition transitioned from one status to another. We use VolatileTime in place of metav1.Time to exclude this from creating equality.Semantic differences (all other things held constant).
                         type: string
-                        format: date-time
                       message:
                         description: A human readable message indicating details about the transition.
                         type: string
@@ -1559,8 +2046,7 @@ metadata:
   name: revisions.serving.knative.dev
   labels:
     app.kubernetes.io/name: knative-serving
-    app.kubernetes.io/version: "1.2.5"
-    serving.knative.dev/release: "v1.2.5"
+    app.kubernetes.io/version: "1.8.0"
     knative.dev/crd-install: "true"
 spec:
   group: serving.knative.dev
@@ -1622,6 +2108,10 @@ spec:
               required:
                 - containers
               properties:
+                affinity:
+                  description: This is accessible behind a feature flag - kubernetes.podspec-affinity
+                  type: object
+                  x-kubernetes-preserve-unknown-fields: true
                 automountServiceAccountToken:
                   description: AutomountServiceAccountToken indicates whether a service account token should be automatically mounted.
                   type: boolean
@@ -1637,12 +2127,12 @@ spec:
                     type: object
                     properties:
                       args:
-                        description: 'Arguments to the entrypoint. The docker image''s CMD is used if this is not provided. Variable references $(VAR_NAME) are expanded using the container''s environment. If a variable cannot be resolved, the reference in the input string will be unchanged. Double $$ are reduced to a single $, which allows for escaping the $(VAR_NAME) syntax: i.e. "$$(VAR_NAME)" will produce the string literal "$(VAR_NAME)". Escaped references will never be expanded, regardless of whether the variable exists or not. Cannot be updated. More info: https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell'
+                        description: 'Arguments to the entrypoint. The container image''s CMD is used if this is not provided. Variable references $(VAR_NAME) are expanded using the container''s environment. If a variable cannot be resolved, the reference in the input string will be unchanged. Double $$ are reduced to a single $, which allows for escaping the $(VAR_NAME) syntax: i.e. "$$(VAR_NAME)" will produce the string literal "$(VAR_NAME)". Escaped references will never be expanded, regardless of whether the variable exists or not. Cannot be updated. More info: https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell'
                         type: array
                         items:
                           type: string
                       command:
-                        description: 'Entrypoint array. Not executed within a shell. The docker image''s ENTRYPOINT is used if this is not provided. Variable references $(VAR_NAME) are expanded using the container''s environment. If a variable cannot be resolved, the reference in the input string will be unchanged. Double $$ are reduced to a single $, which allows for escaping the $(VAR_NAME) syntax: i.e. "$$(VAR_NAME)" will produce the string literal "$(VAR_NAME)". Escaped references will never be expanded, regardless of whether the variable exists or not. Cannot be updated. More info: https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell'
+                        description: 'Entrypoint array. Not executed within a shell. The container image''s ENTRYPOINT is used if this is not provided. Variable references $(VAR_NAME) are expanded using the container''s environment. If a variable cannot be resolved, the reference in the input string will be unchanged. Double $$ are reduced to a single $, which allows for escaping the $(VAR_NAME) syntax: i.e. "$$(VAR_NAME)" will produce the string literal "$(VAR_NAME)". Escaped references will never be expanded, regardless of whether the variable exists or not. Cannot be updated. More info: https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell'
                         type: array
                         items:
                           type: string
@@ -1680,6 +2170,17 @@ spec:
                                     optional:
                                       description: Specify whether the ConfigMap or its key must be defined
                                       type: boolean
+                                  x-kubernetes-map-type: atomic
+                                fieldRef:
+                                  description: This is accessible behind a feature flag - kubernetes.podspec-fieldref
+                                  type: object
+                                  x-kubernetes-preserve-unknown-fields: true
+                                  x-kubernetes-map-type: atomic
+                                resourceFieldRef:
+                                  description: This is accessible behind a feature flag - kubernetes.podspec-fieldref
+                                  type: object
+                                  x-kubernetes-preserve-unknown-fields: true
+                                  x-kubernetes-map-type: atomic
                                 secretKeyRef:
                                   description: Selects a key of a secret in the pod's namespace
                                   type: object
@@ -1695,7 +2196,7 @@ spec:
                                     optional:
                                       description: Specify whether the Secret or its key must be defined
                                       type: boolean
-                              x-kubernetes-preserve-unknown-fields: true
+                                  x-kubernetes-map-type: atomic
                       envFrom:
                         description: List of sources to populate environment variables in the container. The keys defined within a source must be a C_IDENTIFIER. All invalid keys will be reported as an event when the container is starting. When a key exists in multiple sources, the value associated with the last source will take precedence. Values defined by an Env with a duplicate key will take precedence. Cannot be updated.
                         type: array
@@ -1713,6 +2214,7 @@ spec:
                                 optional:
                                   description: Specify whether the ConfigMap must be defined
                                   type: boolean
+                              x-kubernetes-map-type: atomic
                             prefix:
                               description: An optional identifier to prepend to each key in the ConfigMap. Must be a C_IDENTIFIER.
                               type: string
@@ -1726,8 +2228,9 @@ spec:
                                 optional:
                                   description: Specify whether the Secret must be defined
                                   type: boolean
+                              x-kubernetes-map-type: atomic
                       image:
-                        description: 'Docker image name. More info: https://kubernetes.io/docs/concepts/containers/images This field is optional to allow higher level config management to default or override container images in workload controllers like Deployments and StatefulSets.'
+                        description: 'Container image name. More info: https://kubernetes.io/docs/concepts/containers/images This field is optional to allow higher level config management to default or override container images in workload controllers like Deployments and StatefulSets.'
                         type: string
                       imagePullPolicy:
                         description: 'Image pull policy. One of Always, Never, IfNotPresent. Defaults to Always if :latest tag is specified, or IfNotPresent otherwise. Cannot be updated. More info: https://kubernetes.io/docs/concepts/containers/images#updating-images'
@@ -1737,7 +2240,7 @@ spec:
                         type: object
                         properties:
                           exec:
-                            description: One and only one of the following should be specified. Exec specifies the action to take.
+                            description: Exec specifies the action to take.
                             type: object
                             properties:
                               command:
@@ -1775,10 +2278,15 @@ spec:
                               path:
                                 description: Path to access on the HTTP server.
                                 type: string
+                              port:
+                                description: Name or number of the port to access on the container. Number must be in the range 1 to 65535. Name must be an IANA_SVC_NAME.
+                                anyOf:
+                                  - type: integer
+                                  - type: string
+                                x-kubernetes-int-or-string: true
                               scheme:
                                 description: Scheme to use for connecting to the host. Defaults to HTTP.
                                 type: string
-                            x-kubernetes-preserve-unknown-fields: true
                           initialDelaySeconds:
                             description: 'Number of seconds after the container has started before liveness probes are initiated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
                             type: integer
@@ -1792,13 +2300,18 @@ spec:
                             type: integer
                             format: int32
                           tcpSocket:
-                            description: 'TCPSocket specifies an action involving a TCP port. TCP hooks not yet supported TODO: implement a realistic TCP lifecycle hook'
+                            description: TCPSocket specifies an action involving a TCP port.
                             type: object
                             properties:
                               host:
                                 description: 'Optional: Host name to connect to, defaults to the pod IP.'
                                 type: string
-                            x-kubernetes-preserve-unknown-fields: true
+                              port:
+                                description: Number or name of the port to access on the container. Number must be in the range 1 to 65535. Name must be an IANA_SVC_NAME.
+                                anyOf:
+                                  - type: integer
+                                  - type: string
+                                x-kubernetes-int-or-string: true
                           timeoutSeconds:
                             description: 'Number of seconds after which the probe times out. Defaults to 1 second. Minimum value is 1. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
                             type: integer
@@ -1807,7 +2320,7 @@ spec:
                         description: Name of the container specified as a DNS_LABEL. Each container in a pod must have a unique name (DNS_LABEL). Cannot be updated.
                         type: string
                       ports:
-                        description: List of ports to expose from the container. Exposing a port here gives the system additional information about the network connections a container uses, but is primarily informational. Not specifying a port here DOES NOT prevent that port from being exposed. Any port which is listening on the default "0.0.0.0" address inside a container will be accessible from the network. Cannot be updated.
+                        description: List of ports to expose from the container. Not specifying a port here DOES NOT prevent that port from being exposed. Any port which is listening on the default "0.0.0.0" address inside a container will be accessible from the network. Modifying this array with strategic merge patch may corrupt the data. For more information See https://github.com/kubernetes/kubernetes/issues/108255. Cannot be updated.
                         type: array
                         items:
                           description: ContainerPort represents a network port in a single container.
@@ -1826,7 +2339,6 @@ spec:
                               description: Protocol for port. Must be UDP, TCP, or SCTP. Defaults to "TCP".
                               type: string
                               default: TCP
-                          x-kubernetes-preserve-unknown-fields: true
                         x-kubernetes-list-map-keys:
                           - containerPort
                           - protocol
@@ -1836,7 +2348,7 @@ spec:
                         type: object
                         properties:
                           exec:
-                            description: One and only one of the following should be specified. Exec specifies the action to take.
+                            description: Exec specifies the action to take.
                             type: object
                             properties:
                               command:
@@ -1874,10 +2386,15 @@ spec:
                               path:
                                 description: Path to access on the HTTP server.
                                 type: string
+                              port:
+                                description: Name or number of the port to access on the container. Number must be in the range 1 to 65535. Name must be an IANA_SVC_NAME.
+                                anyOf:
+                                  - type: integer
+                                  - type: string
+                                x-kubernetes-int-or-string: true
                               scheme:
                                 description: Scheme to use for connecting to the host. Defaults to HTTP.
                                 type: string
-                            x-kubernetes-preserve-unknown-fields: true
                           initialDelaySeconds:
                             description: 'Number of seconds after the container has started before liveness probes are initiated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
                             type: integer
@@ -1891,13 +2408,18 @@ spec:
                             type: integer
                             format: int32
                           tcpSocket:
-                            description: 'TCPSocket specifies an action involving a TCP port. TCP hooks not yet supported TODO: implement a realistic TCP lifecycle hook'
+                            description: TCPSocket specifies an action involving a TCP port.
                             type: object
                             properties:
                               host:
                                 description: 'Optional: Host name to connect to, defaults to the pod IP.'
                                 type: string
-                            x-kubernetes-preserve-unknown-fields: true
+                              port:
+                                description: Number or name of the port to access on the container. Number must be in the range 1 to 65535. Name must be an IANA_SVC_NAME.
+                                anyOf:
+                                  - type: integer
+                                  - type: string
+                                x-kubernetes-int-or-string: true
                           timeoutSeconds:
                             description: 'Number of seconds after which the probe times out. Defaults to 1 second. Minimum value is 1. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
                             type: integer
@@ -1928,25 +2450,39 @@ spec:
                         description: 'SecurityContext defines the security options the container should be run with. If set, the fields of SecurityContext override the equivalent fields of PodSecurityContext. More info: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/'
                         type: object
                         properties:
+                          allowPrivilegeEscalation:
+                            description: 'AllowPrivilegeEscalation controls whether a process can gain more privileges than its parent process. This bool directly controls if the no_new_privs flag will be set on the container process. AllowPrivilegeEscalation is true always when the container is: 1) run as Privileged 2) has CAP_SYS_ADMIN Note that this field cannot be set when spec.os.name is windows.'
+                            type: boolean
                           capabilities:
-                            description: The capabilities to add/drop when running containers. Defaults to the default set of capabilities granted by the container runtime.
+                            description: The capabilities to add/drop when running containers. Defaults to the default set of capabilities granted by the container runtime. Note that this field cannot be set when spec.os.name is windows.
                             type: object
                             properties:
+                              add:
+                                description: This is accessible behind a feature flag - kubernetes.containerspec-addcapabilities
+                                type: array
+                                items:
+                                  description: Capability represent POSIX capabilities type
+                                  type: string
                               drop:
                                 description: Removed capabilities
                                 type: array
                                 items:
                                   description: Capability represent POSIX capabilities type
                                   type: string
-                            x-kubernetes-preserve-unknown-fields: true
                           readOnlyRootFilesystem:
-                            description: Whether this container has a read-only root filesystem. Default is false.
+                            description: Whether this container has a read-only root filesystem. Default is false. Note that this field cannot be set when spec.os.name is windows.
                             type: boolean
-                          runAsUser:
-                            description: The UID to run the entrypoint of the container process. Defaults to user specified in image metadata if unspecified. May also be set in PodSecurityContext.  If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence.
+                          runAsGroup:
+                            description: The GID to run the entrypoint of the container process. Uses runtime default if unset. May also be set in PodSecurityContext.  If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence. Note that this field cannot be set when spec.os.name is windows.
                             type: integer
                             format: int64
-                        x-kubernetes-preserve-unknown-fields: true
+                          runAsNonRoot:
+                            description: Indicates that the container must run as a non-root user. If true, the Kubelet will validate the image at runtime to ensure that it does not run as UID 0 (root) and fail to start the container if it does. If unset or false, no such validation will be performed. May also be set in PodSecurityContext.  If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence.
+                            type: boolean
+                          runAsUser:
+                            description: The UID to run the entrypoint of the container process. Defaults to user specified in image metadata if unspecified. May also be set in PodSecurityContext.  If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence. Note that this field cannot be set when spec.os.name is windows.
+                            type: integer
+                            format: int64
                       terminationMessagePath:
                         description: 'Optional: Path at which the file to which the container''s termination message will be written is mounted into the container''s filesystem. Message written is intended to be brief final status, such as an assertion failure message. Will be truncated by the node if greater than 4096 bytes. The total message length across all containers will be limited to 12kb. Defaults to /dev/termination-log. Cannot be updated.'
                         type: string
@@ -1978,12 +2514,29 @@ spec:
                       workingDir:
                         description: Container's working directory. If not specified, the container runtime's default will be used, which might be configured in the container image. Cannot be updated.
                         type: string
-                    x-kubernetes-preserve-unknown-fields: true
+                dnsConfig:
+                  description: This is accessible behind a feature flag - kubernetes.podspec-dnsconfig
+                  type: object
+                  x-kubernetes-preserve-unknown-fields: true
+                dnsPolicy:
+                  description: This is accessible behind a feature flag - kubernetes.podspec-dnspolicy
+                  type: string
                 enableServiceLinks:
-                  description: 'EnableServiceLinks indicates whether information about services should be injected into pod''s environment variables, matching the syntax of Docker links. Optional: Defaults to true.'
+                  description: 'EnableServiceLinks indicates whether information about services should be injected into pod''s environment variables, matching the syntax of Docker links. Optional: Knative defaults this to false.'
                   type: boolean
+                hostAliases:
+                  description: This is accessible behind a feature flag - kubernetes.podspec-hostaliases
+                  type: array
+                  items:
+                    description: This is accessible behind a feature flag - kubernetes.podspec-hostaliases
+                    type: object
+                    x-kubernetes-preserve-unknown-fields: true
+                idleTimeoutSeconds:
+                  description: IdleTimeoutSeconds is the maximum duration in seconds a request will be allowed to stay open while not receiving any bytes from the user's application. If unspecified, a system default will be provided.
+                  type: integer
+                  format: int64
                 imagePullSecrets:
-                  description: 'ImagePullSecrets is an optional list of references to secrets in the same namespace to use for pulling any of the images used by this PodSpec. If specified, these secrets will be passed to individual puller implementations for them to use. For example, in the case of docker, only DockerConfig type secrets are honored. More info: https://kubernetes.io/docs/concepts/containers/images#specifying-imagepullsecrets-on-a-pod'
+                  description: 'ImagePullSecrets is an optional list of references to secrets in the same namespace to use for pulling any of the images used by this PodSpec. If specified, these secrets will be passed to individual puller implementations for them to use. More info: https://kubernetes.io/docs/concepts/containers/images#specifying-imagepullsecrets-on-a-pod'
                   type: array
                   items:
                     description: LocalObjectReference contains enough information to let you locate the referenced object inside the same namespace.
@@ -1992,13 +2545,60 @@ spec:
                       name:
                         description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?'
                         type: string
+                    x-kubernetes-map-type: atomic
+                initContainers:
+                  description: 'List of initialization containers belonging to the pod. Init containers are executed in order prior to containers being started. If any init container fails, the pod is considered to have failed and is handled according to its restartPolicy. The name for an init container or normal container must be unique among all containers. Init containers may not have Lifecycle actions, Readiness probes, Liveness probes, or Startup probes. The resourceRequirements of an init container are taken into account during scheduling by finding the highest request/limit for each resource type, and then using the max of of that value or the sum of the normal containers. Limits are applied to init containers in a similar fashion. Init containers cannot currently be added or removed. Cannot be updated. More info: https://kubernetes.io/docs/concepts/workloads/pods/init-containers/'
+                  type: array
+                  items:
+                    description: This is accessible behind a feature flag - kubernetes.podspec-init-containers
+                    type: object
+                    x-kubernetes-preserve-unknown-fields: true
+                nodeSelector:
+                  description: This is accessible behind a feature flag - kubernetes.podspec-nodeselector
+                  type: object
+                  x-kubernetes-preserve-unknown-fields: true
+                  x-kubernetes-map-type: atomic
+                priorityClassName:
+                  description: This is accessible behind a feature flag - kubernetes.podspec-priorityclassname
+                  type: string
+                  x-kubernetes-preserve-unknown-fields: true
+                responseStartTimeoutSeconds:
+                  description: ResponseStartTimeoutSeconds is the maximum duration in seconds that the request routing layer will wait for a request delivered to a container to begin sending any network traffic.
+                  type: integer
+                  format: int64
+                runtimeClassName:
+                  description: This is accessible behind a feature flag - kubernetes.podspec-runtimeclassname
+                  type: string
+                  x-kubernetes-preserve-unknown-fields: true
+                schedulerName:
+                  description: This is accessible behind a feature flag - kubernetes.podspec-schedulername
+                  type: string
+                  x-kubernetes-preserve-unknown-fields: true
+                securityContext:
+                  description: This is accessible behind a feature flag - kubernetes.podspec-securitycontext
+                  type: object
+                  x-kubernetes-preserve-unknown-fields: true
                 serviceAccountName:
                   description: 'ServiceAccountName is the name of the ServiceAccount to use to run this pod. More info: https://kubernetes.io/docs/tasks/configure-pod-container/configure-service-account/'
                   type: string
                 timeoutSeconds:
-                  description: TimeoutSeconds is the maximum duration in seconds that the request routing layer will wait for a request delivered to a container to begin replying (send network traffic). If unspecified, a system default will be provided.
+                  description: TimeoutSeconds is the maximum duration in seconds that the request instance is allowed to respond to a request. If unspecified, a system default will be provided.
                   type: integer
                   format: int64
+                tolerations:
+                  description: This is accessible behind a feature flag - kubernetes.podspec-tolerations
+                  type: array
+                  items:
+                    description: This is accessible behind a feature flag - kubernetes.podspec-tolerations
+                    type: object
+                    x-kubernetes-preserve-unknown-fields: true
+                topologySpreadConstraints:
+                  description: This is accessible behind a feature flag - kubernetes.podspec-topologyspreadconstraints
+                  type: array
+                  items:
+                    description: This is accessible behind a feature flag - kubernetes.podspec-topologyspreadconstraints
+                    type: object
+                    x-kubernetes-preserve-unknown-fields: true
                 volumes:
                   description: 'List of volumes that can be mounted by containers belonging to the pod. More info: https://kubernetes.io/docs/concepts/storage/volumes'
                   type: array
@@ -2009,15 +2609,15 @@ spec:
                       - name
                     properties:
                       configMap:
-                        description: ConfigMap represents a configMap that should populate this volume
+                        description: configMap represents a configMap that should populate this volume
                         type: object
                         properties:
                           defaultMode:
-                            description: 'Optional: mode bits used to set permissions on created files by default. Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511. YAML accepts both octal and decimal values, JSON requires decimal values for mode bits. Defaults to 0644. Directories within the path are not affected by this setting. This might be in conflict with other options that affect the file mode, like fsGroup, and the result can be other mode bits set.'
+                            description: 'defaultMode is optional: mode bits used to set permissions on created files by default. Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511. YAML accepts both octal and decimal values, JSON requires decimal values for mode bits. Defaults to 0644. Directories within the path are not affected by this setting. This might be in conflict with other options that affect the file mode, like fsGroup, and the result can be other mode bits set.'
                             type: integer
                             format: int32
                           items:
-                            description: If unspecified, each key-value pair in the Data field of the referenced ConfigMap will be projected into the volume as a file whose name is the key and content is the value. If specified, the listed keys will be projected into the specified paths, and unlisted keys will not be present. If a key is specified which is not present in the ConfigMap, the volume setup will error unless it is marked optional. Paths must be relative and may not contain the '..' path or start with '..'.
+                            description: items if unspecified, each key-value pair in the Data field of the referenced ConfigMap will be projected into the volume as a file whose name is the key and content is the value. If specified, the listed keys will be projected into the specified paths, and unlisted keys will not be present. If a key is specified which is not present in the ConfigMap, the volume setup will error unless it is marked optional. Paths must be relative and may not contain the '..' path or start with '..'.
                             type: array
                             items:
                               description: Maps a string key to a path within a volume.
@@ -2027,45 +2627,54 @@ spec:
                                 - path
                               properties:
                                 key:
-                                  description: The key to project.
+                                  description: key is the key to project.
                                   type: string
                                 mode:
-                                  description: 'Optional: mode bits used to set permissions on this file. Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511. YAML accepts both octal and decimal values, JSON requires decimal values for mode bits. If not specified, the volume defaultMode will be used. This might be in conflict with other options that affect the file mode, like fsGroup, and the result can be other mode bits set.'
+                                  description: 'mode is Optional: mode bits used to set permissions on this file. Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511. YAML accepts both octal and decimal values, JSON requires decimal values for mode bits. If not specified, the volume defaultMode will be used. This might be in conflict with other options that affect the file mode, like fsGroup, and the result can be other mode bits set.'
                                   type: integer
                                   format: int32
                                 path:
-                                  description: The relative path of the file to map the key to. May not be an absolute path. May not contain the path element '..'. May not start with the string '..'.
+                                  description: path is the relative path of the file to map the key to. May not be an absolute path. May not contain the path element '..'. May not start with the string '..'.
                                   type: string
                           name:
                             description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?'
                             type: string
                           optional:
-                            description: Specify whether the ConfigMap or its keys must be defined
+                            description: optional specify whether the ConfigMap or its keys must be defined
                             type: boolean
+                        x-kubernetes-map-type: atomic
+                      emptyDir:
+                        description: This is accessible behind a feature flag - kubernetes.podspec-emptydir
+                        type: object
+                        x-kubernetes-preserve-unknown-fields: true
                       name:
-                        description: 'Volume''s name. Must be a DNS_LABEL and unique within the pod. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                        description: 'name of the volume. Must be a DNS_LABEL and unique within the pod. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
                         type: string
+                      persistentVolumeClaim:
+                        description: This is accessible behind a feature flag - kubernetes.podspec-persistent-volume-claim
+                        type: object
+                        x-kubernetes-preserve-unknown-fields: true
                       projected:
-                        description: Items for all in one resources secrets, configmaps, and downward API
+                        description: projected items for all in one resources secrets, configmaps, and downward API
                         type: object
                         properties:
                           defaultMode:
-                            description: Mode bits used to set permissions on created files by default. Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511. YAML accepts both octal and decimal values, JSON requires decimal values for mode bits. Directories within the path are not affected by this setting. This might be in conflict with other options that affect the file mode, like fsGroup, and the result can be other mode bits set.
+                            description: defaultMode are the mode bits used to set permissions on created files by default. Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511. YAML accepts both octal and decimal values, JSON requires decimal values for mode bits. Directories within the path are not affected by this setting. This might be in conflict with other options that affect the file mode, like fsGroup, and the result can be other mode bits set.
                             type: integer
                             format: int32
                           sources:
-                            description: list of volume projections
+                            description: sources is the list of volume projections
                             type: array
                             items:
                               description: Projection that may be projected along with other supported volume types
                               type: object
                               properties:
                                 configMap:
-                                  description: information about the configMap data to project
+                                  description: configMap information about the configMap data to project
                                   type: object
                                   properties:
                                     items:
-                                      description: If unspecified, each key-value pair in the Data field of the referenced ConfigMap will be projected into the volume as a file whose name is the key and content is the value. If specified, the listed keys will be projected into the specified paths, and unlisted keys will not be present. If a key is specified which is not present in the ConfigMap, the volume setup will error unless it is marked optional. Paths must be relative and may not contain the '..' path or start with '..'.
+                                      description: items if unspecified, each key-value pair in the Data field of the referenced ConfigMap will be projected into the volume as a file whose name is the key and content is the value. If specified, the listed keys will be projected into the specified paths, and unlisted keys will not be present. If a key is specified which is not present in the ConfigMap, the volume setup will error unless it is marked optional. Paths must be relative and may not contain the '..' path or start with '..'.
                                       type: array
                                       items:
                                         description: Maps a string key to a path within a volume.
@@ -2075,27 +2684,28 @@ spec:
                                           - path
                                         properties:
                                           key:
-                                            description: The key to project.
+                                            description: key is the key to project.
                                             type: string
                                           mode:
-                                            description: 'Optional: mode bits used to set permissions on this file. Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511. YAML accepts both octal and decimal values, JSON requires decimal values for mode bits. If not specified, the volume defaultMode will be used. This might be in conflict with other options that affect the file mode, like fsGroup, and the result can be other mode bits set.'
+                                            description: 'mode is Optional: mode bits used to set permissions on this file. Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511. YAML accepts both octal and decimal values, JSON requires decimal values for mode bits. If not specified, the volume defaultMode will be used. This might be in conflict with other options that affect the file mode, like fsGroup, and the result can be other mode bits set.'
                                             type: integer
                                             format: int32
                                           path:
-                                            description: The relative path of the file to map the key to. May not be an absolute path. May not contain the path element '..'. May not start with the string '..'.
+                                            description: path is the relative path of the file to map the key to. May not be an absolute path. May not contain the path element '..'. May not start with the string '..'.
                                             type: string
                                     name:
                                       description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?'
                                       type: string
                                     optional:
-                                      description: Specify whether the ConfigMap or its keys must be defined
+                                      description: optional specify whether the ConfigMap or its keys must be defined
                                       type: boolean
+                                  x-kubernetes-map-type: atomic
                                 secret:
-                                  description: information about the secret data to project
+                                  description: secret information about the secret data to project
                                   type: object
                                   properties:
                                     items:
-                                      description: If unspecified, each key-value pair in the Data field of the referenced Secret will be projected into the volume as a file whose name is the key and content is the value. If specified, the listed keys will be projected into the specified paths, and unlisted keys will not be present. If a key is specified which is not present in the Secret, the volume setup will error unless it is marked optional. Paths must be relative and may not contain the '..' path or start with '..'.
+                                      description: items if unspecified, each key-value pair in the Data field of the referenced Secret will be projected into the volume as a file whose name is the key and content is the value. If specified, the listed keys will be projected into the specified paths, and unlisted keys will not be present. If a key is specified which is not present in the Secret, the volume setup will error unless it is marked optional. Paths must be relative and may not contain the '..' path or start with '..'.
                                       type: array
                                       items:
                                         description: Maps a string key to a path within a volume.
@@ -2105,47 +2715,48 @@ spec:
                                           - path
                                         properties:
                                           key:
-                                            description: The key to project.
+                                            description: key is the key to project.
                                             type: string
                                           mode:
-                                            description: 'Optional: mode bits used to set permissions on this file. Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511. YAML accepts both octal and decimal values, JSON requires decimal values for mode bits. If not specified, the volume defaultMode will be used. This might be in conflict with other options that affect the file mode, like fsGroup, and the result can be other mode bits set.'
+                                            description: 'mode is Optional: mode bits used to set permissions on this file. Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511. YAML accepts both octal and decimal values, JSON requires decimal values for mode bits. If not specified, the volume defaultMode will be used. This might be in conflict with other options that affect the file mode, like fsGroup, and the result can be other mode bits set.'
                                             type: integer
                                             format: int32
                                           path:
-                                            description: The relative path of the file to map the key to. May not be an absolute path. May not contain the path element '..'. May not start with the string '..'.
+                                            description: path is the relative path of the file to map the key to. May not be an absolute path. May not contain the path element '..'. May not start with the string '..'.
                                             type: string
                                     name:
                                       description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?'
                                       type: string
                                     optional:
-                                      description: Specify whether the Secret or its key must be defined
+                                      description: optional field specify whether the Secret or its key must be defined
                                       type: boolean
+                                  x-kubernetes-map-type: atomic
                                 serviceAccountToken:
-                                  description: information about the serviceAccountToken data to project
+                                  description: serviceAccountToken is information about the serviceAccountToken data to project
                                   type: object
                                   required:
                                     - path
                                   properties:
                                     audience:
-                                      description: Audience is the intended audience of the token. A recipient of a token must identify itself with an identifier specified in the audience of the token, and otherwise should reject the token. The audience defaults to the identifier of the apiserver.
+                                      description: audience is the intended audience of the token. A recipient of a token must identify itself with an identifier specified in the audience of the token, and otherwise should reject the token. The audience defaults to the identifier of the apiserver.
                                       type: string
                                     expirationSeconds:
-                                      description: ExpirationSeconds is the requested duration of validity of the service account token. As the token approaches expiration, the kubelet volume plugin will proactively rotate the service account token. The kubelet will start trying to rotate the token if the token is older than 80 percent of its time to live or if the token is older than 24 hours.Defaults to 1 hour and must be at least 10 minutes.
+                                      description: expirationSeconds is the requested duration of validity of the service account token. As the token approaches expiration, the kubelet volume plugin will proactively rotate the service account token. The kubelet will start trying to rotate the token if the token is older than 80 percent of its time to live or if the token is older than 24 hours.Defaults to 1 hour and must be at least 10 minutes.
                                       type: integer
                                       format: int64
                                     path:
-                                      description: Path is the path relative to the mount point of the file to project the token into.
+                                      description: path is the path relative to the mount point of the file to project the token into.
                                       type: string
                       secret:
-                        description: 'Secret represents a secret that should populate this volume. More info: https://kubernetes.io/docs/concepts/storage/volumes#secret'
+                        description: 'secret represents a secret that should populate this volume. More info: https://kubernetes.io/docs/concepts/storage/volumes#secret'
                         type: object
                         properties:
                           defaultMode:
-                            description: 'Optional: mode bits used to set permissions on created files by default. Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511. YAML accepts both octal and decimal values, JSON requires decimal values for mode bits. Defaults to 0644. Directories within the path are not affected by this setting. This might be in conflict with other options that affect the file mode, like fsGroup, and the result can be other mode bits set.'
+                            description: 'defaultMode is Optional: mode bits used to set permissions on created files by default. Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511. YAML accepts both octal and decimal values, JSON requires decimal values for mode bits. Defaults to 0644. Directories within the path are not affected by this setting. This might be in conflict with other options that affect the file mode, like fsGroup, and the result can be other mode bits set.'
                             type: integer
                             format: int32
                           items:
-                            description: If unspecified, each key-value pair in the Data field of the referenced Secret will be projected into the volume as a file whose name is the key and content is the value. If specified, the listed keys will be projected into the specified paths, and unlisted keys will not be present. If a key is specified which is not present in the Secret, the volume setup will error unless it is marked optional. Paths must be relative and may not contain the '..' path or start with '..'.
+                            description: items If unspecified, each key-value pair in the Data field of the referenced Secret will be projected into the volume as a file whose name is the key and content is the value. If specified, the listed keys will be projected into the specified paths, and unlisted keys will not be present. If a key is specified which is not present in the Secret, the volume setup will error unless it is marked optional. Paths must be relative and may not contain the '..' path or start with '..'.
                             type: array
                             items:
                               description: Maps a string key to a path within a volume.
@@ -2155,23 +2766,21 @@ spec:
                                 - path
                               properties:
                                 key:
-                                  description: The key to project.
+                                  description: key is the key to project.
                                   type: string
                                 mode:
-                                  description: 'Optional: mode bits used to set permissions on this file. Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511. YAML accepts both octal and decimal values, JSON requires decimal values for mode bits. If not specified, the volume defaultMode will be used. This might be in conflict with other options that affect the file mode, like fsGroup, and the result can be other mode bits set.'
+                                  description: 'mode is Optional: mode bits used to set permissions on this file. Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511. YAML accepts both octal and decimal values, JSON requires decimal values for mode bits. If not specified, the volume defaultMode will be used. This might be in conflict with other options that affect the file mode, like fsGroup, and the result can be other mode bits set.'
                                   type: integer
                                   format: int32
                                 path:
-                                  description: The relative path of the file to map the key to. May not be an absolute path. May not contain the path element '..'. May not start with the string '..'.
+                                  description: path is the relative path of the file to map the key to. May not be an absolute path. May not contain the path element '..'. May not start with the string '..'.
                                   type: string
                           optional:
-                            description: Specify whether the Secret or its keys must be defined
+                            description: optional field specify whether the Secret or its keys must be defined
                             type: boolean
                           secretName:
-                            description: 'Name of the secret in the pod''s namespace to use. More info: https://kubernetes.io/docs/concepts/storage/volumes#secret'
+                            description: 'secretName is the name of the secret in the pod''s namespace to use. More info: https://kubernetes.io/docs/concepts/storage/volumes#secret'
                             type: string
-                    x-kubernetes-preserve-unknown-fields: true
-              x-kubernetes-preserve-unknown-fields: true
             status:
               description: RevisionStatus communicates the observed state of the Revision (from the controller).
               type: object
@@ -2198,7 +2807,6 @@ spec:
                       lastTransitionTime:
                         description: LastTransitionTime is the last time the condition transitioned from one status to another. We use VolatileTime in place of metav1.Time to exclude this from creating equality.Semantic differences (all other things held constant).
                         type: string
-                        format: date-time
                       message:
                         description: A human readable message indicating details about the transition.
                         type: string
@@ -2254,8 +2862,7 @@ metadata:
   name: routes.serving.knative.dev
   labels:
     app.kubernetes.io/name: knative-serving
-    app.kubernetes.io/version: "1.2.5"
-    serving.knative.dev/release: "v1.2.5"
+    app.kubernetes.io/version: "1.8.0"
     knative.dev/crd-install: "true"
     duck.knative.dev/addressable: "true"
 spec:
@@ -2318,7 +2925,7 @@ spec:
                         description: LatestRevision may be optionally provided to indicate that the latest ready Revision of the Configuration should be used for this traffic target.  When provided LatestRevision must be true if RevisionName is empty; it must be false when RevisionName is non-empty.
                         type: boolean
                       percent:
-                        description: 'Percent indicates that percentage based routing should be used and the value indicates the percent of traffic that is be routed to this Revision or Configuration. `0` (zero) mean no traffic, `100` means all traffic. When percentage based routing is being used the follow rules apply: - the sum of all percent values must equal 100 - when not specified, the implied value for `percent` is zero for   that particular Revision or Configuration'
+                        description: 'Percent indicates that percentage based routing should be used and the value indicates the percent of traffic that is be routed to this Revision or Configuration. `0` (zero) mean no traffic, `100` means all traffic. When percentage based routing is being used the follow rules apply: - the sum of all percent values must equal 100 - when not specified, the implied value for `percent` is zero for that particular Revision or Configuration'
                         type: integer
                         format: int64
                       revisionName:
@@ -2358,7 +2965,6 @@ spec:
                       lastTransitionTime:
                         description: LastTransitionTime is the last time the condition transitioned from one status to another. We use VolatileTime in place of metav1.Time to exclude this from creating equality.Semantic differences (all other things held constant).
                         type: string
-                        format: date-time
                       message:
                         description: A human readable message indicating details about the transition.
                         type: string
@@ -2392,7 +2998,7 @@ spec:
                         description: LatestRevision may be optionally provided to indicate that the latest ready Revision of the Configuration should be used for this traffic target.  When provided LatestRevision must be true if RevisionName is empty; it must be false when RevisionName is non-empty.
                         type: boolean
                       percent:
-                        description: 'Percent indicates that percentage based routing should be used and the value indicates the percent of traffic that is be routed to this Revision or Configuration. `0` (zero) mean no traffic, `100` means all traffic. When percentage based routing is being used the follow rules apply: - the sum of all percent values must equal 100 - when not specified, the implied value for `percent` is zero for   that particular Revision or Configuration'
+                        description: 'Percent indicates that percentage based routing should be used and the value indicates the percent of traffic that is be routed to this Revision or Configuration. `0` (zero) mean no traffic, `100` means all traffic. When percentage based routing is being used the follow rules apply: - the sum of all percent values must equal 100 - when not specified, the implied value for `percent` is zero for that particular Revision or Configuration'
                         type: integer
                         format: int64
                       revisionName:
@@ -2414,8 +3020,8 @@ metadata:
   name: serverlessservices.networking.internal.knative.dev
   labels:
     app.kubernetes.io/name: knative-serving
-    app.kubernetes.io/version: "1.2.5"
-    serving.knative.dev/release: "v1.2.5"
+    app.kubernetes.io/component: networking
+    app.kubernetes.io/version: "1.8.0"
     knative.dev/crd-install: "true"
 spec:
   group: networking.internal.knative.dev
@@ -2427,8 +3033,107 @@ spec:
         status: {}
       schema:
         openAPIV3Schema:
+          description: 'ServerlessService is a proxy for the K8s service objects containing the endpoints for the revision, whether those are endpoints of the activator or revision pods. See: https://knative.page.link/naxz for details.'
           type: object
-          x-kubernetes-preserve-unknown-fields: true
+          properties:
+            apiVersion:
+              description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+              type: string
+            kind:
+              description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+              type: string
+            metadata:
+              type: object
+            spec:
+              description: 'Spec is the desired state of the ServerlessService. More info: https://github.com/kubernetes/community/blob/master/contributors/devel/sig-architecture/api-conventions.md#spec-and-status'
+              type: object
+              required:
+                - objectRef
+                - protocolType
+              properties:
+                mode:
+                  description: Mode describes the mode of operation of the ServerlessService.
+                  type: string
+                numActivators:
+                  description: NumActivators contains number of Activators that this revision should be assigned. O means — assign all.
+                  type: integer
+                  format: int32
+                objectRef:
+                  description: ObjectRef defines the resource that this ServerlessService is responsible for making "serverless".
+                  type: object
+                  properties:
+                    apiVersion:
+                      description: API version of the referent.
+                      type: string
+                    fieldPath:
+                      description: 'If referring to a piece of an object instead of an entire object, this string should contain a valid JSON/Go field access statement, such as desiredState.manifest.containers[2]. For example, if the object reference is to a container within a pod, this would take on a value like: "spec.containers{name}" (where "name" refers to the name of the container that triggered the event) or if no container name is specified "spec.containers[2]" (container with index 2 in this pod). This syntax is chosen only to have some well-defined way of referencing a part of an object. TODO: this design is not final and this field is subject to change in the future.'
+                      type: string
+                    kind:
+                      description: 'Kind of the referent. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+                      type: string
+                    name:
+                      description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                      type: string
+                    namespace:
+                      description: 'Namespace of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/'
+                      type: string
+                    resourceVersion:
+                      description: 'Specific resourceVersion to which this reference is made, if any. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency'
+                      type: string
+                    uid:
+                      description: 'UID of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids'
+                      type: string
+                  x-kubernetes-map-type: atomic
+                protocolType:
+                  description: The application-layer protocol. Matches `RevisionProtocolType` set on the owning pa/revision. serving imports networking, so just use string.
+                  type: string
+            status:
+              description: 'Status is the current state of the ServerlessService. More info: https://github.com/kubernetes/community/blob/master/contributors/devel/sig-architecture/api-conventions.md#spec-and-status'
+              type: object
+              properties:
+                annotations:
+                  description: Annotations is additional Status fields for the Resource to save some additional State as well as convey more information to the user. This is roughly akin to Annotations on any k8s resource, just the reconciler conveying richer information outwards.
+                  type: object
+                  additionalProperties:
+                    type: string
+                conditions:
+                  description: Conditions the latest available observations of a resource's current state.
+                  type: array
+                  items:
+                    description: 'Condition defines a readiness condition for a Knative resource. See: https://github.com/kubernetes/community/blob/master/contributors/devel/sig-architecture/api-conventions.md#typical-status-properties'
+                    type: object
+                    required:
+                      - status
+                      - type
+                    properties:
+                      lastTransitionTime:
+                        description: LastTransitionTime is the last time the condition transitioned from one status to another. We use VolatileTime in place of metav1.Time to exclude this from creating equality.Semantic differences (all other things held constant).
+                        type: string
+                      message:
+                        description: A human readable message indicating details about the transition.
+                        type: string
+                      reason:
+                        description: The reason for the condition's last transition.
+                        type: string
+                      severity:
+                        description: Severity with which to treat failures of this type of condition. When this is not specified, it defaults to Error.
+                        type: string
+                      status:
+                        description: Status of the condition, one of True, False, Unknown.
+                        type: string
+                      type:
+                        description: Type of condition.
+                        type: string
+                observedGeneration:
+                  description: ObservedGeneration is the 'Generation' of the Service that was last processed by the controller.
+                  type: integer
+                  format: int64
+                privateServiceName:
+                  description: PrivateServiceName holds the name of a core K8s Service resource that load balances over the user service pods backing this Revision.
+                  type: string
+                serviceName:
+                  description: ServiceName holds the name of a core K8s Service resource that load balances over the pods backing this Revision (activator or revision).
+                  type: string
       additionalPrinterColumns:
         - name: Mode
           type: string
@@ -2465,8 +3170,7 @@ metadata:
   name: services.serving.knative.dev
   labels:
     app.kubernetes.io/name: knative-serving
-    app.kubernetes.io/version: "1.2.5"
-    serving.knative.dev/release: "v1.2.5"
+    app.kubernetes.io/version: "1.8.0"
     knative.dev/crd-install: "true"
     duck.knative.dev/addressable: "true"
     duck.knative.dev/podspecable: "true"
@@ -2553,6 +3257,10 @@ spec:
                       required:
                         - containers
                       properties:
+                        affinity:
+                          description: This is accessible behind a feature flag - kubernetes.podspec-affinity
+                          type: object
+                          x-kubernetes-preserve-unknown-fields: true
                         automountServiceAccountToken:
                           description: AutomountServiceAccountToken indicates whether a service account token should be automatically mounted.
                           type: boolean
@@ -2568,12 +3276,12 @@ spec:
                             type: object
                             properties:
                               args:
-                                description: 'Arguments to the entrypoint. The docker image''s CMD is used if this is not provided. Variable references $(VAR_NAME) are expanded using the container''s environment. If a variable cannot be resolved, the reference in the input string will be unchanged. Double $$ are reduced to a single $, which allows for escaping the $(VAR_NAME) syntax: i.e. "$$(VAR_NAME)" will produce the string literal "$(VAR_NAME)". Escaped references will never be expanded, regardless of whether the variable exists or not. Cannot be updated. More info: https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell'
+                                description: 'Arguments to the entrypoint. The container image''s CMD is used if this is not provided. Variable references $(VAR_NAME) are expanded using the container''s environment. If a variable cannot be resolved, the reference in the input string will be unchanged. Double $$ are reduced to a single $, which allows for escaping the $(VAR_NAME) syntax: i.e. "$$(VAR_NAME)" will produce the string literal "$(VAR_NAME)". Escaped references will never be expanded, regardless of whether the variable exists or not. Cannot be updated. More info: https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell'
                                 type: array
                                 items:
                                   type: string
                               command:
-                                description: 'Entrypoint array. Not executed within a shell. The docker image''s ENTRYPOINT is used if this is not provided. Variable references $(VAR_NAME) are expanded using the container''s environment. If a variable cannot be resolved, the reference in the input string will be unchanged. Double $$ are reduced to a single $, which allows for escaping the $(VAR_NAME) syntax: i.e. "$$(VAR_NAME)" will produce the string literal "$(VAR_NAME)". Escaped references will never be expanded, regardless of whether the variable exists or not. Cannot be updated. More info: https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell'
+                                description: 'Entrypoint array. Not executed within a shell. The container image''s ENTRYPOINT is used if this is not provided. Variable references $(VAR_NAME) are expanded using the container''s environment. If a variable cannot be resolved, the reference in the input string will be unchanged. Double $$ are reduced to a single $, which allows for escaping the $(VAR_NAME) syntax: i.e. "$$(VAR_NAME)" will produce the string literal "$(VAR_NAME)". Escaped references will never be expanded, regardless of whether the variable exists or not. Cannot be updated. More info: https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell'
                                 type: array
                                 items:
                                   type: string
@@ -2611,6 +3319,17 @@ spec:
                                             optional:
                                               description: Specify whether the ConfigMap or its key must be defined
                                               type: boolean
+                                          x-kubernetes-map-type: atomic
+                                        fieldRef:
+                                          description: This is accessible behind a feature flag - kubernetes.podspec-fieldref
+                                          type: object
+                                          x-kubernetes-preserve-unknown-fields: true
+                                          x-kubernetes-map-type: atomic
+                                        resourceFieldRef:
+                                          description: This is accessible behind a feature flag - kubernetes.podspec-fieldref
+                                          type: object
+                                          x-kubernetes-preserve-unknown-fields: true
+                                          x-kubernetes-map-type: atomic
                                         secretKeyRef:
                                           description: Selects a key of a secret in the pod's namespace
                                           type: object
@@ -2626,7 +3345,7 @@ spec:
                                             optional:
                                               description: Specify whether the Secret or its key must be defined
                                               type: boolean
-                                      x-kubernetes-preserve-unknown-fields: true
+                                          x-kubernetes-map-type: atomic
                               envFrom:
                                 description: List of sources to populate environment variables in the container. The keys defined within a source must be a C_IDENTIFIER. All invalid keys will be reported as an event when the container is starting. When a key exists in multiple sources, the value associated with the last source will take precedence. Values defined by an Env with a duplicate key will take precedence. Cannot be updated.
                                 type: array
@@ -2644,6 +3363,7 @@ spec:
                                         optional:
                                           description: Specify whether the ConfigMap must be defined
                                           type: boolean
+                                      x-kubernetes-map-type: atomic
                                     prefix:
                                       description: An optional identifier to prepend to each key in the ConfigMap. Must be a C_IDENTIFIER.
                                       type: string
@@ -2657,8 +3377,9 @@ spec:
                                         optional:
                                           description: Specify whether the Secret must be defined
                                           type: boolean
+                                      x-kubernetes-map-type: atomic
                               image:
-                                description: 'Docker image name. More info: https://kubernetes.io/docs/concepts/containers/images This field is optional to allow higher level config management to default or override container images in workload controllers like Deployments and StatefulSets.'
+                                description: 'Container image name. More info: https://kubernetes.io/docs/concepts/containers/images This field is optional to allow higher level config management to default or override container images in workload controllers like Deployments and StatefulSets.'
                                 type: string
                               imagePullPolicy:
                                 description: 'Image pull policy. One of Always, Never, IfNotPresent. Defaults to Always if :latest tag is specified, or IfNotPresent otherwise. Cannot be updated. More info: https://kubernetes.io/docs/concepts/containers/images#updating-images'
@@ -2668,7 +3389,7 @@ spec:
                                 type: object
                                 properties:
                                   exec:
-                                    description: One and only one of the following should be specified. Exec specifies the action to take.
+                                    description: Exec specifies the action to take.
                                     type: object
                                     properties:
                                       command:
@@ -2706,10 +3427,15 @@ spec:
                                       path:
                                         description: Path to access on the HTTP server.
                                         type: string
+                                      port:
+                                        description: Name or number of the port to access on the container. Number must be in the range 1 to 65535. Name must be an IANA_SVC_NAME.
+                                        anyOf:
+                                          - type: integer
+                                          - type: string
+                                        x-kubernetes-int-or-string: true
                                       scheme:
                                         description: Scheme to use for connecting to the host. Defaults to HTTP.
                                         type: string
-                                    x-kubernetes-preserve-unknown-fields: true
                                   initialDelaySeconds:
                                     description: 'Number of seconds after the container has started before liveness probes are initiated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
                                     type: integer
@@ -2723,13 +3449,18 @@ spec:
                                     type: integer
                                     format: int32
                                   tcpSocket:
-                                    description: 'TCPSocket specifies an action involving a TCP port. TCP hooks not yet supported TODO: implement a realistic TCP lifecycle hook'
+                                    description: TCPSocket specifies an action involving a TCP port.
                                     type: object
                                     properties:
                                       host:
                                         description: 'Optional: Host name to connect to, defaults to the pod IP.'
                                         type: string
-                                    x-kubernetes-preserve-unknown-fields: true
+                                      port:
+                                        description: Number or name of the port to access on the container. Number must be in the range 1 to 65535. Name must be an IANA_SVC_NAME.
+                                        anyOf:
+                                          - type: integer
+                                          - type: string
+                                        x-kubernetes-int-or-string: true
                                   timeoutSeconds:
                                     description: 'Number of seconds after which the probe times out. Defaults to 1 second. Minimum value is 1. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
                                     type: integer
@@ -2738,7 +3469,7 @@ spec:
                                 description: Name of the container specified as a DNS_LABEL. Each container in a pod must have a unique name (DNS_LABEL). Cannot be updated.
                                 type: string
                               ports:
-                                description: List of ports to expose from the container. Exposing a port here gives the system additional information about the network connections a container uses, but is primarily informational. Not specifying a port here DOES NOT prevent that port from being exposed. Any port which is listening on the default "0.0.0.0" address inside a container will be accessible from the network. Cannot be updated.
+                                description: List of ports to expose from the container. Not specifying a port here DOES NOT prevent that port from being exposed. Any port which is listening on the default "0.0.0.0" address inside a container will be accessible from the network. Modifying this array with strategic merge patch may corrupt the data. For more information See https://github.com/kubernetes/kubernetes/issues/108255. Cannot be updated.
                                 type: array
                                 items:
                                   description: ContainerPort represents a network port in a single container.
@@ -2757,7 +3488,6 @@ spec:
                                       description: Protocol for port. Must be UDP, TCP, or SCTP. Defaults to "TCP".
                                       type: string
                                       default: TCP
-                                  x-kubernetes-preserve-unknown-fields: true
                                 x-kubernetes-list-map-keys:
                                   - containerPort
                                   - protocol
@@ -2767,7 +3497,7 @@ spec:
                                 type: object
                                 properties:
                                   exec:
-                                    description: One and only one of the following should be specified. Exec specifies the action to take.
+                                    description: Exec specifies the action to take.
                                     type: object
                                     properties:
                                       command:
@@ -2805,10 +3535,15 @@ spec:
                                       path:
                                         description: Path to access on the HTTP server.
                                         type: string
+                                      port:
+                                        description: Name or number of the port to access on the container. Number must be in the range 1 to 65535. Name must be an IANA_SVC_NAME.
+                                        anyOf:
+                                          - type: integer
+                                          - type: string
+                                        x-kubernetes-int-or-string: true
                                       scheme:
                                         description: Scheme to use for connecting to the host. Defaults to HTTP.
                                         type: string
-                                    x-kubernetes-preserve-unknown-fields: true
                                   initialDelaySeconds:
                                     description: 'Number of seconds after the container has started before liveness probes are initiated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
                                     type: integer
@@ -2822,13 +3557,18 @@ spec:
                                     type: integer
                                     format: int32
                                   tcpSocket:
-                                    description: 'TCPSocket specifies an action involving a TCP port. TCP hooks not yet supported TODO: implement a realistic TCP lifecycle hook'
+                                    description: TCPSocket specifies an action involving a TCP port.
                                     type: object
                                     properties:
                                       host:
                                         description: 'Optional: Host name to connect to, defaults to the pod IP.'
                                         type: string
-                                    x-kubernetes-preserve-unknown-fields: true
+                                      port:
+                                        description: Number or name of the port to access on the container. Number must be in the range 1 to 65535. Name must be an IANA_SVC_NAME.
+                                        anyOf:
+                                          - type: integer
+                                          - type: string
+                                        x-kubernetes-int-or-string: true
                                   timeoutSeconds:
                                     description: 'Number of seconds after which the probe times out. Defaults to 1 second. Minimum value is 1. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
                                     type: integer
@@ -2859,25 +3599,39 @@ spec:
                                 description: 'SecurityContext defines the security options the container should be run with. If set, the fields of SecurityContext override the equivalent fields of PodSecurityContext. More info: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/'
                                 type: object
                                 properties:
+                                  allowPrivilegeEscalation:
+                                    description: 'AllowPrivilegeEscalation controls whether a process can gain more privileges than its parent process. This bool directly controls if the no_new_privs flag will be set on the container process. AllowPrivilegeEscalation is true always when the container is: 1) run as Privileged 2) has CAP_SYS_ADMIN Note that this field cannot be set when spec.os.name is windows.'
+                                    type: boolean
                                   capabilities:
-                                    description: The capabilities to add/drop when running containers. Defaults to the default set of capabilities granted by the container runtime.
+                                    description: The capabilities to add/drop when running containers. Defaults to the default set of capabilities granted by the container runtime. Note that this field cannot be set when spec.os.name is windows.
                                     type: object
                                     properties:
+                                      add:
+                                        description: This is accessible behind a feature flag - kubernetes.containerspec-addcapabilities
+                                        type: array
+                                        items:
+                                          description: Capability represent POSIX capabilities type
+                                          type: string
                                       drop:
                                         description: Removed capabilities
                                         type: array
                                         items:
                                           description: Capability represent POSIX capabilities type
                                           type: string
-                                    x-kubernetes-preserve-unknown-fields: true
                                   readOnlyRootFilesystem:
-                                    description: Whether this container has a read-only root filesystem. Default is false.
+                                    description: Whether this container has a read-only root filesystem. Default is false. Note that this field cannot be set when spec.os.name is windows.
                                     type: boolean
-                                  runAsUser:
-                                    description: The UID to run the entrypoint of the container process. Defaults to user specified in image metadata if unspecified. May also be set in PodSecurityContext.  If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence.
+                                  runAsGroup:
+                                    description: The GID to run the entrypoint of the container process. Uses runtime default if unset. May also be set in PodSecurityContext.  If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence. Note that this field cannot be set when spec.os.name is windows.
                                     type: integer
                                     format: int64
-                                x-kubernetes-preserve-unknown-fields: true
+                                  runAsNonRoot:
+                                    description: Indicates that the container must run as a non-root user. If true, the Kubelet will validate the image at runtime to ensure that it does not run as UID 0 (root) and fail to start the container if it does. If unset or false, no such validation will be performed. May also be set in PodSecurityContext.  If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence.
+                                    type: boolean
+                                  runAsUser:
+                                    description: The UID to run the entrypoint of the container process. Defaults to user specified in image metadata if unspecified. May also be set in PodSecurityContext.  If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence. Note that this field cannot be set when spec.os.name is windows.
+                                    type: integer
+                                    format: int64
                               terminationMessagePath:
                                 description: 'Optional: Path at which the file to which the container''s termination message will be written is mounted into the container''s filesystem. Message written is intended to be brief final status, such as an assertion failure message. Will be truncated by the node if greater than 4096 bytes. The total message length across all containers will be limited to 12kb. Defaults to /dev/termination-log. Cannot be updated.'
                                 type: string
@@ -2909,12 +3663,29 @@ spec:
                               workingDir:
                                 description: Container's working directory. If not specified, the container runtime's default will be used, which might be configured in the container image. Cannot be updated.
                                 type: string
-                            x-kubernetes-preserve-unknown-fields: true
+                        dnsConfig:
+                          description: This is accessible behind a feature flag - kubernetes.podspec-dnsconfig
+                          type: object
+                          x-kubernetes-preserve-unknown-fields: true
+                        dnsPolicy:
+                          description: This is accessible behind a feature flag - kubernetes.podspec-dnspolicy
+                          type: string
                         enableServiceLinks:
-                          description: 'EnableServiceLinks indicates whether information about services should be injected into pod''s environment variables, matching the syntax of Docker links. Optional: Defaults to true.'
+                          description: 'EnableServiceLinks indicates whether information about services should be injected into pod''s environment variables, matching the syntax of Docker links. Optional: Knative defaults this to false.'
                           type: boolean
+                        hostAliases:
+                          description: This is accessible behind a feature flag - kubernetes.podspec-hostaliases
+                          type: array
+                          items:
+                            description: This is accessible behind a feature flag - kubernetes.podspec-hostaliases
+                            type: object
+                            x-kubernetes-preserve-unknown-fields: true
+                        idleTimeoutSeconds:
+                          description: IdleTimeoutSeconds is the maximum duration in seconds a request will be allowed to stay open while not receiving any bytes from the user's application. If unspecified, a system default will be provided.
+                          type: integer
+                          format: int64
                         imagePullSecrets:
-                          description: 'ImagePullSecrets is an optional list of references to secrets in the same namespace to use for pulling any of the images used by this PodSpec. If specified, these secrets will be passed to individual puller implementations for them to use. For example, in the case of docker, only DockerConfig type secrets are honored. More info: https://kubernetes.io/docs/concepts/containers/images#specifying-imagepullsecrets-on-a-pod'
+                          description: 'ImagePullSecrets is an optional list of references to secrets in the same namespace to use for pulling any of the images used by this PodSpec. If specified, these secrets will be passed to individual puller implementations for them to use. More info: https://kubernetes.io/docs/concepts/containers/images#specifying-imagepullsecrets-on-a-pod'
                           type: array
                           items:
                             description: LocalObjectReference contains enough information to let you locate the referenced object inside the same namespace.
@@ -2923,13 +3694,60 @@ spec:
                               name:
                                 description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?'
                                 type: string
+                            x-kubernetes-map-type: atomic
+                        initContainers:
+                          description: 'List of initialization containers belonging to the pod. Init containers are executed in order prior to containers being started. If any init container fails, the pod is considered to have failed and is handled according to its restartPolicy. The name for an init container or normal container must be unique among all containers. Init containers may not have Lifecycle actions, Readiness probes, Liveness probes, or Startup probes. The resourceRequirements of an init container are taken into account during scheduling by finding the highest request/limit for each resource type, and then using the max of of that value or the sum of the normal containers. Limits are applied to init containers in a similar fashion. Init containers cannot currently be added or removed. Cannot be updated. More info: https://kubernetes.io/docs/concepts/workloads/pods/init-containers/'
+                          type: array
+                          items:
+                            description: This is accessible behind a feature flag - kubernetes.podspec-init-containers
+                            type: object
+                            x-kubernetes-preserve-unknown-fields: true
+                        nodeSelector:
+                          description: This is accessible behind a feature flag - kubernetes.podspec-nodeselector
+                          type: object
+                          x-kubernetes-preserve-unknown-fields: true
+                          x-kubernetes-map-type: atomic
+                        priorityClassName:
+                          description: This is accessible behind a feature flag - kubernetes.podspec-priorityclassname
+                          type: string
+                          x-kubernetes-preserve-unknown-fields: true
+                        responseStartTimeoutSeconds:
+                          description: ResponseStartTimeoutSeconds is the maximum duration in seconds that the request routing layer will wait for a request delivered to a container to begin sending any network traffic.
+                          type: integer
+                          format: int64
+                        runtimeClassName:
+                          description: This is accessible behind a feature flag - kubernetes.podspec-runtimeclassname
+                          type: string
+                          x-kubernetes-preserve-unknown-fields: true
+                        schedulerName:
+                          description: This is accessible behind a feature flag - kubernetes.podspec-schedulername
+                          type: string
+                          x-kubernetes-preserve-unknown-fields: true
+                        securityContext:
+                          description: This is accessible behind a feature flag - kubernetes.podspec-securitycontext
+                          type: object
+                          x-kubernetes-preserve-unknown-fields: true
                         serviceAccountName:
                           description: 'ServiceAccountName is the name of the ServiceAccount to use to run this pod. More info: https://kubernetes.io/docs/tasks/configure-pod-container/configure-service-account/'
                           type: string
                         timeoutSeconds:
-                          description: TimeoutSeconds is the maximum duration in seconds that the request routing layer will wait for a request delivered to a container to begin replying (send network traffic). If unspecified, a system default will be provided.
+                          description: TimeoutSeconds is the maximum duration in seconds that the request instance is allowed to respond to a request. If unspecified, a system default will be provided.
                           type: integer
                           format: int64
+                        tolerations:
+                          description: This is accessible behind a feature flag - kubernetes.podspec-tolerations
+                          type: array
+                          items:
+                            description: This is accessible behind a feature flag - kubernetes.podspec-tolerations
+                            type: object
+                            x-kubernetes-preserve-unknown-fields: true
+                        topologySpreadConstraints:
+                          description: This is accessible behind a feature flag - kubernetes.podspec-topologyspreadconstraints
+                          type: array
+                          items:
+                            description: This is accessible behind a feature flag - kubernetes.podspec-topologyspreadconstraints
+                            type: object
+                            x-kubernetes-preserve-unknown-fields: true
                         volumes:
                           description: 'List of volumes that can be mounted by containers belonging to the pod. More info: https://kubernetes.io/docs/concepts/storage/volumes'
                           type: array
@@ -2940,15 +3758,15 @@ spec:
                               - name
                             properties:
                               configMap:
-                                description: ConfigMap represents a configMap that should populate this volume
+                                description: configMap represents a configMap that should populate this volume
                                 type: object
                                 properties:
                                   defaultMode:
-                                    description: 'Optional: mode bits used to set permissions on created files by default. Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511. YAML accepts both octal and decimal values, JSON requires decimal values for mode bits. Defaults to 0644. Directories within the path are not affected by this setting. This might be in conflict with other options that affect the file mode, like fsGroup, and the result can be other mode bits set.'
+                                    description: 'defaultMode is optional: mode bits used to set permissions on created files by default. Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511. YAML accepts both octal and decimal values, JSON requires decimal values for mode bits. Defaults to 0644. Directories within the path are not affected by this setting. This might be in conflict with other options that affect the file mode, like fsGroup, and the result can be other mode bits set.'
                                     type: integer
                                     format: int32
                                   items:
-                                    description: If unspecified, each key-value pair in the Data field of the referenced ConfigMap will be projected into the volume as a file whose name is the key and content is the value. If specified, the listed keys will be projected into the specified paths, and unlisted keys will not be present. If a key is specified which is not present in the ConfigMap, the volume setup will error unless it is marked optional. Paths must be relative and may not contain the '..' path or start with '..'.
+                                    description: items if unspecified, each key-value pair in the Data field of the referenced ConfigMap will be projected into the volume as a file whose name is the key and content is the value. If specified, the listed keys will be projected into the specified paths, and unlisted keys will not be present. If a key is specified which is not present in the ConfigMap, the volume setup will error unless it is marked optional. Paths must be relative and may not contain the '..' path or start with '..'.
                                     type: array
                                     items:
                                       description: Maps a string key to a path within a volume.
@@ -2958,45 +3776,54 @@ spec:
                                         - path
                                       properties:
                                         key:
-                                          description: The key to project.
+                                          description: key is the key to project.
                                           type: string
                                         mode:
-                                          description: 'Optional: mode bits used to set permissions on this file. Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511. YAML accepts both octal and decimal values, JSON requires decimal values for mode bits. If not specified, the volume defaultMode will be used. This might be in conflict with other options that affect the file mode, like fsGroup, and the result can be other mode bits set.'
+                                          description: 'mode is Optional: mode bits used to set permissions on this file. Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511. YAML accepts both octal and decimal values, JSON requires decimal values for mode bits. If not specified, the volume defaultMode will be used. This might be in conflict with other options that affect the file mode, like fsGroup, and the result can be other mode bits set.'
                                           type: integer
                                           format: int32
                                         path:
-                                          description: The relative path of the file to map the key to. May not be an absolute path. May not contain the path element '..'. May not start with the string '..'.
+                                          description: path is the relative path of the file to map the key to. May not be an absolute path. May not contain the path element '..'. May not start with the string '..'.
                                           type: string
                                   name:
                                     description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?'
                                     type: string
                                   optional:
-                                    description: Specify whether the ConfigMap or its keys must be defined
+                                    description: optional specify whether the ConfigMap or its keys must be defined
                                     type: boolean
+                                x-kubernetes-map-type: atomic
+                              emptyDir:
+                                description: This is accessible behind a feature flag - kubernetes.podspec-emptydir
+                                type: object
+                                x-kubernetes-preserve-unknown-fields: true
                               name:
-                                description: 'Volume''s name. Must be a DNS_LABEL and unique within the pod. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                                description: 'name of the volume. Must be a DNS_LABEL and unique within the pod. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
                                 type: string
+                              persistentVolumeClaim:
+                                description: This is accessible behind a feature flag - kubernetes.podspec-persistent-volume-claim
+                                type: object
+                                x-kubernetes-preserve-unknown-fields: true
                               projected:
-                                description: Items for all in one resources secrets, configmaps, and downward API
+                                description: projected items for all in one resources secrets, configmaps, and downward API
                                 type: object
                                 properties:
                                   defaultMode:
-                                    description: Mode bits used to set permissions on created files by default. Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511. YAML accepts both octal and decimal values, JSON requires decimal values for mode bits. Directories within the path are not affected by this setting. This might be in conflict with other options that affect the file mode, like fsGroup, and the result can be other mode bits set.
+                                    description: defaultMode are the mode bits used to set permissions on created files by default. Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511. YAML accepts both octal and decimal values, JSON requires decimal values for mode bits. Directories within the path are not affected by this setting. This might be in conflict with other options that affect the file mode, like fsGroup, and the result can be other mode bits set.
                                     type: integer
                                     format: int32
                                   sources:
-                                    description: list of volume projections
+                                    description: sources is the list of volume projections
                                     type: array
                                     items:
                                       description: Projection that may be projected along with other supported volume types
                                       type: object
                                       properties:
                                         configMap:
-                                          description: information about the configMap data to project
+                                          description: configMap information about the configMap data to project
                                           type: object
                                           properties:
                                             items:
-                                              description: If unspecified, each key-value pair in the Data field of the referenced ConfigMap will be projected into the volume as a file whose name is the key and content is the value. If specified, the listed keys will be projected into the specified paths, and unlisted keys will not be present. If a key is specified which is not present in the ConfigMap, the volume setup will error unless it is marked optional. Paths must be relative and may not contain the '..' path or start with '..'.
+                                              description: items if unspecified, each key-value pair in the Data field of the referenced ConfigMap will be projected into the volume as a file whose name is the key and content is the value. If specified, the listed keys will be projected into the specified paths, and unlisted keys will not be present. If a key is specified which is not present in the ConfigMap, the volume setup will error unless it is marked optional. Paths must be relative and may not contain the '..' path or start with '..'.
                                               type: array
                                               items:
                                                 description: Maps a string key to a path within a volume.
@@ -3006,27 +3833,28 @@ spec:
                                                   - path
                                                 properties:
                                                   key:
-                                                    description: The key to project.
+                                                    description: key is the key to project.
                                                     type: string
                                                   mode:
-                                                    description: 'Optional: mode bits used to set permissions on this file. Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511. YAML accepts both octal and decimal values, JSON requires decimal values for mode bits. If not specified, the volume defaultMode will be used. This might be in conflict with other options that affect the file mode, like fsGroup, and the result can be other mode bits set.'
+                                                    description: 'mode is Optional: mode bits used to set permissions on this file. Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511. YAML accepts both octal and decimal values, JSON requires decimal values for mode bits. If not specified, the volume defaultMode will be used. This might be in conflict with other options that affect the file mode, like fsGroup, and the result can be other mode bits set.'
                                                     type: integer
                                                     format: int32
                                                   path:
-                                                    description: The relative path of the file to map the key to. May not be an absolute path. May not contain the path element '..'. May not start with the string '..'.
+                                                    description: path is the relative path of the file to map the key to. May not be an absolute path. May not contain the path element '..'. May not start with the string '..'.
                                                     type: string
                                             name:
                                               description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?'
                                               type: string
                                             optional:
-                                              description: Specify whether the ConfigMap or its keys must be defined
+                                              description: optional specify whether the ConfigMap or its keys must be defined
                                               type: boolean
+                                          x-kubernetes-map-type: atomic
                                         secret:
-                                          description: information about the secret data to project
+                                          description: secret information about the secret data to project
                                           type: object
                                           properties:
                                             items:
-                                              description: If unspecified, each key-value pair in the Data field of the referenced Secret will be projected into the volume as a file whose name is the key and content is the value. If specified, the listed keys will be projected into the specified paths, and unlisted keys will not be present. If a key is specified which is not present in the Secret, the volume setup will error unless it is marked optional. Paths must be relative and may not contain the '..' path or start with '..'.
+                                              description: items if unspecified, each key-value pair in the Data field of the referenced Secret will be projected into the volume as a file whose name is the key and content is the value. If specified, the listed keys will be projected into the specified paths, and unlisted keys will not be present. If a key is specified which is not present in the Secret, the volume setup will error unless it is marked optional. Paths must be relative and may not contain the '..' path or start with '..'.
                                               type: array
                                               items:
                                                 description: Maps a string key to a path within a volume.
@@ -3036,47 +3864,48 @@ spec:
                                                   - path
                                                 properties:
                                                   key:
-                                                    description: The key to project.
+                                                    description: key is the key to project.
                                                     type: string
                                                   mode:
-                                                    description: 'Optional: mode bits used to set permissions on this file. Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511. YAML accepts both octal and decimal values, JSON requires decimal values for mode bits. If not specified, the volume defaultMode will be used. This might be in conflict with other options that affect the file mode, like fsGroup, and the result can be other mode bits set.'
+                                                    description: 'mode is Optional: mode bits used to set permissions on this file. Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511. YAML accepts both octal and decimal values, JSON requires decimal values for mode bits. If not specified, the volume defaultMode will be used. This might be in conflict with other options that affect the file mode, like fsGroup, and the result can be other mode bits set.'
                                                     type: integer
                                                     format: int32
                                                   path:
-                                                    description: The relative path of the file to map the key to. May not be an absolute path. May not contain the path element '..'. May not start with the string '..'.
+                                                    description: path is the relative path of the file to map the key to. May not be an absolute path. May not contain the path element '..'. May not start with the string '..'.
                                                     type: string
                                             name:
                                               description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?'
                                               type: string
                                             optional:
-                                              description: Specify whether the Secret or its key must be defined
+                                              description: optional field specify whether the Secret or its key must be defined
                                               type: boolean
+                                          x-kubernetes-map-type: atomic
                                         serviceAccountToken:
-                                          description: information about the serviceAccountToken data to project
+                                          description: serviceAccountToken is information about the serviceAccountToken data to project
                                           type: object
                                           required:
                                             - path
                                           properties:
                                             audience:
-                                              description: Audience is the intended audience of the token. A recipient of a token must identify itself with an identifier specified in the audience of the token, and otherwise should reject the token. The audience defaults to the identifier of the apiserver.
+                                              description: audience is the intended audience of the token. A recipient of a token must identify itself with an identifier specified in the audience of the token, and otherwise should reject the token. The audience defaults to the identifier of the apiserver.
                                               type: string
                                             expirationSeconds:
-                                              description: ExpirationSeconds is the requested duration of validity of the service account token. As the token approaches expiration, the kubelet volume plugin will proactively rotate the service account token. The kubelet will start trying to rotate the token if the token is older than 80 percent of its time to live or if the token is older than 24 hours.Defaults to 1 hour and must be at least 10 minutes.
+                                              description: expirationSeconds is the requested duration of validity of the service account token. As the token approaches expiration, the kubelet volume plugin will proactively rotate the service account token. The kubelet will start trying to rotate the token if the token is older than 80 percent of its time to live or if the token is older than 24 hours.Defaults to 1 hour and must be at least 10 minutes.
                                               type: integer
                                               format: int64
                                             path:
-                                              description: Path is the path relative to the mount point of the file to project the token into.
+                                              description: path is the path relative to the mount point of the file to project the token into.
                                               type: string
                               secret:
-                                description: 'Secret represents a secret that should populate this volume. More info: https://kubernetes.io/docs/concepts/storage/volumes#secret'
+                                description: 'secret represents a secret that should populate this volume. More info: https://kubernetes.io/docs/concepts/storage/volumes#secret'
                                 type: object
                                 properties:
                                   defaultMode:
-                                    description: 'Optional: mode bits used to set permissions on created files by default. Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511. YAML accepts both octal and decimal values, JSON requires decimal values for mode bits. Defaults to 0644. Directories within the path are not affected by this setting. This might be in conflict with other options that affect the file mode, like fsGroup, and the result can be other mode bits set.'
+                                    description: 'defaultMode is Optional: mode bits used to set permissions on created files by default. Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511. YAML accepts both octal and decimal values, JSON requires decimal values for mode bits. Defaults to 0644. Directories within the path are not affected by this setting. This might be in conflict with other options that affect the file mode, like fsGroup, and the result can be other mode bits set.'
                                     type: integer
                                     format: int32
                                   items:
-                                    description: If unspecified, each key-value pair in the Data field of the referenced Secret will be projected into the volume as a file whose name is the key and content is the value. If specified, the listed keys will be projected into the specified paths, and unlisted keys will not be present. If a key is specified which is not present in the Secret, the volume setup will error unless it is marked optional. Paths must be relative and may not contain the '..' path or start with '..'.
+                                    description: items If unspecified, each key-value pair in the Data field of the referenced Secret will be projected into the volume as a file whose name is the key and content is the value. If specified, the listed keys will be projected into the specified paths, and unlisted keys will not be present. If a key is specified which is not present in the Secret, the volume setup will error unless it is marked optional. Paths must be relative and may not contain the '..' path or start with '..'.
                                     type: array
                                     items:
                                       description: Maps a string key to a path within a volume.
@@ -3086,23 +3915,21 @@ spec:
                                         - path
                                       properties:
                                         key:
-                                          description: The key to project.
+                                          description: key is the key to project.
                                           type: string
                                         mode:
-                                          description: 'Optional: mode bits used to set permissions on this file. Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511. YAML accepts both octal and decimal values, JSON requires decimal values for mode bits. If not specified, the volume defaultMode will be used. This might be in conflict with other options that affect the file mode, like fsGroup, and the result can be other mode bits set.'
+                                          description: 'mode is Optional: mode bits used to set permissions on this file. Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511. YAML accepts both octal and decimal values, JSON requires decimal values for mode bits. If not specified, the volume defaultMode will be used. This might be in conflict with other options that affect the file mode, like fsGroup, and the result can be other mode bits set.'
                                           type: integer
                                           format: int32
                                         path:
-                                          description: The relative path of the file to map the key to. May not be an absolute path. May not contain the path element '..'. May not start with the string '..'.
+                                          description: path is the relative path of the file to map the key to. May not be an absolute path. May not contain the path element '..'. May not start with the string '..'.
                                           type: string
                                   optional:
-                                    description: Specify whether the Secret or its keys must be defined
+                                    description: optional field specify whether the Secret or its keys must be defined
                                     type: boolean
                                   secretName:
-                                    description: 'Name of the secret in the pod''s namespace to use. More info: https://kubernetes.io/docs/concepts/storage/volumes#secret'
+                                    description: 'secretName is the name of the secret in the pod''s namespace to use. More info: https://kubernetes.io/docs/concepts/storage/volumes#secret'
                                     type: string
-                            x-kubernetes-preserve-unknown-fields: true
-                      x-kubernetes-preserve-unknown-fields: true
                 traffic:
                   description: Traffic specifies how to distribute traffic over a collection of revisions and configurations.
                   type: array
@@ -3117,7 +3944,7 @@ spec:
                         description: LatestRevision may be optionally provided to indicate that the latest ready Revision of the Configuration should be used for this traffic target.  When provided LatestRevision must be true if RevisionName is empty; it must be false when RevisionName is non-empty.
                         type: boolean
                       percent:
-                        description: 'Percent indicates that percentage based routing should be used and the value indicates the percent of traffic that is be routed to this Revision or Configuration. `0` (zero) mean no traffic, `100` means all traffic. When percentage based routing is being used the follow rules apply: - the sum of all percent values must equal 100 - when not specified, the implied value for `percent` is zero for   that particular Revision or Configuration'
+                        description: 'Percent indicates that percentage based routing should be used and the value indicates the percent of traffic that is be routed to this Revision or Configuration. `0` (zero) mean no traffic, `100` means all traffic. When percentage based routing is being used the follow rules apply: - the sum of all percent values must equal 100 - when not specified, the implied value for `percent` is zero for that particular Revision or Configuration'
                         type: integer
                         format: int64
                       revisionName:
@@ -3157,7 +3984,6 @@ spec:
                       lastTransitionTime:
                         description: LastTransitionTime is the last time the condition transitioned from one status to another. We use VolatileTime in place of metav1.Time to exclude this from creating equality.Semantic differences (all other things held constant).
                         type: string
-                        format: date-time
                       message:
                         description: A human readable message indicating details about the transition.
                         type: string
@@ -3197,7 +4023,7 @@ spec:
                         description: LatestRevision may be optionally provided to indicate that the latest ready Revision of the Configuration should be used for this traffic target.  When provided LatestRevision must be true if RevisionName is empty; it must be false when RevisionName is non-empty.
                         type: boolean
                       percent:
-                        description: 'Percent indicates that percentage based routing should be used and the value indicates the percent of traffic that is be routed to this Revision or Configuration. `0` (zero) mean no traffic, `100` means all traffic. When percentage based routing is being used the follow rules apply: - the sum of all percent values must equal 100 - when not specified, the implied value for `percent` is zero for   that particular Revision or Configuration'
+                        description: 'Percent indicates that percentage based routing should be used and the value indicates the percent of traffic that is be routed to this Revision or Configuration. `0` (zero) mean no traffic, `100` means all traffic. When percentage based routing is being used the follow rules apply: - the sum of all percent values must equal 100 - when not specified, the implied value for `percent` is zero for that particular Revision or Configuration'
                         type: integer
                         format: int64
                       revisionName:
@@ -3213,6 +4039,21 @@ spec:
                   description: URL holds the url that will distribute traffic over the provided traffic targets. It generally has the form http[s]://{route-name}.{route-namespace}.{cluster-level-suffix}
                   type: string
 ---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: serving-certs-ctrl-ca
+  namespace: knative-serving
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: knative-serving-certs
+  namespace: knative-serving
+  labels:
+    serving-certs-ctrl: "data-plane"
+    networking.internal.knative.dev/certificate-uid: "serving-certs"
+---
 apiVersion: caching.internal.knative.dev/v1alpha1
 kind: Image
 metadata:
@@ -3221,10 +4062,9 @@ metadata:
   labels:
     app.kubernetes.io/component: queue-proxy
     app.kubernetes.io/name: knative-serving
-    app.kubernetes.io/version: "1.2.5"
-    serving.knative.dev/release: "v1.2.5"
+    app.kubernetes.io/version: "1.8.0"
 spec:
-  image: gcr.io/knative-releases/knative.dev/serving/cmd/queue@sha256:14415b204ea8d0567235143a6c3377f49cbd35f18dc84dfa4baa7695c2a9b53d
+  image: gcr.io/knative-releases/knative.dev/serving/cmd/queue@sha256:505179c0c4892ea4a70e78bc52ac21b03cd7f1a763d2ecc78e7bbaa1ae59c86c
 ---
 apiVersion: v1
 kind: ConfigMap
@@ -3234,10 +4074,9 @@ metadata:
   labels:
     app.kubernetes.io/component: autoscaler
     app.kubernetes.io/name: knative-serving
-    app.kubernetes.io/version: "1.2.5"
-    serving.knative.dev/release: "v1.2.5"
+    app.kubernetes.io/version: "1.8.0"
   annotations:
-    knative.dev/example-checksum: "16af78ce"
+    knative.dev/example-checksum: "47c2487f"
 data:
   _example: |
     ################################
@@ -3312,7 +4151,7 @@ data:
     # -1 denotes unlimited target-burst-capacity and activator will always
     # be in the request path.
     # Other negative values are invalid.
-    target-burst-capacity: "200"
+    target-burst-capacity: "211"
 
     # When operating in a stable mode, the autoscaler operates on the
     # average concurrency over the stable window.
@@ -3431,10 +4270,9 @@ metadata:
   labels:
     app.kubernetes.io/name: knative-serving
     app.kubernetes.io/component: controller
-    app.kubernetes.io/version: "1.2.5"
-    serving.knative.dev/release: "v1.2.5"
+    app.kubernetes.io/version: "1.8.0"
   annotations:
-    knative.dev/example-checksum: "a0feb4c6"
+    knative.dev/example-checksum: "e7973912"
 data:
   _example: |
     ################################
@@ -3465,6 +4303,18 @@ data:
     # If this value is increased, the activator's terminationGraceTimeSeconds
     # should also be increased to prevent in-flight requests being disrupted.
     max-revision-timeout-seconds: "600"  # 10 minutes
+
+    # revision-response-start-timeout-seconds contains the default number of
+    # seconds a request will be allowed to stay open while waiting to
+    # receive any bytes from the user's application, if none is specified.
+    #
+    # This defaults to 'revision-timeout-seconds'
+    revision-response-start-timeout-seconds: "300"
+
+    # revision-idle-timeout-seconds contains the default number of
+    # seconds a request will be allowed to stay open while not receiving any
+    # bytes from the user's application, if none is specified.
+    revision-idle-timeout-seconds: "0"  # infinite
 
     # revision-cpu-request contains the cpu allocation to assign
     # to revisions by default.  If omitted, no value is specified
@@ -3560,12 +4410,11 @@ metadata:
   labels:
     app.kubernetes.io/name: knative-serving
     app.kubernetes.io/component: controller
-    app.kubernetes.io/version: "1.2.5"
-    serving.knative.dev/release: "v1.2.5"
+    app.kubernetes.io/version: "1.8.0"
   annotations:
     knative.dev/example-checksum: "dd7ee769"
 data:
-  queueSidecarImage: gcr.io/knative-releases/knative.dev/serving/cmd/queue@sha256:14415b204ea8d0567235143a6c3377f49cbd35f18dc84dfa4baa7695c2a9b53d
+  queue-sidecar-image: gcr.io/knative-releases/knative.dev/serving/cmd/queue@sha256:505179c0c4892ea4a70e78bc52ac21b03cd7f1a763d2ecc78e7bbaa1ae59c86c
   _example: |-
     ################################
     #                              #
@@ -3646,10 +4495,9 @@ metadata:
   labels:
     app.kubernetes.io/name: knative-serving
     app.kubernetes.io/component: controller
-    app.kubernetes.io/version: "1.2.5"
-    serving.knative.dev/release: "v1.2.5"
+    app.kubernetes.io/version: "1.8.0"
   annotations:
-    knative.dev/example-checksum: "81552d0b"
+    knative.dev/example-checksum: "26c09de5"
 data:
   _example: |
     ################################
@@ -3668,16 +4516,6 @@ data:
     # to actually change the configuration.
 
     # Default value for domain.
-    # Although it will match all routes, it is the least-specific rule so it
-    # will only be used if no other domain matches.
-    example.com: |
-
-    # These are example settings of domain.
-    # example.org will be used for routes having app=nonprofit.
-    example.org: |
-      selector:
-        app: nonprofit
-
     # Routes having the cluster domain suffix (by default 'svc.cluster.local')
     # will not be exposed through Ingress. You can define your own label
     # selector to assign that domain suffix to your Route here, or you can set
@@ -3688,6 +4526,16 @@ data:
     svc.cluster.local: |
       selector:
         app: secret
+
+    # These are example settings of domain.
+    # example.com will be used for all routes, but it is the least-specific rule so it
+    # will only be used if no other domain matches.
+    example.com: |
+
+    # example.org will be used for routes having app=nonprofit.
+    example.org: |
+      selector:
+        app: nonprofit
 ---
 apiVersion: v1
 kind: ConfigMap
@@ -3697,10 +4545,9 @@ metadata:
   labels:
     app.kubernetes.io/name: knative-serving
     app.kubernetes.io/component: controller
-    app.kubernetes.io/version: "1.2.5"
-    serving.knative.dev/release: "v1.2.5"
+    app.kubernetes.io/version: "1.8.0"
   annotations:
-    knative.dev/example-checksum: "d9e300ba"
+    knative.dev/example-checksum: "691a192e"
 data:
   _example: |-
     ################################
@@ -3729,6 +4576,12 @@ data:
     # WARNING: Cannot safely be disabled once enabled.
     # See: https://knative.dev/docs/serving/feature-flags/#kubernetes-node-affinity
     kubernetes.podspec-affinity: "disabled"
+
+    # Indicates whether Kubernetes topologySpreadConstraints support is enabled
+    #
+    # WARNING: Cannot safely be disabled once enabled.
+    # See: https://knative.dev/docs/serving/feature-flags/#kubernetes-topology-spread-constraints
+    kubernetes.podspec-topologyspreadconstraints: "disabled"
 
     # Indicates whether Kubernetes hostAliases support is enabled
     #
@@ -3760,6 +4613,18 @@ data:
     # See: https://knative.dev/docs/serving/feature-flags/#kubernetes-runtime-class
     kubernetes.podspec-runtimeclassname: "disabled"
 
+    # Indicates whether Kubernetes DNSPolicy support is enabled
+    #
+    # WARNING: Cannot safely be disabled once enabled.
+    # See: https://knative.dev/docs/serving/feature-flags/#kubernetes-dnspolicy
+    kubernetes.podspec-dnspolicy: "disabled"
+
+    # Indicates whether Kubernetes DNSConfig support is enabled
+    #
+    # WARNING: Cannot safely be disabled once enabled.
+    # See: https://knative.dev/docs/serving/feature-flags/#kubernetes-dnsconfig
+    kubernetes.podspec-dnsconfig: "disabled"
+
     # This feature allows end-users to set a subset of fields on the Pod's SecurityContext
     #
     # When set to "enabled" or "allowed" it allows the following
@@ -3769,6 +4634,7 @@ data:
     # - RunAsNonRoot
     # - SupplementalGroups
     # - RunAsUser
+    # - SeccompProfile
     #
     # This feature flag should be used with caution as the PodSecurityContext
     # properties may have a side-effect on non-user sidecar containers that come
@@ -3820,7 +4686,7 @@ data:
     # Controls whether volume support for EmptyDir is enabled or not.
     # 1. Enabled: enabling EmptyDir volume support
     # 2. Disabled: disabling EmptyDir volume support
-    kubernetes.podspec-volumes-emptydir: "disabled"
+    kubernetes.podspec-volumes-emptydir: "enabled"
 
     # Controls whether init containers support is enabled or not.
     # 1. Enabled: enabling init containers support
@@ -3836,6 +4702,23 @@ data:
     # 1. Enabled: enabling write access for persistent volumes
     # 2. Disabled: disabling write access for persistent volumes
     kubernetes.podspec-persistent-volume-write: "disabled"
+
+    # Controls if the queue proxy podInfo feature is enabled, allowed or disabled
+    #
+    # This feature should be enabled/allowed when using queue proxy Options (Extensions)
+    # Enabling will mount a podInfo volume to the queue proxy container.
+    # The volume will contains an 'annotations' file (from the pod's annotation field).
+    # The annotations in this file include the Service annotations set by the client creating the service.
+    # If mounted, the annotations can be accessed by queue proxy extensions at /etc/podinfo/annnotations
+    #
+    # 1. "enabled": always mount a podInfo volume
+    # 2. "disabled": never mount a podInfo volume
+    # 3. "allowed": by default, do not mount a podInfo volume
+    #   However, a client may mount the podInfo volume on an individual Service by attaching
+    #   the following metadata annotation to the Service: "features.knative.dev/queueproxy-podinfo":"enabled".
+    #
+    # NOTE THAT THIS IS AN EXPERIMENTAL / ALPHA FEATURE
+    queueproxy.mount-podinfo: "disabled"
 ---
 apiVersion: v1
 kind: ConfigMap
@@ -3845,10 +4728,9 @@ metadata:
   labels:
     app.kubernetes.io/name: knative-serving
     app.kubernetes.io/component: controller
-    app.kubernetes.io/version: "1.2.5"
-    serving.knative.dev/release: "v1.2.5"
+    app.kubernetes.io/version: "1.8.0"
   annotations:
-    knative.dev/example-checksum: "51b4d68a"
+    knative.dev/example-checksum: "aa3813a8"
 data:
   _example: |
     ################################
@@ -3865,7 +4747,6 @@ data:
     # These sample configuration options may be copied out of
     # this example block and unindented to be in the data block
     # to actually change the configuration.
-
 
     # ---------------------------------------
     # Garbage Collector Settings
@@ -3889,6 +4770,7 @@ data:
     #
     # Example config to immediately collect any inactive revision:
     #    min-non-active-revisions: "0"
+    #    max-non-active-revisions: "0"
     #    retain-since-create-time: "disabled"
     #    retain-since-last-active-time: "disabled"
     #
@@ -3897,7 +4779,7 @@ data:
     #     retain-since-last-active-time: "disabled"
     #     max-non-active-revisions: "10"
     #
-    # Example config to disable all GC:
+    # Example config to disable all garbage collection:
     #     retain-since-create-time: "disabled"
     #     retain-since-last-active-time: "disabled"
     #     max-non-active-revisions: "disabled"
@@ -3931,8 +4813,7 @@ metadata:
   labels:
     app.kubernetes.io/name: knative-serving
     app.kubernetes.io/component: controller
-    app.kubernetes.io/version: "1.2.5"
-    serving.knative.dev/release: "v1.2.5"
+    app.kubernetes.io/version: "1.8.0"
   annotations:
     knative.dev/example-checksum: "f4b71f57"
 data:
@@ -3977,11 +4858,11 @@ metadata:
   name: config-logging
   namespace: knative-serving
   labels:
-    serving.knative.dev/release: "v1.2.5"
-    app.kubernetes.io/version: "1.2.5"
+    app.kubernetes.io/version: "1.8.0"
+    app.kubernetes.io/component: logging
     app.kubernetes.io/name: knative-serving
   annotations:
-    knative.dev/example-checksum: "be93ff10"
+    knative.dev/example-checksum: "b0f3c6f2"
 data:
   _example: |
     ################################
@@ -4034,6 +4915,7 @@ data:
     loglevel.hpaautoscaler: "info"
     loglevel.net-certmanager-controller: "info"
     loglevel.net-istio-controller: "info"
+    loglevel.net-contour-controller: "info"
 ---
 apiVersion: v1
 kind: ConfigMap
@@ -4042,10 +4924,10 @@ metadata:
   namespace: knative-serving
   labels:
     app.kubernetes.io/name: knative-serving
-    app.kubernetes.io/version: "1.2.5"
-    serving.knative.dev/release: "v1.2.5"
+    app.kubernetes.io/component: networking
+    app.kubernetes.io/version: "1.8.0"
   annotations:
-    knative.dev/example-checksum: "6e2033e0"
+    knative.dev/example-checksum: "73d96d1b"
 data:
   _example: |
     ################################
@@ -4195,6 +5077,16 @@ data:
     # fronting Knative with an external loadbalancer that deals with TLS termination and
     # Knative doesn't know about that otherwise.
     default-external-scheme: "http"
+
+    # internal-encryption indicates whether internal traffic is encrypted or not.
+    # If this is "true", the following traffic are encrypted:
+    #  - ingress to activator
+    #  - ingress to queue-proxy
+    #  - activator to queue-proxy
+    #
+    # NOTE: This flag is in an alpha state and is mostly here to enable internal testing
+    #       for now. Use with caution.
+    internal-encryption: "false"
 ---
 apiVersion: v1
 kind: ConfigMap
@@ -4203,8 +5095,8 @@ metadata:
   namespace: knative-serving
   labels:
     app.kubernetes.io/name: knative-serving
-    app.kubernetes.io/version: "1.2.5"
-    serving.knative.dev/release: "v1.2.5"
+    app.kubernetes.io/component: observability
+    app.kubernetes.io/version: "1.8.0"
   annotations:
     knative.dev/example-checksum: "fed4756e"
 data:
@@ -4297,8 +5189,8 @@ metadata:
   namespace: knative-serving
   labels:
     app.kubernetes.io/name: knative-serving
-    app.kubernetes.io/version: "1.2.5"
-    serving.knative.dev/release: "v1.2.5"
+    app.kubernetes.io/component: tracing
+    app.kubernetes.io/version: "1.8.0"
   annotations:
     knative.dev/example-checksum: "26614636"
 data:
@@ -4332,7 +5224,7 @@ data:
     # Percentage (0-1) of requests to trace
     sample-rate: "0.1"
 ---
-apiVersion: autoscaling/v2beta2
+apiVersion: autoscaling/v2
 kind: HorizontalPodAutoscaler
 metadata:
   name: activator
@@ -4340,8 +5232,7 @@ metadata:
   labels:
     app.kubernetes.io/component: activator
     app.kubernetes.io/name: knative-serving
-    app.kubernetes.io/version: "1.2.5"
-    serving.knative.dev/release: "v1.2.5"
+    app.kubernetes.io/version: "1.8.0"
 spec:
   minReplicas: 1
   maxReplicas: 20
@@ -4365,8 +5256,7 @@ metadata:
   labels:
     app.kubernetes.io/component: activator
     app.kubernetes.io/name: knative-serving
-    app.kubernetes.io/version: "1.2.5"
-    serving.knative.dev/release: "v1.2.5"
+    app.kubernetes.io/version: "1.8.0"
 spec:
   minAvailable: 80%
   selector:
@@ -4380,9 +5270,8 @@ metadata:
   namespace: knative-serving
   labels:
     app.kubernetes.io/component: activator
-    app.kubernetes.io/version: "1.2.5"
+    app.kubernetes.io/version: "1.8.0"
     app.kubernetes.io/name: knative-serving
-    serving.knative.dev/release: "v1.2.5"
 spec:
   selector:
     matchLabels:
@@ -4397,13 +5286,12 @@ spec:
         role: activator
         app.kubernetes.io/component: activator
         app.kubernetes.io/name: knative-serving
-        app.kubernetes.io/version: "1.2.5"
-        serving.knative.dev/release: "v1.2.5"
+        app.kubernetes.io/version: "1.8.0"
     spec:
       serviceAccountName: controller
       containers:
         - name: activator
-          image: gcr.io/knative-releases/knative.dev/serving/cmd/activator@sha256:93ff6e69357785ff97806945b284cbd1d37e50402b876a320645be8877c0d7b7
+          image: gcr.io/knative-releases/knative.dev/serving/cmd/activator@sha256:c3bbf3a96920048869dcab8e133e00f59855670b8a0bbca3d72ced2f512eb5e1
           resources:
             requests:
               cpu: 300m
@@ -4438,7 +5326,9 @@ spec:
             runAsNonRoot: true
             capabilities:
               drop:
-                - all
+                - ALL
+            seccompProfile:
+              type: RuntimeDefault
           ports:
             - name: metrics
               containerPort: 9090
@@ -4475,9 +5365,8 @@ metadata:
   labels:
     app: activator
     app.kubernetes.io/component: activator
-    app.kubernetes.io/version: "1.2.5"
+    app.kubernetes.io/version: "1.8.0"
     app.kubernetes.io/name: knative-serving
-    serving.knative.dev/release: "v1.2.5"
 spec:
   selector:
     app: activator
@@ -4494,6 +5383,9 @@ spec:
     - name: http2
       port: 81
       targetPort: 8013
+    - name: https
+      port: 443
+      targetPort: 8112
   type: ClusterIP
 ---
 apiVersion: apps/v1
@@ -4504,8 +5396,7 @@ metadata:
   labels:
     app.kubernetes.io/component: autoscaler
     app.kubernetes.io/name: knative-serving
-    app.kubernetes.io/version: "1.2.5"
-    serving.knative.dev/release: "v1.2.5"
+    app.kubernetes.io/version: "1.8.0"
 spec:
   replicas: 1
   selector:
@@ -4523,8 +5414,7 @@ spec:
         app: autoscaler
         app.kubernetes.io/component: autoscaler
         app.kubernetes.io/name: knative-serving
-        app.kubernetes.io/version: "1.2.5"
-        serving.knative.dev/release: "v1.2.5"
+        app.kubernetes.io/version: "1.8.0"
     spec:
       affinity:
         podAntiAffinity:
@@ -4538,7 +5428,7 @@ spec:
       serviceAccountName: controller
       containers:
         - name: autoscaler
-          image: gcr.io/knative-releases/knative.dev/serving/cmd/autoscaler@sha256:007820fdb75b60e6fd5a25e65fd6ad9744082a6bf195d72795561c91b425d016
+          image: gcr.io/knative-releases/knative.dev/serving/cmd/autoscaler@sha256:caae5e34b4cb311ed8551f2778cfca566a77a924a59b775bd516fa8b5e3c1d7f
           resources:
             requests:
               cpu: 100m
@@ -4571,7 +5461,9 @@ spec:
             runAsNonRoot: true
             capabilities:
               drop:
-                - all
+                - ALL
+            seccompProfile:
+              type: RuntimeDefault
           ports:
             - name: metrics
               containerPort: 9090
@@ -4600,8 +5492,7 @@ metadata:
     app: autoscaler
     app.kubernetes.io/component: autoscaler
     app.kubernetes.io/name: knative-serving
-    app.kubernetes.io/version: "1.2.5"
-    serving.knative.dev/release: "v1.2.5"
+    app.kubernetes.io/version: "1.8.0"
   name: autoscaler
   namespace: knative-serving
 spec:
@@ -4626,8 +5517,7 @@ metadata:
   labels:
     app.kubernetes.io/component: controller
     app.kubernetes.io/name: knative-serving
-    app.kubernetes.io/version: "1.2.5"
-    serving.knative.dev/release: "v1.2.5"
+    app.kubernetes.io/version: "1.8.0"
 spec:
   selector:
     matchLabels:
@@ -4640,8 +5530,7 @@ spec:
         app: controller
         app.kubernetes.io/component: controller
         app.kubernetes.io/name: knative-serving
-        app.kubernetes.io/version: "1.2.5"
-        serving.knative.dev/release: "v1.2.5"
+        app.kubernetes.io/version: "1.8.0"
     spec:
       affinity:
         podAntiAffinity:
@@ -4655,7 +5544,7 @@ spec:
       serviceAccountName: controller
       containers:
         - name: controller
-          image: gcr.io/knative-releases/knative.dev/serving/cmd/controller@sha256:75cfdcfa050af9522e798e820ba5483b9093de1ce520207a3fedf112d73a4686
+          image: gcr.io/knative-releases/knative.dev/serving/cmd/controller@sha256:38f9557f4d61ec79cc2cdbe76da8df6c6ae5f978a50a2847c22cc61aa240da95
           resources:
             requests:
               cpu: 100m
@@ -4684,7 +5573,9 @@ spec:
             runAsNonRoot: true
             capabilities:
               drop:
-                - all
+                - ALL
+            seccompProfile:
+              type: RuntimeDefault
           ports:
             - name: metrics
               containerPort: 9090
@@ -4698,8 +5589,7 @@ metadata:
     app: controller
     app.kubernetes.io/component: controller
     app.kubernetes.io/name: knative-serving
-    app.kubernetes.io/version: "1.2.5"
-    serving.knative.dev/release: "v1.2.5"
+    app.kubernetes.io/version: "1.8.0"
   name: controller
   namespace: knative-serving
 spec:
@@ -4721,8 +5611,7 @@ metadata:
   labels:
     app.kubernetes.io/component: domain-mapping
     app.kubernetes.io/name: knative-serving
-    app.kubernetes.io/version: "1.2.5"
-    serving.knative.dev/release: "v1.2.5"
+    app.kubernetes.io/version: "1.8.0"
 spec:
   selector:
     matchLabels:
@@ -4735,8 +5624,7 @@ spec:
         app: domain-mapping
         app.kubernetes.io/component: domain-mapping
         app.kubernetes.io/name: knative-serving
-        app.kubernetes.io/version: "1.2.5"
-        serving.knative.dev/release: "v1.2.5"
+        app.kubernetes.io/version: "1.8.0"
     spec:
       affinity:
         podAntiAffinity:
@@ -4750,7 +5638,7 @@ spec:
       serviceAccountName: controller
       containers:
         - name: domain-mapping
-          image: gcr.io/knative-releases/knative.dev/serving/cmd/domain-mapping@sha256:23baa19322320f25a462568eded1276601ef67194883db9211e1ea24f21a0beb
+          image: gcr.io/knative-releases/knative.dev/serving/cmd/domain-mapping@sha256:763d648bf1edee2b4471b0e211dbc53ba2d28f92e4dae28ccd39af7185ef2c96
           resources:
             requests:
               cpu: 30m
@@ -4775,7 +5663,9 @@ spec:
             runAsNonRoot: true
             capabilities:
               drop:
-                - all
+                - ALL
+            seccompProfile:
+              type: RuntimeDefault
           ports:
             - name: metrics
               containerPort: 9090
@@ -4790,8 +5680,7 @@ metadata:
   labels:
     app.kubernetes.io/component: domain-mapping
     app.kubernetes.io/name: knative-serving
-    app.kubernetes.io/version: "1.2.5"
-    serving.knative.dev/release: "v1.2.5"
+    app.kubernetes.io/version: "1.8.0"
 spec:
   selector:
     matchLabels:
@@ -4806,8 +5695,7 @@ spec:
         role: domainmapping-webhook
         app.kubernetes.io/component: domain-mapping
         app.kubernetes.io/name: knative-serving
-        app.kubernetes.io/version: "1.2.5"
-        serving.knative.dev/release: "v1.2.5"
+        app.kubernetes.io/version: "1.8.0"
     spec:
       affinity:
         podAntiAffinity:
@@ -4821,7 +5709,7 @@ spec:
       serviceAccountName: controller
       containers:
         - name: domainmapping-webhook
-          image: gcr.io/knative-releases/knative.dev/serving/cmd/domain-mapping-webhook@sha256:847bb97e38440c71cb4bcc3e430743e18b328ad1e168b6fca35b10353b9a2c22
+          image: gcr.io/knative-releases/knative.dev/serving/cmd/domain-mapping-webhook@sha256:a4ba0076df2efaca2eed561339e21b3a4ca9d90167befd31de882bff69639470
           resources:
             requests:
               cpu: 100m
@@ -4852,7 +5740,9 @@ spec:
             runAsNonRoot: true
             capabilities:
               drop:
-                - all
+                - ALL
+            seccompProfile:
+              type: RuntimeDefault
           ports:
             - name: metrics
               containerPort: 9090
@@ -4887,8 +5777,7 @@ metadata:
     role: domainmapping-webhook
     app.kubernetes.io/component: domain-mapping
     app.kubernetes.io/name: knative-serving
-    app.kubernetes.io/version: "1.2.5"
-    serving.knative.dev/release: "v1.2.5"
+    app.kubernetes.io/version: "1.8.0"
   name: domainmapping-webhook
   namespace: knative-serving
 spec:
@@ -4913,8 +5802,7 @@ metadata:
   labels:
     app.kubernetes.io/component: webhook
     app.kubernetes.io/name: knative-serving
-    app.kubernetes.io/version: "1.2.5"
-    serving.knative.dev/release: "v1.2.5"
+    app.kubernetes.io/version: "1.8.0"
 spec:
   minReplicas: 1
   maxReplicas: 5
@@ -4938,8 +5826,7 @@ metadata:
   labels:
     app.kubernetes.io/component: webhook
     app.kubernetes.io/name: knative-serving
-    app.kubernetes.io/version: "1.2.5"
-    serving.knative.dev/release: "v1.2.5"
+    app.kubernetes.io/version: "1.8.0"
 spec:
   minAvailable: 80%
   selector:
@@ -4952,9 +5839,8 @@ metadata:
   name: webhook
   namespace: knative-serving
   labels:
-    serving.knative.dev/release: "v1.2.5"
     app.kubernetes.io/component: webhook
-    app.kubernetes.io/version: "1.2.5"
+    app.kubernetes.io/version: "1.8.0"
     app.kubernetes.io/name: knative-serving
 spec:
   selector:
@@ -4968,9 +5854,7 @@ spec:
       labels:
         app: webhook
         role: webhook
-        serving.knative.dev/release: "v1.2.5"
-        app.kubernetes.io/component: webhook
-        app.kubernetes.io/version: "1.2.5"
+        app.kubernetes.io/version: "1.8.0"
         app.kubernetes.io/name: knative-serving
     spec:
       affinity:
@@ -4985,7 +5869,7 @@ spec:
       serviceAccountName: controller
       containers:
         - name: webhook
-          image: gcr.io/knative-releases/knative.dev/serving/cmd/webhook@sha256:9084ea8498eae3c6c4364a397d66516a25e48488f4a9871ef765fa554ba483f0
+          image: gcr.io/knative-releases/knative.dev/serving/cmd/webhook@sha256:bc13765ba4895c0fa318a065392d05d0adc0e20415c739e0aacb3f56140bf9ae
           resources:
             requests:
               cpu: 100m
@@ -5018,7 +5902,9 @@ spec:
             runAsNonRoot: true
             capabilities:
               drop:
-                - all
+                - ALL
+            seccompProfile:
+              type: RuntimeDefault
           ports:
             - name: metrics
               containerPort: 9090
@@ -5051,9 +5937,8 @@ kind: Service
 metadata:
   labels:
     role: webhook
-    serving.knative.dev/release: "v1.2.5"
     app.kubernetes.io/component: webhook
-    app.kubernetes.io/version: "1.2.5"
+    app.kubernetes.io/version: "1.8.0"
     app.kubernetes.io/name: knative-serving
   name: webhook
   namespace: knative-serving
@@ -5078,8 +5963,7 @@ metadata:
   labels:
     app.kubernetes.io/component: webhook
     app.kubernetes.io/name: knative-serving
-    app.kubernetes.io/version: "1.2.5"
-    serving.knative.dev/release: "v1.2.5"
+    app.kubernetes.io/version: "1.8.0"
 webhooks:
   - admissionReviewVersions: ["v1", "v1beta1"]
     clientConfig:
@@ -5089,10 +5973,14 @@ webhooks:
     failurePolicy: Fail
     sideEffects: None
     name: config.webhook.serving.knative.dev
-    namespaceSelector:
+    objectSelector:
       matchExpressions:
-        - key: serving.knative.dev/release
-          operator: Exists
+        - key: app.kubernetes.io/name
+          operator: In
+          values: ["knative-serving"]
+        - key: app.kubernetes.io/component
+          operator: In
+          values: ["autoscaler", "controller", "logging", "networking", "observability", "tracing"]
     timeoutSeconds: 10
 ---
 apiVersion: admissionregistration.k8s.io/v1
@@ -5102,8 +5990,7 @@ metadata:
   labels:
     app.kubernetes.io/component: webhook
     app.kubernetes.io/name: knative-serving
-    app.kubernetes.io/version: "1.2.5"
-    serving.knative.dev/release: "v1.2.5"
+    app.kubernetes.io/version: "1.8.0"
 webhooks:
   - admissionReviewVersions: ["v1", "v1beta1"]
     clientConfig:
@@ -5143,8 +6030,7 @@ metadata:
   labels:
     app.kubernetes.io/component: domain-mapping
     app.kubernetes.io/name: knative-serving
-    app.kubernetes.io/version: "1.2.5"
-    serving.knative.dev/release: "v1.2.5"
+    app.kubernetes.io/version: "1.8.0"
 webhooks:
   - admissionReviewVersions: ["v1", "v1beta1"]
     clientConfig:
@@ -5159,14 +6045,14 @@ webhooks:
       - apiGroups:
           - serving.knative.dev
         apiVersions:
-          - v1alpha1
-          - v1beta1
+          - "*"
         operations:
           - CREATE
           - UPDATE
         scope: "*"
         resources:
           - domainmappings
+          - domainmappings/status
 ---
 apiVersion: v1
 kind: Secret
@@ -5176,8 +6062,7 @@ metadata:
   labels:
     app.kubernetes.io/component: domain-mapping
     app.kubernetes.io/name: knative-serving
-    app.kubernetes.io/version: "1.2.5"
-    serving.knative.dev/release: "v1.2.5"
+    app.kubernetes.io/version: "1.8.0"
 ---
 apiVersion: admissionregistration.k8s.io/v1
 kind: ValidatingWebhookConfiguration
@@ -5186,8 +6071,7 @@ metadata:
   labels:
     app.kubernetes.io/component: domain-mapping
     app.kubernetes.io/name: knative-serving
-    app.kubernetes.io/version: "1.2.5"
-    serving.knative.dev/release: "v1.2.5"
+    app.kubernetes.io/version: "1.8.0"
 webhooks:
   - admissionReviewVersions: ["v1", "v1beta1"]
     clientConfig:
@@ -5202,8 +6086,7 @@ webhooks:
       - apiGroups:
           - serving.knative.dev
         apiVersions:
-          - v1alpha1
-          - v1beta1
+          - "*"
         operations:
           - CREATE
           - UPDATE
@@ -5211,6 +6094,7 @@ webhooks:
         scope: "*"
         resources:
           - domainmappings
+          - domainmappings/status
 ---
 apiVersion: admissionregistration.k8s.io/v1
 kind: ValidatingWebhookConfiguration
@@ -5219,8 +6103,7 @@ metadata:
   labels:
     app.kubernetes.io/component: webhook
     app.kubernetes.io/name: knative-serving
-    app.kubernetes.io/version: "1.2.5"
-    serving.knative.dev/release: "v1.2.5"
+    app.kubernetes.io/version: "1.8.0"
 webhooks:
   - admissionReviewVersions: ["v1", "v1beta1"]
     clientConfig:
@@ -5262,6 +6145,6 @@ metadata:
   labels:
     app.kubernetes.io/component: webhook
     app.kubernetes.io/name: knative-serving
-    app.kubernetes.io/version: "1.2.5"
-    serving.knative.dev/release: "v1.2.5"
+    app.kubernetes.io/version: "1.8.0"
 ---
+


### PR DESCRIPTION
Changes:

- Update knative serving manifests to [v1.8.1](https://github.com/knative/serving/releases/tag/knative-v1.8.1) to support K8s-v1.25
- Update Istio Ingress controller manifests to [v1.8.0](https://github.com/knative-sandbox/net-istio/releases/tag/knative-v1.8.0)
- Update `README` files (version references, instructions etc)

Refs: https://github.com/kubeflow/manifests/issues/2325