### PR TITLE
[common/istio] Fix add-anonymous-user-filter due to istio CRD changes

### DIFF
--- a/common/istio/add-anonymous-user-filter/base/envoy-filter.yaml
+++ b/common/istio/add-anonymous-user-filter/base/envoy-filter.yaml
@@ -3,17 +3,20 @@ kind: EnvoyFilter
 metadata:
   name: add-user-filter
 spec:
-  workloadLabels:
-    app: istio-ingressgateway
-  filters:
-  - listenerMatch:
-      listenerType: GATEWAY
-    filterName: envoy.lua
-    filterType: HTTP
-    insertPosition:
-      index: FIRST
-    filterConfig:
-      inlineCode: |
-        function envoy_on_request(request_handle)
-            request_handle:headers():add("kubeflow-userid","anonymous@kubeflow.org")
-        end
+  workloadSelector:
+    labels:
+      app: istio-ingressgateway
+  configPatches:
+  - applyTo: HTTP_FILTER
+    match:
+      context: GATEWAY
+    patch:
+      operation: INSERT_FIRST
+      value:
+       name: envoy.filters.http.lua
+       typed_config:
+          "@type": "type.googleapis.com/envoy.extensions.filters.http.lua.v3.Lua"
+          inlineCode: |
+            function envoy_on_request(request_handle)
+                request_handle:headers():add("kubeflow-userid","anonymous@kubeflow.org")
+            end


### PR DESCRIPTION
**Which issue is resolved by this Pull Request:**
Resolves #
```
error validating data:
  [ValidationError(EnvoyFilter.spec):
    unknown field "filters" in io.istio.networking.v1alpha3.EnvoyFilter.spec,
    ValidationError(EnvoyFilter.spec): unknown field "workloadLabels" in io.istio.networking.v1alpha3.EnvoyFilter.spec];
if you choose to ignore these errors, turn validation off with --validate=false
```

**Description of your changes:**
Conversion of `EnvoyFilter` file to the new istio CRD syntax https://github.com/kubeflow/manifests/blob/610f97049c6258ec687cc9043903e15adf88e1a5/common/istio-1-16/istio-crds/base/crd.yaml#L3069


**Checklist:**
- [ ] Unit tests pass:
  **Make sure you have installed kustomize == 3.2.1**
    1. `make generate-changed-only`
    2. `make test`
