### PR TITLE
fix: istio 1.70 envoy filter chain should be changed.

### DIFF
--- a/common/oidc-client/oidc-authservice/base/envoy-filter.yaml
+++ b/common/oidc-client/oidc-authservice/base/envoy-filter.yaml
@@ -13,7 +13,7 @@ spec:
         listener:
           filterChain:
             filter:
-              name: "envoy.http_connection_manager"
+              name: "envoy.filters.network.http_connection_manager"
       patch:
         # For some reason, INSERT_FIRST doesn't work
         operation: INSERT_BEFORE


### PR DESCRIPTION
**Which issue is resolved by this Pull Request:**

Resolves in latest version of istio , the authn-filter may not work becuase of filterChain `envoy.http_connection_manager` is deactived, and changed it to `envoy.filters.network.http_connection_manager` 

**Description of your changes:**
https://istio.io/latest/docs/reference/config/networking/envoy-filter/#EnvoyFilter-ListenerMatch-FilterChainMatch

**Checklist:**
- [x] Unit tests pass:
  **Make sure you have installed kustomize == 5.0.3**
    1. `make generate-changed-only`
    2. `make test`
