### PR TITLE
change the default istio-ingressgateway service to use NodePort

### DIFF
--- a/common/istio-1-17/istio-install/base/patches/service.yaml
+++ b/common/istio-1-17/istio-install/base/patches/service.yaml
@@ -4,4 +4,4 @@ metadata:
   name: istio-ingressgateway
   namespace: istio-system
 spec:
-  type: ClusterIP
+  type: NodePort


### PR DESCRIPTION
Patch for issue #2518 to allow istio-ingressgateway service to have NodePort be default
