### PR TITLE
removed namespace from clusterissuer kustomize file

### DIFF
--- a/common/cert-manager/kubeflow-issuer/base/kustomization.yaml
+++ b/common/cert-manager/kubeflow-issuer/base/kustomization.yaml
@@ -1,7 +1,6 @@
 # Define the self-signed issuer for Kubeflow
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
-namespace: cert-manager
 commonLabels:
   kustomize.component: cert-manager
   app.kubernetes.io/component: cert-manager


### PR DESCRIPTION
**Description of your changes:**
Removed namespace specification in the cert-manager kustomization.yaml file. Seems to me that `kubectl apply -k` ignores it but `kpt` (1.0.0-beta.47) gives a cryptic error about a cluster scoped resource having a namespace. 



