### PR TITLE
Update PR template to install kustomize 5.0.1

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -6,6 +6,6 @@ Resolves #
 
 **Checklist:**
 - [ ] Unit tests pass:
-  **Make sure you have installed kustomize == 3.2.1**
+  **Make sure you have installed kustomize == 5.0.1**
     1. `make generate-changed-only`
     2. `make test`


### PR DESCRIPTION
**Which issue is resolved by this Pull Request:**
Resolves #

**Description of your changes:**


**Checklist:**
- [ ] Unit tests pass:
  **Make sure you have installed kustomize == 3.2.1**
    1. `make generate-changed-only`
    2. `make test`
