### PR TITLE
Update kubeflow/pipelines manifests from 2.0.0-alpha.7

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ This repo periodically syncs all official Kubeflow components from their respect
 | Katib | apps/katib/upstream | [v0.15.0-rc.0](https://github.com/kubeflow/katib/tree/v0.15.0-rc.0/manifests/v1beta1) |
 | KServe | contrib/kserve/kserve | [v0.10.0](https://github.com/kserve/kserve/tree/v0.10.0/install/v0.10.0) |
 | KServe Models Web App | contrib/kserve/models-web-app | [v0.10.0](https://github.com/kserve/models-web-app/tree/v0.10.0/config) |
-| Kubeflow Pipelines | apps/pipeline/upstream | [2.0.0-alpha.6](https://github.com/kubeflow/pipelines/tree/2.0.0-alpha.6/manifests/kustomize) |
+| Kubeflow Pipelines | apps/pipeline/upstream | [2.0.0-alpha.7](https://github.com/kubeflow/pipelines/tree/2.0.0-alpha.7/manifests/kustomize) |
 | Kubeflow Tekton Pipelines | apps/kfp-tekton/upstream | [v1.5.1](https://github.com/kubeflow/kfp-tekton/tree/v1.5.1/manifests/kustomize) |
 
 The following is also a matrix with versions from common components that are

--- a/apps/pipeline/upstream/base/cache-deployer/kustomization.yaml
+++ b/apps/pipeline/upstream/base/cache-deployer/kustomization.yaml
@@ -8,4 +8,4 @@ commonLabels:
   app: cache-deployer
 images:
   - name: gcr.io/ml-pipeline/cache-deployer
-    newTag: 2.0.0-alpha.6
+    newTag: 2.0.0-alpha.7

--- a/apps/pipeline/upstream/base/cache/kustomization.yaml
+++ b/apps/pipeline/upstream/base/cache/kustomization.yaml
@@ -10,4 +10,4 @@ commonLabels:
   app: cache-server
 images:
   - name: gcr.io/ml-pipeline/cache-server
-    newTag: 2.0.0-alpha.6
+    newTag: 2.0.0-alpha.7

--- a/apps/pipeline/upstream/base/installs/generic/pipeline-install-config.yaml
+++ b/apps/pipeline/upstream/base/installs/generic/pipeline-install-config.yaml
@@ -11,7 +11,7 @@ data:
     until the changes take effect. A quick way to restart all deployments in a
     namespace: `kubectl rollout restart deployment -n <your-namespace>`.
   appName: pipeline
-  appVersion: 2.0.0-alpha.6
+  appVersion: 2.0.0-alpha.7
   dbHost: mysql
   dbPort: "3306"
   mlmdDb: metadb

--- a/apps/pipeline/upstream/base/metadata/base/kustomization.yaml
+++ b/apps/pipeline/upstream/base/metadata/base/kustomization.yaml
@@ -9,4 +9,4 @@ resources:
   - metadata-grpc-sa.yaml
 images:
   - name: gcr.io/ml-pipeline/metadata-envoy
-    newTag: 2.0.0-alpha.6
+    newTag: 2.0.0-alpha.7

--- a/apps/pipeline/upstream/base/pipeline/kustomization.yaml
+++ b/apps/pipeline/upstream/base/pipeline/kustomization.yaml
@@ -37,14 +37,14 @@ resources:
   - kfp-launcher-configmap.yaml
 images:
   - name: gcr.io/ml-pipeline/api-server
-    newTag: 2.0.0-alpha.6
+    newTag: 2.0.0-alpha.7
   - name: gcr.io/ml-pipeline/persistenceagent
-    newTag: 2.0.0-alpha.6
+    newTag: 2.0.0-alpha.7
   - name: gcr.io/ml-pipeline/scheduledworkflow
-    newTag: 2.0.0-alpha.6
+    newTag: 2.0.0-alpha.7
   - name: gcr.io/ml-pipeline/frontend
-    newTag: 2.0.0-alpha.6
+    newTag: 2.0.0-alpha.7
   - name: gcr.io/ml-pipeline/viewer-crd-controller
-    newTag: 2.0.0-alpha.6
+    newTag: 2.0.0-alpha.7
   - name: gcr.io/ml-pipeline/visualization-server
-    newTag: 2.0.0-alpha.6
+    newTag: 2.0.0-alpha.7

--- a/apps/pipeline/upstream/base/pipeline/metadata-writer/kustomization.yaml
+++ b/apps/pipeline/upstream/base/pipeline/metadata-writer/kustomization.yaml
@@ -7,4 +7,4 @@ resources:
   - metadata-writer-sa.yaml
 images:
   - name: gcr.io/ml-pipeline/metadata-writer
-    newTag: 2.0.0-alpha.6
+    newTag: 2.0.0-alpha.7

--- a/apps/pipeline/upstream/env/gcp/inverse-proxy/kustomization.yaml
+++ b/apps/pipeline/upstream/env/gcp/inverse-proxy/kustomization.yaml
@@ -2,7 +2,7 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 images:
   - name: gcr.io/ml-pipeline/inverse-proxy-agent
-    newTag: 2.0.0-alpha.6
+    newTag: 2.0.0-alpha.7
 resources:
   - proxy-configmap.yaml
   - proxy-deployment.yaml

--- a/apps/pipeline/upstream/third-party/mysql/base/mysql-deployment.yaml
+++ b/apps/pipeline/upstream/third-party/mysql/base/mysql-deployment.yaml
@@ -42,6 +42,9 @@ spec:
         # https://dev.mysql.com/doc/refman/8.0/en/server-system-variables.html#sysvar_default_authentication_plugin
         # https://dev.mysql.com/doc/refman/8.0/en/server-system-variables.html#sysvar_authentication_policy
         - --default-authentication-plugin=mysql_native_password
+        # Disable binlog as the logs grow fast and eat up all disk spaces eventually. And KFP doesn't currently utilize binlog.
+        # https://dev.mysql.com/doc/refman/8.0/en/replication-options-binary-log.html#option_mysqld_log-bin
+        - --disable-log-bin
         env:
         - name: MYSQL_ALLOW_EMPTY_PASSWORD
           value: "true"


### PR DESCRIPTION
**Which issue is resolved by this Pull Request:**
Resolves https://github.com/kubeflow/pipelines/issues/8938

Steps to run the sync script for future reference:
1. Export the commit `export COMMIT=2.0.0-alpha.7`
1. Clone the pipelines repo locally and checkout the required commit
```
cd /tmp/
git clone https://github.com/kubeflow/pipelines.git kubeflow-pipelines
git checkout $COMMIT
```
1. cd to root of manifests repo
1. Run the sync script `./hack/sync-pipelines-manifests.sh`
1. Create the PR from your fork

Its worth converting this to a github action in future in the meantime little documentation could save some developer time.