### PR TITLE
Update kubeflow/katib manifests from v0.16.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ This repo periodically syncs all official Kubeflow components from their respect
 | Jupyter Web App | apps/jupyter/jupyter-web-app/upstream | [v1.8.0-rc.5](https://github.com/kubeflow/kubeflow/tree/v1.8.0-rc.5/components/crud-web-apps/jupyter/manifests) |
 | Tensorboards Web App | apps/tensorboard/tensorboards-web-app/upstream | [v1.8.0-rc.5](https://github.com/kubeflow/kubeflow/tree/v1.8.0-rc.5/components/crud-web-apps/tensorboards/manifests) |
 | Volumes Web App | apps/volumes-web-app/upstream | [v1.8.0-rc.5](https://github.com/kubeflow/kubeflow/tree/v1.8.0-rc.5/components/crud-web-apps/volumes/manifests) |
-| Katib | apps/katib/upstream | [v0.16.0-rc.1](https://github.com/kubeflow/katib/tree/v0.16.0-rc.1/manifests/v1beta1) |
+| Katib | apps/katib/upstream | [v0.16.0](https://github.com/kubeflow/katib/tree/v0.16.0/manifests/v1beta1) |
 | KServe | contrib/kserve/kserve | [v0.11.1](https://github.com/kserve/kserve/tree/v0.11.1/install/v0.11.1) |
 | KServe Models Web App | contrib/kserve/models-web-app | [v0.10.0](https://github.com/kserve/models-web-app/tree/v0.10.0/config) |
 | Kubeflow Pipelines | apps/pipeline/upstream | [2.0.3](https://github.com/kubeflow/pipelines/tree/2.0.3/manifests/kustomize) |

--- a/apps/katib/upstream/components/controller/trial-templates.yaml
+++ b/apps/katib/upstream/components/controller/trial-templates.yaml
@@ -15,7 +15,7 @@ data:
         spec:
           containers:
             - name: training-container
-              image: docker.io/kubeflowkatib/mxnet-mnist:v0.16.0-rc.1
+              image: docker.io/kubeflowkatib/mxnet-mnist:v0.16.0
               command:
                 - "python3"
                 - "/opt/mxnet-mnist/mnist.py"
@@ -33,7 +33,7 @@ data:
         spec:
           containers:
             - name: training-container
-              image: docker.io/kubeflowkatib/enas-cnn-cifar10-cpu:v0.16.0-rc.1
+              image: docker.io/kubeflowkatib/enas-cnn-cifar10-cpu:v0.16.0
               command:
                 - python3
                 - -u
@@ -54,7 +54,7 @@ data:
             spec:
               containers:
                 - name: pytorch
-                  image: docker.io/kubeflowkatib/pytorch-mnist-cpu:v0.16.0-rc.1
+                  image: docker.io/kubeflowkatib/pytorch-mnist-cpu:v0.16.0
                   command:
                     - "python3"
                     - "/opt/pytorch-mnist/mnist.py"
@@ -68,7 +68,7 @@ data:
             spec:
               containers:
                 - name: pytorch
-                  image: docker.io/kubeflowkatib/pytorch-mnist-cpu:v0.16.0-rc.1
+                  image: docker.io/kubeflowkatib/pytorch-mnist-cpu:v0.16.0
                   command:
                     - "python3"
                     - "/opt/pytorch-mnist/mnist.py"

--- a/apps/katib/upstream/installs/katib-cert-manager/katib-config.yaml
+++ b/apps/katib/upstream/installs/katib-cert-manager/katib-config.yaml
@@ -14,40 +14,40 @@ init:
 runtime:
   metricsCollectors:
     - kind: StdOut
-      image: docker.io/kubeflowkatib/file-metrics-collector:v0.16.0-rc.1
+      image: docker.io/kubeflowkatib/file-metrics-collector:v0.16.0
     - kind: File
-      image: docker.io/kubeflowkatib/file-metrics-collector:v0.16.0-rc.1
+      image: docker.io/kubeflowkatib/file-metrics-collector:v0.16.0
     - kind: TensorFlowEvent
-      image: docker.io/kubeflowkatib/tfevent-metrics-collector:v0.16.0-rc.1
+      image: docker.io/kubeflowkatib/tfevent-metrics-collector:v0.16.0
       resources:
         limits:
           memory: 1Gi
   suggestions:
     - algorithmName: random
-      image: docker.io/kubeflowkatib/suggestion-hyperopt:v0.16.0-rc.1
+      image: docker.io/kubeflowkatib/suggestion-hyperopt:v0.16.0
     - algorithmName: tpe
-      image: docker.io/kubeflowkatib/suggestion-hyperopt:v0.16.0-rc.1
+      image: docker.io/kubeflowkatib/suggestion-hyperopt:v0.16.0
     - algorithmName: grid
-      image: docker.io/kubeflowkatib/suggestion-optuna:v0.16.0-rc.1
+      image: docker.io/kubeflowkatib/suggestion-optuna:v0.16.0
     - algorithmName: hyperband
-      image: docker.io/kubeflowkatib/suggestion-hyperband:v0.16.0-rc.1
+      image: docker.io/kubeflowkatib/suggestion-hyperband:v0.16.0
     - algorithmName: bayesianoptimization
-      image: docker.io/kubeflowkatib/suggestion-skopt:v0.16.0-rc.1
+      image: docker.io/kubeflowkatib/suggestion-skopt:v0.16.0
     - algorithmName: cmaes
-      image: docker.io/kubeflowkatib/suggestion-goptuna:v0.16.0-rc.1
+      image: docker.io/kubeflowkatib/suggestion-goptuna:v0.16.0
     - algorithmName: sobol
-      image: docker.io/kubeflowkatib/suggestion-goptuna:v0.16.0-rc.1
+      image: docker.io/kubeflowkatib/suggestion-goptuna:v0.16.0
     - algorithmName: multivariate-tpe
-      image: docker.io/kubeflowkatib/suggestion-optuna:v0.16.0-rc.1
+      image: docker.io/kubeflowkatib/suggestion-optuna:v0.16.0
     - algorithmName: enas
-      image: docker.io/kubeflowkatib/suggestion-enas:v0.16.0-rc.1
+      image: docker.io/kubeflowkatib/suggestion-enas:v0.16.0
       resources:
         limits:
           memory: 200Mi
     - algorithmName: darts
-      image: docker.io/kubeflowkatib/suggestion-darts:v0.16.0-rc.1
+      image: docker.io/kubeflowkatib/suggestion-darts:v0.16.0
     - algorithmName: pbt
-      image: docker.io/kubeflowkatib/suggestion-pbt:v0.16.0-rc.1
+      image: docker.io/kubeflowkatib/suggestion-pbt:v0.16.0
       persistentVolumeClaimSpec:
         accessModes:
           - ReadWriteMany
@@ -56,4 +56,4 @@ runtime:
             storage: 5Gi
   earlyStoppings:
     - algorithmName: medianstop
-      image: docker.io/kubeflowkatib/earlystopping-medianstop:v0.16.0-rc.1
+      image: docker.io/kubeflowkatib/earlystopping-medianstop:v0.16.0

--- a/apps/katib/upstream/installs/katib-cert-manager/kustomization.yaml
+++ b/apps/katib/upstream/installs/katib-cert-manager/kustomization.yaml
@@ -22,13 +22,13 @@ resources:
 images:
   - name: docker.io/kubeflowkatib/katib-controller
     newName: docker.io/kubeflowkatib/katib-controller
-    newTag: v0.16.0-rc.1
+    newTag: v0.16.0
   - name: docker.io/kubeflowkatib/katib-db-manager
     newName: docker.io/kubeflowkatib/katib-db-manager
-    newTag: v0.16.0-rc.1
+    newTag: v0.16.0
   - name: docker.io/kubeflowkatib/katib-ui
     newName: docker.io/kubeflowkatib/katib-ui
-    newTag: v0.16.0-rc.1
+    newTag: v0.16.0
 
 patchesStrategicMerge:
   - patches/katib-cert-injection.yaml

--- a/apps/katib/upstream/installs/katib-external-db/katib-config.yaml
+++ b/apps/katib/upstream/installs/katib-external-db/katib-config.yaml
@@ -16,40 +16,40 @@ init:
 runtime:
   metricsCollectors:
     - kind: StdOut
-      image: docker.io/kubeflowkatib/file-metrics-collector:v0.16.0-rc.1
+      image: docker.io/kubeflowkatib/file-metrics-collector:v0.16.0
     - kind: File
-      image: docker.io/kubeflowkatib/file-metrics-collector:v0.16.0-rc.1
+      image: docker.io/kubeflowkatib/file-metrics-collector:v0.16.0
     - kind: TensorFlowEvent
-      image: docker.io/kubeflowkatib/tfevent-metrics-collector:v0.16.0-rc.1
+      image: docker.io/kubeflowkatib/tfevent-metrics-collector:v0.16.0
       resources:
         limits:
           memory: 1Gi
   suggestions:
     - algorithmName: random
-      image: docker.io/kubeflowkatib/suggestion-hyperopt:v0.16.0-rc.1
+      image: docker.io/kubeflowkatib/suggestion-hyperopt:v0.16.0
     - algorithmName: tpe
-      image: docker.io/kubeflowkatib/suggestion-hyperopt:v0.16.0-rc.1
+      image: docker.io/kubeflowkatib/suggestion-hyperopt:v0.16.0
     - algorithmName: grid
-      image: docker.io/kubeflowkatib/suggestion-optuna:v0.16.0-rc.1
+      image: docker.io/kubeflowkatib/suggestion-optuna:v0.16.0
     - algorithmName: hyperband
-      image: docker.io/kubeflowkatib/suggestion-hyperband:v0.16.0-rc.1
+      image: docker.io/kubeflowkatib/suggestion-hyperband:v0.16.0
     - algorithmName: bayesianoptimization
-      image: docker.io/kubeflowkatib/suggestion-skopt:v0.16.0-rc.1
+      image: docker.io/kubeflowkatib/suggestion-skopt:v0.16.0
     - algorithmName: cmaes
-      image: docker.io/kubeflowkatib/suggestion-goptuna:v0.16.0-rc.1
+      image: docker.io/kubeflowkatib/suggestion-goptuna:v0.16.0
     - algorithmName: sobol
-      image: docker.io/kubeflowkatib/suggestion-goptuna:v0.16.0-rc.1
+      image: docker.io/kubeflowkatib/suggestion-goptuna:v0.16.0
     - algorithmName: multivariate-tpe
-      image: docker.io/kubeflowkatib/suggestion-optuna:v0.16.0-rc.1
+      image: docker.io/kubeflowkatib/suggestion-optuna:v0.16.0
     - algorithmName: enas
-      image: docker.io/kubeflowkatib/suggestion-enas:v0.16.0-rc.1
+      image: docker.io/kubeflowkatib/suggestion-enas:v0.16.0
       resources:
         limits:
           memory: 200Mi
     - algorithmName: darts
-      image: docker.io/kubeflowkatib/suggestion-darts:v0.16.0-rc.1
+      image: docker.io/kubeflowkatib/suggestion-darts:v0.16.0
     - algorithmName: pbt
-      image: docker.io/kubeflowkatib/suggestion-pbt:v0.16.0-rc.1
+      image: docker.io/kubeflowkatib/suggestion-pbt:v0.16.0
       persistentVolumeClaimSpec:
         accessModes:
           - ReadWriteMany
@@ -58,4 +58,4 @@ runtime:
             storage: 5Gi
   earlyStoppings:
     - algorithmName: medianstop
-      image: docker.io/kubeflowkatib/earlystopping-medianstop:v0.16.0-rc.1
+      image: docker.io/kubeflowkatib/earlystopping-medianstop:v0.16.0

--- a/apps/katib/upstream/installs/katib-external-db/kustomization.yaml
+++ b/apps/katib/upstream/installs/katib-external-db/kustomization.yaml
@@ -18,13 +18,13 @@ resources:
 images:
   - name: docker.io/kubeflowkatib/katib-controller
     newName: docker.io/kubeflowkatib/katib-controller
-    newTag: v0.16.0-rc.1
+    newTag: v0.16.0
   - name: docker.io/kubeflowkatib/katib-db-manager
     newName: docker.io/kubeflowkatib/katib-db-manager
-    newTag: v0.16.0-rc.1
+    newTag: v0.16.0
   - name: docker.io/kubeflowkatib/katib-ui
     newName: docker.io/kubeflowkatib/katib-ui
-    newTag: v0.16.0-rc.1
+    newTag: v0.16.0
 patchesStrategicMerge:
   - patches/db-manager.yaml
 # Modify katib-mysql-secrets with parameters for the DB.

--- a/apps/katib/upstream/installs/katib-leader-election/katib-config.yaml
+++ b/apps/katib/upstream/installs/katib-leader-election/katib-config.yaml
@@ -17,40 +17,40 @@ init:
 runtime:
   metricsCollectors:
     - kind: StdOut
-      image: docker.io/kubeflowkatib/file-metrics-collector:v0.16.0-rc.1
+      image: docker.io/kubeflowkatib/file-metrics-collector:v0.16.0
     - kind: File
-      image: docker.io/kubeflowkatib/file-metrics-collector:v0.16.0-rc.1
+      image: docker.io/kubeflowkatib/file-metrics-collector:v0.16.0
     - kind: TensorFlowEvent
-      image: docker.io/kubeflowkatib/tfevent-metrics-collector:v0.16.0-rc.1
+      image: docker.io/kubeflowkatib/tfevent-metrics-collector:v0.16.0
       resources:
         limits:
           memory: 1Gi
   suggestions:
     - algorithmName: random
-      image: docker.io/kubeflowkatib/suggestion-hyperopt:v0.16.0-rc.1
+      image: docker.io/kubeflowkatib/suggestion-hyperopt:v0.16.0
     - algorithmName: tpe
-      image: docker.io/kubeflowkatib/suggestion-hyperopt:v0.16.0-rc.1
+      image: docker.io/kubeflowkatib/suggestion-hyperopt:v0.16.0
     - algorithmName: grid
-      image: docker.io/kubeflowkatib/suggestion-optuna:v0.16.0-rc.1
+      image: docker.io/kubeflowkatib/suggestion-optuna:v0.16.0
     - algorithmName: hyperband
-      image: docker.io/kubeflowkatib/suggestion-hyperband:v0.16.0-rc.1
+      image: docker.io/kubeflowkatib/suggestion-hyperband:v0.16.0
     - algorithmName: bayesianoptimization
-      image: docker.io/kubeflowkatib/suggestion-skopt:v0.16.0-rc.1
+      image: docker.io/kubeflowkatib/suggestion-skopt:v0.16.0
     - algorithmName: cmaes
-      image: docker.io/kubeflowkatib/suggestion-goptuna:v0.16.0-rc.1
+      image: docker.io/kubeflowkatib/suggestion-goptuna:v0.16.0
     - algorithmName: sobol
-      image: docker.io/kubeflowkatib/suggestion-goptuna:v0.16.0-rc.1
+      image: docker.io/kubeflowkatib/suggestion-goptuna:v0.16.0
     - algorithmName: multivariate-tpe
-      image: docker.io/kubeflowkatib/suggestion-optuna:v0.16.0-rc.1
+      image: docker.io/kubeflowkatib/suggestion-optuna:v0.16.0
     - algorithmName: enas
-      image: docker.io/kubeflowkatib/suggestion-enas:v0.16.0-rc.1
+      image: docker.io/kubeflowkatib/suggestion-enas:v0.16.0
       resources:
         limits:
           memory: 200Mi
     - algorithmName: darts
-      image: docker.io/kubeflowkatib/suggestion-darts:v0.16.0-rc.1
+      image: docker.io/kubeflowkatib/suggestion-darts:v0.16.0
     - algorithmName: pbt
-      image: docker.io/kubeflowkatib/suggestion-pbt:v0.16.0-rc.1
+      image: docker.io/kubeflowkatib/suggestion-pbt:v0.16.0
       persistentVolumeClaimSpec:
         accessModes:
           - ReadWriteMany
@@ -59,4 +59,4 @@ runtime:
             storage: 5Gi
   earlyStoppings:
     - algorithmName: medianstop
-      image: docker.io/kubeflowkatib/earlystopping-medianstop:v0.16.0-rc.1
+      image: docker.io/kubeflowkatib/earlystopping-medianstop:v0.16.0

--- a/apps/katib/upstream/installs/katib-openshift/katib-config.yaml
+++ b/apps/katib/upstream/installs/katib-openshift/katib-config.yaml
@@ -14,40 +14,40 @@ init:
 runtime:
   metricsCollectors:
     - kind: StdOut
-      image: docker.io/kubeflowkatib/file-metrics-collector:v0.16.0-rc.1
+      image: docker.io/kubeflowkatib/file-metrics-collector:v0.16.0
     - kind: File
-      image: docker.io/kubeflowkatib/file-metrics-collector:v0.16.0-rc.1
+      image: docker.io/kubeflowkatib/file-metrics-collector:v0.16.0
     - kind: TensorFlowEvent
-      image: docker.io/kubeflowkatib/tfevent-metrics-collector:v0.16.0-rc.1
+      image: docker.io/kubeflowkatib/tfevent-metrics-collector:v0.16.0
       resources:
         limits:
           memory: 1Gi
   suggestions:
     - algorithmName: random
-      image: docker.io/kubeflowkatib/suggestion-hyperopt:v0.16.0-rc.1
+      image: docker.io/kubeflowkatib/suggestion-hyperopt:v0.16.0
     - algorithmName: tpe
-      image: docker.io/kubeflowkatib/suggestion-hyperopt:v0.16.0-rc.1
+      image: docker.io/kubeflowkatib/suggestion-hyperopt:v0.16.0
     - algorithmName: grid
-      image: docker.io/kubeflowkatib/suggestion-optuna:v0.16.0-rc.1
+      image: docker.io/kubeflowkatib/suggestion-optuna:v0.16.0
     - algorithmName: hyperband
-      image: docker.io/kubeflowkatib/suggestion-hyperband:v0.16.0-rc.1
+      image: docker.io/kubeflowkatib/suggestion-hyperband:v0.16.0
     - algorithmName: bayesianoptimization
-      image: docker.io/kubeflowkatib/suggestion-skopt:v0.16.0-rc.1
+      image: docker.io/kubeflowkatib/suggestion-skopt:v0.16.0
     - algorithmName: cmaes
-      image: docker.io/kubeflowkatib/suggestion-goptuna:v0.16.0-rc.1
+      image: docker.io/kubeflowkatib/suggestion-goptuna:v0.16.0
     - algorithmName: sobol
-      image: docker.io/kubeflowkatib/suggestion-goptuna:v0.16.0-rc.1
+      image: docker.io/kubeflowkatib/suggestion-goptuna:v0.16.0
     - algorithmName: multivariate-tpe
-      image: docker.io/kubeflowkatib/suggestion-optuna:v0.16.0-rc.1
+      image: docker.io/kubeflowkatib/suggestion-optuna:v0.16.0
     - algorithmName: enas
-      image: docker.io/kubeflowkatib/suggestion-enas:v0.16.0-rc.1
+      image: docker.io/kubeflowkatib/suggestion-enas:v0.16.0
       resources:
         limits:
           memory: 200Mi
     - algorithmName: darts
-      image: docker.io/kubeflowkatib/suggestion-darts:v0.16.0-rc.1
+      image: docker.io/kubeflowkatib/suggestion-darts:v0.16.0
     - algorithmName: pbt
-      image: docker.io/kubeflowkatib/suggestion-pbt:v0.16.0-rc.1
+      image: docker.io/kubeflowkatib/suggestion-pbt:v0.16.0
       persistentVolumeClaimSpec:
         accessModes:
           - ReadWriteMany
@@ -56,4 +56,4 @@ runtime:
             storage: 5Gi
   earlyStoppings:
     - algorithmName: medianstop
-      image: docker.io/kubeflowkatib/earlystopping-medianstop:v0.16.0-rc.1
+      image: docker.io/kubeflowkatib/earlystopping-medianstop:v0.16.0

--- a/apps/katib/upstream/installs/katib-openshift/kustomization.yaml
+++ b/apps/katib/upstream/installs/katib-openshift/kustomization.yaml
@@ -30,13 +30,13 @@ resources:
 images:
   - name: docker.io/kubeflowkatib/katib-controller
     newName: docker.io/kubeflowkatib/katib-controller
-    newTag: v0.16.0-rc.1
+    newTag: v0.16.0
   - name: docker.io/kubeflowkatib/katib-db-manager
     newName: docker.io/kubeflowkatib/katib-db-manager
-    newTag: v0.16.0-rc.1
+    newTag: v0.16.0
   - name: docker.io/kubeflowkatib/katib-ui
     newName: docker.io/kubeflowkatib/katib-ui
-    newTag: v0.16.0-rc.1
+    newTag: v0.16.0
 
 patchesJson6902:
   # Annotate Service to delegate TLS-secret generation to OpenShift service controller

--- a/apps/katib/upstream/installs/katib-standalone-postgres/katib-config.yaml
+++ b/apps/katib/upstream/installs/katib-standalone-postgres/katib-config.yaml
@@ -16,40 +16,40 @@ init:
 runtime:
   metricsCollectors:
     - kind: StdOut
-      image: docker.io/kubeflowkatib/file-metrics-collector:v0.16.0-rc.1
+      image: docker.io/kubeflowkatib/file-metrics-collector:v0.16.0
     - kind: File
-      image: docker.io/kubeflowkatib/file-metrics-collector:v0.16.0-rc.1
+      image: docker.io/kubeflowkatib/file-metrics-collector:v0.16.0
     - kind: TensorFlowEvent
-      image: docker.io/kubeflowkatib/tfevent-metrics-collector:v0.16.0-rc.1
+      image: docker.io/kubeflowkatib/tfevent-metrics-collector:v0.16.0
       resources:
         limits:
           memory: 1Gi
   suggestions:
     - algorithmName: random
-      image: docker.io/kubeflowkatib/suggestion-hyperopt:v0.16.0-rc.1
+      image: docker.io/kubeflowkatib/suggestion-hyperopt:v0.16.0
     - algorithmName: tpe
-      image: docker.io/kubeflowkatib/suggestion-hyperopt:v0.16.0-rc.1
+      image: docker.io/kubeflowkatib/suggestion-hyperopt:v0.16.0
     - algorithmName: grid
-      image: docker.io/kubeflowkatib/suggestion-optuna:v0.16.0-rc.1
+      image: docker.io/kubeflowkatib/suggestion-optuna:v0.16.0
     - algorithmName: hyperband
-      image: docker.io/kubeflowkatib/suggestion-hyperband:v0.16.0-rc.1
+      image: docker.io/kubeflowkatib/suggestion-hyperband:v0.16.0
     - algorithmName: bayesianoptimization
-      image: docker.io/kubeflowkatib/suggestion-skopt:v0.16.0-rc.1
+      image: docker.io/kubeflowkatib/suggestion-skopt:v0.16.0
     - algorithmName: cmaes
-      image: docker.io/kubeflowkatib/suggestion-goptuna:v0.16.0-rc.1
+      image: docker.io/kubeflowkatib/suggestion-goptuna:v0.16.0
     - algorithmName: sobol
-      image: docker.io/kubeflowkatib/suggestion-goptuna:v0.16.0-rc.1
+      image: docker.io/kubeflowkatib/suggestion-goptuna:v0.16.0
     - algorithmName: multivariate-tpe
-      image: docker.io/kubeflowkatib/suggestion-optuna:v0.16.0-rc.1
+      image: docker.io/kubeflowkatib/suggestion-optuna:v0.16.0
     - algorithmName: enas
-      image: docker.io/kubeflowkatib/suggestion-enas:v0.16.0-rc.1
+      image: docker.io/kubeflowkatib/suggestion-enas:v0.16.0
       resources:
         limits:
           memory: 200Mi
     - algorithmName: darts
-      image: docker.io/kubeflowkatib/suggestion-darts:v0.16.0-rc.1
+      image: docker.io/kubeflowkatib/suggestion-darts:v0.16.0
     - algorithmName: pbt
-      image: docker.io/kubeflowkatib/suggestion-pbt:v0.16.0-rc.1
+      image: docker.io/kubeflowkatib/suggestion-pbt:v0.16.0
       persistentVolumeClaimSpec:
         accessModes:
           - ReadWriteMany
@@ -58,4 +58,4 @@ runtime:
             storage: 5Gi
   earlyStoppings:
     - algorithmName: medianstop
-      image: docker.io/kubeflowkatib/earlystopping-medianstop:v0.16.0-rc.1
+      image: docker.io/kubeflowkatib/earlystopping-medianstop:v0.16.0

--- a/apps/katib/upstream/installs/katib-standalone-postgres/kustomization.yaml
+++ b/apps/katib/upstream/installs/katib-standalone-postgres/kustomization.yaml
@@ -20,13 +20,13 @@ resources:
 images:
   - name: docker.io/kubeflowkatib/katib-controller
     newName: docker.io/kubeflowkatib/katib-controller
-    newTag: v0.16.0-rc.1
+    newTag: v0.16.0
   - name: docker.io/kubeflowkatib/katib-db-manager
     newName: docker.io/kubeflowkatib/katib-db-manager
-    newTag: v0.16.0-rc.1
+    newTag: v0.16.0
   - name: docker.io/kubeflowkatib/katib-ui
     newName: docker.io/kubeflowkatib/katib-ui
-    newTag: v0.16.0-rc.1
+    newTag: v0.16.0
 patchesJson6902:
   - target:
       group: apps

--- a/apps/katib/upstream/installs/katib-standalone/katib-config.yaml
+++ b/apps/katib/upstream/installs/katib-standalone/katib-config.yaml
@@ -16,40 +16,40 @@ init:
 runtime:
   metricsCollectors:
     - kind: StdOut
-      image: docker.io/kubeflowkatib/file-metrics-collector:v0.16.0-rc.1
+      image: docker.io/kubeflowkatib/file-metrics-collector:v0.16.0
     - kind: File
-      image: docker.io/kubeflowkatib/file-metrics-collector:v0.16.0-rc.1
+      image: docker.io/kubeflowkatib/file-metrics-collector:v0.16.0
     - kind: TensorFlowEvent
-      image: docker.io/kubeflowkatib/tfevent-metrics-collector:v0.16.0-rc.1
+      image: docker.io/kubeflowkatib/tfevent-metrics-collector:v0.16.0
       resources:
         limits:
           memory: 1Gi
   suggestions:
     - algorithmName: random
-      image: docker.io/kubeflowkatib/suggestion-hyperopt:v0.16.0-rc.1
+      image: docker.io/kubeflowkatib/suggestion-hyperopt:v0.16.0
     - algorithmName: tpe
-      image: docker.io/kubeflowkatib/suggestion-hyperopt:v0.16.0-rc.1
+      image: docker.io/kubeflowkatib/suggestion-hyperopt:v0.16.0
     - algorithmName: grid
-      image: docker.io/kubeflowkatib/suggestion-optuna:v0.16.0-rc.1
+      image: docker.io/kubeflowkatib/suggestion-optuna:v0.16.0
     - algorithmName: hyperband
-      image: docker.io/kubeflowkatib/suggestion-hyperband:v0.16.0-rc.1
+      image: docker.io/kubeflowkatib/suggestion-hyperband:v0.16.0
     - algorithmName: bayesianoptimization
-      image: docker.io/kubeflowkatib/suggestion-skopt:v0.16.0-rc.1
+      image: docker.io/kubeflowkatib/suggestion-skopt:v0.16.0
     - algorithmName: cmaes
-      image: docker.io/kubeflowkatib/suggestion-goptuna:v0.16.0-rc.1
+      image: docker.io/kubeflowkatib/suggestion-goptuna:v0.16.0
     - algorithmName: sobol
-      image: docker.io/kubeflowkatib/suggestion-goptuna:v0.16.0-rc.1
+      image: docker.io/kubeflowkatib/suggestion-goptuna:v0.16.0
     - algorithmName: multivariate-tpe
-      image: docker.io/kubeflowkatib/suggestion-optuna:v0.16.0-rc.1
+      image: docker.io/kubeflowkatib/suggestion-optuna:v0.16.0
     - algorithmName: enas
-      image: docker.io/kubeflowkatib/suggestion-enas:v0.16.0-rc.1
+      image: docker.io/kubeflowkatib/suggestion-enas:v0.16.0
       resources:
         limits:
           memory: 200Mi
     - algorithmName: darts
-      image: docker.io/kubeflowkatib/suggestion-darts:v0.16.0-rc.1
+      image: docker.io/kubeflowkatib/suggestion-darts:v0.16.0
     - algorithmName: pbt
-      image: docker.io/kubeflowkatib/suggestion-pbt:v0.16.0-rc.1
+      image: docker.io/kubeflowkatib/suggestion-pbt:v0.16.0
       persistentVolumeClaimSpec:
         accessModes:
           - ReadWriteMany
@@ -58,4 +58,4 @@ runtime:
             storage: 5Gi
   earlyStoppings:
     - algorithmName: medianstop
-      image: docker.io/kubeflowkatib/earlystopping-medianstop:v0.16.0-rc.1
+      image: docker.io/kubeflowkatib/earlystopping-medianstop:v0.16.0

--- a/apps/katib/upstream/installs/katib-standalone/kustomization.yaml
+++ b/apps/katib/upstream/installs/katib-standalone/kustomization.yaml
@@ -20,13 +20,13 @@ resources:
 images:
   - name: docker.io/kubeflowkatib/katib-controller
     newName: docker.io/kubeflowkatib/katib-controller
-    newTag: v0.16.0-rc.1
+    newTag: v0.16.0
   - name: docker.io/kubeflowkatib/katib-db-manager
     newName: docker.io/kubeflowkatib/katib-db-manager
-    newTag: v0.16.0-rc.1
+    newTag: v0.16.0
   - name: docker.io/kubeflowkatib/katib-ui
     newName: docker.io/kubeflowkatib/katib-ui
-    newTag: v0.16.0-rc.1
+    newTag: v0.16.0
 configMapGenerator:
   - name: katib-config
     behavior: create

--- a/apps/katib/upstream/installs/katib-with-kubeflow/kustomization.yaml
+++ b/apps/katib/upstream/installs/katib-with-kubeflow/kustomization.yaml
@@ -11,13 +11,13 @@ resources:
 images:
   - name: docker.io/kubeflowkatib/katib-controller
     newName: docker.io/kubeflowkatib/katib-controller
-    newTag: v0.16.0-rc.1
+    newTag: v0.16.0
   - name: docker.io/kubeflowkatib/katib-db-manager
     newName: docker.io/kubeflowkatib/katib-db-manager
-    newTag: v0.16.0-rc.1
+    newTag: v0.16.0
   - name: docker.io/kubeflowkatib/katib-ui
     newName: docker.io/kubeflowkatib/katib-ui
-    newTag: v0.16.0-rc.1
+    newTag: v0.16.0
 
 patchesStrategicMerge:
   - patches/remove-namespace.yaml


### PR DESCRIPTION
Sync kubeflow/katib tag v0.16.0 manifests.

WG leads @andreyvelich @johnugeorge https://github.com/orgs/kubeflow/teams/wg-automl-leads
WG liaison @nagar-ajay
cc: @annajung @jbottum
