### PR TITLE
Bump node image to 1.28

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,6 +113,7 @@ kind: Cluster
 apiVersion: kind.x-k8s.io/v1alpha4
 nodes:
 - role: control-plane
+  image: kindest/node:v1.28.0
   kubeadmConfigPatches:
   - |
     kind: ClusterConfiguration
@@ -134,7 +135,7 @@ kind get kubeconfig --name kubeflow > ~/.kube/config
 docker login
 
 kubectl create secret generic regcred \
-    --from-file=.dockerconfigjson=/path/to/.docker/config.json \
+    --from-file=.dockerconfigjson=/home/to/.docker/config.json \
     --type=kubernetes.io/dockerconfigjson
 ```
 


### PR DESCRIPTION
**Which issue is resolved by this Pull Request:**
NA

**Description of your changes:**
Bump node image to 1.28

**Checklist:**
- [ X ] Unit tests pass:
  **Make sure you have installed kustomize == 5.2.1+**
    1. `make generate-changed-only`
    2. `make test`
