### PR TITLE
Reorder oauth2-proxy manifests so that namespace is first

### DIFF
--- a/common/oidc-client/oauth2-proxy/base/kustomization.yaml
+++ b/common/oidc-client/oauth2-proxy/base/kustomization.yaml
@@ -4,8 +4,8 @@ kind: Kustomization
 namespace: oauth2-proxy
 
 resources:
-- deployment.yaml
 - namespace.yaml
+- deployment.yaml
 - oauth2-proxy-config.yaml
 - serviceaccount.yaml
 - service.yaml


### PR DESCRIPTION
**Description of your changes:**
This ensures that the namespace is always deployed before anything else, even if fifo ordering is used with Kustomize.

**Checklist:**
- [ ] Unit tests pass:
  **Make sure you have installed kustomize == 5.2.1+**
    1. `make generate-changed-only`
    2. `make test`
