### PR TITLE
To enable Katib to work on ARM64

### DIFF
--- a/apps/katib/upstream/components/controller/katib-config.yaml
+++ b/apps/katib/upstream/components/controller/katib-config.yaml
@@ -8,13 +8,13 @@ data:
   metrics-collector-sidecar: |-
     {
       "StdOut": {
-        "image": "docker.io/kubeflowkatib/file-metrics-collector:v0.15.0-rc.0"
+        "image": "docker.io/kubeflowkatib/file-metrics-collector:latest"
       },
       "File": {
-        "image": "docker.io/kubeflowkatib/file-metrics-collector:v0.15.0-rc.0"
+        "image": "docker.io/kubeflowkatib/file-metrics-collector:latest"
       },
       "TensorFlowEvent": {
-        "image": "docker.io/kubeflowkatib/tfevent-metrics-collector:v0.15.0-rc.0",
+        "image": "docker.io/kubeflowkatib/tfevent-metrics-collector:latest",
         "resources": {
           "limits": {
             "memory": "1Gi"
@@ -25,31 +25,31 @@ data:
   suggestion: |-
     {
       "random": {
-        "image": "docker.io/kubeflowkatib/suggestion-hyperopt:v0.15.0-rc.0"
+        "image": "docker.io/kubeflowkatib/suggestion-hyperopt:latest"
       },
       "tpe": {
-        "image": "docker.io/kubeflowkatib/suggestion-hyperopt:v0.15.0-rc.0"
+        "image": "docker.io/kubeflowkatib/suggestion-hyperopt:latest"
       },
       "grid": {
-        "image": "docker.io/kubeflowkatib/suggestion-optuna:v0.15.0-rc.0"
+        "image": "docker.io/kubeflowkatib/suggestion-optuna:latest"
       },
       "hyperband": {
-        "image": "docker.io/kubeflowkatib/suggestion-hyperband:v0.15.0-rc.0"
+        "image": "docker.io/kubeflowkatib/suggestion-hyperband:latest"
       },
       "bayesianoptimization": {
-        "image": "docker.io/kubeflowkatib/suggestion-skopt:v0.15.0-rc.0"
+        "image": "docker.io/kubeflowkatib/suggestion-skopt:latest"
       },
       "cmaes": {
-        "image": "docker.io/kubeflowkatib/suggestion-goptuna:v0.15.0-rc.0"
+        "image": "docker.io/kubeflowkatib/suggestion-goptuna:latest"
       },
       "sobol": {
-        "image": "docker.io/kubeflowkatib/suggestion-goptuna:v0.15.0-rc.0"
+        "image": "docker.io/kubeflowkatib/suggestion-goptuna:latest"
       },
       "multivariate-tpe": {
-        "image": "docker.io/kubeflowkatib/suggestion-optuna:v0.15.0-rc.0"
+        "image": "docker.io/kubeflowkatib/suggestion-optuna:latest"
       },
       "enas": {
-        "image": "docker.io/kubeflowkatib/suggestion-enas:v0.15.0-rc.0",
+        "image": "docker.io/kubeflowkatib/suggestion-enas:latest",
         "resources": {
           "limits": {
             "memory": "200Mi"
@@ -57,10 +57,10 @@ data:
         }
       },
       "darts": {
-        "image": "docker.io/kubeflowkatib/suggestion-darts:v0.15.0-rc.0"
+        "image": "docker.io/kubeflowkatib/suggestion-darts:latest"
       },
       "pbt": {
-        "image": "docker.io/kubeflowkatib/suggestion-pbt:v0.15.0-rc.0",
+        "image": "docker.io/kubeflowkatib/suggestion-pbt:latest",
         "persistentVolumeClaimSpec": {
           "accessModes": [
             "ReadWriteMany"
@@ -76,6 +76,6 @@ data:
   early-stopping: |-
     {
       "medianstop": {
-        "image": "docker.io/kubeflowkatib/earlystopping-medianstop:v0.15.0-rc.0"
+        "image": "docker.io/kubeflowkatib/earlystopping-medianstop:latest"
       }
     }


### PR DESCRIPTION
The existing docker images with `v0.15.0-rc.0` tag do not support linux/arm64. So I encountered errors `Back-off restarting failed container` and was able to resolve them by making the change to `latest`, resulting in proper functioning.