### PR TITLE
[kubeflow 1.8] Update kubeflow/pipelines manifests from 2.0.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ This repo periodically syncs all official Kubeflow components from their respect
 | Katib | apps/katib/upstream | [v0.16.0-rc.1](https://github.com/kubeflow/katib/tree/v0.16.0-rc.1/manifests/v1beta1) |
 | KServe | contrib/kserve/kserve | [v0.10.0](https://github.com/kserve/kserve/tree/v0.10.0/install/v0.10.0) |
 | KServe Models Web App | contrib/kserve/models-web-app | [v0.10.0](https://github.com/kserve/models-web-app/tree/v0.10.0/config) |
-| Kubeflow Pipelines | apps/pipeline/upstream | [2.0.0-alpha.7](https://github.com/kubeflow/pipelines/tree/2.0.0-alpha.7/manifests/kustomize) |
+| Kubeflow Pipelines | apps/pipeline/upstream | [2.0.1](https://github.com/kubeflow/pipelines/tree/2.0.1/manifests/kustomize) |
 | Kubeflow Tekton Pipelines | apps/kfp-tekton/upstream | [v2.0.0](https://github.com/kubeflow/kfp-tekton/tree/v2.0.0/manifests/kustomize) |
 
 The following is also a matrix with versions from common components that are

--- a/apps/pipeline/upstream/OWNERS
+++ b/apps/pipeline/upstream/OWNERS
@@ -1,4 +1,6 @@
 approvers:
+  - gkcalat
   - zijianjoy
 reviewers:
+  - gkcalat
   - zijianjoy

--- a/apps/pipeline/upstream/base/cache-deployer/kustomization.yaml
+++ b/apps/pipeline/upstream/base/cache-deployer/kustomization.yaml
@@ -8,4 +8,4 @@ commonLabels:
   app: cache-deployer
 images:
   - name: gcr.io/ml-pipeline/cache-deployer
-    newTag: 2.0.0-alpha.7
+    newTag: 2.0.1

--- a/apps/pipeline/upstream/base/cache/cache-deployment.yaml
+++ b/apps/pipeline/upstream/base/cache/cache-deployment.yaml
@@ -69,6 +69,10 @@ spec:
             valueFrom:
               fieldRef:
                 fieldPath: metadata.namespace
+          # If you update WEBHOOK_PORT, also change the value of the
+          # containerPort "webhook-api" to match.
+          - name: WEBHOOK_PORT
+            value: "8443"
         args: ["--db_driver=$(DBCONFIG_DRIVER)",
                "--db_host=$(DBCONFIG_HOST_NAME)",
                "--db_port=$(DBCONFIG_PORT)",
@@ -76,6 +80,7 @@ spec:
                "--db_user=$(DBCONFIG_USER)",
                "--db_password=$(DBCONFIG_PASSWORD)",
                "--namespace_to_watch=$(NAMESPACE_TO_WATCH)",
+               "--listen_port=$(WEBHOOK_PORT)",
               ]
         imagePullPolicy: Always
         ports:

--- a/apps/pipeline/upstream/base/cache/kustomization.yaml
+++ b/apps/pipeline/upstream/base/cache/kustomization.yaml
@@ -10,4 +10,4 @@ commonLabels:
   app: cache-server
 images:
   - name: gcr.io/ml-pipeline/cache-server
-    newTag: 2.0.0-alpha.7
+    newTag: 2.0.1

--- a/apps/pipeline/upstream/base/installs/generic/pipeline-install-config.yaml
+++ b/apps/pipeline/upstream/base/installs/generic/pipeline-install-config.yaml
@@ -11,7 +11,7 @@ data:
     until the changes take effect. A quick way to restart all deployments in a
     namespace: `kubectl rollout restart deployment -n <your-namespace>`.
   appName: pipeline
-  appVersion: 2.0.0-alpha.7
+  appVersion: 2.0.1
   dbHost: mysql
   dbPort: "3306"
   mlmdDb: metadb

--- a/apps/pipeline/upstream/base/installs/multi-user/persistence-agent/cluster-role.yaml
+++ b/apps/pipeline/upstream/base/installs/multi-user/persistence-agent/cluster-role.yaml
@@ -20,6 +20,13 @@ rules:
   - list
   - watch
 - apiGroups:
+  - pipelines.kubeflow.org
+  resources:
+  - scheduledworkflows
+  - workflows
+  verbs:
+  - report
+- apiGroups:
   - ''
   resources:
   - namespaces

--- a/apps/pipeline/upstream/base/metadata/base/kustomization.yaml
+++ b/apps/pipeline/upstream/base/metadata/base/kustomization.yaml
@@ -9,4 +9,4 @@ resources:
   - metadata-grpc-sa.yaml
 images:
   - name: gcr.io/ml-pipeline/metadata-envoy
-    newTag: 2.0.0-alpha.7
+    newTag: 2.0.1

--- a/apps/pipeline/upstream/base/pipeline/kustomization.yaml
+++ b/apps/pipeline/upstream/base/pipeline/kustomization.yaml
@@ -37,14 +37,14 @@ resources:
   - kfp-launcher-configmap.yaml
 images:
   - name: gcr.io/ml-pipeline/api-server
-    newTag: 2.0.0-alpha.7
+    newTag: 2.0.1
   - name: gcr.io/ml-pipeline/persistenceagent
-    newTag: 2.0.0-alpha.7
+    newTag: 2.0.1
   - name: gcr.io/ml-pipeline/scheduledworkflow
-    newTag: 2.0.0-alpha.7
+    newTag: 2.0.1
   - name: gcr.io/ml-pipeline/frontend
-    newTag: 2.0.0-alpha.7
+    newTag: 2.0.1
   - name: gcr.io/ml-pipeline/viewer-crd-controller
-    newTag: 2.0.0-alpha.7
+    newTag: 2.0.1
   - name: gcr.io/ml-pipeline/visualization-server
-    newTag: 2.0.0-alpha.7
+    newTag: 2.0.1

--- a/apps/pipeline/upstream/base/pipeline/metadata-writer/kustomization.yaml
+++ b/apps/pipeline/upstream/base/pipeline/metadata-writer/kustomization.yaml
@@ -7,4 +7,4 @@ resources:
   - metadata-writer-sa.yaml
 images:
   - name: gcr.io/ml-pipeline/metadata-writer
-    newTag: 2.0.0-alpha.7
+    newTag: 2.0.1

--- a/apps/pipeline/upstream/base/pipeline/ml-pipeline-persistenceagent-deployment.yaml
+++ b/apps/pipeline/upstream/base/pipeline/ml-pipeline-persistenceagent-deployment.yaml
@@ -36,4 +36,15 @@ spec:
           requests:
             cpu: 120m
             memory: 500Mi
+        volumeMounts:
+          - mountPath: /var/run/secrets/kubeflow/tokens
+            name: persistenceagent-sa-token
       serviceAccountName: ml-pipeline-persistenceagent
+      volumes:
+        - name: persistenceagent-sa-token
+          projected:
+            sources:
+              - serviceAccountToken:
+                  path: persistenceagent-sa-token
+                  expirationSeconds: 3600
+                  audience: pipelines.kubeflow.org

--- a/apps/pipeline/upstream/base/pipeline/ml-pipeline-persistenceagent-role.yaml
+++ b/apps/pipeline/upstream/base/pipeline/ml-pipeline-persistenceagent-role.yaml
@@ -20,6 +20,13 @@ rules:
   - list
   - watch
 - apiGroups:
+  - pipelines.kubeflow.org
+  resources:
+  - scheduledworkflows
+  - workflows
+  verbs:
+  - report
+- apiGroups:
   - ''
   resources:
   - namespaces

--- a/apps/pipeline/upstream/base/pipeline/ml-pipeline-viewer-crd-deployment.yaml
+++ b/apps/pipeline/upstream/base/pipeline/ml-pipeline-viewer-crd-deployment.yaml
@@ -22,7 +22,7 @@ spec:
         env:
         - name: MAX_NUM_VIEWERS
           value: "50"
-        - name: MINIO_NAMESPACE
+        - name: NAMESPACE
           valueFrom:
             fieldRef:
               fieldPath: metadata.namespace

--- a/apps/pipeline/upstream/env/gcp/inverse-proxy/kustomization.yaml
+++ b/apps/pipeline/upstream/env/gcp/inverse-proxy/kustomization.yaml
@@ -2,7 +2,7 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 images:
   - name: gcr.io/ml-pipeline/inverse-proxy-agent
-    newTag: 2.0.0-alpha.7
+    newTag: 2.0.1
 resources:
   - proxy-configmap.yaml
   - proxy-deployment.yaml

--- a/apps/pipeline/upstream/env/platform-agnostic-multi-user-emissary/workflow-controller-configmap-patch.yaml
+++ b/apps/pipeline/upstream/env/platform-agnostic-multi-user-emissary/workflow-controller-configmap-patch.yaml
@@ -4,9 +4,9 @@ metadata:
   name: workflow-controller-configmap
 data:
   # References:
-  # * https://github.com/argoproj/argo-workflows/blob/v3.3.8/config/config.go
-  # * https://github.com/argoproj/argo-workflows/blob/v3.3.8/docs/workflow-controller-configmap.md
-  # * https://github.com/argoproj/argo-workflows/blob/v3.3.8/docs/workflow-controller-configmap.yaml
+  # * https://github.com/argoproj/argo-workflows/blob/v3.3.10/config/config.go
+  # * https://github.com/argoproj/argo-workflows/blob/v3.3.10/docs/workflow-controller-configmap.md
+  # * https://github.com/argoproj/argo-workflows/blob/v3.3.10/docs/workflow-controller-configmap.yaml
 
   # Emissary Executor: https://argoproj.github.io/argo-workflows/workflow-executors/#emissary-emissary
   containerRuntimeExecutor: emissary

--- a/apps/pipeline/upstream/env/platform-agnostic-multi-user-pns/workflow-controller-configmap-patch.yaml
+++ b/apps/pipeline/upstream/env/platform-agnostic-multi-user-pns/workflow-controller-configmap-patch.yaml
@@ -4,9 +4,10 @@ metadata:
   name: workflow-controller-configmap
 data:
   # References:
-  # * https://github.com/argoproj/argo-workflows/blob/v3.3.8/config/config.go
-  # * https://github.com/argoproj/argo-workflows/blob/v3.3.8/docs/workflow-controller-configmap.md
-  # * https://github.com/argoproj/argo-workflows/blob/v3.3.8/docs/workflow-controller-configmap.yaml
+  # * https://github.com/argoproj/argo-workflows/blob/v3.3.10/config/config.go
+  # * https://github.com/argoproj/argo-workflows/blob/v3.3.10/docs/workflow-controller-configmap.md
+  # * https://github.com/argoproj/argo-workflows/blob/v3.3.10/docs/workflow-controller-configmap.yaml
 
   # pns executor is a more portable default, see https://github.com/kubeflow/pipelines/issues/1654.
+  # However, it is flaky for containers that run really fast, see https://github.com/kubeflow/pipelines/issues/5285.
   containerRuntimeExecutor: pns

--- a/apps/pipeline/upstream/env/platform-agnostic-pns/workflow-controller-configmap-patch.yaml
+++ b/apps/pipeline/upstream/env/platform-agnostic-pns/workflow-controller-configmap-patch.yaml
@@ -4,11 +4,10 @@ metadata:
   name: workflow-controller-configmap
 data:
   # References:
-  # * https://github.com/argoproj/argo-workflows/blob/v3.3.8/config/config.go
-  # * https://github.com/argoproj/argo-workflows/blob/v3.3.8/docs/workflow-controller-configmap.md
-  # * https://github.com/argoproj/argo-workflows/blob/v3.3.8/docs/workflow-controller-configmap.yaml
+  # * https://github.com/argoproj/argo-workflows/blob/v3.3.10/config/config.go
+  # * https://github.com/argoproj/argo-workflows/blob/v3.3.10/docs/workflow-controller-configmap.md
+  # * https://github.com/argoproj/argo-workflows/blob/v3.3.10/docs/workflow-controller-configmap.yaml
 
   # pns executor is a more portable default, see https://github.com/kubeflow/pipelines/issues/1654.
   # However, it is flaky for containers that run really fast, see https://github.com/kubeflow/pipelines/issues/5285.
-  # So we still default to docker for now.
   containerRuntimeExecutor: pns

--- a/apps/pipeline/upstream/third-party/argo/base/workflow-controller-configmap-patch.yaml
+++ b/apps/pipeline/upstream/third-party/argo/base/workflow-controller-configmap-patch.yaml
@@ -4,9 +4,9 @@ metadata:
   name: workflow-controller-configmap
 data:
   # References:
-  # * https://github.com/argoproj/argo-workflows/blob/v3.3.8/config/config.go
-  # * https://github.com/argoproj/argo-workflows/blob/v3.3.8/docs/workflow-controller-configmap.md
-  # * https://github.com/argoproj/argo-workflows/blob/v3.3.8/docs/workflow-controller-configmap.yaml
+  # * https://github.com/argoproj/argo-workflows/blob/v3.3.10/config/config.go
+  # * https://github.com/argoproj/argo-workflows/blob/v3.3.10/docs/workflow-controller-configmap.md
+  # * https://github.com/argoproj/argo-workflows/blob/v3.3.10/docs/workflow-controller-configmap.yaml
 
   # emissary executor is a more portable default, see https://github.com/kubeflow/pipelines/issues/1654.
   containerRuntimeExecutor: emissary
@@ -39,10 +39,3 @@ data:
         key: secretkey
   executor: |
     imagePullPolicy: IfNotPresent
-    resources:
-      requests:
-        cpu: 0.01
-        memory: 32Mi
-      limits:
-        cpu: 0.5
-        memory: 512Mi

--- a/apps/pipeline/upstream/third-party/argo/base/workflow-controller-deployment-patch.yaml
+++ b/apps/pipeline/upstream/third-party/argo/base/workflow-controller-deployment-patch.yaml
@@ -7,12 +7,12 @@ spec:
     spec:
       containers:
         - name: workflow-controller
-          image: gcr.io/ml-pipeline/workflow-controller:v3.3.8-license-compliance
+          image: gcr.io/ml-pipeline/workflow-controller:v3.3.10-license-compliance
           args:
             - --configmap
             - workflow-controller-configmap
             - --executor-image
-            - gcr.io/ml-pipeline/argoexec:v3.3.8-license-compliance
+            - gcr.io/ml-pipeline/argoexec:v3.3.10-license-compliance
           resources:
             requests:
               cpu: 100m

--- a/apps/pipeline/upstream/third-party/argo/upstream/manifests/Kptfile
+++ b/apps/pipeline/upstream/third-party/argo/upstream/manifests/Kptfile
@@ -7,12 +7,12 @@ upstream:
   git:
     repo: https://github.com/argoproj/argo-workflows
     directory: /manifests
-    ref: v3.3.8
+    ref: v3.3.10
   updateStrategy: resource-merge
 upstreamLock:
   type: git
   git:
     repo: https://github.com/argoproj/argo-workflows
     directory: /manifests
-    ref: v3.3.8
-    commit: 621b0d1a8e09634666ebe403ee7b8fc29db1dc4e
+    ref: v3.3.10
+    commit: b19870d737a14b21d86f6267642a63dd14e5acd5

--- a/apps/pipeline/upstream/third-party/argo/upstream/manifests/base/argo-server/argo-server-deployment.yaml
+++ b/apps/pipeline/upstream/third-party/argo/upstream/manifests/base/argo-server/argo-server-deployment.yaml
@@ -2,6 +2,8 @@ apiVersion: apps/v1
 kind: Deployment
 metadata: # kpt-merge: /argo-server
   name: argo-server
+  annotations:
+    internal.kpt.dev/upstream-identifier: 'apps|Deployment|default|argo-server'
 spec:
   selector:
     matchLabels:

--- a/apps/pipeline/upstream/third-party/argo/upstream/manifests/base/argo-server/argo-server-sa.yaml
+++ b/apps/pipeline/upstream/third-party/argo/upstream/manifests/base/argo-server/argo-server-sa.yaml
@@ -2,3 +2,5 @@ apiVersion: v1
 kind: ServiceAccount
 metadata: # kpt-merge: /argo-server
   name: argo-server
+  annotations:
+    internal.kpt.dev/upstream-identifier: '|ServiceAccount|default|argo-server'

--- a/apps/pipeline/upstream/third-party/argo/upstream/manifests/base/argo-server/argo-server-service.yaml
+++ b/apps/pipeline/upstream/third-party/argo/upstream/manifests/base/argo-server/argo-server-service.yaml
@@ -2,6 +2,8 @@ apiVersion: v1
 kind: Service
 metadata: # kpt-merge: /argo-server
   name: argo-server
+  annotations:
+    internal.kpt.dev/upstream-identifier: '|Service|default|argo-server'
 spec:
   selector:
     app: argo-server

--- a/apps/pipeline/upstream/third-party/argo/upstream/manifests/base/crds/full/argoproj.io_clusterworkflowtemplates.yaml
+++ b/apps/pipeline/upstream/third-party/argo/upstream/manifests/base/crds/full/argoproj.io_clusterworkflowtemplates.yaml
@@ -3,6 +3,8 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata: # kpt-merge: /clusterworkflowtemplates.argoproj.io
   name: clusterworkflowtemplates.argoproj.io
+  annotations:
+    internal.kpt.dev/upstream-identifier: 'apiextensions.k8s.io|CustomResourceDefinition|default|clusterworkflowtemplates.argoproj.io'
 spec:
   group: argoproj.io
   names:

--- a/apps/pipeline/upstream/third-party/argo/upstream/manifests/base/crds/full/argoproj.io_cronworkflows.yaml
+++ b/apps/pipeline/upstream/third-party/argo/upstream/manifests/base/crds/full/argoproj.io_cronworkflows.yaml
@@ -3,6 +3,8 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata: # kpt-merge: /cronworkflows.argoproj.io
   name: cronworkflows.argoproj.io
+  annotations:
+    internal.kpt.dev/upstream-identifier: 'apiextensions.k8s.io|CustomResourceDefinition|default|cronworkflows.argoproj.io'
 spec:
   group: argoproj.io
   names:

--- a/apps/pipeline/upstream/third-party/argo/upstream/manifests/base/crds/full/argoproj.io_workfloweventbindings.yaml
+++ b/apps/pipeline/upstream/third-party/argo/upstream/manifests/base/crds/full/argoproj.io_workfloweventbindings.yaml
@@ -3,6 +3,8 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata: # kpt-merge: /workfloweventbindings.argoproj.io
   name: workfloweventbindings.argoproj.io
+  annotations:
+    internal.kpt.dev/upstream-identifier: 'apiextensions.k8s.io|CustomResourceDefinition|default|workfloweventbindings.argoproj.io'
 spec:
   group: argoproj.io
   names:

--- a/apps/pipeline/upstream/third-party/argo/upstream/manifests/base/crds/full/argoproj.io_workflows.yaml
+++ b/apps/pipeline/upstream/third-party/argo/upstream/manifests/base/crds/full/argoproj.io_workflows.yaml
@@ -3,6 +3,8 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata: # kpt-merge: /workflows.argoproj.io
   name: workflows.argoproj.io
+  annotations:
+    internal.kpt.dev/upstream-identifier: 'apiextensions.k8s.io|CustomResourceDefinition|default|workflows.argoproj.io'
 spec:
   group: argoproj.io
   names:

--- a/apps/pipeline/upstream/third-party/argo/upstream/manifests/base/crds/full/argoproj.io_workflowtaskresults.yaml
+++ b/apps/pipeline/upstream/third-party/argo/upstream/manifests/base/crds/full/argoproj.io_workflowtaskresults.yaml
@@ -3,6 +3,8 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata: # kpt-merge: /workflowtaskresults.argoproj.io
   name: workflowtaskresults.argoproj.io
+  annotations:
+    internal.kpt.dev/upstream-identifier: 'apiextensions.k8s.io|CustomResourceDefinition|default|workflowtaskresults.argoproj.io'
 spec:
   group: argoproj.io
   names:

--- a/apps/pipeline/upstream/third-party/argo/upstream/manifests/base/crds/full/argoproj.io_workflowtasksets.yaml
+++ b/apps/pipeline/upstream/third-party/argo/upstream/manifests/base/crds/full/argoproj.io_workflowtasksets.yaml
@@ -3,6 +3,8 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata: # kpt-merge: /workflowtasksets.argoproj.io
   name: workflowtasksets.argoproj.io
+  annotations:
+    internal.kpt.dev/upstream-identifier: 'apiextensions.k8s.io|CustomResourceDefinition|default|workflowtasksets.argoproj.io'
 spec:
   group: argoproj.io
   names:

--- a/apps/pipeline/upstream/third-party/argo/upstream/manifests/base/crds/full/argoproj.io_workflowtemplates.yaml
+++ b/apps/pipeline/upstream/third-party/argo/upstream/manifests/base/crds/full/argoproj.io_workflowtemplates.yaml
@@ -3,6 +3,8 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata: # kpt-merge: /workflowtemplates.argoproj.io
   name: workflowtemplates.argoproj.io
+  annotations:
+    internal.kpt.dev/upstream-identifier: 'apiextensions.k8s.io|CustomResourceDefinition|default|workflowtemplates.argoproj.io'
 spec:
   group: argoproj.io
   names:

--- a/apps/pipeline/upstream/third-party/argo/upstream/manifests/base/crds/minimal/argoproj.io_clusterworkflowtemplates.yaml
+++ b/apps/pipeline/upstream/third-party/argo/upstream/manifests/base/crds/minimal/argoproj.io_clusterworkflowtemplates.yaml
@@ -2,6 +2,8 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata: # kpt-merge: /clusterworkflowtemplates.argoproj.io
   name: clusterworkflowtemplates.argoproj.io
+  annotations:
+    internal.kpt.dev/upstream-identifier: 'apiextensions.k8s.io|CustomResourceDefinition|default|clusterworkflowtemplates.argoproj.io'
 spec:
   group: argoproj.io
   names:

--- a/apps/pipeline/upstream/third-party/argo/upstream/manifests/base/crds/minimal/argoproj.io_cronworkflows.yaml
+++ b/apps/pipeline/upstream/third-party/argo/upstream/manifests/base/crds/minimal/argoproj.io_cronworkflows.yaml
@@ -2,6 +2,8 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata: # kpt-merge: /cronworkflows.argoproj.io
   name: cronworkflows.argoproj.io
+  annotations:
+    internal.kpt.dev/upstream-identifier: 'apiextensions.k8s.io|CustomResourceDefinition|default|cronworkflows.argoproj.io'
 spec:
   group: argoproj.io
   names:

--- a/apps/pipeline/upstream/third-party/argo/upstream/manifests/base/crds/minimal/argoproj.io_workfloweventbindings.yaml
+++ b/apps/pipeline/upstream/third-party/argo/upstream/manifests/base/crds/minimal/argoproj.io_workfloweventbindings.yaml
@@ -2,6 +2,8 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata: # kpt-merge: /workfloweventbindings.argoproj.io
   name: workfloweventbindings.argoproj.io
+  annotations:
+    internal.kpt.dev/upstream-identifier: 'apiextensions.k8s.io|CustomResourceDefinition|default|workfloweventbindings.argoproj.io'
 spec:
   group: argoproj.io
   names:

--- a/apps/pipeline/upstream/third-party/argo/upstream/manifests/base/crds/minimal/argoproj.io_workflows.yaml
+++ b/apps/pipeline/upstream/third-party/argo/upstream/manifests/base/crds/minimal/argoproj.io_workflows.yaml
@@ -2,6 +2,8 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata: # kpt-merge: /workflows.argoproj.io
   name: workflows.argoproj.io
+  annotations:
+    internal.kpt.dev/upstream-identifier: 'apiextensions.k8s.io|CustomResourceDefinition|default|workflows.argoproj.io'
 spec:
   group: argoproj.io
   names:

--- a/apps/pipeline/upstream/third-party/argo/upstream/manifests/base/crds/minimal/argoproj.io_workflowtaskresults.yaml
+++ b/apps/pipeline/upstream/third-party/argo/upstream/manifests/base/crds/minimal/argoproj.io_workflowtaskresults.yaml
@@ -2,6 +2,8 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata: # kpt-merge: /workflowtaskresults.argoproj.io
   name: workflowtaskresults.argoproj.io
+  annotations:
+    internal.kpt.dev/upstream-identifier: 'apiextensions.k8s.io|CustomResourceDefinition|default|workflowtaskresults.argoproj.io'
 spec:
   group: argoproj.io
   names:

--- a/apps/pipeline/upstream/third-party/argo/upstream/manifests/base/crds/minimal/argoproj.io_workflowtasksets.yaml
+++ b/apps/pipeline/upstream/third-party/argo/upstream/manifests/base/crds/minimal/argoproj.io_workflowtasksets.yaml
@@ -2,6 +2,8 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata: # kpt-merge: /workflowtasksets.argoproj.io
   name: workflowtasksets.argoproj.io
+  annotations:
+    internal.kpt.dev/upstream-identifier: 'apiextensions.k8s.io|CustomResourceDefinition|default|workflowtasksets.argoproj.io'
 spec:
   group: argoproj.io
   names:

--- a/apps/pipeline/upstream/third-party/argo/upstream/manifests/base/crds/minimal/argoproj.io_workflowtemplates.yaml
+++ b/apps/pipeline/upstream/third-party/argo/upstream/manifests/base/crds/minimal/argoproj.io_workflowtemplates.yaml
@@ -2,6 +2,8 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata: # kpt-merge: /workflowtemplates.argoproj.io
   name: workflowtemplates.argoproj.io
+  annotations:
+    internal.kpt.dev/upstream-identifier: 'apiextensions.k8s.io|CustomResourceDefinition|default|workflowtemplates.argoproj.io'
 spec:
   group: argoproj.io
   names:

--- a/apps/pipeline/upstream/third-party/argo/upstream/manifests/base/workflow-controller/workflow-controller-configmap.yaml
+++ b/apps/pipeline/upstream/third-party/argo/upstream/manifests/base/workflow-controller/workflow-controller-configmap.yaml
@@ -2,3 +2,5 @@ apiVersion: v1
 kind: ConfigMap
 metadata: # kpt-merge: /workflow-controller-configmap
   name: workflow-controller-configmap
+  annotations:
+    internal.kpt.dev/upstream-identifier: '|ConfigMap|default|workflow-controller-configmap'

--- a/apps/pipeline/upstream/third-party/argo/upstream/manifests/base/workflow-controller/workflow-controller-deployment.yaml
+++ b/apps/pipeline/upstream/third-party/argo/upstream/manifests/base/workflow-controller/workflow-controller-deployment.yaml
@@ -2,6 +2,8 @@ apiVersion: apps/v1
 kind: Deployment
 metadata: # kpt-merge: /workflow-controller
   name: workflow-controller
+  annotations:
+    internal.kpt.dev/upstream-identifier: 'apps|Deployment|default|workflow-controller'
 spec:
   selector:
     matchLabels:

--- a/apps/pipeline/upstream/third-party/argo/upstream/manifests/base/workflow-controller/workflow-controller-metrics-service.yaml
+++ b/apps/pipeline/upstream/third-party/argo/upstream/manifests/base/workflow-controller/workflow-controller-metrics-service.yaml
@@ -9,6 +9,7 @@ metadata: # kpt-merge: /workflow-controller-metrics
       This service is deprecated. It will be removed in v3.4.
 
       https://github.com/argoproj/argo-workflows/issues/8441
+    internal.kpt.dev/upstream-identifier: '|Service|default|workflow-controller-metrics'
 spec:
   selector:
     app: workflow-controller

--- a/apps/pipeline/upstream/third-party/argo/upstream/manifests/base/workflow-controller/workflow-controller-priorityclass.yaml
+++ b/apps/pipeline/upstream/third-party/argo/upstream/manifests/base/workflow-controller/workflow-controller-priorityclass.yaml
@@ -2,4 +2,6 @@ apiVersion: scheduling.k8s.io/v1
 kind: PriorityClass
 metadata: # kpt-merge: /workflow-controller
   name: workflow-controller
+  annotations:
+    internal.kpt.dev/upstream-identifier: 'scheduling.k8s.io|PriorityClass|default|workflow-controller'
 value: 1000000

--- a/apps/pipeline/upstream/third-party/argo/upstream/manifests/base/workflow-controller/workflow-controller-sa.yaml
+++ b/apps/pipeline/upstream/third-party/argo/upstream/manifests/base/workflow-controller/workflow-controller-sa.yaml
@@ -2,3 +2,5 @@ apiVersion: v1
 kind: ServiceAccount
 metadata: # kpt-merge: /argo
   name: argo
+  annotations:
+    internal.kpt.dev/upstream-identifier: '|ServiceAccount|default|argo'

--- a/apps/pipeline/upstream/third-party/argo/upstream/manifests/cluster-install/argo-server-rbac/argo-server-clusterole.yaml
+++ b/apps/pipeline/upstream/third-party/argo/upstream/manifests/cluster-install/argo-server-rbac/argo-server-clusterole.yaml
@@ -2,6 +2,8 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata: # kpt-merge: /argo-server-cluster-role
   name: argo-server-cluster-role
+  annotations:
+    internal.kpt.dev/upstream-identifier: 'rbac.authorization.k8s.io|ClusterRole|default|argo-server-cluster-role'
 rules:
   - apiGroups:
       - ""

--- a/apps/pipeline/upstream/third-party/argo/upstream/manifests/cluster-install/argo-server-rbac/argo-server-clusterolebinding.yaml
+++ b/apps/pipeline/upstream/third-party/argo/upstream/manifests/cluster-install/argo-server-rbac/argo-server-clusterolebinding.yaml
@@ -2,6 +2,8 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata: # kpt-merge: /argo-server-binding
   name: argo-server-binding
+  annotations:
+    internal.kpt.dev/upstream-identifier: 'rbac.authorization.k8s.io|ClusterRoleBinding|default|argo-server-binding'
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole

--- a/apps/pipeline/upstream/third-party/argo/upstream/manifests/cluster-install/workflow-controller-rbac/workflow-aggregate-roles.yaml
+++ b/apps/pipeline/upstream/third-party/argo/upstream/manifests/cluster-install/workflow-controller-rbac/workflow-aggregate-roles.yaml
@@ -4,6 +4,8 @@ metadata: # kpt-merge: /argo-aggregate-to-view
   name: argo-aggregate-to-view
   labels:
     rbac.authorization.k8s.io/aggregate-to-view: "true"
+  annotations:
+    internal.kpt.dev/upstream-identifier: 'rbac.authorization.k8s.io|ClusterRole|default|argo-aggregate-to-view'
 rules:
 - apiGroups:
   - argoproj.io
@@ -29,6 +31,8 @@ metadata: # kpt-merge: /argo-aggregate-to-edit
   name: argo-aggregate-to-edit
   labels:
     rbac.authorization.k8s.io/aggregate-to-edit: "true"
+  annotations:
+    internal.kpt.dev/upstream-identifier: 'rbac.authorization.k8s.io|ClusterRole|default|argo-aggregate-to-edit'
 rules:
 - apiGroups:
   - argoproj.io
@@ -59,6 +63,8 @@ metadata: # kpt-merge: /argo-aggregate-to-admin
   name: argo-aggregate-to-admin
   labels:
     rbac.authorization.k8s.io/aggregate-to-admin: "true"
+  annotations:
+    internal.kpt.dev/upstream-identifier: 'rbac.authorization.k8s.io|ClusterRole|default|argo-aggregate-to-admin'
 rules:
 - apiGroups:
   - argoproj.io

--- a/apps/pipeline/upstream/third-party/argo/upstream/manifests/cluster-install/workflow-controller-rbac/workflow-controller-clusterrole.yaml
+++ b/apps/pipeline/upstream/third-party/argo/upstream/manifests/cluster-install/workflow-controller-rbac/workflow-controller-clusterrole.yaml
@@ -2,6 +2,8 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata: # kpt-merge: /argo-cluster-role
   name: argo-cluster-role
+  annotations:
+    internal.kpt.dev/upstream-identifier: 'rbac.authorization.k8s.io|ClusterRole|default|argo-cluster-role'
 rules:
 - apiGroups:
   - ""

--- a/apps/pipeline/upstream/third-party/argo/upstream/manifests/cluster-install/workflow-controller-rbac/workflow-controller-clusterrolebinding.yaml
+++ b/apps/pipeline/upstream/third-party/argo/upstream/manifests/cluster-install/workflow-controller-rbac/workflow-controller-clusterrolebinding.yaml
@@ -2,6 +2,8 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata: # kpt-merge: /argo-binding
   name: argo-binding
+  annotations:
+    internal.kpt.dev/upstream-identifier: 'rbac.authorization.k8s.io|ClusterRoleBinding|default|argo-binding'
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole

--- a/apps/pipeline/upstream/third-party/argo/upstream/manifests/cluster-install/workflow-controller-rbac/workflow-controller-role.yaml
+++ b/apps/pipeline/upstream/third-party/argo/upstream/manifests/cluster-install/workflow-controller-rbac/workflow-controller-role.yaml
@@ -2,6 +2,8 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata: # kpt-merge: /argo-role
   name: argo-role
+  annotations:
+    internal.kpt.dev/upstream-identifier: 'rbac.authorization.k8s.io|Role|default|argo-role'
 rules:
   - apiGroups:
       - coordination.k8s.io

--- a/apps/pipeline/upstream/third-party/argo/upstream/manifests/cluster-install/workflow-controller-rbac/workflow-controller-rolebinding.yaml
+++ b/apps/pipeline/upstream/third-party/argo/upstream/manifests/cluster-install/workflow-controller-rbac/workflow-controller-rolebinding.yaml
@@ -2,6 +2,8 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata: # kpt-merge: /argo-binding
   name: argo-binding
+  annotations:
+    internal.kpt.dev/upstream-identifier: 'rbac.authorization.k8s.io|RoleBinding|default|argo-binding'
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role

--- a/apps/pipeline/upstream/third-party/argo/upstream/manifests/namespace-install/argo-server-rbac/argo-server-role.yaml
+++ b/apps/pipeline/upstream/third-party/argo/upstream/manifests/namespace-install/argo-server-rbac/argo-server-role.yaml
@@ -2,6 +2,8 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata: # kpt-merge: /argo-server-role
   name: argo-server-role
+  annotations:
+    internal.kpt.dev/upstream-identifier: 'rbac.authorization.k8s.io|Role|default|argo-server-role'
 rules:
   - apiGroups:
       - ""

--- a/apps/pipeline/upstream/third-party/argo/upstream/manifests/namespace-install/argo-server-rbac/argo-server-rolebinding.yaml
+++ b/apps/pipeline/upstream/third-party/argo/upstream/manifests/namespace-install/argo-server-rbac/argo-server-rolebinding.yaml
@@ -2,6 +2,8 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata: # kpt-merge: /argo-server-binding
   name: argo-server-binding
+  annotations:
+    internal.kpt.dev/upstream-identifier: 'rbac.authorization.k8s.io|RoleBinding|default|argo-server-binding'
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role

--- a/apps/pipeline/upstream/third-party/argo/upstream/manifests/namespace-install/workflow-controller-rbac/workflow-controller-role.yaml
+++ b/apps/pipeline/upstream/third-party/argo/upstream/manifests/namespace-install/workflow-controller-rbac/workflow-controller-role.yaml
@@ -2,6 +2,8 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata: # kpt-merge: /argo-role
   name: argo-role
+  annotations:
+    internal.kpt.dev/upstream-identifier: 'rbac.authorization.k8s.io|Role|default|argo-role'
 rules:
   - apiGroups:
       - coordination.k8s.io

--- a/apps/pipeline/upstream/third-party/argo/upstream/manifests/namespace-install/workflow-controller-rbac/workflow-controller-rolebinding.yaml
+++ b/apps/pipeline/upstream/third-party/argo/upstream/manifests/namespace-install/workflow-controller-rbac/workflow-controller-rolebinding.yaml
@@ -2,6 +2,8 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata: # kpt-merge: /argo-binding
   name: argo-binding
+  annotations:
+    internal.kpt.dev/upstream-identifier: 'rbac.authorization.k8s.io|RoleBinding|default|argo-binding'
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role

--- a/apps/pipeline/upstream/third-party/argo/upstream/manifests/quick-start/base/agent-default-rolebinding.yaml
+++ b/apps/pipeline/upstream/third-party/argo/upstream/manifests/quick-start/base/agent-default-rolebinding.yaml
@@ -2,6 +2,8 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata: # kpt-merge: /agent-default
   name: agent-default
+  annotations:
+    internal.kpt.dev/upstream-identifier: 'rbac.authorization.k8s.io|RoleBinding|default|agent-default'
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role

--- a/apps/pipeline/upstream/third-party/argo/upstream/manifests/quick-start/base/agent-role.yaml
+++ b/apps/pipeline/upstream/third-party/argo/upstream/manifests/quick-start/base/agent-role.yaml
@@ -8,6 +8,7 @@ metadata: # kpt-merge: /agent
       This is the minimum recommended permissions needed if you want to use the agent, e.g. for HTTP or plugin templates.
 
       If <= v3.2 you must replace `workflowtasksets/status` with `patch workflowtasksets`.
+    internal.kpt.dev/upstream-identifier: 'rbac.authorization.k8s.io|Role|default|agent'
 rules:
   - apiGroups:
       - argoproj.io

--- a/apps/pipeline/upstream/third-party/argo/upstream/manifests/quick-start/base/argo-server-sso-secret.yaml
+++ b/apps/pipeline/upstream/third-party/argo/upstream/manifests/quick-start/base/argo-server-sso-secret.yaml
@@ -2,6 +2,8 @@ kind: Secret
 apiVersion: v1
 metadata: # kpt-merge: /argo-server-sso
   name: argo-server-sso
+  annotations:
+    internal.kpt.dev/upstream-identifier: '|Secret|default|argo-server-sso'
 stringData:
   clientID: argo-server
   clientSecret: ZXhhbXBsZS1hcHAtc2VjcmV0

--- a/apps/pipeline/upstream/third-party/argo/upstream/manifests/quick-start/base/artifact-repositories-configmap.yaml
+++ b/apps/pipeline/upstream/third-party/argo/upstream/manifests/quick-start/base/artifact-repositories-configmap.yaml
@@ -6,6 +6,7 @@ metadata: # kpt-merge: /artifact-repositories
     # you'll want to change the default over time, e.g. when you move to new storage solution,
     # so we recommend you version them from the outset by suffixing the version
     workflows.argoproj.io/default-artifact-repository: default-v1
+    internal.kpt.dev/upstream-identifier: '|ConfigMap|default|artifact-repositories'
 data:
   default-v1: |
     archiveLogs: true

--- a/apps/pipeline/upstream/third-party/argo/upstream/manifests/quick-start/base/cluster-workflow-template-rbac.yaml
+++ b/apps/pipeline/upstream/third-party/argo/upstream/manifests/quick-start/base/cluster-workflow-template-rbac.yaml
@@ -2,6 +2,8 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata: # kpt-merge: /argo-server-clusterworkflowtemplate-role
   name: argo-server-clusterworkflowtemplate-role
+  annotations:
+    internal.kpt.dev/upstream-identifier: 'rbac.authorization.k8s.io|ClusterRole|default|argo-server-clusterworkflowtemplate-role'
 rules:
   - apiGroups:
       - argoproj.io
@@ -20,6 +22,8 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata: # kpt-merge: /argo-clusterworkflowtemplate-role
   name: argo-clusterworkflowtemplate-role
+  annotations:
+    internal.kpt.dev/upstream-identifier: 'rbac.authorization.k8s.io|ClusterRole|default|argo-clusterworkflowtemplate-role'
 rules:
   - apiGroups:
       - argoproj.io
@@ -35,6 +39,8 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata: # kpt-merge: /argo-clusterworkflowtemplate-role-binding
   name: argo-clusterworkflowtemplate-role-binding
+  annotations:
+    internal.kpt.dev/upstream-identifier: 'rbac.authorization.k8s.io|ClusterRoleBinding|default|argo-clusterworkflowtemplate-role-binding'
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
@@ -48,6 +54,8 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata: # kpt-merge: /argo-server-clusterworkflowtemplate-role-binding
   name: argo-server-clusterworkflowtemplate-role-binding
+  annotations:
+    internal.kpt.dev/upstream-identifier: 'rbac.authorization.k8s.io|ClusterRoleBinding|default|argo-server-clusterworkflowtemplate-role-binding'
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole

--- a/apps/pipeline/upstream/third-party/argo/upstream/manifests/quick-start/base/executor-default-rolebinding.yaml
+++ b/apps/pipeline/upstream/third-party/argo/upstream/manifests/quick-start/base/executor-default-rolebinding.yaml
@@ -2,6 +2,8 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata: # kpt-merge: /executor-default
   name: executor-default
+  annotations:
+    internal.kpt.dev/upstream-identifier: 'rbac.authorization.k8s.io|RoleBinding|default|executor-default'
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role

--- a/apps/pipeline/upstream/third-party/argo/upstream/manifests/quick-start/base/executor/docker/executor-role.yaml
+++ b/apps/pipeline/upstream/third-party/argo/upstream/manifests/quick-start/base/executor/docker/executor-role.yaml
@@ -7,6 +7,7 @@ metadata: # kpt-merge: /executor
       Recommended minimum permissions for the `docker` executor.
 
       This executor is superseded by  the `emmisary` executor, so we do not recommend you use it anymore.
+    internal.kpt.dev/upstream-identifier: 'rbac.authorization.k8s.io|Role|default|executor'
 rules:
   - apiGroups:
       - argoproj.io

--- a/apps/pipeline/upstream/third-party/argo/upstream/manifests/quick-start/base/executor/emissary/executor-role.yaml
+++ b/apps/pipeline/upstream/third-party/argo/upstream/manifests/quick-start/base/executor/emissary/executor-role.yaml
@@ -5,6 +5,7 @@ metadata: # kpt-merge: /executor
   annotations:
     workflows.argoproj.io/description: |
       Recomended minimum permissions for the `emissary` executor.
+    internal.kpt.dev/upstream-identifier: 'rbac.authorization.k8s.io|Role|default|executor'
 rules:
   - apiGroups:
       - argoproj.io

--- a/apps/pipeline/upstream/third-party/argo/upstream/manifests/quick-start/base/executor/k8sapi/executor-role.yaml
+++ b/apps/pipeline/upstream/third-party/argo/upstream/manifests/quick-start/base/executor/k8sapi/executor-role.yaml
@@ -7,6 +7,7 @@ metadata: # kpt-merge: /executor
       Recommended minimum permissions for `k8siapi` executor.
 
       This executor is superseded by  the `emmisary` executor, so we do not recommend you use it anymore.
+    internal.kpt.dev/upstream-identifier: 'rbac.authorization.k8s.io|Role|default|executor'
 rules:
   - apiGroups:
       - argoproj.io

--- a/apps/pipeline/upstream/third-party/argo/upstream/manifests/quick-start/base/executor/kubelet/executor-role.yaml
+++ b/apps/pipeline/upstream/third-party/argo/upstream/manifests/quick-start/base/executor/kubelet/executor-role.yaml
@@ -7,6 +7,7 @@ metadata: # kpt-merge: /executor
       Recommended minimum permissions for `kubelet` executor.
 
       This executor is superseded by  the `emmisary` executor, so we do not recommend you use it anymore.
+    internal.kpt.dev/upstream-identifier: 'rbac.authorization.k8s.io|Role|default|executor'
 rules:
   - apiGroups:
       - argoproj.io

--- a/apps/pipeline/upstream/third-party/argo/upstream/manifests/quick-start/base/executor/kubelet/kubelet-executor-clusterrole.yaml
+++ b/apps/pipeline/upstream/third-party/argo/upstream/manifests/quick-start/base/executor/kubelet/kubelet-executor-clusterrole.yaml
@@ -2,6 +2,8 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata: # kpt-merge: /kubelet-executor
   name: kubelet-executor
+  annotations:
+    internal.kpt.dev/upstream-identifier: 'rbac.authorization.k8s.io|ClusterRole|default|kubelet-executor'
 rules:
   # This allows the kubelet executor.
   - apiGroups:

--- a/apps/pipeline/upstream/third-party/argo/upstream/manifests/quick-start/base/executor/kubelet/kubelet-executor-default-clusterrolebinding.yaml
+++ b/apps/pipeline/upstream/third-party/argo/upstream/manifests/quick-start/base/executor/kubelet/kubelet-executor-default-clusterrolebinding.yaml
@@ -2,6 +2,8 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata: # kpt-merge: /kubelet-executor-default
   name: kubelet-executor-default
+  annotations:
+    internal.kpt.dev/upstream-identifier: 'rbac.authorization.k8s.io|ClusterRoleBinding|default|kubelet-executor-default'
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole

--- a/apps/pipeline/upstream/third-party/argo/upstream/manifests/quick-start/base/executor/pns/executor-role.yaml
+++ b/apps/pipeline/upstream/third-party/argo/upstream/manifests/quick-start/base/executor/pns/executor-role.yaml
@@ -5,6 +5,7 @@ metadata: # kpt-merge: /executor
   annotations:
     workflows.argoproj.io/description: |
       Recomended minimum permissions for `pns` executor.
+    internal.kpt.dev/upstream-identifier: 'rbac.authorization.k8s.io|Role|default|executor'
 rules:
   - apiGroups:
       - argoproj.io

--- a/apps/pipeline/upstream/third-party/argo/upstream/manifests/quick-start/base/memoizer-default-rolebinding.yaml
+++ b/apps/pipeline/upstream/third-party/argo/upstream/manifests/quick-start/base/memoizer-default-rolebinding.yaml
@@ -2,6 +2,8 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata: # kpt-merge: /memoizer-default
   name: memoizer-default
+  annotations:
+    internal.kpt.dev/upstream-identifier: 'rbac.authorization.k8s.io|RoleBinding|default|memoizer-default'
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role

--- a/apps/pipeline/upstream/third-party/argo/upstream/manifests/quick-start/base/memoizer-role.yaml
+++ b/apps/pipeline/upstream/third-party/argo/upstream/manifests/quick-start/base/memoizer-role.yaml
@@ -5,6 +5,7 @@ metadata: # kpt-merge: /memoizer
   annotations:
     workflows.argoproj.io/description: |
       Only needed if you are using ConfigMap-based cache for memoization.
+    internal.kpt.dev/upstream-identifier: 'rbac.authorization.k8s.io|Role|default|memoizer'
 rules:
   - apiGroups:
       - ""

--- a/apps/pipeline/upstream/third-party/argo/upstream/manifests/quick-start/base/minio/minio-deploy.yaml
+++ b/apps/pipeline/upstream/third-party/argo/upstream/manifests/quick-start/base/minio/minio-deploy.yaml
@@ -4,6 +4,8 @@ metadata: # kpt-merge: /minio
   name: minio
   labels:
     app: minio
+  annotations:
+    internal.kpt.dev/upstream-identifier: 'apps|Deployment|default|minio'
 spec:
   selector:
     matchLabels:
@@ -23,7 +25,10 @@ spec:
               value: password
           ports:
             - containerPort: 9000
-          command: [minio, server, /data]
+              name: api
+            - containerPort: 9001
+              name: dashboard
+          command: [minio, server, --console-address, ":9001", /data]
           lifecycle:
             postStart:
               exec:

--- a/apps/pipeline/upstream/third-party/argo/upstream/manifests/quick-start/base/minio/minio-service.yaml
+++ b/apps/pipeline/upstream/third-party/argo/upstream/manifests/quick-start/base/minio/minio-service.yaml
@@ -4,10 +4,17 @@ metadata: # kpt-merge: /minio
   name: minio
   labels:
     app: minio
+  annotations:
+    internal.kpt.dev/upstream-identifier: '|Service|default|minio'
 spec:
   selector:
     app: minio
   ports:
-    - protocol: TCP
-      port: 9000
+    - port: 9000
+      name: api
+      protocol: TCP
       targetPort: 9000
+    - port: 9001
+      name: dashboard
+      protocol: TCP
+      targetPort: 9001

--- a/apps/pipeline/upstream/third-party/argo/upstream/manifests/quick-start/base/minio/my-minio-cred-secret.yaml
+++ b/apps/pipeline/upstream/third-party/argo/upstream/manifests/quick-start/base/minio/my-minio-cred-secret.yaml
@@ -7,4 +7,6 @@ metadata: # kpt-merge: /my-minio-cred
   name: my-minio-cred
   labels:
     app: minio
+  annotations:
+    internal.kpt.dev/upstream-identifier: '|Secret|default|my-minio-cred'
 type: Opaque

--- a/apps/pipeline/upstream/third-party/argo/upstream/manifests/quick-start/base/overlays/argo-server-deployment.yaml
+++ b/apps/pipeline/upstream/third-party/argo/upstream/manifests/quick-start/base/overlays/argo-server-deployment.yaml
@@ -2,6 +2,8 @@ apiVersion: apps/v1
 kind: Deployment
 metadata: # kpt-merge: /argo-server
   name: argo-server
+  annotations:
+    internal.kpt.dev/upstream-identifier: 'apps|Deployment|default|argo-server'
 spec:
   template:
     spec:

--- a/apps/pipeline/upstream/third-party/argo/upstream/manifests/quick-start/base/overlays/workflow-controller-configmap.yaml
+++ b/apps/pipeline/upstream/third-party/argo/upstream/manifests/quick-start/base/overlays/workflow-controller-configmap.yaml
@@ -58,3 +58,5 @@ data:
 kind: ConfigMap
 metadata: # kpt-merge: /workflow-controller-configmap
   name: workflow-controller-configmap
+  annotations:
+    internal.kpt.dev/upstream-identifier: '|ConfigMap|default|workflow-controller-configmap'

--- a/apps/pipeline/upstream/third-party/argo/upstream/manifests/quick-start/base/pod-manager-default-rolebinding.yaml
+++ b/apps/pipeline/upstream/third-party/argo/upstream/manifests/quick-start/base/pod-manager-default-rolebinding.yaml
@@ -2,6 +2,8 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata: # kpt-merge: /pod-manager-default
   name: pod-manager-default
+  annotations:
+    internal.kpt.dev/upstream-identifier: 'rbac.authorization.k8s.io|RoleBinding|default|pod-manager-default'
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role

--- a/apps/pipeline/upstream/third-party/argo/upstream/manifests/quick-start/base/pod-manager-role.yaml
+++ b/apps/pipeline/upstream/third-party/argo/upstream/manifests/quick-start/base/pod-manager-role.yaml
@@ -6,6 +6,7 @@ metadata: # kpt-merge: /pod-manager
     workflows.argoproj.io/description: |
       This is an example of the permissions you would need if you wanted to use a resource template to create and manage
       other pods. The same pattern would be suitable for other resurces, e.g. a service
+    internal.kpt.dev/upstream-identifier: 'rbac.authorization.k8s.io|Role|default|pod-manager'
 rules:
   - apiGroups:
       - ""

--- a/apps/pipeline/upstream/third-party/argo/upstream/manifests/quick-start/base/prometheus/prometheus-config-cluster.yaml
+++ b/apps/pipeline/upstream/third-party/argo/upstream/manifests/quick-start/base/prometheus/prometheus-config-cluster.yaml
@@ -2,6 +2,8 @@ apiVersion: v1
 kind: ConfigMap
 metadata: # kpt-merge: /prometheus-config
   name: prometheus-config
+  annotations:
+    internal.kpt.dev/upstream-identifier: '|ConfigMap|default|prometheus-config'
 data:
   prometheus.yaml: |
     global:

--- a/apps/pipeline/upstream/third-party/argo/upstream/manifests/quick-start/base/prometheus/prometheus-deployment.yaml
+++ b/apps/pipeline/upstream/third-party/argo/upstream/manifests/quick-start/base/prometheus/prometheus-deployment.yaml
@@ -10,6 +10,8 @@ apiVersion: apps/v1
 kind: Deployment
 metadata: # kpt-merge: /prometheus
   name: prometheus
+  annotations:
+    internal.kpt.dev/upstream-identifier: 'apps|Deployment|default|prometheus'
 spec:
   replicas: 1
   selector:

--- a/apps/pipeline/upstream/third-party/argo/upstream/manifests/quick-start/base/prometheus/prometheus-service.yaml
+++ b/apps/pipeline/upstream/third-party/argo/upstream/manifests/quick-start/base/prometheus/prometheus-service.yaml
@@ -2,6 +2,8 @@ apiVersion: v1
 kind: Service
 metadata: # kpt-merge: /prometheus
   name: prometheus
+  annotations:
+    internal.kpt.dev/upstream-identifier: '|Service|default|prometheus'
 spec:
   selector:
     app: prometheus

--- a/apps/pipeline/upstream/third-party/argo/upstream/manifests/quick-start/base/webhooks/argo-workflows-webhook-clients-secret.yaml
+++ b/apps/pipeline/upstream/third-party/argo/upstream/manifests/quick-start/base/webhooks/argo-workflows-webhook-clients-secret.yaml
@@ -2,6 +2,8 @@ kind: Secret
 apiVersion: v1
 metadata: # kpt-merge: /argo-workflows-webhook-clients
   name: argo-workflows-webhook-clients
+  annotations:
+    internal.kpt.dev/upstream-identifier: '|Secret|default|argo-workflows-webhook-clients'
 # The data keys must be the name of a service account.
 stringData:
   # https://support.atlassian.com/bitbucket-cloud/docs/manage-webhooks/

--- a/apps/pipeline/upstream/third-party/argo/upstream/manifests/quick-start/base/webhooks/github.com-rolebinding.yaml
+++ b/apps/pipeline/upstream/third-party/argo/upstream/manifests/quick-start/base/webhooks/github.com-rolebinding.yaml
@@ -2,6 +2,8 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata: # kpt-merge: /github.com
   name: github.com
+  annotations:
+    internal.kpt.dev/upstream-identifier: 'rbac.authorization.k8s.io|RoleBinding|default|github.com'
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role

--- a/apps/pipeline/upstream/third-party/argo/upstream/manifests/quick-start/base/webhooks/github.com-sa.yaml
+++ b/apps/pipeline/upstream/third-party/argo/upstream/manifests/quick-start/base/webhooks/github.com-sa.yaml
@@ -2,3 +2,5 @@ apiVersion: v1
 kind: ServiceAccount
 metadata: # kpt-merge: /github.com
   name: github.com
+  annotations:
+    internal.kpt.dev/upstream-identifier: '|ServiceAccount|default|github.com'

--- a/apps/pipeline/upstream/third-party/argo/upstream/manifests/quick-start/base/webhooks/submit-workflow-template-role.yaml
+++ b/apps/pipeline/upstream/third-party/argo/upstream/manifests/quick-start/base/webhooks/submit-workflow-template-role.yaml
@@ -4,6 +4,8 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata: # kpt-merge: /submit-workflow-template
   name: submit-workflow-template
+  annotations:
+    internal.kpt.dev/upstream-identifier: 'rbac.authorization.k8s.io|Role|default|submit-workflow-template'
 rules:
   - apiGroups:
       - argoproj.io

--- a/apps/pipeline/upstream/third-party/argo/upstream/manifests/quick-start/base/workflow-default-rolebinding.yaml
+++ b/apps/pipeline/upstream/third-party/argo/upstream/manifests/quick-start/base/workflow-default-rolebinding.yaml
@@ -2,6 +2,8 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata: # kpt-merge: /workflow-default-binding
   name: workflow-default-binding
+  annotations:
+    internal.kpt.dev/upstream-identifier: 'rbac.authorization.k8s.io|RoleBinding|default|workflow-default-binding'
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role

--- a/apps/pipeline/upstream/third-party/argo/upstream/manifests/quick-start/base/workflow-manager-default-rolebinding.yaml
+++ b/apps/pipeline/upstream/third-party/argo/upstream/manifests/quick-start/base/workflow-manager-default-rolebinding.yaml
@@ -2,6 +2,8 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata: # kpt-merge: /workflow-manager-default
   name: workflow-manager-default
+  annotations:
+    internal.kpt.dev/upstream-identifier: 'rbac.authorization.k8s.io|RoleBinding|default|workflow-manager-default'
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role

--- a/apps/pipeline/upstream/third-party/argo/upstream/manifests/quick-start/base/workflow-manager-role.yaml
+++ b/apps/pipeline/upstream/third-party/argo/upstream/manifests/quick-start/base/workflow-manager-role.yaml
@@ -6,6 +6,7 @@ metadata: # kpt-merge: /workflow-manager
     workflows.argoproj.io/description: |
       This is an example of the permissions you would need if you wanted to use a resource template to create and manage
       other workflows. The same pattern would be suitable for other resurces, e.g. a service
+    internal.kpt.dev/upstream-identifier: 'rbac.authorization.k8s.io|Role|default|workflow-manager'
 rules:
   - apiGroups:
       - argoproj.io

--- a/apps/pipeline/upstream/third-party/argo/upstream/manifests/quick-start/minimal/overlays/workflow-controller-configmap.yaml
+++ b/apps/pipeline/upstream/third-party/argo/upstream/manifests/quick-start/minimal/overlays/workflow-controller-configmap.yaml
@@ -7,3 +7,5 @@ data:
 kind: ConfigMap
 metadata: # kpt-merge: /workflow-controller-configmap
   name: workflow-controller-configmap
+  annotations:
+    internal.kpt.dev/upstream-identifier: '|ConfigMap|default|workflow-controller-configmap'

--- a/apps/pipeline/upstream/third-party/argo/upstream/manifests/quick-start/mysql/argo-mysql-config-secret.yaml
+++ b/apps/pipeline/upstream/third-party/argo/upstream/manifests/quick-start/mysql/argo-mysql-config-secret.yaml
@@ -7,4 +7,6 @@ metadata: # kpt-merge: /argo-mysql-config
   name: argo-mysql-config
   labels:
     app: mysql
+  annotations:
+    internal.kpt.dev/upstream-identifier: '|Secret|default|argo-mysql-config'
 type: Opaque

--- a/apps/pipeline/upstream/third-party/argo/upstream/manifests/quick-start/mysql/mysql-deployment.yaml
+++ b/apps/pipeline/upstream/third-party/argo/upstream/manifests/quick-start/mysql/mysql-deployment.yaml
@@ -4,6 +4,8 @@ metadata: # kpt-merge: /mysql
   name: mysql
   labels:
     app: mysql
+  annotations:
+    internal.kpt.dev/upstream-identifier: 'apps|Deployment|default|mysql'
 spec:
   selector:
     matchLabels:

--- a/apps/pipeline/upstream/third-party/argo/upstream/manifests/quick-start/mysql/mysql-service.yaml
+++ b/apps/pipeline/upstream/third-party/argo/upstream/manifests/quick-start/mysql/mysql-service.yaml
@@ -4,6 +4,8 @@ metadata: # kpt-merge: /mysql
   name: mysql
   labels:
     app: mysql
+  annotations:
+    internal.kpt.dev/upstream-identifier: '|Service|default|mysql'
 spec:
   selector:
     app: mysql

--- a/apps/pipeline/upstream/third-party/argo/upstream/manifests/quick-start/mysql/overlays/workflow-controller-configmap.yaml
+++ b/apps/pipeline/upstream/third-party/argo/upstream/manifests/quick-start/mysql/overlays/workflow-controller-configmap.yaml
@@ -26,3 +26,5 @@ data:
 kind: ConfigMap
 metadata: # kpt-merge: /workflow-controller-configmap
   name: workflow-controller-configmap
+  annotations:
+    internal.kpt.dev/upstream-identifier: '|ConfigMap|default|workflow-controller-configmap'

--- a/apps/pipeline/upstream/third-party/argo/upstream/manifests/quick-start/postgres/argo-postgres-config-secret.yaml
+++ b/apps/pipeline/upstream/third-party/argo/upstream/manifests/quick-start/postgres/argo-postgres-config-secret.yaml
@@ -7,4 +7,6 @@ metadata: # kpt-merge: /argo-postgres-config
   name: argo-postgres-config
   labels:
     app: postgres
+  annotations:
+    internal.kpt.dev/upstream-identifier: '|Secret|default|argo-postgres-config'
 type: Opaque

--- a/apps/pipeline/upstream/third-party/argo/upstream/manifests/quick-start/postgres/overlays/workflow-controller-configmap.yaml
+++ b/apps/pipeline/upstream/third-party/argo/upstream/manifests/quick-start/postgres/overlays/workflow-controller-configmap.yaml
@@ -26,3 +26,5 @@ data:
 kind: ConfigMap
 metadata: # kpt-merge: /workflow-controller-configmap
   name: workflow-controller-configmap
+  annotations:
+    internal.kpt.dev/upstream-identifier: '|ConfigMap|default|workflow-controller-configmap'

--- a/apps/pipeline/upstream/third-party/argo/upstream/manifests/quick-start/postgres/postgres-deployment.yaml
+++ b/apps/pipeline/upstream/third-party/argo/upstream/manifests/quick-start/postgres/postgres-deployment.yaml
@@ -4,6 +4,8 @@ metadata: # kpt-merge: /postgres
   name: postgres
   labels:
     app: postgres
+  annotations:
+    internal.kpt.dev/upstream-identifier: 'apps|Deployment|default|postgres'
 spec:
   selector:
     matchLabels:

--- a/apps/pipeline/upstream/third-party/argo/upstream/manifests/quick-start/postgres/postgres-service.yaml
+++ b/apps/pipeline/upstream/third-party/argo/upstream/manifests/quick-start/postgres/postgres-service.yaml
@@ -4,6 +4,8 @@ metadata: # kpt-merge: /postgres
   name: postgres
   labels:
     app: postgres
+  annotations:
+    internal.kpt.dev/upstream-identifier: '|Service|default|postgres'
 spec:
   selector:
     app: postgres

--- a/apps/pipeline/upstream/third-party/argo/upstream/manifests/quick-start/sso/dex/dev-svc.yaml
+++ b/apps/pipeline/upstream/third-party/argo/upstream/manifests/quick-start/sso/dex/dev-svc.yaml
@@ -2,6 +2,8 @@ apiVersion: v1
 kind: Service
 metadata: # kpt-merge: /dex
   name: dex
+  annotations:
+    internal.kpt.dev/upstream-identifier: '|Service|default|dex'
 spec:
   ports:
   - name: http

--- a/apps/pipeline/upstream/third-party/argo/upstream/manifests/quick-start/sso/dex/dex-cm.yaml
+++ b/apps/pipeline/upstream/third-party/argo/upstream/manifests/quick-start/sso/dex/dex-cm.yaml
@@ -32,3 +32,5 @@ data:
 kind: ConfigMap
 metadata: # kpt-merge: /dex
   name: dex
+  annotations:
+    internal.kpt.dev/upstream-identifier: '|ConfigMap|default|dex'

--- a/apps/pipeline/upstream/third-party/argo/upstream/manifests/quick-start/sso/dex/dex-deploy.yaml
+++ b/apps/pipeline/upstream/third-party/argo/upstream/manifests/quick-start/sso/dex/dex-deploy.yaml
@@ -4,6 +4,8 @@ metadata: # kpt-merge: /dex
   labels:
     app: dex
   name: dex
+  annotations:
+    internal.kpt.dev/upstream-identifier: 'apps|Deployment|default|dex'
 spec:
   selector:
     matchLabels:

--- a/apps/pipeline/upstream/third-party/argo/upstream/manifests/quick-start/sso/dex/dex-rb.yaml
+++ b/apps/pipeline/upstream/third-party/argo/upstream/manifests/quick-start/sso/dex/dex-rb.yaml
@@ -2,6 +2,8 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata: # kpt-merge: /dex
   name: dex
+  annotations:
+    internal.kpt.dev/upstream-identifier: 'rbac.authorization.k8s.io|RoleBinding|default|dex'
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role

--- a/apps/pipeline/upstream/third-party/argo/upstream/manifests/quick-start/sso/dex/dex-role.yaml
+++ b/apps/pipeline/upstream/third-party/argo/upstream/manifests/quick-start/sso/dex/dex-role.yaml
@@ -2,6 +2,8 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata: # kpt-merge: /dex
   name: dex
+  annotations:
+    internal.kpt.dev/upstream-identifier: 'rbac.authorization.k8s.io|Role|default|dex'
 rules:
 - apiGroups:
   - ""

--- a/apps/pipeline/upstream/third-party/argo/upstream/manifests/quick-start/sso/dex/dex-sa.yaml
+++ b/apps/pipeline/upstream/third-party/argo/upstream/manifests/quick-start/sso/dex/dex-sa.yaml
@@ -2,3 +2,5 @@ apiVersion: v1
 kind: ServiceAccount
 metadata: # kpt-merge: /dex
   name: dex
+  annotations:
+    internal.kpt.dev/upstream-identifier: '|ServiceAccount|default|dex'

--- a/apps/pipeline/upstream/third-party/argo/upstream/manifests/quick-start/sso/overlays/argo-server-sa.yaml
+++ b/apps/pipeline/upstream/third-party/argo/upstream/manifests/quick-start/sso/overlays/argo-server-sa.yaml
@@ -5,3 +5,4 @@ metadata: # kpt-merge: /argo-server
   annotations:
     workflows.argoproj.io/rbac-rule: "'authors' in groups && email == 'kilgore@kilgore.trout'"
     workflows.argoproj.io/rbac-rule-precedence: "1"
+    internal.kpt.dev/upstream-identifier: '|ServiceAccount|default|argo-server'

--- a/apps/pipeline/upstream/third-party/argo/upstream/manifests/quick-start/sso/overlays/workflow-controller-configmap.yaml
+++ b/apps/pipeline/upstream/third-party/argo/upstream/manifests/quick-start/sso/overlays/workflow-controller-configmap.yaml
@@ -19,3 +19,5 @@ data:
 kind: ConfigMap
 metadata: # kpt-merge: /workflow-controller-configmap
   name: workflow-controller-configmap
+  annotations:
+    internal.kpt.dev/upstream-identifier: '|ConfigMap|default|workflow-controller-configmap'


### PR DESCRIPTION
Sync kubeflow/pipelines tag 2.0.1 manifests.

WG leads @zijianjoy @chensun @kubeflow/wg-pipeline-leads 
WG liaison @Davidnet 
cc: @annajung @jbottum 