### PR TITLE
Feat: Add BentoML Yatai Stack contrib

### DIFF
--- a/.github/workflows/bentoml_kind_test.yaml
+++ b/.github/workflows/bentoml_kind_test.yaml
@@ -1,0 +1,29 @@
+name: Build & Apply BentoML Yatai Stack manifests in KinD
+on:
+  pull_request:
+    paths:
+      - contrib/bentoml/**
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v3
+
+    - name: Install KinD
+      run: ./tests/gh-actions/install_kind.sh
+
+    - name: Create KinD Cluster
+      run: kind create cluster --config tests/gh-actions/kind-cluster-1-24.yaml
+
+    - name: Install kustomize
+      run: ./tests/gh-actions/install_kustomize.sh
+
+    - name: Install cert-manager
+      run: ./tests/gh-actions/install_cert_manager.sh
+
+    - name: Build & Apply manifests
+      run: |
+        cd contrib/bentoml/
+        make test

--- a/contrib/bentoml/Makefile
+++ b/contrib/bentoml/Makefile
@@ -1,0 +1,23 @@
+BENTOML_YATAI_IMAGE_BUILDER_VERSION ?= 1.1.3
+BENTOML_YATAI_DEPLOYMENT_VERSION ?= 1.1.4
+BENTOML_HELM_CHART_REPO ?= https://bentoml.github.io/helm-charts
+
+.PHONY: bentoml-yatai-stack/bases
+bentoml-yatai-stack/bases: clean-kustomize
+	mkdir -p bentoml-yatai-stack/bases/yatai-image-builder
+	cd bentoml-yatai-stack/bases/yatai-image-builder && helm template --skip-tests yatai-image-builder-crds yatai-image-builder-crds --repo ${BENTOML_HELM_CHART_REPO} --namespace kubeflow --version ${BENTOML_YATAI_IMAGE_BUILDER_VERSION} > resources.yaml
+	cd bentoml-yatai-stack/bases/yatai-image-builder && helm template --skip-tests -f ../../../sources/yatai-image-builder-values.yaml yatai-image-builder yatai-image-builder --repo ${BENTOML_HELM_CHART_REPO} --namespace kubeflow --version ${BENTOML_YATAI_IMAGE_BUILDER_VERSION} >> resources.yaml
+	cp sources/kustomization-template.yaml bentoml-yatai-stack/bases/yatai-image-builder/kustomization.yaml
+	mkdir -p bentoml-yatai-stack/bases/yatai-deployment
+	cd bentoml-yatai-stack/bases/yatai-deployment && helm template --skip-tests yatai-deployment-crds yatai-deployment-crds --repo ${BENTOML_HELM_CHART_REPO} --namespace kubeflow --version ${BENTOML_YATAI_DEPLOYMENT_VERSION} > resources.yaml
+	cd bentoml-yatai-stack/bases/yatai-deployment && helm template --skip-tests -f ../../../sources/yatai-deployment-values.yaml yatai-deployment yatai-deployment --repo ${BENTOML_HELM_CHART_REPO} --namespace kubeflow --version ${BENTOML_YATAI_DEPLOYMENT_VERSION} >> resources.yaml
+	cp sources/kustomization-template.yaml bentoml-yatai-stack/bases/yatai-deployment/kustomization.yaml
+
+.PHONY: clean-kustomize
+clean-kustomize:
+	rm -rf bentoml-yatai-stack/bases
+
+.PHONY: test
+test:
+	./test.sh
+

--- a/contrib/bentoml/OWNERS
+++ b/contrib/bentoml/OWNERS
@@ -1,0 +1,2 @@
+approvers:
+  - yubozhao

--- a/contrib/bentoml/README.md
+++ b/contrib/bentoml/README.md
@@ -1,0 +1,193 @@
+# BentoML Yatai Stack
+
+[BentoML Yatai Stack](https://github.com/bentoml/yatai-deployment) is a series of components for deploying models/bentos to Kubernetes at scale
+
+## Requirements
+
+* Kubernetes 1.20 - 1.24
+
+## Installation
+
+    * The yaml assumes you will install in kubeflow namespace
+
+```bash
+kustomize build bentoml-yatai-stack/default | kubectl apply -n kubeflow --server-side -f -
+```
+
+## Upgrating
+
+See [UPGRADE.md](UPGRADE.md)
+
+# Design Proposal
+
+## Why BentoML
+
+![image](https://user-images.githubusercontent.com/861225/212856116-bf873dc8-7da3-4484-9f33-e401e34a82dc.png)
+
+- BentoML is an open-source framework for developing, serving, and deploying ML services.
+    - Building
+        - Unifies ML frameworks with out-of-the-box implementation of popular frameworks
+        - Exposes gRPC and OpenAPI for serving
+        - Provides Python SDK for development
+    - Deployment
+        - Any environment, batch inference, streaming, or online serving
+        - Any cloud platform for on-prem
+        - Full observability support through Grafana
+        - Yatai - BentoML's deployment platform
+
+## User Stories
+
+Goal: From simple Python module to distributed Kubernetes deployment.
+
+Consider the following common ML services involve custom pre and post-processing logic and inference of multiple models.
+
+![image](https://user-images.githubusercontent.com/861225/212856456-866125c8-2bf3-42d4-b031-3c7d89c07f37.png)
+
+### Developing on Kubeflow Notebook
+
+- Create a service using saved model.
+
+```
+%%writefile service.py
+import asyncio
+import bentoml
+
+fraud_detection = bentoml.pytorch.get("fraud_detection:latest").to_runner()
+risk_assessment_1 = bentoml.sklearn.get("risk_assessment_1:latest").to_runner()
+risk_assessment_2 = bentoml.sklearn.get("risk_assessment_2:latest").to_runner()
+risk_assessment_3 = bentoml.sklearn.get("risk_assessment_3:latest").to_runner()
+
+svc = bentoml.Service(
+    name="credit_application",
+    runners=[fraud_detection, risk_assessment_1, risk_assessment_2, risk_assessment_3]
+)
+
+@svc.api(input=bentoml.io.JSON(), output=bentoml.io.JSON())
+async def apply(input_data: dict) -> dict:
+    features = await fetch_features(input_date["user_id"])
+    detection = await fraud_detection.async_run(input_data, features)
+    if detection["confidence"] < CONFIDENCE_THRESHOLD:
+       return REJECTION
+    assessments = await asyncio.gather(
+        risk_assessment_1.async_run(input_data["application"], features),
+        risk_assessment_2.async_run(input_data["application"], features),
+        risk_assessment_3.async_run(input_data["application"], features),
+    )
+    return process_assessments(assessments)
+
+```
+
+- Serve and test the service.
+    
+```
+!bentoml serve service.py:svc --reload
+
+2022-11-07T06:50:53+0000 [INFO] [cli] Prometheus metrics for HTTP BentoServer from "service.py:svc" can be accessed at <http://localhost:3000/metrics>.
+2022-11-07T06:50:53+0000 [INFO] [cli] Starting development HTTP BentoServer from "service.py:svc" listening on <http://0.0.0.0:3000> (Press CTRL+C to quit)
+
+```
+    
+![image](https://user-images.githubusercontent.com/861225/212856978-c8a24c4b-bc5b-4706-887e-81f5be914938.png)
+
+- Build bento
+    
+```
+!bentoml build
+
+Building BentoML service "credit_application:wly5lqc6ncpzwcvj" from build context "."
+Successfully built Bento(tag="credit_application:wly5lqc6ncpzwcvj").
+```
+
+- Export bento to blob storage.
+
+```
+!bentoml export credit_application:wly5lqc6ncpzwcvj s3://your_bento_bucket/credit_application.wly5lqc6ncpzwcvj.bento
+```
+
+### Deploying to Kubernetes
+
+![image](https://user-images.githubusercontent.com/861225/212857708-f96c9877-bb89-4afa-930a-1d2cb0300520.png)
+
+Users can deploy bentos to the K8s cluster in one of the three ways.
+
+#### Kubernetes Python Client
+
+Users can deploy bentos through Kubeflow Notebook with Kubernetes [Python client](https://github.com/kubernetes-client/python)
+
+#### kubectl
+
+BentoML offers two options to deploy bentos directly to the Kubenetes cluster through `kubectl` and the `BentoRequest`, `Bento`, and `BentoDeployment` CRDs.
+
+The first option relies on `yatai-image-builder` to build the OCI image. Users need to create a `BentoRequest` CR and `BentoDeployment` CR to deploy a bento. In the `BentoDeployment` CR, the name of the bento should be defined as the name of the `BentoRequest` CR. If this Bento CR not found, `yatai-deployment` will look for the BentoRequest CR by the same name and wait for the BentoRequest CR to generate the Bento CR. This option will build the OCI image by spawning a pod to run the Kaniko build tool. However, the Kaniko build tool requires root user access. If root user access is not available, consider the second option below.
+
+The second option relies on the users to provide a URI to the pre-built OCI image of the bento. Users need to manually create a Bento CR with the image field defined as the pre-built OCI image URI. Then create a BentoDeployment CR to reference the Bento CR previously created.
+
+#### Kubeflow Pipeline Component
+
+This option will be available in Kubeflow release 1.8.
+
+### Verification
+
+The following installation and testing steps demonstrate how to install Yatai components and deploy bentos through `kubectl` with `BentoRequest` and `BentoDeployment` CRDs.
+
+#### Installation
+
+Install with kustomize command:
+
+```
+kustomize build bentoml-yatai-stack/default | kubectl apply -n kubeflow --server-side -f -
+```
+
+#### Test
+
+Create Bento CR and BentoDeployment CR:
+
+```
+kubectl apply -f example.yaml
+```
+
+Verifying that the bento deployment is running:
+
+```
+kubectl -n kubeflow get deploy -l yatai.ai/bento-deployment=test-yatai
+```
+
+The output of the above command should be like this:
+
+```
+NAME                  READY   UP-TO-DATE   AVAILABLE   AGE
+test-yatai            1/1     1            1           6m12s
+test-yatai-runner-0   1/1     1            1           16m
+```
+
+Verifying that the bento service is created:
+
+```
+kubectl -n kubeflow get service -l yatai.ai/bento-deployment=test-yatai
+```
+
+The output of the above command should look like this:
+
+```
+NAME                                                 TYPE        CLUSTER-IP      EXTERNAL-IP   PORT(S)             AGE
+test-yatai                                           ClusterIP   10.96.150.42    <none>        3000/TCP,3001/TCP   7m59s
+test-yatai-runner-32c50ece701351fb576189d54bd58724   ClusterIP   10.96.193.242   <none>        3000/TCP,3001/TCP   7m39s
+```
+
+Port-forwarding the bento service:
+
+```
+kubectl -n kubeflow port-forward svc/test-yatai 3000:3000
+```
+
+Finally you can test the bento service with the curl command:
+
+```
+curl -X 'POST' http://localhost:3000/classify -d '[[0,1,2,3]]'
+```
+
+The output should be:
+
+```
+[2]
+```

--- a/contrib/bentoml/UPGRADE.md
+++ b/contrib/bentoml/UPGRADE.md
@@ -1,0 +1,35 @@
+# Upgrading Documentation
+
+## Updating manifests
+
+In order to update manifests make sure you are running the commands in linux.
+
+If you are running in another OS, please make sure to update the Makefile commands.
+
+You can refresh the configuration by running:
+
+```
+make bentoml-yatai-stack/base
+```
+
+## Updating to specific version
+
+Upgrading the version can be done by setting the `BENTOML_YATAI_STACK_VERSION` environment variable, such as:
+
+```
+# Set the desired version
+export BENTOML_YATAI_IMAGE_BUILDER_VERSION=1.1.0
+export BENTOML_YATAI_DEPLOYMENT_VERSION=1.1.0
+
+# Rebuild the kustomize bases
+make bentoml-yatai-stack/bases
+
+# Run new manifests against cluster
+kustomize build bentoml-yatai-stack/default | kubectl apply -f -
+```
+
+## Instructions for breaking changes
+
+The [Yatai upgrading docs](https://docs.bentoml.org/projects/yatai) provide step by step overview of breaking changes across minor and patch versions.
+
+

--- a/contrib/bentoml/bentoml-yatai-stack/bases/yatai-deployment/kustomization.yaml
+++ b/contrib/bentoml/bentoml-yatai-stack/bases/yatai-deployment/kustomization.yaml
@@ -1,0 +1,2 @@
+resources:
+- resources.yaml

--- a/contrib/bentoml/bentoml-yatai-stack/bases/yatai-deployment/resources.yaml
+++ b/contrib/bentoml/bentoml-yatai-stack/bases/yatai-deployment/resources.yaml
@@ -1,0 +1,10816 @@
+---
+# Source: yatai-deployment-crds/templates/bentodeployment.yaml
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    cert-manager.io/inject-ca-from: 'kubeflow/yatai-deployment-serving-cert'
+    controller-gen.kubebuilder.io/version: v0.7.0
+  name: bentodeployments.serving.yatai.ai
+spec:
+  conversion:
+    strategy: Webhook
+    webhook:
+      clientConfig:
+        service:
+          name: 'yatai-deployment-webhook-service'
+          namespace: 'kubeflow'
+          path: /convert
+      conversionReviewVersions:
+      - v1
+      - v1alpha1
+      - v1alpha2
+      - v1alpha3
+      - v2alpha1
+  group: serving.yatai.ai
+  names:
+    kind: BentoDeployment
+    listKind: BentoDeploymentList
+    plural: bentodeployments
+    singular: bentodeployment
+  scope: Namespaced
+  versions:
+  - additionalPrinterColumns:
+    - description: BentoTag
+      jsonPath: .spec.bento_tag
+      name: Bento
+      type: string
+    - description: Ready
+      jsonPath: .status.printerReady
+      name: Ready
+      type: string
+    - description: MinReplicas
+      jsonPath: .spec.autoscaling.min_replicas
+      name: MinReplicas
+      type: integer
+    - description: MaxReplicas
+      jsonPath: .spec.autoscaling.max_replicas
+      name: MaxReplicas
+      type: integer
+    - jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: BentoDeployment is the Schema for the bentodeployments API
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: BentoDeploymentSpec defines the desired state of BentoDeployment
+            properties:
+              autoscaling:
+                properties:
+                  cpu:
+                    format: int32
+                    type: integer
+                  gpu:
+                    format: int32
+                    type: integer
+                  max_replicas:
+                    format: int32
+                    type: integer
+                  memory:
+                    type: string
+                  min_replicas:
+                    format: int32
+                    type: integer
+                  qps:
+                    format: int64
+                    type: integer
+                type: object
+              bento_tag:
+                type: string
+              envs:
+                items:
+                  properties:
+                    key:
+                      type: string
+                    value:
+                      type: string
+                  required:
+                  - key
+                  - value
+                  type: object
+                type: array
+              resources:
+                properties:
+                  limits:
+                    properties:
+                      cpu:
+                        type: string
+                      custom:
+                        additionalProperties:
+                          type: string
+                        type: object
+                      gpu:
+                        type: string
+                      memory:
+                        type: string
+                    type: object
+                  requests:
+                    properties:
+                      cpu:
+                        type: string
+                      custom:
+                        additionalProperties:
+                          type: string
+                        type: object
+                      gpu:
+                        type: string
+                      memory:
+                        type: string
+                    type: object
+                type: object
+              runners:
+                items:
+                  properties:
+                    autoscaling:
+                      properties:
+                        maxReplicas:
+                          format: int32
+                          type: integer
+                        metrics:
+                          items:
+                            description: MetricSpec specifies how to scale based on
+                              a single metric (only `type` and one other matching
+                              field should be set at once).
+                            properties:
+                              containerResource:
+                                description: container resource refers to a resource
+                                  metric (such as those specified in requests and
+                                  limits) known to Kubernetes describing a single
+                                  container in each pod of the current scale target
+                                  (e.g. CPU or memory). Such metrics are built in
+                                  to Kubernetes, and have special scaling options
+                                  on top of those available to normal per-pod metrics
+                                  using the "pods" source. This is an alpha feature
+                                  and can be enabled by the HPAContainerMetrics feature
+                                  flag.
+                                properties:
+                                  container:
+                                    description: container is the name of the container
+                                      in the pods of the scaling target
+                                    type: string
+                                  name:
+                                    description: name is the name of the resource
+                                      in question.
+                                    type: string
+                                  target:
+                                    description: target specifies the target value
+                                      for the given metric
+                                    properties:
+                                      averageUtilization:
+                                        description: averageUtilization is the target
+                                          value of the average of the resource metric
+                                          across all relevant pods, represented as
+                                          a percentage of the requested value of the
+                                          resource for the pods. Currently only valid
+                                          for Resource metric source type
+                                        format: int32
+                                        type: integer
+                                      averageValue:
+                                        anyOf:
+                                        - type: integer
+                                        - type: string
+                                        description: averageValue is the target value
+                                          of the average of the metric across all
+                                          relevant pods (as a quantity)
+                                        pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                        x-kubernetes-int-or-string: true
+                                      type:
+                                        description: type represents whether the metric
+                                          type is Utilization, Value, or AverageValue
+                                        type: string
+                                      value:
+                                        anyOf:
+                                        - type: integer
+                                        - type: string
+                                        description: value is the target value of
+                                          the metric (as a quantity).
+                                        pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                        x-kubernetes-int-or-string: true
+                                    required:
+                                    - type
+                                    type: object
+                                required:
+                                - container
+                                - name
+                                - target
+                                type: object
+                              external:
+                                description: external refers to a global metric that
+                                  is not associated with any Kubernetes object. It
+                                  allows autoscaling based on information coming from
+                                  components running outside of cluster (for example
+                                  length of queue in cloud messaging service, or QPS
+                                  from loadbalancer running outside of cluster).
+                                properties:
+                                  metric:
+                                    description: metric identifies the target metric
+                                      by name and selector
+                                    properties:
+                                      name:
+                                        description: name is the name of the given
+                                          metric
+                                        type: string
+                                      selector:
+                                        description: selector is the string-encoded
+                                          form of a standard kubernetes label selector
+                                          for the given metric When set, it is passed
+                                          as an additional parameter to the metrics
+                                          server for more specific metrics scoping.
+                                          When unset, just the metricName will be
+                                          used to gather metrics.
+                                        properties:
+                                          matchExpressions:
+                                            description: matchExpressions is a list
+                                              of label selector requirements. The
+                                              requirements are ANDed.
+                                            items:
+                                              description: A label selector requirement
+                                                is a selector that contains values,
+                                                a key, and an operator that relates
+                                                the key and values.
+                                              properties:
+                                                key:
+                                                  description: key is the label key
+                                                    that the selector applies to.
+                                                  type: string
+                                                operator:
+                                                  description: operator represents
+                                                    a key's relationship to a set
+                                                    of values. Valid operators are
+                                                    In, NotIn, Exists and DoesNotExist.
+                                                  type: string
+                                                values:
+                                                  description: values is an array
+                                                    of string values. If the operator
+                                                    is In or NotIn, the values array
+                                                    must be non-empty. If the operator
+                                                    is Exists or DoesNotExist, the
+                                                    values array must be empty. This
+                                                    array is replaced during a strategic
+                                                    merge patch.
+                                                  items:
+                                                    type: string
+                                                  type: array
+                                              required:
+                                              - key
+                                              - operator
+                                              type: object
+                                            type: array
+                                          matchLabels:
+                                            additionalProperties:
+                                              type: string
+                                            description: matchLabels is a map of {key,value}
+                                              pairs. A single {key,value} in the matchLabels
+                                              map is equivalent to an element of matchExpressions,
+                                              whose key field is "key", the operator
+                                              is "In", and the values array contains
+                                              only "value". The requirements are ANDed.
+                                            type: object
+                                        type: object
+                                    required:
+                                    - name
+                                    type: object
+                                  target:
+                                    description: target specifies the target value
+                                      for the given metric
+                                    properties:
+                                      averageUtilization:
+                                        description: averageUtilization is the target
+                                          value of the average of the resource metric
+                                          across all relevant pods, represented as
+                                          a percentage of the requested value of the
+                                          resource for the pods. Currently only valid
+                                          for Resource metric source type
+                                        format: int32
+                                        type: integer
+                                      averageValue:
+                                        anyOf:
+                                        - type: integer
+                                        - type: string
+                                        description: averageValue is the target value
+                                          of the average of the metric across all
+                                          relevant pods (as a quantity)
+                                        pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                        x-kubernetes-int-or-string: true
+                                      type:
+                                        description: type represents whether the metric
+                                          type is Utilization, Value, or AverageValue
+                                        type: string
+                                      value:
+                                        anyOf:
+                                        - type: integer
+                                        - type: string
+                                        description: value is the target value of
+                                          the metric (as a quantity).
+                                        pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                        x-kubernetes-int-or-string: true
+                                    required:
+                                    - type
+                                    type: object
+                                required:
+                                - metric
+                                - target
+                                type: object
+                              object:
+                                description: object refers to a metric describing
+                                  a single kubernetes object (for example, hits-per-second
+                                  on an Ingress object).
+                                properties:
+                                  describedObject:
+                                    description: CrossVersionObjectReference contains
+                                      enough information to let you identify the referred
+                                      resource.
+                                    properties:
+                                      apiVersion:
+                                        description: API version of the referent
+                                        type: string
+                                      kind:
+                                        description: 'Kind of the referent; More info:
+                                          https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds"'
+                                        type: string
+                                      name:
+                                        description: 'Name of the referent; More info:
+                                          http://kubernetes.io/docs/user-guide/identifiers#names'
+                                        type: string
+                                    required:
+                                    - kind
+                                    - name
+                                    type: object
+                                  metric:
+                                    description: metric identifies the target metric
+                                      by name and selector
+                                    properties:
+                                      name:
+                                        description: name is the name of the given
+                                          metric
+                                        type: string
+                                      selector:
+                                        description: selector is the string-encoded
+                                          form of a standard kubernetes label selector
+                                          for the given metric When set, it is passed
+                                          as an additional parameter to the metrics
+                                          server for more specific metrics scoping.
+                                          When unset, just the metricName will be
+                                          used to gather metrics.
+                                        properties:
+                                          matchExpressions:
+                                            description: matchExpressions is a list
+                                              of label selector requirements. The
+                                              requirements are ANDed.
+                                            items:
+                                              description: A label selector requirement
+                                                is a selector that contains values,
+                                                a key, and an operator that relates
+                                                the key and values.
+                                              properties:
+                                                key:
+                                                  description: key is the label key
+                                                    that the selector applies to.
+                                                  type: string
+                                                operator:
+                                                  description: operator represents
+                                                    a key's relationship to a set
+                                                    of values. Valid operators are
+                                                    In, NotIn, Exists and DoesNotExist.
+                                                  type: string
+                                                values:
+                                                  description: values is an array
+                                                    of string values. If the operator
+                                                    is In or NotIn, the values array
+                                                    must be non-empty. If the operator
+                                                    is Exists or DoesNotExist, the
+                                                    values array must be empty. This
+                                                    array is replaced during a strategic
+                                                    merge patch.
+                                                  items:
+                                                    type: string
+                                                  type: array
+                                              required:
+                                              - key
+                                              - operator
+                                              type: object
+                                            type: array
+                                          matchLabels:
+                                            additionalProperties:
+                                              type: string
+                                            description: matchLabels is a map of {key,value}
+                                              pairs. A single {key,value} in the matchLabels
+                                              map is equivalent to an element of matchExpressions,
+                                              whose key field is "key", the operator
+                                              is "In", and the values array contains
+                                              only "value". The requirements are ANDed.
+                                            type: object
+                                        type: object
+                                    required:
+                                    - name
+                                    type: object
+                                  target:
+                                    description: target specifies the target value
+                                      for the given metric
+                                    properties:
+                                      averageUtilization:
+                                        description: averageUtilization is the target
+                                          value of the average of the resource metric
+                                          across all relevant pods, represented as
+                                          a percentage of the requested value of the
+                                          resource for the pods. Currently only valid
+                                          for Resource metric source type
+                                        format: int32
+                                        type: integer
+                                      averageValue:
+                                        anyOf:
+                                        - type: integer
+                                        - type: string
+                                        description: averageValue is the target value
+                                          of the average of the metric across all
+                                          relevant pods (as a quantity)
+                                        pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                        x-kubernetes-int-or-string: true
+                                      type:
+                                        description: type represents whether the metric
+                                          type is Utilization, Value, or AverageValue
+                                        type: string
+                                      value:
+                                        anyOf:
+                                        - type: integer
+                                        - type: string
+                                        description: value is the target value of
+                                          the metric (as a quantity).
+                                        pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                        x-kubernetes-int-or-string: true
+                                    required:
+                                    - type
+                                    type: object
+                                required:
+                                - describedObject
+                                - metric
+                                - target
+                                type: object
+                              pods:
+                                description: pods refers to a metric describing each
+                                  pod in the current scale target (for example, transactions-processed-per-second).  The
+                                  values will be averaged together before being compared
+                                  to the target value.
+                                properties:
+                                  metric:
+                                    description: metric identifies the target metric
+                                      by name and selector
+                                    properties:
+                                      name:
+                                        description: name is the name of the given
+                                          metric
+                                        type: string
+                                      selector:
+                                        description: selector is the string-encoded
+                                          form of a standard kubernetes label selector
+                                          for the given metric When set, it is passed
+                                          as an additional parameter to the metrics
+                                          server for more specific metrics scoping.
+                                          When unset, just the metricName will be
+                                          used to gather metrics.
+                                        properties:
+                                          matchExpressions:
+                                            description: matchExpressions is a list
+                                              of label selector requirements. The
+                                              requirements are ANDed.
+                                            items:
+                                              description: A label selector requirement
+                                                is a selector that contains values,
+                                                a key, and an operator that relates
+                                                the key and values.
+                                              properties:
+                                                key:
+                                                  description: key is the label key
+                                                    that the selector applies to.
+                                                  type: string
+                                                operator:
+                                                  description: operator represents
+                                                    a key's relationship to a set
+                                                    of values. Valid operators are
+                                                    In, NotIn, Exists and DoesNotExist.
+                                                  type: string
+                                                values:
+                                                  description: values is an array
+                                                    of string values. If the operator
+                                                    is In or NotIn, the values array
+                                                    must be non-empty. If the operator
+                                                    is Exists or DoesNotExist, the
+                                                    values array must be empty. This
+                                                    array is replaced during a strategic
+                                                    merge patch.
+                                                  items:
+                                                    type: string
+                                                  type: array
+                                              required:
+                                              - key
+                                              - operator
+                                              type: object
+                                            type: array
+                                          matchLabels:
+                                            additionalProperties:
+                                              type: string
+                                            description: matchLabels is a map of {key,value}
+                                              pairs. A single {key,value} in the matchLabels
+                                              map is equivalent to an element of matchExpressions,
+                                              whose key field is "key", the operator
+                                              is "In", and the values array contains
+                                              only "value". The requirements are ANDed.
+                                            type: object
+                                        type: object
+                                    required:
+                                    - name
+                                    type: object
+                                  target:
+                                    description: target specifies the target value
+                                      for the given metric
+                                    properties:
+                                      averageUtilization:
+                                        description: averageUtilization is the target
+                                          value of the average of the resource metric
+                                          across all relevant pods, represented as
+                                          a percentage of the requested value of the
+                                          resource for the pods. Currently only valid
+                                          for Resource metric source type
+                                        format: int32
+                                        type: integer
+                                      averageValue:
+                                        anyOf:
+                                        - type: integer
+                                        - type: string
+                                        description: averageValue is the target value
+                                          of the average of the metric across all
+                                          relevant pods (as a quantity)
+                                        pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                        x-kubernetes-int-or-string: true
+                                      type:
+                                        description: type represents whether the metric
+                                          type is Utilization, Value, or AverageValue
+                                        type: string
+                                      value:
+                                        anyOf:
+                                        - type: integer
+                                        - type: string
+                                        description: value is the target value of
+                                          the metric (as a quantity).
+                                        pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                        x-kubernetes-int-or-string: true
+                                    required:
+                                    - type
+                                    type: object
+                                required:
+                                - metric
+                                - target
+                                type: object
+                              resource:
+                                description: resource refers to a resource metric
+                                  (such as those specified in requests and limits)
+                                  known to Kubernetes describing each pod in the current
+                                  scale target (e.g. CPU or memory). Such metrics
+                                  are built in to Kubernetes, and have special scaling
+                                  options on top of those available to normal per-pod
+                                  metrics using the "pods" source.
+                                properties:
+                                  name:
+                                    description: name is the name of the resource
+                                      in question.
+                                    type: string
+                                  target:
+                                    description: target specifies the target value
+                                      for the given metric
+                                    properties:
+                                      averageUtilization:
+                                        description: averageUtilization is the target
+                                          value of the average of the resource metric
+                                          across all relevant pods, represented as
+                                          a percentage of the requested value of the
+                                          resource for the pods. Currently only valid
+                                          for Resource metric source type
+                                        format: int32
+                                        type: integer
+                                      averageValue:
+                                        anyOf:
+                                        - type: integer
+                                        - type: string
+                                        description: averageValue is the target value
+                                          of the average of the metric across all
+                                          relevant pods (as a quantity)
+                                        pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                        x-kubernetes-int-or-string: true
+                                      type:
+                                        description: type represents whether the metric
+                                          type is Utilization, Value, or AverageValue
+                                        type: string
+                                      value:
+                                        anyOf:
+                                        - type: integer
+                                        - type: string
+                                        description: value is the target value of
+                                          the metric (as a quantity).
+                                        pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                        x-kubernetes-int-or-string: true
+                                    required:
+                                    - type
+                                    type: object
+                                required:
+                                - name
+                                - target
+                                type: object
+                              type:
+                                description: 'type is the type of metric source.  It
+                                  should be one of "ContainerResource", "External",
+                                  "Object", "Pods" or "Resource", each mapping to
+                                  a matching field in the object. Note: "ContainerResource"
+                                  type is available on when the feature-gate HPAContainerMetrics
+                                  is enabled'
+                                type: string
+                            required:
+                            - type
+                            type: object
+                          type: array
+                        minReplicas:
+                          format: int32
+                          type: integer
+                      required:
+                      - maxReplicas
+                      type: object
+                    name:
+                      type: string
+                    resources:
+                      description: ResourceRequirements describes the compute resource
+                        requirements.
+                      properties:
+                        limits:
+                          additionalProperties:
+                            anyOf:
+                            - type: integer
+                            - type: string
+                            pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                            x-kubernetes-int-or-string: true
+                          description: 'Limits describes the maximum amount of compute
+                            resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+                          type: object
+                        requests:
+                          additionalProperties:
+                            anyOf:
+                            - type: integer
+                            - type: string
+                            pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                            x-kubernetes-int-or-string: true
+                          description: 'Requests describes the minimum amount of compute
+                            resources required. If Requests is omitted for a container,
+                            it defaults to Limits if that is explicitly specified,
+                            otherwise to an implementation-defined value. More info:
+                            https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+                          type: object
+                      type: object
+                  type: object
+                type: array
+            required:
+            - bento_tag
+            type: object
+          status:
+            description: BentoDeploymentStatus defines the observed state of BentoDeployment
+            properties:
+              availableReplicas:
+                description: Total number of available pods (ready for at least minReadySeconds)
+                  targeted by this deployment.
+                format: int32
+                type: integer
+              podSelector:
+                additionalProperties:
+                  type: string
+                description: 'INSERT ADDITIONAL STATUS FIELD - define observed state
+                  of cluster Important: Run "make" to regenerate code after modifying
+                  this file'
+                type: object
+              printerReady:
+                type: string
+              readyReplicas:
+                description: readyReplicas is the number of pods targeted by this
+                  Deployment with a Ready Condition.
+                format: int32
+                type: integer
+              replicas:
+                description: Total number of non-terminated pods targeted by this
+                  deployment (their labels match the selector).
+                format: int32
+                type: integer
+              unavailableReplicas:
+                description: Total number of unavailable pods targeted by this deployment.
+                  This is the total number of pods that are still required for the
+                  deployment to have 100% available capacity. They may either be pods
+                  that are running but not yet available or pods that still have not
+                  been created.
+                format: int32
+                type: integer
+              updatedReplicas:
+                description: Total number of non-terminated pods targeted by this
+                  deployment that have the desired template spec.
+                format: int32
+                type: integer
+            type: object
+        type: object
+    served: true
+    storage: false
+    subresources:
+      status: {}
+  - additionalPrinterColumns:
+    - description: BentoTag
+      jsonPath: .spec.bento_tag
+      name: Bento
+      type: string
+    - description: Ready
+      jsonPath: .status.printerReady
+      name: Ready
+      type: string
+    - description: MinReplicas
+      jsonPath: .spec.autoscaling.min_replicas
+      name: MinReplicas
+      type: integer
+    - description: MaxReplicas
+      jsonPath: .spec.autoscaling.max_replicas
+      name: MaxReplicas
+      type: integer
+    - jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    name: v1alpha2
+    schema:
+      openAPIV3Schema:
+        description: BentoDeployment is the Schema for the bentodeployments API
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: BentoDeploymentSpec defines the desired state of BentoDeployment
+            properties:
+              autoscaling:
+                properties:
+                  cpu:
+                    format: int32
+                    type: integer
+                  gpu:
+                    format: int32
+                    type: integer
+                  max_replicas:
+                    format: int32
+                    type: integer
+                  memory:
+                    type: string
+                  min_replicas:
+                    format: int32
+                    type: integer
+                  qps:
+                    format: int64
+                    type: integer
+                type: object
+              bento_tag:
+                type: string
+              envs:
+                items:
+                  properties:
+                    key:
+                      type: string
+                    value:
+                      type: string
+                  required:
+                  - key
+                  - value
+                  type: object
+                type: array
+              ingress:
+                properties:
+                  enabled:
+                    type: boolean
+                type: object
+              resources:
+                properties:
+                  limits:
+                    properties:
+                      cpu:
+                        type: string
+                      custom:
+                        additionalProperties:
+                          type: string
+                        type: object
+                      gpu:
+                        type: string
+                      memory:
+                        type: string
+                    type: object
+                  requests:
+                    properties:
+                      cpu:
+                        type: string
+                      custom:
+                        additionalProperties:
+                          type: string
+                        type: object
+                      gpu:
+                        type: string
+                      memory:
+                        type: string
+                    type: object
+                type: object
+              runners:
+                items:
+                  properties:
+                    autoscaling:
+                      properties:
+                        cpu:
+                          format: int32
+                          type: integer
+                        gpu:
+                          format: int32
+                          type: integer
+                        max_replicas:
+                          format: int32
+                          type: integer
+                        memory:
+                          type: string
+                        min_replicas:
+                          format: int32
+                          type: integer
+                        qps:
+                          format: int64
+                          type: integer
+                      type: object
+                    envs:
+                      items:
+                        properties:
+                          key:
+                            type: string
+                          value:
+                            type: string
+                        required:
+                        - key
+                        - value
+                        type: object
+                      type: array
+                    name:
+                      type: string
+                    resources:
+                      properties:
+                        limits:
+                          properties:
+                            cpu:
+                              type: string
+                            custom:
+                              additionalProperties:
+                                type: string
+                              type: object
+                            gpu:
+                              type: string
+                            memory:
+                              type: string
+                          type: object
+                        requests:
+                          properties:
+                            cpu:
+                              type: string
+                            custom:
+                              additionalProperties:
+                                type: string
+                              type: object
+                            gpu:
+                              type: string
+                            memory:
+                              type: string
+                          type: object
+                      type: object
+                  type: object
+                type: array
+            required:
+            - bento_tag
+            type: object
+          status:
+            description: BentoDeploymentStatus defines the observed state of BentoDeployment
+            properties:
+              availableReplicas:
+                description: Total number of available pods (ready for at least minReadySeconds)
+                  targeted by this deployment.
+                format: int32
+                type: integer
+              podSelector:
+                additionalProperties:
+                  type: string
+                description: 'INSERT ADDITIONAL STATUS FIELD - define observed state
+                  of cluster Important: Run "make" to regenerate code after modifying
+                  this file'
+                type: object
+              printerReady:
+                type: string
+              readyReplicas:
+                description: readyReplicas is the number of pods targeted by this
+                  Deployment with a Ready Condition.
+                format: int32
+                type: integer
+              replicas:
+                description: Total number of non-terminated pods targeted by this
+                  deployment (their labels match the selector).
+                format: int32
+                type: integer
+              unavailableReplicas:
+                description: Total number of unavailable pods targeted by this deployment.
+                  This is the total number of pods that are still required for the
+                  deployment to have 100% available capacity. They may either be pods
+                  that are running but not yet available or pods that still have not
+                  been created.
+                format: int32
+                type: integer
+              updatedReplicas:
+                description: Total number of non-terminated pods targeted by this
+                  deployment that have the desired template spec.
+                format: int32
+                type: integer
+            type: object
+        type: object
+    served: true
+    storage: false
+    subresources:
+      status: {}
+  - additionalPrinterColumns:
+    - description: BentoTag
+      jsonPath: .spec.bento_tag
+      name: Bento
+      type: string
+    - description: Ready
+      jsonPath: .status.printerReady
+      name: Ready
+      type: string
+    - description: MinReplicas
+      jsonPath: .spec.autoscaling.min_replicas
+      name: MinReplicas
+      type: integer
+    - description: MaxReplicas
+      jsonPath: .spec.autoscaling.max_replicas
+      name: MaxReplicas
+      type: integer
+    - jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    name: v1alpha3
+    schema:
+      openAPIV3Schema:
+        description: BentoDeployment is the Schema for the bentodeployments API
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: BentoDeploymentSpec defines the desired state of BentoDeployment
+            properties:
+              annotations:
+                additionalProperties:
+                  type: string
+                type: object
+              autoscaling:
+                properties:
+                  cpu:
+                    format: int32
+                    type: integer
+                  gpu:
+                    format: int32
+                    type: integer
+                  max_replicas:
+                    format: int32
+                    type: integer
+                  memory:
+                    type: string
+                  min_replicas:
+                    format: int32
+                    type: integer
+                  qps:
+                    format: int64
+                    type: integer
+                type: object
+              bento_tag:
+                type: string
+              envs:
+                items:
+                  properties:
+                    key:
+                      type: string
+                    value:
+                      type: string
+                  required:
+                  - key
+                  - value
+                  type: object
+                type: array
+              extra_pod_metadata:
+                properties:
+                  annotations:
+                    additionalProperties:
+                      type: string
+                    type: object
+                  labels:
+                    additionalProperties:
+                      type: string
+                    type: object
+                type: object
+              extra_pod_spec:
+                properties:
+                  affinity:
+                    description: Affinity is a group of affinity scheduling rules.
+                    properties:
+                      nodeAffinity:
+                        description: Describes node affinity scheduling rules for
+                          the pod.
+                        properties:
+                          preferredDuringSchedulingIgnoredDuringExecution:
+                            description: The scheduler will prefer to schedule pods
+                              to nodes that satisfy the affinity expressions specified
+                              by this field, but it may choose a node that violates
+                              one or more of the expressions. The node that is most
+                              preferred is the one with the greatest sum of weights,
+                              i.e. for each node that meets all of the scheduling
+                              requirements (resource request, requiredDuringScheduling
+                              affinity expressions, etc.), compute a sum by iterating
+                              through the elements of this field and adding "weight"
+                              to the sum if the node matches the corresponding matchExpressions;
+                              the node(s) with the highest sum are the most preferred.
+                            items:
+                              description: An empty preferred scheduling term matches
+                                all objects with implicit weight 0 (i.e. it's a no-op).
+                                A null preferred scheduling term matches no objects
+                                (i.e. is also a no-op).
+                              properties:
+                                preference:
+                                  description: A node selector term, associated with
+                                    the corresponding weight.
+                                  properties:
+                                    matchExpressions:
+                                      description: A list of node selector requirements
+                                        by node's labels.
+                                      items:
+                                        description: A node selector requirement is
+                                          a selector that contains values, a key,
+                                          and an operator that relates the key and
+                                          values.
+                                        properties:
+                                          key:
+                                            description: The label key that the selector
+                                              applies to.
+                                            type: string
+                                          operator:
+                                            description: Represents a key's relationship
+                                              to a set of values. Valid operators
+                                              are In, NotIn, Exists, DoesNotExist.
+                                              Gt, and Lt.
+                                            type: string
+                                          values:
+                                            description: An array of string values.
+                                              If the operator is In or NotIn, the
+                                              values array must be non-empty. If the
+                                              operator is Exists or DoesNotExist,
+                                              the values array must be empty. If the
+                                              operator is Gt or Lt, the values array
+                                              must have a single element, which will
+                                              be interpreted as an integer. This array
+                                              is replaced during a strategic merge
+                                              patch.
+                                            items:
+                                              type: string
+                                            type: array
+                                        required:
+                                        - key
+                                        - operator
+                                        type: object
+                                      type: array
+                                    matchFields:
+                                      description: A list of node selector requirements
+                                        by node's fields.
+                                      items:
+                                        description: A node selector requirement is
+                                          a selector that contains values, a key,
+                                          and an operator that relates the key and
+                                          values.
+                                        properties:
+                                          key:
+                                            description: The label key that the selector
+                                              applies to.
+                                            type: string
+                                          operator:
+                                            description: Represents a key's relationship
+                                              to a set of values. Valid operators
+                                              are In, NotIn, Exists, DoesNotExist.
+                                              Gt, and Lt.
+                                            type: string
+                                          values:
+                                            description: An array of string values.
+                                              If the operator is In or NotIn, the
+                                              values array must be non-empty. If the
+                                              operator is Exists or DoesNotExist,
+                                              the values array must be empty. If the
+                                              operator is Gt or Lt, the values array
+                                              must have a single element, which will
+                                              be interpreted as an integer. This array
+                                              is replaced during a strategic merge
+                                              patch.
+                                            items:
+                                              type: string
+                                            type: array
+                                        required:
+                                        - key
+                                        - operator
+                                        type: object
+                                      type: array
+                                  type: object
+                                weight:
+                                  description: Weight associated with matching the
+                                    corresponding nodeSelectorTerm, in the range 1-100.
+                                  format: int32
+                                  type: integer
+                              required:
+                              - preference
+                              - weight
+                              type: object
+                            type: array
+                          requiredDuringSchedulingIgnoredDuringExecution:
+                            description: If the affinity requirements specified by
+                              this field are not met at scheduling time, the pod will
+                              not be scheduled onto the node. If the affinity requirements
+                              specified by this field cease to be met at some point
+                              during pod execution (e.g. due to an update), the system
+                              may or may not try to eventually evict the pod from
+                              its node.
+                            properties:
+                              nodeSelectorTerms:
+                                description: Required. A list of node selector terms.
+                                  The terms are ORed.
+                                items:
+                                  description: A null or empty node selector term
+                                    matches no objects. The requirements of them are
+                                    ANDed. The TopologySelectorTerm type implements
+                                    a subset of the NodeSelectorTerm.
+                                  properties:
+                                    matchExpressions:
+                                      description: A list of node selector requirements
+                                        by node's labels.
+                                      items:
+                                        description: A node selector requirement is
+                                          a selector that contains values, a key,
+                                          and an operator that relates the key and
+                                          values.
+                                        properties:
+                                          key:
+                                            description: The label key that the selector
+                                              applies to.
+                                            type: string
+                                          operator:
+                                            description: Represents a key's relationship
+                                              to a set of values. Valid operators
+                                              are In, NotIn, Exists, DoesNotExist.
+                                              Gt, and Lt.
+                                            type: string
+                                          values:
+                                            description: An array of string values.
+                                              If the operator is In or NotIn, the
+                                              values array must be non-empty. If the
+                                              operator is Exists or DoesNotExist,
+                                              the values array must be empty. If the
+                                              operator is Gt or Lt, the values array
+                                              must have a single element, which will
+                                              be interpreted as an integer. This array
+                                              is replaced during a strategic merge
+                                              patch.
+                                            items:
+                                              type: string
+                                            type: array
+                                        required:
+                                        - key
+                                        - operator
+                                        type: object
+                                      type: array
+                                    matchFields:
+                                      description: A list of node selector requirements
+                                        by node's fields.
+                                      items:
+                                        description: A node selector requirement is
+                                          a selector that contains values, a key,
+                                          and an operator that relates the key and
+                                          values.
+                                        properties:
+                                          key:
+                                            description: The label key that the selector
+                                              applies to.
+                                            type: string
+                                          operator:
+                                            description: Represents a key's relationship
+                                              to a set of values. Valid operators
+                                              are In, NotIn, Exists, DoesNotExist.
+                                              Gt, and Lt.
+                                            type: string
+                                          values:
+                                            description: An array of string values.
+                                              If the operator is In or NotIn, the
+                                              values array must be non-empty. If the
+                                              operator is Exists or DoesNotExist,
+                                              the values array must be empty. If the
+                                              operator is Gt or Lt, the values array
+                                              must have a single element, which will
+                                              be interpreted as an integer. This array
+                                              is replaced during a strategic merge
+                                              patch.
+                                            items:
+                                              type: string
+                                            type: array
+                                        required:
+                                        - key
+                                        - operator
+                                        type: object
+                                      type: array
+                                  type: object
+                                type: array
+                            required:
+                            - nodeSelectorTerms
+                            type: object
+                        type: object
+                      podAffinity:
+                        description: Describes pod affinity scheduling rules (e.g.
+                          co-locate this pod in the same node, zone, etc. as some
+                          other pod(s)).
+                        properties:
+                          preferredDuringSchedulingIgnoredDuringExecution:
+                            description: The scheduler will prefer to schedule pods
+                              to nodes that satisfy the affinity expressions specified
+                              by this field, but it may choose a node that violates
+                              one or more of the expressions. The node that is most
+                              preferred is the one with the greatest sum of weights,
+                              i.e. for each node that meets all of the scheduling
+                              requirements (resource request, requiredDuringScheduling
+                              affinity expressions, etc.), compute a sum by iterating
+                              through the elements of this field and adding "weight"
+                              to the sum if the node has pods which matches the corresponding
+                              podAffinityTerm; the node(s) with the highest sum are
+                              the most preferred.
+                            items:
+                              description: The weights of all of the matched WeightedPodAffinityTerm
+                                fields are added per-node to find the most preferred
+                                node(s)
+                              properties:
+                                podAffinityTerm:
+                                  description: Required. A pod affinity term, associated
+                                    with the corresponding weight.
+                                  properties:
+                                    labelSelector:
+                                      description: A label query over a set of resources,
+                                        in this case pods.
+                                      properties:
+                                        matchExpressions:
+                                          description: matchExpressions is a list
+                                            of label selector requirements. The requirements
+                                            are ANDed.
+                                          items:
+                                            description: A label selector requirement
+                                              is a selector that contains values,
+                                              a key, and an operator that relates
+                                              the key and values.
+                                            properties:
+                                              key:
+                                                description: key is the label key
+                                                  that the selector applies to.
+                                                type: string
+                                              operator:
+                                                description: operator represents a
+                                                  key's relationship to a set of values.
+                                                  Valid operators are In, NotIn, Exists
+                                                  and DoesNotExist.
+                                                type: string
+                                              values:
+                                                description: values is an array of
+                                                  string values. If the operator is
+                                                  In or NotIn, the values array must
+                                                  be non-empty. If the operator is
+                                                  Exists or DoesNotExist, the values
+                                                  array must be empty. This array
+                                                  is replaced during a strategic merge
+                                                  patch.
+                                                items:
+                                                  type: string
+                                                type: array
+                                            required:
+                                            - key
+                                            - operator
+                                            type: object
+                                          type: array
+                                        matchLabels:
+                                          additionalProperties:
+                                            type: string
+                                          description: matchLabels is a map of {key,value}
+                                            pairs. A single {key,value} in the matchLabels
+                                            map is equivalent to an element of matchExpressions,
+                                            whose key field is "key", the operator
+                                            is "In", and the values array contains
+                                            only "value". The requirements are ANDed.
+                                          type: object
+                                      type: object
+                                    namespaceSelector:
+                                      description: A label query over the set of namespaces
+                                        that the term applies to. The term is applied
+                                        to the union of the namespaces selected by
+                                        this field and the ones listed in the namespaces
+                                        field. null selector and null or empty namespaces
+                                        list means "this pod's namespace". An empty
+                                        selector ({}) matches all namespaces.
+                                      properties:
+                                        matchExpressions:
+                                          description: matchExpressions is a list
+                                            of label selector requirements. The requirements
+                                            are ANDed.
+                                          items:
+                                            description: A label selector requirement
+                                              is a selector that contains values,
+                                              a key, and an operator that relates
+                                              the key and values.
+                                            properties:
+                                              key:
+                                                description: key is the label key
+                                                  that the selector applies to.
+                                                type: string
+                                              operator:
+                                                description: operator represents a
+                                                  key's relationship to a set of values.
+                                                  Valid operators are In, NotIn, Exists
+                                                  and DoesNotExist.
+                                                type: string
+                                              values:
+                                                description: values is an array of
+                                                  string values. If the operator is
+                                                  In or NotIn, the values array must
+                                                  be non-empty. If the operator is
+                                                  Exists or DoesNotExist, the values
+                                                  array must be empty. This array
+                                                  is replaced during a strategic merge
+                                                  patch.
+                                                items:
+                                                  type: string
+                                                type: array
+                                            required:
+                                            - key
+                                            - operator
+                                            type: object
+                                          type: array
+                                        matchLabels:
+                                          additionalProperties:
+                                            type: string
+                                          description: matchLabels is a map of {key,value}
+                                            pairs. A single {key,value} in the matchLabels
+                                            map is equivalent to an element of matchExpressions,
+                                            whose key field is "key", the operator
+                                            is "In", and the values array contains
+                                            only "value". The requirements are ANDed.
+                                          type: object
+                                      type: object
+                                    namespaces:
+                                      description: namespaces specifies a static list
+                                        of namespace names that the term applies to.
+                                        The term is applied to the union of the namespaces
+                                        listed in this field and the ones selected
+                                        by namespaceSelector. null or empty namespaces
+                                        list and null namespaceSelector means "this
+                                        pod's namespace".
+                                      items:
+                                        type: string
+                                      type: array
+                                    topologyKey:
+                                      description: This pod should be co-located (affinity)
+                                        or not co-located (anti-affinity) with the
+                                        pods matching the labelSelector in the specified
+                                        namespaces, where co-located is defined as
+                                        running on a node whose value of the label
+                                        with key topologyKey matches that of any node
+                                        on which any of the selected pods is running.
+                                        Empty topologyKey is not allowed.
+                                      type: string
+                                  required:
+                                  - topologyKey
+                                  type: object
+                                weight:
+                                  description: weight associated with matching the
+                                    corresponding podAffinityTerm, in the range 1-100.
+                                  format: int32
+                                  type: integer
+                              required:
+                              - podAffinityTerm
+                              - weight
+                              type: object
+                            type: array
+                          requiredDuringSchedulingIgnoredDuringExecution:
+                            description: If the affinity requirements specified by
+                              this field are not met at scheduling time, the pod will
+                              not be scheduled onto the node. If the affinity requirements
+                              specified by this field cease to be met at some point
+                              during pod execution (e.g. due to a pod label update),
+                              the system may or may not try to eventually evict the
+                              pod from its node. When there are multiple elements,
+                              the lists of nodes corresponding to each podAffinityTerm
+                              are intersected, i.e. all terms must be satisfied.
+                            items:
+                              description: Defines a set of pods (namely those matching
+                                the labelSelector relative to the given namespace(s))
+                                that this pod should be co-located (affinity) or not
+                                co-located (anti-affinity) with, where co-located
+                                is defined as running on a node whose value of the
+                                label with key <topologyKey> matches that of any node
+                                on which a pod of the set of pods is running
+                              properties:
+                                labelSelector:
+                                  description: A label query over a set of resources,
+                                    in this case pods.
+                                  properties:
+                                    matchExpressions:
+                                      description: matchExpressions is a list of label
+                                        selector requirements. The requirements are
+                                        ANDed.
+                                      items:
+                                        description: A label selector requirement
+                                          is a selector that contains values, a key,
+                                          and an operator that relates the key and
+                                          values.
+                                        properties:
+                                          key:
+                                            description: key is the label key that
+                                              the selector applies to.
+                                            type: string
+                                          operator:
+                                            description: operator represents a key's
+                                              relationship to a set of values. Valid
+                                              operators are In, NotIn, Exists and
+                                              DoesNotExist.
+                                            type: string
+                                          values:
+                                            description: values is an array of string
+                                              values. If the operator is In or NotIn,
+                                              the values array must be non-empty.
+                                              If the operator is Exists or DoesNotExist,
+                                              the values array must be empty. This
+                                              array is replaced during a strategic
+                                              merge patch.
+                                            items:
+                                              type: string
+                                            type: array
+                                        required:
+                                        - key
+                                        - operator
+                                        type: object
+                                      type: array
+                                    matchLabels:
+                                      additionalProperties:
+                                        type: string
+                                      description: matchLabels is a map of {key,value}
+                                        pairs. A single {key,value} in the matchLabels
+                                        map is equivalent to an element of matchExpressions,
+                                        whose key field is "key", the operator is
+                                        "In", and the values array contains only "value".
+                                        The requirements are ANDed.
+                                      type: object
+                                  type: object
+                                namespaceSelector:
+                                  description: A label query over the set of namespaces
+                                    that the term applies to. The term is applied
+                                    to the union of the namespaces selected by this
+                                    field and the ones listed in the namespaces field.
+                                    null selector and null or empty namespaces list
+                                    means "this pod's namespace". An empty selector
+                                    ({}) matches all namespaces.
+                                  properties:
+                                    matchExpressions:
+                                      description: matchExpressions is a list of label
+                                        selector requirements. The requirements are
+                                        ANDed.
+                                      items:
+                                        description: A label selector requirement
+                                          is a selector that contains values, a key,
+                                          and an operator that relates the key and
+                                          values.
+                                        properties:
+                                          key:
+                                            description: key is the label key that
+                                              the selector applies to.
+                                            type: string
+                                          operator:
+                                            description: operator represents a key's
+                                              relationship to a set of values. Valid
+                                              operators are In, NotIn, Exists and
+                                              DoesNotExist.
+                                            type: string
+                                          values:
+                                            description: values is an array of string
+                                              values. If the operator is In or NotIn,
+                                              the values array must be non-empty.
+                                              If the operator is Exists or DoesNotExist,
+                                              the values array must be empty. This
+                                              array is replaced during a strategic
+                                              merge patch.
+                                            items:
+                                              type: string
+                                            type: array
+                                        required:
+                                        - key
+                                        - operator
+                                        type: object
+                                      type: array
+                                    matchLabels:
+                                      additionalProperties:
+                                        type: string
+                                      description: matchLabels is a map of {key,value}
+                                        pairs. A single {key,value} in the matchLabels
+                                        map is equivalent to an element of matchExpressions,
+                                        whose key field is "key", the operator is
+                                        "In", and the values array contains only "value".
+                                        The requirements are ANDed.
+                                      type: object
+                                  type: object
+                                namespaces:
+                                  description: namespaces specifies a static list
+                                    of namespace names that the term applies to. The
+                                    term is applied to the union of the namespaces
+                                    listed in this field and the ones selected by
+                                    namespaceSelector. null or empty namespaces list
+                                    and null namespaceSelector means "this pod's namespace".
+                                  items:
+                                    type: string
+                                  type: array
+                                topologyKey:
+                                  description: This pod should be co-located (affinity)
+                                    or not co-located (anti-affinity) with the pods
+                                    matching the labelSelector in the specified namespaces,
+                                    where co-located is defined as running on a node
+                                    whose value of the label with key topologyKey
+                                    matches that of any node on which any of the selected
+                                    pods is running. Empty topologyKey is not allowed.
+                                  type: string
+                              required:
+                              - topologyKey
+                              type: object
+                            type: array
+                        type: object
+                      podAntiAffinity:
+                        description: Describes pod anti-affinity scheduling rules
+                          (e.g. avoid putting this pod in the same node, zone, etc.
+                          as some other pod(s)).
+                        properties:
+                          preferredDuringSchedulingIgnoredDuringExecution:
+                            description: The scheduler will prefer to schedule pods
+                              to nodes that satisfy the anti-affinity expressions
+                              specified by this field, but it may choose a node that
+                              violates one or more of the expressions. The node that
+                              is most preferred is the one with the greatest sum of
+                              weights, i.e. for each node that meets all of the scheduling
+                              requirements (resource request, requiredDuringScheduling
+                              anti-affinity expressions, etc.), compute a sum by iterating
+                              through the elements of this field and adding "weight"
+                              to the sum if the node has pods which matches the corresponding
+                              podAffinityTerm; the node(s) with the highest sum are
+                              the most preferred.
+                            items:
+                              description: The weights of all of the matched WeightedPodAffinityTerm
+                                fields are added per-node to find the most preferred
+                                node(s)
+                              properties:
+                                podAffinityTerm:
+                                  description: Required. A pod affinity term, associated
+                                    with the corresponding weight.
+                                  properties:
+                                    labelSelector:
+                                      description: A label query over a set of resources,
+                                        in this case pods.
+                                      properties:
+                                        matchExpressions:
+                                          description: matchExpressions is a list
+                                            of label selector requirements. The requirements
+                                            are ANDed.
+                                          items:
+                                            description: A label selector requirement
+                                              is a selector that contains values,
+                                              a key, and an operator that relates
+                                              the key and values.
+                                            properties:
+                                              key:
+                                                description: key is the label key
+                                                  that the selector applies to.
+                                                type: string
+                                              operator:
+                                                description: operator represents a
+                                                  key's relationship to a set of values.
+                                                  Valid operators are In, NotIn, Exists
+                                                  and DoesNotExist.
+                                                type: string
+                                              values:
+                                                description: values is an array of
+                                                  string values. If the operator is
+                                                  In or NotIn, the values array must
+                                                  be non-empty. If the operator is
+                                                  Exists or DoesNotExist, the values
+                                                  array must be empty. This array
+                                                  is replaced during a strategic merge
+                                                  patch.
+                                                items:
+                                                  type: string
+                                                type: array
+                                            required:
+                                            - key
+                                            - operator
+                                            type: object
+                                          type: array
+                                        matchLabels:
+                                          additionalProperties:
+                                            type: string
+                                          description: matchLabels is a map of {key,value}
+                                            pairs. A single {key,value} in the matchLabels
+                                            map is equivalent to an element of matchExpressions,
+                                            whose key field is "key", the operator
+                                            is "In", and the values array contains
+                                            only "value". The requirements are ANDed.
+                                          type: object
+                                      type: object
+                                    namespaceSelector:
+                                      description: A label query over the set of namespaces
+                                        that the term applies to. The term is applied
+                                        to the union of the namespaces selected by
+                                        this field and the ones listed in the namespaces
+                                        field. null selector and null or empty namespaces
+                                        list means "this pod's namespace". An empty
+                                        selector ({}) matches all namespaces.
+                                      properties:
+                                        matchExpressions:
+                                          description: matchExpressions is a list
+                                            of label selector requirements. The requirements
+                                            are ANDed.
+                                          items:
+                                            description: A label selector requirement
+                                              is a selector that contains values,
+                                              a key, and an operator that relates
+                                              the key and values.
+                                            properties:
+                                              key:
+                                                description: key is the label key
+                                                  that the selector applies to.
+                                                type: string
+                                              operator:
+                                                description: operator represents a
+                                                  key's relationship to a set of values.
+                                                  Valid operators are In, NotIn, Exists
+                                                  and DoesNotExist.
+                                                type: string
+                                              values:
+                                                description: values is an array of
+                                                  string values. If the operator is
+                                                  In or NotIn, the values array must
+                                                  be non-empty. If the operator is
+                                                  Exists or DoesNotExist, the values
+                                                  array must be empty. This array
+                                                  is replaced during a strategic merge
+                                                  patch.
+                                                items:
+                                                  type: string
+                                                type: array
+                                            required:
+                                            - key
+                                            - operator
+                                            type: object
+                                          type: array
+                                        matchLabels:
+                                          additionalProperties:
+                                            type: string
+                                          description: matchLabels is a map of {key,value}
+                                            pairs. A single {key,value} in the matchLabels
+                                            map is equivalent to an element of matchExpressions,
+                                            whose key field is "key", the operator
+                                            is "In", and the values array contains
+                                            only "value". The requirements are ANDed.
+                                          type: object
+                                      type: object
+                                    namespaces:
+                                      description: namespaces specifies a static list
+                                        of namespace names that the term applies to.
+                                        The term is applied to the union of the namespaces
+                                        listed in this field and the ones selected
+                                        by namespaceSelector. null or empty namespaces
+                                        list and null namespaceSelector means "this
+                                        pod's namespace".
+                                      items:
+                                        type: string
+                                      type: array
+                                    topologyKey:
+                                      description: This pod should be co-located (affinity)
+                                        or not co-located (anti-affinity) with the
+                                        pods matching the labelSelector in the specified
+                                        namespaces, where co-located is defined as
+                                        running on a node whose value of the label
+                                        with key topologyKey matches that of any node
+                                        on which any of the selected pods is running.
+                                        Empty topologyKey is not allowed.
+                                      type: string
+                                  required:
+                                  - topologyKey
+                                  type: object
+                                weight:
+                                  description: weight associated with matching the
+                                    corresponding podAffinityTerm, in the range 1-100.
+                                  format: int32
+                                  type: integer
+                              required:
+                              - podAffinityTerm
+                              - weight
+                              type: object
+                            type: array
+                          requiredDuringSchedulingIgnoredDuringExecution:
+                            description: If the anti-affinity requirements specified
+                              by this field are not met at scheduling time, the pod
+                              will not be scheduled onto the node. If the anti-affinity
+                              requirements specified by this field cease to be met
+                              at some point during pod execution (e.g. due to a pod
+                              label update), the system may or may not try to eventually
+                              evict the pod from its node. When there are multiple
+                              elements, the lists of nodes corresponding to each podAffinityTerm
+                              are intersected, i.e. all terms must be satisfied.
+                            items:
+                              description: Defines a set of pods (namely those matching
+                                the labelSelector relative to the given namespace(s))
+                                that this pod should be co-located (affinity) or not
+                                co-located (anti-affinity) with, where co-located
+                                is defined as running on a node whose value of the
+                                label with key <topologyKey> matches that of any node
+                                on which a pod of the set of pods is running
+                              properties:
+                                labelSelector:
+                                  description: A label query over a set of resources,
+                                    in this case pods.
+                                  properties:
+                                    matchExpressions:
+                                      description: matchExpressions is a list of label
+                                        selector requirements. The requirements are
+                                        ANDed.
+                                      items:
+                                        description: A label selector requirement
+                                          is a selector that contains values, a key,
+                                          and an operator that relates the key and
+                                          values.
+                                        properties:
+                                          key:
+                                            description: key is the label key that
+                                              the selector applies to.
+                                            type: string
+                                          operator:
+                                            description: operator represents a key's
+                                              relationship to a set of values. Valid
+                                              operators are In, NotIn, Exists and
+                                              DoesNotExist.
+                                            type: string
+                                          values:
+                                            description: values is an array of string
+                                              values. If the operator is In or NotIn,
+                                              the values array must be non-empty.
+                                              If the operator is Exists or DoesNotExist,
+                                              the values array must be empty. This
+                                              array is replaced during a strategic
+                                              merge patch.
+                                            items:
+                                              type: string
+                                            type: array
+                                        required:
+                                        - key
+                                        - operator
+                                        type: object
+                                      type: array
+                                    matchLabels:
+                                      additionalProperties:
+                                        type: string
+                                      description: matchLabels is a map of {key,value}
+                                        pairs. A single {key,value} in the matchLabels
+                                        map is equivalent to an element of matchExpressions,
+                                        whose key field is "key", the operator is
+                                        "In", and the values array contains only "value".
+                                        The requirements are ANDed.
+                                      type: object
+                                  type: object
+                                namespaceSelector:
+                                  description: A label query over the set of namespaces
+                                    that the term applies to. The term is applied
+                                    to the union of the namespaces selected by this
+                                    field and the ones listed in the namespaces field.
+                                    null selector and null or empty namespaces list
+                                    means "this pod's namespace". An empty selector
+                                    ({}) matches all namespaces.
+                                  properties:
+                                    matchExpressions:
+                                      description: matchExpressions is a list of label
+                                        selector requirements. The requirements are
+                                        ANDed.
+                                      items:
+                                        description: A label selector requirement
+                                          is a selector that contains values, a key,
+                                          and an operator that relates the key and
+                                          values.
+                                        properties:
+                                          key:
+                                            description: key is the label key that
+                                              the selector applies to.
+                                            type: string
+                                          operator:
+                                            description: operator represents a key's
+                                              relationship to a set of values. Valid
+                                              operators are In, NotIn, Exists and
+                                              DoesNotExist.
+                                            type: string
+                                          values:
+                                            description: values is an array of string
+                                              values. If the operator is In or NotIn,
+                                              the values array must be non-empty.
+                                              If the operator is Exists or DoesNotExist,
+                                              the values array must be empty. This
+                                              array is replaced during a strategic
+                                              merge patch.
+                                            items:
+                                              type: string
+                                            type: array
+                                        required:
+                                        - key
+                                        - operator
+                                        type: object
+                                      type: array
+                                    matchLabels:
+                                      additionalProperties:
+                                        type: string
+                                      description: matchLabels is a map of {key,value}
+                                        pairs. A single {key,value} in the matchLabels
+                                        map is equivalent to an element of matchExpressions,
+                                        whose key field is "key", the operator is
+                                        "In", and the values array contains only "value".
+                                        The requirements are ANDed.
+                                      type: object
+                                  type: object
+                                namespaces:
+                                  description: namespaces specifies a static list
+                                    of namespace names that the term applies to. The
+                                    term is applied to the union of the namespaces
+                                    listed in this field and the ones selected by
+                                    namespaceSelector. null or empty namespaces list
+                                    and null namespaceSelector means "this pod's namespace".
+                                  items:
+                                    type: string
+                                  type: array
+                                topologyKey:
+                                  description: This pod should be co-located (affinity)
+                                    or not co-located (anti-affinity) with the pods
+                                    matching the labelSelector in the specified namespaces,
+                                    where co-located is defined as running on a node
+                                    whose value of the label with key topologyKey
+                                    matches that of any node on which any of the selected
+                                    pods is running. Empty topologyKey is not allowed.
+                                  type: string
+                              required:
+                              - topologyKey
+                              type: object
+                            type: array
+                        type: object
+                    type: object
+                  nodeSelector:
+                    additionalProperties:
+                      type: string
+                    type: object
+                  schedulerName:
+                    type: string
+                  tolerations:
+                    items:
+                      description: The pod this Toleration is attached to tolerates
+                        any taint that matches the triple <key,value,effect> using
+                        the matching operator <operator>.
+                      properties:
+                        effect:
+                          description: Effect indicates the taint effect to match.
+                            Empty means match all taint effects. When specified, allowed
+                            values are NoSchedule, PreferNoSchedule and NoExecute.
+                          type: string
+                        key:
+                          description: Key is the taint key that the toleration applies
+                            to. Empty means match all taint keys. If the key is empty,
+                            operator must be Exists; this combination means to match
+                            all values and all keys.
+                          type: string
+                        operator:
+                          description: Operator represents a key's relationship to
+                            the value. Valid operators are Exists and Equal. Defaults
+                            to Equal. Exists is equivalent to wildcard for value,
+                            so that a pod can tolerate all taints of a particular
+                            category.
+                          type: string
+                        tolerationSeconds:
+                          description: TolerationSeconds represents the period of
+                            time the toleration (which must be of effect NoExecute,
+                            otherwise this field is ignored) tolerates the taint.
+                            By default, it is not set, which means tolerate the taint
+                            forever (do not evict). Zero and negative values will
+                            be treated as 0 (evict immediately) by the system.
+                          format: int64
+                          type: integer
+                        value:
+                          description: Value is the taint value the toleration matches
+                            to. If the operator is Exists, the value should be empty,
+                            otherwise just a regular string.
+                          type: string
+                      type: object
+                    type: array
+                  topologySpreadConstraints:
+                    items:
+                      description: TopologySpreadConstraint specifies how to spread
+                        matching pods among the given topology.
+                      properties:
+                        labelSelector:
+                          description: LabelSelector is used to find matching pods.
+                            Pods that match this label selector are counted to determine
+                            the number of pods in their corresponding topology domain.
+                          properties:
+                            matchExpressions:
+                              description: matchExpressions is a list of label selector
+                                requirements. The requirements are ANDed.
+                              items:
+                                description: A label selector requirement is a selector
+                                  that contains values, a key, and an operator that
+                                  relates the key and values.
+                                properties:
+                                  key:
+                                    description: key is the label key that the selector
+                                      applies to.
+                                    type: string
+                                  operator:
+                                    description: operator represents a key's relationship
+                                      to a set of values. Valid operators are In,
+                                      NotIn, Exists and DoesNotExist.
+                                    type: string
+                                  values:
+                                    description: values is an array of string values.
+                                      If the operator is In or NotIn, the values array
+                                      must be non-empty. If the operator is Exists
+                                      or DoesNotExist, the values array must be empty.
+                                      This array is replaced during a strategic merge
+                                      patch.
+                                    items:
+                                      type: string
+                                    type: array
+                                required:
+                                - key
+                                - operator
+                                type: object
+                              type: array
+                            matchLabels:
+                              additionalProperties:
+                                type: string
+                              description: matchLabels is a map of {key,value} pairs.
+                                A single {key,value} in the matchLabels map is equivalent
+                                to an element of matchExpressions, whose key field
+                                is "key", the operator is "In", and the values array
+                                contains only "value". The requirements are ANDed.
+                              type: object
+                          type: object
+                        matchLabelKeys:
+                          description: MatchLabelKeys is a set of pod label keys to
+                            select the pods over which spreading will be calculated.
+                            The keys are used to lookup values from the incoming pod
+                            labels, those key-value labels are ANDed with labelSelector
+                            to select the group of existing pods over which spreading
+                            will be calculated for the incoming pod. Keys that don't
+                            exist in the incoming pod labels will be ignored. A null
+                            or empty list means only match against labelSelector.
+                          items:
+                            type: string
+                          type: array
+                          x-kubernetes-list-type: atomic
+                        maxSkew:
+                          description: 'MaxSkew describes the degree to which pods
+                            may be unevenly distributed. When `whenUnsatisfiable=DoNotSchedule`,
+                            it is the maximum permitted difference between the number
+                            of matching pods in the target topology and the global
+                            minimum. The global minimum is the minimum number of matching
+                            pods in an eligible domain or zero if the number of eligible
+                            domains is less than MinDomains. For example, in a 3-zone
+                            cluster, MaxSkew is set to 1, and pods with the same labelSelector
+                            spread as 2/2/1: In this case, the global minimum is 1.
+                            | zone1 | zone2 | zone3 | |  P P  |  P P  |   P   | -
+                            if MaxSkew is 1, incoming pod can only be scheduled to
+                            zone3 to become 2/2/2; scheduling it onto zone1(zone2)
+                            would make the ActualSkew(3-1) on zone1(zone2) violate
+                            MaxSkew(1). - if MaxSkew is 2, incoming pod can be scheduled
+                            onto any zone. When `whenUnsatisfiable=ScheduleAnyway`,
+                            it is used to give higher precedence to topologies that
+                            satisfy it. It''s a required field. Default value is 1
+                            and 0 is not allowed.'
+                          format: int32
+                          type: integer
+                        minDomains:
+                          description: "MinDomains indicates a minimum number of eligible
+                            domains. When the number of eligible domains with matching
+                            topology keys is less than minDomains, Pod Topology Spread
+                            treats \"global minimum\" as 0, and then the calculation
+                            of Skew is performed. And when the number of eligible
+                            domains with matching topology keys equals or greater
+                            than minDomains, this value has no effect on scheduling.
+                            As a result, when the number of eligible domains is less
+                            than minDomains, scheduler won't schedule more than maxSkew
+                            Pods to those domains. If value is nil, the constraint
+                            behaves as if MinDomains is equal to 1. Valid values are
+                            integers greater than 0. When value is not nil, WhenUnsatisfiable
+                            must be DoNotSchedule. \n For example, in a 3-zone cluster,
+                            MaxSkew is set to 2, MinDomains is set to 5 and pods with
+                            the same labelSelector spread as 2/2/2: | zone1 | zone2
+                            | zone3 | |  P P  |  P P  |  P P  | The number of domains
+                            is less than 5(MinDomains), so \"global minimum\" is treated
+                            as 0. In this situation, new pod with the same labelSelector
+                            cannot be scheduled, because computed skew will be 3(3
+                            - 0) if new Pod is scheduled to any of the three zones,
+                            it will violate MaxSkew. \n This is a beta field and requires
+                            the MinDomainsInPodTopologySpread feature gate to be enabled
+                            (enabled by default)."
+                          format: int32
+                          type: integer
+                        nodeAffinityPolicy:
+                          description: "NodeAffinityPolicy indicates how we will treat
+                            Pod's nodeAffinity/nodeSelector when calculating pod topology
+                            spread skew. Options are: - Honor: only nodes matching
+                            nodeAffinity/nodeSelector are included in the calculations.
+                            - Ignore: nodeAffinity/nodeSelector are ignored. All nodes
+                            are included in the calculations. \n If this value is
+                            nil, the behavior is equivalent to the Honor policy. This
+                            is a alpha-level feature enabled by the NodeInclusionPolicyInPodTopologySpread
+                            feature flag."
+                          type: string
+                        nodeTaintsPolicy:
+                          description: "NodeTaintsPolicy indicates how we will treat
+                            node taints when calculating pod topology spread skew.
+                            Options are: - Honor: nodes without taints, along with
+                            tainted nodes for which the incoming pod has a toleration,
+                            are included. - Ignore: node taints are ignored. All nodes
+                            are included. \n If this value is nil, the behavior is
+                            equivalent to the Ignore policy. This is a alpha-level
+                            feature enabled by the NodeInclusionPolicyInPodTopologySpread
+                            feature flag."
+                          type: string
+                        topologyKey:
+                          description: TopologyKey is the key of node labels. Nodes
+                            that have a label with this key and identical values are
+                            considered to be in the same topology. We consider each
+                            <key, value> as a "bucket", and try to put balanced number
+                            of pods into each bucket. We define a domain as a particular
+                            instance of a topology. Also, we define an eligible domain
+                            as a domain whose nodes meet the requirements of nodeAffinityPolicy
+                            and nodeTaintsPolicy. e.g. If TopologyKey is "kubernetes.io/hostname",
+                            each Node is a domain of that topology. And, if TopologyKey
+                            is "topology.kubernetes.io/zone", each zone is a domain
+                            of that topology. It's a required field.
+                          type: string
+                        whenUnsatisfiable:
+                          description: 'WhenUnsatisfiable indicates how to deal with
+                            a pod if it doesn''t satisfy the spread constraint. -
+                            DoNotSchedule (default) tells the scheduler not to schedule
+                            it. - ScheduleAnyway tells the scheduler to schedule the
+                            pod in any location,   but giving higher precedence to
+                            topologies that would help reduce the   skew. A constraint
+                            is considered "Unsatisfiable" for an incoming pod if and
+                            only if every possible node assignment for that pod would
+                            violate "MaxSkew" on some topology. For example, in a
+                            3-zone cluster, MaxSkew is set to 1, and pods with the
+                            same labelSelector spread as 3/1/1: | zone1 | zone2 |
+                            zone3 | | P P P |   P   |   P   | If WhenUnsatisfiable
+                            is set to DoNotSchedule, incoming pod can only be scheduled
+                            to zone2(zone3) to become 3/2/1(3/1/2) as ActualSkew(2-1)
+                            on zone2(zone3) satisfies MaxSkew(1). In other words,
+                            the cluster can still be imbalanced, but scheduler won''t
+                            make it *more* imbalanced. It''s a required field.'
+                          type: string
+                      required:
+                      - maxSkew
+                      - topologyKey
+                      - whenUnsatisfiable
+                      type: object
+                    type: array
+                type: object
+              ingress:
+                properties:
+                  annotations:
+                    additionalProperties:
+                      type: string
+                    type: object
+                  enabled:
+                    type: boolean
+                  labels:
+                    additionalProperties:
+                      type: string
+                    type: object
+                  tls:
+                    properties:
+                      secretName:
+                        type: string
+                    type: object
+                type: object
+              labels:
+                additionalProperties:
+                  type: string
+                type: object
+              resources:
+                properties:
+                  limits:
+                    properties:
+                      cpu:
+                        type: string
+                      custom:
+                        additionalProperties:
+                          type: string
+                        type: object
+                      gpu:
+                        type: string
+                      memory:
+                        type: string
+                    type: object
+                  requests:
+                    properties:
+                      cpu:
+                        type: string
+                      custom:
+                        additionalProperties:
+                          type: string
+                        type: object
+                      gpu:
+                        type: string
+                      memory:
+                        type: string
+                    type: object
+                type: object
+              runners:
+                items:
+                  properties:
+                    annotations:
+                      additionalProperties:
+                        type: string
+                      type: object
+                    autoscaling:
+                      properties:
+                        cpu:
+                          format: int32
+                          type: integer
+                        gpu:
+                          format: int32
+                          type: integer
+                        max_replicas:
+                          format: int32
+                          type: integer
+                        memory:
+                          type: string
+                        min_replicas:
+                          format: int32
+                          type: integer
+                        qps:
+                          format: int64
+                          type: integer
+                      type: object
+                    envs:
+                      items:
+                        properties:
+                          key:
+                            type: string
+                          value:
+                            type: string
+                        required:
+                        - key
+                        - value
+                        type: object
+                      type: array
+                    extra_pod_metadata:
+                      properties:
+                        annotations:
+                          additionalProperties:
+                            type: string
+                          type: object
+                        labels:
+                          additionalProperties:
+                            type: string
+                          type: object
+                      type: object
+                    extra_pod_spec:
+                      properties:
+                        affinity:
+                          description: Affinity is a group of affinity scheduling
+                            rules.
+                          properties:
+                            nodeAffinity:
+                              description: Describes node affinity scheduling rules
+                                for the pod.
+                              properties:
+                                preferredDuringSchedulingIgnoredDuringExecution:
+                                  description: The scheduler will prefer to schedule
+                                    pods to nodes that satisfy the affinity expressions
+                                    specified by this field, but it may choose a node
+                                    that violates one or more of the expressions.
+                                    The node that is most preferred is the one with
+                                    the greatest sum of weights, i.e. for each node
+                                    that meets all of the scheduling requirements
+                                    (resource request, requiredDuringScheduling affinity
+                                    expressions, etc.), compute a sum by iterating
+                                    through the elements of this field and adding
+                                    "weight" to the sum if the node matches the corresponding
+                                    matchExpressions; the node(s) with the highest
+                                    sum are the most preferred.
+                                  items:
+                                    description: An empty preferred scheduling term
+                                      matches all objects with implicit weight 0 (i.e.
+                                      it's a no-op). A null preferred scheduling term
+                                      matches no objects (i.e. is also a no-op).
+                                    properties:
+                                      preference:
+                                        description: A node selector term, associated
+                                          with the corresponding weight.
+                                        properties:
+                                          matchExpressions:
+                                            description: A list of node selector requirements
+                                              by node's labels.
+                                            items:
+                                              description: A node selector requirement
+                                                is a selector that contains values,
+                                                a key, and an operator that relates
+                                                the key and values.
+                                              properties:
+                                                key:
+                                                  description: The label key that
+                                                    the selector applies to.
+                                                  type: string
+                                                operator:
+                                                  description: Represents a key's
+                                                    relationship to a set of values.
+                                                    Valid operators are In, NotIn,
+                                                    Exists, DoesNotExist. Gt, and
+                                                    Lt.
+                                                  type: string
+                                                values:
+                                                  description: An array of string
+                                                    values. If the operator is In
+                                                    or NotIn, the values array must
+                                                    be non-empty. If the operator
+                                                    is Exists or DoesNotExist, the
+                                                    values array must be empty. If
+                                                    the operator is Gt or Lt, the
+                                                    values array must have a single
+                                                    element, which will be interpreted
+                                                    as an integer. This array is replaced
+                                                    during a strategic merge patch.
+                                                  items:
+                                                    type: string
+                                                  type: array
+                                              required:
+                                              - key
+                                              - operator
+                                              type: object
+                                            type: array
+                                          matchFields:
+                                            description: A list of node selector requirements
+                                              by node's fields.
+                                            items:
+                                              description: A node selector requirement
+                                                is a selector that contains values,
+                                                a key, and an operator that relates
+                                                the key and values.
+                                              properties:
+                                                key:
+                                                  description: The label key that
+                                                    the selector applies to.
+                                                  type: string
+                                                operator:
+                                                  description: Represents a key's
+                                                    relationship to a set of values.
+                                                    Valid operators are In, NotIn,
+                                                    Exists, DoesNotExist. Gt, and
+                                                    Lt.
+                                                  type: string
+                                                values:
+                                                  description: An array of string
+                                                    values. If the operator is In
+                                                    or NotIn, the values array must
+                                                    be non-empty. If the operator
+                                                    is Exists or DoesNotExist, the
+                                                    values array must be empty. If
+                                                    the operator is Gt or Lt, the
+                                                    values array must have a single
+                                                    element, which will be interpreted
+                                                    as an integer. This array is replaced
+                                                    during a strategic merge patch.
+                                                  items:
+                                                    type: string
+                                                  type: array
+                                              required:
+                                              - key
+                                              - operator
+                                              type: object
+                                            type: array
+                                        type: object
+                                      weight:
+                                        description: Weight associated with matching
+                                          the corresponding nodeSelectorTerm, in the
+                                          range 1-100.
+                                        format: int32
+                                        type: integer
+                                    required:
+                                    - preference
+                                    - weight
+                                    type: object
+                                  type: array
+                                requiredDuringSchedulingIgnoredDuringExecution:
+                                  description: If the affinity requirements specified
+                                    by this field are not met at scheduling time,
+                                    the pod will not be scheduled onto the node. If
+                                    the affinity requirements specified by this field
+                                    cease to be met at some point during pod execution
+                                    (e.g. due to an update), the system may or may
+                                    not try to eventually evict the pod from its node.
+                                  properties:
+                                    nodeSelectorTerms:
+                                      description: Required. A list of node selector
+                                        terms. The terms are ORed.
+                                      items:
+                                        description: A null or empty node selector
+                                          term matches no objects. The requirements
+                                          of them are ANDed. The TopologySelectorTerm
+                                          type implements a subset of the NodeSelectorTerm.
+                                        properties:
+                                          matchExpressions:
+                                            description: A list of node selector requirements
+                                              by node's labels.
+                                            items:
+                                              description: A node selector requirement
+                                                is a selector that contains values,
+                                                a key, and an operator that relates
+                                                the key and values.
+                                              properties:
+                                                key:
+                                                  description: The label key that
+                                                    the selector applies to.
+                                                  type: string
+                                                operator:
+                                                  description: Represents a key's
+                                                    relationship to a set of values.
+                                                    Valid operators are In, NotIn,
+                                                    Exists, DoesNotExist. Gt, and
+                                                    Lt.
+                                                  type: string
+                                                values:
+                                                  description: An array of string
+                                                    values. If the operator is In
+                                                    or NotIn, the values array must
+                                                    be non-empty. If the operator
+                                                    is Exists or DoesNotExist, the
+                                                    values array must be empty. If
+                                                    the operator is Gt or Lt, the
+                                                    values array must have a single
+                                                    element, which will be interpreted
+                                                    as an integer. This array is replaced
+                                                    during a strategic merge patch.
+                                                  items:
+                                                    type: string
+                                                  type: array
+                                              required:
+                                              - key
+                                              - operator
+                                              type: object
+                                            type: array
+                                          matchFields:
+                                            description: A list of node selector requirements
+                                              by node's fields.
+                                            items:
+                                              description: A node selector requirement
+                                                is a selector that contains values,
+                                                a key, and an operator that relates
+                                                the key and values.
+                                              properties:
+                                                key:
+                                                  description: The label key that
+                                                    the selector applies to.
+                                                  type: string
+                                                operator:
+                                                  description: Represents a key's
+                                                    relationship to a set of values.
+                                                    Valid operators are In, NotIn,
+                                                    Exists, DoesNotExist. Gt, and
+                                                    Lt.
+                                                  type: string
+                                                values:
+                                                  description: An array of string
+                                                    values. If the operator is In
+                                                    or NotIn, the values array must
+                                                    be non-empty. If the operator
+                                                    is Exists or DoesNotExist, the
+                                                    values array must be empty. If
+                                                    the operator is Gt or Lt, the
+                                                    values array must have a single
+                                                    element, which will be interpreted
+                                                    as an integer. This array is replaced
+                                                    during a strategic merge patch.
+                                                  items:
+                                                    type: string
+                                                  type: array
+                                              required:
+                                              - key
+                                              - operator
+                                              type: object
+                                            type: array
+                                        type: object
+                                      type: array
+                                  required:
+                                  - nodeSelectorTerms
+                                  type: object
+                              type: object
+                            podAffinity:
+                              description: Describes pod affinity scheduling rules
+                                (e.g. co-locate this pod in the same node, zone, etc.
+                                as some other pod(s)).
+                              properties:
+                                preferredDuringSchedulingIgnoredDuringExecution:
+                                  description: The scheduler will prefer to schedule
+                                    pods to nodes that satisfy the affinity expressions
+                                    specified by this field, but it may choose a node
+                                    that violates one or more of the expressions.
+                                    The node that is most preferred is the one with
+                                    the greatest sum of weights, i.e. for each node
+                                    that meets all of the scheduling requirements
+                                    (resource request, requiredDuringScheduling affinity
+                                    expressions, etc.), compute a sum by iterating
+                                    through the elements of this field and adding
+                                    "weight" to the sum if the node has pods which
+                                    matches the corresponding podAffinityTerm; the
+                                    node(s) with the highest sum are the most preferred.
+                                  items:
+                                    description: The weights of all of the matched
+                                      WeightedPodAffinityTerm fields are added per-node
+                                      to find the most preferred node(s)
+                                    properties:
+                                      podAffinityTerm:
+                                        description: Required. A pod affinity term,
+                                          associated with the corresponding weight.
+                                        properties:
+                                          labelSelector:
+                                            description: A label query over a set
+                                              of resources, in this case pods.
+                                            properties:
+                                              matchExpressions:
+                                                description: matchExpressions is a
+                                                  list of label selector requirements.
+                                                  The requirements are ANDed.
+                                                items:
+                                                  description: A label selector requirement
+                                                    is a selector that contains values,
+                                                    a key, and an operator that relates
+                                                    the key and values.
+                                                  properties:
+                                                    key:
+                                                      description: key is the label
+                                                        key that the selector applies
+                                                        to.
+                                                      type: string
+                                                    operator:
+                                                      description: operator represents
+                                                        a key's relationship to a
+                                                        set of values. Valid operators
+                                                        are In, NotIn, Exists and
+                                                        DoesNotExist.
+                                                      type: string
+                                                    values:
+                                                      description: values is an array
+                                                        of string values. If the operator
+                                                        is In or NotIn, the values
+                                                        array must be non-empty. If
+                                                        the operator is Exists or
+                                                        DoesNotExist, the values array
+                                                        must be empty. This array
+                                                        is replaced during a strategic
+                                                        merge patch.
+                                                      items:
+                                                        type: string
+                                                      type: array
+                                                  required:
+                                                  - key
+                                                  - operator
+                                                  type: object
+                                                type: array
+                                              matchLabels:
+                                                additionalProperties:
+                                                  type: string
+                                                description: matchLabels is a map
+                                                  of {key,value} pairs. A single {key,value}
+                                                  in the matchLabels map is equivalent
+                                                  to an element of matchExpressions,
+                                                  whose key field is "key", the operator
+                                                  is "In", and the values array contains
+                                                  only "value". The requirements are
+                                                  ANDed.
+                                                type: object
+                                            type: object
+                                          namespaceSelector:
+                                            description: A label query over the set
+                                              of namespaces that the term applies
+                                              to. The term is applied to the union
+                                              of the namespaces selected by this field
+                                              and the ones listed in the namespaces
+                                              field. null selector and null or empty
+                                              namespaces list means "this pod's namespace".
+                                              An empty selector ({}) matches all namespaces.
+                                            properties:
+                                              matchExpressions:
+                                                description: matchExpressions is a
+                                                  list of label selector requirements.
+                                                  The requirements are ANDed.
+                                                items:
+                                                  description: A label selector requirement
+                                                    is a selector that contains values,
+                                                    a key, and an operator that relates
+                                                    the key and values.
+                                                  properties:
+                                                    key:
+                                                      description: key is the label
+                                                        key that the selector applies
+                                                        to.
+                                                      type: string
+                                                    operator:
+                                                      description: operator represents
+                                                        a key's relationship to a
+                                                        set of values. Valid operators
+                                                        are In, NotIn, Exists and
+                                                        DoesNotExist.
+                                                      type: string
+                                                    values:
+                                                      description: values is an array
+                                                        of string values. If the operator
+                                                        is In or NotIn, the values
+                                                        array must be non-empty. If
+                                                        the operator is Exists or
+                                                        DoesNotExist, the values array
+                                                        must be empty. This array
+                                                        is replaced during a strategic
+                                                        merge patch.
+                                                      items:
+                                                        type: string
+                                                      type: array
+                                                  required:
+                                                  - key
+                                                  - operator
+                                                  type: object
+                                                type: array
+                                              matchLabels:
+                                                additionalProperties:
+                                                  type: string
+                                                description: matchLabels is a map
+                                                  of {key,value} pairs. A single {key,value}
+                                                  in the matchLabels map is equivalent
+                                                  to an element of matchExpressions,
+                                                  whose key field is "key", the operator
+                                                  is "In", and the values array contains
+                                                  only "value". The requirements are
+                                                  ANDed.
+                                                type: object
+                                            type: object
+                                          namespaces:
+                                            description: namespaces specifies a static
+                                              list of namespace names that the term
+                                              applies to. The term is applied to the
+                                              union of the namespaces listed in this
+                                              field and the ones selected by namespaceSelector.
+                                              null or empty namespaces list and null
+                                              namespaceSelector means "this pod's
+                                              namespace".
+                                            items:
+                                              type: string
+                                            type: array
+                                          topologyKey:
+                                            description: This pod should be co-located
+                                              (affinity) or not co-located (anti-affinity)
+                                              with the pods matching the labelSelector
+                                              in the specified namespaces, where co-located
+                                              is defined as running on a node whose
+                                              value of the label with key topologyKey
+                                              matches that of any node on which any
+                                              of the selected pods is running. Empty
+                                              topologyKey is not allowed.
+                                            type: string
+                                        required:
+                                        - topologyKey
+                                        type: object
+                                      weight:
+                                        description: weight associated with matching
+                                          the corresponding podAffinityTerm, in the
+                                          range 1-100.
+                                        format: int32
+                                        type: integer
+                                    required:
+                                    - podAffinityTerm
+                                    - weight
+                                    type: object
+                                  type: array
+                                requiredDuringSchedulingIgnoredDuringExecution:
+                                  description: If the affinity requirements specified
+                                    by this field are not met at scheduling time,
+                                    the pod will not be scheduled onto the node. If
+                                    the affinity requirements specified by this field
+                                    cease to be met at some point during pod execution
+                                    (e.g. due to a pod label update), the system may
+                                    or may not try to eventually evict the pod from
+                                    its node. When there are multiple elements, the
+                                    lists of nodes corresponding to each podAffinityTerm
+                                    are intersected, i.e. all terms must be satisfied.
+                                  items:
+                                    description: Defines a set of pods (namely those
+                                      matching the labelSelector relative to the given
+                                      namespace(s)) that this pod should be co-located
+                                      (affinity) or not co-located (anti-affinity)
+                                      with, where co-located is defined as running
+                                      on a node whose value of the label with key
+                                      <topologyKey> matches that of any node on which
+                                      a pod of the set of pods is running
+                                    properties:
+                                      labelSelector:
+                                        description: A label query over a set of resources,
+                                          in this case pods.
+                                        properties:
+                                          matchExpressions:
+                                            description: matchExpressions is a list
+                                              of label selector requirements. The
+                                              requirements are ANDed.
+                                            items:
+                                              description: A label selector requirement
+                                                is a selector that contains values,
+                                                a key, and an operator that relates
+                                                the key and values.
+                                              properties:
+                                                key:
+                                                  description: key is the label key
+                                                    that the selector applies to.
+                                                  type: string
+                                                operator:
+                                                  description: operator represents
+                                                    a key's relationship to a set
+                                                    of values. Valid operators are
+                                                    In, NotIn, Exists and DoesNotExist.
+                                                  type: string
+                                                values:
+                                                  description: values is an array
+                                                    of string values. If the operator
+                                                    is In or NotIn, the values array
+                                                    must be non-empty. If the operator
+                                                    is Exists or DoesNotExist, the
+                                                    values array must be empty. This
+                                                    array is replaced during a strategic
+                                                    merge patch.
+                                                  items:
+                                                    type: string
+                                                  type: array
+                                              required:
+                                              - key
+                                              - operator
+                                              type: object
+                                            type: array
+                                          matchLabels:
+                                            additionalProperties:
+                                              type: string
+                                            description: matchLabels is a map of {key,value}
+                                              pairs. A single {key,value} in the matchLabels
+                                              map is equivalent to an element of matchExpressions,
+                                              whose key field is "key", the operator
+                                              is "In", and the values array contains
+                                              only "value". The requirements are ANDed.
+                                            type: object
+                                        type: object
+                                      namespaceSelector:
+                                        description: A label query over the set of
+                                          namespaces that the term applies to. The
+                                          term is applied to the union of the namespaces
+                                          selected by this field and the ones listed
+                                          in the namespaces field. null selector and
+                                          null or empty namespaces list means "this
+                                          pod's namespace". An empty selector ({})
+                                          matches all namespaces.
+                                        properties:
+                                          matchExpressions:
+                                            description: matchExpressions is a list
+                                              of label selector requirements. The
+                                              requirements are ANDed.
+                                            items:
+                                              description: A label selector requirement
+                                                is a selector that contains values,
+                                                a key, and an operator that relates
+                                                the key and values.
+                                              properties:
+                                                key:
+                                                  description: key is the label key
+                                                    that the selector applies to.
+                                                  type: string
+                                                operator:
+                                                  description: operator represents
+                                                    a key's relationship to a set
+                                                    of values. Valid operators are
+                                                    In, NotIn, Exists and DoesNotExist.
+                                                  type: string
+                                                values:
+                                                  description: values is an array
+                                                    of string values. If the operator
+                                                    is In or NotIn, the values array
+                                                    must be non-empty. If the operator
+                                                    is Exists or DoesNotExist, the
+                                                    values array must be empty. This
+                                                    array is replaced during a strategic
+                                                    merge patch.
+                                                  items:
+                                                    type: string
+                                                  type: array
+                                              required:
+                                              - key
+                                              - operator
+                                              type: object
+                                            type: array
+                                          matchLabels:
+                                            additionalProperties:
+                                              type: string
+                                            description: matchLabels is a map of {key,value}
+                                              pairs. A single {key,value} in the matchLabels
+                                              map is equivalent to an element of matchExpressions,
+                                              whose key field is "key", the operator
+                                              is "In", and the values array contains
+                                              only "value". The requirements are ANDed.
+                                            type: object
+                                        type: object
+                                      namespaces:
+                                        description: namespaces specifies a static
+                                          list of namespace names that the term applies
+                                          to. The term is applied to the union of
+                                          the namespaces listed in this field and
+                                          the ones selected by namespaceSelector.
+                                          null or empty namespaces list and null namespaceSelector
+                                          means "this pod's namespace".
+                                        items:
+                                          type: string
+                                        type: array
+                                      topologyKey:
+                                        description: This pod should be co-located
+                                          (affinity) or not co-located (anti-affinity)
+                                          with the pods matching the labelSelector
+                                          in the specified namespaces, where co-located
+                                          is defined as running on a node whose value
+                                          of the label with key topologyKey matches
+                                          that of any node on which any of the selected
+                                          pods is running. Empty topologyKey is not
+                                          allowed.
+                                        type: string
+                                    required:
+                                    - topologyKey
+                                    type: object
+                                  type: array
+                              type: object
+                            podAntiAffinity:
+                              description: Describes pod anti-affinity scheduling
+                                rules (e.g. avoid putting this pod in the same node,
+                                zone, etc. as some other pod(s)).
+                              properties:
+                                preferredDuringSchedulingIgnoredDuringExecution:
+                                  description: The scheduler will prefer to schedule
+                                    pods to nodes that satisfy the anti-affinity expressions
+                                    specified by this field, but it may choose a node
+                                    that violates one or more of the expressions.
+                                    The node that is most preferred is the one with
+                                    the greatest sum of weights, i.e. for each node
+                                    that meets all of the scheduling requirements
+                                    (resource request, requiredDuringScheduling anti-affinity
+                                    expressions, etc.), compute a sum by iterating
+                                    through the elements of this field and adding
+                                    "weight" to the sum if the node has pods which
+                                    matches the corresponding podAffinityTerm; the
+                                    node(s) with the highest sum are the most preferred.
+                                  items:
+                                    description: The weights of all of the matched
+                                      WeightedPodAffinityTerm fields are added per-node
+                                      to find the most preferred node(s)
+                                    properties:
+                                      podAffinityTerm:
+                                        description: Required. A pod affinity term,
+                                          associated with the corresponding weight.
+                                        properties:
+                                          labelSelector:
+                                            description: A label query over a set
+                                              of resources, in this case pods.
+                                            properties:
+                                              matchExpressions:
+                                                description: matchExpressions is a
+                                                  list of label selector requirements.
+                                                  The requirements are ANDed.
+                                                items:
+                                                  description: A label selector requirement
+                                                    is a selector that contains values,
+                                                    a key, and an operator that relates
+                                                    the key and values.
+                                                  properties:
+                                                    key:
+                                                      description: key is the label
+                                                        key that the selector applies
+                                                        to.
+                                                      type: string
+                                                    operator:
+                                                      description: operator represents
+                                                        a key's relationship to a
+                                                        set of values. Valid operators
+                                                        are In, NotIn, Exists and
+                                                        DoesNotExist.
+                                                      type: string
+                                                    values:
+                                                      description: values is an array
+                                                        of string values. If the operator
+                                                        is In or NotIn, the values
+                                                        array must be non-empty. If
+                                                        the operator is Exists or
+                                                        DoesNotExist, the values array
+                                                        must be empty. This array
+                                                        is replaced during a strategic
+                                                        merge patch.
+                                                      items:
+                                                        type: string
+                                                      type: array
+                                                  required:
+                                                  - key
+                                                  - operator
+                                                  type: object
+                                                type: array
+                                              matchLabels:
+                                                additionalProperties:
+                                                  type: string
+                                                description: matchLabels is a map
+                                                  of {key,value} pairs. A single {key,value}
+                                                  in the matchLabels map is equivalent
+                                                  to an element of matchExpressions,
+                                                  whose key field is "key", the operator
+                                                  is "In", and the values array contains
+                                                  only "value". The requirements are
+                                                  ANDed.
+                                                type: object
+                                            type: object
+                                          namespaceSelector:
+                                            description: A label query over the set
+                                              of namespaces that the term applies
+                                              to. The term is applied to the union
+                                              of the namespaces selected by this field
+                                              and the ones listed in the namespaces
+                                              field. null selector and null or empty
+                                              namespaces list means "this pod's namespace".
+                                              An empty selector ({}) matches all namespaces.
+                                            properties:
+                                              matchExpressions:
+                                                description: matchExpressions is a
+                                                  list of label selector requirements.
+                                                  The requirements are ANDed.
+                                                items:
+                                                  description: A label selector requirement
+                                                    is a selector that contains values,
+                                                    a key, and an operator that relates
+                                                    the key and values.
+                                                  properties:
+                                                    key:
+                                                      description: key is the label
+                                                        key that the selector applies
+                                                        to.
+                                                      type: string
+                                                    operator:
+                                                      description: operator represents
+                                                        a key's relationship to a
+                                                        set of values. Valid operators
+                                                        are In, NotIn, Exists and
+                                                        DoesNotExist.
+                                                      type: string
+                                                    values:
+                                                      description: values is an array
+                                                        of string values. If the operator
+                                                        is In or NotIn, the values
+                                                        array must be non-empty. If
+                                                        the operator is Exists or
+                                                        DoesNotExist, the values array
+                                                        must be empty. This array
+                                                        is replaced during a strategic
+                                                        merge patch.
+                                                      items:
+                                                        type: string
+                                                      type: array
+                                                  required:
+                                                  - key
+                                                  - operator
+                                                  type: object
+                                                type: array
+                                              matchLabels:
+                                                additionalProperties:
+                                                  type: string
+                                                description: matchLabels is a map
+                                                  of {key,value} pairs. A single {key,value}
+                                                  in the matchLabels map is equivalent
+                                                  to an element of matchExpressions,
+                                                  whose key field is "key", the operator
+                                                  is "In", and the values array contains
+                                                  only "value". The requirements are
+                                                  ANDed.
+                                                type: object
+                                            type: object
+                                          namespaces:
+                                            description: namespaces specifies a static
+                                              list of namespace names that the term
+                                              applies to. The term is applied to the
+                                              union of the namespaces listed in this
+                                              field and the ones selected by namespaceSelector.
+                                              null or empty namespaces list and null
+                                              namespaceSelector means "this pod's
+                                              namespace".
+                                            items:
+                                              type: string
+                                            type: array
+                                          topologyKey:
+                                            description: This pod should be co-located
+                                              (affinity) or not co-located (anti-affinity)
+                                              with the pods matching the labelSelector
+                                              in the specified namespaces, where co-located
+                                              is defined as running on a node whose
+                                              value of the label with key topologyKey
+                                              matches that of any node on which any
+                                              of the selected pods is running. Empty
+                                              topologyKey is not allowed.
+                                            type: string
+                                        required:
+                                        - topologyKey
+                                        type: object
+                                      weight:
+                                        description: weight associated with matching
+                                          the corresponding podAffinityTerm, in the
+                                          range 1-100.
+                                        format: int32
+                                        type: integer
+                                    required:
+                                    - podAffinityTerm
+                                    - weight
+                                    type: object
+                                  type: array
+                                requiredDuringSchedulingIgnoredDuringExecution:
+                                  description: If the anti-affinity requirements specified
+                                    by this field are not met at scheduling time,
+                                    the pod will not be scheduled onto the node. If
+                                    the anti-affinity requirements specified by this
+                                    field cease to be met at some point during pod
+                                    execution (e.g. due to a pod label update), the
+                                    system may or may not try to eventually evict
+                                    the pod from its node. When there are multiple
+                                    elements, the lists of nodes corresponding to
+                                    each podAffinityTerm are intersected, i.e. all
+                                    terms must be satisfied.
+                                  items:
+                                    description: Defines a set of pods (namely those
+                                      matching the labelSelector relative to the given
+                                      namespace(s)) that this pod should be co-located
+                                      (affinity) or not co-located (anti-affinity)
+                                      with, where co-located is defined as running
+                                      on a node whose value of the label with key
+                                      <topologyKey> matches that of any node on which
+                                      a pod of the set of pods is running
+                                    properties:
+                                      labelSelector:
+                                        description: A label query over a set of resources,
+                                          in this case pods.
+                                        properties:
+                                          matchExpressions:
+                                            description: matchExpressions is a list
+                                              of label selector requirements. The
+                                              requirements are ANDed.
+                                            items:
+                                              description: A label selector requirement
+                                                is a selector that contains values,
+                                                a key, and an operator that relates
+                                                the key and values.
+                                              properties:
+                                                key:
+                                                  description: key is the label key
+                                                    that the selector applies to.
+                                                  type: string
+                                                operator:
+                                                  description: operator represents
+                                                    a key's relationship to a set
+                                                    of values. Valid operators are
+                                                    In, NotIn, Exists and DoesNotExist.
+                                                  type: string
+                                                values:
+                                                  description: values is an array
+                                                    of string values. If the operator
+                                                    is In or NotIn, the values array
+                                                    must be non-empty. If the operator
+                                                    is Exists or DoesNotExist, the
+                                                    values array must be empty. This
+                                                    array is replaced during a strategic
+                                                    merge patch.
+                                                  items:
+                                                    type: string
+                                                  type: array
+                                              required:
+                                              - key
+                                              - operator
+                                              type: object
+                                            type: array
+                                          matchLabels:
+                                            additionalProperties:
+                                              type: string
+                                            description: matchLabels is a map of {key,value}
+                                              pairs. A single {key,value} in the matchLabels
+                                              map is equivalent to an element of matchExpressions,
+                                              whose key field is "key", the operator
+                                              is "In", and the values array contains
+                                              only "value". The requirements are ANDed.
+                                            type: object
+                                        type: object
+                                      namespaceSelector:
+                                        description: A label query over the set of
+                                          namespaces that the term applies to. The
+                                          term is applied to the union of the namespaces
+                                          selected by this field and the ones listed
+                                          in the namespaces field. null selector and
+                                          null or empty namespaces list means "this
+                                          pod's namespace". An empty selector ({})
+                                          matches all namespaces.
+                                        properties:
+                                          matchExpressions:
+                                            description: matchExpressions is a list
+                                              of label selector requirements. The
+                                              requirements are ANDed.
+                                            items:
+                                              description: A label selector requirement
+                                                is a selector that contains values,
+                                                a key, and an operator that relates
+                                                the key and values.
+                                              properties:
+                                                key:
+                                                  description: key is the label key
+                                                    that the selector applies to.
+                                                  type: string
+                                                operator:
+                                                  description: operator represents
+                                                    a key's relationship to a set
+                                                    of values. Valid operators are
+                                                    In, NotIn, Exists and DoesNotExist.
+                                                  type: string
+                                                values:
+                                                  description: values is an array
+                                                    of string values. If the operator
+                                                    is In or NotIn, the values array
+                                                    must be non-empty. If the operator
+                                                    is Exists or DoesNotExist, the
+                                                    values array must be empty. This
+                                                    array is replaced during a strategic
+                                                    merge patch.
+                                                  items:
+                                                    type: string
+                                                  type: array
+                                              required:
+                                              - key
+                                              - operator
+                                              type: object
+                                            type: array
+                                          matchLabels:
+                                            additionalProperties:
+                                              type: string
+                                            description: matchLabels is a map of {key,value}
+                                              pairs. A single {key,value} in the matchLabels
+                                              map is equivalent to an element of matchExpressions,
+                                              whose key field is "key", the operator
+                                              is "In", and the values array contains
+                                              only "value". The requirements are ANDed.
+                                            type: object
+                                        type: object
+                                      namespaces:
+                                        description: namespaces specifies a static
+                                          list of namespace names that the term applies
+                                          to. The term is applied to the union of
+                                          the namespaces listed in this field and
+                                          the ones selected by namespaceSelector.
+                                          null or empty namespaces list and null namespaceSelector
+                                          means "this pod's namespace".
+                                        items:
+                                          type: string
+                                        type: array
+                                      topologyKey:
+                                        description: This pod should be co-located
+                                          (affinity) or not co-located (anti-affinity)
+                                          with the pods matching the labelSelector
+                                          in the specified namespaces, where co-located
+                                          is defined as running on a node whose value
+                                          of the label with key topologyKey matches
+                                          that of any node on which any of the selected
+                                          pods is running. Empty topologyKey is not
+                                          allowed.
+                                        type: string
+                                    required:
+                                    - topologyKey
+                                    type: object
+                                  type: array
+                              type: object
+                          type: object
+                        nodeSelector:
+                          additionalProperties:
+                            type: string
+                          type: object
+                        schedulerName:
+                          type: string
+                        tolerations:
+                          items:
+                            description: The pod this Toleration is attached to tolerates
+                              any taint that matches the triple <key,value,effect>
+                              using the matching operator <operator>.
+                            properties:
+                              effect:
+                                description: Effect indicates the taint effect to
+                                  match. Empty means match all taint effects. When
+                                  specified, allowed values are NoSchedule, PreferNoSchedule
+                                  and NoExecute.
+                                type: string
+                              key:
+                                description: Key is the taint key that the toleration
+                                  applies to. Empty means match all taint keys. If
+                                  the key is empty, operator must be Exists; this
+                                  combination means to match all values and all keys.
+                                type: string
+                              operator:
+                                description: Operator represents a key's relationship
+                                  to the value. Valid operators are Exists and Equal.
+                                  Defaults to Equal. Exists is equivalent to wildcard
+                                  for value, so that a pod can tolerate all taints
+                                  of a particular category.
+                                type: string
+                              tolerationSeconds:
+                                description: TolerationSeconds represents the period
+                                  of time the toleration (which must be of effect
+                                  NoExecute, otherwise this field is ignored) tolerates
+                                  the taint. By default, it is not set, which means
+                                  tolerate the taint forever (do not evict). Zero
+                                  and negative values will be treated as 0 (evict
+                                  immediately) by the system.
+                                format: int64
+                                type: integer
+                              value:
+                                description: Value is the taint value the toleration
+                                  matches to. If the operator is Exists, the value
+                                  should be empty, otherwise just a regular string.
+                                type: string
+                            type: object
+                          type: array
+                        topologySpreadConstraints:
+                          items:
+                            description: TopologySpreadConstraint specifies how to
+                              spread matching pods among the given topology.
+                            properties:
+                              labelSelector:
+                                description: LabelSelector is used to find matching
+                                  pods. Pods that match this label selector are counted
+                                  to determine the number of pods in their corresponding
+                                  topology domain.
+                                properties:
+                                  matchExpressions:
+                                    description: matchExpressions is a list of label
+                                      selector requirements. The requirements are
+                                      ANDed.
+                                    items:
+                                      description: A label selector requirement is
+                                        a selector that contains values, a key, and
+                                        an operator that relates the key and values.
+                                      properties:
+                                        key:
+                                          description: key is the label key that the
+                                            selector applies to.
+                                          type: string
+                                        operator:
+                                          description: operator represents a key's
+                                            relationship to a set of values. Valid
+                                            operators are In, NotIn, Exists and DoesNotExist.
+                                          type: string
+                                        values:
+                                          description: values is an array of string
+                                            values. If the operator is In or NotIn,
+                                            the values array must be non-empty. If
+                                            the operator is Exists or DoesNotExist,
+                                            the values array must be empty. This array
+                                            is replaced during a strategic merge patch.
+                                          items:
+                                            type: string
+                                          type: array
+                                      required:
+                                      - key
+                                      - operator
+                                      type: object
+                                    type: array
+                                  matchLabels:
+                                    additionalProperties:
+                                      type: string
+                                    description: matchLabels is a map of {key,value}
+                                      pairs. A single {key,value} in the matchLabels
+                                      map is equivalent to an element of matchExpressions,
+                                      whose key field is "key", the operator is "In",
+                                      and the values array contains only "value".
+                                      The requirements are ANDed.
+                                    type: object
+                                type: object
+                              matchLabelKeys:
+                                description: MatchLabelKeys is a set of pod label
+                                  keys to select the pods over which spreading will
+                                  be calculated. The keys are used to lookup values
+                                  from the incoming pod labels, those key-value labels
+                                  are ANDed with labelSelector to select the group
+                                  of existing pods over which spreading will be calculated
+                                  for the incoming pod. Keys that don't exist in the
+                                  incoming pod labels will be ignored. A null or empty
+                                  list means only match against labelSelector.
+                                items:
+                                  type: string
+                                type: array
+                                x-kubernetes-list-type: atomic
+                              maxSkew:
+                                description: 'MaxSkew describes the degree to which
+                                  pods may be unevenly distributed. When `whenUnsatisfiable=DoNotSchedule`,
+                                  it is the maximum permitted difference between the
+                                  number of matching pods in the target topology and
+                                  the global minimum. The global minimum is the minimum
+                                  number of matching pods in an eligible domain or
+                                  zero if the number of eligible domains is less than
+                                  MinDomains. For example, in a 3-zone cluster, MaxSkew
+                                  is set to 1, and pods with the same labelSelector
+                                  spread as 2/2/1: In this case, the global minimum
+                                  is 1. | zone1 | zone2 | zone3 | |  P P  |  P P  |   P   |
+                                  - if MaxSkew is 1, incoming pod can only be scheduled
+                                  to zone3 to become 2/2/2; scheduling it onto zone1(zone2)
+                                  would make the ActualSkew(3-1) on zone1(zone2) violate
+                                  MaxSkew(1). - if MaxSkew is 2, incoming pod can
+                                  be scheduled onto any zone. When `whenUnsatisfiable=ScheduleAnyway`,
+                                  it is used to give higher precedence to topologies
+                                  that satisfy it. It''s a required field. Default
+                                  value is 1 and 0 is not allowed.'
+                                format: int32
+                                type: integer
+                              minDomains:
+                                description: "MinDomains indicates a minimum number
+                                  of eligible domains. When the number of eligible
+                                  domains with matching topology keys is less than
+                                  minDomains, Pod Topology Spread treats \"global
+                                  minimum\" as 0, and then the calculation of Skew
+                                  is performed. And when the number of eligible domains
+                                  with matching topology keys equals or greater than
+                                  minDomains, this value has no effect on scheduling.
+                                  As a result, when the number of eligible domains
+                                  is less than minDomains, scheduler won't schedule
+                                  more than maxSkew Pods to those domains. If value
+                                  is nil, the constraint behaves as if MinDomains
+                                  is equal to 1. Valid values are integers greater
+                                  than 0. When value is not nil, WhenUnsatisfiable
+                                  must be DoNotSchedule. \n For example, in a 3-zone
+                                  cluster, MaxSkew is set to 2, MinDomains is set
+                                  to 5 and pods with the same labelSelector spread
+                                  as 2/2/2: | zone1 | zone2 | zone3 | |  P P  |  P
+                                  P  |  P P  | The number of domains is less than
+                                  5(MinDomains), so \"global minimum\" is treated
+                                  as 0. In this situation, new pod with the same labelSelector
+                                  cannot be scheduled, because computed skew will
+                                  be 3(3 - 0) if new Pod is scheduled to any of the
+                                  three zones, it will violate MaxSkew. \n This is
+                                  a beta field and requires the MinDomainsInPodTopologySpread
+                                  feature gate to be enabled (enabled by default)."
+                                format: int32
+                                type: integer
+                              nodeAffinityPolicy:
+                                description: "NodeAffinityPolicy indicates how we
+                                  will treat Pod's nodeAffinity/nodeSelector when
+                                  calculating pod topology spread skew. Options are:
+                                  - Honor: only nodes matching nodeAffinity/nodeSelector
+                                  are included in the calculations. - Ignore: nodeAffinity/nodeSelector
+                                  are ignored. All nodes are included in the calculations.
+                                  \n If this value is nil, the behavior is equivalent
+                                  to the Honor policy. This is a alpha-level feature
+                                  enabled by the NodeInclusionPolicyInPodTopologySpread
+                                  feature flag."
+                                type: string
+                              nodeTaintsPolicy:
+                                description: "NodeTaintsPolicy indicates how we will
+                                  treat node taints when calculating pod topology
+                                  spread skew. Options are: - Honor: nodes without
+                                  taints, along with tainted nodes for which the incoming
+                                  pod has a toleration, are included. - Ignore: node
+                                  taints are ignored. All nodes are included. \n If
+                                  this value is nil, the behavior is equivalent to
+                                  the Ignore policy. This is a alpha-level feature
+                                  enabled by the NodeInclusionPolicyInPodTopologySpread
+                                  feature flag."
+                                type: string
+                              topologyKey:
+                                description: TopologyKey is the key of node labels.
+                                  Nodes that have a label with this key and identical
+                                  values are considered to be in the same topology.
+                                  We consider each <key, value> as a "bucket", and
+                                  try to put balanced number of pods into each bucket.
+                                  We define a domain as a particular instance of a
+                                  topology. Also, we define an eligible domain as
+                                  a domain whose nodes meet the requirements of nodeAffinityPolicy
+                                  and nodeTaintsPolicy. e.g. If TopologyKey is "kubernetes.io/hostname",
+                                  each Node is a domain of that topology. And, if
+                                  TopologyKey is "topology.kubernetes.io/zone", each
+                                  zone is a domain of that topology. It's a required
+                                  field.
+                                type: string
+                              whenUnsatisfiable:
+                                description: 'WhenUnsatisfiable indicates how to deal
+                                  with a pod if it doesn''t satisfy the spread constraint.
+                                  - DoNotSchedule (default) tells the scheduler not
+                                  to schedule it. - ScheduleAnyway tells the scheduler
+                                  to schedule the pod in any location,   but giving
+                                  higher precedence to topologies that would help
+                                  reduce the   skew. A constraint is considered "Unsatisfiable"
+                                  for an incoming pod if and only if every possible
+                                  node assignment for that pod would violate "MaxSkew"
+                                  on some topology. For example, in a 3-zone cluster,
+                                  MaxSkew is set to 1, and pods with the same labelSelector
+                                  spread as 3/1/1: | zone1 | zone2 | zone3 | | P P
+                                  P |   P   |   P   | If WhenUnsatisfiable is set
+                                  to DoNotSchedule, incoming pod can only be scheduled
+                                  to zone2(zone3) to become 3/2/1(3/1/2) as ActualSkew(2-1)
+                                  on zone2(zone3) satisfies MaxSkew(1). In other words,
+                                  the cluster can still be imbalanced, but scheduler
+                                  won''t make it *more* imbalanced. It''s a required
+                                  field.'
+                                type: string
+                            required:
+                            - maxSkew
+                            - topologyKey
+                            - whenUnsatisfiable
+                            type: object
+                          type: array
+                      type: object
+                    labels:
+                      additionalProperties:
+                        type: string
+                      type: object
+                    name:
+                      type: string
+                    resources:
+                      properties:
+                        limits:
+                          properties:
+                            cpu:
+                              type: string
+                            custom:
+                              additionalProperties:
+                                type: string
+                              type: object
+                            gpu:
+                              type: string
+                            memory:
+                              type: string
+                          type: object
+                        requests:
+                          properties:
+                            cpu:
+                              type: string
+                            custom:
+                              additionalProperties:
+                                type: string
+                              type: object
+                            gpu:
+                              type: string
+                            memory:
+                              type: string
+                          type: object
+                      type: object
+                  type: object
+                type: array
+            required:
+            - bento_tag
+            type: object
+          status:
+            description: BentoDeploymentStatus defines the observed state of BentoDeployment
+            properties:
+              availableReplicas:
+                description: Total number of available pods (ready for at least minReadySeconds)
+                  targeted by this deployment.
+                format: int32
+                type: integer
+              podSelector:
+                additionalProperties:
+                  type: string
+                description: 'INSERT ADDITIONAL STATUS FIELD - define observed state
+                  of cluster Important: Run "make" to regenerate code after modifying
+                  this file'
+                type: object
+              printerReady:
+                type: string
+              readyReplicas:
+                description: readyReplicas is the number of pods targeted by this
+                  Deployment with a Ready Condition.
+                format: int32
+                type: integer
+              replicas:
+                description: Total number of non-terminated pods targeted by this
+                  deployment (their labels match the selector).
+                format: int32
+                type: integer
+              unavailableReplicas:
+                description: Total number of unavailable pods targeted by this deployment.
+                  This is the total number of pods that are still required for the
+                  deployment to have 100% available capacity. They may either be pods
+                  that are running but not yet available or pods that still have not
+                  been created.
+                format: int32
+                type: integer
+              updatedReplicas:
+                description: Total number of non-terminated pods targeted by this
+                  deployment that have the desired template spec.
+                format: int32
+                type: integer
+            type: object
+        type: object
+    served: true
+    storage: false
+    subresources:
+      status: {}
+  - additionalPrinterColumns:
+    - description: Bento
+      jsonPath: .spec.bento
+      name: Bento
+      type: string
+    - description: Available
+      jsonPath: .status.conditions[?(@.type=='Available')].status
+      name: Available
+      type: string
+    - jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    name: v2alpha1
+    schema:
+      openAPIV3Schema:
+        description: BentoDeployment is the Schema for the bentodeployments API
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: BentoDeploymentSpec defines the desired state of BentoDeployment
+            properties:
+              annotations:
+                additionalProperties:
+                  type: string
+                type: object
+              autoscaling:
+                properties:
+                  behavior:
+                    description: HorizontalPodAutoscalerBehavior configures the scaling
+                      behavior of the target in both Up and Down directions (scaleUp
+                      and scaleDown fields respectively).
+                    properties:
+                      scaleDown:
+                        description: scaleDown is scaling policy for scaling Down.
+                          If not set, the default value is to allow to scale down
+                          to minReplicas pods, with a 300 second stabilization window
+                          (i.e., the highest recommendation for the last 300sec is
+                          used).
+                        properties:
+                          policies:
+                            description: policies is a list of potential scaling polices
+                              which can be used during scaling. At least one policy
+                              must be specified, otherwise the HPAScalingRules will
+                              be discarded as invalid
+                            items:
+                              description: HPAScalingPolicy is a single policy which
+                                must hold true for a specified past interval.
+                              properties:
+                                periodSeconds:
+                                  description: PeriodSeconds specifies the window
+                                    of time for which the policy should hold true.
+                                    PeriodSeconds must be greater than zero and less
+                                    than or equal to 1800 (30 min).
+                                  format: int32
+                                  type: integer
+                                type:
+                                  description: Type is used to specify the scaling
+                                    policy.
+                                  type: string
+                                value:
+                                  description: Value contains the amount of change
+                                    which is permitted by the policy. It must be greater
+                                    than zero
+                                  format: int32
+                                  type: integer
+                              required:
+                              - periodSeconds
+                              - type
+                              - value
+                              type: object
+                            type: array
+                          selectPolicy:
+                            description: selectPolicy is used to specify which policy
+                              should be used. If not set, the default value MaxPolicySelect
+                              is used.
+                            type: string
+                          stabilizationWindowSeconds:
+                            description: 'StabilizationWindowSeconds is the number
+                              of seconds for which past recommendations should be
+                              considered while scaling up or scaling down. StabilizationWindowSeconds
+                              must be greater than or equal to zero and less than
+                              or equal to 3600 (one hour). If not set, use the default
+                              values: - For scale up: 0 (i.e. no stabilization is
+                              done). - For scale down: 300 (i.e. the stabilization
+                              window is 300 seconds long).'
+                            format: int32
+                            type: integer
+                        type: object
+                      scaleUp:
+                        description: 'scaleUp is scaling policy for scaling Up. If
+                          not set, the default value is the higher of:   * increase
+                          no more than 4 pods per 60 seconds   * double the number
+                          of pods per 60 seconds No stabilization is used.'
+                        properties:
+                          policies:
+                            description: policies is a list of potential scaling polices
+                              which can be used during scaling. At least one policy
+                              must be specified, otherwise the HPAScalingRules will
+                              be discarded as invalid
+                            items:
+                              description: HPAScalingPolicy is a single policy which
+                                must hold true for a specified past interval.
+                              properties:
+                                periodSeconds:
+                                  description: PeriodSeconds specifies the window
+                                    of time for which the policy should hold true.
+                                    PeriodSeconds must be greater than zero and less
+                                    than or equal to 1800 (30 min).
+                                  format: int32
+                                  type: integer
+                                type:
+                                  description: Type is used to specify the scaling
+                                    policy.
+                                  type: string
+                                value:
+                                  description: Value contains the amount of change
+                                    which is permitted by the policy. It must be greater
+                                    than zero
+                                  format: int32
+                                  type: integer
+                              required:
+                              - periodSeconds
+                              - type
+                              - value
+                              type: object
+                            type: array
+                          selectPolicy:
+                            description: selectPolicy is used to specify which policy
+                              should be used. If not set, the default value MaxPolicySelect
+                              is used.
+                            type: string
+                          stabilizationWindowSeconds:
+                            description: 'StabilizationWindowSeconds is the number
+                              of seconds for which past recommendations should be
+                              considered while scaling up or scaling down. StabilizationWindowSeconds
+                              must be greater than or equal to zero and less than
+                              or equal to 3600 (one hour). If not set, use the default
+                              values: - For scale up: 0 (i.e. no stabilization is
+                              done). - For scale down: 300 (i.e. the stabilization
+                              window is 300 seconds long).'
+                            format: int32
+                            type: integer
+                        type: object
+                    type: object
+                  maxReplicas:
+                    format: int32
+                    type: integer
+                  metrics:
+                    items:
+                      description: MetricSpec specifies how to scale based on a single
+                        metric (only `type` and one other matching field should be
+                        set at once).
+                      properties:
+                        containerResource:
+                          description: container resource refers to a resource metric
+                            (such as those specified in requests and limits) known
+                            to Kubernetes describing a single container in each pod
+                            of the current scale target (e.g. CPU or memory). Such
+                            metrics are built in to Kubernetes, and have special scaling
+                            options on top of those available to normal per-pod metrics
+                            using the "pods" source. This is an alpha feature and
+                            can be enabled by the HPAContainerMetrics feature flag.
+                          properties:
+                            container:
+                              description: container is the name of the container
+                                in the pods of the scaling target
+                              type: string
+                            name:
+                              description: name is the name of the resource in question.
+                              type: string
+                            target:
+                              description: target specifies the target value for the
+                                given metric
+                              properties:
+                                averageUtilization:
+                                  description: averageUtilization is the target value
+                                    of the average of the resource metric across all
+                                    relevant pods, represented as a percentage of
+                                    the requested value of the resource for the pods.
+                                    Currently only valid for Resource metric source
+                                    type
+                                  format: int32
+                                  type: integer
+                                averageValue:
+                                  anyOf:
+                                  - type: integer
+                                  - type: string
+                                  description: averageValue is the target value of
+                                    the average of the metric across all relevant
+                                    pods (as a quantity)
+                                  pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                  x-kubernetes-int-or-string: true
+                                type:
+                                  description: type represents whether the metric
+                                    type is Utilization, Value, or AverageValue
+                                  type: string
+                                value:
+                                  anyOf:
+                                  - type: integer
+                                  - type: string
+                                  description: value is the target value of the metric
+                                    (as a quantity).
+                                  pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                  x-kubernetes-int-or-string: true
+                              required:
+                              - type
+                              type: object
+                          required:
+                          - container
+                          - name
+                          - target
+                          type: object
+                        external:
+                          description: external refers to a global metric that is
+                            not associated with any Kubernetes object. It allows autoscaling
+                            based on information coming from components running outside
+                            of cluster (for example length of queue in cloud messaging
+                            service, or QPS from loadbalancer running outside of cluster).
+                          properties:
+                            metric:
+                              description: metric identifies the target metric by
+                                name and selector
+                              properties:
+                                name:
+                                  description: name is the name of the given metric
+                                  type: string
+                                selector:
+                                  description: selector is the string-encoded form
+                                    of a standard kubernetes label selector for the
+                                    given metric When set, it is passed as an additional
+                                    parameter to the metrics server for more specific
+                                    metrics scoping. When unset, just the metricName
+                                    will be used to gather metrics.
+                                  properties:
+                                    matchExpressions:
+                                      description: matchExpressions is a list of label
+                                        selector requirements. The requirements are
+                                        ANDed.
+                                      items:
+                                        description: A label selector requirement
+                                          is a selector that contains values, a key,
+                                          and an operator that relates the key and
+                                          values.
+                                        properties:
+                                          key:
+                                            description: key is the label key that
+                                              the selector applies to.
+                                            type: string
+                                          operator:
+                                            description: operator represents a key's
+                                              relationship to a set of values. Valid
+                                              operators are In, NotIn, Exists and
+                                              DoesNotExist.
+                                            type: string
+                                          values:
+                                            description: values is an array of string
+                                              values. If the operator is In or NotIn,
+                                              the values array must be non-empty.
+                                              If the operator is Exists or DoesNotExist,
+                                              the values array must be empty. This
+                                              array is replaced during a strategic
+                                              merge patch.
+                                            items:
+                                              type: string
+                                            type: array
+                                        required:
+                                        - key
+                                        - operator
+                                        type: object
+                                      type: array
+                                    matchLabels:
+                                      additionalProperties:
+                                        type: string
+                                      description: matchLabels is a map of {key,value}
+                                        pairs. A single {key,value} in the matchLabels
+                                        map is equivalent to an element of matchExpressions,
+                                        whose key field is "key", the operator is
+                                        "In", and the values array contains only "value".
+                                        The requirements are ANDed.
+                                      type: object
+                                  type: object
+                              required:
+                              - name
+                              type: object
+                            target:
+                              description: target specifies the target value for the
+                                given metric
+                              properties:
+                                averageUtilization:
+                                  description: averageUtilization is the target value
+                                    of the average of the resource metric across all
+                                    relevant pods, represented as a percentage of
+                                    the requested value of the resource for the pods.
+                                    Currently only valid for Resource metric source
+                                    type
+                                  format: int32
+                                  type: integer
+                                averageValue:
+                                  anyOf:
+                                  - type: integer
+                                  - type: string
+                                  description: averageValue is the target value of
+                                    the average of the metric across all relevant
+                                    pods (as a quantity)
+                                  pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                  x-kubernetes-int-or-string: true
+                                type:
+                                  description: type represents whether the metric
+                                    type is Utilization, Value, or AverageValue
+                                  type: string
+                                value:
+                                  anyOf:
+                                  - type: integer
+                                  - type: string
+                                  description: value is the target value of the metric
+                                    (as a quantity).
+                                  pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                  x-kubernetes-int-or-string: true
+                              required:
+                              - type
+                              type: object
+                          required:
+                          - metric
+                          - target
+                          type: object
+                        object:
+                          description: object refers to a metric describing a single
+                            kubernetes object (for example, hits-per-second on an
+                            Ingress object).
+                          properties:
+                            describedObject:
+                              description: CrossVersionObjectReference contains enough
+                                information to let you identify the referred resource.
+                              properties:
+                                apiVersion:
+                                  description: API version of the referent
+                                  type: string
+                                kind:
+                                  description: 'Kind of the referent; More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds"'
+                                  type: string
+                                name:
+                                  description: 'Name of the referent; More info: http://kubernetes.io/docs/user-guide/identifiers#names'
+                                  type: string
+                              required:
+                              - kind
+                              - name
+                              type: object
+                            metric:
+                              description: metric identifies the target metric by
+                                name and selector
+                              properties:
+                                name:
+                                  description: name is the name of the given metric
+                                  type: string
+                                selector:
+                                  description: selector is the string-encoded form
+                                    of a standard kubernetes label selector for the
+                                    given metric When set, it is passed as an additional
+                                    parameter to the metrics server for more specific
+                                    metrics scoping. When unset, just the metricName
+                                    will be used to gather metrics.
+                                  properties:
+                                    matchExpressions:
+                                      description: matchExpressions is a list of label
+                                        selector requirements. The requirements are
+                                        ANDed.
+                                      items:
+                                        description: A label selector requirement
+                                          is a selector that contains values, a key,
+                                          and an operator that relates the key and
+                                          values.
+                                        properties:
+                                          key:
+                                            description: key is the label key that
+                                              the selector applies to.
+                                            type: string
+                                          operator:
+                                            description: operator represents a key's
+                                              relationship to a set of values. Valid
+                                              operators are In, NotIn, Exists and
+                                              DoesNotExist.
+                                            type: string
+                                          values:
+                                            description: values is an array of string
+                                              values. If the operator is In or NotIn,
+                                              the values array must be non-empty.
+                                              If the operator is Exists or DoesNotExist,
+                                              the values array must be empty. This
+                                              array is replaced during a strategic
+                                              merge patch.
+                                            items:
+                                              type: string
+                                            type: array
+                                        required:
+                                        - key
+                                        - operator
+                                        type: object
+                                      type: array
+                                    matchLabels:
+                                      additionalProperties:
+                                        type: string
+                                      description: matchLabels is a map of {key,value}
+                                        pairs. A single {key,value} in the matchLabels
+                                        map is equivalent to an element of matchExpressions,
+                                        whose key field is "key", the operator is
+                                        "In", and the values array contains only "value".
+                                        The requirements are ANDed.
+                                      type: object
+                                  type: object
+                              required:
+                              - name
+                              type: object
+                            target:
+                              description: target specifies the target value for the
+                                given metric
+                              properties:
+                                averageUtilization:
+                                  description: averageUtilization is the target value
+                                    of the average of the resource metric across all
+                                    relevant pods, represented as a percentage of
+                                    the requested value of the resource for the pods.
+                                    Currently only valid for Resource metric source
+                                    type
+                                  format: int32
+                                  type: integer
+                                averageValue:
+                                  anyOf:
+                                  - type: integer
+                                  - type: string
+                                  description: averageValue is the target value of
+                                    the average of the metric across all relevant
+                                    pods (as a quantity)
+                                  pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                  x-kubernetes-int-or-string: true
+                                type:
+                                  description: type represents whether the metric
+                                    type is Utilization, Value, or AverageValue
+                                  type: string
+                                value:
+                                  anyOf:
+                                  - type: integer
+                                  - type: string
+                                  description: value is the target value of the metric
+                                    (as a quantity).
+                                  pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                  x-kubernetes-int-or-string: true
+                              required:
+                              - type
+                              type: object
+                          required:
+                          - describedObject
+                          - metric
+                          - target
+                          type: object
+                        pods:
+                          description: pods refers to a metric describing each pod
+                            in the current scale target (for example, transactions-processed-per-second).  The
+                            values will be averaged together before being compared
+                            to the target value.
+                          properties:
+                            metric:
+                              description: metric identifies the target metric by
+                                name and selector
+                              properties:
+                                name:
+                                  description: name is the name of the given metric
+                                  type: string
+                                selector:
+                                  description: selector is the string-encoded form
+                                    of a standard kubernetes label selector for the
+                                    given metric When set, it is passed as an additional
+                                    parameter to the metrics server for more specific
+                                    metrics scoping. When unset, just the metricName
+                                    will be used to gather metrics.
+                                  properties:
+                                    matchExpressions:
+                                      description: matchExpressions is a list of label
+                                        selector requirements. The requirements are
+                                        ANDed.
+                                      items:
+                                        description: A label selector requirement
+                                          is a selector that contains values, a key,
+                                          and an operator that relates the key and
+                                          values.
+                                        properties:
+                                          key:
+                                            description: key is the label key that
+                                              the selector applies to.
+                                            type: string
+                                          operator:
+                                            description: operator represents a key's
+                                              relationship to a set of values. Valid
+                                              operators are In, NotIn, Exists and
+                                              DoesNotExist.
+                                            type: string
+                                          values:
+                                            description: values is an array of string
+                                              values. If the operator is In or NotIn,
+                                              the values array must be non-empty.
+                                              If the operator is Exists or DoesNotExist,
+                                              the values array must be empty. This
+                                              array is replaced during a strategic
+                                              merge patch.
+                                            items:
+                                              type: string
+                                            type: array
+                                        required:
+                                        - key
+                                        - operator
+                                        type: object
+                                      type: array
+                                    matchLabels:
+                                      additionalProperties:
+                                        type: string
+                                      description: matchLabels is a map of {key,value}
+                                        pairs. A single {key,value} in the matchLabels
+                                        map is equivalent to an element of matchExpressions,
+                                        whose key field is "key", the operator is
+                                        "In", and the values array contains only "value".
+                                        The requirements are ANDed.
+                                      type: object
+                                  type: object
+                              required:
+                              - name
+                              type: object
+                            target:
+                              description: target specifies the target value for the
+                                given metric
+                              properties:
+                                averageUtilization:
+                                  description: averageUtilization is the target value
+                                    of the average of the resource metric across all
+                                    relevant pods, represented as a percentage of
+                                    the requested value of the resource for the pods.
+                                    Currently only valid for Resource metric source
+                                    type
+                                  format: int32
+                                  type: integer
+                                averageValue:
+                                  anyOf:
+                                  - type: integer
+                                  - type: string
+                                  description: averageValue is the target value of
+                                    the average of the metric across all relevant
+                                    pods (as a quantity)
+                                  pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                  x-kubernetes-int-or-string: true
+                                type:
+                                  description: type represents whether the metric
+                                    type is Utilization, Value, or AverageValue
+                                  type: string
+                                value:
+                                  anyOf:
+                                  - type: integer
+                                  - type: string
+                                  description: value is the target value of the metric
+                                    (as a quantity).
+                                  pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                  x-kubernetes-int-or-string: true
+                              required:
+                              - type
+                              type: object
+                          required:
+                          - metric
+                          - target
+                          type: object
+                        resource:
+                          description: resource refers to a resource metric (such
+                            as those specified in requests and limits) known to Kubernetes
+                            describing each pod in the current scale target (e.g.
+                            CPU or memory). Such metrics are built in to Kubernetes,
+                            and have special scaling options on top of those available
+                            to normal per-pod metrics using the "pods" source.
+                          properties:
+                            name:
+                              description: name is the name of the resource in question.
+                              type: string
+                            target:
+                              description: target specifies the target value for the
+                                given metric
+                              properties:
+                                averageUtilization:
+                                  description: averageUtilization is the target value
+                                    of the average of the resource metric across all
+                                    relevant pods, represented as a percentage of
+                                    the requested value of the resource for the pods.
+                                    Currently only valid for Resource metric source
+                                    type
+                                  format: int32
+                                  type: integer
+                                averageValue:
+                                  anyOf:
+                                  - type: integer
+                                  - type: string
+                                  description: averageValue is the target value of
+                                    the average of the metric across all relevant
+                                    pods (as a quantity)
+                                  pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                  x-kubernetes-int-or-string: true
+                                type:
+                                  description: type represents whether the metric
+                                    type is Utilization, Value, or AverageValue
+                                  type: string
+                                value:
+                                  anyOf:
+                                  - type: integer
+                                  - type: string
+                                  description: value is the target value of the metric
+                                    (as a quantity).
+                                  pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                  x-kubernetes-int-or-string: true
+                              required:
+                              - type
+                              type: object
+                          required:
+                          - name
+                          - target
+                          type: object
+                        type:
+                          description: 'type is the type of metric source.  It should
+                            be one of "ContainerResource", "External", "Object", "Pods"
+                            or "Resource", each mapping to a matching field in the
+                            object. Note: "ContainerResource" type is available on
+                            when the feature-gate HPAContainerMetrics is enabled'
+                          type: string
+                      required:
+                      - type
+                      type: object
+                    type: array
+                  minReplicas:
+                    format: int32
+                    type: integer
+                required:
+                - maxReplicas
+                - minReplicas
+                type: object
+              bento:
+                type: string
+              envs:
+                items:
+                  description: EnvVar represents an environment variable present in
+                    a Container.
+                  properties:
+                    name:
+                      description: Name of the environment variable. Must be a C_IDENTIFIER.
+                      type: string
+                    value:
+                      description: 'Variable references $(VAR_NAME) are expanded using
+                        the previously defined environment variables in the container
+                        and any service environment variables. If a variable cannot
+                        be resolved, the reference in the input string will be unchanged.
+                        Double $$ are reduced to a single $, which allows for escaping
+                        the $(VAR_NAME) syntax: i.e. "$$(VAR_NAME)" will produce the
+                        string literal "$(VAR_NAME)". Escaped references will never
+                        be expanded, regardless of whether the variable exists or
+                        not. Defaults to "".'
+                      type: string
+                    valueFrom:
+                      description: Source for the environment variable's value. Cannot
+                        be used if value is not empty.
+                      properties:
+                        configMapKeyRef:
+                          description: Selects a key of a ConfigMap.
+                          properties:
+                            key:
+                              description: The key to select.
+                              type: string
+                            name:
+                              description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                TODO: Add other useful fields. apiVersion, kind, uid?'
+                              type: string
+                            optional:
+                              description: Specify whether the ConfigMap or its key
+                                must be defined
+                              type: boolean
+                          required:
+                          - key
+                          type: object
+                        fieldRef:
+                          description: 'Selects a field of the pod: supports metadata.name,
+                            metadata.namespace, `metadata.labels[''<KEY>'']`, `metadata.annotations[''<KEY>'']`,
+                            spec.nodeName, spec.serviceAccountName, status.hostIP,
+                            status.podIP, status.podIPs.'
+                          properties:
+                            apiVersion:
+                              description: Version of the schema the FieldPath is
+                                written in terms of, defaults to "v1".
+                              type: string
+                            fieldPath:
+                              description: Path of the field to select in the specified
+                                API version.
+                              type: string
+                          required:
+                          - fieldPath
+                          type: object
+                        resourceFieldRef:
+                          description: 'Selects a resource of the container: only
+                            resources limits and requests (limits.cpu, limits.memory,
+                            limits.ephemeral-storage, requests.cpu, requests.memory
+                            and requests.ephemeral-storage) are currently supported.'
+                          properties:
+                            containerName:
+                              description: 'Container name: required for volumes,
+                                optional for env vars'
+                              type: string
+                            divisor:
+                              anyOf:
+                              - type: integer
+                              - type: string
+                              description: Specifies the output format of the exposed
+                                resources, defaults to "1"
+                              pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                              x-kubernetes-int-or-string: true
+                            resource:
+                              description: 'Required: resource to select'
+                              type: string
+                          required:
+                          - resource
+                          type: object
+                        secretKeyRef:
+                          description: Selects a key of a secret in the pod's namespace
+                          properties:
+                            key:
+                              description: The key of the secret to select from.  Must
+                                be a valid secret key.
+                              type: string
+                            name:
+                              description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                TODO: Add other useful fields. apiVersion, kind, uid?'
+                              type: string
+                            optional:
+                              description: Specify whether the Secret or its key must
+                                be defined
+                              type: boolean
+                          required:
+                          - key
+                          type: object
+                      type: object
+                  required:
+                  - name
+                  type: object
+                type: array
+              extraPodMetadata:
+                properties:
+                  annotations:
+                    additionalProperties:
+                      type: string
+                    type: object
+                  labels:
+                    additionalProperties:
+                      type: string
+                    type: object
+                type: object
+              extraPodSpec:
+                properties:
+                  affinity:
+                    description: Affinity is a group of affinity scheduling rules.
+                    properties:
+                      nodeAffinity:
+                        description: Describes node affinity scheduling rules for
+                          the pod.
+                        properties:
+                          preferredDuringSchedulingIgnoredDuringExecution:
+                            description: The scheduler will prefer to schedule pods
+                              to nodes that satisfy the affinity expressions specified
+                              by this field, but it may choose a node that violates
+                              one or more of the expressions. The node that is most
+                              preferred is the one with the greatest sum of weights,
+                              i.e. for each node that meets all of the scheduling
+                              requirements (resource request, requiredDuringScheduling
+                              affinity expressions, etc.), compute a sum by iterating
+                              through the elements of this field and adding "weight"
+                              to the sum if the node matches the corresponding matchExpressions;
+                              the node(s) with the highest sum are the most preferred.
+                            items:
+                              description: An empty preferred scheduling term matches
+                                all objects with implicit weight 0 (i.e. it's a no-op).
+                                A null preferred scheduling term matches no objects
+                                (i.e. is also a no-op).
+                              properties:
+                                preference:
+                                  description: A node selector term, associated with
+                                    the corresponding weight.
+                                  properties:
+                                    matchExpressions:
+                                      description: A list of node selector requirements
+                                        by node's labels.
+                                      items:
+                                        description: A node selector requirement is
+                                          a selector that contains values, a key,
+                                          and an operator that relates the key and
+                                          values.
+                                        properties:
+                                          key:
+                                            description: The label key that the selector
+                                              applies to.
+                                            type: string
+                                          operator:
+                                            description: Represents a key's relationship
+                                              to a set of values. Valid operators
+                                              are In, NotIn, Exists, DoesNotExist.
+                                              Gt, and Lt.
+                                            type: string
+                                          values:
+                                            description: An array of string values.
+                                              If the operator is In or NotIn, the
+                                              values array must be non-empty. If the
+                                              operator is Exists or DoesNotExist,
+                                              the values array must be empty. If the
+                                              operator is Gt or Lt, the values array
+                                              must have a single element, which will
+                                              be interpreted as an integer. This array
+                                              is replaced during a strategic merge
+                                              patch.
+                                            items:
+                                              type: string
+                                            type: array
+                                        required:
+                                        - key
+                                        - operator
+                                        type: object
+                                      type: array
+                                    matchFields:
+                                      description: A list of node selector requirements
+                                        by node's fields.
+                                      items:
+                                        description: A node selector requirement is
+                                          a selector that contains values, a key,
+                                          and an operator that relates the key and
+                                          values.
+                                        properties:
+                                          key:
+                                            description: The label key that the selector
+                                              applies to.
+                                            type: string
+                                          operator:
+                                            description: Represents a key's relationship
+                                              to a set of values. Valid operators
+                                              are In, NotIn, Exists, DoesNotExist.
+                                              Gt, and Lt.
+                                            type: string
+                                          values:
+                                            description: An array of string values.
+                                              If the operator is In or NotIn, the
+                                              values array must be non-empty. If the
+                                              operator is Exists or DoesNotExist,
+                                              the values array must be empty. If the
+                                              operator is Gt or Lt, the values array
+                                              must have a single element, which will
+                                              be interpreted as an integer. This array
+                                              is replaced during a strategic merge
+                                              patch.
+                                            items:
+                                              type: string
+                                            type: array
+                                        required:
+                                        - key
+                                        - operator
+                                        type: object
+                                      type: array
+                                  type: object
+                                weight:
+                                  description: Weight associated with matching the
+                                    corresponding nodeSelectorTerm, in the range 1-100.
+                                  format: int32
+                                  type: integer
+                              required:
+                              - preference
+                              - weight
+                              type: object
+                            type: array
+                          requiredDuringSchedulingIgnoredDuringExecution:
+                            description: If the affinity requirements specified by
+                              this field are not met at scheduling time, the pod will
+                              not be scheduled onto the node. If the affinity requirements
+                              specified by this field cease to be met at some point
+                              during pod execution (e.g. due to an update), the system
+                              may or may not try to eventually evict the pod from
+                              its node.
+                            properties:
+                              nodeSelectorTerms:
+                                description: Required. A list of node selector terms.
+                                  The terms are ORed.
+                                items:
+                                  description: A null or empty node selector term
+                                    matches no objects. The requirements of them are
+                                    ANDed. The TopologySelectorTerm type implements
+                                    a subset of the NodeSelectorTerm.
+                                  properties:
+                                    matchExpressions:
+                                      description: A list of node selector requirements
+                                        by node's labels.
+                                      items:
+                                        description: A node selector requirement is
+                                          a selector that contains values, a key,
+                                          and an operator that relates the key and
+                                          values.
+                                        properties:
+                                          key:
+                                            description: The label key that the selector
+                                              applies to.
+                                            type: string
+                                          operator:
+                                            description: Represents a key's relationship
+                                              to a set of values. Valid operators
+                                              are In, NotIn, Exists, DoesNotExist.
+                                              Gt, and Lt.
+                                            type: string
+                                          values:
+                                            description: An array of string values.
+                                              If the operator is In or NotIn, the
+                                              values array must be non-empty. If the
+                                              operator is Exists or DoesNotExist,
+                                              the values array must be empty. If the
+                                              operator is Gt or Lt, the values array
+                                              must have a single element, which will
+                                              be interpreted as an integer. This array
+                                              is replaced during a strategic merge
+                                              patch.
+                                            items:
+                                              type: string
+                                            type: array
+                                        required:
+                                        - key
+                                        - operator
+                                        type: object
+                                      type: array
+                                    matchFields:
+                                      description: A list of node selector requirements
+                                        by node's fields.
+                                      items:
+                                        description: A node selector requirement is
+                                          a selector that contains values, a key,
+                                          and an operator that relates the key and
+                                          values.
+                                        properties:
+                                          key:
+                                            description: The label key that the selector
+                                              applies to.
+                                            type: string
+                                          operator:
+                                            description: Represents a key's relationship
+                                              to a set of values. Valid operators
+                                              are In, NotIn, Exists, DoesNotExist.
+                                              Gt, and Lt.
+                                            type: string
+                                          values:
+                                            description: An array of string values.
+                                              If the operator is In or NotIn, the
+                                              values array must be non-empty. If the
+                                              operator is Exists or DoesNotExist,
+                                              the values array must be empty. If the
+                                              operator is Gt or Lt, the values array
+                                              must have a single element, which will
+                                              be interpreted as an integer. This array
+                                              is replaced during a strategic merge
+                                              patch.
+                                            items:
+                                              type: string
+                                            type: array
+                                        required:
+                                        - key
+                                        - operator
+                                        type: object
+                                      type: array
+                                  type: object
+                                type: array
+                            required:
+                            - nodeSelectorTerms
+                            type: object
+                        type: object
+                      podAffinity:
+                        description: Describes pod affinity scheduling rules (e.g.
+                          co-locate this pod in the same node, zone, etc. as some
+                          other pod(s)).
+                        properties:
+                          preferredDuringSchedulingIgnoredDuringExecution:
+                            description: The scheduler will prefer to schedule pods
+                              to nodes that satisfy the affinity expressions specified
+                              by this field, but it may choose a node that violates
+                              one or more of the expressions. The node that is most
+                              preferred is the one with the greatest sum of weights,
+                              i.e. for each node that meets all of the scheduling
+                              requirements (resource request, requiredDuringScheduling
+                              affinity expressions, etc.), compute a sum by iterating
+                              through the elements of this field and adding "weight"
+                              to the sum if the node has pods which matches the corresponding
+                              podAffinityTerm; the node(s) with the highest sum are
+                              the most preferred.
+                            items:
+                              description: The weights of all of the matched WeightedPodAffinityTerm
+                                fields are added per-node to find the most preferred
+                                node(s)
+                              properties:
+                                podAffinityTerm:
+                                  description: Required. A pod affinity term, associated
+                                    with the corresponding weight.
+                                  properties:
+                                    labelSelector:
+                                      description: A label query over a set of resources,
+                                        in this case pods.
+                                      properties:
+                                        matchExpressions:
+                                          description: matchExpressions is a list
+                                            of label selector requirements. The requirements
+                                            are ANDed.
+                                          items:
+                                            description: A label selector requirement
+                                              is a selector that contains values,
+                                              a key, and an operator that relates
+                                              the key and values.
+                                            properties:
+                                              key:
+                                                description: key is the label key
+                                                  that the selector applies to.
+                                                type: string
+                                              operator:
+                                                description: operator represents a
+                                                  key's relationship to a set of values.
+                                                  Valid operators are In, NotIn, Exists
+                                                  and DoesNotExist.
+                                                type: string
+                                              values:
+                                                description: values is an array of
+                                                  string values. If the operator is
+                                                  In or NotIn, the values array must
+                                                  be non-empty. If the operator is
+                                                  Exists or DoesNotExist, the values
+                                                  array must be empty. This array
+                                                  is replaced during a strategic merge
+                                                  patch.
+                                                items:
+                                                  type: string
+                                                type: array
+                                            required:
+                                            - key
+                                            - operator
+                                            type: object
+                                          type: array
+                                        matchLabels:
+                                          additionalProperties:
+                                            type: string
+                                          description: matchLabels is a map of {key,value}
+                                            pairs. A single {key,value} in the matchLabels
+                                            map is equivalent to an element of matchExpressions,
+                                            whose key field is "key", the operator
+                                            is "In", and the values array contains
+                                            only "value". The requirements are ANDed.
+                                          type: object
+                                      type: object
+                                    namespaceSelector:
+                                      description: A label query over the set of namespaces
+                                        that the term applies to. The term is applied
+                                        to the union of the namespaces selected by
+                                        this field and the ones listed in the namespaces
+                                        field. null selector and null or empty namespaces
+                                        list means "this pod's namespace". An empty
+                                        selector ({}) matches all namespaces.
+                                      properties:
+                                        matchExpressions:
+                                          description: matchExpressions is a list
+                                            of label selector requirements. The requirements
+                                            are ANDed.
+                                          items:
+                                            description: A label selector requirement
+                                              is a selector that contains values,
+                                              a key, and an operator that relates
+                                              the key and values.
+                                            properties:
+                                              key:
+                                                description: key is the label key
+                                                  that the selector applies to.
+                                                type: string
+                                              operator:
+                                                description: operator represents a
+                                                  key's relationship to a set of values.
+                                                  Valid operators are In, NotIn, Exists
+                                                  and DoesNotExist.
+                                                type: string
+                                              values:
+                                                description: values is an array of
+                                                  string values. If the operator is
+                                                  In or NotIn, the values array must
+                                                  be non-empty. If the operator is
+                                                  Exists or DoesNotExist, the values
+                                                  array must be empty. This array
+                                                  is replaced during a strategic merge
+                                                  patch.
+                                                items:
+                                                  type: string
+                                                type: array
+                                            required:
+                                            - key
+                                            - operator
+                                            type: object
+                                          type: array
+                                        matchLabels:
+                                          additionalProperties:
+                                            type: string
+                                          description: matchLabels is a map of {key,value}
+                                            pairs. A single {key,value} in the matchLabels
+                                            map is equivalent to an element of matchExpressions,
+                                            whose key field is "key", the operator
+                                            is "In", and the values array contains
+                                            only "value". The requirements are ANDed.
+                                          type: object
+                                      type: object
+                                    namespaces:
+                                      description: namespaces specifies a static list
+                                        of namespace names that the term applies to.
+                                        The term is applied to the union of the namespaces
+                                        listed in this field and the ones selected
+                                        by namespaceSelector. null or empty namespaces
+                                        list and null namespaceSelector means "this
+                                        pod's namespace".
+                                      items:
+                                        type: string
+                                      type: array
+                                    topologyKey:
+                                      description: This pod should be co-located (affinity)
+                                        or not co-located (anti-affinity) with the
+                                        pods matching the labelSelector in the specified
+                                        namespaces, where co-located is defined as
+                                        running on a node whose value of the label
+                                        with key topologyKey matches that of any node
+                                        on which any of the selected pods is running.
+                                        Empty topologyKey is not allowed.
+                                      type: string
+                                  required:
+                                  - topologyKey
+                                  type: object
+                                weight:
+                                  description: weight associated with matching the
+                                    corresponding podAffinityTerm, in the range 1-100.
+                                  format: int32
+                                  type: integer
+                              required:
+                              - podAffinityTerm
+                              - weight
+                              type: object
+                            type: array
+                          requiredDuringSchedulingIgnoredDuringExecution:
+                            description: If the affinity requirements specified by
+                              this field are not met at scheduling time, the pod will
+                              not be scheduled onto the node. If the affinity requirements
+                              specified by this field cease to be met at some point
+                              during pod execution (e.g. due to a pod label update),
+                              the system may or may not try to eventually evict the
+                              pod from its node. When there are multiple elements,
+                              the lists of nodes corresponding to each podAffinityTerm
+                              are intersected, i.e. all terms must be satisfied.
+                            items:
+                              description: Defines a set of pods (namely those matching
+                                the labelSelector relative to the given namespace(s))
+                                that this pod should be co-located (affinity) or not
+                                co-located (anti-affinity) with, where co-located
+                                is defined as running on a node whose value of the
+                                label with key <topologyKey> matches that of any node
+                                on which a pod of the set of pods is running
+                              properties:
+                                labelSelector:
+                                  description: A label query over a set of resources,
+                                    in this case pods.
+                                  properties:
+                                    matchExpressions:
+                                      description: matchExpressions is a list of label
+                                        selector requirements. The requirements are
+                                        ANDed.
+                                      items:
+                                        description: A label selector requirement
+                                          is a selector that contains values, a key,
+                                          and an operator that relates the key and
+                                          values.
+                                        properties:
+                                          key:
+                                            description: key is the label key that
+                                              the selector applies to.
+                                            type: string
+                                          operator:
+                                            description: operator represents a key's
+                                              relationship to a set of values. Valid
+                                              operators are In, NotIn, Exists and
+                                              DoesNotExist.
+                                            type: string
+                                          values:
+                                            description: values is an array of string
+                                              values. If the operator is In or NotIn,
+                                              the values array must be non-empty.
+                                              If the operator is Exists or DoesNotExist,
+                                              the values array must be empty. This
+                                              array is replaced during a strategic
+                                              merge patch.
+                                            items:
+                                              type: string
+                                            type: array
+                                        required:
+                                        - key
+                                        - operator
+                                        type: object
+                                      type: array
+                                    matchLabels:
+                                      additionalProperties:
+                                        type: string
+                                      description: matchLabels is a map of {key,value}
+                                        pairs. A single {key,value} in the matchLabels
+                                        map is equivalent to an element of matchExpressions,
+                                        whose key field is "key", the operator is
+                                        "In", and the values array contains only "value".
+                                        The requirements are ANDed.
+                                      type: object
+                                  type: object
+                                namespaceSelector:
+                                  description: A label query over the set of namespaces
+                                    that the term applies to. The term is applied
+                                    to the union of the namespaces selected by this
+                                    field and the ones listed in the namespaces field.
+                                    null selector and null or empty namespaces list
+                                    means "this pod's namespace". An empty selector
+                                    ({}) matches all namespaces.
+                                  properties:
+                                    matchExpressions:
+                                      description: matchExpressions is a list of label
+                                        selector requirements. The requirements are
+                                        ANDed.
+                                      items:
+                                        description: A label selector requirement
+                                          is a selector that contains values, a key,
+                                          and an operator that relates the key and
+                                          values.
+                                        properties:
+                                          key:
+                                            description: key is the label key that
+                                              the selector applies to.
+                                            type: string
+                                          operator:
+                                            description: operator represents a key's
+                                              relationship to a set of values. Valid
+                                              operators are In, NotIn, Exists and
+                                              DoesNotExist.
+                                            type: string
+                                          values:
+                                            description: values is an array of string
+                                              values. If the operator is In or NotIn,
+                                              the values array must be non-empty.
+                                              If the operator is Exists or DoesNotExist,
+                                              the values array must be empty. This
+                                              array is replaced during a strategic
+                                              merge patch.
+                                            items:
+                                              type: string
+                                            type: array
+                                        required:
+                                        - key
+                                        - operator
+                                        type: object
+                                      type: array
+                                    matchLabels:
+                                      additionalProperties:
+                                        type: string
+                                      description: matchLabels is a map of {key,value}
+                                        pairs. A single {key,value} in the matchLabels
+                                        map is equivalent to an element of matchExpressions,
+                                        whose key field is "key", the operator is
+                                        "In", and the values array contains only "value".
+                                        The requirements are ANDed.
+                                      type: object
+                                  type: object
+                                namespaces:
+                                  description: namespaces specifies a static list
+                                    of namespace names that the term applies to. The
+                                    term is applied to the union of the namespaces
+                                    listed in this field and the ones selected by
+                                    namespaceSelector. null or empty namespaces list
+                                    and null namespaceSelector means "this pod's namespace".
+                                  items:
+                                    type: string
+                                  type: array
+                                topologyKey:
+                                  description: This pod should be co-located (affinity)
+                                    or not co-located (anti-affinity) with the pods
+                                    matching the labelSelector in the specified namespaces,
+                                    where co-located is defined as running on a node
+                                    whose value of the label with key topologyKey
+                                    matches that of any node on which any of the selected
+                                    pods is running. Empty topologyKey is not allowed.
+                                  type: string
+                              required:
+                              - topologyKey
+                              type: object
+                            type: array
+                        type: object
+                      podAntiAffinity:
+                        description: Describes pod anti-affinity scheduling rules
+                          (e.g. avoid putting this pod in the same node, zone, etc.
+                          as some other pod(s)).
+                        properties:
+                          preferredDuringSchedulingIgnoredDuringExecution:
+                            description: The scheduler will prefer to schedule pods
+                              to nodes that satisfy the anti-affinity expressions
+                              specified by this field, but it may choose a node that
+                              violates one or more of the expressions. The node that
+                              is most preferred is the one with the greatest sum of
+                              weights, i.e. for each node that meets all of the scheduling
+                              requirements (resource request, requiredDuringScheduling
+                              anti-affinity expressions, etc.), compute a sum by iterating
+                              through the elements of this field and adding "weight"
+                              to the sum if the node has pods which matches the corresponding
+                              podAffinityTerm; the node(s) with the highest sum are
+                              the most preferred.
+                            items:
+                              description: The weights of all of the matched WeightedPodAffinityTerm
+                                fields are added per-node to find the most preferred
+                                node(s)
+                              properties:
+                                podAffinityTerm:
+                                  description: Required. A pod affinity term, associated
+                                    with the corresponding weight.
+                                  properties:
+                                    labelSelector:
+                                      description: A label query over a set of resources,
+                                        in this case pods.
+                                      properties:
+                                        matchExpressions:
+                                          description: matchExpressions is a list
+                                            of label selector requirements. The requirements
+                                            are ANDed.
+                                          items:
+                                            description: A label selector requirement
+                                              is a selector that contains values,
+                                              a key, and an operator that relates
+                                              the key and values.
+                                            properties:
+                                              key:
+                                                description: key is the label key
+                                                  that the selector applies to.
+                                                type: string
+                                              operator:
+                                                description: operator represents a
+                                                  key's relationship to a set of values.
+                                                  Valid operators are In, NotIn, Exists
+                                                  and DoesNotExist.
+                                                type: string
+                                              values:
+                                                description: values is an array of
+                                                  string values. If the operator is
+                                                  In or NotIn, the values array must
+                                                  be non-empty. If the operator is
+                                                  Exists or DoesNotExist, the values
+                                                  array must be empty. This array
+                                                  is replaced during a strategic merge
+                                                  patch.
+                                                items:
+                                                  type: string
+                                                type: array
+                                            required:
+                                            - key
+                                            - operator
+                                            type: object
+                                          type: array
+                                        matchLabels:
+                                          additionalProperties:
+                                            type: string
+                                          description: matchLabels is a map of {key,value}
+                                            pairs. A single {key,value} in the matchLabels
+                                            map is equivalent to an element of matchExpressions,
+                                            whose key field is "key", the operator
+                                            is "In", and the values array contains
+                                            only "value". The requirements are ANDed.
+                                          type: object
+                                      type: object
+                                    namespaceSelector:
+                                      description: A label query over the set of namespaces
+                                        that the term applies to. The term is applied
+                                        to the union of the namespaces selected by
+                                        this field and the ones listed in the namespaces
+                                        field. null selector and null or empty namespaces
+                                        list means "this pod's namespace". An empty
+                                        selector ({}) matches all namespaces.
+                                      properties:
+                                        matchExpressions:
+                                          description: matchExpressions is a list
+                                            of label selector requirements. The requirements
+                                            are ANDed.
+                                          items:
+                                            description: A label selector requirement
+                                              is a selector that contains values,
+                                              a key, and an operator that relates
+                                              the key and values.
+                                            properties:
+                                              key:
+                                                description: key is the label key
+                                                  that the selector applies to.
+                                                type: string
+                                              operator:
+                                                description: operator represents a
+                                                  key's relationship to a set of values.
+                                                  Valid operators are In, NotIn, Exists
+                                                  and DoesNotExist.
+                                                type: string
+                                              values:
+                                                description: values is an array of
+                                                  string values. If the operator is
+                                                  In or NotIn, the values array must
+                                                  be non-empty. If the operator is
+                                                  Exists or DoesNotExist, the values
+                                                  array must be empty. This array
+                                                  is replaced during a strategic merge
+                                                  patch.
+                                                items:
+                                                  type: string
+                                                type: array
+                                            required:
+                                            - key
+                                            - operator
+                                            type: object
+                                          type: array
+                                        matchLabels:
+                                          additionalProperties:
+                                            type: string
+                                          description: matchLabels is a map of {key,value}
+                                            pairs. A single {key,value} in the matchLabels
+                                            map is equivalent to an element of matchExpressions,
+                                            whose key field is "key", the operator
+                                            is "In", and the values array contains
+                                            only "value". The requirements are ANDed.
+                                          type: object
+                                      type: object
+                                    namespaces:
+                                      description: namespaces specifies a static list
+                                        of namespace names that the term applies to.
+                                        The term is applied to the union of the namespaces
+                                        listed in this field and the ones selected
+                                        by namespaceSelector. null or empty namespaces
+                                        list and null namespaceSelector means "this
+                                        pod's namespace".
+                                      items:
+                                        type: string
+                                      type: array
+                                    topologyKey:
+                                      description: This pod should be co-located (affinity)
+                                        or not co-located (anti-affinity) with the
+                                        pods matching the labelSelector in the specified
+                                        namespaces, where co-located is defined as
+                                        running on a node whose value of the label
+                                        with key topologyKey matches that of any node
+                                        on which any of the selected pods is running.
+                                        Empty topologyKey is not allowed.
+                                      type: string
+                                  required:
+                                  - topologyKey
+                                  type: object
+                                weight:
+                                  description: weight associated with matching the
+                                    corresponding podAffinityTerm, in the range 1-100.
+                                  format: int32
+                                  type: integer
+                              required:
+                              - podAffinityTerm
+                              - weight
+                              type: object
+                            type: array
+                          requiredDuringSchedulingIgnoredDuringExecution:
+                            description: If the anti-affinity requirements specified
+                              by this field are not met at scheduling time, the pod
+                              will not be scheduled onto the node. If the anti-affinity
+                              requirements specified by this field cease to be met
+                              at some point during pod execution (e.g. due to a pod
+                              label update), the system may or may not try to eventually
+                              evict the pod from its node. When there are multiple
+                              elements, the lists of nodes corresponding to each podAffinityTerm
+                              are intersected, i.e. all terms must be satisfied.
+                            items:
+                              description: Defines a set of pods (namely those matching
+                                the labelSelector relative to the given namespace(s))
+                                that this pod should be co-located (affinity) or not
+                                co-located (anti-affinity) with, where co-located
+                                is defined as running on a node whose value of the
+                                label with key <topologyKey> matches that of any node
+                                on which a pod of the set of pods is running
+                              properties:
+                                labelSelector:
+                                  description: A label query over a set of resources,
+                                    in this case pods.
+                                  properties:
+                                    matchExpressions:
+                                      description: matchExpressions is a list of label
+                                        selector requirements. The requirements are
+                                        ANDed.
+                                      items:
+                                        description: A label selector requirement
+                                          is a selector that contains values, a key,
+                                          and an operator that relates the key and
+                                          values.
+                                        properties:
+                                          key:
+                                            description: key is the label key that
+                                              the selector applies to.
+                                            type: string
+                                          operator:
+                                            description: operator represents a key's
+                                              relationship to a set of values. Valid
+                                              operators are In, NotIn, Exists and
+                                              DoesNotExist.
+                                            type: string
+                                          values:
+                                            description: values is an array of string
+                                              values. If the operator is In or NotIn,
+                                              the values array must be non-empty.
+                                              If the operator is Exists or DoesNotExist,
+                                              the values array must be empty. This
+                                              array is replaced during a strategic
+                                              merge patch.
+                                            items:
+                                              type: string
+                                            type: array
+                                        required:
+                                        - key
+                                        - operator
+                                        type: object
+                                      type: array
+                                    matchLabels:
+                                      additionalProperties:
+                                        type: string
+                                      description: matchLabels is a map of {key,value}
+                                        pairs. A single {key,value} in the matchLabels
+                                        map is equivalent to an element of matchExpressions,
+                                        whose key field is "key", the operator is
+                                        "In", and the values array contains only "value".
+                                        The requirements are ANDed.
+                                      type: object
+                                  type: object
+                                namespaceSelector:
+                                  description: A label query over the set of namespaces
+                                    that the term applies to. The term is applied
+                                    to the union of the namespaces selected by this
+                                    field and the ones listed in the namespaces field.
+                                    null selector and null or empty namespaces list
+                                    means "this pod's namespace". An empty selector
+                                    ({}) matches all namespaces.
+                                  properties:
+                                    matchExpressions:
+                                      description: matchExpressions is a list of label
+                                        selector requirements. The requirements are
+                                        ANDed.
+                                      items:
+                                        description: A label selector requirement
+                                          is a selector that contains values, a key,
+                                          and an operator that relates the key and
+                                          values.
+                                        properties:
+                                          key:
+                                            description: key is the label key that
+                                              the selector applies to.
+                                            type: string
+                                          operator:
+                                            description: operator represents a key's
+                                              relationship to a set of values. Valid
+                                              operators are In, NotIn, Exists and
+                                              DoesNotExist.
+                                            type: string
+                                          values:
+                                            description: values is an array of string
+                                              values. If the operator is In or NotIn,
+                                              the values array must be non-empty.
+                                              If the operator is Exists or DoesNotExist,
+                                              the values array must be empty. This
+                                              array is replaced during a strategic
+                                              merge patch.
+                                            items:
+                                              type: string
+                                            type: array
+                                        required:
+                                        - key
+                                        - operator
+                                        type: object
+                                      type: array
+                                    matchLabels:
+                                      additionalProperties:
+                                        type: string
+                                      description: matchLabels is a map of {key,value}
+                                        pairs. A single {key,value} in the matchLabels
+                                        map is equivalent to an element of matchExpressions,
+                                        whose key field is "key", the operator is
+                                        "In", and the values array contains only "value".
+                                        The requirements are ANDed.
+                                      type: object
+                                  type: object
+                                namespaces:
+                                  description: namespaces specifies a static list
+                                    of namespace names that the term applies to. The
+                                    term is applied to the union of the namespaces
+                                    listed in this field and the ones selected by
+                                    namespaceSelector. null or empty namespaces list
+                                    and null namespaceSelector means "this pod's namespace".
+                                  items:
+                                    type: string
+                                  type: array
+                                topologyKey:
+                                  description: This pod should be co-located (affinity)
+                                    or not co-located (anti-affinity) with the pods
+                                    matching the labelSelector in the specified namespaces,
+                                    where co-located is defined as running on a node
+                                    whose value of the label with key topologyKey
+                                    matches that of any node on which any of the selected
+                                    pods is running. Empty topologyKey is not allowed.
+                                  type: string
+                              required:
+                              - topologyKey
+                              type: object
+                            type: array
+                        type: object
+                    type: object
+                  containers:
+                    items:
+                      description: A single application container that you want to
+                        run within a pod.
+                      properties:
+                        args:
+                          description: 'Arguments to the entrypoint. The container
+                            image''s CMD is used if this is not provided. Variable
+                            references $(VAR_NAME) are expanded using the container''s
+                            environment. If a variable cannot be resolved, the reference
+                            in the input string will be unchanged. Double $$ are reduced
+                            to a single $, which allows for escaping the $(VAR_NAME)
+                            syntax: i.e. "$$(VAR_NAME)" will produce the string literal
+                            "$(VAR_NAME)". Escaped references will never be expanded,
+                            regardless of whether the variable exists or not. Cannot
+                            be updated. More info: https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell'
+                          items:
+                            type: string
+                          type: array
+                        command:
+                          description: 'Entrypoint array. Not executed within a shell.
+                            The container image''s ENTRYPOINT is used if this is not
+                            provided. Variable references $(VAR_NAME) are expanded
+                            using the container''s environment. If a variable cannot
+                            be resolved, the reference in the input string will be
+                            unchanged. Double $$ are reduced to a single $, which
+                            allows for escaping the $(VAR_NAME) syntax: i.e. "$$(VAR_NAME)"
+                            will produce the string literal "$(VAR_NAME)". Escaped
+                            references will never be expanded, regardless of whether
+                            the variable exists or not. Cannot be updated. More info:
+                            https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell'
+                          items:
+                            type: string
+                          type: array
+                        env:
+                          description: List of environment variables to set in the
+                            container. Cannot be updated.
+                          items:
+                            description: EnvVar represents an environment variable
+                              present in a Container.
+                            properties:
+                              name:
+                                description: Name of the environment variable. Must
+                                  be a C_IDENTIFIER.
+                                type: string
+                              value:
+                                description: 'Variable references $(VAR_NAME) are
+                                  expanded using the previously defined environment
+                                  variables in the container and any service environment
+                                  variables. If a variable cannot be resolved, the
+                                  reference in the input string will be unchanged.
+                                  Double $$ are reduced to a single $, which allows
+                                  for escaping the $(VAR_NAME) syntax: i.e. "$$(VAR_NAME)"
+                                  will produce the string literal "$(VAR_NAME)". Escaped
+                                  references will never be expanded, regardless of
+                                  whether the variable exists or not. Defaults to
+                                  "".'
+                                type: string
+                              valueFrom:
+                                description: Source for the environment variable's
+                                  value. Cannot be used if value is not empty.
+                                properties:
+                                  configMapKeyRef:
+                                    description: Selects a key of a ConfigMap.
+                                    properties:
+                                      key:
+                                        description: The key to select.
+                                        type: string
+                                      name:
+                                        description: 'Name of the referent. More info:
+                                          https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                          TODO: Add other useful fields. apiVersion,
+                                          kind, uid?'
+                                        type: string
+                                      optional:
+                                        description: Specify whether the ConfigMap
+                                          or its key must be defined
+                                        type: boolean
+                                    required:
+                                    - key
+                                    type: object
+                                  fieldRef:
+                                    description: 'Selects a field of the pod: supports
+                                      metadata.name, metadata.namespace, `metadata.labels[''<KEY>'']`,
+                                      `metadata.annotations[''<KEY>'']`, spec.nodeName,
+                                      spec.serviceAccountName, status.hostIP, status.podIP,
+                                      status.podIPs.'
+                                    properties:
+                                      apiVersion:
+                                        description: Version of the schema the FieldPath
+                                          is written in terms of, defaults to "v1".
+                                        type: string
+                                      fieldPath:
+                                        description: Path of the field to select in
+                                          the specified API version.
+                                        type: string
+                                    required:
+                                    - fieldPath
+                                    type: object
+                                  resourceFieldRef:
+                                    description: 'Selects a resource of the container:
+                                      only resources limits and requests (limits.cpu,
+                                      limits.memory, limits.ephemeral-storage, requests.cpu,
+                                      requests.memory and requests.ephemeral-storage)
+                                      are currently supported.'
+                                    properties:
+                                      containerName:
+                                        description: 'Container name: required for
+                                          volumes, optional for env vars'
+                                        type: string
+                                      divisor:
+                                        anyOf:
+                                        - type: integer
+                                        - type: string
+                                        description: Specifies the output format of
+                                          the exposed resources, defaults to "1"
+                                        pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                        x-kubernetes-int-or-string: true
+                                      resource:
+                                        description: 'Required: resource to select'
+                                        type: string
+                                    required:
+                                    - resource
+                                    type: object
+                                  secretKeyRef:
+                                    description: Selects a key of a secret in the
+                                      pod's namespace
+                                    properties:
+                                      key:
+                                        description: The key of the secret to select
+                                          from.  Must be a valid secret key.
+                                        type: string
+                                      name:
+                                        description: 'Name of the referent. More info:
+                                          https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                          TODO: Add other useful fields. apiVersion,
+                                          kind, uid?'
+                                        type: string
+                                      optional:
+                                        description: Specify whether the Secret or
+                                          its key must be defined
+                                        type: boolean
+                                    required:
+                                    - key
+                                    type: object
+                                type: object
+                            required:
+                            - name
+                            type: object
+                          type: array
+                        envFrom:
+                          description: List of sources to populate environment variables
+                            in the container. The keys defined within a source must
+                            be a C_IDENTIFIER. All invalid keys will be reported as
+                            an event when the container is starting. When a key exists
+                            in multiple sources, the value associated with the last
+                            source will take precedence. Values defined by an Env
+                            with a duplicate key will take precedence. Cannot be updated.
+                          items:
+                            description: EnvFromSource represents the source of a
+                              set of ConfigMaps
+                            properties:
+                              configMapRef:
+                                description: The ConfigMap to select from
+                                properties:
+                                  name:
+                                    description: 'Name of the referent. More info:
+                                      https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                      TODO: Add other useful fields. apiVersion, kind,
+                                      uid?'
+                                    type: string
+                                  optional:
+                                    description: Specify whether the ConfigMap must
+                                      be defined
+                                    type: boolean
+                                type: object
+                              prefix:
+                                description: An optional identifier to prepend to
+                                  each key in the ConfigMap. Must be a C_IDENTIFIER.
+                                type: string
+                              secretRef:
+                                description: The Secret to select from
+                                properties:
+                                  name:
+                                    description: 'Name of the referent. More info:
+                                      https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                      TODO: Add other useful fields. apiVersion, kind,
+                                      uid?'
+                                    type: string
+                                  optional:
+                                    description: Specify whether the Secret must be
+                                      defined
+                                    type: boolean
+                                type: object
+                            type: object
+                          type: array
+                        image:
+                          description: 'Container image name. More info: https://kubernetes.io/docs/concepts/containers/images
+                            This field is optional to allow higher level config management
+                            to default or override container images in workload controllers
+                            like Deployments and StatefulSets.'
+                          type: string
+                        imagePullPolicy:
+                          description: 'Image pull policy. One of Always, Never, IfNotPresent.
+                            Defaults to Always if :latest tag is specified, or IfNotPresent
+                            otherwise. Cannot be updated. More info: https://kubernetes.io/docs/concepts/containers/images#updating-images'
+                          type: string
+                        lifecycle:
+                          description: Actions that the management system should take
+                            in response to container lifecycle events. Cannot be updated.
+                          properties:
+                            postStart:
+                              description: 'PostStart is called immediately after
+                                a container is created. If the handler fails, the
+                                container is terminated and restarted according to
+                                its restart policy. Other management of the container
+                                blocks until the hook completes. More info: https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/#container-hooks'
+                              properties:
+                                exec:
+                                  description: Exec specifies the action to take.
+                                  properties:
+                                    command:
+                                      description: Command is the command line to
+                                        execute inside the container, the working
+                                        directory for the command  is root ('/') in
+                                        the container's filesystem. The command is
+                                        simply exec'd, it is not run inside a shell,
+                                        so traditional shell instructions ('|', etc)
+                                        won't work. To use a shell, you need to explicitly
+                                        call out to that shell. Exit status of 0 is
+                                        treated as live/healthy and non-zero is unhealthy.
+                                      items:
+                                        type: string
+                                      type: array
+                                  type: object
+                                httpGet:
+                                  description: HTTPGet specifies the http request
+                                    to perform.
+                                  properties:
+                                    host:
+                                      description: Host name to connect to, defaults
+                                        to the pod IP. You probably want to set "Host"
+                                        in httpHeaders instead.
+                                      type: string
+                                    httpHeaders:
+                                      description: Custom headers to set in the request.
+                                        HTTP allows repeated headers.
+                                      items:
+                                        description: HTTPHeader describes a custom
+                                          header to be used in HTTP probes
+                                        properties:
+                                          name:
+                                            description: The header field name
+                                            type: string
+                                          value:
+                                            description: The header field value
+                                            type: string
+                                        required:
+                                        - name
+                                        - value
+                                        type: object
+                                      type: array
+                                    path:
+                                      description: Path to access on the HTTP server.
+                                      type: string
+                                    port:
+                                      anyOf:
+                                      - type: integer
+                                      - type: string
+                                      description: Name or number of the port to access
+                                        on the container. Number must be in the range
+                                        1 to 65535. Name must be an IANA_SVC_NAME.
+                                      x-kubernetes-int-or-string: true
+                                    scheme:
+                                      description: Scheme to use for connecting to
+                                        the host. Defaults to HTTP.
+                                      type: string
+                                  required:
+                                  - port
+                                  type: object
+                                tcpSocket:
+                                  description: Deprecated. TCPSocket is NOT supported
+                                    as a LifecycleHandler and kept for the backward
+                                    compatibility. There are no validation of this
+                                    field and lifecycle hooks will fail in runtime
+                                    when tcp handler is specified.
+                                  properties:
+                                    host:
+                                      description: 'Optional: Host name to connect
+                                        to, defaults to the pod IP.'
+                                      type: string
+                                    port:
+                                      anyOf:
+                                      - type: integer
+                                      - type: string
+                                      description: Number or name of the port to access
+                                        on the container. Number must be in the range
+                                        1 to 65535. Name must be an IANA_SVC_NAME.
+                                      x-kubernetes-int-or-string: true
+                                  required:
+                                  - port
+                                  type: object
+                              type: object
+                            preStop:
+                              description: 'PreStop is called immediately before a
+                                container is terminated due to an API request or management
+                                event such as liveness/startup probe failure, preemption,
+                                resource contention, etc. The handler is not called
+                                if the container crashes or exits. The Pod''s termination
+                                grace period countdown begins before the PreStop hook
+                                is executed. Regardless of the outcome of the handler,
+                                the container will eventually terminate within the
+                                Pod''s termination grace period (unless delayed by
+                                finalizers). Other management of the container blocks
+                                until the hook completes or until the termination
+                                grace period is reached. More info: https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/#container-hooks'
+                              properties:
+                                exec:
+                                  description: Exec specifies the action to take.
+                                  properties:
+                                    command:
+                                      description: Command is the command line to
+                                        execute inside the container, the working
+                                        directory for the command  is root ('/') in
+                                        the container's filesystem. The command is
+                                        simply exec'd, it is not run inside a shell,
+                                        so traditional shell instructions ('|', etc)
+                                        won't work. To use a shell, you need to explicitly
+                                        call out to that shell. Exit status of 0 is
+                                        treated as live/healthy and non-zero is unhealthy.
+                                      items:
+                                        type: string
+                                      type: array
+                                  type: object
+                                httpGet:
+                                  description: HTTPGet specifies the http request
+                                    to perform.
+                                  properties:
+                                    host:
+                                      description: Host name to connect to, defaults
+                                        to the pod IP. You probably want to set "Host"
+                                        in httpHeaders instead.
+                                      type: string
+                                    httpHeaders:
+                                      description: Custom headers to set in the request.
+                                        HTTP allows repeated headers.
+                                      items:
+                                        description: HTTPHeader describes a custom
+                                          header to be used in HTTP probes
+                                        properties:
+                                          name:
+                                            description: The header field name
+                                            type: string
+                                          value:
+                                            description: The header field value
+                                            type: string
+                                        required:
+                                        - name
+                                        - value
+                                        type: object
+                                      type: array
+                                    path:
+                                      description: Path to access on the HTTP server.
+                                      type: string
+                                    port:
+                                      anyOf:
+                                      - type: integer
+                                      - type: string
+                                      description: Name or number of the port to access
+                                        on the container. Number must be in the range
+                                        1 to 65535. Name must be an IANA_SVC_NAME.
+                                      x-kubernetes-int-or-string: true
+                                    scheme:
+                                      description: Scheme to use for connecting to
+                                        the host. Defaults to HTTP.
+                                      type: string
+                                  required:
+                                  - port
+                                  type: object
+                                tcpSocket:
+                                  description: Deprecated. TCPSocket is NOT supported
+                                    as a LifecycleHandler and kept for the backward
+                                    compatibility. There are no validation of this
+                                    field and lifecycle hooks will fail in runtime
+                                    when tcp handler is specified.
+                                  properties:
+                                    host:
+                                      description: 'Optional: Host name to connect
+                                        to, defaults to the pod IP.'
+                                      type: string
+                                    port:
+                                      anyOf:
+                                      - type: integer
+                                      - type: string
+                                      description: Number or name of the port to access
+                                        on the container. Number must be in the range
+                                        1 to 65535. Name must be an IANA_SVC_NAME.
+                                      x-kubernetes-int-or-string: true
+                                  required:
+                                  - port
+                                  type: object
+                              type: object
+                          type: object
+                        livenessProbe:
+                          description: 'Periodic probe of container liveness. Container
+                            will be restarted if the probe fails. Cannot be updated.
+                            More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                          properties:
+                            exec:
+                              description: Exec specifies the action to take.
+                              properties:
+                                command:
+                                  description: Command is the command line to execute
+                                    inside the container, the working directory for
+                                    the command  is root ('/') in the container's
+                                    filesystem. The command is simply exec'd, it is
+                                    not run inside a shell, so traditional shell instructions
+                                    ('|', etc) won't work. To use a shell, you need
+                                    to explicitly call out to that shell. Exit status
+                                    of 0 is treated as live/healthy and non-zero is
+                                    unhealthy.
+                                  items:
+                                    type: string
+                                  type: array
+                              type: object
+                            failureThreshold:
+                              description: Minimum consecutive failures for the probe
+                                to be considered failed after having succeeded. Defaults
+                                to 3. Minimum value is 1.
+                              format: int32
+                              type: integer
+                            grpc:
+                              description: GRPC specifies an action involving a GRPC
+                                port. This is a beta field and requires enabling GRPCContainerProbe
+                                feature gate.
+                              properties:
+                                port:
+                                  description: Port number of the gRPC service. Number
+                                    must be in the range 1 to 65535.
+                                  format: int32
+                                  type: integer
+                                service:
+                                  description: "Service is the name of the service
+                                    to place in the gRPC HealthCheckRequest (see https://github.com/grpc/grpc/blob/master/doc/health-checking.md).
+                                    \n If this is not specified, the default behavior
+                                    is defined by gRPC."
+                                  type: string
+                              required:
+                              - port
+                              type: object
+                            httpGet:
+                              description: HTTPGet specifies the http request to perform.
+                              properties:
+                                host:
+                                  description: Host name to connect to, defaults to
+                                    the pod IP. You probably want to set "Host" in
+                                    httpHeaders instead.
+                                  type: string
+                                httpHeaders:
+                                  description: Custom headers to set in the request.
+                                    HTTP allows repeated headers.
+                                  items:
+                                    description: HTTPHeader describes a custom header
+                                      to be used in HTTP probes
+                                    properties:
+                                      name:
+                                        description: The header field name
+                                        type: string
+                                      value:
+                                        description: The header field value
+                                        type: string
+                                    required:
+                                    - name
+                                    - value
+                                    type: object
+                                  type: array
+                                path:
+                                  description: Path to access on the HTTP server.
+                                  type: string
+                                port:
+                                  anyOf:
+                                  - type: integer
+                                  - type: string
+                                  description: Name or number of the port to access
+                                    on the container. Number must be in the range
+                                    1 to 65535. Name must be an IANA_SVC_NAME.
+                                  x-kubernetes-int-or-string: true
+                                scheme:
+                                  description: Scheme to use for connecting to the
+                                    host. Defaults to HTTP.
+                                  type: string
+                              required:
+                              - port
+                              type: object
+                            initialDelaySeconds:
+                              description: 'Number of seconds after the container
+                                has started before liveness probes are initiated.
+                                More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                              format: int32
+                              type: integer
+                            periodSeconds:
+                              description: How often (in seconds) to perform the probe.
+                                Default to 10 seconds. Minimum value is 1.
+                              format: int32
+                              type: integer
+                            successThreshold:
+                              description: Minimum consecutive successes for the probe
+                                to be considered successful after having failed. Defaults
+                                to 1. Must be 1 for liveness and startup. Minimum
+                                value is 1.
+                              format: int32
+                              type: integer
+                            tcpSocket:
+                              description: TCPSocket specifies an action involving
+                                a TCP port.
+                              properties:
+                                host:
+                                  description: 'Optional: Host name to connect to,
+                                    defaults to the pod IP.'
+                                  type: string
+                                port:
+                                  anyOf:
+                                  - type: integer
+                                  - type: string
+                                  description: Number or name of the port to access
+                                    on the container. Number must be in the range
+                                    1 to 65535. Name must be an IANA_SVC_NAME.
+                                  x-kubernetes-int-or-string: true
+                              required:
+                              - port
+                              type: object
+                            terminationGracePeriodSeconds:
+                              description: Optional duration in seconds the pod needs
+                                to terminate gracefully upon probe failure. The grace
+                                period is the duration in seconds after the processes
+                                running in the pod are sent a termination signal and
+                                the time when the processes are forcibly halted with
+                                a kill signal. Set this value longer than the expected
+                                cleanup time for your process. If this value is nil,
+                                the pod's terminationGracePeriodSeconds will be used.
+                                Otherwise, this value overrides the value provided
+                                by the pod spec. Value must be non-negative integer.
+                                The value zero indicates stop immediately via the
+                                kill signal (no opportunity to shut down). This is
+                                a beta field and requires enabling ProbeTerminationGracePeriod
+                                feature gate. Minimum value is 1. spec.terminationGracePeriodSeconds
+                                is used if unset.
+                              format: int64
+                              type: integer
+                            timeoutSeconds:
+                              description: 'Number of seconds after which the probe
+                                times out. Defaults to 1 second. Minimum value is
+                                1. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                              format: int32
+                              type: integer
+                          type: object
+                        name:
+                          description: Name of the container specified as a DNS_LABEL.
+                            Each container in a pod must have a unique name (DNS_LABEL).
+                            Cannot be updated.
+                          type: string
+                        ports:
+                          description: List of ports to expose from the container.
+                            Not specifying a port here DOES NOT prevent that port
+                            from being exposed. Any port which is listening on the
+                            default "0.0.0.0" address inside a container will be accessible
+                            from the network. Modifying this array with strategic
+                            merge patch may corrupt the data. For more information
+                            See https://github.com/kubernetes/kubernetes/issues/108255.
+                            Cannot be updated.
+                          items:
+                            description: ContainerPort represents a network port in
+                              a single container.
+                            properties:
+                              containerPort:
+                                description: Number of port to expose on the pod's
+                                  IP address. This must be a valid port number, 0
+                                  < x < 65536.
+                                format: int32
+                                type: integer
+                              hostIP:
+                                description: What host IP to bind the external port
+                                  to.
+                                type: string
+                              hostPort:
+                                description: Number of port to expose on the host.
+                                  If specified, this must be a valid port number,
+                                  0 < x < 65536. If HostNetwork is specified, this
+                                  must match ContainerPort. Most containers do not
+                                  need this.
+                                format: int32
+                                type: integer
+                              name:
+                                description: If specified, this must be an IANA_SVC_NAME
+                                  and unique within the pod. Each named port in a
+                                  pod must have a unique name. Name for the port that
+                                  can be referred to by services.
+                                type: string
+                              protocol:
+                                default: TCP
+                                description: Protocol for port. Must be UDP, TCP,
+                                  or SCTP. Defaults to "TCP".
+                                type: string
+                            required:
+                            - containerPort
+                            type: object
+                          type: array
+                          x-kubernetes-list-map-keys:
+                          - containerPort
+                          - protocol
+                          x-kubernetes-list-type: map
+                        readinessProbe:
+                          description: 'Periodic probe of container service readiness.
+                            Container will be removed from service endpoints if the
+                            probe fails. Cannot be updated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                          properties:
+                            exec:
+                              description: Exec specifies the action to take.
+                              properties:
+                                command:
+                                  description: Command is the command line to execute
+                                    inside the container, the working directory for
+                                    the command  is root ('/') in the container's
+                                    filesystem. The command is simply exec'd, it is
+                                    not run inside a shell, so traditional shell instructions
+                                    ('|', etc) won't work. To use a shell, you need
+                                    to explicitly call out to that shell. Exit status
+                                    of 0 is treated as live/healthy and non-zero is
+                                    unhealthy.
+                                  items:
+                                    type: string
+                                  type: array
+                              type: object
+                            failureThreshold:
+                              description: Minimum consecutive failures for the probe
+                                to be considered failed after having succeeded. Defaults
+                                to 3. Minimum value is 1.
+                              format: int32
+                              type: integer
+                            grpc:
+                              description: GRPC specifies an action involving a GRPC
+                                port. This is a beta field and requires enabling GRPCContainerProbe
+                                feature gate.
+                              properties:
+                                port:
+                                  description: Port number of the gRPC service. Number
+                                    must be in the range 1 to 65535.
+                                  format: int32
+                                  type: integer
+                                service:
+                                  description: "Service is the name of the service
+                                    to place in the gRPC HealthCheckRequest (see https://github.com/grpc/grpc/blob/master/doc/health-checking.md).
+                                    \n If this is not specified, the default behavior
+                                    is defined by gRPC."
+                                  type: string
+                              required:
+                              - port
+                              type: object
+                            httpGet:
+                              description: HTTPGet specifies the http request to perform.
+                              properties:
+                                host:
+                                  description: Host name to connect to, defaults to
+                                    the pod IP. You probably want to set "Host" in
+                                    httpHeaders instead.
+                                  type: string
+                                httpHeaders:
+                                  description: Custom headers to set in the request.
+                                    HTTP allows repeated headers.
+                                  items:
+                                    description: HTTPHeader describes a custom header
+                                      to be used in HTTP probes
+                                    properties:
+                                      name:
+                                        description: The header field name
+                                        type: string
+                                      value:
+                                        description: The header field value
+                                        type: string
+                                    required:
+                                    - name
+                                    - value
+                                    type: object
+                                  type: array
+                                path:
+                                  description: Path to access on the HTTP server.
+                                  type: string
+                                port:
+                                  anyOf:
+                                  - type: integer
+                                  - type: string
+                                  description: Name or number of the port to access
+                                    on the container. Number must be in the range
+                                    1 to 65535. Name must be an IANA_SVC_NAME.
+                                  x-kubernetes-int-or-string: true
+                                scheme:
+                                  description: Scheme to use for connecting to the
+                                    host. Defaults to HTTP.
+                                  type: string
+                              required:
+                              - port
+                              type: object
+                            initialDelaySeconds:
+                              description: 'Number of seconds after the container
+                                has started before liveness probes are initiated.
+                                More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                              format: int32
+                              type: integer
+                            periodSeconds:
+                              description: How often (in seconds) to perform the probe.
+                                Default to 10 seconds. Minimum value is 1.
+                              format: int32
+                              type: integer
+                            successThreshold:
+                              description: Minimum consecutive successes for the probe
+                                to be considered successful after having failed. Defaults
+                                to 1. Must be 1 for liveness and startup. Minimum
+                                value is 1.
+                              format: int32
+                              type: integer
+                            tcpSocket:
+                              description: TCPSocket specifies an action involving
+                                a TCP port.
+                              properties:
+                                host:
+                                  description: 'Optional: Host name to connect to,
+                                    defaults to the pod IP.'
+                                  type: string
+                                port:
+                                  anyOf:
+                                  - type: integer
+                                  - type: string
+                                  description: Number or name of the port to access
+                                    on the container. Number must be in the range
+                                    1 to 65535. Name must be an IANA_SVC_NAME.
+                                  x-kubernetes-int-or-string: true
+                              required:
+                              - port
+                              type: object
+                            terminationGracePeriodSeconds:
+                              description: Optional duration in seconds the pod needs
+                                to terminate gracefully upon probe failure. The grace
+                                period is the duration in seconds after the processes
+                                running in the pod are sent a termination signal and
+                                the time when the processes are forcibly halted with
+                                a kill signal. Set this value longer than the expected
+                                cleanup time for your process. If this value is nil,
+                                the pod's terminationGracePeriodSeconds will be used.
+                                Otherwise, this value overrides the value provided
+                                by the pod spec. Value must be non-negative integer.
+                                The value zero indicates stop immediately via the
+                                kill signal (no opportunity to shut down). This is
+                                a beta field and requires enabling ProbeTerminationGracePeriod
+                                feature gate. Minimum value is 1. spec.terminationGracePeriodSeconds
+                                is used if unset.
+                              format: int64
+                              type: integer
+                            timeoutSeconds:
+                              description: 'Number of seconds after which the probe
+                                times out. Defaults to 1 second. Minimum value is
+                                1. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                              format: int32
+                              type: integer
+                          type: object
+                        resources:
+                          description: 'Compute Resources required by this container.
+                            Cannot be updated. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+                          properties:
+                            limits:
+                              additionalProperties:
+                                anyOf:
+                                - type: integer
+                                - type: string
+                                pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                x-kubernetes-int-or-string: true
+                              description: 'Limits describes the maximum amount of
+                                compute resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+                              type: object
+                            requests:
+                              additionalProperties:
+                                anyOf:
+                                - type: integer
+                                - type: string
+                                pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                x-kubernetes-int-or-string: true
+                              description: 'Requests describes the minimum amount
+                                of compute resources required. If Requests is omitted
+                                for a container, it defaults to Limits if that is
+                                explicitly specified, otherwise to an implementation-defined
+                                value. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+                              type: object
+                          type: object
+                        securityContext:
+                          description: 'SecurityContext defines the security options
+                            the container should be run with. If set, the fields of
+                            SecurityContext override the equivalent fields of PodSecurityContext.
+                            More info: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/'
+                          properties:
+                            allowPrivilegeEscalation:
+                              description: 'AllowPrivilegeEscalation controls whether
+                                a process can gain more privileges than its parent
+                                process. This bool directly controls if the no_new_privs
+                                flag will be set on the container process. AllowPrivilegeEscalation
+                                is true always when the container is: 1) run as Privileged
+                                2) has CAP_SYS_ADMIN Note that this field cannot be
+                                set when spec.os.name is windows.'
+                              type: boolean
+                            capabilities:
+                              description: The capabilities to add/drop when running
+                                containers. Defaults to the default set of capabilities
+                                granted by the container runtime. Note that this field
+                                cannot be set when spec.os.name is windows.
+                              properties:
+                                add:
+                                  description: Added capabilities
+                                  items:
+                                    description: Capability represent POSIX capabilities
+                                      type
+                                    type: string
+                                  type: array
+                                drop:
+                                  description: Removed capabilities
+                                  items:
+                                    description: Capability represent POSIX capabilities
+                                      type
+                                    type: string
+                                  type: array
+                              type: object
+                            privileged:
+                              description: Run container in privileged mode. Processes
+                                in privileged containers are essentially equivalent
+                                to root on the host. Defaults to false. Note that
+                                this field cannot be set when spec.os.name is windows.
+                              type: boolean
+                            procMount:
+                              description: procMount denotes the type of proc mount
+                                to use for the containers. The default is DefaultProcMount
+                                which uses the container runtime defaults for readonly
+                                paths and masked paths. This requires the ProcMountType
+                                feature flag to be enabled. Note that this field cannot
+                                be set when spec.os.name is windows.
+                              type: string
+                            readOnlyRootFilesystem:
+                              description: Whether this container has a read-only
+                                root filesystem. Default is false. Note that this
+                                field cannot be set when spec.os.name is windows.
+                              type: boolean
+                            runAsGroup:
+                              description: The GID to run the entrypoint of the container
+                                process. Uses runtime default if unset. May also be
+                                set in PodSecurityContext.  If set in both SecurityContext
+                                and PodSecurityContext, the value specified in SecurityContext
+                                takes precedence. Note that this field cannot be set
+                                when spec.os.name is windows.
+                              format: int64
+                              type: integer
+                            runAsNonRoot:
+                              description: Indicates that the container must run as
+                                a non-root user. If true, the Kubelet will validate
+                                the image at runtime to ensure that it does not run
+                                as UID 0 (root) and fail to start the container if
+                                it does. If unset or false, no such validation will
+                                be performed. May also be set in PodSecurityContext.  If
+                                set in both SecurityContext and PodSecurityContext,
+                                the value specified in SecurityContext takes precedence.
+                              type: boolean
+                            runAsUser:
+                              description: The UID to run the entrypoint of the container
+                                process. Defaults to user specified in image metadata
+                                if unspecified. May also be set in PodSecurityContext.  If
+                                set in both SecurityContext and PodSecurityContext,
+                                the value specified in SecurityContext takes precedence.
+                                Note that this field cannot be set when spec.os.name
+                                is windows.
+                              format: int64
+                              type: integer
+                            seLinuxOptions:
+                              description: The SELinux context to be applied to the
+                                container. If unspecified, the container runtime will
+                                allocate a random SELinux context for each container.  May
+                                also be set in PodSecurityContext.  If set in both
+                                SecurityContext and PodSecurityContext, the value
+                                specified in SecurityContext takes precedence. Note
+                                that this field cannot be set when spec.os.name is
+                                windows.
+                              properties:
+                                level:
+                                  description: Level is SELinux level label that applies
+                                    to the container.
+                                  type: string
+                                role:
+                                  description: Role is a SELinux role label that applies
+                                    to the container.
+                                  type: string
+                                type:
+                                  description: Type is a SELinux type label that applies
+                                    to the container.
+                                  type: string
+                                user:
+                                  description: User is a SELinux user label that applies
+                                    to the container.
+                                  type: string
+                              type: object
+                            seccompProfile:
+                              description: The seccomp options to use by this container.
+                                If seccomp options are provided at both the pod &
+                                container level, the container options override the
+                                pod options. Note that this field cannot be set when
+                                spec.os.name is windows.
+                              properties:
+                                localhostProfile:
+                                  description: localhostProfile indicates a profile
+                                    defined in a file on the node should be used.
+                                    The profile must be preconfigured on the node
+                                    to work. Must be a descending path, relative to
+                                    the kubelet's configured seccomp profile location.
+                                    Must only be set if type is "Localhost".
+                                  type: string
+                                type:
+                                  description: "type indicates which kind of seccomp
+                                    profile will be applied. Valid options are: \n
+                                    Localhost - a profile defined in a file on the
+                                    node should be used. RuntimeDefault - the container
+                                    runtime default profile should be used. Unconfined
+                                    - no profile should be applied."
+                                  type: string
+                              required:
+                              - type
+                              type: object
+                            windowsOptions:
+                              description: The Windows specific settings applied to
+                                all containers. If unspecified, the options from the
+                                PodSecurityContext will be used. If set in both SecurityContext
+                                and PodSecurityContext, the value specified in SecurityContext
+                                takes precedence. Note that this field cannot be set
+                                when spec.os.name is linux.
+                              properties:
+                                gmsaCredentialSpec:
+                                  description: GMSACredentialSpec is where the GMSA
+                                    admission webhook (https://github.com/kubernetes-sigs/windows-gmsa)
+                                    inlines the contents of the GMSA credential spec
+                                    named by the GMSACredentialSpecName field.
+                                  type: string
+                                gmsaCredentialSpecName:
+                                  description: GMSACredentialSpecName is the name
+                                    of the GMSA credential spec to use.
+                                  type: string
+                                hostProcess:
+                                  description: HostProcess determines if a container
+                                    should be run as a 'Host Process' container. This
+                                    field is alpha-level and will only be honored
+                                    by components that enable the WindowsHostProcessContainers
+                                    feature flag. Setting this field without the feature
+                                    flag will result in errors when validating the
+                                    Pod. All of a Pod's containers must have the same
+                                    effective HostProcess value (it is not allowed
+                                    to have a mix of HostProcess containers and non-HostProcess
+                                    containers).  In addition, if HostProcess is true
+                                    then HostNetwork must also be set to true.
+                                  type: boolean
+                                runAsUserName:
+                                  description: The UserName in Windows to run the
+                                    entrypoint of the container process. Defaults
+                                    to the user specified in image metadata if unspecified.
+                                    May also be set in PodSecurityContext. If set
+                                    in both SecurityContext and PodSecurityContext,
+                                    the value specified in SecurityContext takes precedence.
+                                  type: string
+                              type: object
+                          type: object
+                        startupProbe:
+                          description: 'StartupProbe indicates that the Pod has successfully
+                            initialized. If specified, no other probes are executed
+                            until this completes successfully. If this probe fails,
+                            the Pod will be restarted, just as if the livenessProbe
+                            failed. This can be used to provide different probe parameters
+                            at the beginning of a Pod''s lifecycle, when it might
+                            take a long time to load data or warm a cache, than during
+                            steady-state operation. This cannot be updated. More info:
+                            https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                          properties:
+                            exec:
+                              description: Exec specifies the action to take.
+                              properties:
+                                command:
+                                  description: Command is the command line to execute
+                                    inside the container, the working directory for
+                                    the command  is root ('/') in the container's
+                                    filesystem. The command is simply exec'd, it is
+                                    not run inside a shell, so traditional shell instructions
+                                    ('|', etc) won't work. To use a shell, you need
+                                    to explicitly call out to that shell. Exit status
+                                    of 0 is treated as live/healthy and non-zero is
+                                    unhealthy.
+                                  items:
+                                    type: string
+                                  type: array
+                              type: object
+                            failureThreshold:
+                              description: Minimum consecutive failures for the probe
+                                to be considered failed after having succeeded. Defaults
+                                to 3. Minimum value is 1.
+                              format: int32
+                              type: integer
+                            grpc:
+                              description: GRPC specifies an action involving a GRPC
+                                port. This is a beta field and requires enabling GRPCContainerProbe
+                                feature gate.
+                              properties:
+                                port:
+                                  description: Port number of the gRPC service. Number
+                                    must be in the range 1 to 65535.
+                                  format: int32
+                                  type: integer
+                                service:
+                                  description: "Service is the name of the service
+                                    to place in the gRPC HealthCheckRequest (see https://github.com/grpc/grpc/blob/master/doc/health-checking.md).
+                                    \n If this is not specified, the default behavior
+                                    is defined by gRPC."
+                                  type: string
+                              required:
+                              - port
+                              type: object
+                            httpGet:
+                              description: HTTPGet specifies the http request to perform.
+                              properties:
+                                host:
+                                  description: Host name to connect to, defaults to
+                                    the pod IP. You probably want to set "Host" in
+                                    httpHeaders instead.
+                                  type: string
+                                httpHeaders:
+                                  description: Custom headers to set in the request.
+                                    HTTP allows repeated headers.
+                                  items:
+                                    description: HTTPHeader describes a custom header
+                                      to be used in HTTP probes
+                                    properties:
+                                      name:
+                                        description: The header field name
+                                        type: string
+                                      value:
+                                        description: The header field value
+                                        type: string
+                                    required:
+                                    - name
+                                    - value
+                                    type: object
+                                  type: array
+                                path:
+                                  description: Path to access on the HTTP server.
+                                  type: string
+                                port:
+                                  anyOf:
+                                  - type: integer
+                                  - type: string
+                                  description: Name or number of the port to access
+                                    on the container. Number must be in the range
+                                    1 to 65535. Name must be an IANA_SVC_NAME.
+                                  x-kubernetes-int-or-string: true
+                                scheme:
+                                  description: Scheme to use for connecting to the
+                                    host. Defaults to HTTP.
+                                  type: string
+                              required:
+                              - port
+                              type: object
+                            initialDelaySeconds:
+                              description: 'Number of seconds after the container
+                                has started before liveness probes are initiated.
+                                More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                              format: int32
+                              type: integer
+                            periodSeconds:
+                              description: How often (in seconds) to perform the probe.
+                                Default to 10 seconds. Minimum value is 1.
+                              format: int32
+                              type: integer
+                            successThreshold:
+                              description: Minimum consecutive successes for the probe
+                                to be considered successful after having failed. Defaults
+                                to 1. Must be 1 for liveness and startup. Minimum
+                                value is 1.
+                              format: int32
+                              type: integer
+                            tcpSocket:
+                              description: TCPSocket specifies an action involving
+                                a TCP port.
+                              properties:
+                                host:
+                                  description: 'Optional: Host name to connect to,
+                                    defaults to the pod IP.'
+                                  type: string
+                                port:
+                                  anyOf:
+                                  - type: integer
+                                  - type: string
+                                  description: Number or name of the port to access
+                                    on the container. Number must be in the range
+                                    1 to 65535. Name must be an IANA_SVC_NAME.
+                                  x-kubernetes-int-or-string: true
+                              required:
+                              - port
+                              type: object
+                            terminationGracePeriodSeconds:
+                              description: Optional duration in seconds the pod needs
+                                to terminate gracefully upon probe failure. The grace
+                                period is the duration in seconds after the processes
+                                running in the pod are sent a termination signal and
+                                the time when the processes are forcibly halted with
+                                a kill signal. Set this value longer than the expected
+                                cleanup time for your process. If this value is nil,
+                                the pod's terminationGracePeriodSeconds will be used.
+                                Otherwise, this value overrides the value provided
+                                by the pod spec. Value must be non-negative integer.
+                                The value zero indicates stop immediately via the
+                                kill signal (no opportunity to shut down). This is
+                                a beta field and requires enabling ProbeTerminationGracePeriod
+                                feature gate. Minimum value is 1. spec.terminationGracePeriodSeconds
+                                is used if unset.
+                              format: int64
+                              type: integer
+                            timeoutSeconds:
+                              description: 'Number of seconds after which the probe
+                                times out. Defaults to 1 second. Minimum value is
+                                1. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                              format: int32
+                              type: integer
+                          type: object
+                        stdin:
+                          description: Whether this container should allocate a buffer
+                            for stdin in the container runtime. If this is not set,
+                            reads from stdin in the container will always result in
+                            EOF. Default is false.
+                          type: boolean
+                        stdinOnce:
+                          description: Whether the container runtime should close
+                            the stdin channel after it has been opened by a single
+                            attach. When stdin is true the stdin stream will remain
+                            open across multiple attach sessions. If stdinOnce is
+                            set to true, stdin is opened on container start, is empty
+                            until the first client attaches to stdin, and then remains
+                            open and accepts data until the client disconnects, at
+                            which time stdin is closed and remains closed until the
+                            container is restarted. If this flag is false, a container
+                            processes that reads from stdin will never receive an
+                            EOF. Default is false
+                          type: boolean
+                        terminationMessagePath:
+                          description: 'Optional: Path at which the file to which
+                            the container''s termination message will be written is
+                            mounted into the container''s filesystem. Message written
+                            is intended to be brief final status, such as an assertion
+                            failure message. Will be truncated by the node if greater
+                            than 4096 bytes. The total message length across all containers
+                            will be limited to 12kb. Defaults to /dev/termination-log.
+                            Cannot be updated.'
+                          type: string
+                        terminationMessagePolicy:
+                          description: Indicate how the termination message should
+                            be populated. File will use the contents of terminationMessagePath
+                            to populate the container status message on both success
+                            and failure. FallbackToLogsOnError will use the last chunk
+                            of container log output if the termination message file
+                            is empty and the container exited with an error. The log
+                            output is limited to 2048 bytes or 80 lines, whichever
+                            is smaller. Defaults to File. Cannot be updated.
+                          type: string
+                        tty:
+                          description: Whether this container should allocate a TTY
+                            for itself, also requires 'stdin' to be true. Default
+                            is false.
+                          type: boolean
+                        volumeDevices:
+                          description: volumeDevices is the list of block devices
+                            to be used by the container.
+                          items:
+                            description: volumeDevice describes a mapping of a raw
+                              block device within a container.
+                            properties:
+                              devicePath:
+                                description: devicePath is the path inside of the
+                                  container that the device will be mapped to.
+                                type: string
+                              name:
+                                description: name must match the name of a persistentVolumeClaim
+                                  in the pod
+                                type: string
+                            required:
+                            - devicePath
+                            - name
+                            type: object
+                          type: array
+                        volumeMounts:
+                          description: Pod volumes to mount into the container's filesystem.
+                            Cannot be updated.
+                          items:
+                            description: VolumeMount describes a mounting of a Volume
+                              within a container.
+                            properties:
+                              mountPath:
+                                description: Path within the container at which the
+                                  volume should be mounted.  Must not contain ':'.
+                                type: string
+                              mountPropagation:
+                                description: mountPropagation determines how mounts
+                                  are propagated from the host to container and the
+                                  other way around. When not set, MountPropagationNone
+                                  is used. This field is beta in 1.10.
+                                type: string
+                              name:
+                                description: This must match the Name of a Volume.
+                                type: string
+                              readOnly:
+                                description: Mounted read-only if true, read-write
+                                  otherwise (false or unspecified). Defaults to false.
+                                type: boolean
+                              subPath:
+                                description: Path within the volume from which the
+                                  container's volume should be mounted. Defaults to
+                                  "" (volume's root).
+                                type: string
+                              subPathExpr:
+                                description: Expanded path within the volume from
+                                  which the container's volume should be mounted.
+                                  Behaves similarly to SubPath but environment variable
+                                  references $(VAR_NAME) are expanded using the container's
+                                  environment. Defaults to "" (volume's root). SubPathExpr
+                                  and SubPath are mutually exclusive.
+                                type: string
+                            required:
+                            - mountPath
+                            - name
+                            type: object
+                          type: array
+                        workingDir:
+                          description: Container's working directory. If not specified,
+                            the container runtime's default will be used, which might
+                            be configured in the container image. Cannot be updated.
+                          type: string
+                      required:
+                      - name
+                      type: object
+                    type: array
+                  nodeSelector:
+                    additionalProperties:
+                      type: string
+                    type: object
+                  schedulerName:
+                    type: string
+                  serviceAccountName:
+                    type: string
+                  tolerations:
+                    items:
+                      description: The pod this Toleration is attached to tolerates
+                        any taint that matches the triple <key,value,effect> using
+                        the matching operator <operator>.
+                      properties:
+                        effect:
+                          description: Effect indicates the taint effect to match.
+                            Empty means match all taint effects. When specified, allowed
+                            values are NoSchedule, PreferNoSchedule and NoExecute.
+                          type: string
+                        key:
+                          description: Key is the taint key that the toleration applies
+                            to. Empty means match all taint keys. If the key is empty,
+                            operator must be Exists; this combination means to match
+                            all values and all keys.
+                          type: string
+                        operator:
+                          description: Operator represents a key's relationship to
+                            the value. Valid operators are Exists and Equal. Defaults
+                            to Equal. Exists is equivalent to wildcard for value,
+                            so that a pod can tolerate all taints of a particular
+                            category.
+                          type: string
+                        tolerationSeconds:
+                          description: TolerationSeconds represents the period of
+                            time the toleration (which must be of effect NoExecute,
+                            otherwise this field is ignored) tolerates the taint.
+                            By default, it is not set, which means tolerate the taint
+                            forever (do not evict). Zero and negative values will
+                            be treated as 0 (evict immediately) by the system.
+                          format: int64
+                          type: integer
+                        value:
+                          description: Value is the taint value the toleration matches
+                            to. If the operator is Exists, the value should be empty,
+                            otherwise just a regular string.
+                          type: string
+                      type: object
+                    type: array
+                  topologySpreadConstraints:
+                    items:
+                      description: TopologySpreadConstraint specifies how to spread
+                        matching pods among the given topology.
+                      properties:
+                        labelSelector:
+                          description: LabelSelector is used to find matching pods.
+                            Pods that match this label selector are counted to determine
+                            the number of pods in their corresponding topology domain.
+                          properties:
+                            matchExpressions:
+                              description: matchExpressions is a list of label selector
+                                requirements. The requirements are ANDed.
+                              items:
+                                description: A label selector requirement is a selector
+                                  that contains values, a key, and an operator that
+                                  relates the key and values.
+                                properties:
+                                  key:
+                                    description: key is the label key that the selector
+                                      applies to.
+                                    type: string
+                                  operator:
+                                    description: operator represents a key's relationship
+                                      to a set of values. Valid operators are In,
+                                      NotIn, Exists and DoesNotExist.
+                                    type: string
+                                  values:
+                                    description: values is an array of string values.
+                                      If the operator is In or NotIn, the values array
+                                      must be non-empty. If the operator is Exists
+                                      or DoesNotExist, the values array must be empty.
+                                      This array is replaced during a strategic merge
+                                      patch.
+                                    items:
+                                      type: string
+                                    type: array
+                                required:
+                                - key
+                                - operator
+                                type: object
+                              type: array
+                            matchLabels:
+                              additionalProperties:
+                                type: string
+                              description: matchLabels is a map of {key,value} pairs.
+                                A single {key,value} in the matchLabels map is equivalent
+                                to an element of matchExpressions, whose key field
+                                is "key", the operator is "In", and the values array
+                                contains only "value". The requirements are ANDed.
+                              type: object
+                          type: object
+                        matchLabelKeys:
+                          description: MatchLabelKeys is a set of pod label keys to
+                            select the pods over which spreading will be calculated.
+                            The keys are used to lookup values from the incoming pod
+                            labels, those key-value labels are ANDed with labelSelector
+                            to select the group of existing pods over which spreading
+                            will be calculated for the incoming pod. Keys that don't
+                            exist in the incoming pod labels will be ignored. A null
+                            or empty list means only match against labelSelector.
+                          items:
+                            type: string
+                          type: array
+                          x-kubernetes-list-type: atomic
+                        maxSkew:
+                          description: 'MaxSkew describes the degree to which pods
+                            may be unevenly distributed. When `whenUnsatisfiable=DoNotSchedule`,
+                            it is the maximum permitted difference between the number
+                            of matching pods in the target topology and the global
+                            minimum. The global minimum is the minimum number of matching
+                            pods in an eligible domain or zero if the number of eligible
+                            domains is less than MinDomains. For example, in a 3-zone
+                            cluster, MaxSkew is set to 1, and pods with the same labelSelector
+                            spread as 2/2/1: In this case, the global minimum is 1.
+                            | zone1 | zone2 | zone3 | |  P P  |  P P  |   P   | -
+                            if MaxSkew is 1, incoming pod can only be scheduled to
+                            zone3 to become 2/2/2; scheduling it onto zone1(zone2)
+                            would make the ActualSkew(3-1) on zone1(zone2) violate
+                            MaxSkew(1). - if MaxSkew is 2, incoming pod can be scheduled
+                            onto any zone. When `whenUnsatisfiable=ScheduleAnyway`,
+                            it is used to give higher precedence to topologies that
+                            satisfy it. It''s a required field. Default value is 1
+                            and 0 is not allowed.'
+                          format: int32
+                          type: integer
+                        minDomains:
+                          description: "MinDomains indicates a minimum number of eligible
+                            domains. When the number of eligible domains with matching
+                            topology keys is less than minDomains, Pod Topology Spread
+                            treats \"global minimum\" as 0, and then the calculation
+                            of Skew is performed. And when the number of eligible
+                            domains with matching topology keys equals or greater
+                            than minDomains, this value has no effect on scheduling.
+                            As a result, when the number of eligible domains is less
+                            than minDomains, scheduler won't schedule more than maxSkew
+                            Pods to those domains. If value is nil, the constraint
+                            behaves as if MinDomains is equal to 1. Valid values are
+                            integers greater than 0. When value is not nil, WhenUnsatisfiable
+                            must be DoNotSchedule. \n For example, in a 3-zone cluster,
+                            MaxSkew is set to 2, MinDomains is set to 5 and pods with
+                            the same labelSelector spread as 2/2/2: | zone1 | zone2
+                            | zone3 | |  P P  |  P P  |  P P  | The number of domains
+                            is less than 5(MinDomains), so \"global minimum\" is treated
+                            as 0. In this situation, new pod with the same labelSelector
+                            cannot be scheduled, because computed skew will be 3(3
+                            - 0) if new Pod is scheduled to any of the three zones,
+                            it will violate MaxSkew. \n This is a beta field and requires
+                            the MinDomainsInPodTopologySpread feature gate to be enabled
+                            (enabled by default)."
+                          format: int32
+                          type: integer
+                        nodeAffinityPolicy:
+                          description: "NodeAffinityPolicy indicates how we will treat
+                            Pod's nodeAffinity/nodeSelector when calculating pod topology
+                            spread skew. Options are: - Honor: only nodes matching
+                            nodeAffinity/nodeSelector are included in the calculations.
+                            - Ignore: nodeAffinity/nodeSelector are ignored. All nodes
+                            are included in the calculations. \n If this value is
+                            nil, the behavior is equivalent to the Honor policy. This
+                            is a alpha-level feature enabled by the NodeInclusionPolicyInPodTopologySpread
+                            feature flag."
+                          type: string
+                        nodeTaintsPolicy:
+                          description: "NodeTaintsPolicy indicates how we will treat
+                            node taints when calculating pod topology spread skew.
+                            Options are: - Honor: nodes without taints, along with
+                            tainted nodes for which the incoming pod has a toleration,
+                            are included. - Ignore: node taints are ignored. All nodes
+                            are included. \n If this value is nil, the behavior is
+                            equivalent to the Ignore policy. This is a alpha-level
+                            feature enabled by the NodeInclusionPolicyInPodTopologySpread
+                            feature flag."
+                          type: string
+                        topologyKey:
+                          description: TopologyKey is the key of node labels. Nodes
+                            that have a label with this key and identical values are
+                            considered to be in the same topology. We consider each
+                            <key, value> as a "bucket", and try to put balanced number
+                            of pods into each bucket. We define a domain as a particular
+                            instance of a topology. Also, we define an eligible domain
+                            as a domain whose nodes meet the requirements of nodeAffinityPolicy
+                            and nodeTaintsPolicy. e.g. If TopologyKey is "kubernetes.io/hostname",
+                            each Node is a domain of that topology. And, if TopologyKey
+                            is "topology.kubernetes.io/zone", each zone is a domain
+                            of that topology. It's a required field.
+                          type: string
+                        whenUnsatisfiable:
+                          description: 'WhenUnsatisfiable indicates how to deal with
+                            a pod if it doesn''t satisfy the spread constraint. -
+                            DoNotSchedule (default) tells the scheduler not to schedule
+                            it. - ScheduleAnyway tells the scheduler to schedule the
+                            pod in any location,   but giving higher precedence to
+                            topologies that would help reduce the   skew. A constraint
+                            is considered "Unsatisfiable" for an incoming pod if and
+                            only if every possible node assignment for that pod would
+                            violate "MaxSkew" on some topology. For example, in a
+                            3-zone cluster, MaxSkew is set to 1, and pods with the
+                            same labelSelector spread as 3/1/1: | zone1 | zone2 |
+                            zone3 | | P P P |   P   |   P   | If WhenUnsatisfiable
+                            is set to DoNotSchedule, incoming pod can only be scheduled
+                            to zone2(zone3) to become 3/2/1(3/1/2) as ActualSkew(2-1)
+                            on zone2(zone3) satisfies MaxSkew(1). In other words,
+                            the cluster can still be imbalanced, but scheduler won''t
+                            make it *more* imbalanced. It''s a required field.'
+                          type: string
+                      required:
+                      - maxSkew
+                      - topologyKey
+                      - whenUnsatisfiable
+                      type: object
+                    type: array
+                type: object
+              ingress:
+                properties:
+                  annotations:
+                    additionalProperties:
+                      type: string
+                    type: object
+                  enabled:
+                    type: boolean
+                  labels:
+                    additionalProperties:
+                      type: string
+                    type: object
+                  tls:
+                    properties:
+                      secretName:
+                        type: string
+                    type: object
+                type: object
+              labels:
+                additionalProperties:
+                  type: string
+                type: object
+              monitorExporter:
+                properties:
+                  enabled:
+                    type: boolean
+                  options:
+                    additionalProperties:
+                      type: string
+                    type: object
+                  output:
+                    type: string
+                type: object
+              resources:
+                properties:
+                  limits:
+                    properties:
+                      cpu:
+                        type: string
+                      custom:
+                        additionalProperties:
+                          type: string
+                        type: object
+                      gpu:
+                        type: string
+                      memory:
+                        type: string
+                    type: object
+                  requests:
+                    properties:
+                      cpu:
+                        type: string
+                      custom:
+                        additionalProperties:
+                          type: string
+                        type: object
+                      gpu:
+                        type: string
+                      memory:
+                        type: string
+                    type: object
+                type: object
+              runners:
+                items:
+                  properties:
+                    annotations:
+                      additionalProperties:
+                        type: string
+                      type: object
+                    autoscaling:
+                      properties:
+                        behavior:
+                          description: HorizontalPodAutoscalerBehavior configures
+                            the scaling behavior of the target in both Up and Down
+                            directions (scaleUp and scaleDown fields respectively).
+                          properties:
+                            scaleDown:
+                              description: scaleDown is scaling policy for scaling
+                                Down. If not set, the default value is to allow to
+                                scale down to minReplicas pods, with a 300 second
+                                stabilization window (i.e., the highest recommendation
+                                for the last 300sec is used).
+                              properties:
+                                policies:
+                                  description: policies is a list of potential scaling
+                                    polices which can be used during scaling. At least
+                                    one policy must be specified, otherwise the HPAScalingRules
+                                    will be discarded as invalid
+                                  items:
+                                    description: HPAScalingPolicy is a single policy
+                                      which must hold true for a specified past interval.
+                                    properties:
+                                      periodSeconds:
+                                        description: PeriodSeconds specifies the window
+                                          of time for which the policy should hold
+                                          true. PeriodSeconds must be greater than
+                                          zero and less than or equal to 1800 (30
+                                          min).
+                                        format: int32
+                                        type: integer
+                                      type:
+                                        description: Type is used to specify the scaling
+                                          policy.
+                                        type: string
+                                      value:
+                                        description: Value contains the amount of
+                                          change which is permitted by the policy.
+                                          It must be greater than zero
+                                        format: int32
+                                        type: integer
+                                    required:
+                                    - periodSeconds
+                                    - type
+                                    - value
+                                    type: object
+                                  type: array
+                                selectPolicy:
+                                  description: selectPolicy is used to specify which
+                                    policy should be used. If not set, the default
+                                    value MaxPolicySelect is used.
+                                  type: string
+                                stabilizationWindowSeconds:
+                                  description: 'StabilizationWindowSeconds is the
+                                    number of seconds for which past recommendations
+                                    should be considered while scaling up or scaling
+                                    down. StabilizationWindowSeconds must be greater
+                                    than or equal to zero and less than or equal to
+                                    3600 (one hour). If not set, use the default values:
+                                    - For scale up: 0 (i.e. no stabilization is done).
+                                    - For scale down: 300 (i.e. the stabilization
+                                    window is 300 seconds long).'
+                                  format: int32
+                                  type: integer
+                              type: object
+                            scaleUp:
+                              description: 'scaleUp is scaling policy for scaling
+                                Up. If not set, the default value is the higher of:   *
+                                increase no more than 4 pods per 60 seconds   * double
+                                the number of pods per 60 seconds No stabilization
+                                is used.'
+                              properties:
+                                policies:
+                                  description: policies is a list of potential scaling
+                                    polices which can be used during scaling. At least
+                                    one policy must be specified, otherwise the HPAScalingRules
+                                    will be discarded as invalid
+                                  items:
+                                    description: HPAScalingPolicy is a single policy
+                                      which must hold true for a specified past interval.
+                                    properties:
+                                      periodSeconds:
+                                        description: PeriodSeconds specifies the window
+                                          of time for which the policy should hold
+                                          true. PeriodSeconds must be greater than
+                                          zero and less than or equal to 1800 (30
+                                          min).
+                                        format: int32
+                                        type: integer
+                                      type:
+                                        description: Type is used to specify the scaling
+                                          policy.
+                                        type: string
+                                      value:
+                                        description: Value contains the amount of
+                                          change which is permitted by the policy.
+                                          It must be greater than zero
+                                        format: int32
+                                        type: integer
+                                    required:
+                                    - periodSeconds
+                                    - type
+                                    - value
+                                    type: object
+                                  type: array
+                                selectPolicy:
+                                  description: selectPolicy is used to specify which
+                                    policy should be used. If not set, the default
+                                    value MaxPolicySelect is used.
+                                  type: string
+                                stabilizationWindowSeconds:
+                                  description: 'StabilizationWindowSeconds is the
+                                    number of seconds for which past recommendations
+                                    should be considered while scaling up or scaling
+                                    down. StabilizationWindowSeconds must be greater
+                                    than or equal to zero and less than or equal to
+                                    3600 (one hour). If not set, use the default values:
+                                    - For scale up: 0 (i.e. no stabilization is done).
+                                    - For scale down: 300 (i.e. the stabilization
+                                    window is 300 seconds long).'
+                                  format: int32
+                                  type: integer
+                              type: object
+                          type: object
+                        maxReplicas:
+                          format: int32
+                          type: integer
+                        metrics:
+                          items:
+                            description: MetricSpec specifies how to scale based on
+                              a single metric (only `type` and one other matching
+                              field should be set at once).
+                            properties:
+                              containerResource:
+                                description: container resource refers to a resource
+                                  metric (such as those specified in requests and
+                                  limits) known to Kubernetes describing a single
+                                  container in each pod of the current scale target
+                                  (e.g. CPU or memory). Such metrics are built in
+                                  to Kubernetes, and have special scaling options
+                                  on top of those available to normal per-pod metrics
+                                  using the "pods" source. This is an alpha feature
+                                  and can be enabled by the HPAContainerMetrics feature
+                                  flag.
+                                properties:
+                                  container:
+                                    description: container is the name of the container
+                                      in the pods of the scaling target
+                                    type: string
+                                  name:
+                                    description: name is the name of the resource
+                                      in question.
+                                    type: string
+                                  target:
+                                    description: target specifies the target value
+                                      for the given metric
+                                    properties:
+                                      averageUtilization:
+                                        description: averageUtilization is the target
+                                          value of the average of the resource metric
+                                          across all relevant pods, represented as
+                                          a percentage of the requested value of the
+                                          resource for the pods. Currently only valid
+                                          for Resource metric source type
+                                        format: int32
+                                        type: integer
+                                      averageValue:
+                                        anyOf:
+                                        - type: integer
+                                        - type: string
+                                        description: averageValue is the target value
+                                          of the average of the metric across all
+                                          relevant pods (as a quantity)
+                                        pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                        x-kubernetes-int-or-string: true
+                                      type:
+                                        description: type represents whether the metric
+                                          type is Utilization, Value, or AverageValue
+                                        type: string
+                                      value:
+                                        anyOf:
+                                        - type: integer
+                                        - type: string
+                                        description: value is the target value of
+                                          the metric (as a quantity).
+                                        pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                        x-kubernetes-int-or-string: true
+                                    required:
+                                    - type
+                                    type: object
+                                required:
+                                - container
+                                - name
+                                - target
+                                type: object
+                              external:
+                                description: external refers to a global metric that
+                                  is not associated with any Kubernetes object. It
+                                  allows autoscaling based on information coming from
+                                  components running outside of cluster (for example
+                                  length of queue in cloud messaging service, or QPS
+                                  from loadbalancer running outside of cluster).
+                                properties:
+                                  metric:
+                                    description: metric identifies the target metric
+                                      by name and selector
+                                    properties:
+                                      name:
+                                        description: name is the name of the given
+                                          metric
+                                        type: string
+                                      selector:
+                                        description: selector is the string-encoded
+                                          form of a standard kubernetes label selector
+                                          for the given metric When set, it is passed
+                                          as an additional parameter to the metrics
+                                          server for more specific metrics scoping.
+                                          When unset, just the metricName will be
+                                          used to gather metrics.
+                                        properties:
+                                          matchExpressions:
+                                            description: matchExpressions is a list
+                                              of label selector requirements. The
+                                              requirements are ANDed.
+                                            items:
+                                              description: A label selector requirement
+                                                is a selector that contains values,
+                                                a key, and an operator that relates
+                                                the key and values.
+                                              properties:
+                                                key:
+                                                  description: key is the label key
+                                                    that the selector applies to.
+                                                  type: string
+                                                operator:
+                                                  description: operator represents
+                                                    a key's relationship to a set
+                                                    of values. Valid operators are
+                                                    In, NotIn, Exists and DoesNotExist.
+                                                  type: string
+                                                values:
+                                                  description: values is an array
+                                                    of string values. If the operator
+                                                    is In or NotIn, the values array
+                                                    must be non-empty. If the operator
+                                                    is Exists or DoesNotExist, the
+                                                    values array must be empty. This
+                                                    array is replaced during a strategic
+                                                    merge patch.
+                                                  items:
+                                                    type: string
+                                                  type: array
+                                              required:
+                                              - key
+                                              - operator
+                                              type: object
+                                            type: array
+                                          matchLabels:
+                                            additionalProperties:
+                                              type: string
+                                            description: matchLabels is a map of {key,value}
+                                              pairs. A single {key,value} in the matchLabels
+                                              map is equivalent to an element of matchExpressions,
+                                              whose key field is "key", the operator
+                                              is "In", and the values array contains
+                                              only "value". The requirements are ANDed.
+                                            type: object
+                                        type: object
+                                    required:
+                                    - name
+                                    type: object
+                                  target:
+                                    description: target specifies the target value
+                                      for the given metric
+                                    properties:
+                                      averageUtilization:
+                                        description: averageUtilization is the target
+                                          value of the average of the resource metric
+                                          across all relevant pods, represented as
+                                          a percentage of the requested value of the
+                                          resource for the pods. Currently only valid
+                                          for Resource metric source type
+                                        format: int32
+                                        type: integer
+                                      averageValue:
+                                        anyOf:
+                                        - type: integer
+                                        - type: string
+                                        description: averageValue is the target value
+                                          of the average of the metric across all
+                                          relevant pods (as a quantity)
+                                        pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                        x-kubernetes-int-or-string: true
+                                      type:
+                                        description: type represents whether the metric
+                                          type is Utilization, Value, or AverageValue
+                                        type: string
+                                      value:
+                                        anyOf:
+                                        - type: integer
+                                        - type: string
+                                        description: value is the target value of
+                                          the metric (as a quantity).
+                                        pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                        x-kubernetes-int-or-string: true
+                                    required:
+                                    - type
+                                    type: object
+                                required:
+                                - metric
+                                - target
+                                type: object
+                              object:
+                                description: object refers to a metric describing
+                                  a single kubernetes object (for example, hits-per-second
+                                  on an Ingress object).
+                                properties:
+                                  describedObject:
+                                    description: CrossVersionObjectReference contains
+                                      enough information to let you identify the referred
+                                      resource.
+                                    properties:
+                                      apiVersion:
+                                        description: API version of the referent
+                                        type: string
+                                      kind:
+                                        description: 'Kind of the referent; More info:
+                                          https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds"'
+                                        type: string
+                                      name:
+                                        description: 'Name of the referent; More info:
+                                          http://kubernetes.io/docs/user-guide/identifiers#names'
+                                        type: string
+                                    required:
+                                    - kind
+                                    - name
+                                    type: object
+                                  metric:
+                                    description: metric identifies the target metric
+                                      by name and selector
+                                    properties:
+                                      name:
+                                        description: name is the name of the given
+                                          metric
+                                        type: string
+                                      selector:
+                                        description: selector is the string-encoded
+                                          form of a standard kubernetes label selector
+                                          for the given metric When set, it is passed
+                                          as an additional parameter to the metrics
+                                          server for more specific metrics scoping.
+                                          When unset, just the metricName will be
+                                          used to gather metrics.
+                                        properties:
+                                          matchExpressions:
+                                            description: matchExpressions is a list
+                                              of label selector requirements. The
+                                              requirements are ANDed.
+                                            items:
+                                              description: A label selector requirement
+                                                is a selector that contains values,
+                                                a key, and an operator that relates
+                                                the key and values.
+                                              properties:
+                                                key:
+                                                  description: key is the label key
+                                                    that the selector applies to.
+                                                  type: string
+                                                operator:
+                                                  description: operator represents
+                                                    a key's relationship to a set
+                                                    of values. Valid operators are
+                                                    In, NotIn, Exists and DoesNotExist.
+                                                  type: string
+                                                values:
+                                                  description: values is an array
+                                                    of string values. If the operator
+                                                    is In or NotIn, the values array
+                                                    must be non-empty. If the operator
+                                                    is Exists or DoesNotExist, the
+                                                    values array must be empty. This
+                                                    array is replaced during a strategic
+                                                    merge patch.
+                                                  items:
+                                                    type: string
+                                                  type: array
+                                              required:
+                                              - key
+                                              - operator
+                                              type: object
+                                            type: array
+                                          matchLabels:
+                                            additionalProperties:
+                                              type: string
+                                            description: matchLabels is a map of {key,value}
+                                              pairs. A single {key,value} in the matchLabels
+                                              map is equivalent to an element of matchExpressions,
+                                              whose key field is "key", the operator
+                                              is "In", and the values array contains
+                                              only "value". The requirements are ANDed.
+                                            type: object
+                                        type: object
+                                    required:
+                                    - name
+                                    type: object
+                                  target:
+                                    description: target specifies the target value
+                                      for the given metric
+                                    properties:
+                                      averageUtilization:
+                                        description: averageUtilization is the target
+                                          value of the average of the resource metric
+                                          across all relevant pods, represented as
+                                          a percentage of the requested value of the
+                                          resource for the pods. Currently only valid
+                                          for Resource metric source type
+                                        format: int32
+                                        type: integer
+                                      averageValue:
+                                        anyOf:
+                                        - type: integer
+                                        - type: string
+                                        description: averageValue is the target value
+                                          of the average of the metric across all
+                                          relevant pods (as a quantity)
+                                        pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                        x-kubernetes-int-or-string: true
+                                      type:
+                                        description: type represents whether the metric
+                                          type is Utilization, Value, or AverageValue
+                                        type: string
+                                      value:
+                                        anyOf:
+                                        - type: integer
+                                        - type: string
+                                        description: value is the target value of
+                                          the metric (as a quantity).
+                                        pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                        x-kubernetes-int-or-string: true
+                                    required:
+                                    - type
+                                    type: object
+                                required:
+                                - describedObject
+                                - metric
+                                - target
+                                type: object
+                              pods:
+                                description: pods refers to a metric describing each
+                                  pod in the current scale target (for example, transactions-processed-per-second).  The
+                                  values will be averaged together before being compared
+                                  to the target value.
+                                properties:
+                                  metric:
+                                    description: metric identifies the target metric
+                                      by name and selector
+                                    properties:
+                                      name:
+                                        description: name is the name of the given
+                                          metric
+                                        type: string
+                                      selector:
+                                        description: selector is the string-encoded
+                                          form of a standard kubernetes label selector
+                                          for the given metric When set, it is passed
+                                          as an additional parameter to the metrics
+                                          server for more specific metrics scoping.
+                                          When unset, just the metricName will be
+                                          used to gather metrics.
+                                        properties:
+                                          matchExpressions:
+                                            description: matchExpressions is a list
+                                              of label selector requirements. The
+                                              requirements are ANDed.
+                                            items:
+                                              description: A label selector requirement
+                                                is a selector that contains values,
+                                                a key, and an operator that relates
+                                                the key and values.
+                                              properties:
+                                                key:
+                                                  description: key is the label key
+                                                    that the selector applies to.
+                                                  type: string
+                                                operator:
+                                                  description: operator represents
+                                                    a key's relationship to a set
+                                                    of values. Valid operators are
+                                                    In, NotIn, Exists and DoesNotExist.
+                                                  type: string
+                                                values:
+                                                  description: values is an array
+                                                    of string values. If the operator
+                                                    is In or NotIn, the values array
+                                                    must be non-empty. If the operator
+                                                    is Exists or DoesNotExist, the
+                                                    values array must be empty. This
+                                                    array is replaced during a strategic
+                                                    merge patch.
+                                                  items:
+                                                    type: string
+                                                  type: array
+                                              required:
+                                              - key
+                                              - operator
+                                              type: object
+                                            type: array
+                                          matchLabels:
+                                            additionalProperties:
+                                              type: string
+                                            description: matchLabels is a map of {key,value}
+                                              pairs. A single {key,value} in the matchLabels
+                                              map is equivalent to an element of matchExpressions,
+                                              whose key field is "key", the operator
+                                              is "In", and the values array contains
+                                              only "value". The requirements are ANDed.
+                                            type: object
+                                        type: object
+                                    required:
+                                    - name
+                                    type: object
+                                  target:
+                                    description: target specifies the target value
+                                      for the given metric
+                                    properties:
+                                      averageUtilization:
+                                        description: averageUtilization is the target
+                                          value of the average of the resource metric
+                                          across all relevant pods, represented as
+                                          a percentage of the requested value of the
+                                          resource for the pods. Currently only valid
+                                          for Resource metric source type
+                                        format: int32
+                                        type: integer
+                                      averageValue:
+                                        anyOf:
+                                        - type: integer
+                                        - type: string
+                                        description: averageValue is the target value
+                                          of the average of the metric across all
+                                          relevant pods (as a quantity)
+                                        pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                        x-kubernetes-int-or-string: true
+                                      type:
+                                        description: type represents whether the metric
+                                          type is Utilization, Value, or AverageValue
+                                        type: string
+                                      value:
+                                        anyOf:
+                                        - type: integer
+                                        - type: string
+                                        description: value is the target value of
+                                          the metric (as a quantity).
+                                        pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                        x-kubernetes-int-or-string: true
+                                    required:
+                                    - type
+                                    type: object
+                                required:
+                                - metric
+                                - target
+                                type: object
+                              resource:
+                                description: resource refers to a resource metric
+                                  (such as those specified in requests and limits)
+                                  known to Kubernetes describing each pod in the current
+                                  scale target (e.g. CPU or memory). Such metrics
+                                  are built in to Kubernetes, and have special scaling
+                                  options on top of those available to normal per-pod
+                                  metrics using the "pods" source.
+                                properties:
+                                  name:
+                                    description: name is the name of the resource
+                                      in question.
+                                    type: string
+                                  target:
+                                    description: target specifies the target value
+                                      for the given metric
+                                    properties:
+                                      averageUtilization:
+                                        description: averageUtilization is the target
+                                          value of the average of the resource metric
+                                          across all relevant pods, represented as
+                                          a percentage of the requested value of the
+                                          resource for the pods. Currently only valid
+                                          for Resource metric source type
+                                        format: int32
+                                        type: integer
+                                      averageValue:
+                                        anyOf:
+                                        - type: integer
+                                        - type: string
+                                        description: averageValue is the target value
+                                          of the average of the metric across all
+                                          relevant pods (as a quantity)
+                                        pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                        x-kubernetes-int-or-string: true
+                                      type:
+                                        description: type represents whether the metric
+                                          type is Utilization, Value, or AverageValue
+                                        type: string
+                                      value:
+                                        anyOf:
+                                        - type: integer
+                                        - type: string
+                                        description: value is the target value of
+                                          the metric (as a quantity).
+                                        pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                        x-kubernetes-int-or-string: true
+                                    required:
+                                    - type
+                                    type: object
+                                required:
+                                - name
+                                - target
+                                type: object
+                              type:
+                                description: 'type is the type of metric source.  It
+                                  should be one of "ContainerResource", "External",
+                                  "Object", "Pods" or "Resource", each mapping to
+                                  a matching field in the object. Note: "ContainerResource"
+                                  type is available on when the feature-gate HPAContainerMetrics
+                                  is enabled'
+                                type: string
+                            required:
+                            - type
+                            type: object
+                          type: array
+                        minReplicas:
+                          format: int32
+                          type: integer
+                      required:
+                      - maxReplicas
+                      - minReplicas
+                      type: object
+                    envs:
+                      items:
+                        description: EnvVar represents an environment variable present
+                          in a Container.
+                        properties:
+                          name:
+                            description: Name of the environment variable. Must be
+                              a C_IDENTIFIER.
+                            type: string
+                          value:
+                            description: 'Variable references $(VAR_NAME) are expanded
+                              using the previously defined environment variables in
+                              the container and any service environment variables.
+                              If a variable cannot be resolved, the reference in the
+                              input string will be unchanged. Double $$ are reduced
+                              to a single $, which allows for escaping the $(VAR_NAME)
+                              syntax: i.e. "$$(VAR_NAME)" will produce the string
+                              literal "$(VAR_NAME)". Escaped references will never
+                              be expanded, regardless of whether the variable exists
+                              or not. Defaults to "".'
+                            type: string
+                          valueFrom:
+                            description: Source for the environment variable's value.
+                              Cannot be used if value is not empty.
+                            properties:
+                              configMapKeyRef:
+                                description: Selects a key of a ConfigMap.
+                                properties:
+                                  key:
+                                    description: The key to select.
+                                    type: string
+                                  name:
+                                    description: 'Name of the referent. More info:
+                                      https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                      TODO: Add other useful fields. apiVersion, kind,
+                                      uid?'
+                                    type: string
+                                  optional:
+                                    description: Specify whether the ConfigMap or
+                                      its key must be defined
+                                    type: boolean
+                                required:
+                                - key
+                                type: object
+                              fieldRef:
+                                description: 'Selects a field of the pod: supports
+                                  metadata.name, metadata.namespace, `metadata.labels[''<KEY>'']`,
+                                  `metadata.annotations[''<KEY>'']`, spec.nodeName,
+                                  spec.serviceAccountName, status.hostIP, status.podIP,
+                                  status.podIPs.'
+                                properties:
+                                  apiVersion:
+                                    description: Version of the schema the FieldPath
+                                      is written in terms of, defaults to "v1".
+                                    type: string
+                                  fieldPath:
+                                    description: Path of the field to select in the
+                                      specified API version.
+                                    type: string
+                                required:
+                                - fieldPath
+                                type: object
+                              resourceFieldRef:
+                                description: 'Selects a resource of the container:
+                                  only resources limits and requests (limits.cpu,
+                                  limits.memory, limits.ephemeral-storage, requests.cpu,
+                                  requests.memory and requests.ephemeral-storage)
+                                  are currently supported.'
+                                properties:
+                                  containerName:
+                                    description: 'Container name: required for volumes,
+                                      optional for env vars'
+                                    type: string
+                                  divisor:
+                                    anyOf:
+                                    - type: integer
+                                    - type: string
+                                    description: Specifies the output format of the
+                                      exposed resources, defaults to "1"
+                                    pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                    x-kubernetes-int-or-string: true
+                                  resource:
+                                    description: 'Required: resource to select'
+                                    type: string
+                                required:
+                                - resource
+                                type: object
+                              secretKeyRef:
+                                description: Selects a key of a secret in the pod's
+                                  namespace
+                                properties:
+                                  key:
+                                    description: The key of the secret to select from.  Must
+                                      be a valid secret key.
+                                    type: string
+                                  name:
+                                    description: 'Name of the referent. More info:
+                                      https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                      TODO: Add other useful fields. apiVersion, kind,
+                                      uid?'
+                                    type: string
+                                  optional:
+                                    description: Specify whether the Secret or its
+                                      key must be defined
+                                    type: boolean
+                                required:
+                                - key
+                                type: object
+                            type: object
+                        required:
+                        - name
+                        type: object
+                      type: array
+                    extraPodMetadata:
+                      properties:
+                        annotations:
+                          additionalProperties:
+                            type: string
+                          type: object
+                        labels:
+                          additionalProperties:
+                            type: string
+                          type: object
+                      type: object
+                    extraPodSpec:
+                      properties:
+                        affinity:
+                          description: Affinity is a group of affinity scheduling
+                            rules.
+                          properties:
+                            nodeAffinity:
+                              description: Describes node affinity scheduling rules
+                                for the pod.
+                              properties:
+                                preferredDuringSchedulingIgnoredDuringExecution:
+                                  description: The scheduler will prefer to schedule
+                                    pods to nodes that satisfy the affinity expressions
+                                    specified by this field, but it may choose a node
+                                    that violates one or more of the expressions.
+                                    The node that is most preferred is the one with
+                                    the greatest sum of weights, i.e. for each node
+                                    that meets all of the scheduling requirements
+                                    (resource request, requiredDuringScheduling affinity
+                                    expressions, etc.), compute a sum by iterating
+                                    through the elements of this field and adding
+                                    "weight" to the sum if the node matches the corresponding
+                                    matchExpressions; the node(s) with the highest
+                                    sum are the most preferred.
+                                  items:
+                                    description: An empty preferred scheduling term
+                                      matches all objects with implicit weight 0 (i.e.
+                                      it's a no-op). A null preferred scheduling term
+                                      matches no objects (i.e. is also a no-op).
+                                    properties:
+                                      preference:
+                                        description: A node selector term, associated
+                                          with the corresponding weight.
+                                        properties:
+                                          matchExpressions:
+                                            description: A list of node selector requirements
+                                              by node's labels.
+                                            items:
+                                              description: A node selector requirement
+                                                is a selector that contains values,
+                                                a key, and an operator that relates
+                                                the key and values.
+                                              properties:
+                                                key:
+                                                  description: The label key that
+                                                    the selector applies to.
+                                                  type: string
+                                                operator:
+                                                  description: Represents a key's
+                                                    relationship to a set of values.
+                                                    Valid operators are In, NotIn,
+                                                    Exists, DoesNotExist. Gt, and
+                                                    Lt.
+                                                  type: string
+                                                values:
+                                                  description: An array of string
+                                                    values. If the operator is In
+                                                    or NotIn, the values array must
+                                                    be non-empty. If the operator
+                                                    is Exists or DoesNotExist, the
+                                                    values array must be empty. If
+                                                    the operator is Gt or Lt, the
+                                                    values array must have a single
+                                                    element, which will be interpreted
+                                                    as an integer. This array is replaced
+                                                    during a strategic merge patch.
+                                                  items:
+                                                    type: string
+                                                  type: array
+                                              required:
+                                              - key
+                                              - operator
+                                              type: object
+                                            type: array
+                                          matchFields:
+                                            description: A list of node selector requirements
+                                              by node's fields.
+                                            items:
+                                              description: A node selector requirement
+                                                is a selector that contains values,
+                                                a key, and an operator that relates
+                                                the key and values.
+                                              properties:
+                                                key:
+                                                  description: The label key that
+                                                    the selector applies to.
+                                                  type: string
+                                                operator:
+                                                  description: Represents a key's
+                                                    relationship to a set of values.
+                                                    Valid operators are In, NotIn,
+                                                    Exists, DoesNotExist. Gt, and
+                                                    Lt.
+                                                  type: string
+                                                values:
+                                                  description: An array of string
+                                                    values. If the operator is In
+                                                    or NotIn, the values array must
+                                                    be non-empty. If the operator
+                                                    is Exists or DoesNotExist, the
+                                                    values array must be empty. If
+                                                    the operator is Gt or Lt, the
+                                                    values array must have a single
+                                                    element, which will be interpreted
+                                                    as an integer. This array is replaced
+                                                    during a strategic merge patch.
+                                                  items:
+                                                    type: string
+                                                  type: array
+                                              required:
+                                              - key
+                                              - operator
+                                              type: object
+                                            type: array
+                                        type: object
+                                      weight:
+                                        description: Weight associated with matching
+                                          the corresponding nodeSelectorTerm, in the
+                                          range 1-100.
+                                        format: int32
+                                        type: integer
+                                    required:
+                                    - preference
+                                    - weight
+                                    type: object
+                                  type: array
+                                requiredDuringSchedulingIgnoredDuringExecution:
+                                  description: If the affinity requirements specified
+                                    by this field are not met at scheduling time,
+                                    the pod will not be scheduled onto the node. If
+                                    the affinity requirements specified by this field
+                                    cease to be met at some point during pod execution
+                                    (e.g. due to an update), the system may or may
+                                    not try to eventually evict the pod from its node.
+                                  properties:
+                                    nodeSelectorTerms:
+                                      description: Required. A list of node selector
+                                        terms. The terms are ORed.
+                                      items:
+                                        description: A null or empty node selector
+                                          term matches no objects. The requirements
+                                          of them are ANDed. The TopologySelectorTerm
+                                          type implements a subset of the NodeSelectorTerm.
+                                        properties:
+                                          matchExpressions:
+                                            description: A list of node selector requirements
+                                              by node's labels.
+                                            items:
+                                              description: A node selector requirement
+                                                is a selector that contains values,
+                                                a key, and an operator that relates
+                                                the key and values.
+                                              properties:
+                                                key:
+                                                  description: The label key that
+                                                    the selector applies to.
+                                                  type: string
+                                                operator:
+                                                  description: Represents a key's
+                                                    relationship to a set of values.
+                                                    Valid operators are In, NotIn,
+                                                    Exists, DoesNotExist. Gt, and
+                                                    Lt.
+                                                  type: string
+                                                values:
+                                                  description: An array of string
+                                                    values. If the operator is In
+                                                    or NotIn, the values array must
+                                                    be non-empty. If the operator
+                                                    is Exists or DoesNotExist, the
+                                                    values array must be empty. If
+                                                    the operator is Gt or Lt, the
+                                                    values array must have a single
+                                                    element, which will be interpreted
+                                                    as an integer. This array is replaced
+                                                    during a strategic merge patch.
+                                                  items:
+                                                    type: string
+                                                  type: array
+                                              required:
+                                              - key
+                                              - operator
+                                              type: object
+                                            type: array
+                                          matchFields:
+                                            description: A list of node selector requirements
+                                              by node's fields.
+                                            items:
+                                              description: A node selector requirement
+                                                is a selector that contains values,
+                                                a key, and an operator that relates
+                                                the key and values.
+                                              properties:
+                                                key:
+                                                  description: The label key that
+                                                    the selector applies to.
+                                                  type: string
+                                                operator:
+                                                  description: Represents a key's
+                                                    relationship to a set of values.
+                                                    Valid operators are In, NotIn,
+                                                    Exists, DoesNotExist. Gt, and
+                                                    Lt.
+                                                  type: string
+                                                values:
+                                                  description: An array of string
+                                                    values. If the operator is In
+                                                    or NotIn, the values array must
+                                                    be non-empty. If the operator
+                                                    is Exists or DoesNotExist, the
+                                                    values array must be empty. If
+                                                    the operator is Gt or Lt, the
+                                                    values array must have a single
+                                                    element, which will be interpreted
+                                                    as an integer. This array is replaced
+                                                    during a strategic merge patch.
+                                                  items:
+                                                    type: string
+                                                  type: array
+                                              required:
+                                              - key
+                                              - operator
+                                              type: object
+                                            type: array
+                                        type: object
+                                      type: array
+                                  required:
+                                  - nodeSelectorTerms
+                                  type: object
+                              type: object
+                            podAffinity:
+                              description: Describes pod affinity scheduling rules
+                                (e.g. co-locate this pod in the same node, zone, etc.
+                                as some other pod(s)).
+                              properties:
+                                preferredDuringSchedulingIgnoredDuringExecution:
+                                  description: The scheduler will prefer to schedule
+                                    pods to nodes that satisfy the affinity expressions
+                                    specified by this field, but it may choose a node
+                                    that violates one or more of the expressions.
+                                    The node that is most preferred is the one with
+                                    the greatest sum of weights, i.e. for each node
+                                    that meets all of the scheduling requirements
+                                    (resource request, requiredDuringScheduling affinity
+                                    expressions, etc.), compute a sum by iterating
+                                    through the elements of this field and adding
+                                    "weight" to the sum if the node has pods which
+                                    matches the corresponding podAffinityTerm; the
+                                    node(s) with the highest sum are the most preferred.
+                                  items:
+                                    description: The weights of all of the matched
+                                      WeightedPodAffinityTerm fields are added per-node
+                                      to find the most preferred node(s)
+                                    properties:
+                                      podAffinityTerm:
+                                        description: Required. A pod affinity term,
+                                          associated with the corresponding weight.
+                                        properties:
+                                          labelSelector:
+                                            description: A label query over a set
+                                              of resources, in this case pods.
+                                            properties:
+                                              matchExpressions:
+                                                description: matchExpressions is a
+                                                  list of label selector requirements.
+                                                  The requirements are ANDed.
+                                                items:
+                                                  description: A label selector requirement
+                                                    is a selector that contains values,
+                                                    a key, and an operator that relates
+                                                    the key and values.
+                                                  properties:
+                                                    key:
+                                                      description: key is the label
+                                                        key that the selector applies
+                                                        to.
+                                                      type: string
+                                                    operator:
+                                                      description: operator represents
+                                                        a key's relationship to a
+                                                        set of values. Valid operators
+                                                        are In, NotIn, Exists and
+                                                        DoesNotExist.
+                                                      type: string
+                                                    values:
+                                                      description: values is an array
+                                                        of string values. If the operator
+                                                        is In or NotIn, the values
+                                                        array must be non-empty. If
+                                                        the operator is Exists or
+                                                        DoesNotExist, the values array
+                                                        must be empty. This array
+                                                        is replaced during a strategic
+                                                        merge patch.
+                                                      items:
+                                                        type: string
+                                                      type: array
+                                                  required:
+                                                  - key
+                                                  - operator
+                                                  type: object
+                                                type: array
+                                              matchLabels:
+                                                additionalProperties:
+                                                  type: string
+                                                description: matchLabels is a map
+                                                  of {key,value} pairs. A single {key,value}
+                                                  in the matchLabels map is equivalent
+                                                  to an element of matchExpressions,
+                                                  whose key field is "key", the operator
+                                                  is "In", and the values array contains
+                                                  only "value". The requirements are
+                                                  ANDed.
+                                                type: object
+                                            type: object
+                                          namespaceSelector:
+                                            description: A label query over the set
+                                              of namespaces that the term applies
+                                              to. The term is applied to the union
+                                              of the namespaces selected by this field
+                                              and the ones listed in the namespaces
+                                              field. null selector and null or empty
+                                              namespaces list means "this pod's namespace".
+                                              An empty selector ({}) matches all namespaces.
+                                            properties:
+                                              matchExpressions:
+                                                description: matchExpressions is a
+                                                  list of label selector requirements.
+                                                  The requirements are ANDed.
+                                                items:
+                                                  description: A label selector requirement
+                                                    is a selector that contains values,
+                                                    a key, and an operator that relates
+                                                    the key and values.
+                                                  properties:
+                                                    key:
+                                                      description: key is the label
+                                                        key that the selector applies
+                                                        to.
+                                                      type: string
+                                                    operator:
+                                                      description: operator represents
+                                                        a key's relationship to a
+                                                        set of values. Valid operators
+                                                        are In, NotIn, Exists and
+                                                        DoesNotExist.
+                                                      type: string
+                                                    values:
+                                                      description: values is an array
+                                                        of string values. If the operator
+                                                        is In or NotIn, the values
+                                                        array must be non-empty. If
+                                                        the operator is Exists or
+                                                        DoesNotExist, the values array
+                                                        must be empty. This array
+                                                        is replaced during a strategic
+                                                        merge patch.
+                                                      items:
+                                                        type: string
+                                                      type: array
+                                                  required:
+                                                  - key
+                                                  - operator
+                                                  type: object
+                                                type: array
+                                              matchLabels:
+                                                additionalProperties:
+                                                  type: string
+                                                description: matchLabels is a map
+                                                  of {key,value} pairs. A single {key,value}
+                                                  in the matchLabels map is equivalent
+                                                  to an element of matchExpressions,
+                                                  whose key field is "key", the operator
+                                                  is "In", and the values array contains
+                                                  only "value". The requirements are
+                                                  ANDed.
+                                                type: object
+                                            type: object
+                                          namespaces:
+                                            description: namespaces specifies a static
+                                              list of namespace names that the term
+                                              applies to. The term is applied to the
+                                              union of the namespaces listed in this
+                                              field and the ones selected by namespaceSelector.
+                                              null or empty namespaces list and null
+                                              namespaceSelector means "this pod's
+                                              namespace".
+                                            items:
+                                              type: string
+                                            type: array
+                                          topologyKey:
+                                            description: This pod should be co-located
+                                              (affinity) or not co-located (anti-affinity)
+                                              with the pods matching the labelSelector
+                                              in the specified namespaces, where co-located
+                                              is defined as running on a node whose
+                                              value of the label with key topologyKey
+                                              matches that of any node on which any
+                                              of the selected pods is running. Empty
+                                              topologyKey is not allowed.
+                                            type: string
+                                        required:
+                                        - topologyKey
+                                        type: object
+                                      weight:
+                                        description: weight associated with matching
+                                          the corresponding podAffinityTerm, in the
+                                          range 1-100.
+                                        format: int32
+                                        type: integer
+                                    required:
+                                    - podAffinityTerm
+                                    - weight
+                                    type: object
+                                  type: array
+                                requiredDuringSchedulingIgnoredDuringExecution:
+                                  description: If the affinity requirements specified
+                                    by this field are not met at scheduling time,
+                                    the pod will not be scheduled onto the node. If
+                                    the affinity requirements specified by this field
+                                    cease to be met at some point during pod execution
+                                    (e.g. due to a pod label update), the system may
+                                    or may not try to eventually evict the pod from
+                                    its node. When there are multiple elements, the
+                                    lists of nodes corresponding to each podAffinityTerm
+                                    are intersected, i.e. all terms must be satisfied.
+                                  items:
+                                    description: Defines a set of pods (namely those
+                                      matching the labelSelector relative to the given
+                                      namespace(s)) that this pod should be co-located
+                                      (affinity) or not co-located (anti-affinity)
+                                      with, where co-located is defined as running
+                                      on a node whose value of the label with key
+                                      <topologyKey> matches that of any node on which
+                                      a pod of the set of pods is running
+                                    properties:
+                                      labelSelector:
+                                        description: A label query over a set of resources,
+                                          in this case pods.
+                                        properties:
+                                          matchExpressions:
+                                            description: matchExpressions is a list
+                                              of label selector requirements. The
+                                              requirements are ANDed.
+                                            items:
+                                              description: A label selector requirement
+                                                is a selector that contains values,
+                                                a key, and an operator that relates
+                                                the key and values.
+                                              properties:
+                                                key:
+                                                  description: key is the label key
+                                                    that the selector applies to.
+                                                  type: string
+                                                operator:
+                                                  description: operator represents
+                                                    a key's relationship to a set
+                                                    of values. Valid operators are
+                                                    In, NotIn, Exists and DoesNotExist.
+                                                  type: string
+                                                values:
+                                                  description: values is an array
+                                                    of string values. If the operator
+                                                    is In or NotIn, the values array
+                                                    must be non-empty. If the operator
+                                                    is Exists or DoesNotExist, the
+                                                    values array must be empty. This
+                                                    array is replaced during a strategic
+                                                    merge patch.
+                                                  items:
+                                                    type: string
+                                                  type: array
+                                              required:
+                                              - key
+                                              - operator
+                                              type: object
+                                            type: array
+                                          matchLabels:
+                                            additionalProperties:
+                                              type: string
+                                            description: matchLabels is a map of {key,value}
+                                              pairs. A single {key,value} in the matchLabels
+                                              map is equivalent to an element of matchExpressions,
+                                              whose key field is "key", the operator
+                                              is "In", and the values array contains
+                                              only "value". The requirements are ANDed.
+                                            type: object
+                                        type: object
+                                      namespaceSelector:
+                                        description: A label query over the set of
+                                          namespaces that the term applies to. The
+                                          term is applied to the union of the namespaces
+                                          selected by this field and the ones listed
+                                          in the namespaces field. null selector and
+                                          null or empty namespaces list means "this
+                                          pod's namespace". An empty selector ({})
+                                          matches all namespaces.
+                                        properties:
+                                          matchExpressions:
+                                            description: matchExpressions is a list
+                                              of label selector requirements. The
+                                              requirements are ANDed.
+                                            items:
+                                              description: A label selector requirement
+                                                is a selector that contains values,
+                                                a key, and an operator that relates
+                                                the key and values.
+                                              properties:
+                                                key:
+                                                  description: key is the label key
+                                                    that the selector applies to.
+                                                  type: string
+                                                operator:
+                                                  description: operator represents
+                                                    a key's relationship to a set
+                                                    of values. Valid operators are
+                                                    In, NotIn, Exists and DoesNotExist.
+                                                  type: string
+                                                values:
+                                                  description: values is an array
+                                                    of string values. If the operator
+                                                    is In or NotIn, the values array
+                                                    must be non-empty. If the operator
+                                                    is Exists or DoesNotExist, the
+                                                    values array must be empty. This
+                                                    array is replaced during a strategic
+                                                    merge patch.
+                                                  items:
+                                                    type: string
+                                                  type: array
+                                              required:
+                                              - key
+                                              - operator
+                                              type: object
+                                            type: array
+                                          matchLabels:
+                                            additionalProperties:
+                                              type: string
+                                            description: matchLabels is a map of {key,value}
+                                              pairs. A single {key,value} in the matchLabels
+                                              map is equivalent to an element of matchExpressions,
+                                              whose key field is "key", the operator
+                                              is "In", and the values array contains
+                                              only "value". The requirements are ANDed.
+                                            type: object
+                                        type: object
+                                      namespaces:
+                                        description: namespaces specifies a static
+                                          list of namespace names that the term applies
+                                          to. The term is applied to the union of
+                                          the namespaces listed in this field and
+                                          the ones selected by namespaceSelector.
+                                          null or empty namespaces list and null namespaceSelector
+                                          means "this pod's namespace".
+                                        items:
+                                          type: string
+                                        type: array
+                                      topologyKey:
+                                        description: This pod should be co-located
+                                          (affinity) or not co-located (anti-affinity)
+                                          with the pods matching the labelSelector
+                                          in the specified namespaces, where co-located
+                                          is defined as running on a node whose value
+                                          of the label with key topologyKey matches
+                                          that of any node on which any of the selected
+                                          pods is running. Empty topologyKey is not
+                                          allowed.
+                                        type: string
+                                    required:
+                                    - topologyKey
+                                    type: object
+                                  type: array
+                              type: object
+                            podAntiAffinity:
+                              description: Describes pod anti-affinity scheduling
+                                rules (e.g. avoid putting this pod in the same node,
+                                zone, etc. as some other pod(s)).
+                              properties:
+                                preferredDuringSchedulingIgnoredDuringExecution:
+                                  description: The scheduler will prefer to schedule
+                                    pods to nodes that satisfy the anti-affinity expressions
+                                    specified by this field, but it may choose a node
+                                    that violates one or more of the expressions.
+                                    The node that is most preferred is the one with
+                                    the greatest sum of weights, i.e. for each node
+                                    that meets all of the scheduling requirements
+                                    (resource request, requiredDuringScheduling anti-affinity
+                                    expressions, etc.), compute a sum by iterating
+                                    through the elements of this field and adding
+                                    "weight" to the sum if the node has pods which
+                                    matches the corresponding podAffinityTerm; the
+                                    node(s) with the highest sum are the most preferred.
+                                  items:
+                                    description: The weights of all of the matched
+                                      WeightedPodAffinityTerm fields are added per-node
+                                      to find the most preferred node(s)
+                                    properties:
+                                      podAffinityTerm:
+                                        description: Required. A pod affinity term,
+                                          associated with the corresponding weight.
+                                        properties:
+                                          labelSelector:
+                                            description: A label query over a set
+                                              of resources, in this case pods.
+                                            properties:
+                                              matchExpressions:
+                                                description: matchExpressions is a
+                                                  list of label selector requirements.
+                                                  The requirements are ANDed.
+                                                items:
+                                                  description: A label selector requirement
+                                                    is a selector that contains values,
+                                                    a key, and an operator that relates
+                                                    the key and values.
+                                                  properties:
+                                                    key:
+                                                      description: key is the label
+                                                        key that the selector applies
+                                                        to.
+                                                      type: string
+                                                    operator:
+                                                      description: operator represents
+                                                        a key's relationship to a
+                                                        set of values. Valid operators
+                                                        are In, NotIn, Exists and
+                                                        DoesNotExist.
+                                                      type: string
+                                                    values:
+                                                      description: values is an array
+                                                        of string values. If the operator
+                                                        is In or NotIn, the values
+                                                        array must be non-empty. If
+                                                        the operator is Exists or
+                                                        DoesNotExist, the values array
+                                                        must be empty. This array
+                                                        is replaced during a strategic
+                                                        merge patch.
+                                                      items:
+                                                        type: string
+                                                      type: array
+                                                  required:
+                                                  - key
+                                                  - operator
+                                                  type: object
+                                                type: array
+                                              matchLabels:
+                                                additionalProperties:
+                                                  type: string
+                                                description: matchLabels is a map
+                                                  of {key,value} pairs. A single {key,value}
+                                                  in the matchLabels map is equivalent
+                                                  to an element of matchExpressions,
+                                                  whose key field is "key", the operator
+                                                  is "In", and the values array contains
+                                                  only "value". The requirements are
+                                                  ANDed.
+                                                type: object
+                                            type: object
+                                          namespaceSelector:
+                                            description: A label query over the set
+                                              of namespaces that the term applies
+                                              to. The term is applied to the union
+                                              of the namespaces selected by this field
+                                              and the ones listed in the namespaces
+                                              field. null selector and null or empty
+                                              namespaces list means "this pod's namespace".
+                                              An empty selector ({}) matches all namespaces.
+                                            properties:
+                                              matchExpressions:
+                                                description: matchExpressions is a
+                                                  list of label selector requirements.
+                                                  The requirements are ANDed.
+                                                items:
+                                                  description: A label selector requirement
+                                                    is a selector that contains values,
+                                                    a key, and an operator that relates
+                                                    the key and values.
+                                                  properties:
+                                                    key:
+                                                      description: key is the label
+                                                        key that the selector applies
+                                                        to.
+                                                      type: string
+                                                    operator:
+                                                      description: operator represents
+                                                        a key's relationship to a
+                                                        set of values. Valid operators
+                                                        are In, NotIn, Exists and
+                                                        DoesNotExist.
+                                                      type: string
+                                                    values:
+                                                      description: values is an array
+                                                        of string values. If the operator
+                                                        is In or NotIn, the values
+                                                        array must be non-empty. If
+                                                        the operator is Exists or
+                                                        DoesNotExist, the values array
+                                                        must be empty. This array
+                                                        is replaced during a strategic
+                                                        merge patch.
+                                                      items:
+                                                        type: string
+                                                      type: array
+                                                  required:
+                                                  - key
+                                                  - operator
+                                                  type: object
+                                                type: array
+                                              matchLabels:
+                                                additionalProperties:
+                                                  type: string
+                                                description: matchLabels is a map
+                                                  of {key,value} pairs. A single {key,value}
+                                                  in the matchLabels map is equivalent
+                                                  to an element of matchExpressions,
+                                                  whose key field is "key", the operator
+                                                  is "In", and the values array contains
+                                                  only "value". The requirements are
+                                                  ANDed.
+                                                type: object
+                                            type: object
+                                          namespaces:
+                                            description: namespaces specifies a static
+                                              list of namespace names that the term
+                                              applies to. The term is applied to the
+                                              union of the namespaces listed in this
+                                              field and the ones selected by namespaceSelector.
+                                              null or empty namespaces list and null
+                                              namespaceSelector means "this pod's
+                                              namespace".
+                                            items:
+                                              type: string
+                                            type: array
+                                          topologyKey:
+                                            description: This pod should be co-located
+                                              (affinity) or not co-located (anti-affinity)
+                                              with the pods matching the labelSelector
+                                              in the specified namespaces, where co-located
+                                              is defined as running on a node whose
+                                              value of the label with key topologyKey
+                                              matches that of any node on which any
+                                              of the selected pods is running. Empty
+                                              topologyKey is not allowed.
+                                            type: string
+                                        required:
+                                        - topologyKey
+                                        type: object
+                                      weight:
+                                        description: weight associated with matching
+                                          the corresponding podAffinityTerm, in the
+                                          range 1-100.
+                                        format: int32
+                                        type: integer
+                                    required:
+                                    - podAffinityTerm
+                                    - weight
+                                    type: object
+                                  type: array
+                                requiredDuringSchedulingIgnoredDuringExecution:
+                                  description: If the anti-affinity requirements specified
+                                    by this field are not met at scheduling time,
+                                    the pod will not be scheduled onto the node. If
+                                    the anti-affinity requirements specified by this
+                                    field cease to be met at some point during pod
+                                    execution (e.g. due to a pod label update), the
+                                    system may or may not try to eventually evict
+                                    the pod from its node. When there are multiple
+                                    elements, the lists of nodes corresponding to
+                                    each podAffinityTerm are intersected, i.e. all
+                                    terms must be satisfied.
+                                  items:
+                                    description: Defines a set of pods (namely those
+                                      matching the labelSelector relative to the given
+                                      namespace(s)) that this pod should be co-located
+                                      (affinity) or not co-located (anti-affinity)
+                                      with, where co-located is defined as running
+                                      on a node whose value of the label with key
+                                      <topologyKey> matches that of any node on which
+                                      a pod of the set of pods is running
+                                    properties:
+                                      labelSelector:
+                                        description: A label query over a set of resources,
+                                          in this case pods.
+                                        properties:
+                                          matchExpressions:
+                                            description: matchExpressions is a list
+                                              of label selector requirements. The
+                                              requirements are ANDed.
+                                            items:
+                                              description: A label selector requirement
+                                                is a selector that contains values,
+                                                a key, and an operator that relates
+                                                the key and values.
+                                              properties:
+                                                key:
+                                                  description: key is the label key
+                                                    that the selector applies to.
+                                                  type: string
+                                                operator:
+                                                  description: operator represents
+                                                    a key's relationship to a set
+                                                    of values. Valid operators are
+                                                    In, NotIn, Exists and DoesNotExist.
+                                                  type: string
+                                                values:
+                                                  description: values is an array
+                                                    of string values. If the operator
+                                                    is In or NotIn, the values array
+                                                    must be non-empty. If the operator
+                                                    is Exists or DoesNotExist, the
+                                                    values array must be empty. This
+                                                    array is replaced during a strategic
+                                                    merge patch.
+                                                  items:
+                                                    type: string
+                                                  type: array
+                                              required:
+                                              - key
+                                              - operator
+                                              type: object
+                                            type: array
+                                          matchLabels:
+                                            additionalProperties:
+                                              type: string
+                                            description: matchLabels is a map of {key,value}
+                                              pairs. A single {key,value} in the matchLabels
+                                              map is equivalent to an element of matchExpressions,
+                                              whose key field is "key", the operator
+                                              is "In", and the values array contains
+                                              only "value". The requirements are ANDed.
+                                            type: object
+                                        type: object
+                                      namespaceSelector:
+                                        description: A label query over the set of
+                                          namespaces that the term applies to. The
+                                          term is applied to the union of the namespaces
+                                          selected by this field and the ones listed
+                                          in the namespaces field. null selector and
+                                          null or empty namespaces list means "this
+                                          pod's namespace". An empty selector ({})
+                                          matches all namespaces.
+                                        properties:
+                                          matchExpressions:
+                                            description: matchExpressions is a list
+                                              of label selector requirements. The
+                                              requirements are ANDed.
+                                            items:
+                                              description: A label selector requirement
+                                                is a selector that contains values,
+                                                a key, and an operator that relates
+                                                the key and values.
+                                              properties:
+                                                key:
+                                                  description: key is the label key
+                                                    that the selector applies to.
+                                                  type: string
+                                                operator:
+                                                  description: operator represents
+                                                    a key's relationship to a set
+                                                    of values. Valid operators are
+                                                    In, NotIn, Exists and DoesNotExist.
+                                                  type: string
+                                                values:
+                                                  description: values is an array
+                                                    of string values. If the operator
+                                                    is In or NotIn, the values array
+                                                    must be non-empty. If the operator
+                                                    is Exists or DoesNotExist, the
+                                                    values array must be empty. This
+                                                    array is replaced during a strategic
+                                                    merge patch.
+                                                  items:
+                                                    type: string
+                                                  type: array
+                                              required:
+                                              - key
+                                              - operator
+                                              type: object
+                                            type: array
+                                          matchLabels:
+                                            additionalProperties:
+                                              type: string
+                                            description: matchLabels is a map of {key,value}
+                                              pairs. A single {key,value} in the matchLabels
+                                              map is equivalent to an element of matchExpressions,
+                                              whose key field is "key", the operator
+                                              is "In", and the values array contains
+                                              only "value". The requirements are ANDed.
+                                            type: object
+                                        type: object
+                                      namespaces:
+                                        description: namespaces specifies a static
+                                          list of namespace names that the term applies
+                                          to. The term is applied to the union of
+                                          the namespaces listed in this field and
+                                          the ones selected by namespaceSelector.
+                                          null or empty namespaces list and null namespaceSelector
+                                          means "this pod's namespace".
+                                        items:
+                                          type: string
+                                        type: array
+                                      topologyKey:
+                                        description: This pod should be co-located
+                                          (affinity) or not co-located (anti-affinity)
+                                          with the pods matching the labelSelector
+                                          in the specified namespaces, where co-located
+                                          is defined as running on a node whose value
+                                          of the label with key topologyKey matches
+                                          that of any node on which any of the selected
+                                          pods is running. Empty topologyKey is not
+                                          allowed.
+                                        type: string
+                                    required:
+                                    - topologyKey
+                                    type: object
+                                  type: array
+                              type: object
+                          type: object
+                        containers:
+                          items:
+                            description: A single application container that you want
+                              to run within a pod.
+                            properties:
+                              args:
+                                description: 'Arguments to the entrypoint. The container
+                                  image''s CMD is used if this is not provided. Variable
+                                  references $(VAR_NAME) are expanded using the container''s
+                                  environment. If a variable cannot be resolved, the
+                                  reference in the input string will be unchanged.
+                                  Double $$ are reduced to a single $, which allows
+                                  for escaping the $(VAR_NAME) syntax: i.e. "$$(VAR_NAME)"
+                                  will produce the string literal "$(VAR_NAME)". Escaped
+                                  references will never be expanded, regardless of
+                                  whether the variable exists or not. Cannot be updated.
+                                  More info: https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell'
+                                items:
+                                  type: string
+                                type: array
+                              command:
+                                description: 'Entrypoint array. Not executed within
+                                  a shell. The container image''s ENTRYPOINT is used
+                                  if this is not provided. Variable references $(VAR_NAME)
+                                  are expanded using the container''s environment.
+                                  If a variable cannot be resolved, the reference
+                                  in the input string will be unchanged. Double $$
+                                  are reduced to a single $, which allows for escaping
+                                  the $(VAR_NAME) syntax: i.e. "$$(VAR_NAME)" will
+                                  produce the string literal "$(VAR_NAME)". Escaped
+                                  references will never be expanded, regardless of
+                                  whether the variable exists or not. Cannot be updated.
+                                  More info: https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell'
+                                items:
+                                  type: string
+                                type: array
+                              env:
+                                description: List of environment variables to set
+                                  in the container. Cannot be updated.
+                                items:
+                                  description: EnvVar represents an environment variable
+                                    present in a Container.
+                                  properties:
+                                    name:
+                                      description: Name of the environment variable.
+                                        Must be a C_IDENTIFIER.
+                                      type: string
+                                    value:
+                                      description: 'Variable references $(VAR_NAME)
+                                        are expanded using the previously defined
+                                        environment variables in the container and
+                                        any service environment variables. If a variable
+                                        cannot be resolved, the reference in the input
+                                        string will be unchanged. Double $$ are reduced
+                                        to a single $, which allows for escaping the
+                                        $(VAR_NAME) syntax: i.e. "$$(VAR_NAME)" will
+                                        produce the string literal "$(VAR_NAME)".
+                                        Escaped references will never be expanded,
+                                        regardless of whether the variable exists
+                                        or not. Defaults to "".'
+                                      type: string
+                                    valueFrom:
+                                      description: Source for the environment variable's
+                                        value. Cannot be used if value is not empty.
+                                      properties:
+                                        configMapKeyRef:
+                                          description: Selects a key of a ConfigMap.
+                                          properties:
+                                            key:
+                                              description: The key to select.
+                                              type: string
+                                            name:
+                                              description: 'Name of the referent.
+                                                More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                                TODO: Add other useful fields. apiVersion,
+                                                kind, uid?'
+                                              type: string
+                                            optional:
+                                              description: Specify whether the ConfigMap
+                                                or its key must be defined
+                                              type: boolean
+                                          required:
+                                          - key
+                                          type: object
+                                        fieldRef:
+                                          description: 'Selects a field of the pod:
+                                            supports metadata.name, metadata.namespace,
+                                            `metadata.labels[''<KEY>'']`, `metadata.annotations[''<KEY>'']`,
+                                            spec.nodeName, spec.serviceAccountName,
+                                            status.hostIP, status.podIP, status.podIPs.'
+                                          properties:
+                                            apiVersion:
+                                              description: Version of the schema the
+                                                FieldPath is written in terms of,
+                                                defaults to "v1".
+                                              type: string
+                                            fieldPath:
+                                              description: Path of the field to select
+                                                in the specified API version.
+                                              type: string
+                                          required:
+                                          - fieldPath
+                                          type: object
+                                        resourceFieldRef:
+                                          description: 'Selects a resource of the
+                                            container: only resources limits and requests
+                                            (limits.cpu, limits.memory, limits.ephemeral-storage,
+                                            requests.cpu, requests.memory and requests.ephemeral-storage)
+                                            are currently supported.'
+                                          properties:
+                                            containerName:
+                                              description: 'Container name: required
+                                                for volumes, optional for env vars'
+                                              type: string
+                                            divisor:
+                                              anyOf:
+                                              - type: integer
+                                              - type: string
+                                              description: Specifies the output format
+                                                of the exposed resources, defaults
+                                                to "1"
+                                              pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                              x-kubernetes-int-or-string: true
+                                            resource:
+                                              description: 'Required: resource to
+                                                select'
+                                              type: string
+                                          required:
+                                          - resource
+                                          type: object
+                                        secretKeyRef:
+                                          description: Selects a key of a secret in
+                                            the pod's namespace
+                                          properties:
+                                            key:
+                                              description: The key of the secret to
+                                                select from.  Must be a valid secret
+                                                key.
+                                              type: string
+                                            name:
+                                              description: 'Name of the referent.
+                                                More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                                TODO: Add other useful fields. apiVersion,
+                                                kind, uid?'
+                                              type: string
+                                            optional:
+                                              description: Specify whether the Secret
+                                                or its key must be defined
+                                              type: boolean
+                                          required:
+                                          - key
+                                          type: object
+                                      type: object
+                                  required:
+                                  - name
+                                  type: object
+                                type: array
+                              envFrom:
+                                description: List of sources to populate environment
+                                  variables in the container. The keys defined within
+                                  a source must be a C_IDENTIFIER. All invalid keys
+                                  will be reported as an event when the container
+                                  is starting. When a key exists in multiple sources,
+                                  the value associated with the last source will take
+                                  precedence. Values defined by an Env with a duplicate
+                                  key will take precedence. Cannot be updated.
+                                items:
+                                  description: EnvFromSource represents the source
+                                    of a set of ConfigMaps
+                                  properties:
+                                    configMapRef:
+                                      description: The ConfigMap to select from
+                                      properties:
+                                        name:
+                                          description: 'Name of the referent. More
+                                            info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                            TODO: Add other useful fields. apiVersion,
+                                            kind, uid?'
+                                          type: string
+                                        optional:
+                                          description: Specify whether the ConfigMap
+                                            must be defined
+                                          type: boolean
+                                      type: object
+                                    prefix:
+                                      description: An optional identifier to prepend
+                                        to each key in the ConfigMap. Must be a C_IDENTIFIER.
+                                      type: string
+                                    secretRef:
+                                      description: The Secret to select from
+                                      properties:
+                                        name:
+                                          description: 'Name of the referent. More
+                                            info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                            TODO: Add other useful fields. apiVersion,
+                                            kind, uid?'
+                                          type: string
+                                        optional:
+                                          description: Specify whether the Secret
+                                            must be defined
+                                          type: boolean
+                                      type: object
+                                  type: object
+                                type: array
+                              image:
+                                description: 'Container image name. More info: https://kubernetes.io/docs/concepts/containers/images
+                                  This field is optional to allow higher level config
+                                  management to default or override container images
+                                  in workload controllers like Deployments and StatefulSets.'
+                                type: string
+                              imagePullPolicy:
+                                description: 'Image pull policy. One of Always, Never,
+                                  IfNotPresent. Defaults to Always if :latest tag
+                                  is specified, or IfNotPresent otherwise. Cannot
+                                  be updated. More info: https://kubernetes.io/docs/concepts/containers/images#updating-images'
+                                type: string
+                              lifecycle:
+                                description: Actions that the management system should
+                                  take in response to container lifecycle events.
+                                  Cannot be updated.
+                                properties:
+                                  postStart:
+                                    description: 'PostStart is called immediately
+                                      after a container is created. If the handler
+                                      fails, the container is terminated and restarted
+                                      according to its restart policy. Other management
+                                      of the container blocks until the hook completes.
+                                      More info: https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/#container-hooks'
+                                    properties:
+                                      exec:
+                                        description: Exec specifies the action to
+                                          take.
+                                        properties:
+                                          command:
+                                            description: Command is the command line
+                                              to execute inside the container, the
+                                              working directory for the command  is
+                                              root ('/') in the container's filesystem.
+                                              The command is simply exec'd, it is
+                                              not run inside a shell, so traditional
+                                              shell instructions ('|', etc) won't
+                                              work. To use a shell, you need to explicitly
+                                              call out to that shell. Exit status
+                                              of 0 is treated as live/healthy and
+                                              non-zero is unhealthy.
+                                            items:
+                                              type: string
+                                            type: array
+                                        type: object
+                                      httpGet:
+                                        description: HTTPGet specifies the http request
+                                          to perform.
+                                        properties:
+                                          host:
+                                            description: Host name to connect to,
+                                              defaults to the pod IP. You probably
+                                              want to set "Host" in httpHeaders instead.
+                                            type: string
+                                          httpHeaders:
+                                            description: Custom headers to set in
+                                              the request. HTTP allows repeated headers.
+                                            items:
+                                              description: HTTPHeader describes a
+                                                custom header to be used in HTTP probes
+                                              properties:
+                                                name:
+                                                  description: The header field name
+                                                  type: string
+                                                value:
+                                                  description: The header field value
+                                                  type: string
+                                              required:
+                                              - name
+                                              - value
+                                              type: object
+                                            type: array
+                                          path:
+                                            description: Path to access on the HTTP
+                                              server.
+                                            type: string
+                                          port:
+                                            anyOf:
+                                            - type: integer
+                                            - type: string
+                                            description: Name or number of the port
+                                              to access on the container. Number must
+                                              be in the range 1 to 65535. Name must
+                                              be an IANA_SVC_NAME.
+                                            x-kubernetes-int-or-string: true
+                                          scheme:
+                                            description: Scheme to use for connecting
+                                              to the host. Defaults to HTTP.
+                                            type: string
+                                        required:
+                                        - port
+                                        type: object
+                                      tcpSocket:
+                                        description: Deprecated. TCPSocket is NOT
+                                          supported as a LifecycleHandler and kept
+                                          for the backward compatibility. There are
+                                          no validation of this field and lifecycle
+                                          hooks will fail in runtime when tcp handler
+                                          is specified.
+                                        properties:
+                                          host:
+                                            description: 'Optional: Host name to connect
+                                              to, defaults to the pod IP.'
+                                            type: string
+                                          port:
+                                            anyOf:
+                                            - type: integer
+                                            - type: string
+                                            description: Number or name of the port
+                                              to access on the container. Number must
+                                              be in the range 1 to 65535. Name must
+                                              be an IANA_SVC_NAME.
+                                            x-kubernetes-int-or-string: true
+                                        required:
+                                        - port
+                                        type: object
+                                    type: object
+                                  preStop:
+                                    description: 'PreStop is called immediately before
+                                      a container is terminated due to an API request
+                                      or management event such as liveness/startup
+                                      probe failure, preemption, resource contention,
+                                      etc. The handler is not called if the container
+                                      crashes or exits. The Pod''s termination grace
+                                      period countdown begins before the PreStop hook
+                                      is executed. Regardless of the outcome of the
+                                      handler, the container will eventually terminate
+                                      within the Pod''s termination grace period (unless
+                                      delayed by finalizers). Other management of
+                                      the container blocks until the hook completes
+                                      or until the termination grace period is reached.
+                                      More info: https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/#container-hooks'
+                                    properties:
+                                      exec:
+                                        description: Exec specifies the action to
+                                          take.
+                                        properties:
+                                          command:
+                                            description: Command is the command line
+                                              to execute inside the container, the
+                                              working directory for the command  is
+                                              root ('/') in the container's filesystem.
+                                              The command is simply exec'd, it is
+                                              not run inside a shell, so traditional
+                                              shell instructions ('|', etc) won't
+                                              work. To use a shell, you need to explicitly
+                                              call out to that shell. Exit status
+                                              of 0 is treated as live/healthy and
+                                              non-zero is unhealthy.
+                                            items:
+                                              type: string
+                                            type: array
+                                        type: object
+                                      httpGet:
+                                        description: HTTPGet specifies the http request
+                                          to perform.
+                                        properties:
+                                          host:
+                                            description: Host name to connect to,
+                                              defaults to the pod IP. You probably
+                                              want to set "Host" in httpHeaders instead.
+                                            type: string
+                                          httpHeaders:
+                                            description: Custom headers to set in
+                                              the request. HTTP allows repeated headers.
+                                            items:
+                                              description: HTTPHeader describes a
+                                                custom header to be used in HTTP probes
+                                              properties:
+                                                name:
+                                                  description: The header field name
+                                                  type: string
+                                                value:
+                                                  description: The header field value
+                                                  type: string
+                                              required:
+                                              - name
+                                              - value
+                                              type: object
+                                            type: array
+                                          path:
+                                            description: Path to access on the HTTP
+                                              server.
+                                            type: string
+                                          port:
+                                            anyOf:
+                                            - type: integer
+                                            - type: string
+                                            description: Name or number of the port
+                                              to access on the container. Number must
+                                              be in the range 1 to 65535. Name must
+                                              be an IANA_SVC_NAME.
+                                            x-kubernetes-int-or-string: true
+                                          scheme:
+                                            description: Scheme to use for connecting
+                                              to the host. Defaults to HTTP.
+                                            type: string
+                                        required:
+                                        - port
+                                        type: object
+                                      tcpSocket:
+                                        description: Deprecated. TCPSocket is NOT
+                                          supported as a LifecycleHandler and kept
+                                          for the backward compatibility. There are
+                                          no validation of this field and lifecycle
+                                          hooks will fail in runtime when tcp handler
+                                          is specified.
+                                        properties:
+                                          host:
+                                            description: 'Optional: Host name to connect
+                                              to, defaults to the pod IP.'
+                                            type: string
+                                          port:
+                                            anyOf:
+                                            - type: integer
+                                            - type: string
+                                            description: Number or name of the port
+                                              to access on the container. Number must
+                                              be in the range 1 to 65535. Name must
+                                              be an IANA_SVC_NAME.
+                                            x-kubernetes-int-or-string: true
+                                        required:
+                                        - port
+                                        type: object
+                                    type: object
+                                type: object
+                              livenessProbe:
+                                description: 'Periodic probe of container liveness.
+                                  Container will be restarted if the probe fails.
+                                  Cannot be updated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                                properties:
+                                  exec:
+                                    description: Exec specifies the action to take.
+                                    properties:
+                                      command:
+                                        description: Command is the command line to
+                                          execute inside the container, the working
+                                          directory for the command  is root ('/')
+                                          in the container's filesystem. The command
+                                          is simply exec'd, it is not run inside a
+                                          shell, so traditional shell instructions
+                                          ('|', etc) won't work. To use a shell, you
+                                          need to explicitly call out to that shell.
+                                          Exit status of 0 is treated as live/healthy
+                                          and non-zero is unhealthy.
+                                        items:
+                                          type: string
+                                        type: array
+                                    type: object
+                                  failureThreshold:
+                                    description: Minimum consecutive failures for
+                                      the probe to be considered failed after having
+                                      succeeded. Defaults to 3. Minimum value is 1.
+                                    format: int32
+                                    type: integer
+                                  grpc:
+                                    description: GRPC specifies an action involving
+                                      a GRPC port. This is a beta field and requires
+                                      enabling GRPCContainerProbe feature gate.
+                                    properties:
+                                      port:
+                                        description: Port number of the gRPC service.
+                                          Number must be in the range 1 to 65535.
+                                        format: int32
+                                        type: integer
+                                      service:
+                                        description: "Service is the name of the service
+                                          to place in the gRPC HealthCheckRequest
+                                          (see https://github.com/grpc/grpc/blob/master/doc/health-checking.md).
+                                          \n If this is not specified, the default
+                                          behavior is defined by gRPC."
+                                        type: string
+                                    required:
+                                    - port
+                                    type: object
+                                  httpGet:
+                                    description: HTTPGet specifies the http request
+                                      to perform.
+                                    properties:
+                                      host:
+                                        description: Host name to connect to, defaults
+                                          to the pod IP. You probably want to set
+                                          "Host" in httpHeaders instead.
+                                        type: string
+                                      httpHeaders:
+                                        description: Custom headers to set in the
+                                          request. HTTP allows repeated headers.
+                                        items:
+                                          description: HTTPHeader describes a custom
+                                            header to be used in HTTP probes
+                                          properties:
+                                            name:
+                                              description: The header field name
+                                              type: string
+                                            value:
+                                              description: The header field value
+                                              type: string
+                                          required:
+                                          - name
+                                          - value
+                                          type: object
+                                        type: array
+                                      path:
+                                        description: Path to access on the HTTP server.
+                                        type: string
+                                      port:
+                                        anyOf:
+                                        - type: integer
+                                        - type: string
+                                        description: Name or number of the port to
+                                          access on the container. Number must be
+                                          in the range 1 to 65535. Name must be an
+                                          IANA_SVC_NAME.
+                                        x-kubernetes-int-or-string: true
+                                      scheme:
+                                        description: Scheme to use for connecting
+                                          to the host. Defaults to HTTP.
+                                        type: string
+                                    required:
+                                    - port
+                                    type: object
+                                  initialDelaySeconds:
+                                    description: 'Number of seconds after the container
+                                      has started before liveness probes are initiated.
+                                      More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                                    format: int32
+                                    type: integer
+                                  periodSeconds:
+                                    description: How often (in seconds) to perform
+                                      the probe. Default to 10 seconds. Minimum value
+                                      is 1.
+                                    format: int32
+                                    type: integer
+                                  successThreshold:
+                                    description: Minimum consecutive successes for
+                                      the probe to be considered successful after
+                                      having failed. Defaults to 1. Must be 1 for
+                                      liveness and startup. Minimum value is 1.
+                                    format: int32
+                                    type: integer
+                                  tcpSocket:
+                                    description: TCPSocket specifies an action involving
+                                      a TCP port.
+                                    properties:
+                                      host:
+                                        description: 'Optional: Host name to connect
+                                          to, defaults to the pod IP.'
+                                        type: string
+                                      port:
+                                        anyOf:
+                                        - type: integer
+                                        - type: string
+                                        description: Number or name of the port to
+                                          access on the container. Number must be
+                                          in the range 1 to 65535. Name must be an
+                                          IANA_SVC_NAME.
+                                        x-kubernetes-int-or-string: true
+                                    required:
+                                    - port
+                                    type: object
+                                  terminationGracePeriodSeconds:
+                                    description: Optional duration in seconds the
+                                      pod needs to terminate gracefully upon probe
+                                      failure. The grace period is the duration in
+                                      seconds after the processes running in the pod
+                                      are sent a termination signal and the time when
+                                      the processes are forcibly halted with a kill
+                                      signal. Set this value longer than the expected
+                                      cleanup time for your process. If this value
+                                      is nil, the pod's terminationGracePeriodSeconds
+                                      will be used. Otherwise, this value overrides
+                                      the value provided by the pod spec. Value must
+                                      be non-negative integer. The value zero indicates
+                                      stop immediately via the kill signal (no opportunity
+                                      to shut down). This is a beta field and requires
+                                      enabling ProbeTerminationGracePeriod feature
+                                      gate. Minimum value is 1. spec.terminationGracePeriodSeconds
+                                      is used if unset.
+                                    format: int64
+                                    type: integer
+                                  timeoutSeconds:
+                                    description: 'Number of seconds after which the
+                                      probe times out. Defaults to 1 second. Minimum
+                                      value is 1. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                                    format: int32
+                                    type: integer
+                                type: object
+                              name:
+                                description: Name of the container specified as a
+                                  DNS_LABEL. Each container in a pod must have a unique
+                                  name (DNS_LABEL). Cannot be updated.
+                                type: string
+                              ports:
+                                description: List of ports to expose from the container.
+                                  Not specifying a port here DOES NOT prevent that
+                                  port from being exposed. Any port which is listening
+                                  on the default "0.0.0.0" address inside a container
+                                  will be accessible from the network. Modifying this
+                                  array with strategic merge patch may corrupt the
+                                  data. For more information See https://github.com/kubernetes/kubernetes/issues/108255.
+                                  Cannot be updated.
+                                items:
+                                  description: ContainerPort represents a network
+                                    port in a single container.
+                                  properties:
+                                    containerPort:
+                                      description: Number of port to expose on the
+                                        pod's IP address. This must be a valid port
+                                        number, 0 < x < 65536.
+                                      format: int32
+                                      type: integer
+                                    hostIP:
+                                      description: What host IP to bind the external
+                                        port to.
+                                      type: string
+                                    hostPort:
+                                      description: Number of port to expose on the
+                                        host. If specified, this must be a valid port
+                                        number, 0 < x < 65536. If HostNetwork is specified,
+                                        this must match ContainerPort. Most containers
+                                        do not need this.
+                                      format: int32
+                                      type: integer
+                                    name:
+                                      description: If specified, this must be an IANA_SVC_NAME
+                                        and unique within the pod. Each named port
+                                        in a pod must have a unique name. Name for
+                                        the port that can be referred to by services.
+                                      type: string
+                                    protocol:
+                                      default: TCP
+                                      description: Protocol for port. Must be UDP,
+                                        TCP, or SCTP. Defaults to "TCP".
+                                      type: string
+                                  required:
+                                  - containerPort
+                                  type: object
+                                type: array
+                                x-kubernetes-list-map-keys:
+                                - containerPort
+                                - protocol
+                                x-kubernetes-list-type: map
+                              readinessProbe:
+                                description: 'Periodic probe of container service
+                                  readiness. Container will be removed from service
+                                  endpoints if the probe fails. Cannot be updated.
+                                  More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                                properties:
+                                  exec:
+                                    description: Exec specifies the action to take.
+                                    properties:
+                                      command:
+                                        description: Command is the command line to
+                                          execute inside the container, the working
+                                          directory for the command  is root ('/')
+                                          in the container's filesystem. The command
+                                          is simply exec'd, it is not run inside a
+                                          shell, so traditional shell instructions
+                                          ('|', etc) won't work. To use a shell, you
+                                          need to explicitly call out to that shell.
+                                          Exit status of 0 is treated as live/healthy
+                                          and non-zero is unhealthy.
+                                        items:
+                                          type: string
+                                        type: array
+                                    type: object
+                                  failureThreshold:
+                                    description: Minimum consecutive failures for
+                                      the probe to be considered failed after having
+                                      succeeded. Defaults to 3. Minimum value is 1.
+                                    format: int32
+                                    type: integer
+                                  grpc:
+                                    description: GRPC specifies an action involving
+                                      a GRPC port. This is a beta field and requires
+                                      enabling GRPCContainerProbe feature gate.
+                                    properties:
+                                      port:
+                                        description: Port number of the gRPC service.
+                                          Number must be in the range 1 to 65535.
+                                        format: int32
+                                        type: integer
+                                      service:
+                                        description: "Service is the name of the service
+                                          to place in the gRPC HealthCheckRequest
+                                          (see https://github.com/grpc/grpc/blob/master/doc/health-checking.md).
+                                          \n If this is not specified, the default
+                                          behavior is defined by gRPC."
+                                        type: string
+                                    required:
+                                    - port
+                                    type: object
+                                  httpGet:
+                                    description: HTTPGet specifies the http request
+                                      to perform.
+                                    properties:
+                                      host:
+                                        description: Host name to connect to, defaults
+                                          to the pod IP. You probably want to set
+                                          "Host" in httpHeaders instead.
+                                        type: string
+                                      httpHeaders:
+                                        description: Custom headers to set in the
+                                          request. HTTP allows repeated headers.
+                                        items:
+                                          description: HTTPHeader describes a custom
+                                            header to be used in HTTP probes
+                                          properties:
+                                            name:
+                                              description: The header field name
+                                              type: string
+                                            value:
+                                              description: The header field value
+                                              type: string
+                                          required:
+                                          - name
+                                          - value
+                                          type: object
+                                        type: array
+                                      path:
+                                        description: Path to access on the HTTP server.
+                                        type: string
+                                      port:
+                                        anyOf:
+                                        - type: integer
+                                        - type: string
+                                        description: Name or number of the port to
+                                          access on the container. Number must be
+                                          in the range 1 to 65535. Name must be an
+                                          IANA_SVC_NAME.
+                                        x-kubernetes-int-or-string: true
+                                      scheme:
+                                        description: Scheme to use for connecting
+                                          to the host. Defaults to HTTP.
+                                        type: string
+                                    required:
+                                    - port
+                                    type: object
+                                  initialDelaySeconds:
+                                    description: 'Number of seconds after the container
+                                      has started before liveness probes are initiated.
+                                      More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                                    format: int32
+                                    type: integer
+                                  periodSeconds:
+                                    description: How often (in seconds) to perform
+                                      the probe. Default to 10 seconds. Minimum value
+                                      is 1.
+                                    format: int32
+                                    type: integer
+                                  successThreshold:
+                                    description: Minimum consecutive successes for
+                                      the probe to be considered successful after
+                                      having failed. Defaults to 1. Must be 1 for
+                                      liveness and startup. Minimum value is 1.
+                                    format: int32
+                                    type: integer
+                                  tcpSocket:
+                                    description: TCPSocket specifies an action involving
+                                      a TCP port.
+                                    properties:
+                                      host:
+                                        description: 'Optional: Host name to connect
+                                          to, defaults to the pod IP.'
+                                        type: string
+                                      port:
+                                        anyOf:
+                                        - type: integer
+                                        - type: string
+                                        description: Number or name of the port to
+                                          access on the container. Number must be
+                                          in the range 1 to 65535. Name must be an
+                                          IANA_SVC_NAME.
+                                        x-kubernetes-int-or-string: true
+                                    required:
+                                    - port
+                                    type: object
+                                  terminationGracePeriodSeconds:
+                                    description: Optional duration in seconds the
+                                      pod needs to terminate gracefully upon probe
+                                      failure. The grace period is the duration in
+                                      seconds after the processes running in the pod
+                                      are sent a termination signal and the time when
+                                      the processes are forcibly halted with a kill
+                                      signal. Set this value longer than the expected
+                                      cleanup time for your process. If this value
+                                      is nil, the pod's terminationGracePeriodSeconds
+                                      will be used. Otherwise, this value overrides
+                                      the value provided by the pod spec. Value must
+                                      be non-negative integer. The value zero indicates
+                                      stop immediately via the kill signal (no opportunity
+                                      to shut down). This is a beta field and requires
+                                      enabling ProbeTerminationGracePeriod feature
+                                      gate. Minimum value is 1. spec.terminationGracePeriodSeconds
+                                      is used if unset.
+                                    format: int64
+                                    type: integer
+                                  timeoutSeconds:
+                                    description: 'Number of seconds after which the
+                                      probe times out. Defaults to 1 second. Minimum
+                                      value is 1. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                                    format: int32
+                                    type: integer
+                                type: object
+                              resources:
+                                description: 'Compute Resources required by this container.
+                                  Cannot be updated. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+                                properties:
+                                  limits:
+                                    additionalProperties:
+                                      anyOf:
+                                      - type: integer
+                                      - type: string
+                                      pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                      x-kubernetes-int-or-string: true
+                                    description: 'Limits describes the maximum amount
+                                      of compute resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+                                    type: object
+                                  requests:
+                                    additionalProperties:
+                                      anyOf:
+                                      - type: integer
+                                      - type: string
+                                      pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                      x-kubernetes-int-or-string: true
+                                    description: 'Requests describes the minimum amount
+                                      of compute resources required. If Requests is
+                                      omitted for a container, it defaults to Limits
+                                      if that is explicitly specified, otherwise to
+                                      an implementation-defined value. More info:
+                                      https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+                                    type: object
+                                type: object
+                              securityContext:
+                                description: 'SecurityContext defines the security
+                                  options the container should be run with. If set,
+                                  the fields of SecurityContext override the equivalent
+                                  fields of PodSecurityContext. More info: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/'
+                                properties:
+                                  allowPrivilegeEscalation:
+                                    description: 'AllowPrivilegeEscalation controls
+                                      whether a process can gain more privileges than
+                                      its parent process. This bool directly controls
+                                      if the no_new_privs flag will be set on the
+                                      container process. AllowPrivilegeEscalation
+                                      is true always when the container is: 1) run
+                                      as Privileged 2) has CAP_SYS_ADMIN Note that
+                                      this field cannot be set when spec.os.name is
+                                      windows.'
+                                    type: boolean
+                                  capabilities:
+                                    description: The capabilities to add/drop when
+                                      running containers. Defaults to the default
+                                      set of capabilities granted by the container
+                                      runtime. Note that this field cannot be set
+                                      when spec.os.name is windows.
+                                    properties:
+                                      add:
+                                        description: Added capabilities
+                                        items:
+                                          description: Capability represent POSIX
+                                            capabilities type
+                                          type: string
+                                        type: array
+                                      drop:
+                                        description: Removed capabilities
+                                        items:
+                                          description: Capability represent POSIX
+                                            capabilities type
+                                          type: string
+                                        type: array
+                                    type: object
+                                  privileged:
+                                    description: Run container in privileged mode.
+                                      Processes in privileged containers are essentially
+                                      equivalent to root on the host. Defaults to
+                                      false. Note that this field cannot be set when
+                                      spec.os.name is windows.
+                                    type: boolean
+                                  procMount:
+                                    description: procMount denotes the type of proc
+                                      mount to use for the containers. The default
+                                      is DefaultProcMount which uses the container
+                                      runtime defaults for readonly paths and masked
+                                      paths. This requires the ProcMountType feature
+                                      flag to be enabled. Note that this field cannot
+                                      be set when spec.os.name is windows.
+                                    type: string
+                                  readOnlyRootFilesystem:
+                                    description: Whether this container has a read-only
+                                      root filesystem. Default is false. Note that
+                                      this field cannot be set when spec.os.name is
+                                      windows.
+                                    type: boolean
+                                  runAsGroup:
+                                    description: The GID to run the entrypoint of
+                                      the container process. Uses runtime default
+                                      if unset. May also be set in PodSecurityContext.  If
+                                      set in both SecurityContext and PodSecurityContext,
+                                      the value specified in SecurityContext takes
+                                      precedence. Note that this field cannot be set
+                                      when spec.os.name is windows.
+                                    format: int64
+                                    type: integer
+                                  runAsNonRoot:
+                                    description: Indicates that the container must
+                                      run as a non-root user. If true, the Kubelet
+                                      will validate the image at runtime to ensure
+                                      that it does not run as UID 0 (root) and fail
+                                      to start the container if it does. If unset
+                                      or false, no such validation will be performed.
+                                      May also be set in PodSecurityContext.  If set
+                                      in both SecurityContext and PodSecurityContext,
+                                      the value specified in SecurityContext takes
+                                      precedence.
+                                    type: boolean
+                                  runAsUser:
+                                    description: The UID to run the entrypoint of
+                                      the container process. Defaults to user specified
+                                      in image metadata if unspecified. May also be
+                                      set in PodSecurityContext.  If set in both SecurityContext
+                                      and PodSecurityContext, the value specified
+                                      in SecurityContext takes precedence. Note that
+                                      this field cannot be set when spec.os.name is
+                                      windows.
+                                    format: int64
+                                    type: integer
+                                  seLinuxOptions:
+                                    description: The SELinux context to be applied
+                                      to the container. If unspecified, the container
+                                      runtime will allocate a random SELinux context
+                                      for each container.  May also be set in PodSecurityContext.  If
+                                      set in both SecurityContext and PodSecurityContext,
+                                      the value specified in SecurityContext takes
+                                      precedence. Note that this field cannot be set
+                                      when spec.os.name is windows.
+                                    properties:
+                                      level:
+                                        description: Level is SELinux level label
+                                          that applies to the container.
+                                        type: string
+                                      role:
+                                        description: Role is a SELinux role label
+                                          that applies to the container.
+                                        type: string
+                                      type:
+                                        description: Type is a SELinux type label
+                                          that applies to the container.
+                                        type: string
+                                      user:
+                                        description: User is a SELinux user label
+                                          that applies to the container.
+                                        type: string
+                                    type: object
+                                  seccompProfile:
+                                    description: The seccomp options to use by this
+                                      container. If seccomp options are provided at
+                                      both the pod & container level, the container
+                                      options override the pod options. Note that
+                                      this field cannot be set when spec.os.name is
+                                      windows.
+                                    properties:
+                                      localhostProfile:
+                                        description: localhostProfile indicates a
+                                          profile defined in a file on the node should
+                                          be used. The profile must be preconfigured
+                                          on the node to work. Must be a descending
+                                          path, relative to the kubelet's configured
+                                          seccomp profile location. Must only be set
+                                          if type is "Localhost".
+                                        type: string
+                                      type:
+                                        description: "type indicates which kind of
+                                          seccomp profile will be applied. Valid options
+                                          are: \n Localhost - a profile defined in
+                                          a file on the node should be used. RuntimeDefault
+                                          - the container runtime default profile
+                                          should be used. Unconfined - no profile
+                                          should be applied."
+                                        type: string
+                                    required:
+                                    - type
+                                    type: object
+                                  windowsOptions:
+                                    description: The Windows specific settings applied
+                                      to all containers. If unspecified, the options
+                                      from the PodSecurityContext will be used. If
+                                      set in both SecurityContext and PodSecurityContext,
+                                      the value specified in SecurityContext takes
+                                      precedence. Note that this field cannot be set
+                                      when spec.os.name is linux.
+                                    properties:
+                                      gmsaCredentialSpec:
+                                        description: GMSACredentialSpec is where the
+                                          GMSA admission webhook (https://github.com/kubernetes-sigs/windows-gmsa)
+                                          inlines the contents of the GMSA credential
+                                          spec named by the GMSACredentialSpecName
+                                          field.
+                                        type: string
+                                      gmsaCredentialSpecName:
+                                        description: GMSACredentialSpecName is the
+                                          name of the GMSA credential spec to use.
+                                        type: string
+                                      hostProcess:
+                                        description: HostProcess determines if a container
+                                          should be run as a 'Host Process' container.
+                                          This field is alpha-level and will only
+                                          be honored by components that enable the
+                                          WindowsHostProcessContainers feature flag.
+                                          Setting this field without the feature flag
+                                          will result in errors when validating the
+                                          Pod. All of a Pod's containers must have
+                                          the same effective HostProcess value (it
+                                          is not allowed to have a mix of HostProcess
+                                          containers and non-HostProcess containers).  In
+                                          addition, if HostProcess is true then HostNetwork
+                                          must also be set to true.
+                                        type: boolean
+                                      runAsUserName:
+                                        description: The UserName in Windows to run
+                                          the entrypoint of the container process.
+                                          Defaults to the user specified in image
+                                          metadata if unspecified. May also be set
+                                          in PodSecurityContext. If set in both SecurityContext
+                                          and PodSecurityContext, the value specified
+                                          in SecurityContext takes precedence.
+                                        type: string
+                                    type: object
+                                type: object
+                              startupProbe:
+                                description: 'StartupProbe indicates that the Pod
+                                  has successfully initialized. If specified, no other
+                                  probes are executed until this completes successfully.
+                                  If this probe fails, the Pod will be restarted,
+                                  just as if the livenessProbe failed. This can be
+                                  used to provide different probe parameters at the
+                                  beginning of a Pod''s lifecycle, when it might take
+                                  a long time to load data or warm a cache, than during
+                                  steady-state operation. This cannot be updated.
+                                  More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                                properties:
+                                  exec:
+                                    description: Exec specifies the action to take.
+                                    properties:
+                                      command:
+                                        description: Command is the command line to
+                                          execute inside the container, the working
+                                          directory for the command  is root ('/')
+                                          in the container's filesystem. The command
+                                          is simply exec'd, it is not run inside a
+                                          shell, so traditional shell instructions
+                                          ('|', etc) won't work. To use a shell, you
+                                          need to explicitly call out to that shell.
+                                          Exit status of 0 is treated as live/healthy
+                                          and non-zero is unhealthy.
+                                        items:
+                                          type: string
+                                        type: array
+                                    type: object
+                                  failureThreshold:
+                                    description: Minimum consecutive failures for
+                                      the probe to be considered failed after having
+                                      succeeded. Defaults to 3. Minimum value is 1.
+                                    format: int32
+                                    type: integer
+                                  grpc:
+                                    description: GRPC specifies an action involving
+                                      a GRPC port. This is a beta field and requires
+                                      enabling GRPCContainerProbe feature gate.
+                                    properties:
+                                      port:
+                                        description: Port number of the gRPC service.
+                                          Number must be in the range 1 to 65535.
+                                        format: int32
+                                        type: integer
+                                      service:
+                                        description: "Service is the name of the service
+                                          to place in the gRPC HealthCheckRequest
+                                          (see https://github.com/grpc/grpc/blob/master/doc/health-checking.md).
+                                          \n If this is not specified, the default
+                                          behavior is defined by gRPC."
+                                        type: string
+                                    required:
+                                    - port
+                                    type: object
+                                  httpGet:
+                                    description: HTTPGet specifies the http request
+                                      to perform.
+                                    properties:
+                                      host:
+                                        description: Host name to connect to, defaults
+                                          to the pod IP. You probably want to set
+                                          "Host" in httpHeaders instead.
+                                        type: string
+                                      httpHeaders:
+                                        description: Custom headers to set in the
+                                          request. HTTP allows repeated headers.
+                                        items:
+                                          description: HTTPHeader describes a custom
+                                            header to be used in HTTP probes
+                                          properties:
+                                            name:
+                                              description: The header field name
+                                              type: string
+                                            value:
+                                              description: The header field value
+                                              type: string
+                                          required:
+                                          - name
+                                          - value
+                                          type: object
+                                        type: array
+                                      path:
+                                        description: Path to access on the HTTP server.
+                                        type: string
+                                      port:
+                                        anyOf:
+                                        - type: integer
+                                        - type: string
+                                        description: Name or number of the port to
+                                          access on the container. Number must be
+                                          in the range 1 to 65535. Name must be an
+                                          IANA_SVC_NAME.
+                                        x-kubernetes-int-or-string: true
+                                      scheme:
+                                        description: Scheme to use for connecting
+                                          to the host. Defaults to HTTP.
+                                        type: string
+                                    required:
+                                    - port
+                                    type: object
+                                  initialDelaySeconds:
+                                    description: 'Number of seconds after the container
+                                      has started before liveness probes are initiated.
+                                      More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                                    format: int32
+                                    type: integer
+                                  periodSeconds:
+                                    description: How often (in seconds) to perform
+                                      the probe. Default to 10 seconds. Minimum value
+                                      is 1.
+                                    format: int32
+                                    type: integer
+                                  successThreshold:
+                                    description: Minimum consecutive successes for
+                                      the probe to be considered successful after
+                                      having failed. Defaults to 1. Must be 1 for
+                                      liveness and startup. Minimum value is 1.
+                                    format: int32
+                                    type: integer
+                                  tcpSocket:
+                                    description: TCPSocket specifies an action involving
+                                      a TCP port.
+                                    properties:
+                                      host:
+                                        description: 'Optional: Host name to connect
+                                          to, defaults to the pod IP.'
+                                        type: string
+                                      port:
+                                        anyOf:
+                                        - type: integer
+                                        - type: string
+                                        description: Number or name of the port to
+                                          access on the container. Number must be
+                                          in the range 1 to 65535. Name must be an
+                                          IANA_SVC_NAME.
+                                        x-kubernetes-int-or-string: true
+                                    required:
+                                    - port
+                                    type: object
+                                  terminationGracePeriodSeconds:
+                                    description: Optional duration in seconds the
+                                      pod needs to terminate gracefully upon probe
+                                      failure. The grace period is the duration in
+                                      seconds after the processes running in the pod
+                                      are sent a termination signal and the time when
+                                      the processes are forcibly halted with a kill
+                                      signal. Set this value longer than the expected
+                                      cleanup time for your process. If this value
+                                      is nil, the pod's terminationGracePeriodSeconds
+                                      will be used. Otherwise, this value overrides
+                                      the value provided by the pod spec. Value must
+                                      be non-negative integer. The value zero indicates
+                                      stop immediately via the kill signal (no opportunity
+                                      to shut down). This is a beta field and requires
+                                      enabling ProbeTerminationGracePeriod feature
+                                      gate. Minimum value is 1. spec.terminationGracePeriodSeconds
+                                      is used if unset.
+                                    format: int64
+                                    type: integer
+                                  timeoutSeconds:
+                                    description: 'Number of seconds after which the
+                                      probe times out. Defaults to 1 second. Minimum
+                                      value is 1. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                                    format: int32
+                                    type: integer
+                                type: object
+                              stdin:
+                                description: Whether this container should allocate
+                                  a buffer for stdin in the container runtime. If
+                                  this is not set, reads from stdin in the container
+                                  will always result in EOF. Default is false.
+                                type: boolean
+                              stdinOnce:
+                                description: Whether the container runtime should
+                                  close the stdin channel after it has been opened
+                                  by a single attach. When stdin is true the stdin
+                                  stream will remain open across multiple attach sessions.
+                                  If stdinOnce is set to true, stdin is opened on
+                                  container start, is empty until the first client
+                                  attaches to stdin, and then remains open and accepts
+                                  data until the client disconnects, at which time
+                                  stdin is closed and remains closed until the container
+                                  is restarted. If this flag is false, a container
+                                  processes that reads from stdin will never receive
+                                  an EOF. Default is false
+                                type: boolean
+                              terminationMessagePath:
+                                description: 'Optional: Path at which the file to
+                                  which the container''s termination message will
+                                  be written is mounted into the container''s filesystem.
+                                  Message written is intended to be brief final status,
+                                  such as an assertion failure message. Will be truncated
+                                  by the node if greater than 4096 bytes. The total
+                                  message length across all containers will be limited
+                                  to 12kb. Defaults to /dev/termination-log. Cannot
+                                  be updated.'
+                                type: string
+                              terminationMessagePolicy:
+                                description: Indicate how the termination message
+                                  should be populated. File will use the contents
+                                  of terminationMessagePath to populate the container
+                                  status message on both success and failure. FallbackToLogsOnError
+                                  will use the last chunk of container log output
+                                  if the termination message file is empty and the
+                                  container exited with an error. The log output is
+                                  limited to 2048 bytes or 80 lines, whichever is
+                                  smaller. Defaults to File. Cannot be updated.
+                                type: string
+                              tty:
+                                description: Whether this container should allocate
+                                  a TTY for itself, also requires 'stdin' to be true.
+                                  Default is false.
+                                type: boolean
+                              volumeDevices:
+                                description: volumeDevices is the list of block devices
+                                  to be used by the container.
+                                items:
+                                  description: volumeDevice describes a mapping of
+                                    a raw block device within a container.
+                                  properties:
+                                    devicePath:
+                                      description: devicePath is the path inside of
+                                        the container that the device will be mapped
+                                        to.
+                                      type: string
+                                    name:
+                                      description: name must match the name of a persistentVolumeClaim
+                                        in the pod
+                                      type: string
+                                  required:
+                                  - devicePath
+                                  - name
+                                  type: object
+                                type: array
+                              volumeMounts:
+                                description: Pod volumes to mount into the container's
+                                  filesystem. Cannot be updated.
+                                items:
+                                  description: VolumeMount describes a mounting of
+                                    a Volume within a container.
+                                  properties:
+                                    mountPath:
+                                      description: Path within the container at which
+                                        the volume should be mounted.  Must not contain
+                                        ':'.
+                                      type: string
+                                    mountPropagation:
+                                      description: mountPropagation determines how
+                                        mounts are propagated from the host to container
+                                        and the other way around. When not set, MountPropagationNone
+                                        is used. This field is beta in 1.10.
+                                      type: string
+                                    name:
+                                      description: This must match the Name of a Volume.
+                                      type: string
+                                    readOnly:
+                                      description: Mounted read-only if true, read-write
+                                        otherwise (false or unspecified). Defaults
+                                        to false.
+                                      type: boolean
+                                    subPath:
+                                      description: Path within the volume from which
+                                        the container's volume should be mounted.
+                                        Defaults to "" (volume's root).
+                                      type: string
+                                    subPathExpr:
+                                      description: Expanded path within the volume
+                                        from which the container's volume should be
+                                        mounted. Behaves similarly to SubPath but
+                                        environment variable references $(VAR_NAME)
+                                        are expanded using the container's environment.
+                                        Defaults to "" (volume's root). SubPathExpr
+                                        and SubPath are mutually exclusive.
+                                      type: string
+                                  required:
+                                  - mountPath
+                                  - name
+                                  type: object
+                                type: array
+                              workingDir:
+                                description: Container's working directory. If not
+                                  specified, the container runtime's default will
+                                  be used, which might be configured in the container
+                                  image. Cannot be updated.
+                                type: string
+                            required:
+                            - name
+                            type: object
+                          type: array
+                        nodeSelector:
+                          additionalProperties:
+                            type: string
+                          type: object
+                        schedulerName:
+                          type: string
+                        serviceAccountName:
+                          type: string
+                        tolerations:
+                          items:
+                            description: The pod this Toleration is attached to tolerates
+                              any taint that matches the triple <key,value,effect>
+                              using the matching operator <operator>.
+                            properties:
+                              effect:
+                                description: Effect indicates the taint effect to
+                                  match. Empty means match all taint effects. When
+                                  specified, allowed values are NoSchedule, PreferNoSchedule
+                                  and NoExecute.
+                                type: string
+                              key:
+                                description: Key is the taint key that the toleration
+                                  applies to. Empty means match all taint keys. If
+                                  the key is empty, operator must be Exists; this
+                                  combination means to match all values and all keys.
+                                type: string
+                              operator:
+                                description: Operator represents a key's relationship
+                                  to the value. Valid operators are Exists and Equal.
+                                  Defaults to Equal. Exists is equivalent to wildcard
+                                  for value, so that a pod can tolerate all taints
+                                  of a particular category.
+                                type: string
+                              tolerationSeconds:
+                                description: TolerationSeconds represents the period
+                                  of time the toleration (which must be of effect
+                                  NoExecute, otherwise this field is ignored) tolerates
+                                  the taint. By default, it is not set, which means
+                                  tolerate the taint forever (do not evict). Zero
+                                  and negative values will be treated as 0 (evict
+                                  immediately) by the system.
+                                format: int64
+                                type: integer
+                              value:
+                                description: Value is the taint value the toleration
+                                  matches to. If the operator is Exists, the value
+                                  should be empty, otherwise just a regular string.
+                                type: string
+                            type: object
+                          type: array
+                        topologySpreadConstraints:
+                          items:
+                            description: TopologySpreadConstraint specifies how to
+                              spread matching pods among the given topology.
+                            properties:
+                              labelSelector:
+                                description: LabelSelector is used to find matching
+                                  pods. Pods that match this label selector are counted
+                                  to determine the number of pods in their corresponding
+                                  topology domain.
+                                properties:
+                                  matchExpressions:
+                                    description: matchExpressions is a list of label
+                                      selector requirements. The requirements are
+                                      ANDed.
+                                    items:
+                                      description: A label selector requirement is
+                                        a selector that contains values, a key, and
+                                        an operator that relates the key and values.
+                                      properties:
+                                        key:
+                                          description: key is the label key that the
+                                            selector applies to.
+                                          type: string
+                                        operator:
+                                          description: operator represents a key's
+                                            relationship to a set of values. Valid
+                                            operators are In, NotIn, Exists and DoesNotExist.
+                                          type: string
+                                        values:
+                                          description: values is an array of string
+                                            values. If the operator is In or NotIn,
+                                            the values array must be non-empty. If
+                                            the operator is Exists or DoesNotExist,
+                                            the values array must be empty. This array
+                                            is replaced during a strategic merge patch.
+                                          items:
+                                            type: string
+                                          type: array
+                                      required:
+                                      - key
+                                      - operator
+                                      type: object
+                                    type: array
+                                  matchLabels:
+                                    additionalProperties:
+                                      type: string
+                                    description: matchLabels is a map of {key,value}
+                                      pairs. A single {key,value} in the matchLabels
+                                      map is equivalent to an element of matchExpressions,
+                                      whose key field is "key", the operator is "In",
+                                      and the values array contains only "value".
+                                      The requirements are ANDed.
+                                    type: object
+                                type: object
+                              matchLabelKeys:
+                                description: MatchLabelKeys is a set of pod label
+                                  keys to select the pods over which spreading will
+                                  be calculated. The keys are used to lookup values
+                                  from the incoming pod labels, those key-value labels
+                                  are ANDed with labelSelector to select the group
+                                  of existing pods over which spreading will be calculated
+                                  for the incoming pod. Keys that don't exist in the
+                                  incoming pod labels will be ignored. A null or empty
+                                  list means only match against labelSelector.
+                                items:
+                                  type: string
+                                type: array
+                                x-kubernetes-list-type: atomic
+                              maxSkew:
+                                description: 'MaxSkew describes the degree to which
+                                  pods may be unevenly distributed. When `whenUnsatisfiable=DoNotSchedule`,
+                                  it is the maximum permitted difference between the
+                                  number of matching pods in the target topology and
+                                  the global minimum. The global minimum is the minimum
+                                  number of matching pods in an eligible domain or
+                                  zero if the number of eligible domains is less than
+                                  MinDomains. For example, in a 3-zone cluster, MaxSkew
+                                  is set to 1, and pods with the same labelSelector
+                                  spread as 2/2/1: In this case, the global minimum
+                                  is 1. | zone1 | zone2 | zone3 | |  P P  |  P P  |   P   |
+                                  - if MaxSkew is 1, incoming pod can only be scheduled
+                                  to zone3 to become 2/2/2; scheduling it onto zone1(zone2)
+                                  would make the ActualSkew(3-1) on zone1(zone2) violate
+                                  MaxSkew(1). - if MaxSkew is 2, incoming pod can
+                                  be scheduled onto any zone. When `whenUnsatisfiable=ScheduleAnyway`,
+                                  it is used to give higher precedence to topologies
+                                  that satisfy it. It''s a required field. Default
+                                  value is 1 and 0 is not allowed.'
+                                format: int32
+                                type: integer
+                              minDomains:
+                                description: "MinDomains indicates a minimum number
+                                  of eligible domains. When the number of eligible
+                                  domains with matching topology keys is less than
+                                  minDomains, Pod Topology Spread treats \"global
+                                  minimum\" as 0, and then the calculation of Skew
+                                  is performed. And when the number of eligible domains
+                                  with matching topology keys equals or greater than
+                                  minDomains, this value has no effect on scheduling.
+                                  As a result, when the number of eligible domains
+                                  is less than minDomains, scheduler won't schedule
+                                  more than maxSkew Pods to those domains. If value
+                                  is nil, the constraint behaves as if MinDomains
+                                  is equal to 1. Valid values are integers greater
+                                  than 0. When value is not nil, WhenUnsatisfiable
+                                  must be DoNotSchedule. \n For example, in a 3-zone
+                                  cluster, MaxSkew is set to 2, MinDomains is set
+                                  to 5 and pods with the same labelSelector spread
+                                  as 2/2/2: | zone1 | zone2 | zone3 | |  P P  |  P
+                                  P  |  P P  | The number of domains is less than
+                                  5(MinDomains), so \"global minimum\" is treated
+                                  as 0. In this situation, new pod with the same labelSelector
+                                  cannot be scheduled, because computed skew will
+                                  be 3(3 - 0) if new Pod is scheduled to any of the
+                                  three zones, it will violate MaxSkew. \n This is
+                                  a beta field and requires the MinDomainsInPodTopologySpread
+                                  feature gate to be enabled (enabled by default)."
+                                format: int32
+                                type: integer
+                              nodeAffinityPolicy:
+                                description: "NodeAffinityPolicy indicates how we
+                                  will treat Pod's nodeAffinity/nodeSelector when
+                                  calculating pod topology spread skew. Options are:
+                                  - Honor: only nodes matching nodeAffinity/nodeSelector
+                                  are included in the calculations. - Ignore: nodeAffinity/nodeSelector
+                                  are ignored. All nodes are included in the calculations.
+                                  \n If this value is nil, the behavior is equivalent
+                                  to the Honor policy. This is a alpha-level feature
+                                  enabled by the NodeInclusionPolicyInPodTopologySpread
+                                  feature flag."
+                                type: string
+                              nodeTaintsPolicy:
+                                description: "NodeTaintsPolicy indicates how we will
+                                  treat node taints when calculating pod topology
+                                  spread skew. Options are: - Honor: nodes without
+                                  taints, along with tainted nodes for which the incoming
+                                  pod has a toleration, are included. - Ignore: node
+                                  taints are ignored. All nodes are included. \n If
+                                  this value is nil, the behavior is equivalent to
+                                  the Ignore policy. This is a alpha-level feature
+                                  enabled by the NodeInclusionPolicyInPodTopologySpread
+                                  feature flag."
+                                type: string
+                              topologyKey:
+                                description: TopologyKey is the key of node labels.
+                                  Nodes that have a label with this key and identical
+                                  values are considered to be in the same topology.
+                                  We consider each <key, value> as a "bucket", and
+                                  try to put balanced number of pods into each bucket.
+                                  We define a domain as a particular instance of a
+                                  topology. Also, we define an eligible domain as
+                                  a domain whose nodes meet the requirements of nodeAffinityPolicy
+                                  and nodeTaintsPolicy. e.g. If TopologyKey is "kubernetes.io/hostname",
+                                  each Node is a domain of that topology. And, if
+                                  TopologyKey is "topology.kubernetes.io/zone", each
+                                  zone is a domain of that topology. It's a required
+                                  field.
+                                type: string
+                              whenUnsatisfiable:
+                                description: 'WhenUnsatisfiable indicates how to deal
+                                  with a pod if it doesn''t satisfy the spread constraint.
+                                  - DoNotSchedule (default) tells the scheduler not
+                                  to schedule it. - ScheduleAnyway tells the scheduler
+                                  to schedule the pod in any location,   but giving
+                                  higher precedence to topologies that would help
+                                  reduce the   skew. A constraint is considered "Unsatisfiable"
+                                  for an incoming pod if and only if every possible
+                                  node assignment for that pod would violate "MaxSkew"
+                                  on some topology. For example, in a 3-zone cluster,
+                                  MaxSkew is set to 1, and pods with the same labelSelector
+                                  spread as 3/1/1: | zone1 | zone2 | zone3 | | P P
+                                  P |   P   |   P   | If WhenUnsatisfiable is set
+                                  to DoNotSchedule, incoming pod can only be scheduled
+                                  to zone2(zone3) to become 3/2/1(3/1/2) as ActualSkew(2-1)
+                                  on zone2(zone3) satisfies MaxSkew(1). In other words,
+                                  the cluster can still be imbalanced, but scheduler
+                                  won''t make it *more* imbalanced. It''s a required
+                                  field.'
+                                type: string
+                            required:
+                            - maxSkew
+                            - topologyKey
+                            - whenUnsatisfiable
+                            type: object
+                          type: array
+                      type: object
+                    labels:
+                      additionalProperties:
+                        type: string
+                      type: object
+                    name:
+                      type: string
+                    resources:
+                      properties:
+                        limits:
+                          properties:
+                            cpu:
+                              type: string
+                            custom:
+                              additionalProperties:
+                                type: string
+                              type: object
+                            gpu:
+                              type: string
+                            memory:
+                              type: string
+                          type: object
+                        requests:
+                          properties:
+                            cpu:
+                              type: string
+                            custom:
+                              additionalProperties:
+                                type: string
+                              type: object
+                            gpu:
+                              type: string
+                            memory:
+                              type: string
+                          type: object
+                      type: object
+                  type: object
+                type: array
+            required:
+            - bento
+            type: object
+          status:
+            description: BentoDeploymentStatus defines the observed state of BentoDeployment
+            properties:
+              conditions:
+                description: 'INSERT ADDITIONAL STATUS FIELD - define observed state
+                  of cluster Important: Run "make" to regenerate code after modifying
+                  this file'
+                items:
+                  description: "Condition contains details for one aspect of the current
+                    state of this API Resource. --- This struct is intended for direct
+                    use as an array at the field path .status.conditions.  For example,
+                    \n \ttype FooStatus struct{ \t    // Represents the observations
+                    of a foo's current state. \t    // Known .status.conditions.type
+                    are: \"Available\", \"Progressing\", and \"Degraded\" \t    //
+                    +patchMergeKey=type \t    // +patchStrategy=merge \t    // +listType=map
+                    \t    // +listMapKey=type \t    Conditions []metav1.Condition
+                    `json:\"conditions,omitempty\" patchStrategy:\"merge\" patchMergeKey:\"type\"
+                    protobuf:\"bytes,1,rep,name=conditions\"` \n \t    // other fields
+                    \t}"
+                  properties:
+                    lastTransitionTime:
+                      description: lastTransitionTime is the last time the condition
+                        transitioned from one status to another. This should be when
+                        the underlying condition changed.  If that is not known, then
+                        using the time when the API field changed is acceptable.
+                      format: date-time
+                      type: string
+                    message:
+                      description: message is a human readable message indicating
+                        details about the transition. This may be an empty string.
+                      maxLength: 32768
+                      type: string
+                    observedGeneration:
+                      description: observedGeneration represents the .metadata.generation
+                        that the condition was set based upon. For instance, if .metadata.generation
+                        is currently 12, but the .status.conditions[x].observedGeneration
+                        is 9, the condition is out of date with respect to the current
+                        state of the instance.
+                      format: int64
+                      minimum: 0
+                      type: integer
+                    reason:
+                      description: reason contains a programmatic identifier indicating
+                        the reason for the condition's last transition. Producers
+                        of specific condition types may define expected values and
+                        meanings for this field, and whether the values are considered
+                        a guaranteed API. The value should be a CamelCase string.
+                        This field may not be empty.
+                      maxLength: 1024
+                      minLength: 1
+                      pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                      type: string
+                    status:
+                      description: status of the condition, one of True, False, Unknown.
+                      enum:
+                      - "True"
+                      - "False"
+                      - Unknown
+                      type: string
+                    type:
+                      description: type of condition in CamelCase or in foo.example.com/CamelCase.
+                        --- Many .condition.type values are consistent across resources
+                        like Available, but because arbitrary conditions can be useful
+                        (see .node.status.conditions), the ability to deconflict is
+                        important. The regex it matches is (dns1123SubdomainFmt/)?(qualifiedNameFmt)
+                      maxLength: 316
+                      pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                      type: string
+                  required:
+                  - lastTransitionTime
+                  - message
+                  - reason
+                  - status
+                  - type
+                  type: object
+                type: array
+              podSelector:
+                additionalProperties:
+                  type: string
+                type: object
+            required:
+            - conditions
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: []
+  storedVersions: []
+---
+# Source: yatai-deployment/templates/serviceaccount.yaml
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: yatai-deployment
+  namespace: kubeflow
+  labels:
+    helm.sh/chart: yatai-deployment-1.1.4
+    app.kubernetes.io/name: yatai-deployment
+    app.kubernetes.io/instance: yatai-deployment
+    app.kubernetes.io/version: "1.1.4"
+    app.kubernetes.io/managed-by: Helm
+---
+# Source: yatai-deployment/templates/secret-env.yaml
+apiVersion: v1
+kind: Secret
+metadata:
+  name: yatai-deployment-env
+  namespace: kubeflow
+  labels:
+    helm.sh/chart: yatai-deployment-1.1.4
+    app.kubernetes.io/name: yatai-deployment
+    app.kubernetes.io/instance: yatai-deployment
+    app.kubernetes.io/version: "1.1.4"
+    app.kubernetes.io/managed-by: Helm
+type: Opaque
+stringData:
+  YATAI_SYSTEM_NAMESPACE: kubeflow
+  YATAI_API_TOKEN: "yrfiGXV1dw0X99eR"
+
+  INTERNAL_IMAGES_METRICS_TRANSFORMER: "quay.io/bentoml/yatai-bento-metrics-transformer:0.0.3"
+  INTERNAL_IMAGES_DEBUGGER: "quay.io/bentoml/bento-debugger:0.0.5"
+---
+# Source: yatai-deployment/templates/secret-shared-env.yaml
+apiVersion: v1
+kind: Secret
+metadata:
+  name: yatai-deployment-shared-env
+  namespace: kubeflow
+  labels:
+    helm.sh/chart: yatai-deployment-1.1.4
+    app.kubernetes.io/name: yatai-deployment
+    app.kubernetes.io/instance: yatai-deployment
+    app.kubernetes.io/version: "1.1.4"
+    app.kubernetes.io/managed-by: Helm
+type: Opaque
+stringData:
+  YATAI_DEPLOYMENT_NAMESPACE: kubeflow
+  BENTO_DEPLOYMENT_NAMESPACES: "kubeflow"
+---
+# Source: yatai-deployment/templates/configmap-network.yaml
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: network
+  namespace: kubeflow
+  labels:
+    helm.sh/chart: yatai-deployment-1.1.4
+    app.kubernetes.io/name: yatai-deployment
+    app.kubernetes.io/instance: yatai-deployment
+    app.kubernetes.io/version: "1.1.4"
+    app.kubernetes.io/managed-by: Helm
+data:
+  ingress-class: nginx
+  ingress-path: "/"
+  ingress-path-type: "ImplementationSpecific"
+---
+# Source: yatai-deployment/templates/role-in-yatai-system-namespace.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: yatai-deployment-in-yatai-system
+  namespace: kubeflow
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - secrets
+  resourceNames:
+  - yatai-common-env
+  - yatai-deployment-shared-env
+  verbs:
+  - get
+  - list
+  - watch
+---
+# Source: yatai-deployment/templates/role-with-bento-deployment.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: yatai-deployment-with-bento-deployment
+  namespace: "kubeflow"
+rules:
+- apiGroups:
+  - apps
+  resources:
+  - deployments
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - autoscaling
+  resources:
+  - horizontalpodautoscalers
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - configmaps
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - events
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - pods
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - services
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - events.k8s.io
+  resources:
+  - events
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - networking.k8s.io
+  resources:
+  - ingresses
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - serving.yatai.ai
+  resources:
+  - bentodeployments
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - serving.yatai.ai
+  resources:
+  - bentodeployments/finalizers
+  verbs:
+  - update
+- apiGroups:
+  - serving.yatai.ai
+  resources:
+  - bentodeployments/status
+  verbs:
+  - get
+  - patch
+  - update
+- apiGroups:
+  - resources.yatai.ai
+  resources:
+  - bentorequests
+  verbs:
+  - get
+  - list
+  - watch
+  - patch
+  - update
+  - create
+- apiGroups:
+  - resources.yatai.ai
+  resources:
+  - bentorequests/status
+  verbs:
+  - get
+- apiGroups:
+  - resources.yatai.ai
+  resources:
+  - bentoes
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - resources.yatai.ai
+  resources:
+  - bentoes/status
+  verbs:
+  - get
+- apiGroups:
+  - ""
+  resources:
+  - serviceaccounts
+  verbs:
+  - get
+  - list
+  - watch
+---
+# Source: yatai-deployment/templates/role-yatai-in-yatai-system-namespace.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: yatai-role-for-yatai-deployment
+  namespace: kubeflow
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - secrets
+  resourceNames:
+  - yatai-common-env
+  - yatai-deployment-shared-env
+  verbs:
+  - get
+  - list
+  - watch
+---
+# Source: yatai-deployment/templates/role-yatai-with-bento-deployment.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: yatai-with-bento-deployment
+  namespace: "kubeflow"
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - namespaces
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - apps
+  resources:
+  - replicasets
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - apps
+  resources:
+  - deployments
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - configmaps
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - events
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - pods
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - pods/exec
+  verbs:
+  - create
+  - update
+  - patch
+  - get
+  - list
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - pods/attach
+  verbs:
+  - create
+  - update
+  - patch
+  - get
+  - list
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - pods/ephemeralcontainers
+  verbs:
+  - create
+  - update
+  - patch
+  - get
+  - list
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - pods/log
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - events.k8s.io
+  resources:
+  - events
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - networking.k8s.io
+  resources:
+  - ingresses
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - serving.yatai.ai
+  resources:
+  - bentodeployments
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - serving.yatai.ai
+  resources:
+  - bentodeployments/finalizers
+  verbs:
+  - update
+- apiGroups:
+  - serving.yatai.ai
+  resources:
+  - bentodeployments/status
+  verbs:
+  - get
+  - patch
+  - update
+---
+# Source: yatai-deployment/templates/role-yatai-with-yatai-deployment.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: yatai-with-yatai-deployment
+  namespace: kubeflow
+rules:
+- apiGroups:
+  - apps
+  resources:
+  - replicasets
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - apps
+  resources:
+  - deployments
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - configmaps
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - events
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - events.k8s.io
+  resources:
+  - events
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - pods
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - pods/exec
+  verbs:
+  - create
+  - update
+  - patch
+  - get
+  - list
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - pods/attach
+  verbs:
+  - create
+  - update
+  - patch
+  - get
+  - list
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - pods/ephemeralcontainers
+  verbs:
+  - create
+  - update
+  - patch
+  - get
+  - list
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - pods/log
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - secrets
+  resourceNames:
+  - yatai-deployment-env
+  verbs:
+  - get
+  - list
+  - watch
+---
+# Source: yatai-deployment/templates/role.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: yatai-deployment
+  namespace: kubeflow
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - configmaps
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - events
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - events.k8s.io
+  resources:
+  - events
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - coordination.k8s.io
+  resources:
+  - leases
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - networking.k8s.io
+  resources:
+  - ingresses
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+---
+# Source: yatai-deployment/templates/rolebinding-in-yatai-system-namespace.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: yatai-deployment-in-yatai-system
+  namespace: kubeflow
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: yatai-deployment-in-yatai-system
+subjects:
+  - kind: ServiceAccount
+    name: yatai-deployment
+    namespace: kubeflow
+---
+# Source: yatai-deployment/templates/rolebinding-with-bento-deployment.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: yatai-deployment-with-bento-deployment
+  namespace: "kubeflow"
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: yatai-deployment-with-bento-deployment
+subjects:
+  - kind: ServiceAccount
+    name: yatai-deployment
+    namespace: kubeflow
+---
+# Source: yatai-deployment/templates/rolebinding-yatai-in-yatai-system-namespace.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: yatai-role-for-yatai-deployment
+  namespace: kubeflow
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: yatai-role-for-yatai-deployment
+subjects:
+  - kind: ServiceAccount
+    name: yatai
+    namespace: kubeflow
+---
+# Source: yatai-deployment/templates/rolebinding-yatai-with-bento-deployment.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: yatai-with-bento-deployment
+  namespace: "kubeflow"
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: yatai-with-bento-deployment
+subjects:
+  - kind: ServiceAccount
+    name: yatai
+    namespace: kubeflow
+---
+# Source: yatai-deployment/templates/rolebinding-yatai-with-yatai-deployment.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: yatai-with-yatai-deployment
+  namespace: kubeflow
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: yatai-with-yatai-deployment
+subjects:
+  - kind: ServiceAccount
+    name: yatai
+    namespace: kubeflow
+---
+# Source: yatai-deployment/templates/rolebinding.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: yatai-deployment
+  namespace: kubeflow
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: yatai-deployment
+subjects:
+  - kind: ServiceAccount
+    name: yatai-deployment
+    namespace: kubeflow
+---
+# Source: yatai-deployment/templates/service.yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: yatai-deployment-webhook-service
+  namespace: kubeflow
+  labels:
+    helm.sh/chart: yatai-deployment-1.1.4
+    app.kubernetes.io/name: yatai-deployment
+    app.kubernetes.io/instance: yatai-deployment
+    app.kubernetes.io/version: "1.1.4"
+    app.kubernetes.io/managed-by: Helm
+spec:
+  ports:
+  - port: 443
+    protocol: TCP
+    targetPort: 9443
+  selector:
+    app.kubernetes.io/name: yatai-deployment
+    app.kubernetes.io/instance: yatai-deployment
+---
+# Source: yatai-deployment/templates/deployment.yaml
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: yatai-deployment
+  namespace: kubeflow
+  labels:
+    helm.sh/chart: yatai-deployment-1.1.4
+    app.kubernetes.io/name: yatai-deployment
+    app.kubernetes.io/instance: yatai-deployment
+    app.kubernetes.io/version: "1.1.4"
+    app.kubernetes.io/managed-by: Helm
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: yatai-deployment
+      app.kubernetes.io/instance: yatai-deployment
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: yatai-deployment
+        app.kubernetes.io/instance: yatai-deployment
+    spec:
+      serviceAccountName: yatai-deployment
+      securityContext:
+        runAsNonRoot: true
+        seccompProfile:
+          type: RuntimeDefault
+      containers:
+        - name: manager
+          args:
+            - --health-probe-bind-address=:8081
+            - --metrics-bind-address=127.0.0.1:8080
+            - --leader-elect
+          command:
+            - /manager
+          env:
+            - name: SYSTEM_NAMESPACE
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
+          envFrom:
+            - secretRef:
+                name: yatai-deployment-env
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+              - ALL
+          image: "quay.io/bentoml/yatai-deployment:1.1.4"
+          imagePullPolicy: IfNotPresent
+
+          ports:
+          - containerPort: 9443
+            name: webhook-server
+            protocol: TCP
+
+          livenessProbe:
+            failureThreshold: 3
+            httpGet:
+              path: /healthz
+              port: 8081
+              scheme: HTTP
+            initialDelaySeconds: 15
+            periodSeconds: 20
+            successThreshold: 1
+            timeoutSeconds: 1
+
+          readinessProbe:
+            failureThreshold: 3
+            httpGet:
+              path: /readyz
+              port: 8081
+              scheme: HTTP
+            initialDelaySeconds: 5
+            periodSeconds: 10
+            successThreshold: 1
+            timeoutSeconds: 1
+
+          resources:
+            {}
+
+          volumeMounts:
+          - mountPath: /tmp/k8s-webhook-server/serving-certs
+            name: cert
+            readOnly: true
+      volumes:
+      - name: cert
+        secret:
+          defaultMode: 420
+          secretName: yatai-deployment-webhook-server-cert
+---
+# Source: yatai-deployment/templates/certificate.yaml
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: yatai-deployment-serving-cert
+  namespace: kubeflow
+  labels:
+    helm.sh/chart: yatai-deployment-1.1.4
+    app.kubernetes.io/name: yatai-deployment
+    app.kubernetes.io/instance: yatai-deployment
+    app.kubernetes.io/version: "1.1.4"
+    app.kubernetes.io/managed-by: Helm
+spec:
+  dnsNames:
+  - yatai-deployment-webhook-service.kubeflow.svc
+  - yatai-deployment-webhook-service.kubeflow.svc.cluster.local
+  issuerRef:
+    kind: Issuer
+    name: yatai-deployment-selfsigned-issuer
+  secretName: yatai-deployment-webhook-server-cert
+---
+# Source: yatai-deployment/templates/issuer.yaml
+apiVersion: cert-manager.io/v1
+kind: Issuer
+metadata:
+  name: yatai-deployment-selfsigned-issuer
+  namespace: kubeflow
+  labels:
+    helm.sh/chart: yatai-deployment-1.1.4
+    app.kubernetes.io/name: yatai-deployment
+    app.kubernetes.io/instance: yatai-deployment
+    app.kubernetes.io/version: "1.1.4"
+    app.kubernetes.io/managed-by: Helm
+spec:
+  selfSigned: {}

--- a/contrib/bentoml/bentoml-yatai-stack/bases/yatai-image-builder/kustomization.yaml
+++ b/contrib/bentoml/bentoml-yatai-stack/bases/yatai-image-builder/kustomization.yaml
@@ -1,0 +1,2 @@
+resources:
+- resources.yaml

--- a/contrib/bentoml/bentoml-yatai-stack/bases/yatai-image-builder/resources.yaml
+++ b/contrib/bentoml/bentoml-yatai-stack/bases/yatai-image-builder/resources.yaml
@@ -1,0 +1,2157 @@
+---
+# Source: yatai-image-builder-crds/templates/bentorequest.yaml
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.9.2
+  creationTimestamp: null
+  name: bentoes.resources.yatai.ai
+spec:
+  group: resources.yatai.ai
+  names:
+    kind: Bento
+    listKind: BentoList
+    plural: bentoes
+    singular: bento
+  scope: Namespaced
+  versions:
+  - additionalPrinterColumns:
+    - description: Tag
+      jsonPath: .spec.tag
+      name: Tag
+      type: string
+    - description: Image
+      jsonPath: .spec.image
+      name: Image
+      type: string
+    - jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: Bento is the Schema for the bentoes API
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: BentoSpec defines the desired state of Bento
+            properties:
+              context:
+                properties:
+                  bentomlVersion:
+                    type: string
+                type: object
+              image:
+                type: string
+              imagePullSecrets:
+                items:
+                  description: LocalObjectReference contains enough information to let you locate the referenced object inside the same namespace.
+                  properties:
+                    name:
+                      description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?'
+                      type: string
+                  type: object
+                  x-kubernetes-map-type: atomic
+                type: array
+              runners:
+                items:
+                  properties:
+                    modelTags:
+                      items:
+                        type: string
+                      type: array
+                    name:
+                      type: string
+                    runnableType:
+                      type: string
+                  required:
+                  - name
+                  type: object
+                type: array
+              tag:
+                type: string
+            required:
+            - image
+            - tag
+            type: object
+          status:
+            description: BentoStatus defines the observed state of Bento
+            properties:
+              ready:
+                description: 'INSERT ADDITIONAL STATUS FIELD - define observed state of cluster Important: Run "make" to regenerate code after modifying this file'
+                type: boolean
+            required:
+            - ready
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
+---
+# Source: yatai-image-builder-crds/templates/bentorequest.yaml
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.9.2
+  creationTimestamp: null
+  name: bentorequests.resources.yatai.ai
+spec:
+  group: resources.yatai.ai
+  names:
+    kind: BentoRequest
+    listKind: BentoRequestList
+    plural: bentorequests
+    singular: bentorequest
+  scope: Namespaced
+  versions:
+  - additionalPrinterColumns:
+    - description: Bento Tag
+      jsonPath: .spec.bentoTag
+      name: Bento-Tag
+      type: string
+    - description: Download URL
+      jsonPath: .spec.downloadUrl
+      name: Download-Url
+      type: string
+    - description: Image
+      jsonPath: .spec.image
+      name: Image
+      type: string
+    - description: Image Exists
+      jsonPath: .status.conditions[?(@.type=='ImageExists')].status
+      name: Image-Exists
+      type: string
+    - description: Bento Available
+      jsonPath: .status.conditions[?(@.type=='BentoAvailable')].status
+      name: Bento-Available
+      type: string
+    - description: Image Builder Pod Phase
+      jsonPath: .status.imageBuilderPodStatus.phase
+      name: Image-Builder-Pod-Phase
+      type: string
+    - jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: BentoRequest is the Schema for the bentorequests API
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: BentoRequestSpec defines the desired state of BentoRequest
+            properties:
+              bentoTag:
+                type: string
+              context:
+                properties:
+                  bentomlVersion:
+                    type: string
+                type: object
+              dockerConfigJsonSecretName:
+                type: string
+              downloadUrl:
+                type: string
+              downloaderContainerEnvFrom:
+                items:
+                  description: EnvFromSource represents the source of a set of ConfigMaps
+                  properties:
+                    configMapRef:
+                      description: The ConfigMap to select from
+                      properties:
+                        name:
+                          description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?'
+                          type: string
+                        optional:
+                          description: Specify whether the ConfigMap must be defined
+                          type: boolean
+                      type: object
+                      x-kubernetes-map-type: atomic
+                    prefix:
+                      description: An optional identifier to prepend to each key in the ConfigMap. Must be a C_IDENTIFIER.
+                      type: string
+                    secretRef:
+                      description: The Secret to select from
+                      properties:
+                        name:
+                          description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?'
+                          type: string
+                        optional:
+                          description: Specify whether the Secret must be defined
+                          type: boolean
+                      type: object
+                      x-kubernetes-map-type: atomic
+                  type: object
+                type: array
+              image:
+                type: string
+              imageBuildTimeout:
+                description: A Duration represents the elapsed time between two instants as an int64 nanosecond count. The representation limits the largest representable duration to approximately 290 years.
+                format: int64
+                type: integer
+              imageBuilderContainerResources:
+                description: ResourceRequirements describes the compute resource requirements.
+                properties:
+                  limits:
+                    additionalProperties:
+                      anyOf:
+                      - type: integer
+                      - type: string
+                      pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                      x-kubernetes-int-or-string: true
+                    description: 'Limits describes the maximum amount of compute resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+                    type: object
+                  requests:
+                    additionalProperties:
+                      anyOf:
+                      - type: integer
+                      - type: string
+                      pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                      x-kubernetes-int-or-string: true
+                    description: 'Requests describes the minimum amount of compute resources required. If Requests is omitted for a container, it defaults to Limits if that is explicitly specified, otherwise to an implementation-defined value. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+                    type: object
+                type: object
+              imageBuilderExtraContainerEnv:
+                items:
+                  description: EnvVar represents an environment variable present in a Container.
+                  properties:
+                    name:
+                      description: Name of the environment variable. Must be a C_IDENTIFIER.
+                      type: string
+                    value:
+                      description: 'Variable references $(VAR_NAME) are expanded using the previously defined environment variables in the container and any service environment variables. If a variable cannot be resolved, the reference in the input string will be unchanged. Double $$ are reduced to a single $, which allows for escaping the $(VAR_NAME) syntax: i.e. "$$(VAR_NAME)" will produce the string literal "$(VAR_NAME)". Escaped references will never be expanded, regardless of whether the variable exists or not. Defaults to "".'
+                      type: string
+                    valueFrom:
+                      description: Source for the environment variable's value. Cannot be used if value is not empty.
+                      properties:
+                        configMapKeyRef:
+                          description: Selects a key of a ConfigMap.
+                          properties:
+                            key:
+                              description: The key to select.
+                              type: string
+                            name:
+                              description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?'
+                              type: string
+                            optional:
+                              description: Specify whether the ConfigMap or its key must be defined
+                              type: boolean
+                          required:
+                          - key
+                          type: object
+                          x-kubernetes-map-type: atomic
+                        fieldRef:
+                          description: 'Selects a field of the pod: supports metadata.name, metadata.namespace, `metadata.labels[''<KEY>'']`, `metadata.annotations[''<KEY>'']`, spec.nodeName, spec.serviceAccountName, status.hostIP, status.podIP, status.podIPs.'
+                          properties:
+                            apiVersion:
+                              description: Version of the schema the FieldPath is written in terms of, defaults to "v1".
+                              type: string
+                            fieldPath:
+                              description: Path of the field to select in the specified API version.
+                              type: string
+                          required:
+                          - fieldPath
+                          type: object
+                          x-kubernetes-map-type: atomic
+                        resourceFieldRef:
+                          description: 'Selects a resource of the container: only resources limits and requests (limits.cpu, limits.memory, limits.ephemeral-storage, requests.cpu, requests.memory and requests.ephemeral-storage) are currently supported.'
+                          properties:
+                            containerName:
+                              description: 'Container name: required for volumes, optional for env vars'
+                              type: string
+                            divisor:
+                              anyOf:
+                              - type: integer
+                              - type: string
+                              description: Specifies the output format of the exposed resources, defaults to "1"
+                              pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                              x-kubernetes-int-or-string: true
+                            resource:
+                              description: 'Required: resource to select'
+                              type: string
+                          required:
+                          - resource
+                          type: object
+                          x-kubernetes-map-type: atomic
+                        secretKeyRef:
+                          description: Selects a key of a secret in the pod's namespace
+                          properties:
+                            key:
+                              description: The key of the secret to select from.  Must be a valid secret key.
+                              type: string
+                            name:
+                              description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?'
+                              type: string
+                            optional:
+                              description: Specify whether the Secret or its key must be defined
+                              type: boolean
+                          required:
+                          - key
+                          type: object
+                          x-kubernetes-map-type: atomic
+                      type: object
+                  required:
+                  - name
+                  type: object
+                type: array
+              imageBuilderExtraPodMetadata:
+                properties:
+                  annotations:
+                    additionalProperties:
+                      type: string
+                    type: object
+                  labels:
+                    additionalProperties:
+                      type: string
+                    type: object
+                type: object
+              imageBuilderExtraPodSpec:
+                properties:
+                  affinity:
+                    description: Affinity is a group of affinity scheduling rules.
+                    properties:
+                      nodeAffinity:
+                        description: Describes node affinity scheduling rules for the pod.
+                        properties:
+                          preferredDuringSchedulingIgnoredDuringExecution:
+                            description: The scheduler will prefer to schedule pods to nodes that satisfy the affinity expressions specified by this field, but it may choose a node that violates one or more of the expressions. The node that is most preferred is the one with the greatest sum of weights, i.e. for each node that meets all of the scheduling requirements (resource request, requiredDuringScheduling affinity expressions, etc.), compute a sum by iterating through the elements of this field and adding "weight" to the sum if the node matches the corresponding matchExpressions; the node(s) with the highest sum are the most preferred.
+                            items:
+                              description: An empty preferred scheduling term matches all objects with implicit weight 0 (i.e. it's a no-op). A null preferred scheduling term matches no objects (i.e. is also a no-op).
+                              properties:
+                                preference:
+                                  description: A node selector term, associated with the corresponding weight.
+                                  properties:
+                                    matchExpressions:
+                                      description: A list of node selector requirements by node's labels.
+                                      items:
+                                        description: A node selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                                        properties:
+                                          key:
+                                            description: The label key that the selector applies to.
+                                            type: string
+                                          operator:
+                                            description: Represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
+                                            type: string
+                                          values:
+                                            description: An array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. If the operator is Gt or Lt, the values array must have a single element, which will be interpreted as an integer. This array is replaced during a strategic merge patch.
+                                            items:
+                                              type: string
+                                            type: array
+                                        required:
+                                        - key
+                                        - operator
+                                        type: object
+                                      type: array
+                                    matchFields:
+                                      description: A list of node selector requirements by node's fields.
+                                      items:
+                                        description: A node selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                                        properties:
+                                          key:
+                                            description: The label key that the selector applies to.
+                                            type: string
+                                          operator:
+                                            description: Represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
+                                            type: string
+                                          values:
+                                            description: An array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. If the operator is Gt or Lt, the values array must have a single element, which will be interpreted as an integer. This array is replaced during a strategic merge patch.
+                                            items:
+                                              type: string
+                                            type: array
+                                        required:
+                                        - key
+                                        - operator
+                                        type: object
+                                      type: array
+                                  type: object
+                                  x-kubernetes-map-type: atomic
+                                weight:
+                                  description: Weight associated with matching the corresponding nodeSelectorTerm, in the range 1-100.
+                                  format: int32
+                                  type: integer
+                              required:
+                              - preference
+                              - weight
+                              type: object
+                            type: array
+                          requiredDuringSchedulingIgnoredDuringExecution:
+                            description: If the affinity requirements specified by this field are not met at scheduling time, the pod will not be scheduled onto the node. If the affinity requirements specified by this field cease to be met at some point during pod execution (e.g. due to an update), the system may or may not try to eventually evict the pod from its node.
+                            properties:
+                              nodeSelectorTerms:
+                                description: Required. A list of node selector terms. The terms are ORed.
+                                items:
+                                  description: A null or empty node selector term matches no objects. The requirements of them are ANDed. The TopologySelectorTerm type implements a subset of the NodeSelectorTerm.
+                                  properties:
+                                    matchExpressions:
+                                      description: A list of node selector requirements by node's labels.
+                                      items:
+                                        description: A node selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                                        properties:
+                                          key:
+                                            description: The label key that the selector applies to.
+                                            type: string
+                                          operator:
+                                            description: Represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
+                                            type: string
+                                          values:
+                                            description: An array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. If the operator is Gt or Lt, the values array must have a single element, which will be interpreted as an integer. This array is replaced during a strategic merge patch.
+                                            items:
+                                              type: string
+                                            type: array
+                                        required:
+                                        - key
+                                        - operator
+                                        type: object
+                                      type: array
+                                    matchFields:
+                                      description: A list of node selector requirements by node's fields.
+                                      items:
+                                        description: A node selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                                        properties:
+                                          key:
+                                            description: The label key that the selector applies to.
+                                            type: string
+                                          operator:
+                                            description: Represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
+                                            type: string
+                                          values:
+                                            description: An array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. If the operator is Gt or Lt, the values array must have a single element, which will be interpreted as an integer. This array is replaced during a strategic merge patch.
+                                            items:
+                                              type: string
+                                            type: array
+                                        required:
+                                        - key
+                                        - operator
+                                        type: object
+                                      type: array
+                                  type: object
+                                  x-kubernetes-map-type: atomic
+                                type: array
+                            required:
+                            - nodeSelectorTerms
+                            type: object
+                            x-kubernetes-map-type: atomic
+                        type: object
+                      podAffinity:
+                        description: Describes pod affinity scheduling rules (e.g. co-locate this pod in the same node, zone, etc. as some other pod(s)).
+                        properties:
+                          preferredDuringSchedulingIgnoredDuringExecution:
+                            description: The scheduler will prefer to schedule pods to nodes that satisfy the affinity expressions specified by this field, but it may choose a node that violates one or more of the expressions. The node that is most preferred is the one with the greatest sum of weights, i.e. for each node that meets all of the scheduling requirements (resource request, requiredDuringScheduling affinity expressions, etc.), compute a sum by iterating through the elements of this field and adding "weight" to the sum if the node has pods which matches the corresponding podAffinityTerm; the node(s) with the highest sum are the most preferred.
+                            items:
+                              description: The weights of all of the matched WeightedPodAffinityTerm fields are added per-node to find the most preferred node(s)
+                              properties:
+                                podAffinityTerm:
+                                  description: Required. A pod affinity term, associated with the corresponding weight.
+                                  properties:
+                                    labelSelector:
+                                      description: A label query over a set of resources, in this case pods.
+                                      properties:
+                                        matchExpressions:
+                                          description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
+                                          items:
+                                            description: A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                                            properties:
+                                              key:
+                                                description: key is the label key that the selector applies to.
+                                                type: string
+                                              operator:
+                                                description: operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.
+                                                type: string
+                                              values:
+                                                description: values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.
+                                                items:
+                                                  type: string
+                                                type: array
+                                            required:
+                                            - key
+                                            - operator
+                                            type: object
+                                          type: array
+                                        matchLabels:
+                                          additionalProperties:
+                                            type: string
+                                          description: matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                          type: object
+                                      type: object
+                                      x-kubernetes-map-type: atomic
+                                    namespaceSelector:
+                                      description: A label query over the set of namespaces that the term applies to. The term is applied to the union of the namespaces selected by this field and the ones listed in the namespaces field. null selector and null or empty namespaces list means "this pod's namespace". An empty selector ({}) matches all namespaces.
+                                      properties:
+                                        matchExpressions:
+                                          description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
+                                          items:
+                                            description: A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                                            properties:
+                                              key:
+                                                description: key is the label key that the selector applies to.
+                                                type: string
+                                              operator:
+                                                description: operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.
+                                                type: string
+                                              values:
+                                                description: values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.
+                                                items:
+                                                  type: string
+                                                type: array
+                                            required:
+                                            - key
+                                            - operator
+                                            type: object
+                                          type: array
+                                        matchLabels:
+                                          additionalProperties:
+                                            type: string
+                                          description: matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                          type: object
+                                      type: object
+                                      x-kubernetes-map-type: atomic
+                                    namespaces:
+                                      description: namespaces specifies a static list of namespace names that the term applies to. The term is applied to the union of the namespaces listed in this field and the ones selected by namespaceSelector. null or empty namespaces list and null namespaceSelector means "this pod's namespace".
+                                      items:
+                                        type: string
+                                      type: array
+                                    topologyKey:
+                                      description: This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching the labelSelector in the specified namespaces, where co-located is defined as running on a node whose value of the label with key topologyKey matches that of any node on which any of the selected pods is running. Empty topologyKey is not allowed.
+                                      type: string
+                                  required:
+                                  - topologyKey
+                                  type: object
+                                weight:
+                                  description: weight associated with matching the corresponding podAffinityTerm, in the range 1-100.
+                                  format: int32
+                                  type: integer
+                              required:
+                              - podAffinityTerm
+                              - weight
+                              type: object
+                            type: array
+                          requiredDuringSchedulingIgnoredDuringExecution:
+                            description: If the affinity requirements specified by this field are not met at scheduling time, the pod will not be scheduled onto the node. If the affinity requirements specified by this field cease to be met at some point during pod execution (e.g. due to a pod label update), the system may or may not try to eventually evict the pod from its node. When there are multiple elements, the lists of nodes corresponding to each podAffinityTerm are intersected, i.e. all terms must be satisfied.
+                            items:
+                              description: Defines a set of pods (namely those matching the labelSelector relative to the given namespace(s)) that this pod should be co-located (affinity) or not co-located (anti-affinity) with, where co-located is defined as running on a node whose value of the label with key <topologyKey> matches that of any node on which a pod of the set of pods is running
+                              properties:
+                                labelSelector:
+                                  description: A label query over a set of resources, in this case pods.
+                                  properties:
+                                    matchExpressions:
+                                      description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
+                                      items:
+                                        description: A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                                        properties:
+                                          key:
+                                            description: key is the label key that the selector applies to.
+                                            type: string
+                                          operator:
+                                            description: operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.
+                                            type: string
+                                          values:
+                                            description: values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.
+                                            items:
+                                              type: string
+                                            type: array
+                                        required:
+                                        - key
+                                        - operator
+                                        type: object
+                                      type: array
+                                    matchLabels:
+                                      additionalProperties:
+                                        type: string
+                                      description: matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                      type: object
+                                  type: object
+                                  x-kubernetes-map-type: atomic
+                                namespaceSelector:
+                                  description: A label query over the set of namespaces that the term applies to. The term is applied to the union of the namespaces selected by this field and the ones listed in the namespaces field. null selector and null or empty namespaces list means "this pod's namespace". An empty selector ({}) matches all namespaces.
+                                  properties:
+                                    matchExpressions:
+                                      description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
+                                      items:
+                                        description: A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                                        properties:
+                                          key:
+                                            description: key is the label key that the selector applies to.
+                                            type: string
+                                          operator:
+                                            description: operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.
+                                            type: string
+                                          values:
+                                            description: values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.
+                                            items:
+                                              type: string
+                                            type: array
+                                        required:
+                                        - key
+                                        - operator
+                                        type: object
+                                      type: array
+                                    matchLabels:
+                                      additionalProperties:
+                                        type: string
+                                      description: matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                      type: object
+                                  type: object
+                                  x-kubernetes-map-type: atomic
+                                namespaces:
+                                  description: namespaces specifies a static list of namespace names that the term applies to. The term is applied to the union of the namespaces listed in this field and the ones selected by namespaceSelector. null or empty namespaces list and null namespaceSelector means "this pod's namespace".
+                                  items:
+                                    type: string
+                                  type: array
+                                topologyKey:
+                                  description: This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching the labelSelector in the specified namespaces, where co-located is defined as running on a node whose value of the label with key topologyKey matches that of any node on which any of the selected pods is running. Empty topologyKey is not allowed.
+                                  type: string
+                              required:
+                              - topologyKey
+                              type: object
+                            type: array
+                        type: object
+                      podAntiAffinity:
+                        description: Describes pod anti-affinity scheduling rules (e.g. avoid putting this pod in the same node, zone, etc. as some other pod(s)).
+                        properties:
+                          preferredDuringSchedulingIgnoredDuringExecution:
+                            description: The scheduler will prefer to schedule pods to nodes that satisfy the anti-affinity expressions specified by this field, but it may choose a node that violates one or more of the expressions. The node that is most preferred is the one with the greatest sum of weights, i.e. for each node that meets all of the scheduling requirements (resource request, requiredDuringScheduling anti-affinity expressions, etc.), compute a sum by iterating through the elements of this field and adding "weight" to the sum if the node has pods which matches the corresponding podAffinityTerm; the node(s) with the highest sum are the most preferred.
+                            items:
+                              description: The weights of all of the matched WeightedPodAffinityTerm fields are added per-node to find the most preferred node(s)
+                              properties:
+                                podAffinityTerm:
+                                  description: Required. A pod affinity term, associated with the corresponding weight.
+                                  properties:
+                                    labelSelector:
+                                      description: A label query over a set of resources, in this case pods.
+                                      properties:
+                                        matchExpressions:
+                                          description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
+                                          items:
+                                            description: A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                                            properties:
+                                              key:
+                                                description: key is the label key that the selector applies to.
+                                                type: string
+                                              operator:
+                                                description: operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.
+                                                type: string
+                                              values:
+                                                description: values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.
+                                                items:
+                                                  type: string
+                                                type: array
+                                            required:
+                                            - key
+                                            - operator
+                                            type: object
+                                          type: array
+                                        matchLabels:
+                                          additionalProperties:
+                                            type: string
+                                          description: matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                          type: object
+                                      type: object
+                                      x-kubernetes-map-type: atomic
+                                    namespaceSelector:
+                                      description: A label query over the set of namespaces that the term applies to. The term is applied to the union of the namespaces selected by this field and the ones listed in the namespaces field. null selector and null or empty namespaces list means "this pod's namespace". An empty selector ({}) matches all namespaces.
+                                      properties:
+                                        matchExpressions:
+                                          description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
+                                          items:
+                                            description: A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                                            properties:
+                                              key:
+                                                description: key is the label key that the selector applies to.
+                                                type: string
+                                              operator:
+                                                description: operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.
+                                                type: string
+                                              values:
+                                                description: values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.
+                                                items:
+                                                  type: string
+                                                type: array
+                                            required:
+                                            - key
+                                            - operator
+                                            type: object
+                                          type: array
+                                        matchLabels:
+                                          additionalProperties:
+                                            type: string
+                                          description: matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                          type: object
+                                      type: object
+                                      x-kubernetes-map-type: atomic
+                                    namespaces:
+                                      description: namespaces specifies a static list of namespace names that the term applies to. The term is applied to the union of the namespaces listed in this field and the ones selected by namespaceSelector. null or empty namespaces list and null namespaceSelector means "this pod's namespace".
+                                      items:
+                                        type: string
+                                      type: array
+                                    topologyKey:
+                                      description: This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching the labelSelector in the specified namespaces, where co-located is defined as running on a node whose value of the label with key topologyKey matches that of any node on which any of the selected pods is running. Empty topologyKey is not allowed.
+                                      type: string
+                                  required:
+                                  - topologyKey
+                                  type: object
+                                weight:
+                                  description: weight associated with matching the corresponding podAffinityTerm, in the range 1-100.
+                                  format: int32
+                                  type: integer
+                              required:
+                              - podAffinityTerm
+                              - weight
+                              type: object
+                            type: array
+                          requiredDuringSchedulingIgnoredDuringExecution:
+                            description: If the anti-affinity requirements specified by this field are not met at scheduling time, the pod will not be scheduled onto the node. If the anti-affinity requirements specified by this field cease to be met at some point during pod execution (e.g. due to a pod label update), the system may or may not try to eventually evict the pod from its node. When there are multiple elements, the lists of nodes corresponding to each podAffinityTerm are intersected, i.e. all terms must be satisfied.
+                            items:
+                              description: Defines a set of pods (namely those matching the labelSelector relative to the given namespace(s)) that this pod should be co-located (affinity) or not co-located (anti-affinity) with, where co-located is defined as running on a node whose value of the label with key <topologyKey> matches that of any node on which a pod of the set of pods is running
+                              properties:
+                                labelSelector:
+                                  description: A label query over a set of resources, in this case pods.
+                                  properties:
+                                    matchExpressions:
+                                      description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
+                                      items:
+                                        description: A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                                        properties:
+                                          key:
+                                            description: key is the label key that the selector applies to.
+                                            type: string
+                                          operator:
+                                            description: operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.
+                                            type: string
+                                          values:
+                                            description: values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.
+                                            items:
+                                              type: string
+                                            type: array
+                                        required:
+                                        - key
+                                        - operator
+                                        type: object
+                                      type: array
+                                    matchLabels:
+                                      additionalProperties:
+                                        type: string
+                                      description: matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                      type: object
+                                  type: object
+                                  x-kubernetes-map-type: atomic
+                                namespaceSelector:
+                                  description: A label query over the set of namespaces that the term applies to. The term is applied to the union of the namespaces selected by this field and the ones listed in the namespaces field. null selector and null or empty namespaces list means "this pod's namespace". An empty selector ({}) matches all namespaces.
+                                  properties:
+                                    matchExpressions:
+                                      description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
+                                      items:
+                                        description: A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                                        properties:
+                                          key:
+                                            description: key is the label key that the selector applies to.
+                                            type: string
+                                          operator:
+                                            description: operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.
+                                            type: string
+                                          values:
+                                            description: values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.
+                                            items:
+                                              type: string
+                                            type: array
+                                        required:
+                                        - key
+                                        - operator
+                                        type: object
+                                      type: array
+                                    matchLabels:
+                                      additionalProperties:
+                                        type: string
+                                      description: matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                      type: object
+                                  type: object
+                                  x-kubernetes-map-type: atomic
+                                namespaces:
+                                  description: namespaces specifies a static list of namespace names that the term applies to. The term is applied to the union of the namespaces listed in this field and the ones selected by namespaceSelector. null or empty namespaces list and null namespaceSelector means "this pod's namespace".
+                                  items:
+                                    type: string
+                                  type: array
+                                topologyKey:
+                                  description: This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching the labelSelector in the specified namespaces, where co-located is defined as running on a node whose value of the label with key topologyKey matches that of any node on which any of the selected pods is running. Empty topologyKey is not allowed.
+                                  type: string
+                              required:
+                              - topologyKey
+                              type: object
+                            type: array
+                        type: object
+                    type: object
+                  nodeSelector:
+                    additionalProperties:
+                      type: string
+                    type: object
+                  schedulerName:
+                    type: string
+                  serviceAccountName:
+                    type: string
+                  tolerations:
+                    items:
+                      description: The pod this Toleration is attached to tolerates any taint that matches the triple <key,value,effect> using the matching operator <operator>.
+                      properties:
+                        effect:
+                          description: Effect indicates the taint effect to match. Empty means match all taint effects. When specified, allowed values are NoSchedule, PreferNoSchedule and NoExecute.
+                          type: string
+                        key:
+                          description: Key is the taint key that the toleration applies to. Empty means match all taint keys. If the key is empty, operator must be Exists; this combination means to match all values and all keys.
+                          type: string
+                        operator:
+                          description: Operator represents a key's relationship to the value. Valid operators are Exists and Equal. Defaults to Equal. Exists is equivalent to wildcard for value, so that a pod can tolerate all taints of a particular category.
+                          type: string
+                        tolerationSeconds:
+                          description: TolerationSeconds represents the period of time the toleration (which must be of effect NoExecute, otherwise this field is ignored) tolerates the taint. By default, it is not set, which means tolerate the taint forever (do not evict). Zero and negative values will be treated as 0 (evict immediately) by the system.
+                          format: int64
+                          type: integer
+                        value:
+                          description: Value is the taint value the toleration matches to. If the operator is Exists, the value should be empty, otherwise just a regular string.
+                          type: string
+                      type: object
+                    type: array
+                  topologySpreadConstraints:
+                    items:
+                      description: TopologySpreadConstraint specifies how to spread matching pods among the given topology.
+                      properties:
+                        labelSelector:
+                          description: LabelSelector is used to find matching pods. Pods that match this label selector are counted to determine the number of pods in their corresponding topology domain.
+                          properties:
+                            matchExpressions:
+                              description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
+                              items:
+                                description: A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                                properties:
+                                  key:
+                                    description: key is the label key that the selector applies to.
+                                    type: string
+                                  operator:
+                                    description: operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.
+                                    type: string
+                                  values:
+                                    description: values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.
+                                    items:
+                                      type: string
+                                    type: array
+                                required:
+                                - key
+                                - operator
+                                type: object
+                              type: array
+                            matchLabels:
+                              additionalProperties:
+                                type: string
+                              description: matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
+                              type: object
+                          type: object
+                          x-kubernetes-map-type: atomic
+                        matchLabelKeys:
+                          description: MatchLabelKeys is a set of pod label keys to select the pods over which spreading will be calculated. The keys are used to lookup values from the incoming pod labels, those key-value labels are ANDed with labelSelector to select the group of existing pods over which spreading will be calculated for the incoming pod. Keys that don't exist in the incoming pod labels will be ignored. A null or empty list means only match against labelSelector.
+                          items:
+                            type: string
+                          type: array
+                          x-kubernetes-list-type: atomic
+                        maxSkew:
+                          description: 'MaxSkew describes the degree to which pods may be unevenly distributed. When `whenUnsatisfiable=DoNotSchedule`, it is the maximum permitted difference between the number of matching pods in the target topology and the global minimum. The global minimum is the minimum number of matching pods in an eligible domain or zero if the number of eligible domains is less than MinDomains. For example, in a 3-zone cluster, MaxSkew is set to 1, and pods with the same labelSelector spread as 2/2/1: In this case, the global minimum is 1. | zone1 | zone2 | zone3 | |  P P  |  P P  |   P   | - if MaxSkew is 1, incoming pod can only be scheduled to zone3 to become 2/2/2; scheduling it onto zone1(zone2) would make the ActualSkew(3-1) on zone1(zone2) violate MaxSkew(1). - if MaxSkew is 2, incoming pod can be scheduled onto any zone. When `whenUnsatisfiable=ScheduleAnyway`, it is used to give higher precedence to topologies that satisfy it. It''s a required field. Default value is 1 and 0 is not allowed.'
+                          format: int32
+                          type: integer
+                        minDomains:
+                          description: "MinDomains indicates a minimum number of eligible domains. When the number of eligible domains with matching topology keys is less than minDomains, Pod Topology Spread treats \"global minimum\" as 0, and then the calculation of Skew is performed. And when the number of eligible domains with matching topology keys equals or greater than minDomains, this value has no effect on scheduling. As a result, when the number of eligible domains is less than minDomains, scheduler won't schedule more than maxSkew Pods to those domains. If value is nil, the constraint behaves as if MinDomains is equal to 1. Valid values are integers greater than 0. When value is not nil, WhenUnsatisfiable must be DoNotSchedule. \n For example, in a 3-zone cluster, MaxSkew is set to 2, MinDomains is set to 5 and pods with the same labelSelector spread as 2/2/2: | zone1 | zone2 | zone3 | |  P P  |  P P  |  P P  | The number of domains is less than 5(MinDomains), so \"global minimum\" is treated as 0. In this situation, new pod with the same labelSelector cannot be scheduled, because computed skew will be 3(3 - 0) if new Pod is scheduled to any of the three zones, it will violate MaxSkew. \n This is a beta field and requires the MinDomainsInPodTopologySpread feature gate to be enabled (enabled by default)."
+                          format: int32
+                          type: integer
+                        nodeAffinityPolicy:
+                          description: "NodeAffinityPolicy indicates how we will treat Pod's nodeAffinity/nodeSelector when calculating pod topology spread skew. Options are: - Honor: only nodes matching nodeAffinity/nodeSelector are included in the calculations. - Ignore: nodeAffinity/nodeSelector are ignored. All nodes are included in the calculations. \n If this value is nil, the behavior is equivalent to the Honor policy. This is a alpha-level feature enabled by the NodeInclusionPolicyInPodTopologySpread feature flag."
+                          type: string
+                        nodeTaintsPolicy:
+                          description: "NodeTaintsPolicy indicates how we will treat node taints when calculating pod topology spread skew. Options are: - Honor: nodes without taints, along with tainted nodes for which the incoming pod has a toleration, are included. - Ignore: node taints are ignored. All nodes are included. \n If this value is nil, the behavior is equivalent to the Ignore policy. This is a alpha-level feature enabled by the NodeInclusionPolicyInPodTopologySpread feature flag."
+                          type: string
+                        topologyKey:
+                          description: TopologyKey is the key of node labels. Nodes that have a label with this key and identical values are considered to be in the same topology. We consider each <key, value> as a "bucket", and try to put balanced number of pods into each bucket. We define a domain as a particular instance of a topology. Also, we define an eligible domain as a domain whose nodes meet the requirements of nodeAffinityPolicy and nodeTaintsPolicy. e.g. If TopologyKey is "kubernetes.io/hostname", each Node is a domain of that topology. And, if TopologyKey is "topology.kubernetes.io/zone", each zone is a domain of that topology. It's a required field.
+                          type: string
+                        whenUnsatisfiable:
+                          description: 'WhenUnsatisfiable indicates how to deal with a pod if it doesn''t satisfy the spread constraint. - DoNotSchedule (default) tells the scheduler not to schedule it. - ScheduleAnyway tells the scheduler to schedule the pod in any location, but giving higher precedence to topologies that would help reduce the skew. A constraint is considered "Unsatisfiable" for an incoming pod if and only if every possible node assignment for that pod would violate "MaxSkew" on some topology. For example, in a 3-zone cluster, MaxSkew is set to 1, and pods with the same labelSelector spread as 3/1/1: | zone1 | zone2 | zone3 | | P P P |   P   |   P   | If WhenUnsatisfiable is set to DoNotSchedule, incoming pod can only be scheduled to zone2(zone3) to become 3/2/1(3/1/2) as ActualSkew(2-1) on zone2(zone3) satisfies MaxSkew(1). In other words, the cluster can still be imbalanced, but scheduler won''t make it *more* imbalanced. It''s a required field.'
+                          type: string
+                      required:
+                      - maxSkew
+                      - topologyKey
+                      - whenUnsatisfiable
+                      type: object
+                    type: array
+                type: object
+              models:
+                items:
+                  properties:
+                    downloadUrl:
+                      type: string
+                    tag:
+                      type: string
+                  required:
+                  - tag
+                  type: object
+                type: array
+              ociRegistryInsecure:
+                type: boolean
+              runners:
+                items:
+                  properties:
+                    modelTags:
+                      items:
+                        type: string
+                      type: array
+                    name:
+                      type: string
+                    runnableType:
+                      type: string
+                  required:
+                  - name
+                  type: object
+                type: array
+            required:
+            - bentoTag
+            type: object
+          status:
+            description: BentoRequestStatus defines the observed state of BentoRequest
+            properties:
+              conditions:
+                description: 'INSERT ADDITIONAL STATUS FIELD - define observed state of cluster Important: Run "make" to regenerate code after modifying this file'
+                items:
+                  description: "Condition contains details for one aspect of the current state of this API Resource. --- This struct is intended for direct use as an array at the field path .status.conditions.  For example, \n type FooStatus struct{ // Represents the observations of a foo's current state. // Known .status.conditions.type are: \"Available\", \"Progressing\", and \"Degraded\" // +patchMergeKey=type // +patchStrategy=merge // +listType=map // +listMapKey=type Conditions []metav1.Condition `json:\"conditions,omitempty\" patchStrategy:\"merge\" patchMergeKey:\"type\" protobuf:\"bytes,1,rep,name=conditions\"` \n // other fields }"
+                  properties:
+                    lastTransitionTime:
+                      description: lastTransitionTime is the last time the condition transitioned from one status to another. This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+                      format: date-time
+                      type: string
+                    message:
+                      description: message is a human readable message indicating details about the transition. This may be an empty string.
+                      maxLength: 32768
+                      type: string
+                    observedGeneration:
+                      description: observedGeneration represents the .metadata.generation that the condition was set based upon. For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date with respect to the current state of the instance.
+                      format: int64
+                      minimum: 0
+                      type: integer
+                    reason:
+                      description: reason contains a programmatic identifier indicating the reason for the condition's last transition. Producers of specific condition types may define expected values and meanings for this field, and whether the values are considered a guaranteed API. The value should be a CamelCase string. This field may not be empty.
+                      maxLength: 1024
+                      minLength: 1
+                      pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                      type: string
+                    status:
+                      description: status of the condition, one of True, False, Unknown.
+                      enum:
+                      - "True"
+                      - "False"
+                      - Unknown
+                      type: string
+                    type:
+                      description: type of condition in CamelCase or in foo.example.com/CamelCase. --- Many .condition.type values are consistent across resources like Available, but because arbitrary conditions can be useful (see .node.status.conditions), the ability to deconflict is important. The regex it matches is (dns1123SubdomainFmt/)?(qualifiedNameFmt)
+                      maxLength: 316
+                      pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                      type: string
+                  required:
+                  - lastTransitionTime
+                  - message
+                  - reason
+                  - status
+                  - type
+                  type: object
+                type: array
+              imageBuilderPodStatus:
+                description: PodStatus represents information about the status of a pod. Status may trail the actual state of a system, especially if the node that hosts the pod cannot contact the control plane.
+                properties:
+                  conditions:
+                    description: 'Current service state of pod. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#pod-conditions'
+                    items:
+                      description: PodCondition contains details for the current condition of this pod.
+                      properties:
+                        lastProbeTime:
+                          description: Last time we probed the condition.
+                          format: date-time
+                          type: string
+                        lastTransitionTime:
+                          description: Last time the condition transitioned from one status to another.
+                          format: date-time
+                          type: string
+                        message:
+                          description: Human-readable message indicating details about last transition.
+                          type: string
+                        reason:
+                          description: Unique, one-word, CamelCase reason for the condition's last transition.
+                          type: string
+                        status:
+                          description: 'Status is the status of the condition. Can be True, False, Unknown. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#pod-conditions'
+                          type: string
+                        type:
+                          description: 'Type is the type of the condition. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#pod-conditions'
+                          type: string
+                      required:
+                      - status
+                      - type
+                      type: object
+                    type: array
+                  containerStatuses:
+                    description: 'The list has one entry per container in the manifest. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#pod-and-container-status'
+                    items:
+                      description: ContainerStatus contains details for the current status of this container.
+                      properties:
+                        containerID:
+                          description: Container's ID in the format '<type>://<container_id>'.
+                          type: string
+                        image:
+                          description: 'The image the container is running. More info: https://kubernetes.io/docs/concepts/containers/images.'
+                          type: string
+                        imageID:
+                          description: ImageID of the container's image.
+                          type: string
+                        lastState:
+                          description: Details about the container's last termination condition.
+                          properties:
+                            running:
+                              description: Details about a running container
+                              properties:
+                                startedAt:
+                                  description: Time at which the container was last (re-)started
+                                  format: date-time
+                                  type: string
+                              type: object
+                            terminated:
+                              description: Details about a terminated container
+                              properties:
+                                containerID:
+                                  description: Container's ID in the format '<type>://<container_id>'
+                                  type: string
+                                exitCode:
+                                  description: Exit status from the last termination of the container
+                                  format: int32
+                                  type: integer
+                                finishedAt:
+                                  description: Time at which the container last terminated
+                                  format: date-time
+                                  type: string
+                                message:
+                                  description: Message regarding the last termination of the container
+                                  type: string
+                                reason:
+                                  description: (brief) reason from the last termination of the container
+                                  type: string
+                                signal:
+                                  description: Signal from the last termination of the container
+                                  format: int32
+                                  type: integer
+                                startedAt:
+                                  description: Time at which previous execution of the container started
+                                  format: date-time
+                                  type: string
+                              required:
+                              - exitCode
+                              type: object
+                            waiting:
+                              description: Details about a waiting container
+                              properties:
+                                message:
+                                  description: Message regarding why the container is not yet running.
+                                  type: string
+                                reason:
+                                  description: (brief) reason the container is not yet running.
+                                  type: string
+                              type: object
+                          type: object
+                        name:
+                          description: This must be a DNS_LABEL. Each container in a pod must have a unique name. Cannot be updated.
+                          type: string
+                        ready:
+                          description: Specifies whether the container has passed its readiness probe.
+                          type: boolean
+                        restartCount:
+                          description: The number of times the container has been restarted.
+                          format: int32
+                          type: integer
+                        started:
+                          description: Specifies whether the container has passed its startup probe. Initialized as false, becomes true after startupProbe is considered successful. Resets to false when the container is restarted, or if kubelet loses state temporarily. Is always true when no startupProbe is defined.
+                          type: boolean
+                        state:
+                          description: Details about the container's current condition.
+                          properties:
+                            running:
+                              description: Details about a running container
+                              properties:
+                                startedAt:
+                                  description: Time at which the container was last (re-)started
+                                  format: date-time
+                                  type: string
+                              type: object
+                            terminated:
+                              description: Details about a terminated container
+                              properties:
+                                containerID:
+                                  description: Container's ID in the format '<type>://<container_id>'
+                                  type: string
+                                exitCode:
+                                  description: Exit status from the last termination of the container
+                                  format: int32
+                                  type: integer
+                                finishedAt:
+                                  description: Time at which the container last terminated
+                                  format: date-time
+                                  type: string
+                                message:
+                                  description: Message regarding the last termination of the container
+                                  type: string
+                                reason:
+                                  description: (brief) reason from the last termination of the container
+                                  type: string
+                                signal:
+                                  description: Signal from the last termination of the container
+                                  format: int32
+                                  type: integer
+                                startedAt:
+                                  description: Time at which previous execution of the container started
+                                  format: date-time
+                                  type: string
+                              required:
+                              - exitCode
+                              type: object
+                            waiting:
+                              description: Details about a waiting container
+                              properties:
+                                message:
+                                  description: Message regarding why the container is not yet running.
+                                  type: string
+                                reason:
+                                  description: (brief) reason the container is not yet running.
+                                  type: string
+                              type: object
+                          type: object
+                      required:
+                      - image
+                      - imageID
+                      - name
+                      - ready
+                      - restartCount
+                      type: object
+                    type: array
+                  ephemeralContainerStatuses:
+                    description: Status for any ephemeral containers that have run in this pod.
+                    items:
+                      description: ContainerStatus contains details for the current status of this container.
+                      properties:
+                        containerID:
+                          description: Container's ID in the format '<type>://<container_id>'.
+                          type: string
+                        image:
+                          description: 'The image the container is running. More info: https://kubernetes.io/docs/concepts/containers/images.'
+                          type: string
+                        imageID:
+                          description: ImageID of the container's image.
+                          type: string
+                        lastState:
+                          description: Details about the container's last termination condition.
+                          properties:
+                            running:
+                              description: Details about a running container
+                              properties:
+                                startedAt:
+                                  description: Time at which the container was last (re-)started
+                                  format: date-time
+                                  type: string
+                              type: object
+                            terminated:
+                              description: Details about a terminated container
+                              properties:
+                                containerID:
+                                  description: Container's ID in the format '<type>://<container_id>'
+                                  type: string
+                                exitCode:
+                                  description: Exit status from the last termination of the container
+                                  format: int32
+                                  type: integer
+                                finishedAt:
+                                  description: Time at which the container last terminated
+                                  format: date-time
+                                  type: string
+                                message:
+                                  description: Message regarding the last termination of the container
+                                  type: string
+                                reason:
+                                  description: (brief) reason from the last termination of the container
+                                  type: string
+                                signal:
+                                  description: Signal from the last termination of the container
+                                  format: int32
+                                  type: integer
+                                startedAt:
+                                  description: Time at which previous execution of the container started
+                                  format: date-time
+                                  type: string
+                              required:
+                              - exitCode
+                              type: object
+                            waiting:
+                              description: Details about a waiting container
+                              properties:
+                                message:
+                                  description: Message regarding why the container is not yet running.
+                                  type: string
+                                reason:
+                                  description: (brief) reason the container is not yet running.
+                                  type: string
+                              type: object
+                          type: object
+                        name:
+                          description: This must be a DNS_LABEL. Each container in a pod must have a unique name. Cannot be updated.
+                          type: string
+                        ready:
+                          description: Specifies whether the container has passed its readiness probe.
+                          type: boolean
+                        restartCount:
+                          description: The number of times the container has been restarted.
+                          format: int32
+                          type: integer
+                        started:
+                          description: Specifies whether the container has passed its startup probe. Initialized as false, becomes true after startupProbe is considered successful. Resets to false when the container is restarted, or if kubelet loses state temporarily. Is always true when no startupProbe is defined.
+                          type: boolean
+                        state:
+                          description: Details about the container's current condition.
+                          properties:
+                            running:
+                              description: Details about a running container
+                              properties:
+                                startedAt:
+                                  description: Time at which the container was last (re-)started
+                                  format: date-time
+                                  type: string
+                              type: object
+                            terminated:
+                              description: Details about a terminated container
+                              properties:
+                                containerID:
+                                  description: Container's ID in the format '<type>://<container_id>'
+                                  type: string
+                                exitCode:
+                                  description: Exit status from the last termination of the container
+                                  format: int32
+                                  type: integer
+                                finishedAt:
+                                  description: Time at which the container last terminated
+                                  format: date-time
+                                  type: string
+                                message:
+                                  description: Message regarding the last termination of the container
+                                  type: string
+                                reason:
+                                  description: (brief) reason from the last termination of the container
+                                  type: string
+                                signal:
+                                  description: Signal from the last termination of the container
+                                  format: int32
+                                  type: integer
+                                startedAt:
+                                  description: Time at which previous execution of the container started
+                                  format: date-time
+                                  type: string
+                              required:
+                              - exitCode
+                              type: object
+                            waiting:
+                              description: Details about a waiting container
+                              properties:
+                                message:
+                                  description: Message regarding why the container is not yet running.
+                                  type: string
+                                reason:
+                                  description: (brief) reason the container is not yet running.
+                                  type: string
+                              type: object
+                          type: object
+                      required:
+                      - image
+                      - imageID
+                      - name
+                      - ready
+                      - restartCount
+                      type: object
+                    type: array
+                  hostIP:
+                    description: IP address of the host to which the pod is assigned. Empty if not yet scheduled.
+                    type: string
+                  initContainerStatuses:
+                    description: 'The list has one entry per init container in the manifest. The most recent successful init container will have ready = true, the most recently started container will have startTime set. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#pod-and-container-status'
+                    items:
+                      description: ContainerStatus contains details for the current status of this container.
+                      properties:
+                        containerID:
+                          description: Container's ID in the format '<type>://<container_id>'.
+                          type: string
+                        image:
+                          description: 'The image the container is running. More info: https://kubernetes.io/docs/concepts/containers/images.'
+                          type: string
+                        imageID:
+                          description: ImageID of the container's image.
+                          type: string
+                        lastState:
+                          description: Details about the container's last termination condition.
+                          properties:
+                            running:
+                              description: Details about a running container
+                              properties:
+                                startedAt:
+                                  description: Time at which the container was last (re-)started
+                                  format: date-time
+                                  type: string
+                              type: object
+                            terminated:
+                              description: Details about a terminated container
+                              properties:
+                                containerID:
+                                  description: Container's ID in the format '<type>://<container_id>'
+                                  type: string
+                                exitCode:
+                                  description: Exit status from the last termination of the container
+                                  format: int32
+                                  type: integer
+                                finishedAt:
+                                  description: Time at which the container last terminated
+                                  format: date-time
+                                  type: string
+                                message:
+                                  description: Message regarding the last termination of the container
+                                  type: string
+                                reason:
+                                  description: (brief) reason from the last termination of the container
+                                  type: string
+                                signal:
+                                  description: Signal from the last termination of the container
+                                  format: int32
+                                  type: integer
+                                startedAt:
+                                  description: Time at which previous execution of the container started
+                                  format: date-time
+                                  type: string
+                              required:
+                              - exitCode
+                              type: object
+                            waiting:
+                              description: Details about a waiting container
+                              properties:
+                                message:
+                                  description: Message regarding why the container is not yet running.
+                                  type: string
+                                reason:
+                                  description: (brief) reason the container is not yet running.
+                                  type: string
+                              type: object
+                          type: object
+                        name:
+                          description: This must be a DNS_LABEL. Each container in a pod must have a unique name. Cannot be updated.
+                          type: string
+                        ready:
+                          description: Specifies whether the container has passed its readiness probe.
+                          type: boolean
+                        restartCount:
+                          description: The number of times the container has been restarted.
+                          format: int32
+                          type: integer
+                        started:
+                          description: Specifies whether the container has passed its startup probe. Initialized as false, becomes true after startupProbe is considered successful. Resets to false when the container is restarted, or if kubelet loses state temporarily. Is always true when no startupProbe is defined.
+                          type: boolean
+                        state:
+                          description: Details about the container's current condition.
+                          properties:
+                            running:
+                              description: Details about a running container
+                              properties:
+                                startedAt:
+                                  description: Time at which the container was last (re-)started
+                                  format: date-time
+                                  type: string
+                              type: object
+                            terminated:
+                              description: Details about a terminated container
+                              properties:
+                                containerID:
+                                  description: Container's ID in the format '<type>://<container_id>'
+                                  type: string
+                                exitCode:
+                                  description: Exit status from the last termination of the container
+                                  format: int32
+                                  type: integer
+                                finishedAt:
+                                  description: Time at which the container last terminated
+                                  format: date-time
+                                  type: string
+                                message:
+                                  description: Message regarding the last termination of the container
+                                  type: string
+                                reason:
+                                  description: (brief) reason from the last termination of the container
+                                  type: string
+                                signal:
+                                  description: Signal from the last termination of the container
+                                  format: int32
+                                  type: integer
+                                startedAt:
+                                  description: Time at which previous execution of the container started
+                                  format: date-time
+                                  type: string
+                              required:
+                              - exitCode
+                              type: object
+                            waiting:
+                              description: Details about a waiting container
+                              properties:
+                                message:
+                                  description: Message regarding why the container is not yet running.
+                                  type: string
+                                reason:
+                                  description: (brief) reason the container is not yet running.
+                                  type: string
+                              type: object
+                          type: object
+                      required:
+                      - image
+                      - imageID
+                      - name
+                      - ready
+                      - restartCount
+                      type: object
+                    type: array
+                  message:
+                    description: A human readable message indicating details about why the pod is in this condition.
+                    type: string
+                  nominatedNodeName:
+                    description: nominatedNodeName is set only when this pod preempts other pods on the node, but it cannot be scheduled right away as preemption victims receive their graceful termination periods. This field does not guarantee that the pod will be scheduled on this node. Scheduler may decide to place the pod elsewhere if other nodes become available sooner. Scheduler may also decide to give the resources on this node to a higher priority pod that is created after preemption. As a result, this field may be different than PodSpec.nodeName when the pod is scheduled.
+                    type: string
+                  phase:
+                    description: "The phase of a Pod is a simple, high-level summary of where the Pod is in its lifecycle. The conditions array, the reason and message fields, and the individual container status arrays contain more detail about the pod's status. There are five possible phase values: \n Pending: The pod has been accepted by the Kubernetes system, but one or more of the container images has not been created. This includes time before being scheduled as well as time spent downloading images over the network, which could take a while. Running: The pod has been bound to a node, and all of the containers have been created. At least one container is still running, or is in the process of starting or restarting. Succeeded: All containers in the pod have terminated in success, and will not be restarted. Failed: All containers in the pod have terminated, and at least one container has terminated in failure. The container either exited with non-zero status or was terminated by the system. Unknown: For some reason the state of the pod could not be obtained, typically due to an error in communicating with the host of the pod. \n More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#pod-phase"
+                    type: string
+                  podIP:
+                    description: IP address allocated to the pod. Routable at least within the cluster. Empty if not yet allocated.
+                    type: string
+                  podIPs:
+                    description: podIPs holds the IP addresses allocated to the pod. If this field is specified, the 0th entry must match the podIP field. Pods may be allocated at most 1 value for each of IPv4 and IPv6. This list is empty if no IPs have been allocated yet.
+                    items:
+                      description: "IP address information for entries in the (plural) PodIPs field. Each entry includes: \n IP: An IP address allocated to the pod. Routable at least within the cluster."
+                      properties:
+                        ip:
+                          description: ip is an IP address (IPv4 or IPv6) assigned to the pod
+                          type: string
+                      type: object
+                    type: array
+                  qosClass:
+                    description: 'The Quality of Service (QOS) classification assigned to the pod based on resource requirements See PodQOSClass type for available QOS classes More info: https://git.k8s.io/community/contributors/design-proposals/node/resource-qos.md'
+                    type: string
+                  reason:
+                    description: A brief CamelCase message indicating details about why the pod is in this state. e.g. 'Evicted'
+                    type: string
+                  startTime:
+                    description: RFC 3339 date and time at which the object was acknowledged by the Kubelet. This is before the Kubelet pulled the container image(s) for the pod.
+                    format: date-time
+                    type: string
+                type: object
+            required:
+            - conditions
+            - imageBuilderPodStatus
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
+---
+# Source: yatai-image-builder/templates/serviceaccount.yaml
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: yatai-image-builder
+  namespace: kubeflow
+  labels:
+    helm.sh/chart: yatai-image-builder-1.1.3
+    app.kubernetes.io/name: yatai-image-builder
+    app.kubernetes.io/instance: yatai-image-builder
+    app.kubernetes.io/version: "1.1.3"
+    app.kubernetes.io/managed-by: Helm
+---
+# Source: yatai-image-builder/templates/secret-env.yaml
+apiVersion: v1
+kind: Secret
+metadata:
+  name: yatai-image-builder-env
+  namespace: kubeflow
+  labels:
+    helm.sh/chart: yatai-image-builder-1.1.3
+    app.kubernetes.io/name: yatai-image-builder
+    app.kubernetes.io/instance: yatai-image-builder
+    app.kubernetes.io/version: "1.1.3"
+    app.kubernetes.io/managed-by: Helm
+type: Opaque
+stringData:
+  YATAI_IMAGE_BUILDER_SHARED_ENV_SECRET_NAME: yatai-image-builder-shared-env
+
+  YATAI_SYSTEM_NAMESPACE: kubeflow
+  YATAI_API_TOKEN: "SqXTUo0q8nqRtWQn"
+
+  DOCKER_REGISTRY_SERVER: "127.0.0.1:5000"
+  DOCKER_REGISTRY_IN_CLUSTER_SERVER: "docker-registry.kubeflow.svc.cluster.local:5000"
+  DOCKER_REGISTRY_USERNAME: ""
+  DOCKER_REGISTRY_PASSWORD: ""
+  DOCKER_REGISTRY_SECURE: "false"
+  DOCKER_REGISTRY_BENTO_REPOSITORY_NAME: "yatai-bentos"
+
+  INTERNAL_IMAGES_BENTO_DOWNLOADER: "quay.io/bentoml/bento-downloader:0.0.1"
+  INTERNAL_IMAGES_KANIKO: "quay.io/bentoml/kaniko:1.9.1"
+  INTERNAL_IMAGES_BUILDKIT: "quay.io/bentoml/buildkit:master"
+  INTERNAL_IMAGES_BUILDKIT_ROOTLESS: "quay.io/bentoml/buildkit:master-rootless"
+
+  BENTO_IMAGE_BUILD_ENGINE: "kaniko"
+---
+# Source: yatai-image-builder/templates/secret-shared-env.yaml
+apiVersion: v1
+kind: Secret
+metadata:
+  name: yatai-image-builder-shared-env
+  namespace: kubeflow
+  labels:
+    helm.sh/chart: yatai-image-builder-1.1.3
+    app.kubernetes.io/name: yatai-image-builder
+    app.kubernetes.io/instance: yatai-image-builder
+    app.kubernetes.io/version: "1.1.3"
+    app.kubernetes.io/managed-by: Helm
+type: Opaque
+stringData:
+  YATAI_IMAGE_BUILDER_NAMESPACE: kubeflow
+---
+# Source: yatai-image-builder/templates/secret-yatai-common-env.yaml
+apiVersion: v1
+kind: Secret
+metadata:
+  name: yatai-common-env
+  namespace: kubeflow
+  labels:
+    helm.sh/chart: yatai-image-builder-1.1.3
+    app.kubernetes.io/name: yatai-image-builder
+    app.kubernetes.io/instance: yatai-image-builder
+    app.kubernetes.io/version: "1.1.3"
+    app.kubernetes.io/managed-by: Helm
+type: Opaque
+stringData:
+  YATAI_ENDPOINT: ""
+  YATAI_CLUSTER_NAME: "default"
+---
+# Source: yatai-image-builder/templates/clusterrole-yatai-with-bento-request.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: yatai-with-bento-request-kubeflow
+rules:
+- apiGroups:
+  - resources.yatai.ai
+  resources:
+  - bentorequests
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - resources.yatai.ai
+  resources:
+  - bentorequests/finalizers
+  verbs:
+  - update
+- apiGroups:
+  - resources.yatai.ai
+  resources:
+  - bentorequests/status
+  verbs:
+  - get
+  - patch
+  - update
+- apiGroups:
+  - resources.yatai.ai
+  resources:
+  - bentoes
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - resources.yatai.ai
+  resources:
+  - bentoes/finalizers
+  verbs:
+  - update
+- apiGroups:
+  - resources.yatai.ai
+  resources:
+  - bentoes/status
+  verbs:
+  - get
+  - patch
+  - update
+---
+# Source: yatai-image-builder/templates/clusterrole.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: yatai-image-builder-kubeflow
+rules:
+- apiGroups:
+  - resources.yatai.ai
+  resources:
+  - bentorequests
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - resources.yatai.ai
+  resources:
+  - bentorequests/status
+  verbs:
+  - update
+- apiGroups:
+  - resources.yatai.ai
+  resources:
+  - bentoes
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - resources.yatai.ai
+  resources:
+  - bentoes/status
+  verbs:
+  - update
+- apiGroups:
+  - ""
+  resources:
+  - pods
+  verbs:
+  - create
+  - delete
+  - update
+  - patch
+  - get
+  - list
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - configmaps
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - secrets
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - events
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - serviceaccounts
+  verbs:
+  - get
+  - list
+  - watch
+---
+# Source: yatai-image-builder/templates/clusterrolebinding-yatai-with-bento-request.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: yatai-with-bento-request-kubeflow
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: yatai-with-bento-request-kubeflow
+subjects:
+- kind: ServiceAccount
+  name: yatai
+  namespace: kubeflow
+---
+# Source: yatai-image-builder/templates/clusterrolebinding.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: yatai-image-builder-kubeflow
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: yatai-image-builder-kubeflow
+subjects:
+- kind: ServiceAccount
+  name: yatai-image-builder
+  namespace: kubeflow
+---
+# Source: yatai-image-builder/templates/role-in-yatai-system-namespace.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: yatai-image-builder-in-yatai-system
+  namespace: kubeflow
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - secrets
+  resourceNames:
+  - yatai-common-env
+  - yatai-image-builder-shared-env
+  verbs:
+  - get
+  - list
+  - watch
+---
+# Source: yatai-image-builder/templates/role-yatai-in-yatai-system-namespace.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: yatai-role-for-yatai-image-builder
+  namespace: kubeflow
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - secrets
+  resourceNames:
+  - yatai-common-env
+  - yatai-image-builder-shared-env
+  verbs:
+  - get
+  - list
+  - watch
+---
+# Source: yatai-image-builder/templates/role-yatai-with-yatai-image-builder.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: yatai-with-yatai-image-builder
+  namespace: kubeflow
+rules:
+- apiGroups:
+  - apps
+  resources:
+  - replicasets
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - apps
+  resources:
+  - deployments
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - configmaps
+  resourceNames:
+  - yatai-image-builder-config
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - events
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - events.k8s.io
+  resources:
+  - events
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - pods
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - pods/exec
+  verbs:
+  - create
+  - update
+  - patch
+  - get
+  - list
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - pods/attach
+  verbs:
+  - create
+  - update
+  - patch
+  - get
+  - list
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - pods/ephemeralcontainers
+  verbs:
+  - create
+  - update
+  - patch
+  - get
+  - list
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - pods/log
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - secrets
+  resourceNames:
+  - yatai-image-builder-env
+  - yatai-image-builder-build-args
+  verbs:
+  - get
+  - list
+  - watch
+---
+# Source: yatai-image-builder/templates/role.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: yatai-image-builder
+  namespace: kubeflow
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - secrets
+  resourceNames:
+  - yatai-image-builder-build-args
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - configmaps
+  resourceNames:
+  - yatai-image-builder-config
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - events
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - events.k8s.io
+  resources:
+  - events
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - coordination.k8s.io
+  resources:
+  - leases
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+---
+# Source: yatai-image-builder/templates/rolebinding-in-yatai-system-namespace.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: yatai-image-builder-in-yatai-system
+  namespace: kubeflow
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: yatai-image-builder-in-yatai-system
+subjects:
+  - kind: ServiceAccount
+    name: yatai-image-builder
+    namespace: kubeflow
+---
+# Source: yatai-image-builder/templates/rolebinding-yatai-in-yatai-system-namespace.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: yatai-role-for-yatai-image-builder
+  namespace: kubeflow
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: yatai-role-for-yatai-image-builder
+subjects:
+  - kind: ServiceAccount
+    name: yatai
+    namespace: kubeflow
+---
+# Source: yatai-image-builder/templates/rolebinding-yatai-with-yatai-image-builder.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: yatai-with-yatai-image-builder
+  namespace: kubeflow
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: yatai-with-yatai-image-builder
+subjects:
+  - kind: ServiceAccount
+    name: yatai
+    namespace: kubeflow
+---
+# Source: yatai-image-builder/templates/rolebinding.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: yatai-image-builder
+  namespace: kubeflow
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: yatai-image-builder
+subjects:
+  - kind: ServiceAccount
+    name: yatai-image-builder
+    namespace: kubeflow
+---
+# Source: yatai-image-builder/templates/service.yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: yatai-image-builder-webhook-service
+  namespace: kubeflow
+  labels:
+    helm.sh/chart: yatai-image-builder-1.1.3
+    app.kubernetes.io/name: yatai-image-builder
+    app.kubernetes.io/instance: yatai-image-builder
+    app.kubernetes.io/version: "1.1.3"
+    app.kubernetes.io/managed-by: Helm
+spec:
+  ports:
+  - port: 443
+    protocol: TCP
+    targetPort: 9443
+  selector:
+    app.kubernetes.io/name: yatai-image-builder
+    app.kubernetes.io/instance: yatai-image-builder
+---
+# Source: yatai-image-builder/templates/deployment.yaml
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: yatai-image-builder
+  namespace: kubeflow
+  labels:
+    helm.sh/chart: yatai-image-builder-1.1.3
+    app.kubernetes.io/name: yatai-image-builder
+    app.kubernetes.io/instance: yatai-image-builder
+    app.kubernetes.io/version: "1.1.3"
+    app.kubernetes.io/managed-by: Helm
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: yatai-image-builder
+      app.kubernetes.io/instance: yatai-image-builder
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: yatai-image-builder
+        app.kubernetes.io/instance: yatai-image-builder
+    spec:
+      serviceAccountName: yatai-image-builder
+      securityContext:
+        {}
+      containers:
+        - name: manager
+          args:
+            - --health-probe-bind-address=:8081
+            - --metrics-bind-address=127.0.0.1:8080
+            - --leader-elect
+          command:
+            - /manager
+          env:
+            - name: SYSTEM_NAMESPACE
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
+          envFrom:
+            - secretRef:
+                name: yatai-image-builder-env
+          securityContext:
+            {}
+          image: "quay.io/bentoml/yatai-image-builder:1.1.3"
+          imagePullPolicy: IfNotPresent
+
+          ports:
+          - containerPort: 9443
+            name: webhook-server
+            protocol: TCP
+
+          livenessProbe:
+            failureThreshold: 3
+            httpGet:
+              path: /healthz
+              port: 8081
+              scheme: HTTP
+            initialDelaySeconds: 15
+            periodSeconds: 20
+            successThreshold: 1
+            timeoutSeconds: 1
+
+          readinessProbe:
+            failureThreshold: 3
+            httpGet:
+              path: /readyz
+              port: 8081
+              scheme: HTTP
+            initialDelaySeconds: 5
+            periodSeconds: 10
+            successThreshold: 1
+            timeoutSeconds: 1
+
+          resources:
+            {}
+
+          volumeMounts:
+          - mountPath: /tmp/k8s-webhook-server/serving-certs
+            name: cert
+            readOnly: true
+      volumes:
+      - name: cert
+        secret:
+          defaultMode: 420
+          secretName: yatai-image-builder-webhook-server-cert
+---
+# Source: yatai-image-builder/templates/certificate.yaml
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: yatai-image-builder-serving-cert
+  namespace: kubeflow
+  labels:
+    helm.sh/chart: yatai-image-builder-1.1.3
+    app.kubernetes.io/name: yatai-image-builder
+    app.kubernetes.io/instance: yatai-image-builder
+    app.kubernetes.io/version: "1.1.3"
+    app.kubernetes.io/managed-by: Helm
+spec:
+  dnsNames:
+  - yatai-image-builder-webhook-service.kubeflow.svc
+  - yatai-image-builder-webhook-service.kubeflow.svc.cluster.local
+  issuerRef:
+    kind: Issuer
+    name: yatai-image-builder-selfsigned-issuer
+  secretName: yatai-image-builder-webhook-server-cert
+---
+# Source: yatai-image-builder/templates/issuer.yaml
+apiVersion: cert-manager.io/v1
+kind: Issuer
+metadata:
+  name: yatai-image-builder-selfsigned-issuer
+  namespace: kubeflow
+  labels:
+    helm.sh/chart: yatai-image-builder-1.1.3
+    app.kubernetes.io/name: yatai-image-builder
+    app.kubernetes.io/instance: yatai-image-builder
+    app.kubernetes.io/version: "1.1.3"
+    app.kubernetes.io/managed-by: Helm
+spec:
+  selfSigned: {}

--- a/contrib/bentoml/bentoml-yatai-stack/default/kustomization.yaml
+++ b/contrib/bentoml/bentoml-yatai-stack/default/kustomization.yaml
@@ -1,0 +1,6 @@
+# Adds namespace to all resources.
+namespace: kubeflow
+
+bases:
+- ../bases/yatai-image-builder
+- ../bases/yatai-deployment

--- a/contrib/bentoml/example.yaml
+++ b/contrib/bentoml/example.yaml
@@ -1,0 +1,57 @@
+apiVersion: resources.yatai.ai/v1alpha1
+kind: Bento
+metadata:
+  name: test-yatai
+  namespace: kubeflow
+spec:
+  image: quay.io/bentoml/iris_classifier:r4zint4b567i4usu
+  runners:
+  - name: iris_clf
+    runnableType: SklearnRunnable
+  tag: iris_classifier:r4zint4b567i4usu
+---
+apiVersion: serving.yatai.ai/v2alpha1
+kind: BentoDeployment
+metadata:
+  name: test-yatai
+  namespace: kubeflow
+spec:
+  autoscaling:
+    maxReplicas: 2
+    metrics:
+    - resource:
+        name: cpu
+        target:
+          averageUtilization: 80
+          type: Utilization
+      type: Resource
+    minReplicas: 1
+  bento: test-yatai
+  ingress:
+    enabled: false
+  resources:
+    limits:
+      cpu: 1000m
+      memory: 1024Mi
+    requests:
+      cpu: 100m
+      memory: 200Mi
+  runners:
+  - autoscaling:
+      maxReplicas: 2
+      metrics:
+      - resource:
+          name: cpu
+          target:
+            averageUtilization: 80
+            type: Utilization
+        type: Resource
+      minReplicas: 1
+    name: iris_clf
+    resources:
+      limits:
+        cpu: 1000m
+        memory: 1024Mi
+      requests:
+        cpu: 100m
+        memory: 200Mi

--- a/contrib/bentoml/sources/kustomization-template.yaml
+++ b/contrib/bentoml/sources/kustomization-template.yaml
@@ -1,0 +1,2 @@
+resources:
+- resources.yaml

--- a/contrib/bentoml/sources/yatai-deployment-values.yaml
+++ b/contrib/bentoml/sources/yatai-deployment-values.yaml
@@ -1,0 +1,20 @@
+yataiSystem:
+  namespace: "kubeflow"
+
+yatai:
+  endpoint: ''
+
+layers:
+  network:
+    ingressClass: nginx
+    ingressAnnotations: {}
+
+    ingressPath: /
+    ingressPathType: ImplementationSpecific
+
+    domainSuffix: ''
+
+    automaticDomainSuffixGeneration: false
+
+bentoDeploymentNamespaces: ["kubeflow"]
+

--- a/contrib/bentoml/sources/yatai-image-builder-values.yaml
+++ b/contrib/bentoml/sources/yatai-image-builder-values.yaml
@@ -1,0 +1,13 @@
+yataiSystem:
+  namespace: "kubeflow"
+
+yatai:
+  endpoint: ''
+
+dockerRegistry:
+  bentoRepositoryName: yatai-bentos
+  inClusterServer: docker-registry.kubeflow.svc.cluster.local:5000
+  password: ""
+  secure: false
+  server: 127.0.0.1:5000
+  username: ""

--- a/contrib/bentoml/test.sh
+++ b/contrib/bentoml/test.sh
@@ -1,0 +1,36 @@
+#!/bin/bash
+
+set -xe
+
+kubectl create ns kubeflow || echo "namespace kubeflow already exists"
+kustomize build bentoml-yatai-stack/default | kubectl apply --server-side -f -
+kubectl -n kubeflow wait --for=condition=available --timeout=600s deploy/yatai-image-builder
+kubectl -n kubeflow wait --for=condition=available --timeout=600s deploy/yatai-deployment
+sleep 5
+kubectl apply -n kubeflow -f example.yaml
+sleep 5
+kubectl -n kubeflow logs deploy/yatai-deployment
+sleep 5
+kubectl -n kubeflow wait --for=condition=available --timeout=600s deploy/test-yatai
+kubectl -n kubeflow wait --for=condition=available --timeout=600s deploy/test-yatai-runner-0
+
+kubectl -n kubeflow port-forward svc/test-yatai 3333:3000 &
+PID=$!
+
+function trap_handler {
+ kill $PID
+ kubectl -n kubeflow logs -l yatai.ai/bento-deployment=test-yatai --tail=100
+ kubectl -n kubeflow delete -f example.yaml
+ kustomize build bentoml-yatai-stack/default | kubectl delete -f -
+}
+
+trap trap_handler EXIT
+
+sleep 5
+
+output=$(curl --fail -X 'POST' http://localhost:3333/classify -d '[[0,1,2,3]]')
+echo "output: '${output}'"
+if [[ $output != *'[2]'* ]]; then
+  echo "Test failed"
+  exit 1
+fi


### PR DESCRIPTION
# Design Proposal

## Why BentoML

![image](https://user-images.githubusercontent.com/861225/212856116-bf873dc8-7da3-4484-9f33-e401e34a82dc.png)

- BentoML is an open-source framework for developing, serving, and deploying ML services.
    - Building
        - Unifies ML frameworks with out-of-the-box implementation of popular frameworks
        - Exposes gRPC and OpenAPI for serving
        - Provides Python SDK for development
    - Deployment
        - Any environment, batch inference, streaming, or online serving
        - Any cloud platform for on-prem
        - Full observability support through Grafana
        - Yatai - BentoML's deployment platform

## User Stories

Goal: From simple Python module to distributed Kubernetes deployment.

Consider the following common ML services involve custom pre and post-processing logic and inference of multiple models.

![image](https://user-images.githubusercontent.com/861225/212856456-866125c8-2bf3-42d4-b031-3c7d89c07f37.png)

### Developing on Kubeflow Notebook

- Create a service using saved model.

```
%%writefile service.py
import asyncio
import bentoml

fraud_detection = bentoml.pytorch.get("fraud_detection:latest").to_runner()
risk_assessment_1 = bentoml.sklearn.get("risk_assessment_1:latest").to_runner()
risk_assessment_2 = bentoml.sklearn.get("risk_assessment_2:latest").to_runner()
risk_assessment_3 = bentoml.sklearn.get("risk_assessment_3:latest").to_runner()

svc = bentoml.Service(
    name="credit_application",
    runners=[fraud_detection, risk_assessment_1, risk_assessment_2, risk_assessment_3]
)

@svc.api(input=bentoml.io.JSON(), output=bentoml.io.JSON())
async def apply(input_data: dict) -> dict:
    features = await fetch_features(input_date["user_id"])
    detection = await fraud_detection.async_run(input_data, features)
    if detection["confidence"] < CONFIDENCE_THRESHOLD:
       return REJECTION
    assessments = await asyncio.gather(
        risk_assessment_1.async_run(input_data["application"], features),
        risk_assessment_2.async_run(input_data["application"], features),
        risk_assessment_3.async_run(input_data["application"], features),
    )
    return process_assessments(assessments)

```

- Serve and test the service.
    
```
!bentoml serve service.py:svc --reload

2022-11-07T06:50:53+0000 [INFO] [cli] Prometheus metrics for HTTP BentoServer from "service.py:svc" can be accessed at <http://localhost:3000/metrics>.
2022-11-07T06:50:53+0000 [INFO] [cli] Starting development HTTP BentoServer from "service.py:svc" listening on <http://0.0.0.0:3000/> (Press CTRL+C to quit)

```
    
![image](https://user-images.githubusercontent.com/861225/212856978-c8a24c4b-bc5b-4706-887e-81f5be914938.png)

- Build bento
    
```
!bentoml build

Building BentoML service "credit_application:wly5lqc6ncpzwcvj" from build context "."
Successfully built Bento(tag="credit_application:wly5lqc6ncpzwcvj").
```

- Export bento to blob storage.

```
!bentoml export credit_application:wly5lqc6ncpzwcvj s3://your_bento_bucket/credit_application.wly5lqc6ncpzwcvj.bento
```

### Deploying to Kubernetes

![image](https://user-images.githubusercontent.com/861225/212857708-f96c9877-bb89-4afa-930a-1d2cb0300520.png)

Users can deploy bentos to the K8s cluster in one of the three ways.

#### Kubernetes Python Client

Users can deploy bentos through Kubeflow Notebook with Kubernetes [Python client](https://github.com/kubernetes-client/python)

#### kubectl

BentoML offers two options to deploy bentos directly to the Kubenetes cluster through `kubectl` and the `BentoRequest`, `Bento`, and `BentoDeployment` CRDs.

The first option relies on `yatai-image-builder` to build the OCI image. Users need to create a `BentoRequest` CR and `BentoDeployment` CR to deploy a bento. In the `BentoDeployment` CR, the name of the bento should be defined as the name of the `BentoRequest` CR. If this Bento CR not found, `yatai-deployment` will look for the BentoRequest CR by the same name and wait for the BentoRequest CR to generate the Bento CR. This option will build the OCI image by spawning a pod to run the Kaniko build tool. However, the Kaniko build tool requires root user access. If root user access is not available, consider the second option below.

The second option relies on the users to provide a URI to the pre-built OCI image of the bento. Users need to manually create a Bento CR with the image field defined as the pre-built OCI image URI. Then create a BentoDeployment CR to reference the Bento CR previously created.

#### Kubeflow Pipeline Component

This option will be available in Kubeflow release 1.8.

### Verification

The following installation and testing steps demonstrate how to install Yatai components and deploy bentos through `kubectl` with `BentoRequest` and `BentoDeployment` CRDs.

#### Installation

Install with kustomize command:

```
kustomize build bentoml-yatai-stack/default | kubectl apply -n kubeflow --server-side -f -
```

#### Test

Create Bento CR and BentoDeployment CR:

```
kubectl apply -f example.yaml
```

Verifying that the bento deployment is running:

```
kubectl -n kubeflow get deploy -l yatai.ai/bento-deployment=test-yatai
```

The output of the above command should be like this:

```
NAME                  READY   UP-TO-DATE   AVAILABLE   AGE
test-yatai            1/1     1            1           6m12s
test-yatai-runner-0   1/1     1            1           16m
```

Verifying that the bento service is created:

```
kubectl -n kubeflow get service -l yatai.ai/bento-deployment=test-yatai
```

The output of the above command should look like this:

```
NAME                                                 TYPE        CLUSTER-IP      EXTERNAL-IP   PORT(S)             AGE
test-yatai                                           ClusterIP   10.96.150.42    <none>        3000/TCP,3001/TCP   7m59s
test-yatai-runner-32c50ece701351fb576189d54bd58724   ClusterIP   10.96.193.242   <none>        3000/TCP,3001/TCP   7m39s
```

Port-forwarding the bento service:

```
kubectl -n kubeflow port-forward svc/test-yatai 3000:3000
```

Finally you can test the bento service with the curl command:

```
curl -X 'POST' http://localhost:3000/classify -d '[[0,1,2,3]]'
```

The output should be:

```
[2]
```