### PR TITLE
centraldashboard: Rename Models to Endpoints

### DIFF
--- a/apps/centraldashboard/upstream/base/configmap.yaml
+++ b/apps/centraldashboard/upstream/base/configmap.yaml
@@ -28,7 +28,7 @@ data:
         {
           "type": "item",
           "link": "/models/",
-          "text": "Models",
+          "text": "Endpoints",
           "icon": "kubeflow:models"
         },
         {

--- a/apps/centraldashboard/upstream/overlays/kserve/patches/configmap.yaml
+++ b/apps/centraldashboard/upstream/overlays/kserve/patches/configmap.yaml
@@ -28,7 +28,7 @@ data:
         {
           "type": "item",
           "link": "/kserve-endpoints/",
-          "text": "Models",
+          "text": "Endpoints",
           "icon": "kubeflow:models"
         },
         {


### PR DESCRIPTION
This PR renames `Models` to `Endpoints` in the central dashboard.

![image](https://user-images.githubusercontent.com/87971102/214794086-d89b5662-5c76-4695-a55b-1410fef31a95.png)

Related issue: https://github.com/kserve/kserve/issues/2534
Related PR: https://github.com/kserve/models-web-app/pull/57