### PR TITLE
Update seldon manifests from v1.18.1

### DIFF
--- a/contrib/seldon/Makefile
+++ b/contrib/seldon/Makefile
@@ -1,9 +1,11 @@
 
-SELDON_VERSION ?= 1.17.1
+SELDON_VERSION ?= 1.18.1
+# This could be replaced by a local path if required
+SELDON_OPERATOR_CHART ?= seldon-core-operator --repo https://storage.googleapis.com/seldon-charts
 
 seldon-core-operator/base: clean-kustomize
 	mkdir -p seldon-core-operator/base
-	cd seldon-core-operator/base && helm template -f ../../values.yaml seldon-core seldon-core-operator --repo https://storage.googleapis.com/seldon-charts --namespace kubeflow --version ${SELDON_VERSION}  > resources.yaml
+	cd seldon-core-operator/base && helm template -f ../../values.yaml seldon-core ${SELDON_OPERATOR_CHART} --namespace kubeflow --version ${SELDON_VERSION}  > resources.yaml
 	sed -i 's#cert-manager.io/inject-ca-from:.*#cert-manager.io/inject-ca-from: kubeflow/seldon-serving-cert#g' seldon-core-operator/base/resources.yaml
 	sed -i "s#'seldon-webhook-service.kubeflow.svc.cluster.local'#"'seldon-webhook-service.$$(SERVICE_NAMESPACE).svc.cluster.local#' seldon-core-operator/base/resources.yaml
 	sed -i "s#commonName: 'seldon-webhook-service.kubeflow.svc'#"'commonName: seldon-webhook-service.$$(CERTIFICATE_NAMESPACE).svc#' seldon-core-operator/base/resources.yaml

--- a/contrib/seldon/seldon-core-operator/base/resources.yaml
+++ b/contrib/seldon/seldon-core-operator/base/resources.yaml
@@ -7,7 +7,7 @@ metadata:
     app: seldon
     app.kubernetes.io/instance: 'seldon-core'
     app.kubernetes.io/name: 'seldon-core-operator'
-    app.kubernetes.io/version: '1.17.1'
+    app.kubernetes.io/version: '1.18.1'
   name: 'seldon-manager'
   namespace: 'kubeflow'
 ---
@@ -20,7 +20,7 @@ metadata:
     app: seldon
     app.kubernetes.io/instance: 'seldon-core'
     app.kubernetes.io/name: 'seldon-core-operator'
-    app.kubernetes.io/version: '1.17.1'
+    app.kubernetes.io/version: '1.18.1'
   name: seldon-manager-role-kubeflow
 rules:
 - apiGroups:
@@ -288,7 +288,7 @@ metadata:
     app: seldon
     app.kubernetes.io/instance: 'seldon-core'
     app.kubernetes.io/name: 'seldon-core-operator'
-    app.kubernetes.io/version: '1.17.1'
+    app.kubernetes.io/version: '1.18.1'
   name: seldon-manager-sas-role-kubeflow
 rules:
 - apiGroups:
@@ -325,7 +325,7 @@ metadata:
     app: seldon
     app.kubernetes.io/instance: 'seldon-core'
     app.kubernetes.io/name: 'seldon-core-operator'
-    app.kubernetes.io/version: '1.17.1'
+    app.kubernetes.io/version: '1.18.1'
   name: seldon-webhook-role-kubeflow
 rules:
 - apiGroups:
@@ -372,7 +372,7 @@ metadata:
     app: seldon
     app.kubernetes.io/instance: 'seldon-core'
     app.kubernetes.io/name: 'seldon-core-operator'
-    app.kubernetes.io/version: '1.17.1'
+    app.kubernetes.io/version: '1.18.1'
   name: seldon-manager-rolebinding-kubeflow
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -391,7 +391,7 @@ metadata:
     app: seldon
     app.kubernetes.io/instance: 'seldon-core'
     app.kubernetes.io/name: 'seldon-core-operator'
-    app.kubernetes.io/version: '1.17.1'
+    app.kubernetes.io/version: '1.18.1'
   name: seldon-manager-sas-rolebinding-kubeflow
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -410,7 +410,7 @@ metadata:
     app: seldon
     app.kubernetes.io/instance: 'seldon-core'
     app.kubernetes.io/name: 'seldon-core-operator'
-    app.kubernetes.io/version: '1.17.1'
+    app.kubernetes.io/version: '1.18.1'
   name: seldon-webhook-rolebinding-kubeflow
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -429,7 +429,7 @@ metadata:
     app: seldon
     app.kubernetes.io/instance: 'seldon-core'
     app.kubernetes.io/name: 'seldon-core-operator'
-    app.kubernetes.io/version: '1.17.1'
+    app.kubernetes.io/version: '1.18.1'
   name: seldon-leader-election-role
   namespace: 'kubeflow'
 rules:
@@ -481,7 +481,7 @@ metadata:
     app: seldon
     app.kubernetes.io/instance: 'seldon-core'
     app.kubernetes.io/name: 'seldon-core-operator'
-    app.kubernetes.io/version: '1.17.1'
+    app.kubernetes.io/version: '1.18.1'
   name: seldon-leader-election-rolebinding
   namespace: 'kubeflow'
 roleRef:
@@ -501,7 +501,7 @@ metadata:
     app: seldon
     app.kubernetes.io/instance: 'seldon-core'
     app.kubernetes.io/name: 'seldon-core-operator'
-    app.kubernetes.io/version: '1.17.1'
+    app.kubernetes.io/version: '1.18.1'
     control-plane: seldon-controller-manager
   name: seldon-controller-manager
   namespace: 'kubeflow'
@@ -531,6 +531,7 @@ spec:
       - args:
         - --enable-leader-election
         - --webhook-port=4443
+        - --metrics-addr=:8080
         - --create-resources=$(MANAGER_CREATE_RESOURCES)
         - --log-level=$(MANAGER_LOG_LEVEL)
         - --leader-election-id=$(MANAGER_LEADER_ELECTION_ID)
@@ -615,7 +616,7 @@ spec:
         - name: USE_EXECUTOR
           value: 'true'
         - name: EXECUTOR_CONTAINER_IMAGE_AND_VERSION
-          value: 'docker.io/seldonio/seldon-core-executor:1.17.1'
+          value: 'docker.io/seldonio/seldon-core-executor:1.18.1'
         - name: EXECUTOR_CONTAINER_IMAGE_PULL_POLICY
           value: 'IfNotPresent'
         - name: EXECUTOR_PROMETHEUS_PATH
@@ -648,7 +649,7 @@ spec:
           value: 'false'
         - name: EXECUTOR_FULL_HEALTH_CHECKS
           value: 'false'
-        image: 'docker.io/seldonio/seldon-core-operator:1.17.1'
+        image: 'docker.io/seldonio/seldon-core-operator:1.18.1'
         imagePullPolicy: 'IfNotPresent'
         name: manager
         ports:
@@ -680,7 +681,7 @@ metadata:
     app: seldon
     app.kubernetes.io/instance: 'seldon-core'
     app.kubernetes.io/name: 'seldon-core-operator'
-    app.kubernetes.io/version: '1.17.1'
+    app.kubernetes.io/version: '1.18.1'
   name: seldon-serving-cert
   namespace: 'kubeflow'
 spec:
@@ -701,7 +702,7 @@ metadata:
     app: seldon
     app.kubernetes.io/instance: 'seldon-core'
     app.kubernetes.io/name: 'seldon-core-operator'
-    app.kubernetes.io/version: '1.17.1'
+    app.kubernetes.io/version: '1.18.1'
   name: seldon-selfsigned-issuer
   namespace: 'kubeflow'
 spec:

--- a/hack/sync-seldon-manifests.sh
+++ b/hack/sync-seldon-manifests.sh
@@ -1,0 +1,88 @@
+#!/usr/bin/env bash
+
+# This script aims at helping create a PR to update the manifests of the
+# contrib/seldon repo.
+# This script:
+# 1. Checks out a new branch
+# 2. Copies files to the correct places
+# 3. Commits the changes
+#
+# Afterwards the developers can submit the PR to the kubeflow/manifests
+# repo, based on that local branch
+# It must be executed directly from its directory
+
+# strict mode http://redsymbol.net/articles/unofficial-bash-strict-mode/
+set -euxo pipefail
+IFS=$'\n\t'
+
+COMMIT="v1.18.1" # You can use tags as well
+SRC_DIR=${SRC_DIR:=/tmp/seldon}
+BRANCH=${BRANCH:=sync-seldon-core-manifests-${COMMIT?}}
+UPDATE_ECHO_MODEL=false
+
+SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
+MANIFESTS_DIR=$(dirname $SCRIPT_DIR)
+
+echo "Creating branch: ${BRANCH}"
+
+if [ -n "$(git status --porcelain)" ]; then
+  echo "WARNING: You have uncommitted changes"
+fi
+if [ `git branch --list $BRANCH` ]
+then
+   echo "WARNING: Branch $BRANCH already exists."
+fi
+
+# Create the branch in the manifests repository
+if ! git show-ref --verify --quiet refs/heads/$BRANCH; then
+    git checkout -b $BRANCH
+else
+    echo "Branch $BRANCH already exists."
+fi
+echo "Checking out in $SRC_DIR to $COMMIT..."
+
+# Checkout the Seldon repository
+mkdir -p $SRC_DIR
+cd $SRC_DIR
+if [ ! -d "seldon-core/.git" ]; then
+    git clone https://github.com/SeldonIO/seldon-core.git
+fi
+cd $SRC_DIR/seldon-core
+if ! git rev-parse --verify --quiet $COMMIT; then
+    git checkout -b $COMMIT
+else
+    git checkout $COMMIT
+fi
+
+
+if [ -n "$(git status --porcelain)" ]; then
+  echo "WARNING: You have uncommitted changes"
+fi
+
+echo "Updating seldon manifests..."
+DST_DIR=$MANIFESTS_DIR/contrib/seldon
+
+cd $DST_DIR
+SRC_TXT="SELDON_VERSION ?= .*"
+DST_TXT="SELDON_VERSION ?= ${COMMIT:1}"
+sed -i "s|$SRC_TXT|$DST_TXT|g" ${DST_DIR}/Makefile
+# Update manifests
+SELDON_OPERATOR_CHART="$SRC_DIR/seldon-core/helm-charts/seldon-core-operator" make seldon-core-operator/base
+
+echo "Successfully updated all manifests."
+
+if [ "$UPDATE_ECHO_MODEL" = "true" ]; then
+    echo "Updating seldonio/echo-model version..."
+    SRC_TXT="seldonio/echo-model:[0-9]\+\.[0-9]\+\.[0-9]\+"
+    DST_TXT="seldonio/echo-model:${COMMIT:1}"
+    sed -i "s|$SRC_TXT|$DST_TXT|g" ${DST_DIR}/README.md
+    sed -i "s|$SRC_TXT|$DST_TXT|g" ${DST_DIR}/example.yaml
+    echo "Successfully updated seldonio/echo-model."
+fi
+
+
+echo "Committing the changes..."
+cd $MANIFESTS_DIR
+git add contrib/seldon
+git add README.md
+git commit -s -m "Update seldon manifests from ${COMMIT}"


### PR DESCRIPTION
**Which issue is resolved by this Pull Request:**

Resolves https://github.com/kubeflow/manifests/issues/2673

**Description of your changes:**

- [x] Update seldon-core-operator to version `v1.18.1` following the `UPGRADE.md` guide
- [x] Add sync script to automate the manifests upgrade from github repo

I had to slightly change the `contrib/seldon/Makefile` because the `v1.18.1` charts seem not present in https://storage.googleapis.com/seldon-charts helm chart repo, therefore I switched to download the github repo and using local helm chart. 

**Checklist:**
- [x] Unit tests pass:
  **Make sure you have installed kustomize == 5.2.1+**
    1. `make generate-changed-only`
    2. `make test`
