### PR TITLE
Fix #2229 - dex-passwords in common/dex/base

### DIFF
--- a/common/dex/base/dex-passwords.yaml
+++ b/common/dex/base/dex-passwords.yaml
@@ -2,5 +2,5 @@ apiVersion: v1
 kind: Secret
 metadata:
   name: dex-passwords
-data:
+stringData:
   DEX_USER_PASSWORD: $2y$12$4K/VkmDd1q1Orb3xAt82zu8gk7Ad6ReFR4LCP9UeYE90NLiN9Df72

--- a/common/dex/base/kustomization.yaml
+++ b/common/dex/base/kustomization.yaml
@@ -7,6 +7,7 @@ resources:
 - crds.yaml
 - deployment.yaml
 - service.yaml
+- dex-passwords.yaml
 generatorOptions:
   disableNameSuffixHash: true
 


### PR DESCRIPTION
The dex-passwords secret has not been defined properly and the secret wasn't added to the dex kustomization file.

**Description of your changes:**
The changes are done as discussed in https://github.com/kubeflow/manifests/pull/2229#pullrequestreview-1799825164.
