### PR TITLE
Fixes centraldashboard for kustomize 5

### DIFF
--- a/apps/centraldashboard/upstream/base/deployment.yaml
+++ b/apps/centraldashboard/upstream/base/deployment.yaml
@@ -31,15 +31,15 @@ spec:
           protocol: TCP
         env:
         - name: USERID_HEADER
-          value: $(CD_USERID_HEADER)
+          value: CD_USERID_HEADER_PLACEHOLDER
         - name: USERID_PREFIX
-          value: $(CD_USERID_PREFIX)
+          value: CD_USERID_PREFIX_PLACEHOLDER
         - name: PROFILES_KFAM_SERVICE_HOST
           value: profiles-kfam.kubeflow
         - name: REGISTRATION_FLOW
-          value: $(CD_REGISTRATION_FLOW)
+          value: CD_REGISTRATION_FLOW_PLACEHOLDER
         - name: DASHBOARD_LINKS_CONFIGMAP
-          value: $(CD_CONFIGMAP_NAME)
+          value: CD_CONFIGMAP_NAME_PLACEHOLDER
         - name: LOGOUT_URL
           value: '/authservice/logout'
         - name: POD_NAMESPACE

--- a/apps/centraldashboard/upstream/base/kustomization.yaml
+++ b/apps/centraldashboard/upstream/base/kustomization.yaml
@@ -10,11 +10,6 @@ resources:
 - service-account.yaml
 - service.yaml
 - configmap.yaml
-commonLabels:
-  kustomize.component: centraldashboard
-  app: centraldashboard
-  app.kubernetes.io/component: centraldashboard
-  app.kubernetes.io/name: centraldashboard
 images:
 - name: docker.io/kubeflownotebookswg/centraldashboard
   newName: docker.io/kubeflownotebookswg/centraldashboard
@@ -25,46 +20,64 @@ configMapGenerator:
   name: centraldashboard-parameters
 generatorOptions:
   disableNameSuffixHash: true
-vars:
-- fieldref:
-    fieldPath: metadata.namespace
-  name: CD_NAMESPACE
-  objref:
-    apiVersion: v1
-    kind: Service
-    name: centraldashboard
-- fieldref:
-    fieldPath: data.CD_CLUSTER_DOMAIN
-  name: CD_CLUSTER_DOMAIN
-  objref:
-    apiVersion: v1
-    kind: ConfigMap
-    name: centraldashboard-parameters
-- fieldref:
+labels:
+- includeSelectors: true
+  pairs:
+    app: centraldashboard
+    app.kubernetes.io/component: centraldashboard
+    app.kubernetes.io/name: centraldashboard
+    kustomize.component: centraldashboard
+
+replacements:
+- source:
     fieldPath: data.CD_USERID_HEADER
-  name: CD_USERID_HEADER
-  objref:
-    apiVersion: v1
     kind: ConfigMap
     name: centraldashboard-parameters
-- fieldref:
+    version: v1
+  targets:
+  - fieldPaths:
+    - spec.template.spec.containers.0.env.0.value
+    select:
+      group: apps
+      kind: Deployment
+      name: centraldashboard
+      version: v1
+- source:
     fieldPath: data.CD_USERID_PREFIX
-  name: CD_USERID_PREFIX
-  objref:
-    apiVersion: v1
     kind: ConfigMap
     name: centraldashboard-parameters
-- fieldref:
+    version: v1
+  targets:
+  - fieldPaths:
+    - spec.template.spec.containers.0.env.1.value
+    select:
+      group: apps
+      kind: Deployment
+      name: centraldashboard
+      version: v1
+- source:
     fieldPath: data.CD_REGISTRATION_FLOW
-  name: CD_REGISTRATION_FLOW
-  objref:
-    apiVersion: v1
     kind: ConfigMap
     name: centraldashboard-parameters
-- fieldref:
+    version: v1
+  targets:
+  - fieldPaths:
+    - spec.template.spec.containers.0.env.3.value
+    select:
+      group: apps
+      kind: Deployment
+      name: centraldashboard
+      version: v1
+- source:
     fieldPath: metadata.name
-  name: CD_CONFIGMAP_NAME
-  objref:
-    apiVersion: v1
     kind: ConfigMap
     name: centraldashboard-config
+    version: v1
+  targets:
+  - fieldPaths:
+    - spec.template.spec.containers.0.env.4.value
+    select:
+      group: apps
+      kind: Deployment
+      name: centraldashboard
+      version: v1

--- a/apps/centraldashboard/upstream/overlays/istio/kustomization.yaml
+++ b/apps/centraldashboard/upstream/overlays/istio/kustomization.yaml
@@ -1,18 +1,49 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
-
 resources:
 - ../../base
 - virtual-service.yaml
 - authorizationpolicy.yaml
-
 namespace: kubeflow
-
-commonLabels:
-  kustomize.component: centraldashboard
-  app: centraldashboard
-  app.kubernetes.io/component: centraldashboard
-  app.kubernetes.io/name: centraldashboard
-
+replacements:
+- source:
+    fieldPath: metadata.namespace
+    kind: Service
+    name: centraldashboard
+    version: v1
+  targets:
+  - fieldPaths:
+    - spec.http.0.route.0.destination.host
+    options:
+      delimiter: .
+      index: 1
+    select:
+      group: networking.istio.io
+      kind: VirtualService
+      name: centraldashboard
+      version: v1alpha3
+- source:
+    fieldPath: data.CD_CLUSTER_DOMAIN
+    kind: ConfigMap
+    name: centraldashboard-parameters
+    version: v1
+  targets:
+  - fieldPaths:
+    - spec.http.0.route.0.destination.host
+    options:
+      delimiter: .
+      index: 3
+    select:
+      group: networking.istio.io
+      kind: VirtualService
+      name: centraldashboard
+      version: v1alpha3
 configurations:
 - params.yaml
+labels:
+- includeSelectors: true
+  pairs:
+    app: centraldashboard
+    app.kubernetes.io/component: centraldashboard
+    app.kubernetes.io/name: centraldashboard
+    kustomize.component: centraldashboard

--- a/apps/centraldashboard/upstream/overlays/istio/virtual-service.yaml
+++ b/apps/centraldashboard/upstream/overlays/istio/virtual-service.yaml
@@ -15,6 +15,6 @@ spec:
       uri: /
     route:
     - destination:
-        host: centraldashboard.$(CD_NAMESPACE).svc.$(CD_CLUSTER_DOMAIN)
+        host: centraldashboard.CD_NAMESPACE_PLACEHOLDER.svc.CD_CLUSTER_DOMAIN_PLACEHOLDER
         port:
           number: 80

--- a/apps/centraldashboard/upstream/overlays/kserve/kustomization.yaml
+++ b/apps/centraldashboard/upstream/overlays/kserve/kustomization.yaml
@@ -1,14 +1,13 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
-
 resources:
 - ../istio
-
-commonLabels:
-  kustomize.component: centraldashboard
-  app: centraldashboard
-  app.kubernetes.io/component: centraldashboard
-  app.kubernetes.io/name: centraldashboard
-
-patchesStrategicMerge:
-- patches/configmap.yaml
+labels:
+- includeSelectors: true
+  pairs:
+    app: centraldashboard
+    app.kubernetes.io/component: centraldashboard
+    app.kubernetes.io/name: centraldashboard
+    kustomize.component: centraldashboard
+patches:
+- path: patches/configmap.yaml


### PR DESCRIPTION
While the command is running:
```
kustomize build apps/centraldashboard/upstream/overlays/kserve
```
A warning appeared:
```
# Warning: 'commonLabels' is deprecated. Please use 'labels' instead. Run 'kustomize edit fix' to update your Kustomization automatically.
# Warning: 'patchesStrategicMerge' is deprecated. Please use 'patches' instead. Run 'kustomize edit fix' to update your Kustomization automatically.
# Warning: 'commonLabels' is deprecated. Please use 'labels' instead. Run 'kustomize edit fix' to update your Kustomization automatically.
# Warning: 'commonLabels' is deprecated. Please use 'labels' instead. Run 'kustomize edit fix' to update your Kustomization automatically.
# Warning: 'vars' is deprecated. Please use 'replacements' instead. [EXPERIMENTAL] Run 'kustomize edit fix' to update your Kustomization automatically.
```
I used the command:
```
kustomize edit fix --vars
```
And also corrected errors received when executing this command. Manifests are now generated without warnings.

Please note that this PR should not affect the manifests themselves in any way, only the warning is removed.

So, when correcting errors, an error appears and manifests stop working:
```
kustomize edit fix --vars
# Warning: 'commonLabels' is deprecated. Please use 'labels' instead. Run 'kustomize edit fix' to update your Kustomization automatically.
# Warning: 'vars' is deprecated. Please use 'replacements' instead. [EXPERIMENTAL] Run 'kustomize edit fix' to update your Kustomization automatically.
2024/01/03 11:36:03 well-defined vars that were never replaced: CD_CLUSTER_DOMAIN,CD_NAMESPACE

Fixed fields:
  patchesJson6902 -> patches
  patchesStrategicMerge -> patches
  commonLabels -> labels
  vars -> replacements
Warning: 'Fixed' kustomization now produces the error when running `kustomize build`: replacements must specify a source and at least one target
```

Resolves #

**Description of your changes:**


**Checklist:**
- [ ] Unit tests pass:
  **Make sure you have installed kustomize == 3.2.1**
    1. `make generate-changed-only`
    2. `make test`
