### PR TITLE
Update kubeflow/pipelines manifests from 2.0.3

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ This repo periodically syncs all official Kubeflow components from their respect
 | Katib | apps/katib/upstream | [v0.16.0-rc.1](https://github.com/kubeflow/katib/tree/v0.16.0-rc.1/manifests/v1beta1) |
 | KServe | contrib/kserve/kserve | [v0.11.1](https://github.com/kserve/kserve/tree/v0.11.1/install/v0.11.1) |
 | KServe Models Web App | contrib/kserve/models-web-app | [v0.10.0](https://github.com/kserve/models-web-app/tree/v0.10.0/config) |
-| Kubeflow Pipelines | apps/pipeline/upstream | [2.0.2](https://github.com/kubeflow/pipelines/tree/2.0.2/manifests/kustomize) |
+| Kubeflow Pipelines | apps/pipeline/upstream | [2.0.3](https://github.com/kubeflow/pipelines/tree/2.0.3/manifests/kustomize) |
 | Kubeflow Tekton Pipelines | apps/kfp-tekton/upstream | [2.0.1](https://github.com/kubeflow/kfp-tekton/tree/2.0.x/manifests/kustomize) |
 =======
 

--- a/apps/pipeline/upstream/base/cache-deployer/kustomization.yaml
+++ b/apps/pipeline/upstream/base/cache-deployer/kustomization.yaml
@@ -8,4 +8,4 @@ commonLabels:
   app: cache-deployer
 images:
   - name: gcr.io/ml-pipeline/cache-deployer
-    newTag: 2.0.2
+    newTag: 2.0.3

--- a/apps/pipeline/upstream/base/cache/kustomization.yaml
+++ b/apps/pipeline/upstream/base/cache/kustomization.yaml
@@ -10,4 +10,4 @@ commonLabels:
   app: cache-server
 images:
   - name: gcr.io/ml-pipeline/cache-server
-    newTag: 2.0.2
+    newTag: 2.0.3

--- a/apps/pipeline/upstream/base/installs/generic/pipeline-install-config.yaml
+++ b/apps/pipeline/upstream/base/installs/generic/pipeline-install-config.yaml
@@ -11,7 +11,7 @@ data:
     until the changes take effect. A quick way to restart all deployments in a
     namespace: `kubectl rollout restart deployment -n <your-namespace>`.
   appName: pipeline
-  appVersion: 2.0.2
+  appVersion: 2.0.3
   dbHost: mysql # relic to be removed after release
   dbPort: "3306" # relic to be removed after release
   dbType: mysql

--- a/apps/pipeline/upstream/base/installs/generic/postgres/pipeline-install-config.yaml
+++ b/apps/pipeline/upstream/base/installs/generic/postgres/pipeline-install-config.yaml
@@ -14,7 +14,7 @@ data:
   appVersion: 2.0.0
   dbHost: postgres  # relic to be removed after release
   dbPort: "5432"    # relic to be removed after release
-  dbType: postgres
+  dbType: postgres  
   postgresHost: postgres
   postgresPort: "5432"
   mlmdDb: metadb

--- a/apps/pipeline/upstream/base/metadata/base/kustomization.yaml
+++ b/apps/pipeline/upstream/base/metadata/base/kustomization.yaml
@@ -9,4 +9,4 @@ resources:
   - metadata-grpc-sa.yaml
 images:
   - name: gcr.io/ml-pipeline/metadata-envoy
-    newTag: 2.0.2
+    newTag: 2.0.3

--- a/apps/pipeline/upstream/base/pipeline/kustomization.yaml
+++ b/apps/pipeline/upstream/base/pipeline/kustomization.yaml
@@ -37,14 +37,14 @@ resources:
   - kfp-launcher-configmap.yaml
 images:
   - name: gcr.io/ml-pipeline/api-server
-    newTag: 2.0.2
+    newTag: 2.0.3
   - name: gcr.io/ml-pipeline/persistenceagent
-    newTag: 2.0.2
+    newTag: 2.0.3
   - name: gcr.io/ml-pipeline/scheduledworkflow
-    newTag: 2.0.2
+    newTag: 2.0.3
   - name: gcr.io/ml-pipeline/frontend
-    newTag: 2.0.2
+    newTag: 2.0.3
   - name: gcr.io/ml-pipeline/viewer-crd-controller
-    newTag: 2.0.2
+    newTag: 2.0.3
   - name: gcr.io/ml-pipeline/visualization-server
-    newTag: 2.0.2
+    newTag: 2.0.3

--- a/apps/pipeline/upstream/base/pipeline/metadata-writer/kustomization.yaml
+++ b/apps/pipeline/upstream/base/pipeline/metadata-writer/kustomization.yaml
@@ -7,4 +7,4 @@ resources:
   - metadata-writer-sa.yaml
 images:
   - name: gcr.io/ml-pipeline/metadata-writer
-    newTag: 2.0.2
+    newTag: 2.0.3

--- a/apps/pipeline/upstream/env/gcp/inverse-proxy/kustomization.yaml
+++ b/apps/pipeline/upstream/env/gcp/inverse-proxy/kustomization.yaml
@@ -2,7 +2,7 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 images:
   - name: gcr.io/ml-pipeline/inverse-proxy-agent
-    newTag: 2.0.2
+    newTag: 2.0.3
 resources:
   - proxy-configmap.yaml
   - proxy-deployment.yaml


### PR DESCRIPTION
Sync kubeflow/pipelines tag 2.0.3 manifests.

WG leads @chensun @kubeflow/wg-pipeline-leads 
WG liaison @Davidnet
cc: @annajung @jbottum

