### PR TITLE
Sync MWA manifests from 0.10.0 and show KF version in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,8 @@ Starting from Kubeflow 1.3, all components should be deployable using `kustomize
 
 ## Kubeflow components versions
 
+### Kubeflow Version: latest
+
 This repo periodically syncs all official Kubeflow components from their respective upstream repos. The following matrix shows the git version that we include for each component:
 
 | Component | Local Manifests Path | Upstream Revision |
@@ -50,7 +52,7 @@ This repo periodically syncs all official Kubeflow components from their respect
 | Jupyter Web App | apps/jupyter/jupyter-web-app/upstream | [v1.7.0-rc.0](https://github.com/kubeflow/kubeflow/tree/v1.7.0-rc.0/components/crud-web-apps/jupyter/manifests) |
 | Tensorboards Web App | apps/tensorboard/tensorboards-web-app/upstream | [v1.7.0-rc.0](https://github.com/kubeflow/kubeflow/tree/v1.7.0-rc.0/components/crud-web-apps/tensorboards/manifests) |
 | Volumes Web App | apps/volumes-web-app/upstream | [v1.7.0-rc.0](https://github.com/kubeflow/kubeflow/tree/v1.7.0-rc.0/components/crud-web-apps/volumes/manifests) |
-| Katib | apps/katib/upstream | [v0.14.0-rc.0](https://github.com/kubeflow/katib/tree/v0.14.0-rc.0/manifests/v1beta1) |
+| Katib | apps/katib/upstream | [v0.15.0-rc.0](https://github.com/kubeflow/katib/tree/v0.15.0-rc.0/manifests/v1beta1) |
 | KServe | contrib/kserve/kserve | [v0.10.0](https://github.com/kserve/kserve/tree/v0.10.0/install/v0.10.0) |
 | KServe Models Web App | contrib/kserve/models-web-app | [v0.10.0](https://github.com/kserve/models-web-app/tree/v0.10.0/config) |
 | Kubeflow Pipelines | apps/pipeline/upstream | [2.0.0-alpha.6](https://github.com/kubeflow/pipelines/tree/2.0.0-alpha.6/manifests/kustomize) |
@@ -67,7 +69,7 @@ used from the different projects of Kubeflow:
 
 ## Installation
 
-Starting from Kubeflow 1.3, the Manifests WG provides two options for installing Kubeflow official components and common services with kustomize. The aim is to help end users install easily and to help distribution owners build their opinionated distributions from a tested starting point:
+The Manifests WG provides two options for installing Kubeflow official components and common services with kustomize. The aim is to help end users install easily and to help distribution owners build their opinionated distributions from a tested starting point:
 
 1. Single-command installation of all components under `apps` and `common`
 2. Multi-command, individual components installation for `apps` and `common`

--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ This repo periodically syncs all official Kubeflow components from their respect
 | Tensorboards Web App | apps/tensorboard/tensorboards-web-app/upstream | [v1.7.0-rc.0](https://github.com/kubeflow/kubeflow/tree/v1.7.0-rc.0/components/crud-web-apps/tensorboards/manifests) |
 | Volumes Web App | apps/volumes-web-app/upstream | [v1.7.0-rc.0](https://github.com/kubeflow/kubeflow/tree/v1.7.0-rc.0/components/crud-web-apps/volumes/manifests) |
 | Katib | apps/katib/upstream | [v0.14.0-rc.0](https://github.com/kubeflow/katib/tree/v0.14.0-rc.0/manifests/v1beta1) |
-| KServe | contrib/kserve/kserve | [release-0.8](https://github.com/kserve/kserve/tree/8079f375cbcedc4d45a1b4aade2e2308ea6f9ae8/install/v0.8.0) |
+| KServe | contrib/kserve/kserve | [v0.10.0](https://github.com/kserve/kserve/tree/v0.10.0/install/v0.10.0) |
 | KServe Models Web App | contrib/kserve/models-web-app | [v0.10.0](https://github.com/kserve/models-web-app/tree/v0.10.0/config) |
 | Kubeflow Pipelines | apps/pipeline/upstream | [2.0.0-alpha.6](https://github.com/kubeflow/pipelines/tree/2.0.0-alpha.6/manifests/kustomize) |
 | Kubeflow Tekton Pipelines | apps/kfp-tekton/upstream | [v1.5.1](https://github.com/kubeflow/kfp-tekton/tree/v1.5.1/manifests/kustomize) |

--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ This repo periodically syncs all official Kubeflow components from their respect
 | Volumes Web App | apps/volumes-web-app/upstream | [v1.7.0-rc.0](https://github.com/kubeflow/kubeflow/tree/v1.7.0-rc.0/components/crud-web-apps/volumes/manifests) |
 | Katib | apps/katib/upstream | [v0.14.0-rc.0](https://github.com/kubeflow/katib/tree/v0.14.0-rc.0/manifests/v1beta1) |
 | KServe | contrib/kserve/kserve | [release-0.8](https://github.com/kserve/kserve/tree/8079f375cbcedc4d45a1b4aade2e2308ea6f9ae8/install/v0.8.0) |
-| KServe Models Web App | contrib/kserve/models-web-app | [v0.8.1](https://github.com/kserve/models-web-app/tree/v0.8.1/config) |
+| KServe Models Web App | contrib/kserve/models-web-app | [v0.10.0](https://github.com/kserve/models-web-app/tree/v0.10.0/config) |
 | Kubeflow Pipelines | apps/pipeline/upstream | [2.0.0-alpha.6](https://github.com/kubeflow/pipelines/tree/2.0.0-alpha.6/manifests/kustomize) |
 | Kubeflow Tekton Pipelines | apps/kfp-tekton/upstream | [v1.5.1](https://github.com/kubeflow/kfp-tekton/tree/v1.5.1/manifests/kustomize) |
 

--- a/contrib/kserve/models-web-app/base/deployment.yaml
+++ b/contrib/kserve/models-web-app/base/deployment.yaml
@@ -14,7 +14,7 @@ spec:
         app.kubernetes.io/component: kserve-models-web-app
     spec:
       containers:
-      - image: kserve/models-web-app:v0.8.0
+      - image: kserve/models-web-app:latest
         imagePullPolicy: Always
         name: kserve-models-web-app
         envFrom:

--- a/contrib/kserve/models-web-app/base/kustomization.yaml
+++ b/contrib/kserve/models-web-app/base/kustomization.yaml
@@ -13,7 +13,7 @@ commonLabels:
 images:
 - name: kserve/models-web-app
   newName: kserve/models-web-app
-  newTag: v0.8.0
+  newTag: v0.10.0
 configMapGenerator:
   - name: kserve-models-web-app-config
     literals:

--- a/tests/gh-actions/install_knative.sh
+++ b/tests/gh-actions/install_knative.sh
@@ -9,5 +9,5 @@ kustomize build common/knative/knative-serving/base | kubectl apply -f -
 kustomize build common/istio-1-16/cluster-local-gateway/base | kubectl apply -f -
 kustomize build common/istio-1-16/kubeflow-istio-resources/base | kubectl apply -f -
 
-kubectl wait --for=condition=Ready pods --all --all-namespaces --timeout 180s
+kubectl wait --for=condition=Ready pods --all --all-namespaces --timeout 600s
 kubectl patch cm config-domain --patch '{"data":{"example.com":""}}' -n knative-serving

--- a/tests/gh-actions/install_kserve.sh
+++ b/tests/gh-actions/install_kserve.sh
@@ -9,4 +9,4 @@ echo "Waiting for crd/clusterservingruntimes.serving.kserve.io to be available .
 kubectl wait --for condition=established --timeout=30s crd/clusterservingruntimes.serving.kserve.io
 kustomize build kserve | kubectl apply -f -
 kustomize build models-web-app/overlays/kubeflow | kubectl apply -f -
-kubectl wait --for=condition=Ready pods --all --all-namespaces --timeout 180s
+kubectl wait --for=condition=Ready pods --all --all-namespaces --timeout 600s

--- a/tests/gh-actions/install_pipelines.sh
+++ b/tests/gh-actions/install_pipelines.sh
@@ -8,4 +8,4 @@ echo "Waiting for crd/compositecontrollers.metacontroller.k8s.io to be available
 kubectl wait --for condition=established --timeout=30s crd/compositecontrollers.metacontroller.k8s.io
 kustomize build env/cert-manager/platform-agnostic-multi-user | kubectl apply -f -
 sleep 60
-kubectl wait --for=condition=Ready pods --all --all-namespaces --timeout 180s
+kubectl wait --for=condition=Ready pods --all --all-namespaces --timeout 600s


### PR DESCRIPTION
Update the models web app manifests for the `v0.10.0` tag.

Also made some minor updates to the README in preparation for the release branch. Main one being that the README now explicitly shows the KF version. This is to make it slightly easier for anyone rebasing/merging a release branch into their own to have a single place to know which KF version they had used.

/cc @DomFleischmann 