### PR TITLE
Add tests for rootless containers

### DIFF
--- a/tests/README.md
+++ b/tests/README.md
@@ -15,8 +15,6 @@ included in the tests.
 
 ### Test Suite
 
-**To use KFserving v0.5/0.6 instead of KServe v0.7, comment the 6,7th lines and uncomment the 10,11th lines here [e2e/utils/kserve.py](https://github.com/kubeflow/manifests/compare/master/tests/e2e/utils/kserve.py#L6-L11)**
-
 The e2e tests are completely independent of the underlying K8s cluster, as well
 as the platform of the cluster. These tests should be able to run in real
 world clusters, as well as ephemeral ones like KinD.

--- a/tests/e2e/README.md
+++ b/tests/e2e/README.md
@@ -13,7 +13,7 @@ This test is using the following Kubeflow CRDs:
 The heart of this test is the `mnist.py` python script, which applies and waits
 for the CRDs to complete. The python scripts are all expecting that
 1. `kubectl` is configured with access to a Kubeflow cluster
-2. `kustomize` 3.2.0 is available
+2. `kustomize` 5.0.3+ is available
 3. The KFP backend is proxied to localhost
 
 While the `mnist.py` is used for running the test, it is advised to use the

--- a/tests/e2e/mnist.py
+++ b/tests/e2e/mnist.py
@@ -1,8 +1,8 @@
 """E2E Kubeflow test that tesst Pipelines, Katib, TFJobs and KServe.
 
 Requires:
-pip install kfp==1.8.4
-pip install kubeflow-katib==0.12.0
+pip install kfp==1.8.22
+pip install kubeflow-katib==0.15.0
 """
 import kfp
 import kfp.dsl as dsl

--- a/tests/e2e/runasnonroot.sh
+++ b/tests/e2e/runasnonroot.sh
@@ -1,35 +1,81 @@
 #!/bin/bash
-
+# set -euxo
 namespace="kubeflow"
 error_flag=0
 
-# Get a list of pod names in the specified namespace
-pod_names=$(kubectl get pods -n $namespace -o json | jq -r '.items[].metadata.name')
-echo "Checking for root containers in namespace $namespace"
+# Function to check if 'id' command is available in a container
+has_id_command() {
+  local pod_name="$1"
+  local container_name="$2"
 
-# Loop through the pod names and execute the 'id' command within each container
+  # Execute 'id' command and capture the output
+  if kubectl exec -it -n "$namespace" "$pod_name" -c "$container_name" -- id -u >/dev/null 2>&1; then
+    return 0  # 'id' command is available
+  else
+    return 1  # 'id' command is not available
+  fi
+}
+
+# Function to check if 'runAsNonRoot' is present in the container's security context
+has_runAsNonRoot() {
+  local pod_name="$1"
+  local container_name="$2"
+
+  # Use jq to check if 'securityContext' is missing in the container's security context
+  local securityContext=$(kubectl get pod -n "$namespace" "$pod_name" -o json | jq -r '.spec.containers[] | select(.name == "'"$container_name"'").securityContext')
+  
+  if [ "$securityContext" = "null" ]; then
+    echo "Error: 'securityContext' is missing in container $container_name of pod $pod_name"
+    return 1  # 'securityContext' is missing (fail)
+  fi
+  
+  # Use jq to check if 'runAsNonRoot' is missing in the container's security context
+  local runAsNonRoot=$(kubectl get pod -n "$namespace" "$pod_name" -o json | jq -r '.spec.containers[] | select(.name == "'"$container_name"'").securityContext.runAsNonRoot // "Missing"')
+
+  if [ "$runAsNonRoot" = "Missing" ]; then
+    echo "Error: 'runAsNonRoot' is missing in container $container_name of pod $pod_name"
+    return 1  # 'runAsNonRoot' is missing (fail)
+  else
+    return 0  # 'runAsNonRoot' is present
+  fi
+}
+
+# Get a list of pod names in the specified namespace that are not in the "Completed" state
+pod_names=$(kubectl get pods -n "$namespace" --field-selector=status.phase!=Succeeded,status.phase!=Failed -o json | jq -r '.items[].metadata.name')
+
+# Loop through the pod names and execute checks
 for pod_name in $pod_names; do
   echo "Entering pod $pod_name in namespace $namespace..."
-  
-  container_names=$(kubectl get pod -n $namespace $pod_name -o json | jq -r '.spec.containers[].name')
+
+  container_names=$(kubectl get pod -n "$namespace" "$pod_name" -o json | jq -r '.spec.containers[].name')
 
   for container_name in $container_names; do
-    user_id=$(kubectl exec -it -n $namespace $pod_name -c $container_name -- id -u)
-    # echo "Container: $container_name - User ID: $user_id"
-    
-    if [ "$user_id" -eq 0 ]; then
-      echo "Error: Pod $pod_name contains user ID 0 in container $container_name"
+    if ! has_runAsNonRoot "$pod_name" "$container_name"; then
       error_flag=1
     fi
-  done
 
-  echo "-------------------------------------"
+    if has_id_command "$pod_name" "$container_name"; then
+      user_id=$(kubectl exec -it -n "$namespace" "$pod_name" -c "$container_name" -- id -u)
+      
+      # Clean up whitespace in the user_id using tr
+      user_id_cleaned=$(echo -n "$user_id" | tr -d '[:space:]')
+
+      if [ "$user_id_cleaned" = "0" ]; then
+        echo "Error: Pod $pod_name contains user ID 0 in container $container_name"
+        error_flag=1
+      else
+        echo "Container: $container_name - User ID: $user_id_cleaned"
+      fi
+    else
+      echo "Warning: 'id' command not available in container $container_name"
+    fi
+  done
 done
 
-# Exit with an error if any pod contains user ID 0
+# Exit with an error if any pod contains an error condition
 if [ $error_flag -eq 1 ]; then
   exit 1
 fi
 
-# Exit successfully if no pod contains user ID 0
+# Exit successfully
 exit 0

--- a/tests/e2e/runasnonroot.sh
+++ b/tests/e2e/runasnonroot.sh
@@ -1,0 +1,35 @@
+#!/bin/bash
+
+namespace="kubeflow"
+error_flag=0
+
+# Get a list of pod names in the specified namespace
+pod_names=$(kubectl get pods -n $namespace -o json | jq -r '.items[].metadata.name')
+echo "Checking for root containers in namespace $namespace"
+
+# Loop through the pod names and execute the 'id' command within each container
+for pod_name in $pod_names; do
+  echo "Entering pod $pod_name in namespace $namespace..."
+  
+  container_names=$(kubectl get pod -n $namespace $pod_name -o json | jq -r '.spec.containers[].name')
+
+  for container_name in $container_names; do
+    user_id=$(kubectl exec -it -n $namespace $pod_name -c $container_name -- id -u)
+    # echo "Container: $container_name - User ID: $user_id"
+    
+    if [ "$user_id" -eq 0 ]; then
+      echo "Error: Pod $pod_name contains user ID 0 in container $container_name"
+      error_flag=1
+    fi
+  done
+
+  echo "-------------------------------------"
+done
+
+# Exit with an error if any pod contains user ID 0
+if [ $error_flag -eq 1 ]; then
+  exit 1
+fi
+
+# Exit successfully if no pod contains user ID 0
+exit 0

--- a/tests/e2e/runasnonroot.sh
+++ b/tests/e2e/runasnonroot.sh
@@ -41,7 +41,7 @@ has_securityContext_and_runAsNonRoot() {
   local securityContextContainer=$(kubectl get pod -n "$namespace" "$pod_name" -o json | jq -r '.spec.containers[] | select(.name == "'"$container_name"'").securityContext')
 
   if [ "$securityContextContainer" = "null" ]; then
-    if [ "$runAsNonRootPod" = "Missing" ]; then
+    if [ "$securityContextPod" = "null" ]; then
       echo "Error: 'securityContext' is missing at the pod and container level in container $container_name of pod $pod_name"
       return 1
     else

--- a/tests/e2e/runner.sh
+++ b/tests/e2e/runner.sh
@@ -10,6 +10,8 @@ echo "Setting up port-forward..."
 
 echo "Running the tests."""
 python3 mnist.py
+# runasnonroot.sh
+
 
 echo "Cleaning up opened processes."""
 ./hack/cleanup_proxies.sh

--- a/tests/e2e/utils/kserve.py
+++ b/tests/e2e/utils/kserve.py
@@ -1,15 +1,8 @@
 from kfp import components
 
-
 def create_serving_task(model_name, model_namespace, tfjob_op, model_volume_op):
-
     api_version = 'serving.kserve.io/v1beta1'
     serving_component_url = 'https://raw.githubusercontent.com/kubeflow/pipelines/master/components/kserve/component.yaml'
-
-    # Uncomment the following two lines if you are using KFServing v0.6.x or v0.5.x
-    # api_version = 'serving.kubeflow.org/v1beta1'
-    # serving_component_url = 'https://raw.githubusercontent.com/kubeflow/pipelines/master/components/kubeflow/kfserving/component.yaml'
-
     inference_service = '''
 apiVersion: "{}"
 kind: "InferenceService"


### PR DESCRIPTION
**Which issue is resolved by this Pull Request:**
We need to list all containers that do not have runasnonroot set or run as the root user. Based on this list i can create per workinggroup patches and at some point we can just enable the test in the e2e pipeline.

**Description of your changes:**
Adding tests to warn and later on error on root containers in the cicd.
