### PR TITLE
Update kubeflow/training-operator manifests from v1.6.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ This repo periodically syncs all official Kubeflow components from their respect
 
 | Component | Local Manifests Path | Upstream Revision |
 | - | - | - |
-| Training Operator | apps/training-operator/upstream | [v1.6.0-rc.1](https://github.com/kubeflow/training-operator/tree/v1.6.0-rc.1/manifests) |
+| Training Operator | apps/training-operator/upstream | [v1.6.0](https://github.com/kubeflow/training-operator/tree/v1.6.0/manifests) |
 | Notebook Controller | apps/jupyter/notebook-controller/upstream | [v1.7.0-rc.1](https://github.com/kubeflow/kubeflow/tree/v1.7.0-rc.1/components/notebook-controller/config) |
 | Tensorboard Controller | apps/tensorboard/tensorboard-controller/upstream | [v1.7.0-rc.1](https://github.com/kubeflow/kubeflow/tree/v1.7.0-rc.1/components/tensorboard-controller/config) |
 | Central Dashboard | apps/centraldashboard/upstream | [v1.7.0-rc.1](https://github.com/kubeflow/kubeflow/tree/v1.7.0-rc.1/components/centraldashboard/manifests) |


### PR DESCRIPTION
Update 1.7 branch with final v1.6.0 training operator release.
