### PR TITLE
manifest version policy doc for manifest repo

### DIFF
--- a/versioning.md
+++ b/versioning.md
@@ -1,0 +1,3 @@
+Manifest Working Group Versioning
+
+The Manifest Working Group's Versioning policy is defined in detail in the Kubeflow Release Handbook. Please find those details [here.](https://github.com/kubeflow/community/blob/master/releases/handbook.md#feature-freeze-2-weeks) 


### PR DESCRIPTION
Manifest versioning policy doc for the manifest repo.    Since the details of the Manifest Versioning policy are defined in the Kubeflow Release Handbook, we are linking to that text.    This link will provide a single source of truth for the policy and avoid duplication errors.

**Which issue is resolved by this Pull Request:**
Resolves #

**Description of your changes:**


**Checklist:**
- [ ] Unit tests pass:
  **Make sure you have installed kustomize == 3.2.1**
    1. `make generate-changed-only`
    2. `make test`
