### PR TITLE
Improve dex kustomizations readability

### DIFF
--- a/common/dex/base/kustomization.yaml
+++ b/common/dex/base/kustomization.yaml
@@ -1,6 +1,7 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 namespace: auth
+
 resources:
 - namespace.yaml
 - config-map.yaml
@@ -8,6 +9,7 @@ resources:
 - deployment.yaml
 - service.yaml
 - dex-passwords.yaml
+
 generatorOptions:
   disableNameSuffixHash: true
 

--- a/common/dex/overlays/istio/kustomization.yaml
+++ b/common/dex/overlays/istio/kustomization.yaml
@@ -1,27 +1,30 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
+namespace: auth
+
 resources:
 - ../../base
 - virtual-service.yaml
-namespace: auth
+
 configurations:
 - params.yaml
+
 replacements:
 - source:
-    fieldPath: metadata.name
+    version: v1
     kind: Service
     name: dex
-    version: v1
+    fieldPath: metadata.name
   targets:
   - fieldPaths:
     - spec.http.0.route.0.destination.host
     options:
       delimiter: .
     select:
+      version: v1alpha3
       group: networking.istio.io
       kind: VirtualService
       name: dex
-      version: v1alpha3
 - source:
     fieldPath: metadata.namespace
     kind: Service
@@ -34,7 +37,7 @@ replacements:
       delimiter: .
       index: 1
     select:
+      version: v1alpha3
       group: networking.istio.io
       kind: VirtualService
       name: dex
-      version: v1alpha3


### PR DESCRIPTION
The overlays for ldap and github were not taken into consideration because atm they don't work because the dex's base kustimization doesn't define dex-parameters CM anymore.

These changes shouldn't cause any differences in generated manifests.

**Description of your changes:**
Implementing changes discussed here: https://github.com/kubeflow/manifests/pull/2586#issuecomment-1874255700

**Checklist:**
- [x] test if there are no differences in generated manifest
  ```
  $ git reset --hard
  HEAD is now at 2d047ae6 Improve dex kustomizations readability

  $ kustomize build common/dex/overlays/istio/ > dex.overlay.istio.improve-dex-kustomization-readability.yaml
  $ kustomize build common/dex/base/ > dex.overlay.base.improve-dex-kustomization-readability.yaml

  $ git checkout master
  $ git log -1
  commit ed4caf3e26060f626571b421185326257777576c (HEAD -> master, origin/master)
  Author:     Aleksey Karpov <86011874+alekseyolg@users.noreply.github.com>
  AuthorDate: Tue Jan 2 19:49:15 2024 +0300
  Commit:     GitHub <noreply@github.com>
  CommitDate: Tue Jan 2 16:49:15 2024 +0000

      Fixes dex for kustomize 5 (#2586)

      * Fixes user-namespace for kustomize 5

      * Fixes dex for kustomize 5
  $ kustomize build common/dex/base/ > dex.overlay.base.master.yaml
  $ kustomize build common/dex/overlays/istio/ > dex.overlay.istio.master.yaml

  $ diff dex.overlay.base.improve-dex-kustomization-readability.yaml dex.overlay.base.master.yaml
  $ diff dex.overlay.istio.improve-dex-kustomization-readability.yaml dex.overlay.istio.master.yaml
  ```