### PR TITLE
Change extract_images.sh to include Model Registry

### DIFF
--- a/hack/extract_images.sh
+++ b/hack/extract_images.sh
@@ -18,6 +18,7 @@ declare -A wg_dirs=(
   [manifests]="../common/cert-manager/cert-manager/base ../common/cert-manager/kubeflow-issuer/base ../common/istio-1-17/istio-crds/base ../common/istio-1-17/istio-namespace/base ../common/istio-1-17/istio-install/overlays/oauth2-proxy ../common/oidc-client/oauth2-proxy/overlays/m2m-self-signed ../common/dex/overlays/oauth2-proxy ../common/knative/knative-serving/overlays/gateways ../common/knative/knative-eventing/base ../common/istio-1-17/cluster-local-gateway/base ../common/kubeflow-namespace/base ../common/kubeflow-roles/base ../common/istio-1-17/kubeflow-istio-resources/base"
   [workbenches]="../apps/pvcviewer-controller/upstream/base ../apps/admission-webhook/upstream/overlays ../apps/centraldashboard/upstream/overlays/oauth2-proxy ../apps/jupyter/jupyter-web-app/upstream/overlays ../apps/volumes-web-app/upstream/overlays ../apps/tensorboard/tensorboards-web-app/upstream/overlays ../apps/profiles/upstream/overlays ../apps/jupyter/notebook-controller/upstream/overlays ../apps/tensorboard/tensorboard-controller/upstream/overlays"
   [serving]="../contrib/kserve - ../contrib/kserve/models-web-app/overlays/kubeflow"
+  [model-registry]="../apps/model-registry/upstream"
 )
 
 save_images() {


### PR DESCRIPTION
# Pull Request Template for Kubeflow manifests Issues

## ✏️ A brief description of the changes
Included in `hack/extract_images.sh` script the Model Registry images.

## 📦 List any dependencies that are required for this change
N/A

## 🐛 If this PR is related to an issue, please put the link of the issue here.
N/A


  
## ✅ Unit Test Checklist
  
  - [X] 🛠️ Make sure you have installed kustomize == 5.2.1+     
  - [ ] ✍️ Have you written new tests for your core changes, as applicable?      
  - [X] 🔄 Have you successfully run existing tests with your changes ?    
  - [X] 🚀 Have you successfully run existing and new tests with your changes ?

## ✅ Contributor checklist
  - [x] All the commits have been _signed-off_  (To pass the `DCO` check)
  - [X] Submit the [Contributor License Agreements](https://cla.developers.google.com/clas) (To pass the `cla/google` check)


---     
 
>You can join our slack channel **wg-manifests** [here](https://www.kubeflow.org/docs/about/community/). This link also contains our meeting schedule.
  