### PR TITLE
add Model Registry networkpolicy

### DIFF
--- a/common/networkpolicies/base/kustomization.yaml
+++ b/common/networkpolicies/base/kustomization.yaml
@@ -16,6 +16,7 @@ resources:
   - minio.yaml
   - ml-pipeline-ui.yaml
   - ml-pipeline.yaml
+  - model-registry.yaml
   - poddefaults.yaml
   - pvcviewer-webhook.yaml
   - seldon.yaml

--- a/common/networkpolicies/base/model-registry.yaml
+++ b/common/networkpolicies/base/model-registry.yaml
@@ -24,7 +24,6 @@ spec:
                 operator: In
                 values:
                   - istio-system
-        - podSelector: {} # allow all pods from the same namespace
       ports:
         - protocol: TCP
           port: 8080

--- a/common/networkpolicies/base/model-registry.yaml
+++ b/common/networkpolicies/base/model-registry.yaml
@@ -25,5 +25,10 @@ spec:
                 values:
                   - istio-system
         - podSelector: {} # allow all pods from the same namespace
+      ports:
+        - protocol: TCP
+          port: 8080
+        - protocol: TCP
+          port: 9090
   policyTypes:
     - Ingress

--- a/common/networkpolicies/base/model-registry.yaml
+++ b/common/networkpolicies/base/model-registry.yaml
@@ -1,0 +1,29 @@
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: model-registry
+  namespace: kubeflow
+spec:
+  podSelector:
+    matchExpressions:
+      - key: component
+        operator: In
+        values:
+          - model-registry-server
+  ingress:
+    - from:
+        - namespaceSelector:
+            matchExpressions:
+              - key: app.kubernetes.io/part-of
+                operator: In
+                values:
+                  - kubeflow-profile
+        - namespaceSelector:
+            matchExpressions:
+              - key: kubernetes.io/metadata.name
+                operator: In
+                values:
+                  - istio-system
+        - podSelector: {} # allow all pods from the same namespace
+  policyTypes:
+    - Ingress


### PR DESCRIPTION
Raising as draft following indication on #2701 but not yet sure how to manually verify: I've tested with `1.9.0-rc.0` on a local cluster, both with _and_ without this network policy, I can reach the service both externally the cluster (authenticated call) and from another pod in a different namespace (namespace "default" using wget from an hello-world pod).

**Which issue is resolved by this Pull Request:**
Resolves #2701 

**Description of your changes:**


**Checklist:**
- [ ] Unit tests pass:
  **Make sure you have installed kustomize == 5.2.1+**
    1. `make generate-changed-only`
    2. `make test`
