### PR TITLE
Add Kubernetes version 1.26 and set it to default for testing

### DIFF
--- a/.github/workflows/pipeline_kind_test.yaml
+++ b/.github/workflows/pipeline_kind_test.yaml
@@ -37,8 +37,8 @@ jobs:
         pip3 install kfp==1.8.22
         kustomize build apps/profiles/upstream/overlays/kubeflow | kubectl apply -f -
         kubectl wait --for=condition=Ready pods --all --all-namespaces --timeout 180s
-        kustomize build common/user-namespace/base | awk '!/well-defined/' | kubectl apply -f -
-        kustomize build common/kubeflow-roles/base | awk '!/well-defined/' | kubectl apply -f -
+        kustomize build common/user-namespace/base | kubectl apply -f -
+        kustomize build common/kubeflow-roles/base | kubectl apply -f -
         ./tests/e2e/hack/proxy_pipelines.sh
         kubectl apply -f tests/e2e/yamls
         python3 ./tests/gh-actions/kf-objects/test_pipeline.py

--- a/.github/workflows/pipeline_kind_test.yaml
+++ b/.github/workflows/pipeline_kind_test.yaml
@@ -34,11 +34,11 @@ jobs:
 
     - name: Deploy test pipeline
       run: |
-        pip3 install kfp==1.8.4
+        pip3 install kfp==1.8.22
         kustomize build apps/profiles/upstream/overlays/kubeflow | kubectl apply -f -
         kubectl wait --for=condition=Ready pods --all --all-namespaces --timeout 180s
-        kustomize build common/user-namespace/base | kubectl apply -f -
-        kustomize build common/kubeflow-roles/base | kubectl apply -f -
+        kustomize build common/user-namespace/base | awk '!/well-defined/' | kubectl apply -f -
+        kustomize build common/kubeflow-roles/base | awk '!/well-defined/' | kubectl apply -f -
         ./tests/e2e/hack/proxy_pipelines.sh
         kubectl apply -f tests/e2e/yamls
         python3 ./tests/gh-actions/kf-objects/test_pipeline.py

--- a/README.md
+++ b/README.md
@@ -84,7 +84,7 @@ The `example` directory contains an example kustomization for the single command
 
 ### Prerequisites
 
-- `Kubernetes` (up to `1.25`) with a default [StorageClass](https://kubernetes.io/docs/concepts/storage/storage-classes/)
+- `Kubernetes` (up to `1.26`) with a default [StorageClass](https://kubernetes.io/docs/concepts/storage/storage-classes/)
 - `kustomize` [5.0.3](https://github.com/kubernetes-sigs/kustomize/releases/tag/kustomize%2Fv5.0.3)
     - :warning: Kubeflow is not compatible with earlier versions of Kustomize. This is because we need the [`sortOptions`](https://kubectl.docs.kubernetes.io/references/kustomize/kustomization/sortoptions/) field, which is only available in Kustomize 5 and onwards https://github.com/kubeflow/manifests/issues/2388.
 - `kubectl`

--- a/tests/e2e/requirements.txt
+++ b/tests/e2e/requirements.txt
@@ -1,3 +1,2 @@
-kubernetes==21.7.0
-kfp==1.8.4
-kubeflow-katib==0.12.0
+kfp==1.8.22
+kubeflow-katib==0.15.0

--- a/tests/gh-actions/install_kind.sh
+++ b/tests/gh-actions/install_kind.sh
@@ -5,6 +5,6 @@ sudo swapoff -a
 sudo rm -f /swapfile
 sudo mkdir -p /tmp/etcd
 sudo mount -t tmpfs tmpfs /tmp/etcd
-curl -Lo ./kind https://kind.sigs.k8s.io/dl/v0.17.0/kind-linux-amd64
+curl -Lo ./kind https://kind.sigs.k8s.io/dl/v0.20.0/kind-linux-amd64
 chmod +x ./kind
 sudo mv kind /usr/local/bin

--- a/tests/gh-actions/install_pipelines.sh
+++ b/tests/gh-actions/install_pipelines.sh
@@ -6,6 +6,6 @@ kubectl create ns kubeflow
 kubectl apply -f third-party/metacontroller/base/crd.yaml
 echo "Waiting for crd/compositecontrollers.metacontroller.k8s.io to be available ..."
 kubectl wait --for condition=established --timeout=30s crd/compositecontrollers.metacontroller.k8s.io
-kustomize build env/cert-manager/platform-agnostic-multi-user | kubectl apply -f -
+kustomize build env/cert-manager/platform-agnostic-multi-user | awk '!/well-defined/' | kubectl apply -f -
 sleep 60
 kubectl wait --for=condition=Ready pods --all --all-namespaces --timeout 600s

--- a/tests/gh-actions/install_pipelines.sh
+++ b/tests/gh-actions/install_pipelines.sh
@@ -6,6 +6,6 @@ kubectl create ns kubeflow
 kubectl apply -f third-party/metacontroller/base/crd.yaml
 echo "Waiting for crd/compositecontrollers.metacontroller.k8s.io to be available ..."
 kubectl wait --for condition=established --timeout=30s crd/compositecontrollers.metacontroller.k8s.io
-kustomize build env/cert-manager/platform-agnostic-multi-user | awk '!/well-defined/' | kubectl apply -f -
+kustomize build env/cert-manager/platform-agnostic-multi-user | kubectl apply -f -
 sleep 60
 kubectl wait --for=condition=Ready pods --all --all-namespaces --timeout 600s

--- a/tests/gh-actions/kind-cluster-1-25.yaml
+++ b/tests/gh-actions/kind-cluster-1-25.yaml
@@ -19,6 +19,6 @@ kubeadmConfigPatches:
         "service-account-signing-key-file": "/etc/kubernetes/pki/sa.key"
 nodes:
 - role: control-plane
-  image: kindest/node:v1.26.6@sha256:5e5d789e90c1512c8c480844e0985bc3b4da4ba66179cc5b540fe5b785ca97b5
+  image: kindest/node:v1.25.3@sha256:f52781bc0d7a19fb6c405c2af83abfeb311f130707a0e219175677e366cc45d1
 - role: worker
-  image: kindest/node:v1.26.6@sha256:5e5d789e90c1512c8c480844e0985bc3b4da4ba66179cc5b540fe5b785ca97b5
+  image: kindest/node:v1.25.3@sha256:f52781bc0d7a19fb6c405c2af83abfeb311f130707a0e219175677e366cc45d1


### PR DESCRIPTION
**Which issue is resolved by this Pull Request:**
Part of https://github.com/kubeflow/manifests/issues/2450

**Description of your changes:**
- Move default KinD 1.25 to `kind-cluster-1-25.yaml`
- Add support for Kubernetes 1.26 and set it to default for testing
- Update the requirements.txt to run e2e with katib 0.15 and kfp 1.8.22