### PR TITLE
remove creationTimestamp line

### DIFF
--- a/apps/profiles/upstream/crd/bases/kubeflow.org_profiles.yaml
+++ b/apps/profiles/upstream/crd/bases/kubeflow.org_profiles.yaml
@@ -4,7 +4,6 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     controller-gen.kubebuilder.io/version: v0.8.0
-  creationTimestamp: null
   name: profiles.kubeflow.org
 spec:
   group: kubeflow.org


### PR DESCRIPTION
**Which issue is resolved by this Pull Request:**
Resolves https://github.com/kubeflow/kubeflow/issues/7041, https://github.com/GoogleCloudPlatform/kubeflow-distribution/issues/431


**Description of your changes:**
When deploying KF 1.7 on GCP, this line,
```
creationTimestamp: null
```
 caused the following error in deployment:
```
error: unable to decode "apps/profiles/build/apiextensions.k8s.io_v1_customresourcedefinition_profiles.kubeflow.org.yaml": parsing time "null" as "2006-01-02T15:04:05Z07:00": cannot parse "null" as "2006"
```
This seems to be due to golang being unable to handle `null` when unmarshalling timestamp. Currently, users have to manually remove this line every time for the deployment to succeed.

