### PR TITLE
Setup KF Model Registry GH tests

### DIFF
--- a/.github/workflows/model_registry_test.yaml
+++ b/.github/workflows/model_registry_test.yaml
@@ -1,0 +1,42 @@
+# If anyone changes or improve the following tests for Model Registry, please 
+# consider reflecting the same changes on https://github.com/kubeflow/model-registry
+name: Deploy and test Kubeflow Model Registry
+on:
+  pull_request:
+    paths:
+      - apps/model-registry/upstream/**
+      - tests/gh-actions/kind-cluster.yaml
+      - tests/gh-actions/install_istio.sh
+
+jobs:
+  build-kfmr:
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v4
+
+    - name: Install KinD
+      run: ./tests/gh-actions/install_kind.sh
+
+    - name: Create KinD Cluster
+      run: kind create cluster --config tests/gh-actions/kind-cluster.yaml
+
+    - name: Install kustomize
+      run: ./tests/gh-actions/install_kustomize.sh
+
+    - name: Install Istio
+      run: ./tests/gh-actions/install_istio.sh
+
+    - name: Create kubeflow namespace
+      run: kustomize build common/kubeflow-namespace/base | kubectl apply -f -
+
+    - name: Build & Apply KF Model Registry manifests
+      run: |
+        kustomize build apps/model-registry/upstream/overlays/db | kubectl apply -f -
+        kustomize build apps/model-registry/upstream/options/istio | kubectl apply -f -
+
+    - name: Test KF Model Registry deployment
+      run: |
+        echo "Waiting for all Model Registry Pods to become ready..."
+        kubectl wait --for=condition=available -n kubeflow deployment/model-registry-db --timeout=600s
+        kubectl wait --for=condition=available -n kubeflow deployment/model-registry-deployment --timeout=600s


### PR DESCRIPTION
**Which issue is resolved by this Pull Request:**
Resolves #

Followup of https://github.com/kubeflow/manifests/issues/2631

**Description of your changes:**

Add GH test for Kubeflow Model Registry component.

**Checklist:**
- [x] Unit tests pass:
  **Make sure you have installed kustomize == 5.2.1+**
    1. `make generate-changed-only`
    2. `make test`
