### PR TITLE
Add Anna Jung as reviewer

### DIFF
--- a/OWNERS
+++ b/OWNERS
@@ -5,8 +5,4 @@ approvers:
   - StefanoFioravanzo
   - yanniszark
 reviewers:
-  - elikatsis
-  - kimwnasptd
-  - PatrickXYS
-  - StefanoFioravanzo
-  - yanniszark
+  - annajung

--- a/contrib/OWNERS
+++ b/contrib/OWNERS
@@ -1,2 +1,3 @@
 reviewers:
+  - annajung
   - juliusvonkohout


### PR DESCRIPTION
Following up with another way overdue PR, for adding @annajung as a reviewer in both repo wide and in `/contrib` sub-directory.

Anna has made huge contributions to the manifests repo throughout the last 2 years. Some highlights:
1. Helped shape and review the release handbook, that contained the release process for manifests https://github.com/kubeflow/manifests/pull/1907
2. Worked on the testing of manifests and how to setup an E2E infra (in-progress [[doc]](https://docs.google.com/document/d/1UV7qsTdFWWiuqsoYjbadhW3zg8JPHqYeVMH0y24uFO0/edit?usp=sharing)) https://github.com/kubeflow/testing/issues/1006 https://github.com/kubeflow/manifests/pull/2273
3. Has been a release manager for KF 1.6 and run the whole lifecycle of updating the manifests https://github.com/kubeflow/community/blob/master/releases/release-1.6/release-team.md
4. Has lead the effort of cleaning up the `/contrib` repo https://github.com/kubeflow/manifests/issues/2311

The above contributions touch all the pillars of the manifests repo:
1. Experience with the release process
2. Overview of the testing infra
3. Work/Reviewing the current addons we have

The above list, plus contributions on the common components owned by manifests (Istio, Knative, Cert Manager etc), is what I consider the main areas for promoting someone as an approver to the repo. And of course having a track record of being able to efficiently communicate and lead efforts in this areas.

So with the above I propose Anna to be a reviewer for both `/contrib` and for the whole repo

/cc @kubeflow/wg-manifests-leads 

NOTE: I'm removing the current reviewers, since they are already in the approvers list
