### PR TITLE
Update kustomization.yaml - update tag and repo

### DIFF
--- a/common/oidc-authservice/base/kustomization.yaml
+++ b/common/oidc-authservice/base/kustomization.yaml
@@ -43,5 +43,5 @@ configurations:
 - params.yaml
 images:
 - name: gcr.io/arrikto/kubeflow/oidc-authservice
-  newName: gcr.io/arrikto/kubeflow/oidc-authservice
-  newTag: e236439
+  newName: gcr.io/arrikto/oidc-authservice
+  newTag: 0c4ea9a


### PR DESCRIPTION
The given image does not work in KF, this commit updates it from gcr.io/arrikto/kubeflow/oidc-authservice:e236439 to gcr.io/arrikto/oidc-authservice:0c4ea9a , note that registry link and tag is updated.

fixes kubeflow/manifests#2423

**Which issue is resolved by this Pull Request:**
Resolves #2423

**Description of your changes:**
Update of oidc-authservice image from gcr.io/arrikto/kubeflow/oidc-authservice:e236439 to gcr.io/arrikto/oidc-authservice:0c4ea9a as described in issue #2423 
