### PR TITLE
Fixes kubeflow-issuer for kustomize 5

### DIFF
--- a/common/cert-manager/kubeflow-issuer/base/kustomization.yaml
+++ b/common/cert-manager/kubeflow-issuer/base/kustomization.yaml
@@ -1,9 +1,11 @@
 # Define the self-signed issuer for Kubeflow
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
-commonLabels:
-  kustomize.component: cert-manager
-  app.kubernetes.io/component: cert-manager
-  app.kubernetes.io/name: cert-manager
 resources:
 - cluster-issuer.yaml
+labels:
+- includeSelectors: true
+  pairs:
+    app.kubernetes.io/component: cert-manager
+    app.kubernetes.io/name: cert-manager
+    kustomize.component: cert-manager


### PR DESCRIPTION
While the command is running:
```
kustomize build common/cert-manager/kubeflow-issuer/base
```
A warning appeared:
```
# Warning: 'commonLabels' is deprecated. Please use 'labels' instead. Run 'kustomize edit fix' to update your Kustomization automatically.
```
I used the command:
```
kustomize edit fix --vars
```
And also corrected errors received when executing this command. Manifests are now generated without warnings.

Please note that this PR should not affect the manifests themselves in any way, only the warning is removed.

**Checklist:**
- [ ] Unit tests pass:
  **Make sure you have installed kustomize == 5.2.1+**
    1. `make generate-changed-only`
    2. `make test`
