### PR TITLE
fix most kustomize v5 warnings

### DIFF
--- a/common/cert-manager/kubeflow-issuer/base/kustomization.yaml
+++ b/common/cert-manager/kubeflow-issuer/base/kustomization.yaml
@@ -1,9 +1,11 @@
 # Define the self-signed issuer for Kubeflow
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
-commonLabels:
-  kustomize.component: cert-manager
-  app.kubernetes.io/component: cert-manager
-  app.kubernetes.io/name: cert-manager
 resources:
 - cluster-issuer.yaml
+labels:
+- includeSelectors: true
+  pairs:
+    app.kubernetes.io/component: cert-manager
+    app.kubernetes.io/name: cert-manager
+    kustomize.component: cert-manager

--- a/common/istio-1-17/cluster-local-gateway/base/kustomization.yaml
+++ b/common/istio-1-17/cluster-local-gateway/base/kustomization.yaml
@@ -8,5 +8,5 @@ resources:
 - gateway-authorizationpolicy.yaml
 - gateway.yaml
 
-patchesStrategicMerge:
-- patches/remove-pdb.yaml
+patches:
+- path: patches/remove-pdb.yaml

--- a/common/istio-cni-1-17/cluster-local-gateway/base/kustomization.yaml
+++ b/common/istio-cni-1-17/cluster-local-gateway/base/kustomization.yaml
@@ -8,5 +8,5 @@ resources:
 - gateway-authorizationpolicy.yaml
 - gateway.yaml
 
-patchesStrategicMerge:
-- patches/remove-pdb.yaml
+patches:
+- path: patches/remove-pdb.yaml

--- a/common/knative/README.md
+++ b/common/knative/README.md
@@ -36,17 +36,6 @@ The manifests for Knative Serving are based off the following:
     yq eval -i 'explode(.)' knative-serving-post-install-jobs/base/serving-post-install-jobs.yaml
     ```
 
-1. Remove the `knative-ingress-gateway` Gateway, since we use the Kubeflow
-   gateway. We will make this into a patch once we update kustomize to v4,
-   which supports removing CRs with patches. See:
-   https://github.com/kubernetes-sigs/kustomize/issues/3694
-
-    ```sh
-    yq eval -i 'select((.kind == "Gateway" and .metadata.name == "knative-ingress-gateway") | not)' knative-serving/base/upstream/net-istio.yaml
-    ```
-
-    NOTE: You'll need to remove a redundant `{}` at the end of the `knative-serving/base/upstream/net-istio.yaml` file.
-
 1. Set `metadata.name` in the serving post-install job, to be deploy-able with
    `kustomize` and `kubectl apply`:
 
@@ -56,13 +45,9 @@ The manifests for Knative Serving are based off the following:
     yq eval -i 'select(.kind == "Job" and .metadata.generateName == "storage-version-migration-serving-") | .metadata.name = "storage-version-migration-serving"' knative-serving-post-install-jobs/base/serving-post-install-jobs.yaml
     ```
 
-
-NOTE: You'll need to remove a redundant `{}` at the end of the `knative-serving/base/upstream/net-istio.yaml` and 
-`knative-serving/base/upstream/serving-core.yaml` files.
-
 ### Changes from upstream
 
-- In `knative-serving/base/upstream/net-istio.yaml`, the `knative-ingress-gateway` Gateway is removed since we use the Kubeflow gateway.
+- The `knative-ingress-gateway` Gateway is removed since we use the Kubeflow gateway.
 - In `config-istio`, the Knative gateway is set to use `gateway.kubeflow.kubeflow-gateway`.
 - In `config-deployment`, `progressDeadline` is set to `600s` as sometimes large models need longer than
   the default of `120s` to start the containers.

--- a/common/knative/knative-eventing/base/kustomization.yaml
+++ b/common/knative/knative-eventing/base/kustomization.yaml
@@ -2,14 +2,16 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 namespace: knative-eventing
 resources:
-- upstream/eventing-core.yaml 
+- upstream/eventing-core.yaml
 # Uncomment to install In-Memory Channels as messaging layer: 
 # - upstream/in-memory-channel.yaml
 # Uncomment to install MT-channel-based Broker layer
 # - upstream/mt-channel-broker.yaml
-patchesStrategicMerge:
-- patches/clusterrole-patch.yaml
-commonLabels:
-  kustomize.component: knative
-  app.kubernetes.io/component: knative-eventing
-  app.kubernetes.io/name: knative-eventing
+labels:
+- includeSelectors: true
+  pairs:
+    app.kubernetes.io/component: knative-eventing
+    app.kubernetes.io/name: knative-eventing
+    kustomize.component: knative
+patches:
+- path: patches/clusterrole-patch.yaml

--- a/common/knative/knative-serving/base/kustomization.yaml
+++ b/common/knative/knative-serving/base/kustomization.yaml
@@ -15,3 +15,4 @@ patches:
 - path: patches/knative-serving-namespaced-edit.yaml
 - path: patches/knative-serving-namespaced-view.yaml
 - path: patches/service-labels.yaml
+- path: patches/remove-gateway.yaml

--- a/common/knative/knative-serving/base/patches/remove-gateway.yaml
+++ b/common/knative/knative-serving/base/patches/remove-gateway.yaml
@@ -1,0 +1,6 @@
+$patch: delete
+apiVersion: networking.istio.io/v1beta1
+kind: Gateway
+metadata:
+  name: knative-ingress-gateway
+  namespace: knative-serving

--- a/common/knative/knative-serving/base/upstream/net-istio.yaml
+++ b/common/knative/knative-serving/base/upstream/net-istio.yaml
@@ -16,6 +16,27 @@ rules:
 apiVersion: networking.istio.io/v1beta1
 kind: Gateway
 metadata:
+  name: knative-ingress-gateway
+  namespace: knative-serving
+  labels:
+    app.kubernetes.io/component: net-istio
+    app.kubernetes.io/name: knative-serving
+    app.kubernetes.io/version: "1.10.1"
+    networking.knative.dev/ingress-provider: istio
+spec:
+  selector:
+    istio: ingressgateway
+  servers:
+    - port:
+        number: 80
+        name: http
+        protocol: HTTP
+      hosts:
+        - "*"
+---
+apiVersion: networking.istio.io/v1beta1
+kind: Gateway
+metadata:
   name: knative-local-gateway
   namespace: knative-serving
   labels:


### PR DESCRIPTION
**Which issue is resolved by this Pull Request:**

Related to https://github.com/kubeflow/manifests/issues/2388

**Description of your changes:**

Fix most Kustomize v5 warnings related to for `common/`.
The warning about `vars` being deprecated is still present for `oidc-client/oidc-authservice/base/kustomization.yaml` as I weren't successful in fixing it without changes.
kustomize build generates no changes between old and new version.

**Checklist:**

- [ ] Unit tests pass:
  **Make sure you have installed kustomize == 5.0.3**
    1. `make generate-changed-only`
    2. `make test`
