### PR TITLE
Fix contrib/metacontroller folder

### DIFF
--- a/.github/workflows/metacontroller_kind_test.yaml
+++ b/.github/workflows/metacontroller_kind_test.yaml
@@ -1,0 +1,32 @@
+name: Build & Apply contrib/metacontroller in KinD
+on:
+  pull_request:
+    paths:
+      - contrib/metacontroller/**
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v3
+
+    - name: Install KinD
+      run: ./tests/gh-actions/install_kind.sh
+
+    - name: Create KinD Cluster
+      run: kind create cluster --config ./tests/gh-actions/kind-cluster-1-24.yaml
+
+    - name: Install kustomize
+      run: ./tests/gh-actions/install_kustomize.sh
+
+    - name: Install Istio
+      run: ./tests/gh-actions/install_istio.sh
+
+    - name: Install cert-manager
+      run: ./tests/gh-actions/install_cert_manager.sh
+
+    - name: Build & Apply manifests
+      run: |
+        cd contrib/metacontroller/
+        make test

--- a/.github/workflows/metacontroller_kind_test.yaml
+++ b/.github/workflows/metacontroller_kind_test.yaml
@@ -15,7 +15,7 @@ jobs:
       run: ./tests/gh-actions/install_kind.sh
 
     - name: Create KinD Cluster
-      run: kind create cluster --config ./tests/gh-actions/kind-cluster-1-24.yaml
+      run: kind create cluster --config ./tests/gh-actions/kind-cluster.yaml
 
     - name: Install kustomize
       run: ./tests/gh-actions/install_kustomize.sh

--- a/contrib/metacontroller/Makefile
+++ b/contrib/metacontroller/Makefile
@@ -1,0 +1,58 @@
+BUILD_DIR=./build
+
+.PHONY: hydrate
+hydrate:
+	rm -r -f "${BUILD_DIR}"
+	mkdir -p "${BUILD_DIR}"
+	kustomize build -o "${BUILD_DIR}" ./base
+	echo "Succesfully built into ${BUILD_DIR}."
+
+.PHONY: clean-build
+clean-build:
+	rm -r -f "${BUILD_DIR}"
+	echo "Succesfully cleaned ${BUILD_DIR}."
+
+.PHONY: apply
+apply: hydrate
+	kubectl apply -f "${BUILD_DIR}"
+	echo "Succesfully applied from ${BUILD_DIR}."
+
+.PHONY: delete
+delete: hydrate
+	kubectl delete -f "${BUILD_DIR}"
+	echo "Succesfully deleted metacontroller."
+
+.PHONY: test
+test: test-deploy test-catset-controller test-deploy-cleanup
+
+.PHONY: test-deploy
+test-deploy:
+	kubectl create namespace kubeflow || echo "Found 'kubeflow' namespace"
+	kustomize build ./base | kubectl apply -f -
+	sleep 30
+	# Check CRDs
+	kubectl -n kubeflow wait --for=condition=established --timeout=60s crd/compositecontrollers.metacontroller.k8s.io
+	kubectl -n kubeflow wait --for=condition=established --timeout=60s crd/controllerrevisions.metacontroller.k8s.io
+	kubectl -n kubeflow wait --for=condition=established --timeout=60s crd/decoratorcontrollers.metacontroller.k8s.io
+	# Check ServiceAccount
+	kubectl get -n kubeflow serviceaccount/meta-controller-service
+	kubectl get -n kubeflow clusterrolebinding/meta-controller-cluster-role-binding
+	# Check StatefulSet
+	kubectl -n kubeflow rollout status --watch --timeout=60s StatefulSet/metacontroller
+	echo "[Test] contrib/metacontroller deployment PASSED"
+
+.PHONY: test-deploy-cleanup
+test-deploy-cleanup:
+	# Cleanup
+	kustomize build ./base | kubectl delete -f -
+
+.PHONY: test-catset-controller
+test-catset-controller:
+	# Create a sample CRD
+	kubectl apply -f test/catset-controller.yaml
+	sleep 30
+	# Check a custom CRD
+	kubectl -n kubeflow get compositecontrollers/catset-controller
+	# Cleanup
+	kubectl delete compositecontrollers/catset-controller
+	echo "[Test] contrib/metacontroller catset-controller PASSED"

--- a/contrib/metacontroller/Makefile
+++ b/contrib/metacontroller/Makefile
@@ -56,3 +56,8 @@ test-catset-controller:
 	# Cleanup
 	kubectl delete compositecontrollers/catset-controller
 	echo "[Test] contrib/metacontroller catset-controller PASSED"
+
+.PHONY: pull
+pull:
+	# Check ./UPGRADE.md for instructions on how to pull updated manifests
+	kpt pkg update .@${KFP_VERSION}

--- a/contrib/metacontroller/README.md
+++ b/contrib/metacontroller/README.md
@@ -11,6 +11,12 @@ Metacontroller is an add-on for Kubernetes that makes it easy to write and deplo
 - You should have `kubectl` available and configured to talk to the desired cluster.
 - `kustomize`.
 
+## Compile manifests
+
+```bash
+make hydrate
+```
+
 ## Install Metacontroller
 
 ```bash
@@ -21,6 +27,12 @@ make apply
 
 ```bash
 make test
+```
+
+## Uninstall Metacontroller
+
+```bash
+make delete
 ```
 
 ## Upgrade Metacontroller

--- a/contrib/metacontroller/README.md
+++ b/contrib/metacontroller/README.md
@@ -1,16 +1,28 @@
 # Metacontroller
 
 - [Official documentation](https://metacontroller.github.io/metacontroller/)
-- [Official repoitory](https://github.com/metacontroller/metacontroller)
+- [Official repository](https://github.com/metacontroller/metacontroller)
 
-## Upgrade
+Metacontroller is an add-on for Kubernetes that makes it easy to write and deploy custom controllers.
 
-Metacontroller is pulled from [Kubeflow Pipelines third-party folder](https://github.com/kubeflow/pipelines/tree/master/manifests/kustomize/third-party/metacontroller). To update this component specify the desired KFP version and run the following command in console from the root directory **/**:
+## Prerequisites
+
+- Kubernetes v1.16+ (because of maintainability, e2e test suite might not cover all releases).
+- You should have `kubectl` available and configured to talk to the desired cluster.
+- `kustomize`.
+
+## Install Metacontroller
 
 ```bash
-export KFP_VERSION=2.0.0-alpha.3   # specify KFP version
-kpt pkg update ./contrib/metacontroller@${KFP_VERSION}
+make apply
 ```
 
-Alternatively, you can copy the content from [Kubeflow Pipelines third-party folder](https://github.com/kubeflow/pipelines/tree/master/manifests/kustomize/third-party/metacontroller) by choosing the appropriate `TAG` in that repository.
+## Verify deployment
 
+```bash
+make test
+```
+
+## Upgrade Metacontroller
+
+To upgrade to the lates version used in Kubeflow, follow the steps in [UPGRADE.md](./UPDGRADE.md).

--- a/contrib/metacontroller/UPDGRADE.md
+++ b/contrib/metacontroller/UPDGRADE.md
@@ -1,11 +1,9 @@
 # Upgrade Metacontroller
 
-Metacontroller is pulled from [Kubeflow Pipelines third-party folder](https://github.com/kubeflow/pipelines/tree/master/manifests/kustomize/third-party/metacontroller). To update this component specify the desired KFP version and run the following command in console from the root directory **/**:
+Metacontroller is pulled from [Kubeflow Pipelines's (KFP) third-party folder](https://github.com/kubeflow/pipelines/tree/master/manifests/kustomize/third-party/metacontroller). To update this component specify the desired Kubeflow Pipelines version as `KFP_VERSION` environment variable and run `make pull` in console:
 
 ```bash
-export KFP_VERSION=2.0.0-alpha.3   # specify KFP version
-kpt pkg update ./contrib/metacontroller@${KFP_VERSION}
+KFP_VERSION=2.0.0-alpha.3 make pull
 ```
 
 Alternatively, you can copy the content from [Kubeflow Pipelines third-party folder](https://github.com/kubeflow/pipelines/tree/master/manifests/kustomize/third-party/metacontroller) by choosing the appropriate `TAG` in that repository.
-

--- a/contrib/metacontroller/UPDGRADE.md
+++ b/contrib/metacontroller/UPDGRADE.md
@@ -1,0 +1,11 @@
+# Upgrade Metacontroller
+
+Metacontroller is pulled from [Kubeflow Pipelines third-party folder](https://github.com/kubeflow/pipelines/tree/master/manifests/kustomize/third-party/metacontroller). To update this component specify the desired KFP version and run the following command in console from the root directory **/**:
+
+```bash
+export KFP_VERSION=2.0.0-alpha.3   # specify KFP version
+kpt pkg update ./contrib/metacontroller@${KFP_VERSION}
+```
+
+Alternatively, you can copy the content from [Kubeflow Pipelines third-party folder](https://github.com/kubeflow/pipelines/tree/master/manifests/kustomize/third-party/metacontroller) by choosing the appropriate `TAG` in that repository.
+

--- a/contrib/metacontroller/base/stateful-set.yaml
+++ b/contrib/metacontroller/base/stateful-set.yaml
@@ -32,7 +32,7 @@ spec:
           securityContext:
             capabilities:
               drop:
-              - ALL
+                - ALL
             readOnlyRootFilesystem: true
             runAsNonRoot: true
             runAsUser: 1000

--- a/contrib/metacontroller/test/catset-controller.yaml
+++ b/contrib/metacontroller/test/catset-controller.yaml
@@ -1,10 +1,10 @@
 apiVersion: metacontroller.k8s.io/v1alpha1
 kind: CompositeController
-metadata:
+metadata: # kpt-merge: /catset-controller
   name: catset-controller
 spec:
   parentResource:
-    apiVersion: ctl.enisoc.com/v1 
+    apiVersion: ctl.enisoc.com/v1
     resource: catsets
     revisionHistory:
       fieldPaths:

--- a/contrib/metacontroller/test/catset-controller.yaml
+++ b/contrib/metacontroller/test/catset-controller.yaml
@@ -1,0 +1,27 @@
+apiVersion: metacontroller.k8s.io/v1alpha1
+kind: CompositeController
+metadata:
+  name: catset-controller
+spec:
+  parentResource:
+    apiVersion: ctl.enisoc.com/v1 
+    resource: catsets
+    revisionHistory:
+      fieldPaths:
+      - spec.template
+  childResources:
+  - apiVersion: v1
+    resource: pods
+    updateStrategy:
+      method: RollingRecreate
+      statusChecks:
+        conditions:
+        - type: Ready
+          status: "True"
+  - apiVersion: v1
+    resource: persistentvolumeclaims
+  hooks:
+    sync:
+      webhook:
+        url: http://catset-controller.metacontroller/sync
+        timeout: 10s


### PR DESCRIPTION
Updating `contrib/metacontroller` to address #2311 and to comply with [contrib guidelines](https://github.com/kubeflow/manifests/blob/master/proposals/20220926-contrib-component-guidelines.md)

**Description of your changes:**
- Added tests
- Added `UPGRADE.md`
- Updated `README.md`
- Added `metacontroller_kind_test.yaml` to GH-actions

**Checklist:**
- [x] Tested on Kubeflow 1.6.1 (GKE 1.22)