### PR TITLE
Add steps to install Kubeflow on kind

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,6 +99,45 @@ The `example` directory contains an example kustomization for the single command
 
 ### Install with a single command
 
+#### Prerequisites
+- `kind`
+- `docker`
+- Linux kernel subsystem changes
+    - `sudo sysctl fs.inotify.max_user_instances=2280`
+    - `sudo sysctl fs.inotify.max_user_watches=1255360`
+
+#### Create kind cluster
+```sh
+cat <<EOF | kind create cluster --name=kubeflow  --kubeconfig mycluster.yaml --config=-
+kind: Cluster
+apiVersion: kind.x-k8s.io/v1alpha4
+nodes:
+- role: control-plane
+  kubeadmConfigPatches:
+  - |
+    kind: ClusterConfiguration
+    apiServer:
+      extraArgs:
+        "service-account-issuer": "kubernetes.default.svc"
+        "service-account-signing-key-file": "/etc/kubernetes/pki/sa.key"
+EOF
+```
+
+#### Save kubeconfig
+```sh
+kind get kubeconfig --name kubeflow > ~/.kube/config
+```
+
+#### Create a Secret based on existing credentials in order to pull the images
+```sh
+docker login
+
+kubectl create secret generic regcred \
+    --from-file=.dockerconfigjson=/path/to/.docker/config.json \
+    --type=kubernetes.io/dockerconfigjson
+```
+
+#### Install with a single command
 You can install all Kubeflow official components (residing under `apps`) and all common services (residing under `common`) using the following command:
 
 ```sh


### PR DESCRIPTION
**Which issue is resolved by this Pull Request:**
Resolves the missing steps to be able to get Kubeflow up and running locally.

**Description of your changes:**
It will add some steps in order to make it easy to have Kubeflow on top of kind.


**Checklist:**
- [ x ] Unit tests pass:
  **Make sure you have installed kustomize == 5.0.3**
    1. `make generate-changed-only`
    2. `make test`
