### PR TITLE
chore: replace arrikto/kubeflow container registry with kubeflowmanifestswg

### DIFF
--- a/common/oidc-client/oidc-authservice/base/kustomization.yaml
+++ b/common/oidc-client/oidc-authservice/base/kustomization.yaml
@@ -43,5 +43,5 @@ configurations:
   - params.yaml
 images:
   - name: gcr.io/arrikto/kubeflow/oidc-authservice
-    newName: gcr.io/arrikto/kubeflow/oidc-authservice
+    newName: docker.io/kubeflowmanifestswg/oidc-authservice
     newTag: e236439


### PR DESCRIPTION
Use the kubeflow manifests WG mirrored container images for pulling oidc-authservice.

**Which issue is resolved by this Pull Request:**
Part of #2469

**Description of your changes:**
Mirrored the `gcr.io/arrikto/kubeflow/oidc-authservice:e236439` over to `docker.io/kubeflowmanifestswg/oidc-authservice:e236439`

cc: @kimwnasptd @annajung 