### PR TITLE
Update kubeflow/kubeflow manifests from v1.7.0-rc.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,14 +42,14 @@ This repo periodically syncs all official Kubeflow components from their respect
 | Component | Local Manifests Path | Upstream Revision |
 | - | - | - |
 | Training Operator | apps/training-operator/upstream | [v1.6.0-rc.0](https://github.com/kubeflow/training-operator/tree/v1.6.0-rc.0/manifests) |
-| Notebook Controller | apps/jupyter/notebook-controller/upstream | [a74094c3a](https://github.com/kubeflow/kubeflow/tree/a74094c3a/components/notebook-controller/config) |
-| Tensorboard Controller | apps/tensorboard/tensorboard-controller/upstream | [a74094c3a](https://github.com/kubeflow/kubeflow/tree/a74094c3a/components/tensorboard-controller/config) |
-| Central Dashboard | apps/centraldashboard/upstream | [a74094c3a](https://github.com/kubeflow/kubeflow/tree/a74094c3a/components/centraldashboard/manifests) |
-| Profiles + KFAM | apps/profiles/upstream | [a74094c3a](https://github.com/kubeflow/kubeflow/tree/a74094c3a/components/profile-controller/config) |
-| PodDefaults Webhook | apps/admission-webhook/upstream | [a74094c3a](https://github.com/kubeflow/kubeflow/tree/a74094c3a/components/admission-webhook/manifests) |
-| Jupyter Web App | apps/jupyter/jupyter-web-app/upstream | [a74094c3a](https://github.com/kubeflow/kubeflow/tree/a74094c3a/components/crud-web-apps/jupyter/manifests) |
-| Tensorboards Web App | apps/tensorboard/tensorboards-web-app/upstream | [a74094c3a](https://github.com/kubeflow/kubeflow/tree/a74094c3a/components/crud-web-apps/tensorboards/manifests) |
-| Volumes Web App | apps/volumes-web-app/upstream | [a74094c3a](https://github.com/kubeflow/kubeflow/tree/a74094c3a/components/crud-web-apps/volumes/manifests) |
+| Notebook Controller | apps/jupyter/notebook-controller/upstream | [v1.7.0-rc.0](https://github.com/kubeflow/kubeflow/tree/v1.7.0-rc.0/components/notebook-controller/config) |
+| Tensorboard Controller | apps/tensorboard/tensorboard-controller/upstream | [v1.7.0-rc.0](https://github.com/kubeflow/kubeflow/tree/v1.7.0-rc.0/components/tensorboard-controller/config) |
+| Central Dashboard | apps/centraldashboard/upstream | [v1.7.0-rc.0](https://github.com/kubeflow/kubeflow/tree/v1.7.0-rc.0/components/centraldashboard/manifests) |
+| Profiles + KFAM | apps/profiles/upstream | [v1.7.0-rc.0](https://github.com/kubeflow/kubeflow/tree/v1.7.0-rc.0/components/profile-controller/config) |
+| PodDefaults Webhook | apps/admission-webhook/upstream | [v1.7.0-rc.0](https://github.com/kubeflow/kubeflow/tree/v1.7.0-rc.0/components/admission-webhook/manifests) |
+| Jupyter Web App | apps/jupyter/jupyter-web-app/upstream | [v1.7.0-rc.0](https://github.com/kubeflow/kubeflow/tree/v1.7.0-rc.0/components/crud-web-apps/jupyter/manifests) |
+| Tensorboards Web App | apps/tensorboard/tensorboards-web-app/upstream | [v1.7.0-rc.0](https://github.com/kubeflow/kubeflow/tree/v1.7.0-rc.0/components/crud-web-apps/tensorboards/manifests) |
+| Volumes Web App | apps/volumes-web-app/upstream | [v1.7.0-rc.0](https://github.com/kubeflow/kubeflow/tree/v1.7.0-rc.0/components/crud-web-apps/volumes/manifests) |
 | Katib | apps/katib/upstream | [v0.14.0-rc.0](https://github.com/kubeflow/katib/tree/v0.14.0-rc.0/manifests/v1beta1) |
 | KServe | contrib/kserve/kserve | [release-0.8](https://github.com/kserve/kserve/tree/8079f375cbcedc4d45a1b4aade2e2308ea6f9ae8/install/v0.8.0) |
 | KServe Models Web App | contrib/kserve/models-web-app | [v0.8.1](https://github.com/kserve/models-web-app/tree/v0.8.1/config) |


### PR DESCRIPTION
Update the manifests for Notebooks WG components from the newly cut [`v1.7.0-rc.0`](https://github.com/kubeflow/kubeflow/tree/v1.7.0-rc.0) tag, thanks @DomFleischmann!

/cc @elikatsis 
