### PR TITLE
Upgrade dex to 2.39.1

### DIFF
--- a/common/dex/base/deployment.yaml
+++ b/common/dex/base/deployment.yaml
@@ -16,7 +16,7 @@ spec:
     spec:
       serviceAccountName: dex
       containers:
-      - image: ghcr.io/dexidp/dex:v2.36.0
+      - image: ghcr.io/dexidp/dex:v2.39.1
         name: dex
         command: ["dex", "serve", "/etc/dex/cfg/config.yaml"]
         ports:


### PR DESCRIPTION
**Which issue is resolved by this Pull Request:**
Resolves #

**Description of your changes:**

Upgrade `dex` to `2.39.1`

**Checklist:**
- [x] Unit tests pass:
  **Make sure you have installed kustomize == 5.2.1+**
    1. `make generate-changed-only`
    2. `make test`
