### PR TITLE
fix `common/cert-manager/kubeflow-issuer/base` kustomize warnings

### DIFF
--- a/common/cert-manager/kubeflow-issuer/base/kustomization.yaml
+++ b/common/cert-manager/kubeflow-issuer/base/kustomization.yaml
@@ -1,9 +1,11 @@
 # Define the self-signed issuer for Kubeflow
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
-commonLabels:
-  kustomize.component: cert-manager
-  app.kubernetes.io/component: cert-manager
-  app.kubernetes.io/name: cert-manager
 resources:
 - cluster-issuer.yaml
+labels:
+- includeSelectors: true
+  pairs:
+    app.kubernetes.io/component: cert-manager
+    app.kubernetes.io/name: cert-manager
+    kustomize.component: cert-manager


### PR DESCRIPTION
**Which issue is resolved by this Pull Request:**

Related to https://github.com/kubeflow/manifests/issues/2388

**Description of your changes:**

Fix Kustomize v5 warnings for `common/cert-manager/kubeflow-issuer/base`
kustomize build generates no changes between old and new version.

**Checklist:**
- [ ] Unit tests pass:
  **Make sure you have installed kustomize == 5.0.3**
    1. `make generate-changed-only`
    2. `make test`
