### PR TITLE
Update kubeflow/training-operator manifests from v1.7.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ This repo periodically syncs all official Kubeflow components from their respect
 
 | Component | Local Manifests Path | Upstream Revision |
 | - | - | - |
-| Training Operator | apps/training-operator/upstream | [v1.7.0-rc.0](https://github.com/kubeflow/training-operator/tree/v1.7.0-rc.0/manifests) |
+| Training Operator | apps/training-operator/upstream | [v1.7.0](https://github.com/kubeflow/training-operator/tree/v1.7.0/manifests) |
 | Notebook Controller | apps/jupyter/notebook-controller/upstream | [v1.8.0-rc.5](https://github.com/kubeflow/kubeflow/tree/v1.8.0-rc.5/components/notebook-controller/config) |
 | PVC Viewer Controller | apps/pvcviewer-roller/upstream | [v1.8.0-rc.5](https://github.com/kubeflow/kubeflow/tree/v1.8.0-rc.5/components/pvcviewer-controller/config) |
 | Tensorboard Controller | apps/tensorboard/tensorboard-controller/upstream | [v1.8.0-rc.5](https://github.com/kubeflow/kubeflow/tree/v1.8.0-rc.5/components/tensorboard-controller/config) |


### PR DESCRIPTION
Sync kubeflow/training-operator tag v1.7.0 manifests

WG leads @andreyvelich @johnugeorge @kubeflow/wg-training-leads 
WG liaison @nagar-ajay
cc: @annajung @jbottum
