### PR TITLE
Uncomment profiles manifests in example dir

### DIFF
--- a/example/kustomization.yaml
+++ b/example/kustomization.yaml
@@ -38,7 +38,7 @@ resources:
 # Notebook Controller
 - ../apps/jupyter/notebook-controller/upstream/overlays/kubeflow
 # Profiles + KFAM
-# - ../apps/profiles/upstream/overlays/kubeflow
+- ../apps/profiles/upstream/overlays/kubeflow
 # Volumes Web App
 - ../apps/volumes-web-app/upstream/overlays/istio
 # Tensorboards Controller


### PR DESCRIPTION
It seems like the profiles manifests where commented out accidentally when updating the seldon manifests. This was causing the one-line installation to fail. By uncommenting this line the installation should work again.

