### PR TITLE
Adding kubeflow-groups headers for kubeflow components

### DIFF
--- a/common/oidc-authservice/base/envoy-filter.yaml
+++ b/common/oidc-authservice/base/envoy-filter.yaml
@@ -38,3 +38,4 @@ spec:
                 allowed_upstream_headers:
                   patterns:
                     - exact: "kubeflow-userid"
+                    - exact: "kubeflow-groups"


### PR DESCRIPTION
Following those PR:
- https://github.com/kubeflow/kubeflow/pull/7022
- https://github.com/kubeflow/pipelines/pull/8918

The [oidc-authservice](https://github.com/arrikto/oidc-authservice) support **GROUPS_HEADER**, the istio configuration need to be adjusted to allow kubeflow components to consume it. Adding `kubeflow-groups` allows the components to access the header.
