### PR TITLE
Update OWNERS

### DIFF
--- a/OWNERS
+++ b/OWNERS
@@ -1,10 +1,6 @@
 approvers:
-  - elikatsis
   - juliusvonkohout
   - kimwnasptd
-  - PatrickXYS
-  - StefanoFioravanzo
-  - yanniszark
 reviewers:
   - juliusvonkohout
   - kimwnasptd


### PR DESCRIPTION
Reduce to active maintainers, since most new contributors are confused if maintainers do not respond, but are listed in their PRs as approvers.

The latest commit from the removed approvers is 3 years old https://github.com/kubeflow/manifests/commit/7f8e6d83c735874c34bb53ec9cbc105f41b8b71e

CC @andreyvelich and KSC

CC @kubeflow/wg-manifests-leads @kimwnasptd @rimolive 

Here is an example of the problem:

![grafik](https://github.com/kubeflow/manifests/assets/45896133/c2d506be-6960-4fc9-92f3-b1e0b0c65f9d)


