### PR TITLE
Fixes dex for kustomize 5

### DIFF
--- a/common/dex/overlays/istio/kustomization.yaml
+++ b/common/dex/overlays/istio/kustomization.yaml
@@ -1,26 +1,40 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
-
 resources:
 - ../../base
 - virtual-service.yaml
-
 namespace: auth
-
-vars:
-- name: DEX_SERVICE
-  objref:
-    kind: Service
-    name: dex
-    apiVersion: v1
-  fieldref:
-    fieldpath: metadata.name
-- name: DEX_NAMESPACE
-  objref:
-    kind: Service
-    name: dex
-    apiVersion: v1
-  fieldref:
-    fieldpath: metadata.namespace
 configurations:
 - params.yaml
+replacements:
+- source:
+    fieldPath: metadata.name
+    kind: Service
+    name: dex
+    version: v1
+  targets:
+  - fieldPaths:
+    - spec.http.0.route.0.destination.host
+    options:
+      delimiter: .
+    select:
+      group: networking.istio.io
+      kind: VirtualService
+      name: dex
+      version: v1alpha3
+- source:
+    fieldPath: metadata.namespace
+    kind: Service
+    name: dex
+    version: v1
+  targets:
+  - fieldPaths:
+    - spec.http.0.route.0.destination.host
+    options:
+      delimiter: .
+      index: 1
+    select:
+      group: networking.istio.io
+      kind: VirtualService
+      name: dex
+      version: v1alpha3

--- a/common/user-namespace/base/kustomization.yaml
+++ b/common/user-namespace/base/kustomization.yaml
@@ -5,25 +5,37 @@ kind: Kustomization
 resources:
 - profile-instance.yaml
 configMapGenerator:
-- name: default-install-config
-  envs:
+- envs:
   - params.env
-vars:
+  name: default-install-config
 # These vars are used for substituing in the parameters from the config map
 # into the Profiles custom resource.
-- name: user
-  objref:
-    kind: ConfigMap
-    name: default-install-config
-    apiVersion: v1
-  fieldref:
-    fieldpath: data.user
-- name: profile-name
-  objref:
-    kind: ConfigMap
-    name: default-install-config
-    apiVersion: v1
-  fieldref:
-    fieldpath: data.profile-name
 configurations:
 - params.yaml
+replacements:
+- source:
+    fieldPath: data.user
+    kind: ConfigMap
+    name: default-install-config
+    version: v1
+  targets:
+  - fieldPaths:
+    - spec.owner.name
+    select:
+      group: kubeflow.org
+      kind: Profile
+      name: $(profile-name)
+      version: v1beta1
+- source:
+    fieldPath: data.profile-name
+    kind: ConfigMap
+    name: default-install-config
+    version: v1
+  targets:
+  - fieldPaths:
+    - metadata.name
+    select:
+      group: kubeflow.org
+      kind: Profile
+      name: $(profile-name)
+      version: v1beta1


### PR DESCRIPTION
While the command is running:
```
kustomize build common/dex/overlays/istio
```
A warning appeared:
```
# Warning: 'vars' is deprecated. Please use 'replacements' instead. [EXPERIMENTAL] Run 'kustomize edit fix' to update your Kustomization automatically.
```
I used the command:
```
kustomize edit fix --vars
```
And also corrected errors received when executing this command. Manifests are now generated without warnings.

Please note that this PR should not affect the manifests themselves in any way, only the warning is removed.

Resolves #

**Description of your changes:**


**Checklist:**
- [ ] Unit tests pass:
  **Make sure you have installed kustomize == 3.2.1**
    1. `make generate-changed-only`
    2. `make test`
