### PR TITLE
removed namespace from kubeflow cluster issuer

### DIFF
--- a/common/cert-manager/kubeflow-issuer/base/kustomization.yaml
+++ b/common/cert-manager/kubeflow-issuer/base/kustomization.yaml
@@ -1,7 +1,6 @@
 # Define the self-signed issuer for Kubeflow
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
-namespace: cert-manager
 commonLabels:
   kustomize.component: cert-manager
   app.kubernetes.io/component: cert-manager


### PR DESCRIPTION
**Description of your changes:**
Tried to apply manifests generated via kustomize  with `kpt live apply -` and it complained that the kubeflow clusterissuer had a namespace specified. The error message was terse and I had to go digging for it. Seems like 'kubectl' just ignored it but kpt did not. 