### PR TITLE
Update kubeflow/kubeflow manifests from v1.8.0-rc.6

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,15 +45,15 @@ This repo periodically syncs all official Kubeflow components from their respect
 | Component | Local Manifests Path | Upstream Revision |
 | - | - | - |
 | Training Operator | apps/training-operator/upstream | [v1.7.0-rc.0](https://github.com/kubeflow/training-operator/tree/v1.7.0-rc.0/manifests) |
-| Notebook Controller | apps/jupyter/notebook-controller/upstream | [v1.8.0-rc.5](https://github.com/kubeflow/kubeflow/tree/v1.8.0-rc.5/components/notebook-controller/config) |
-| PVC Viewer Controller | apps/pvcviewer-roller/upstream | [v1.8.0-rc.5](https://github.com/kubeflow/kubeflow/tree/v1.8.0-rc.5/components/pvcviewer-controller/config) |
-| Tensorboard Controller | apps/tensorboard/tensorboard-controller/upstream | [v1.8.0-rc.5](https://github.com/kubeflow/kubeflow/tree/v1.8.0-rc.5/components/tensorboard-controller/config) |
-| Central Dashboard | apps/centraldashboard/upstream | [v1.8.0-rc.5](https://github.com/kubeflow/kubeflow/tree/v1.8.0-rc.5/components/centraldashboard/manifests) |
-| Profiles + KFAM | apps/profiles/upstream | [v1.8.0-rc.5](https://github.com/kubeflow/kubeflow/tree/v1.8.0-rc.5/components/profile-controller/config) |
-| PodDefaults Webhook | apps/admission-webhook/upstream | [v1.8.0-rc.5](https://github.com/kubeflow/kubeflow/tree/v1.8.0-rc.5/components/admission-webhook/manifests) |
-| Jupyter Web App | apps/jupyter/jupyter-web-app/upstream | [v1.8.0-rc.5](https://github.com/kubeflow/kubeflow/tree/v1.8.0-rc.5/components/crud-web-apps/jupyter/manifests) |
-| Tensorboards Web App | apps/tensorboard/tensorboards-web-app/upstream | [v1.8.0-rc.5](https://github.com/kubeflow/kubeflow/tree/v1.8.0-rc.5/components/crud-web-apps/tensorboards/manifests) |
-| Volumes Web App | apps/volumes-web-app/upstream | [v1.8.0-rc.5](https://github.com/kubeflow/kubeflow/tree/v1.8.0-rc.5/components/crud-web-apps/volumes/manifests) |
+| Notebook Controller | apps/jupyter/notebook-controller/upstream | [v1.8.0-rc.6](https://github.com/kubeflow/kubeflow/tree/v1.8.0-rc.6/components/notebook-controller/config) |
+| PVC Viewer Controller | apps/pvcviewer-roller/upstream | [v1.8.0-rc.6](https://github.com/kubeflow/kubeflow/tree/v1.8.0-rc.6/components/pvcviewer-controller/config) |
+| Tensorboard Controller | apps/tensorboard/tensorboard-controller/upstream | [v1.8.0-rc.6](https://github.com/kubeflow/kubeflow/tree/v1.8.0-rc.6/components/tensorboard-controller/config) |
+| Central Dashboard | apps/centraldashboard/upstream | [v1.8.0-rc.6](https://github.com/kubeflow/kubeflow/tree/v1.8.0-rc.6/components/centraldashboard/manifests) |
+| Profiles + KFAM | apps/profiles/upstream | [v1.8.0-rc.6](https://github.com/kubeflow/kubeflow/tree/v1.8.0-rc.6/components/profile-controller/config) |
+| PodDefaults Webhook | apps/admission-webhook/upstream | [v1.8.0-rc.6](https://github.com/kubeflow/kubeflow/tree/v1.8.0-rc.6/components/admission-webhook/manifests) |
+| Jupyter Web App | apps/jupyter/jupyter-web-app/upstream | [v1.8.0-rc.6](https://github.com/kubeflow/kubeflow/tree/v1.8.0-rc.6/components/crud-web-apps/jupyter/manifests) |
+| Tensorboards Web App | apps/tensorboard/tensorboards-web-app/upstream | [v1.8.0-rc.6](https://github.com/kubeflow/kubeflow/tree/v1.8.0-rc.6/components/crud-web-apps/tensorboards/manifests) |
+| Volumes Web App | apps/volumes-web-app/upstream | [v1.8.0-rc.6](https://github.com/kubeflow/kubeflow/tree/v1.8.0-rc.6/components/crud-web-apps/volumes/manifests) |
 | Katib | apps/katib/upstream | [v0.16.0-rc.1](https://github.com/kubeflow/katib/tree/v0.16.0-rc.1/manifests/v1beta1) |
 | KServe | contrib/kserve/kserve | [v0.11.1](https://github.com/kserve/kserve/tree/v0.11.1/install/v0.11.1) |
 | KServe Models Web App | contrib/kserve/models-web-app | [v0.10.0](https://github.com/kserve/models-web-app/tree/v0.10.0/config) |

--- a/apps/admission-webhook/upstream/base/kustomization.yaml
+++ b/apps/admission-webhook/upstream/base/kustomization.yaml
@@ -16,7 +16,7 @@ commonLabels:
 images:
 - name: docker.io/kubeflownotebookswg/poddefaults-webhook
   newName: docker.io/kubeflownotebookswg/poddefaults-webhook
-  newTag: v1.8.0-rc.5
+  newTag: v1.8.0-rc.6
 namespace: kubeflow
 generatorOptions:
   disableNameSuffixHash: true

--- a/apps/centraldashboard/upstream/base/kustomization.yaml
+++ b/apps/centraldashboard/upstream/base/kustomization.yaml
@@ -18,7 +18,7 @@ commonLabels:
 images:
 - name: docker.io/kubeflownotebookswg/centraldashboard
   newName: docker.io/kubeflownotebookswg/centraldashboard
-  newTag: v1.8.0-rc.5
+  newTag: v1.8.0-rc.6
 configMapGenerator:
 - envs:
   - params.env

--- a/apps/jupyter/jupyter-web-app/upstream/base/configs/spawner_ui_config.yaml
+++ b/apps/jupyter/jupyter-web-app/upstream/base/configs/spawner_ui_config.yaml
@@ -37,15 +37,15 @@ spawnerFormDefaults:
   ################################################################
   image:
     # the default container image
-    value: kubeflownotebookswg/jupyter-scipy:v1.8.0-rc.5
+    value: kubeflownotebookswg/jupyter-scipy:v1.8.0-rc.6
 
     # the list of available container images in the dropdown
     options:
-    - kubeflownotebookswg/jupyter-scipy:v1.8.0-rc.5
-    - kubeflownotebookswg/jupyter-pytorch-full:v1.8.0-rc.5
-    - kubeflownotebookswg/jupyter-pytorch-cuda-full:v1.8.0-rc.5
-    - kubeflownotebookswg/jupyter-tensorflow-full:v1.8.0-rc.5
-    - kubeflownotebookswg/jupyter-tensorflow-cuda-full:v1.8.0-rc.5
+    - kubeflownotebookswg/jupyter-scipy:v1.8.0-rc.6
+    - kubeflownotebookswg/jupyter-pytorch-full:v1.8.0-rc.6
+    - kubeflownotebookswg/jupyter-pytorch-cuda-full:v1.8.0-rc.6
+    - kubeflownotebookswg/jupyter-tensorflow-full:v1.8.0-rc.6
+    - kubeflownotebookswg/jupyter-tensorflow-cuda-full:v1.8.0-rc.6
 
   ################################################################
   # VSCode-like Container Images (Group 1)
@@ -60,11 +60,11 @@ spawnerFormDefaults:
   ################################################################
   imageGroupOne:
     # the default container image
-    value: kubeflownotebookswg/codeserver-python:v1.8.0-rc.5
+    value: kubeflownotebookswg/codeserver-python:v1.8.0-rc.6
 
     # the list of available container images in the dropdown
     options:
-    - kubeflownotebookswg/codeserver-python:v1.8.0-rc.5
+    - kubeflownotebookswg/codeserver-python:v1.8.0-rc.6
 
   ################################################################
   # RStudio-like Container Images (Group 2)
@@ -81,11 +81,11 @@ spawnerFormDefaults:
   ################################################################
   imageGroupTwo:
     # the default container image
-    value: kubeflownotebookswg/rstudio-tidyverse:v1.8.0-rc.5
+    value: kubeflownotebookswg/rstudio-tidyverse:v1.8.0-rc.6
 
     # the list of available container images in the dropdown
     options:
-    - kubeflownotebookswg/rstudio-tidyverse:v1.8.0-rc.5
+    - kubeflownotebookswg/rstudio-tidyverse:v1.8.0-rc.6
 
   ################################################################
   # CPU Resources

--- a/apps/jupyter/jupyter-web-app/upstream/base/kustomization.yaml
+++ b/apps/jupyter/jupyter-web-app/upstream/base/kustomization.yaml
@@ -23,7 +23,7 @@ commonLabels:
 images:
 - name: docker.io/kubeflownotebookswg/jupyter-web-app
   newName: docker.io/kubeflownotebookswg/jupyter-web-app
-  newTag: v1.8.0-rc.5
+  newTag: v1.8.0-rc.6
 # We need the name to be unique without the suffix because the original name is what
 # gets used with patches
 configMapGenerator:

--- a/apps/jupyter/notebook-controller/upstream/base/kustomization.yaml
+++ b/apps/jupyter/notebook-controller/upstream/base/kustomization.yaml
@@ -5,4 +5,4 @@ resources:
 images:
 - name: docker.io/kubeflownotebookswg/notebook-controller
   newName: docker.io/kubeflownotebookswg/notebook-controller
-  newTag: v1.8.0-rc.5
+  newTag: v1.8.0-rc.6

--- a/apps/profiles/upstream/base/kustomization.yaml
+++ b/apps/profiles/upstream/base/kustomization.yaml
@@ -12,7 +12,7 @@ patchesStrategicMerge:
 images:
 - name: docker.io/kubeflownotebookswg/profile-controller
   newName: docker.io/kubeflownotebookswg/profile-controller
-  newTag: v1.8.0-rc.5
+  newTag: v1.8.0-rc.6
 
 configMapGenerator:
 - name: namespace-labels-data

--- a/apps/profiles/upstream/overlays/kubeflow/kustomization.yaml
+++ b/apps/profiles/upstream/overlays/kubeflow/kustomization.yaml
@@ -29,4 +29,4 @@ vars:
 images:
 - name: docker.io/kubeflownotebookswg/kfam
   newName: docker.io/kubeflownotebookswg/kfam
-  newTag: v1.8.0-rc.5
+  newTag: v1.8.0-rc.6

--- a/apps/pvcviewer-controller/upstream/base/kustomization.yaml
+++ b/apps/pvcviewer-controller/upstream/base/kustomization.yaml
@@ -6,4 +6,4 @@ resources:
 images:
 - name: docker.io/kubeflownotebookswg/pvcviewer-controller
   newName: docker.io/kubeflownotebookswg/pvcviewer-controller
-  newTag: v1.8.0-rc.5
+  newTag: v1.8.0-rc.6

--- a/apps/tensorboard/tensorboard-controller/upstream/base/kustomization.yaml
+++ b/apps/tensorboard/tensorboard-controller/upstream/base/kustomization.yaml
@@ -13,4 +13,4 @@ patchesStrategicMerge:
 images:
 - name: docker.io/kubeflownotebookswg/tensorboard-controller
   newName: docker.io/kubeflownotebookswg/tensorboard-controller
-  newTag: v1.8.0-rc.5
+  newTag: v1.8.0-rc.6

--- a/apps/tensorboard/tensorboards-web-app/upstream/base/kustomization.yaml
+++ b/apps/tensorboard/tensorboards-web-app/upstream/base/kustomization.yaml
@@ -14,7 +14,7 @@ commonLabels:
 images:
 - name: docker.io/kubeflownotebookswg/tensorboards-web-app
   newName: docker.io/kubeflownotebookswg/tensorboards-web-app
-  newTag: v1.8.0-rc.5
+  newTag: v1.8.0-rc.6
 # We need the name to be unique without the suffix because the original name is what
 # gets used with patches
 configMapGenerator:

--- a/apps/volumes-web-app/upstream/base/kustomization.yaml
+++ b/apps/volumes-web-app/upstream/base/kustomization.yaml
@@ -14,7 +14,7 @@ commonLabels:
 images:
 - name: docker.io/kubeflownotebookswg/volumes-web-app
   newName: docker.io/kubeflownotebookswg/volumes-web-app
-  newTag: v1.8.0-rc.5
+  newTag: v1.8.0-rc.6
 # We need the name to be unique without the suffix because the original name is what
 # gets used with patches
 configMapGenerator:


### PR DESCRIPTION
Sync kubeflow/kubeflow tag v1.8.0-rc.6 manifests.

WG leads @kimwnasptd @thesuperzapper @kubeflow/wg-notebooks-leads 
cc: @annajung @jbottum
