### PR TITLE
Replacing autoscaling/v2beta2 by autoscaling/v2

### DIFF
--- a/common/knative/knative-serving/base/upstream/serving-core.yaml
+++ b/common/knative/knative-serving/base/upstream/serving-core.yaml
@@ -5794,7 +5794,7 @@ spec:
   selector:
     role: domainmapping-webhook
 ---
-apiVersion: autoscaling/v2beta2
+apiVersion: autoscaling/v2
 kind: HorizontalPodAutoscaler
 metadata:
   name: webhook


### PR DESCRIPTION
## Description

apiVersion `autoscaling/v2beta2` for HorizontalPodAutoscaler is deprecated and need to be replaced by apiVersion `autoscaling/v2`.

The change has already been made in multiple files but was still v2beta2 in `common/knative/knative-serving/base/upstream/serving-core.yaml` .

 