### PR TITLE
fix `common/istio-1-17/cluster-local-gateway/base` kustomize warnings

### DIFF
--- a/common/istio-1-17/cluster-local-gateway/base/kustomization.yaml
+++ b/common/istio-1-17/cluster-local-gateway/base/kustomization.yaml
@@ -8,5 +8,5 @@ resources:
 - gateway-authorizationpolicy.yaml
 - gateway.yaml
 
-patchesStrategicMerge:
-- patches/remove-pdb.yaml
+patches:
+- path: patches/remove-pdb.yaml


### PR DESCRIPTION
**Which issue is resolved by this Pull Request:**

Related to https://github.com/kubeflow/manifests/issues/2388

**Description of your changes:**

Fix Kustomize v5 warnings for `common/istio-1-17/cluster-local-gateway/base`
kustomize build generates no changes between old and new version.

**Checklist:**
- [ ] Unit tests pass:
  **Make sure you have installed kustomize == 5.0.3**
    1. `make generate-changed-only`
    2. `make test`
