### PR TITLE
Backup ~/.kube/config before the replacement

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,6 +125,7 @@ EOF
 
 #### Save kubeconfig
 ```sh
+mv ~/.kube/config ~/.kube/config_backup
 kind get kubeconfig --name kubeflow > ~/.kube/config
 ```
 


### PR DESCRIPTION
Append failed during the kind cluster deletion

**Which issue is resolved by this Pull Request:**
Some users didn't like the idea of replacing all the content of `~/.kube/config`

**Description of your changes:**
Backup the `~/.kube/config` before the replacement

**Checklist:**
- [ X ] Unit tests pass:
  **Make sure you have installed kustomize == 5.0.3**
    1. `make generate-changed-only`
    2. `make test`
