### PR TITLE
Fix image name ($VOLUME_VIEWER_IMAGE) produced by hack/extract_images.sh

### DIFF
--- a/hack/extract_images.sh
+++ b/hack/extract_images.sh
@@ -62,7 +62,7 @@ for wg in "${!wg_dirs[@]}"; do
           continue
         fi
         # Grep the output of 'kustomize build' command for 'image:' and '- image' lines and return just the image itself
-        mapfile kimages -t  <<< "$(grep '\-\?\s\image:'<<<"$kbuild" | sed -re 's/\s-?\simage: *//;s/^[ \t]*//g' | sed '/^$/d;/{/d' )"
+        mapfile kimages -t  <<< "$(grep '\-\?\s\image:'<<<"$kbuild" | sed -re 's/\s-?\simage: *//;s/^[ \t]*//g' | sed '/^\$/d;/{/d' )"
         wg_images+=("${kimages[@]}")
     done
   done


### PR DESCRIPTION
Fix unresolved image name ($VOLUME_VIEWER_IMAGE) produced by hack/extract_images.sh

**Which issue is resolved by this Pull Request:**
Resolves #2560

**Description of your changes:**
Fix the `sed` command that deletes all lines starting with the `$` sign or curly brackets. Usually, such lines come from plain  CRDs and PodTemplates, multiline configs.   

**Checklist:**
- [ ] Unit tests pass:
  **Make sure you have installed kustomize == 3.2.1**
    1. `make generate-changed-only`
    2. `make test`
