### PR TITLE
Add Julius von Kohout as reviewer for /contrib

### DIFF
--- a/contrib/OWNERS
+++ b/contrib/OWNERS
@@ -1,0 +1,2 @@
+reviewers:
+  - juliusvonkohout


### PR DESCRIPTION
@juliusvonkohout has been helping on the Manifests WG for a very long time and has done an amazing job on reviews on the `/contrib` folder. For this reason I'd like to promote Julius to be a reviewer for the `/contrib` dir.

I'm also creating this PR after looking at https://github.com/kubeflow/manifests/pull/2337. I believe that we should have a more granular process of adding someone as an approver in the whole repo and taking iterative steps. The first one is to acknowledge Julius' help on reviews and ensure the OWNERS file represent that. Then move progressively based on the (great!) contributions that will be getting merged.

At the same time I want to ensure that we have a common process for next steps for everyone, and I think https://github.com/kubeflow/community/pull/591 is the best place for this.

Contributions:
* KServe (review): https://github.com/kubeflow/manifests/pull/2355
* BentoML (review): https://github.com/kubeflow/manifests/pull/2350
* KubeRay: https://docs.google.com/document/d/1SP-COL6O-ETMQny7zXbrbEL4zZBG3REErWjfcvFZVEw/edit?resourcekey=0-IaUGVemd2XX6MGTgifDbpg

cc @kubeflow/wg-manifests-leads 