### PR TITLE
Promote Julius von Kohout from reviewer to approver for /contrib 

### DIFF
--- a/contrib/OWNERS
+++ b/contrib/OWNERS
@@ -1,3 +1,5 @@
 reviewers:
   - annajung
   - juliusvonkohout
+approvers:
+  - juliusvonkohout


### PR DESCRIPTION
**Which issue is resolved by this Pull Request:**
Resolves the current problem that the bentoml update and ray integration is stalled because of lack of approvers. In the future this will also relieve some burden of the manifests maintainers.

Follow up of https://github.com/kubeflow/manifests/pull/2371 and https://github.com/kubeflow/manifests/blob/master/contrib/networkpolicies/OWNERS

@kimwnasptd then we can progress with https://github.com/kubeflow/manifests/pull/2383 and https://github.com/kubeflow/manifests/pull/2414


orthogonal to https://github.com/kubeflow/manifests/pull/2337/

**Checklist:**
- [ ] Unit tests pass:
  **Make sure you have installed kustomize == 3.2.1**
    1. `make generate-changed-only`
    2. `make test`
