### PR TITLE
Fix `common/knative/knative-eventing/base` kustomize warnings

### DIFF
--- a/common/knative/knative-eventing/base/kustomization.yaml
+++ b/common/knative/knative-eventing/base/kustomization.yaml
@@ -2,14 +2,16 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 namespace: knative-eventing
 resources:
-- upstream/eventing-core.yaml 
+- upstream/eventing-core.yaml
 # Uncomment to install In-Memory Channels as messaging layer: 
 # - upstream/in-memory-channel.yaml
 # Uncomment to install MT-channel-based Broker layer
 # - upstream/mt-channel-broker.yaml
-patchesStrategicMerge:
-- patches/clusterrole-patch.yaml
-commonLabels:
-  kustomize.component: knative
-  app.kubernetes.io/component: knative-eventing
-  app.kubernetes.io/name: knative-eventing
+labels:
+- includeSelectors: true
+  pairs:
+    app.kubernetes.io/component: knative-eventing
+    app.kubernetes.io/name: knative-eventing
+    kustomize.component: knative
+patches:
+- path: patches/clusterrole-patch.yaml


### PR DESCRIPTION
**Which issue is resolved by this Pull Request:**

Related to https://github.com/kubeflow/manifests/issues/2388

**Description of your changes:**

Fix Kustomize v5 warnings for `common/knative/knative-eventing/base`
kustomize build generates no changes between old and new version.

**Checklist:**
- [ ] Unit tests pass:
  **Make sure you have installed kustomize == 5.0.3**
    1. `make generate-changed-only`
    2. `make test`
