### PR TITLE
Add model registry sync script

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,7 @@ This repo periodically syncs all official Kubeflow components from their respect
 | KServe Models Web App | contrib/kserve/models-web-app | [v0.10.0](https://github.com/kserve/models-web-app/tree/v0.10.0/config) |
 | Kubeflow Pipelines | apps/pipeline/upstream | [2.0.5](https://github.com/kubeflow/pipelines/tree/2.0.5/manifests/kustomize) |
 | Kubeflow Tekton Pipelines | apps/kfp-tekton/upstream | [2.0.5](https://github.com/kubeflow/kfp-tekton/tree/2.0.5/manifests/kustomize) |
+| Kubeflow Model Registry | apps/model-registry/upstream | [main](https://github.com/kubeflow/model-registry/tree/main/manifests/kustomize) |
 
 The following is also a matrix with versions from common components that are
 used from the different projects of Kubeflow:

--- a/hack/sync-model-registry-manifests.sh
+++ b/hack/sync-model-registry-manifests.sh
@@ -1,0 +1,78 @@
+#!/usr/bin/env bash
+
+# This script aims at helping create a PR to update the manifests of the
+# kubeflow/model-registry repo.
+# This script:
+# 1. Checks out a new branch
+# 2. Copies files to the correct places
+# 3. Commits the changes
+#
+# Afterwards the developers can submit the PR to the kubeflow/manifests
+# repo, based on that local branch
+
+# strict mode http://redsymbol.net/articles/unofficial-bash-strict-mode/
+set -euo pipefail
+IFS=$'\n\t'
+
+DEV_MODE=${DEV_MODE:=false}
+SRC_DIR=${SRC_DIR:=/tmp/kubeflow-model-registry}
+BRANCH=${BRANCH:=sync-kubeflow-model-registry-manifests-${COMMIT?}}
+
+SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
+MANIFESTS_DIR=$(dirname $SCRIPT_DIR)
+
+if [ "$DEV_MODE" != "false" ]; then
+    echo "WARNING: Dev mode enabled..."
+fi
+
+echo "Creating branch: ${BRANCH}"
+
+# DEV: Comment out this if you are testing locally
+if [ -n "$(git status --porcelain)" ]; then
+  # Uncommitted changes
+  echo "WARNING: You have uncommitted changes, exiting..."
+  exit 1
+fi
+
+if [ `git branch --list $BRANCH` ]
+then
+   echo "WARNING: Branch $BRANCH already exists. Exiting..."
+   exit 1
+fi
+
+# DEV: If you are testing locally set DEV_MODE=true to skip this step
+if [ "$DEV_MODE" = "false" ]; then
+    git checkout -b $BRANCH
+fi
+
+echo "Checking out in $SRC_DIR to $COMMIT..."
+cd $SRC_DIR
+if [ -n "$(git status --porcelain)" ]; then
+  # Uncommitted changes
+  echo "WARNING: You have uncommitted changes, exiting..."
+  exit 1
+fi
+git checkout $COMMIT
+
+echo "Copying model-registry manifests..."
+DST_DIR=$MANIFESTS_DIR/apps/model-registry/upstream
+rm -rf $DST_DIR
+mkdir -p $DST_DIR
+cp $SRC_DIR/manifests/kustomize/* $DST_DIR -r
+
+echo "Successfully copied all manifests."
+
+echo "Updating README..."
+SRC_TXT="\[.*\](https://github.com/kubeflow/model-registry/tree/.*/manifests/kustomize)"
+DST_TXT="\[$COMMIT\](https://github.com/kubeflow/model-registry/tree/$COMMIT/manifests/kustomize)"
+
+sed -i "s|$SRC_TXT|$DST_TXT|g" ${MANIFESTS_DIR}/README.md
+
+# DEV: If you are testing locally set DEV_MODE=true to skip this step
+if [ "$DEV_MODE" = "false" ]; then
+    echo "Committing the changes..."
+    cd $MANIFESTS_DIR
+    git add apps
+    git add README.md
+    git commit -s -m "Update kubeflow/model-registry manifests from ${COMMIT}"
+fi


### PR DESCRIPTION
**Which issue is resolved by this Pull Request:**
Resolves https://github.com/kubeflow/manifests/issues/2631

**Description of your changes:**

- Added script to automatically fetch model-registry manifests, followed the same approach that has been done for other components
- Updated README adding model-registry row, since there is no version yet I linked `main` branch

**Checklist:**
- [ ] Unit tests pass:
  **Make sure you have installed kustomize == 5.2.1+**
    1. `make generate-changed-only`
    2. `make test`
