### PR TITLE
Also use hashFromEnv for oauth2-proxy overlay

### DIFF
--- a/common/dex/overlays/oauth2-proxy/config-map.yaml
+++ b/common/dex/overlays/oauth2-proxy/config-map.yaml
@@ -19,9 +19,7 @@ data:
     enablePasswordDB: true
     staticPasswords:
     - email: user@example.com
-      hash: $2y$12$4K/VkmDd1q1Orb3xAt82zu8gk7Ad6ReFR4LCP9UeYE90NLiN9Df72
-      # https://github.com/dexidp/dex/pull/1601/commits
-      # FIXME: Use hashFromEnv instead
+      hashFromEnv: DEX_USER_PASSWORD
       username: user
       userID: "15841185641784"
     staticClients:


### PR DESCRIPTION
**Description of your changes:**
Same as cd991e6010a8c694a729d2978f4c8be597669fff


**Checklist:**
- [ ] Unit tests pass:
  **Make sure you have installed kustomize == 5.2.1+**
    1. `make generate-changed-only`
    2. `make test`
