### PR TITLE
Sync kserve manifests 0.13.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ This repo periodically syncs all official Kubeflow components from their respect
 | Tensorboards Web App | apps/tensorboard/tensorboards-web-app/upstream | [v1.9.0-rc.0](https://github.com/kubeflow/kubeflow/tree/v1.9.0-rc.0/components/crud-web-apps/tensorboards/manifests) |
 | Volumes Web App | apps/volumes-web-app/upstream | [v1.9.0-rc.0](https://github.com/kubeflow/kubeflow/tree/v1.9.0-rc.0/components/crud-web-apps/volumes/manifests) |
 | Katib | apps/katib/upstream | [v0.17.0-rc.0](https://github.com/kubeflow/katib/tree/v0.17.0-rc.0/manifests/v1beta1) |
-| KServe | contrib/kserve/kserve | [0.12.1](https://github.com/kserve/kserve/tree/0.12.1/install/v0.12.1) |
+| KServe | contrib/kserve/kserve | [0.13.0](https://github.com/kserve/kserve/releases/tag/v0.13.0) |
 | KServe Models Web App | contrib/kserve/models-web-app | [v0.10.0](https://github.com/kserve/models-web-app/tree/v0.10.0/config) |
 | Kubeflow Pipelines | apps/pipeline/upstream | [2.2.0](https://github.com/kubeflow/pipelines/tree/2.2.0/manifests/kustomize) |
 | Kubeflow Tekton Pipelines | apps/kfp-tekton/upstream | [2.0.5](https://github.com/kubeflow/kfp-tekton/tree/2.0.5/manifests/kustomize) |

--- a/contrib/kserve/kserve/kserve-cluster-resources.yaml
+++ b/contrib/kserve/kserve/kserve-cluster-resources.yaml
@@ -9,7 +9,7 @@ spec:
   containers:
   - args:
     - --model_name={{.Name}}
-    image: kserve/huggingfaceserver:v0.12.1
+    image: kserve/huggingfaceserver:v0.13.0
     name: kserve-container
     resources:
       limits:
@@ -41,7 +41,7 @@ spec:
     - --model_dir=/mnt/models
     - --http_port=8080
     - --nthread=1
-    image: kserve/lgbserver:v0.12.1
+    image: kserve/lgbserver:v0.13.0
     name: kserve-container
     resources:
       limits:
@@ -123,7 +123,7 @@ spec:
     - --model_name={{.Name}}
     - --model_dir=/mnt/models
     - --http_port=8080
-    image: kserve/paddleserver:v0.12.1
+    image: kserve/paddleserver:v0.13.0
     name: kserve-container
     resources:
       limits:
@@ -154,7 +154,7 @@ spec:
     - --model_name={{.Name}}
     - --model_dir=/mnt/models
     - --http_port=8080
-    image: kserve/pmmlserver:v0.12.1
+    image: kserve/pmmlserver:v0.13.0
     name: kserve-container
     resources:
       limits:
@@ -189,7 +189,7 @@ spec:
     - --model_name={{.Name}}
     - --model_dir=/mnt/models
     - --http_port=8080
-    image: kserve/sklearnserver:v0.12.1
+    image: kserve/sklearnserver:v0.13.0
     name: kserve-container
     resources:
       limits:
@@ -348,7 +348,7 @@ spec:
     - --model_dir=/mnt/models
     - --http_port=8080
     - --nthread=1
-    image: kserve/xgbserver:v0.12.1
+    image: kserve/xgbserver:v0.13.0
     name: kserve-container
     resources:
       limits:
@@ -372,7 +372,7 @@ metadata:
   name: default
 spec:
   container:
-    image: kserve/storage-initializer:v0.12.1
+    image: kserve/storage-initializer:v0.13.0
     name: storage-initializer
     resources:
       limits:

--- a/contrib/kserve/kserve/kserve.yaml
+++ b/contrib/kserve/kserve/kserve.yaml
@@ -3105,17 +3105,6 @@ metadata:
     controller-gen.kubebuilder.io/version: v0.12.0
   name: inferenceservices.serving.kserve.io
 spec:
-  conversion:
-    strategy: Webhook
-    webhook:
-      clientConfig:
-        caBundle: Cg==
-        service:
-          name: kserve-webhook-server-service
-          namespace: kserve
-          path: /convert
-      conversionReviewVersions:
-      - v1beta1
   group: serving.kserve.io
   names:
     kind: InferenceService
@@ -3124,7 +3113,6 @@ spec:
     shortNames:
     - isvc
     singular: inferenceservice
-  preserveUnknownFields: false
   scope: Namespaced
   versions:
   - additionalPrinterColumns:
@@ -3530,637 +3518,6 @@ spec:
                               type: object
                             type: array
                         type: object
-                    type: object
-                  alibi:
-                    properties:
-                      args:
-                        items:
-                          type: string
-                        type: array
-                      command:
-                        items:
-                          type: string
-                        type: array
-                      config:
-                        additionalProperties:
-                          type: string
-                        type: object
-                      env:
-                        items:
-                          properties:
-                            name:
-                              type: string
-                            value:
-                              type: string
-                            valueFrom:
-                              properties:
-                                configMapKeyRef:
-                                  properties:
-                                    key:
-                                      type: string
-                                    name:
-                                      type: string
-                                    optional:
-                                      type: boolean
-                                  required:
-                                  - key
-                                  type: object
-                                  x-kubernetes-map-type: atomic
-                                fieldRef:
-                                  properties:
-                                    apiVersion:
-                                      type: string
-                                    fieldPath:
-                                      type: string
-                                  required:
-                                  - fieldPath
-                                  type: object
-                                  x-kubernetes-map-type: atomic
-                                resourceFieldRef:
-                                  properties:
-                                    containerName:
-                                      type: string
-                                    divisor:
-                                      anyOf:
-                                      - type: integer
-                                      - type: string
-                                      pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                                      x-kubernetes-int-or-string: true
-                                    resource:
-                                      type: string
-                                  required:
-                                  - resource
-                                  type: object
-                                  x-kubernetes-map-type: atomic
-                                secretKeyRef:
-                                  properties:
-                                    key:
-                                      type: string
-                                    name:
-                                      type: string
-                                    optional:
-                                      type: boolean
-                                  required:
-                                  - key
-                                  type: object
-                                  x-kubernetes-map-type: atomic
-                              type: object
-                          required:
-                          - name
-                          type: object
-                        type: array
-                      envFrom:
-                        items:
-                          properties:
-                            configMapRef:
-                              properties:
-                                name:
-                                  type: string
-                                optional:
-                                  type: boolean
-                              type: object
-                              x-kubernetes-map-type: atomic
-                            prefix:
-                              type: string
-                            secretRef:
-                              properties:
-                                name:
-                                  type: string
-                                optional:
-                                  type: boolean
-                              type: object
-                              x-kubernetes-map-type: atomic
-                          type: object
-                        type: array
-                      image:
-                        type: string
-                      imagePullPolicy:
-                        type: string
-                      lifecycle:
-                        properties:
-                          postStart:
-                            properties:
-                              exec:
-                                properties:
-                                  command:
-                                    items:
-                                      type: string
-                                    type: array
-                                type: object
-                              httpGet:
-                                properties:
-                                  host:
-                                    type: string
-                                  httpHeaders:
-                                    items:
-                                      properties:
-                                        name:
-                                          type: string
-                                        value:
-                                          type: string
-                                      required:
-                                      - name
-                                      - value
-                                      type: object
-                                    type: array
-                                  path:
-                                    type: string
-                                  port:
-                                    anyOf:
-                                    - type: integer
-                                    - type: string
-                                    x-kubernetes-int-or-string: true
-                                  scheme:
-                                    type: string
-                                required:
-                                - port
-                                type: object
-                              tcpSocket:
-                                properties:
-                                  host:
-                                    type: string
-                                  port:
-                                    anyOf:
-                                    - type: integer
-                                    - type: string
-                                    x-kubernetes-int-or-string: true
-                                required:
-                                - port
-                                type: object
-                            type: object
-                          preStop:
-                            properties:
-                              exec:
-                                properties:
-                                  command:
-                                    items:
-                                      type: string
-                                    type: array
-                                type: object
-                              httpGet:
-                                properties:
-                                  host:
-                                    type: string
-                                  httpHeaders:
-                                    items:
-                                      properties:
-                                        name:
-                                          type: string
-                                        value:
-                                          type: string
-                                      required:
-                                      - name
-                                      - value
-                                      type: object
-                                    type: array
-                                  path:
-                                    type: string
-                                  port:
-                                    anyOf:
-                                    - type: integer
-                                    - type: string
-                                    x-kubernetes-int-or-string: true
-                                  scheme:
-                                    type: string
-                                required:
-                                - port
-                                type: object
-                              tcpSocket:
-                                properties:
-                                  host:
-                                    type: string
-                                  port:
-                                    anyOf:
-                                    - type: integer
-                                    - type: string
-                                    x-kubernetes-int-or-string: true
-                                required:
-                                - port
-                                type: object
-                            type: object
-                        type: object
-                      livenessProbe:
-                        properties:
-                          exec:
-                            properties:
-                              command:
-                                items:
-                                  type: string
-                                type: array
-                            type: object
-                          failureThreshold:
-                            format: int32
-                            type: integer
-                          grpc:
-                            properties:
-                              port:
-                                format: int32
-                                type: integer
-                              service:
-                                type: string
-                            required:
-                            - port
-                            type: object
-                          httpGet:
-                            properties:
-                              host:
-                                type: string
-                              httpHeaders:
-                                items:
-                                  properties:
-                                    name:
-                                      type: string
-                                    value:
-                                      type: string
-                                  required:
-                                  - name
-                                  - value
-                                  type: object
-                                type: array
-                              path:
-                                type: string
-                              port:
-                                anyOf:
-                                - type: integer
-                                - type: string
-                                x-kubernetes-int-or-string: true
-                              scheme:
-                                type: string
-                            type: object
-                          initialDelaySeconds:
-                            format: int32
-                            type: integer
-                          periodSeconds:
-                            format: int32
-                            type: integer
-                          successThreshold:
-                            format: int32
-                            type: integer
-                          tcpSocket:
-                            properties:
-                              host:
-                                type: string
-                              port:
-                                anyOf:
-                                - type: integer
-                                - type: string
-                                x-kubernetes-int-or-string: true
-                            type: object
-                          terminationGracePeriodSeconds:
-                            format: int64
-                            type: integer
-                          timeoutSeconds:
-                            format: int32
-                            type: integer
-                        type: object
-                      name:
-                        type: string
-                      ports:
-                        items:
-                          properties:
-                            containerPort:
-                              format: int32
-                              type: integer
-                            hostIP:
-                              type: string
-                            hostPort:
-                              format: int32
-                              type: integer
-                            name:
-                              type: string
-                            protocol:
-                              default: TCP
-                              type: string
-                          required:
-                          - containerPort
-                          type: object
-                        type: array
-                        x-kubernetes-list-map-keys:
-                        - containerPort
-                        - protocol
-                        x-kubernetes-list-type: map
-                      readinessProbe:
-                        properties:
-                          exec:
-                            properties:
-                              command:
-                                items:
-                                  type: string
-                                type: array
-                            type: object
-                          failureThreshold:
-                            format: int32
-                            type: integer
-                          grpc:
-                            properties:
-                              port:
-                                format: int32
-                                type: integer
-                              service:
-                                type: string
-                            required:
-                            - port
-                            type: object
-                          httpGet:
-                            properties:
-                              host:
-                                type: string
-                              httpHeaders:
-                                items:
-                                  properties:
-                                    name:
-                                      type: string
-                                    value:
-                                      type: string
-                                  required:
-                                  - name
-                                  - value
-                                  type: object
-                                type: array
-                              path:
-                                type: string
-                              port:
-                                anyOf:
-                                - type: integer
-                                - type: string
-                                x-kubernetes-int-or-string: true
-                              scheme:
-                                type: string
-                            type: object
-                          initialDelaySeconds:
-                            format: int32
-                            type: integer
-                          periodSeconds:
-                            format: int32
-                            type: integer
-                          successThreshold:
-                            format: int32
-                            type: integer
-                          tcpSocket:
-                            properties:
-                              host:
-                                type: string
-                              port:
-                                anyOf:
-                                - type: integer
-                                - type: string
-                                x-kubernetes-int-or-string: true
-                            type: object
-                          terminationGracePeriodSeconds:
-                            format: int64
-                            type: integer
-                          timeoutSeconds:
-                            format: int32
-                            type: integer
-                        type: object
-                      resizePolicy:
-                        items:
-                          properties:
-                            resourceName:
-                              type: string
-                            restartPolicy:
-                              type: string
-                          required:
-                          - resourceName
-                          - restartPolicy
-                          type: object
-                        type: array
-                        x-kubernetes-list-type: atomic
-                      resources:
-                        properties:
-                          claims:
-                            items:
-                              properties:
-                                name:
-                                  type: string
-                              required:
-                              - name
-                              type: object
-                            type: array
-                            x-kubernetes-list-map-keys:
-                            - name
-                            x-kubernetes-list-type: map
-                          limits:
-                            additionalProperties:
-                              anyOf:
-                              - type: integer
-                              - type: string
-                              pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                              x-kubernetes-int-or-string: true
-                            type: object
-                          requests:
-                            additionalProperties:
-                              anyOf:
-                              - type: integer
-                              - type: string
-                              pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                              x-kubernetes-int-or-string: true
-                            type: object
-                        type: object
-                      restartPolicy:
-                        type: string
-                      runtimeVersion:
-                        type: string
-                      securityContext:
-                        properties:
-                          allowPrivilegeEscalation:
-                            type: boolean
-                          capabilities:
-                            properties:
-                              add:
-                                items:
-                                  type: string
-                                type: array
-                              drop:
-                                items:
-                                  type: string
-                                type: array
-                            type: object
-                          privileged:
-                            type: boolean
-                          procMount:
-                            type: string
-                          readOnlyRootFilesystem:
-                            type: boolean
-                          runAsGroup:
-                            format: int64
-                            type: integer
-                          runAsNonRoot:
-                            type: boolean
-                          runAsUser:
-                            format: int64
-                            type: integer
-                          seLinuxOptions:
-                            properties:
-                              level:
-                                type: string
-                              role:
-                                type: string
-                              type:
-                                type: string
-                              user:
-                                type: string
-                            type: object
-                          seccompProfile:
-                            properties:
-                              localhostProfile:
-                                type: string
-                              type:
-                                type: string
-                            required:
-                            - type
-                            type: object
-                          windowsOptions:
-                            properties:
-                              gmsaCredentialSpec:
-                                type: string
-                              gmsaCredentialSpecName:
-                                type: string
-                              hostProcess:
-                                type: boolean
-                              runAsUserName:
-                                type: string
-                            type: object
-                        type: object
-                      startupProbe:
-                        properties:
-                          exec:
-                            properties:
-                              command:
-                                items:
-                                  type: string
-                                type: array
-                            type: object
-                          failureThreshold:
-                            format: int32
-                            type: integer
-                          grpc:
-                            properties:
-                              port:
-                                format: int32
-                                type: integer
-                              service:
-                                type: string
-                            required:
-                            - port
-                            type: object
-                          httpGet:
-                            properties:
-                              host:
-                                type: string
-                              httpHeaders:
-                                items:
-                                  properties:
-                                    name:
-                                      type: string
-                                    value:
-                                      type: string
-                                  required:
-                                  - name
-                                  - value
-                                  type: object
-                                type: array
-                              path:
-                                type: string
-                              port:
-                                anyOf:
-                                - type: integer
-                                - type: string
-                                x-kubernetes-int-or-string: true
-                              scheme:
-                                type: string
-                            required:
-                            - port
-                            type: object
-                          initialDelaySeconds:
-                            format: int32
-                            type: integer
-                          periodSeconds:
-                            format: int32
-                            type: integer
-                          successThreshold:
-                            format: int32
-                            type: integer
-                          tcpSocket:
-                            properties:
-                              host:
-                                type: string
-                              port:
-                                anyOf:
-                                - type: integer
-                                - type: string
-                                x-kubernetes-int-or-string: true
-                            required:
-                            - port
-                            type: object
-                          terminationGracePeriodSeconds:
-                            format: int64
-                            type: integer
-                          timeoutSeconds:
-                            format: int32
-                            type: integer
-                        type: object
-                      stdin:
-                        type: boolean
-                      stdinOnce:
-                        type: boolean
-                      storage:
-                        properties:
-                          key:
-                            type: string
-                          parameters:
-                            additionalProperties:
-                              type: string
-                            type: object
-                          path:
-                            type: string
-                          schemaPath:
-                            type: string
-                        type: object
-                      storageUri:
-                        type: string
-                      terminationMessagePath:
-                        type: string
-                      terminationMessagePolicy:
-                        type: string
-                      tty:
-                        type: boolean
-                      type:
-                        type: string
-                      volumeDevices:
-                        items:
-                          properties:
-                            devicePath:
-                              type: string
-                            name:
-                              type: string
-                          required:
-                          - devicePath
-                          - name
-                          type: object
-                        type: array
-                      volumeMounts:
-                        items:
-                          properties:
-                            mountPath:
-                              type: string
-                            mountPropagation:
-                              type: string
-                            name:
-                              type: string
-                            readOnly:
-                              type: boolean
-                            subPath:
-                              type: string
-                            subPathExpr:
-                              type: string
-                          required:
-                          - mountPath
-                          - name
-                          type: object
-                        type: array
-                      workingDir:
-                        type: string
                     type: object
                   annotations:
                     additionalProperties:
@@ -5430,6 +4787,24 @@ spec:
                       - name
                       type: object
                     type: array
+                  deploymentStrategy:
+                    properties:
+                      rollingUpdate:
+                        properties:
+                          maxSurge:
+                            anyOf:
+                            - type: integer
+                            - type: string
+                            x-kubernetes-int-or-string: true
+                          maxUnavailable:
+                            anyOf:
+                            - type: integer
+                            - type: string
+                            x-kubernetes-int-or-string: true
+                        type: object
+                      type:
+                        type: string
+                    type: object
                   dnsConfig:
                     properties:
                       nameservers:
@@ -8075,6 +7450,24 @@ spec:
                       - name
                       type: object
                     type: array
+                  deploymentStrategy:
+                    properties:
+                      rollingUpdate:
+                        properties:
+                          maxSurge:
+                            anyOf:
+                            - type: integer
+                            - type: string
+                            x-kubernetes-int-or-string: true
+                          maxUnavailable:
+                            anyOf:
+                            - type: integer
+                            - type: string
+                            x-kubernetes-int-or-string: true
+                        type: object
+                      type:
+                        type: string
+                    type: object
                   dnsConfig:
                     properties:
                       nameservers:
@@ -17628,6 +17021,24 @@ spec:
                       - name
                       type: object
                     type: array
+                  deploymentStrategy:
+                    properties:
+                      rollingUpdate:
+                        properties:
+                          maxSurge:
+                            anyOf:
+                            - type: integer
+                            - type: string
+                            x-kubernetes-int-or-string: true
+                          maxUnavailable:
+                            anyOf:
+                            - type: integer
+                            - type: string
+                            x-kubernetes-int-or-string: true
+                        type: object
+                      type:
+                        type: string
+                    type: object
                   dnsConfig:
                     properties:
                       nameservers:
@@ -21547,9 +20958,7 @@ rules:
   verbs:
   - create
   - get
-  - list
   - update
-  - watch
 - apiGroups:
   - ""
   resources:
@@ -21586,18 +20995,14 @@ rules:
   - create
   - delete
   - get
-  - list
   - patch
   - update
-  - watch
 - apiGroups:
   - ""
   resources:
   - serviceaccounts
   verbs:
   - get
-  - list
-  - watch
 - apiGroups:
   - ""
   resources:
@@ -21871,28 +21276,22 @@ data:
     options may be copied out of\n# this example block and unindented to be in the
     data block\n# to actually change the configuration.\n\n# ======================================
     EXPLAINERS CONFIGURATION ======================================\n# Example\nexplainers:
-    |-\n  {\n      \"alibi\": {\n          \"image\" : \"kserve/alibi-explainer\",\n
-    \         \"defaultImageVersion\": \"latest\"\n      },\n      \"art\": {\n          \"image\"
-    : \"kserve/art-explainer\",\n          \"defaultImageVersion\": \"latest\"\n      }\n
-    \ }\n# Alibi and Art Explainer runtime configuration\n explainers: |-\n   {\n
-    \      # Alibi explainer runtime configuration\n       \"alibi\": {\n           #
-    image contains the default Alibi explainer serving runtime image uri.\n           \"image\"
-    : \"kserve/alibi-explainer\",\n           \n           # defautltImageVersion
-    contains the Alibi explainer serving runtime default image version.\n           \"defaultImageVersion\":
-    \"latest\"\n       },\n       # Art explainer runtime configuration\n       \"art\":
-    {\n           # image contains the default Art explainer serving runtime image
-    uri.\n           \"image\" : \"kserve/art-explainer\",\n   \n           # defautltImageVersion
-    contains the Art explainer serving runtime default image version.\n           \"defaultImageVersion\":
+    |-\n  {\n      \"art\": {\n          \"image\" : \"kserve/art-explainer\",\n          \"defaultImageVersion\":
+    \"latest\"\n      }\n  }\n# Art Explainer runtime configuration\n explainers:
+    |-\n   {\n       # Art explainer runtime configuration\n       \"art\": {\n           #
+    image contains the default Art explainer serving runtime image uri.\n           \"image\"
+    : \"kserve/art-explainer\",\n   \n           # defautltImageVersion contains the
+    Art explainer serving runtime default image version.\n           \"defaultImageVersion\":
     \"latest\"\n       }\n   }\n \n # ====================================== STORAGE
     INITIALIZER CONFIGURATION ======================================\n # Example\n
-    storageInitializer: |-\n   {\n       \"image\" : \"kserve/storage-initializer:v0.12.1\",\n
+    storageInitializer: |-\n   {\n       \"image\" : \"kserve/storage-initializer:v0.13.0\",\n
     \      \"memoryRequest\": \"100Mi\",\n       \"memoryLimit\": \"1Gi\",\n       \"cpuRequest\":
     \"100m\",\n       \"cpuLimit\": \"1\",\n       \"caBundleConfigMapName\": \"\",\n
     \      \"caBundleVolumeMountPath\": \"/etc/ssl/custom-certs\",\n       \"enableDirectPvcVolumeMount\":
     false,\n       \"enableModelcar\": false,\n       \"cpuModelcar\": \"10m\",\n
     \      \"memoryModelcar\": \"15Mi\"\n   }\n storageInitializer: |-\n   {\n       #
     image contains the default storage initializer image uri.\n       \"image\" :
-    \"kserve/storage-initializer:v0.12.1\",\n       \n       # memoryRequest is the
+    \"kserve/storage-initializer:v0.13.0\",\n       \n       # memoryRequest is the
     requests.memory to set for the storage initializer init container.\n       \"memoryRequest\":
     \"100Mi\",\n   \n        # memoryLimit is the limits.memory to set for the storage
     initializer init container.\n       \"memoryLimit\": \"1Gi\",\n       \n       #
@@ -21973,7 +21372,8 @@ data:
     \      \"ingressService\" : \"istio-ingressgateway.istio-system.svc.cluster.local\",\n
     \      \"localGateway\" : \"knative-serving/knative-local-gateway\",\n       \"localGatewayService\"
     : \"knative-local-gateway.istio-system.svc.cluster.local\",\n       \"ingressDomain\"
-    \ : \"example.com\",\n       \"ingressClassName\" : \"istio\",\n       \"domainTemplate\":
+    \ : \"example.com\",\n       \"additionalIngressDomains\": [\"additional-example.com\",
+    \"additional-example-1.com\"],\n       \"ingressClassName\" : \"istio\",\n       \"domainTemplate\":
     \"{{ .Name }}-{{ .Namespace }}.{{ .IngressDomain }}\",\n       \"urlScheme\":
     \"http\",\n       \"disableIstioVirtualHost\": false,\n       \"disableIngressCreation\":
     false\n   }\n ingress: |-\n   {\n       # ingressGateway specifies the ingress
@@ -21994,9 +21394,12 @@ data:
     \n       # ingressDomain specifies the domain name which is used for creating
     the url.\n       # If ingressDomain is empty then example.com is used as default
     domain.\n       # NOTE: This configuration only applicable for raw deployment.\n
-    \      \"ingressDomain\"  : \"example.com\",\n \n       # ingressClassName specifies
-    the ingress controller to use for ingress traffic.\n       # This is optional
-    and if omitted the default ingress in the cluster is used.\n       # https://kubernetes.io/docs/concepts/services-networking/ingress/#default-ingress-class\n
+    \      \"ingressDomain\"  : \"example.com\",\n\n       # additionalIngressDomains
+    specifies the additional domain names which are used for creating the url.\n       \"additionalIngressDomains\":
+    [\"additional-example.com\", \"additional-example-1.com\"]\n\n       # ingressClassName
+    specifies the ingress controller to use for ingress traffic.\n       # This is
+    optional and if omitted the default ingress in the cluster is used.\n       #
+    https://kubernetes.io/docs/concepts/services-networking/ingress/#default-ingress-class\n
     \      # NOTE: This configuration only applicable for raw deployment.\n       \"ingressClassName\"
     : \"istio\",\n \n       # domainTemplate specifies the template for generating
     domain/url for each inference service by combining variable from:\n       # Name
@@ -22027,11 +21430,11 @@ data:
     NOTE: This configuration only applicable to serverless deployment.\n       \"pathTemplate\":
     \"/serving/{{ .Namespace }}/{{ .Name }}\"\n   }\n \n # ======================================
     LOGGER CONFIGURATION ======================================\n # Example\n logger:
-    |-\n   {\n       \"image\" : \"kserve/agent:v0.12.1\",\n       \"memoryRequest\":
+    |-\n   {\n       \"image\" : \"kserve/agent:v0.13.0\",\n       \"memoryRequest\":
     \"100Mi\",\n       \"memoryLimit\": \"1Gi\",\n       \"cpuRequest\": \"100m\",\n
     \      \"cpuLimit\": \"1\",\n       \"defaultUrl\": \"http://default-broker\"\n
     \  }\n logger: |-\n   {\n       # image contains the default logger image uri.\n
-    \      \"image\" : \"kserve/agent:v0.12.1\",\n   \n       # memoryRequest is the
+    \      \"image\" : \"kserve/agent:v0.13.0\",\n   \n       # memoryRequest is the
     requests.memory to set for the logger container.\n       \"memoryRequest\": \"100Mi\",\n
     \      \n       # memoryLimit is the limits.memory to set for the logger container.\n
     \      \"memoryLimit\": \"1Gi\",\n       \n       # cpuRequest is the requests.cpu
@@ -22040,11 +21443,11 @@ data:
     \"1\",\n       \n       # defaultUrl specifies the default logger url. If logger
     is not specified in the resource this url is used.\n       \"defaultUrl\": \"http://default-broker\"\n
     \  }\n \n # ====================================== BATCHER CONFIGURATION ======================================\n
-    # Example\n batcher: |-\n   {\n       \"image\" : \"kserve/agent:v0.12.1\",\n       \"memoryRequest\":
+    # Example\n batcher: |-\n   {\n       \"image\" : \"kserve/agent:v0.13.0\",\n       \"memoryRequest\":
     \"1Gi\",\n       \"memoryLimit\": \"1Gi\",\n       \"cpuRequest\": \"1\",\n       \"cpuLimit\":
     \"1\",\n       \"maxBatchSize\": \"32\",\n       \"maxLatency\": \"5000\"\n   }\n
     batcher: |-\n   {\n       # image contains the default batcher image uri.\n       \"image\"
-    : \"kserve/agent:v0.12.1\",\n       \n       # memoryRequest is the requests.memory
+    : \"kserve/agent:v0.13.0\",\n       \n       # memoryRequest is the requests.memory
     to set for the batcher container.\n       \"memoryRequest\": \"1Gi\",\n   \n       #
     memoryLimit is the limits.memory to set for the batcher container.\n       \"memoryLimit\":
     \"1Gi\",\n       \n       # cpuRequest is the requests.cpu to set for the batcher
@@ -22054,10 +21457,10 @@ data:
     \      # maxLatency is the default maximum latency in milliseconds for batcher
     to wait and collect the batch.\n       \"maxLatency\": \"5000\"\n   }\n \n # ======================================
     AGENT CONFIGURATION ======================================\n # Example\n agent:
-    |-\n   {\n       \"image\" : \"kserve/agent:v0.12.1\",\n       \"memoryRequest\":
+    |-\n   {\n       \"image\" : \"kserve/agent:v0.13.0\",\n       \"memoryRequest\":
     \"100Mi\",\n       \"memoryLimit\": \"1Gi\",\n       \"cpuRequest\": \"100m\",\n
     \      \"cpuLimit\": \"1\"\n   }\n agent: |-\n   {\n       # image contains the
-    default agent image uri.\n       \"image\" : \"kserve/agent:v0.12.1\",\n   \n       #
+    default agent image uri.\n       \"image\" : \"kserve/agent:v0.13.0\",\n   \n       #
     memoryRequest is the requests.memory to set for the agent container.\n       \"memoryRequest\":
     \"100Mi\",\n   \n       # memoryLimit is the limits.memory to set for the agent
     container.\n       \"memoryLimit\": \"1Gi\",\n       \n       # cpuRequest is
@@ -22065,12 +21468,12 @@ data:
     \      \n       # cpuLimit is the limits.cpu to set for the agent container.\n
     \      \"cpuLimit\": \"1\"\n   }\n \n # ======================================
     ROUTER CONFIGURATION ======================================\n # Example\n router:
-    |-\n   {\n       \"image\" : \"kserve/router:v0.12.1\",\n       \"memoryRequest\":
+    |-\n   {\n       \"image\" : \"kserve/router:v0.13.0\",\n       \"memoryRequest\":
     \"100Mi\",\n       \"memoryLimit\": \"1Gi\",\n       \"cpuRequest\": \"100m\",\n
     \      \"cpuLimit\": \"1\",\n       \"headers\": {\n         \"propagate\": []\n
     \      }\n   }\n # router is the implementation of inference graph.\n router:
     |-\n   {\n       # image contains the default router image uri.\n       \"image\"
-    : \"kserve/router:v0.12.1\",\n       \n       # memoryRequest is the requests.memory
+    : \"kserve/router:v0.13.0\",\n       \n       # memoryRequest is the requests.memory
     to set for the router container.\n       \"memoryRequest\": \"100Mi\",\n       \n
     \      # memoryLimit is the limits.memory to set for the router container.\n       \"memoryLimit\":
     \"1Gi\",\n       \n       # cpuRequest is the requests.cpu to set for the router
@@ -22109,7 +21512,7 @@ data:
     \    \"enablePrometheusScraping\" : \"false\"\n   }"
   agent: |-
     {
-        "image" : "kserve/agent:v0.12.1",
+        "image" : "kserve/agent:v0.13.0",
         "memoryRequest": "100Mi",
         "memoryLimit": "1Gi",
         "cpuRequest": "100m",
@@ -22117,7 +21520,7 @@ data:
     }
   batcher: |-
     {
-        "image" : "kserve/agent:v0.12.1",
+        "image" : "kserve/agent:v0.13.0",
         "memoryRequest": "1Gi",
         "memoryLimit": "1Gi",
         "cpuRequest": "1",
@@ -22151,10 +21554,6 @@ data:
     }
   explainers: |-
     {
-        "alibi": {
-            "image" : "kserve/alibi-explainer",
-            "defaultImageVersion": "latest"
-        },
         "art": {
             "image" : "kserve/art-explainer",
             "defaultImageVersion": "latest"
@@ -22175,7 +21574,7 @@ data:
     }
   logger: |-
     {
-        "image" : "kserve/agent:v0.12.1",
+        "image" : "kserve/agent:v0.13.0",
         "memoryRequest": "100Mi",
         "memoryLimit": "1Gi",
         "cpuRequest": "100m",
@@ -22189,7 +21588,7 @@ data:
     }
   router: |-
     {
-        "image" : "kserve/router:v0.12.1",
+        "image" : "kserve/router:v0.13.0",
         "memoryRequest": "100Mi",
         "memoryLimit": "1Gi",
         "cpuRequest": "100m",
@@ -22197,7 +21596,7 @@ data:
     }
   storageInitializer: |-
     {
-        "image" : "kserve/storage-initializer:v0.12.1",
+        "image" : "kserve/storage-initializer:v0.13.0",
         "memoryRequest": "100Mi",
         "memoryLimit": "1Gi",
         "cpuRequest": "100m",
@@ -22304,7 +21703,7 @@ spec:
               fieldPath: metadata.namespace
         - name: SECRET_NAME
           value: kserve-webhook-server-cert
-        image: kserve/kserve-controller:v0.12.1
+        image: kserve/kserve-controller:v0.13.0
         imagePullPolicy: Always
         livenessProbe:
           failureThreshold: 5

--- a/contrib/kserve/kserve/kserve_kubeflow.yaml
+++ b/contrib/kserve/kserve/kserve_kubeflow.yaml
@@ -3108,17 +3108,6 @@ metadata:
     app.kubernetes.io/name: kserve
   name: inferenceservices.serving.kserve.io
 spec:
-  conversion:
-    strategy: Webhook
-    webhook:
-      clientConfig:
-        caBundle: Cg==
-        service:
-          name: kserve-webhook-server-service
-          namespace: kubeflow
-          path: /convert
-      conversionReviewVersions:
-        - v1beta1
   group: serving.kserve.io
   names:
     kind: InferenceService
@@ -3127,7 +3116,6 @@ spec:
     shortNames:
       - isvc
     singular: inferenceservice
-  preserveUnknownFields: false
   scope: Namespaced
   versions:
     - additionalPrinterColumns:
@@ -3533,637 +3521,6 @@ spec:
                                 type: object
                               type: array
                           type: object
-                      type: object
-                    alibi:
-                      properties:
-                        args:
-                          items:
-                            type: string
-                          type: array
-                        command:
-                          items:
-                            type: string
-                          type: array
-                        config:
-                          additionalProperties:
-                            type: string
-                          type: object
-                        env:
-                          items:
-                            properties:
-                              name:
-                                type: string
-                              value:
-                                type: string
-                              valueFrom:
-                                properties:
-                                  configMapKeyRef:
-                                    properties:
-                                      key:
-                                        type: string
-                                      name:
-                                        type: string
-                                      optional:
-                                        type: boolean
-                                    required:
-                                      - key
-                                    type: object
-                                    x-kubernetes-map-type: atomic
-                                  fieldRef:
-                                    properties:
-                                      apiVersion:
-                                        type: string
-                                      fieldPath:
-                                        type: string
-                                    required:
-                                      - fieldPath
-                                    type: object
-                                    x-kubernetes-map-type: atomic
-                                  resourceFieldRef:
-                                    properties:
-                                      containerName:
-                                        type: string
-                                      divisor:
-                                        anyOf:
-                                          - type: integer
-                                          - type: string
-                                        pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                                        x-kubernetes-int-or-string: true
-                                      resource:
-                                        type: string
-                                    required:
-                                      - resource
-                                    type: object
-                                    x-kubernetes-map-type: atomic
-                                  secretKeyRef:
-                                    properties:
-                                      key:
-                                        type: string
-                                      name:
-                                        type: string
-                                      optional:
-                                        type: boolean
-                                    required:
-                                      - key
-                                    type: object
-                                    x-kubernetes-map-type: atomic
-                                type: object
-                            required:
-                              - name
-                            type: object
-                          type: array
-                        envFrom:
-                          items:
-                            properties:
-                              configMapRef:
-                                properties:
-                                  name:
-                                    type: string
-                                  optional:
-                                    type: boolean
-                                type: object
-                                x-kubernetes-map-type: atomic
-                              prefix:
-                                type: string
-                              secretRef:
-                                properties:
-                                  name:
-                                    type: string
-                                  optional:
-                                    type: boolean
-                                type: object
-                                x-kubernetes-map-type: atomic
-                            type: object
-                          type: array
-                        image:
-                          type: string
-                        imagePullPolicy:
-                          type: string
-                        lifecycle:
-                          properties:
-                            postStart:
-                              properties:
-                                exec:
-                                  properties:
-                                    command:
-                                      items:
-                                        type: string
-                                      type: array
-                                  type: object
-                                httpGet:
-                                  properties:
-                                    host:
-                                      type: string
-                                    httpHeaders:
-                                      items:
-                                        properties:
-                                          name:
-                                            type: string
-                                          value:
-                                            type: string
-                                        required:
-                                          - name
-                                          - value
-                                        type: object
-                                      type: array
-                                    path:
-                                      type: string
-                                    port:
-                                      anyOf:
-                                        - type: integer
-                                        - type: string
-                                      x-kubernetes-int-or-string: true
-                                    scheme:
-                                      type: string
-                                  required:
-                                    - port
-                                  type: object
-                                tcpSocket:
-                                  properties:
-                                    host:
-                                      type: string
-                                    port:
-                                      anyOf:
-                                        - type: integer
-                                        - type: string
-                                      x-kubernetes-int-or-string: true
-                                  required:
-                                    - port
-                                  type: object
-                              type: object
-                            preStop:
-                              properties:
-                                exec:
-                                  properties:
-                                    command:
-                                      items:
-                                        type: string
-                                      type: array
-                                  type: object
-                                httpGet:
-                                  properties:
-                                    host:
-                                      type: string
-                                    httpHeaders:
-                                      items:
-                                        properties:
-                                          name:
-                                            type: string
-                                          value:
-                                            type: string
-                                        required:
-                                          - name
-                                          - value
-                                        type: object
-                                      type: array
-                                    path:
-                                      type: string
-                                    port:
-                                      anyOf:
-                                        - type: integer
-                                        - type: string
-                                      x-kubernetes-int-or-string: true
-                                    scheme:
-                                      type: string
-                                  required:
-                                    - port
-                                  type: object
-                                tcpSocket:
-                                  properties:
-                                    host:
-                                      type: string
-                                    port:
-                                      anyOf:
-                                        - type: integer
-                                        - type: string
-                                      x-kubernetes-int-or-string: true
-                                  required:
-                                    - port
-                                  type: object
-                              type: object
-                          type: object
-                        livenessProbe:
-                          properties:
-                            exec:
-                              properties:
-                                command:
-                                  items:
-                                    type: string
-                                  type: array
-                              type: object
-                            failureThreshold:
-                              format: int32
-                              type: integer
-                            grpc:
-                              properties:
-                                port:
-                                  format: int32
-                                  type: integer
-                                service:
-                                  type: string
-                              required:
-                                - port
-                              type: object
-                            httpGet:
-                              properties:
-                                host:
-                                  type: string
-                                httpHeaders:
-                                  items:
-                                    properties:
-                                      name:
-                                        type: string
-                                      value:
-                                        type: string
-                                    required:
-                                      - name
-                                      - value
-                                    type: object
-                                  type: array
-                                path:
-                                  type: string
-                                port:
-                                  anyOf:
-                                    - type: integer
-                                    - type: string
-                                  x-kubernetes-int-or-string: true
-                                scheme:
-                                  type: string
-                              type: object
-                            initialDelaySeconds:
-                              format: int32
-                              type: integer
-                            periodSeconds:
-                              format: int32
-                              type: integer
-                            successThreshold:
-                              format: int32
-                              type: integer
-                            tcpSocket:
-                              properties:
-                                host:
-                                  type: string
-                                port:
-                                  anyOf:
-                                    - type: integer
-                                    - type: string
-                                  x-kubernetes-int-or-string: true
-                              type: object
-                            terminationGracePeriodSeconds:
-                              format: int64
-                              type: integer
-                            timeoutSeconds:
-                              format: int32
-                              type: integer
-                          type: object
-                        name:
-                          type: string
-                        ports:
-                          items:
-                            properties:
-                              containerPort:
-                                format: int32
-                                type: integer
-                              hostIP:
-                                type: string
-                              hostPort:
-                                format: int32
-                                type: integer
-                              name:
-                                type: string
-                              protocol:
-                                default: TCP
-                                type: string
-                            required:
-                              - containerPort
-                            type: object
-                          type: array
-                          x-kubernetes-list-map-keys:
-                            - containerPort
-                            - protocol
-                          x-kubernetes-list-type: map
-                        readinessProbe:
-                          properties:
-                            exec:
-                              properties:
-                                command:
-                                  items:
-                                    type: string
-                                  type: array
-                              type: object
-                            failureThreshold:
-                              format: int32
-                              type: integer
-                            grpc:
-                              properties:
-                                port:
-                                  format: int32
-                                  type: integer
-                                service:
-                                  type: string
-                              required:
-                                - port
-                              type: object
-                            httpGet:
-                              properties:
-                                host:
-                                  type: string
-                                httpHeaders:
-                                  items:
-                                    properties:
-                                      name:
-                                        type: string
-                                      value:
-                                        type: string
-                                    required:
-                                      - name
-                                      - value
-                                    type: object
-                                  type: array
-                                path:
-                                  type: string
-                                port:
-                                  anyOf:
-                                    - type: integer
-                                    - type: string
-                                  x-kubernetes-int-or-string: true
-                                scheme:
-                                  type: string
-                              type: object
-                            initialDelaySeconds:
-                              format: int32
-                              type: integer
-                            periodSeconds:
-                              format: int32
-                              type: integer
-                            successThreshold:
-                              format: int32
-                              type: integer
-                            tcpSocket:
-                              properties:
-                                host:
-                                  type: string
-                                port:
-                                  anyOf:
-                                    - type: integer
-                                    - type: string
-                                  x-kubernetes-int-or-string: true
-                              type: object
-                            terminationGracePeriodSeconds:
-                              format: int64
-                              type: integer
-                            timeoutSeconds:
-                              format: int32
-                              type: integer
-                          type: object
-                        resizePolicy:
-                          items:
-                            properties:
-                              resourceName:
-                                type: string
-                              restartPolicy:
-                                type: string
-                            required:
-                              - resourceName
-                              - restartPolicy
-                            type: object
-                          type: array
-                          x-kubernetes-list-type: atomic
-                        resources:
-                          properties:
-                            claims:
-                              items:
-                                properties:
-                                  name:
-                                    type: string
-                                required:
-                                  - name
-                                type: object
-                              type: array
-                              x-kubernetes-list-map-keys:
-                                - name
-                              x-kubernetes-list-type: map
-                            limits:
-                              additionalProperties:
-                                anyOf:
-                                  - type: integer
-                                  - type: string
-                                pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                                x-kubernetes-int-or-string: true
-                              type: object
-                            requests:
-                              additionalProperties:
-                                anyOf:
-                                  - type: integer
-                                  - type: string
-                                pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                                x-kubernetes-int-or-string: true
-                              type: object
-                          type: object
-                        restartPolicy:
-                          type: string
-                        runtimeVersion:
-                          type: string
-                        securityContext:
-                          properties:
-                            allowPrivilegeEscalation:
-                              type: boolean
-                            capabilities:
-                              properties:
-                                add:
-                                  items:
-                                    type: string
-                                  type: array
-                                drop:
-                                  items:
-                                    type: string
-                                  type: array
-                              type: object
-                            privileged:
-                              type: boolean
-                            procMount:
-                              type: string
-                            readOnlyRootFilesystem:
-                              type: boolean
-                            runAsGroup:
-                              format: int64
-                              type: integer
-                            runAsNonRoot:
-                              type: boolean
-                            runAsUser:
-                              format: int64
-                              type: integer
-                            seLinuxOptions:
-                              properties:
-                                level:
-                                  type: string
-                                role:
-                                  type: string
-                                type:
-                                  type: string
-                                user:
-                                  type: string
-                              type: object
-                            seccompProfile:
-                              properties:
-                                localhostProfile:
-                                  type: string
-                                type:
-                                  type: string
-                              required:
-                                - type
-                              type: object
-                            windowsOptions:
-                              properties:
-                                gmsaCredentialSpec:
-                                  type: string
-                                gmsaCredentialSpecName:
-                                  type: string
-                                hostProcess:
-                                  type: boolean
-                                runAsUserName:
-                                  type: string
-                              type: object
-                          type: object
-                        startupProbe:
-                          properties:
-                            exec:
-                              properties:
-                                command:
-                                  items:
-                                    type: string
-                                  type: array
-                              type: object
-                            failureThreshold:
-                              format: int32
-                              type: integer
-                            grpc:
-                              properties:
-                                port:
-                                  format: int32
-                                  type: integer
-                                service:
-                                  type: string
-                              required:
-                                - port
-                              type: object
-                            httpGet:
-                              properties:
-                                host:
-                                  type: string
-                                httpHeaders:
-                                  items:
-                                    properties:
-                                      name:
-                                        type: string
-                                      value:
-                                        type: string
-                                    required:
-                                      - name
-                                      - value
-                                    type: object
-                                  type: array
-                                path:
-                                  type: string
-                                port:
-                                  anyOf:
-                                    - type: integer
-                                    - type: string
-                                  x-kubernetes-int-or-string: true
-                                scheme:
-                                  type: string
-                              required:
-                                - port
-                              type: object
-                            initialDelaySeconds:
-                              format: int32
-                              type: integer
-                            periodSeconds:
-                              format: int32
-                              type: integer
-                            successThreshold:
-                              format: int32
-                              type: integer
-                            tcpSocket:
-                              properties:
-                                host:
-                                  type: string
-                                port:
-                                  anyOf:
-                                    - type: integer
-                                    - type: string
-                                  x-kubernetes-int-or-string: true
-                              required:
-                                - port
-                              type: object
-                            terminationGracePeriodSeconds:
-                              format: int64
-                              type: integer
-                            timeoutSeconds:
-                              format: int32
-                              type: integer
-                          type: object
-                        stdin:
-                          type: boolean
-                        stdinOnce:
-                          type: boolean
-                        storage:
-                          properties:
-                            key:
-                              type: string
-                            parameters:
-                              additionalProperties:
-                                type: string
-                              type: object
-                            path:
-                              type: string
-                            schemaPath:
-                              type: string
-                          type: object
-                        storageUri:
-                          type: string
-                        terminationMessagePath:
-                          type: string
-                        terminationMessagePolicy:
-                          type: string
-                        tty:
-                          type: boolean
-                        type:
-                          type: string
-                        volumeDevices:
-                          items:
-                            properties:
-                              devicePath:
-                                type: string
-                              name:
-                                type: string
-                            required:
-                              - devicePath
-                              - name
-                            type: object
-                          type: array
-                        volumeMounts:
-                          items:
-                            properties:
-                              mountPath:
-                                type: string
-                              mountPropagation:
-                                type: string
-                              name:
-                                type: string
-                              readOnly:
-                                type: boolean
-                              subPath:
-                                type: string
-                              subPathExpr:
-                                type: string
-                            required:
-                              - mountPath
-                              - name
-                            type: object
-                          type: array
-                        workingDir:
-                          type: string
                       type: object
                     annotations:
                       additionalProperties:
@@ -5433,6 +4790,24 @@ spec:
                           - name
                         type: object
                       type: array
+                    deploymentStrategy:
+                      properties:
+                        rollingUpdate:
+                          properties:
+                            maxSurge:
+                              anyOf:
+                                - type: integer
+                                - type: string
+                              x-kubernetes-int-or-string: true
+                            maxUnavailable:
+                              anyOf:
+                                - type: integer
+                                - type: string
+                              x-kubernetes-int-or-string: true
+                          type: object
+                        type:
+                          type: string
+                      type: object
                     dnsConfig:
                       properties:
                         nameservers:
@@ -8078,6 +7453,24 @@ spec:
                           - name
                         type: object
                       type: array
+                    deploymentStrategy:
+                      properties:
+                        rollingUpdate:
+                          properties:
+                            maxSurge:
+                              anyOf:
+                                - type: integer
+                                - type: string
+                              x-kubernetes-int-or-string: true
+                            maxUnavailable:
+                              anyOf:
+                                - type: integer
+                                - type: string
+                              x-kubernetes-int-or-string: true
+                          type: object
+                        type:
+                          type: string
+                      type: object
                     dnsConfig:
                       properties:
                         nameservers:
@@ -17631,6 +17024,24 @@ spec:
                           - name
                         type: object
                       type: array
+                    deploymentStrategy:
+                      properties:
+                        rollingUpdate:
+                          properties:
+                            maxSurge:
+                              anyOf:
+                                - type: integer
+                                - type: string
+                              x-kubernetes-int-or-string: true
+                            maxUnavailable:
+                              anyOf:
+                                - type: integer
+                                - type: string
+                              x-kubernetes-int-or-string: true
+                          type: object
+                        type:
+                          type: string
+                      type: object
                     dnsConfig:
                       properties:
                         nameservers:
@@ -21563,9 +20974,7 @@ rules:
     verbs:
       - create
       - get
-      - list
       - update
-      - watch
   - apiGroups:
       - ""
     resources:
@@ -21602,18 +21011,14 @@ rules:
       - create
       - delete
       - get
-      - list
       - patch
       - update
-      - watch
   - apiGroups:
       - ""
     resources:
       - serviceaccounts
     verbs:
       - get
-      - list
-      - watch
   - apiGroups:
       - ""
     resources:
@@ -21983,10 +21388,10 @@ subjects:
 ---
 apiVersion: v1
 data:
-  _example: "################################\n#                              #\n#    EXAMPLE CONFIGURATION     #\n#                              #\n################################\n\n# This block is not actually functional configuration,\n# but serves to illustrate the available configuration\n# options and document them in a way that is accessible\n# to users that `kubectl edit` this config map.\n#\n# These sample configuration options may be copied out of\n# this example block and unindented to be in the data block\n# to actually change the configuration.\n\n# ====================================== EXPLAINERS CONFIGURATION ======================================\n# Example\nexplainers: |-\n  {\n      \"alibi\": {\n          \"image\" : \"kserve/alibi-explainer\",\n          \"defaultImageVersion\": \"latest\"\n      },\n      \"art\": {\n          \"image\" : \"kserve/art-explainer\",\n          \"defaultImageVersion\": \"latest\"\n      }\n  }\n# Alibi and Art Explainer runtime configuration\n explainers: |-\n   {\n       # Alibi explainer runtime configuration\n       \"alibi\": {\n           # image contains the default Alibi explainer serving runtime image uri.\n           \"image\" : \"kserve/alibi-explainer\",\n           \n           # defautltImageVersion contains the Alibi explainer serving runtime default image version.\n           \"defaultImageVersion\": \"latest\"\n       },\n       # Art explainer runtime configuration\n       \"art\": {\n           # image contains the default Art explainer serving runtime image uri.\n           \"image\" : \"kserve/art-explainer\",\n   \n           # defautltImageVersion contains the Art explainer serving runtime default image version.\n           \"defaultImageVersion\": \"latest\"\n       }\n   }\n \n # ====================================== STORAGE INITIALIZER CONFIGURATION ======================================\n # Example\n storageInitializer: |-\n   {\n       \"image\" : \"kserve/storage-initializer:v0.12.1\",\n       \"memoryRequest\": \"100Mi\",\n       \"memoryLimit\": \"1Gi\",\n       \"cpuRequest\": \"100m\",\n       \"cpuLimit\": \"1\",\n       \"caBundleConfigMapName\": \"\",\n       \"caBundleVolumeMountPath\": \"/etc/ssl/custom-certs\",\n       \"enableDirectPvcVolumeMount\": false,\n       \"enableModelcar\": false,\n       \"cpuModelcar\": \"10m\",\n       \"memoryModelcar\": \"15Mi\"\n   }\n storageInitializer: |-\n   {\n       # image contains the default storage initializer image uri.\n       \"image\" : \"kserve/storage-initializer:v0.12.1\",\n       \n       # memoryRequest is the requests.memory to set for the storage initializer init container.\n       \"memoryRequest\": \"100Mi\",\n   \n        # memoryLimit is the limits.memory to set for the storage initializer init container.\n       \"memoryLimit\": \"1Gi\",\n       \n       # cpuRequest is the requests.cpu to set for the storage initializer init container.\n       \"cpuRequest\": \"100m\",\n       \n       # cpuLimit is the limits.cpu to set for the storage initializer init container.\n       \"cpuLimit\": \"1\",\n   \n       # caBundleConfigMapName is the ConfigMap will be copied to a user namespace for the storage initializer init container.\n       \"caBundleConfigMapName\": \"\",\n\n       # caBundleVolumeMountPath is the mount point for the configmap set by caBundleConfigMapName for the storage initializer init container.\n       \"caBundleVolumeMountPath\": \"/etc/ssl/custom-certs\",\n\n       # enableDirectPvcVolumeMount controls whether users can mount pvc volumes directly.\n       # if pvc volume is provided in storageuri then the pvc volume is directly mounted to /mnt/models in the user container.\n       # rather than symlink it to a shared volume. For more info see https://github.com/kserve/kserve/issues/2737\n       \"enableDirectPvcVolumeMount\": true,\n\n       # enableModelcar enabled allows you to directly access an OCI container image by\n       # using a source URL with an \"oci://\" schema.\n       \"enableModelcar\": false,\n\n       # cpuModelcar is the cpu request and limit that is used for the passive modelcar container. It can be\n       # set very low, but should be allowed by any Kubernetes LimitRange that might apply.\n       \"cpuModelcar\": \"10m\",\n\n       # cpuModelcar is the memory request and limit that is used for the passive modelcar container. It can be\n       # set very low, but should be allowed by any Kubernetes LimitRange that might apply.\n       \"memoryModelcar\": \"15Mi\",\n\n       # uidModelcar is the UID under with which the modelcar process and the main container is running.\n       # Some Kubernetes clusters might require this to be root (0). If not set the user id is left untouched (default)\n       \"uidModelcar\": 10\n   }\n \n # ====================================== CREDENTIALS ======================================\n # Example\n credentials: |-\n   {\n      \"storageSpecSecretName\": \"storage-config\",\n      \"storageSecretNameAnnotation\": \"serving.kserve.io/storageSecretName\",\n      \"gcs\": {\n          \"gcsCredentialFileName\": \"gcloud-application-credentials.json\"\n      },\n      \"s3\": {\n          \"s3AccessKeyIDName\": \"AWS_ACCESS_KEY_ID\",\n          \"s3SecretAccessKeyName\": \"AWS_SECRET_ACCESS_KEY\",\n          \"s3Endpoint\": \"\",\n          \"s3UseHttps\": \"\",\n          \"s3Region\": \"\",\n          \"s3VerifySSL\": \"\",\n          \"s3UseVirtualBucket\": \"\",\n          \"s3UseAccelerate\": \"\",\n          \"s3UseAnonymousCredential\": \"\",\n          \"s3CABundle\": \"\"\n      }\n   }\n # This is a global configuration used for downloading models from the cloud storage.\n # You can override this configuration by specifying the annotations on service account or static secret.\n # https://kserve.github.io/website/master/modelserving/storage/s3/s3/\n # For a quick reference about AWS ENV variables:\n # AWS Cli: https://docs.aws.amazon.com/cli/latest/userguide/cli-configure-envvars.html\n # Boto: https://boto3.amazonaws.com/v1/documentation/api/latest/guide/configuration.html#using-environment-variables\n #\n # The `s3AccessKeyIDName` and `s3SecretAccessKeyName` fields are only used from this configmap when static credentials (IAM User Access Key Secret)\n # are used as the authentication method for AWS S3.\n # The rest of the fields are used in both authentication methods (IAM Role for Service Account & IAM User Access Key Secret) if a non-empty value is provided.\n credentials: |-\n   {\n      # storageSpecSecretName contains the secret name which has the credentials for downloading the model.\n      # This option is used when specifying the storage spec on isvc yaml.\n      \"storageSpecSecretName\": \"storage-config\",\n\n      # The annotation can be specified on isvc yaml to allow overriding with the secret name reference from the annotation value.\n      # When using storageUri the order of the precedence is: secret name reference annotation > secret name references from service account\n      # When using storageSpec the order of the precedence is: secret name reference annotation > storageSpecSecretName in configmap\n\n      # Configuration for google cloud storage\n      \"gcs\": {\n          # gcsCredentialFileName specifies the filename of the gcs credential\n          \"gcsCredentialFileName\": \"gcloud-application-credentials.json\"\n      },\n      \n      # Configuration for aws s3 storage. This add the corresponding environmental variables to the storage initializer init container.\n      # For more info on s3 storage see https://kserve.github.io/website/master/modelserving/storage/s3/s3/\n      \"s3\": {\n          # s3AccessKeyIDName specifies the s3 access key id name\n          \"s3AccessKeyIDName\": \"AWS_ACCESS_KEY_ID\",\n   \n          # s3SecretAccessKeyName specifies the s3 secret access key name\n          \"s3SecretAccessKeyName\": \"AWS_SECRET_ACCESS_KEY\",\n          \n          # s3Endpoint specifies the s3 endpoint\n          \"s3Endpoint\": \"\",\n          \n          # s3UseHttps controls whether to use secure https or unsecure http to download models.\n          # Allowed values are 0 and 1.\n          \"s3UseHttps\": \"\",\n   \n          # s3Region specifies the region of the bucket.\n          \"s3Region\": \"\",\n          \n          # s3VerifySSL controls whether to verify the tls/ssl certificate.\n          \"s3VerifySSL\": \"\",\n          \n          # s3UseVirtualBucket configures whether it is a virtual bucket or not.\n          \"s3UseVirtualBucket\": \"\",\n\n          # s3UseAccelerate configures whether to use transfer acceleration.\n          \"s3UseAccelerate\": \"\",\n           \n          # s3UseAnonymousCredential configures whether to use anonymous credentials to download the model or not.\n          \"s3UseAnonymousCredential\": \"\",\n          \n          # s3CABundle specifies the path to a certificate bundle to use for HTTPS certificate validation.\n          \"s3CABundle\": \"\"\n      }\n   }\n \n # ====================================== INGRESS CONFIGURATION ======================================\n # Example\n ingress: |-\n   {\n       \"ingressGateway\" : \"knative-serving/knative-ingress-gateway\",\n       \"ingressService\" : \"istio-ingressgateway.istio-system.svc.cluster.local\",\n       \"localGateway\" : \"knative-serving/knative-local-gateway\",\n       \"localGatewayService\" : \"knative-local-gateway.istio-system.svc.cluster.local\",\n       \"ingressDomain\"  : \"example.com\",\n       \"ingressClassName\" : \"istio\",\n       \"domainTemplate\": \"{{ .Name }}-{{ .Namespace }}.{{ .IngressDomain }}\",\n       \"urlScheme\": \"http\",\n       \"disableIstioVirtualHost\": false,\n       \"disableIngressCreation\": false\n   }\n ingress: |-\n   {\n       # ingressGateway specifies the ingress gateway to serve external traffic.\n       # The gateway should be specified in format <gateway namespace>/<gateway name>\n       # NOTE: This configuration only applicable for serverless deployment with Istio configured as network layer.\n       \"ingressGateway\" : \"knative-serving/knative-ingress-gateway\",\n \n       # ingressService specifies the hostname of the ingress service.\n       # NOTE: This configuration only applicable for serverless deployment with Istio configured as network layer.\n       \"ingressService\" : \"istio-ingressgateway.istio-system.svc.cluster.local\",\n \n       # localGateway specifies the gateway which handles the network traffic within the cluster.\n       # NOTE: This configuration only applicable for serverless deployment with Istio configured as network layer.\n       \"localGateway\" : \"knative-serving/knative-local-gateway\",\n \n       # localGatewayService specifies the hostname of the local gateway service.\n       # NOTE: This configuration only applicable for serverless deployment with Istio configured as network layer.\n       \"localGatewayService\" : \"knative-local-gateway.istio-system.svc.cluster.local\",\n \n       # ingressDomain specifies the domain name which is used for creating the url.\n       # If ingressDomain is empty then example.com is used as default domain.\n       # NOTE: This configuration only applicable for raw deployment.\n       \"ingressDomain\"  : \"example.com\",\n \n       # ingressClassName specifies the ingress controller to use for ingress traffic.\n       # This is optional and if omitted the default ingress in the cluster is used.\n       # https://kubernetes.io/docs/concepts/services-networking/ingress/#default-ingress-class\n       # NOTE: This configuration only applicable for raw deployment.\n       \"ingressClassName\" : \"istio\",\n \n       # domainTemplate specifies the template for generating domain/url for each inference service by combining variable from:\n       # Name of the inference service  ( {{ .Name}} )\n       # Namespace of the inference service ( {{ .Namespace }} )\n       # Annotation of the inference service ( {{ .Annotations.key }} )\n       # Label of the inference service ( {{ .Labels.key }} )\n       # IngressDomain ( {{ .IngressDomain }} )\n       # If domain template is empty the default template {{ .Name }}-{{ .Namespace }}.{{ .IngressDomain }} is used.\n       # NOTE: This configuration only applicable for raw deployment.\n       \"domainTemplate\": \"{{ .Name }}-{{ .Namespace }}.{{ .IngressDomain }}\",\n \n       # urlScheme specifies the url scheme to use for inference service and inference graph.\n       # If urlScheme is empty then by default http is used.\n       \"urlScheme\": \"http\",\n \n       # disableIstioVirtualHost controls whether to use istio as network layer.\n       # By default istio is used as the network layer. When DisableIstioVirtualHost is true, KServe does not\n       # create the top level virtual service thus Istio is no longer required for serverless mode.\n       # By setting this field to true, user can use other networking layers supported by knative.\n       # For more info https://github.com/kserve/kserve/pull/2380, https://kserve.github.io/website/master/admin/serverless/kourier_networking/.\n       # NOTE: This configuration is only applicable to serverless deployment.\n       \"disableIstioVirtualHost\": false,\n\n       # disableIngressCreation controls whether to disable ingress creation for raw deployment mode.\n       \"disableIngressCreation\": false,\n \n       # pathTemplate specifies the template for generating path based url for each inference service.\n       # The following variables can be used in the template for generating url.\n       # Name of the inference service  ( {{ .Name}} )\n       # Namespace of the inference service ( {{ .Namespace }} )\n       # For more info https://github.com/kserve/kserve/issues/2257.\n       # NOTE: This configuration only applicable to serverless deployment.\n       \"pathTemplate\": \"/serving/{{ .Namespace }}/{{ .Name }}\"\n   }\n \n # ====================================== LOGGER CONFIGURATION ======================================\n # Example\n logger: |-\n   {\n       \"image\" : \"kserve/agent:v0.12.1\",\n       \"memoryRequest\": \"100Mi\",\n       \"memoryLimit\": \"1Gi\",\n       \"cpuRequest\": \"100m\",\n       \"cpuLimit\": \"1\",\n       \"defaultUrl\": \"http://default-broker\"\n   }\n logger: |-\n   {\n       # image contains the default logger image uri.\n       \"image\" : \"kserve/agent:v0.12.1\",\n   \n       # memoryRequest is the requests.memory to set for the logger container.\n       \"memoryRequest\": \"100Mi\",\n       \n       # memoryLimit is the limits.memory to set for the logger container.\n       \"memoryLimit\": \"1Gi\",\n       \n       # cpuRequest is the requests.cpu to set for the logger container.\n       \"cpuRequest\": \"100m\",\n       \n       # cpuLimit is the limits.cpu to set for the logger container.\n       \"cpuLimit\": \"1\",\n       \n       # defaultUrl specifies the default logger url. If logger is not specified in the resource this url is used.\n       \"defaultUrl\": \"http://default-broker\"\n   }\n \n # ====================================== BATCHER CONFIGURATION ======================================\n # Example\n batcher: |-\n   {\n       \"image\" : \"kserve/agent:v0.12.1\",\n       \"memoryRequest\": \"1Gi\",\n       \"memoryLimit\": \"1Gi\",\n       \"cpuRequest\": \"1\",\n       \"cpuLimit\": \"1\",\n       \"maxBatchSize\": \"32\",\n       \"maxLatency\": \"5000\"\n   }\n batcher: |-\n   {\n       # image contains the default batcher image uri.\n       \"image\" : \"kserve/agent:v0.12.1\",\n       \n       # memoryRequest is the requests.memory to set for the batcher container.\n       \"memoryRequest\": \"1Gi\",\n   \n       # memoryLimit is the limits.memory to set for the batcher container.\n       \"memoryLimit\": \"1Gi\",\n       \n       # cpuRequest is the requests.cpu to set for the batcher container.\n       \"cpuRequest\": \"1\",\n       \n       # cpuLimit is the limits.cpu to set for the batcher container.\n       \"cpuLimit\": \"1\"\n\n       # maxBatchSize is the default maximum batch size for batcher.\n       \"maxBatchSize\": \"32\",\n\n       # maxLatency is the default maximum latency in milliseconds for batcher to wait and collect the batch.\n       \"maxLatency\": \"5000\"\n   }\n \n # ====================================== AGENT CONFIGURATION ======================================\n # Example\n agent: |-\n   {\n       \"image\" : \"kserve/agent:v0.12.1\",\n       \"memoryRequest\": \"100Mi\",\n       \"memoryLimit\": \"1Gi\",\n       \"cpuRequest\": \"100m\",\n       \"cpuLimit\": \"1\"\n   }\n agent: |-\n   {\n       # image contains the default agent image uri.\n       \"image\" : \"kserve/agent:v0.12.1\",\n   \n       # memoryRequest is the requests.memory to set for the agent container.\n       \"memoryRequest\": \"100Mi\",\n   \n       # memoryLimit is the limits.memory to set for the agent container.\n       \"memoryLimit\": \"1Gi\",\n       \n       # cpuRequest is the requests.cpu to set for the agent container.\n       \"cpuRequest\": \"100m\",\n       \n       # cpuLimit is the limits.cpu to set for the agent container.\n       \"cpuLimit\": \"1\"\n   }\n \n # ====================================== ROUTER CONFIGURATION ======================================\n # Example\n router: |-\n   {\n       \"image\" : \"kserve/router:v0.12.1\",\n       \"memoryRequest\": \"100Mi\",\n       \"memoryLimit\": \"1Gi\",\n       \"cpuRequest\": \"100m\",\n       \"cpuLimit\": \"1\",\n       \"headers\": {\n         \"propagate\": []\n       }\n   }\n # router is the implementation of inference graph.\n router: |-\n   {\n       # image contains the default router image uri.\n       \"image\" : \"kserve/router:v0.12.1\",\n       \n       # memoryRequest is the requests.memory to set for the router container.\n       \"memoryRequest\": \"100Mi\",\n       \n       # memoryLimit is the limits.memory to set for the router container.\n       \"memoryLimit\": \"1Gi\",\n       \n       # cpuRequest is the requests.cpu to set for the router container.\n       \"cpuRequest\": \"100m\",\n       \n       # cpuLimit is the limits.cpu to set for the router container.\n       \"cpuLimit\": \"1\",\n       \n       # Propagate the specified headers to all the steps specified in an InferenceGraph. \n       # You can either specify the exact header names or use [Golang supported regex patterns]\n       # (https://pkg.go.dev/regexp/syntax@go1.21.3#hdr-Syntax) to propagate multiple headers.\n       \"headers\": {\n         \"propagate\": [\n            \"Authorization\",\n            \"Test-Header-*\",\n            \"*Trace-Id*\"\n         ]\n       }\n   }\n \n # ====================================== DEPLOYMENT CONFIGURATION ======================================\n # Example\n deploy: |-\n   {\n     \"defaultDeploymentMode\": \"Serverless\"\n   }\n deploy: |-\n   {\n     # defaultDeploymentMode specifies the default deployment mode of the kserve. The supported values are\n     # Serverless, RawDeployment and ModelMesh. Users can override the deployment mode at service level\n     # by adding the annotation serving.kserve.io/deploymentMode.For more info on deployment mode visit\n     # Serverless https://kserve.github.io/website/master/admin/serverless/serverless/\n     # RawDeployment https://kserve.github.io/website/master/admin/kubernetes_deployment/\n     # ModelMesh https://kserve.github.io/website/master/admin/modelmesh/\n     \"defaultDeploymentMode\": \"Serverless\"\n   }\n \n # ====================================== METRICS CONFIGURATION ======================================\n # Example\n metricsAggregator: |-\n   {\n     \"enableMetricAggregation\": \"false\",\n     \"enablePrometheusScraping\" : \"false\"\n   }\n # For more info see https://github.com/kserve/kserve/blob/master/qpext/README.md\n metricsAggregator: |-\n   {\n     # enableMetricAggregation configures metric aggregation annotation. This adds the annotation serving.kserve.io/enable-metric-aggregation to every\n     # service with the specified boolean value. If true enables metric aggregation in queue-proxy by setting env vars in the queue proxy container\n     # to configure scraping ports.\n     \"enableMetricAggregation\": \"false\",\n     \n     # enablePrometheusScraping configures metric aggregation annotation. This adds the annotation serving.kserve.io/enable-metric-aggregation to every\n     # service with the specified boolean value. If true, prometheus annotations are added to the pod. If serving.kserve.io/enable-metric-aggregation is false,\n     # the prometheus port is set with the default prometheus scraping port 9090, otherwise the prometheus port annotation is set with the metric aggregation port.\n     \"enablePrometheusScraping\" : \"false\"\n   }"
+  _example: "################################\n#                              #\n#    EXAMPLE CONFIGURATION     #\n#                              #\n################################\n\n# This block is not actually functional configuration,\n# but serves to illustrate the available configuration\n# options and document them in a way that is accessible\n# to users that `kubectl edit` this config map.\n#\n# These sample configuration options may be copied out of\n# this example block and unindented to be in the data block\n# to actually change the configuration.\n\n# ====================================== EXPLAINERS CONFIGURATION ======================================\n# Example\nexplainers: |-\n  {\n      \"art\": {\n          \"image\" : \"kserve/art-explainer\",\n          \"defaultImageVersion\": \"latest\"\n      }\n  }\n# Art Explainer runtime configuration\n explainers: |-\n   {\n       # Art explainer runtime configuration\n       \"art\": {\n           # image contains the default Art explainer serving runtime image uri.\n           \"image\" : \"kserve/art-explainer\",\n   \n           # defautltImageVersion contains the Art explainer serving runtime default image version.\n           \"defaultImageVersion\": \"latest\"\n       }\n   }\n \n # ====================================== STORAGE INITIALIZER CONFIGURATION ======================================\n # Example\n storageInitializer: |-\n   {\n       \"image\" : \"kserve/storage-initializer:v0.13.0\",\n       \"memoryRequest\": \"100Mi\",\n       \"memoryLimit\": \"1Gi\",\n       \"cpuRequest\": \"100m\",\n       \"cpuLimit\": \"1\",\n       \"caBundleConfigMapName\": \"\",\n       \"caBundleVolumeMountPath\": \"/etc/ssl/custom-certs\",\n       \"enableDirectPvcVolumeMount\": false,\n       \"enableModelcar\": false,\n       \"cpuModelcar\": \"10m\",\n       \"memoryModelcar\": \"15Mi\"\n   }\n storageInitializer: |-\n   {\n       # image contains the default storage initializer image uri.\n       \"image\" : \"kserve/storage-initializer:v0.13.0\",\n       \n       # memoryRequest is the requests.memory to set for the storage initializer init container.\n       \"memoryRequest\": \"100Mi\",\n   \n        # memoryLimit is the limits.memory to set for the storage initializer init container.\n       \"memoryLimit\": \"1Gi\",\n       \n       # cpuRequest is the requests.cpu to set for the storage initializer init container.\n       \"cpuRequest\": \"100m\",\n       \n       # cpuLimit is the limits.cpu to set for the storage initializer init container.\n       \"cpuLimit\": \"1\",\n   \n       # caBundleConfigMapName is the ConfigMap will be copied to a user namespace for the storage initializer init container.\n       \"caBundleConfigMapName\": \"\",\n\n       # caBundleVolumeMountPath is the mount point for the configmap set by caBundleConfigMapName for the storage initializer init container.\n       \"caBundleVolumeMountPath\": \"/etc/ssl/custom-certs\",\n\n       # enableDirectPvcVolumeMount controls whether users can mount pvc volumes directly.\n       # if pvc volume is provided in storageuri then the pvc volume is directly mounted to /mnt/models in the user container.\n       # rather than symlink it to a shared volume. For more info see https://github.com/kserve/kserve/issues/2737\n       \"enableDirectPvcVolumeMount\": true,\n\n       # enableModelcar enabled allows you to directly access an OCI container image by\n       # using a source URL with an \"oci://\" schema.\n       \"enableModelcar\": false,\n\n       # cpuModelcar is the cpu request and limit that is used for the passive modelcar container. It can be\n       # set very low, but should be allowed by any Kubernetes LimitRange that might apply.\n       \"cpuModelcar\": \"10m\",\n\n       # cpuModelcar is the memory request and limit that is used for the passive modelcar container. It can be\n       # set very low, but should be allowed by any Kubernetes LimitRange that might apply.\n       \"memoryModelcar\": \"15Mi\",\n\n       # uidModelcar is the UID under with which the modelcar process and the main container is running.\n       # Some Kubernetes clusters might require this to be root (0). If not set the user id is left untouched (default)\n       \"uidModelcar\": 10\n   }\n \n # ====================================== CREDENTIALS ======================================\n # Example\n credentials: |-\n   {\n      \"storageSpecSecretName\": \"storage-config\",\n      \"storageSecretNameAnnotation\": \"serving.kserve.io/storageSecretName\",\n      \"gcs\": {\n          \"gcsCredentialFileName\": \"gcloud-application-credentials.json\"\n      },\n      \"s3\": {\n          \"s3AccessKeyIDName\": \"AWS_ACCESS_KEY_ID\",\n          \"s3SecretAccessKeyName\": \"AWS_SECRET_ACCESS_KEY\",\n          \"s3Endpoint\": \"\",\n          \"s3UseHttps\": \"\",\n          \"s3Region\": \"\",\n          \"s3VerifySSL\": \"\",\n          \"s3UseVirtualBucket\": \"\",\n          \"s3UseAccelerate\": \"\",\n          \"s3UseAnonymousCredential\": \"\",\n          \"s3CABundle\": \"\"\n      }\n   }\n # This is a global configuration used for downloading models from the cloud storage.\n # You can override this configuration by specifying the annotations on service account or static secret.\n # https://kserve.github.io/website/master/modelserving/storage/s3/s3/\n # For a quick reference about AWS ENV variables:\n # AWS Cli: https://docs.aws.amazon.com/cli/latest/userguide/cli-configure-envvars.html\n # Boto: https://boto3.amazonaws.com/v1/documentation/api/latest/guide/configuration.html#using-environment-variables\n #\n # The `s3AccessKeyIDName` and `s3SecretAccessKeyName` fields are only used from this configmap when static credentials (IAM User Access Key Secret)\n # are used as the authentication method for AWS S3.\n # The rest of the fields are used in both authentication methods (IAM Role for Service Account & IAM User Access Key Secret) if a non-empty value is provided.\n credentials: |-\n   {\n      # storageSpecSecretName contains the secret name which has the credentials for downloading the model.\n      # This option is used when specifying the storage spec on isvc yaml.\n      \"storageSpecSecretName\": \"storage-config\",\n\n      # The annotation can be specified on isvc yaml to allow overriding with the secret name reference from the annotation value.\n      # When using storageUri the order of the precedence is: secret name reference annotation > secret name references from service account\n      # When using storageSpec the order of the precedence is: secret name reference annotation > storageSpecSecretName in configmap\n\n      # Configuration for google cloud storage\n      \"gcs\": {\n          # gcsCredentialFileName specifies the filename of the gcs credential\n          \"gcsCredentialFileName\": \"gcloud-application-credentials.json\"\n      },\n      \n      # Configuration for aws s3 storage. This add the corresponding environmental variables to the storage initializer init container.\n      # For more info on s3 storage see https://kserve.github.io/website/master/modelserving/storage/s3/s3/\n      \"s3\": {\n          # s3AccessKeyIDName specifies the s3 access key id name\n          \"s3AccessKeyIDName\": \"AWS_ACCESS_KEY_ID\",\n   \n          # s3SecretAccessKeyName specifies the s3 secret access key name\n          \"s3SecretAccessKeyName\": \"AWS_SECRET_ACCESS_KEY\",\n          \n          # s3Endpoint specifies the s3 endpoint\n          \"s3Endpoint\": \"\",\n          \n          # s3UseHttps controls whether to use secure https or unsecure http to download models.\n          # Allowed values are 0 and 1.\n          \"s3UseHttps\": \"\",\n   \n          # s3Region specifies the region of the bucket.\n          \"s3Region\": \"\",\n          \n          # s3VerifySSL controls whether to verify the tls/ssl certificate.\n          \"s3VerifySSL\": \"\",\n          \n          # s3UseVirtualBucket configures whether it is a virtual bucket or not.\n          \"s3UseVirtualBucket\": \"\",\n\n          # s3UseAccelerate configures whether to use transfer acceleration.\n          \"s3UseAccelerate\": \"\",\n           \n          # s3UseAnonymousCredential configures whether to use anonymous credentials to download the model or not.\n          \"s3UseAnonymousCredential\": \"\",\n          \n          # s3CABundle specifies the path to a certificate bundle to use for HTTPS certificate validation.\n          \"s3CABundle\": \"\"\n      }\n   }\n \n # ====================================== INGRESS CONFIGURATION ======================================\n # Example\n ingress: |-\n   {\n       \"ingressGateway\" : \"knative-serving/knative-ingress-gateway\",\n       \"ingressService\" : \"istio-ingressgateway.istio-system.svc.cluster.local\",\n       \"localGateway\" : \"knative-serving/knative-local-gateway\",\n       \"localGatewayService\" : \"knative-local-gateway.istio-system.svc.cluster.local\",\n       \"ingressDomain\"  : \"example.com\",\n       \"additionalIngressDomains\": [\"additional-example.com\", \"additional-example-1.com\"],\n       \"ingressClassName\" : \"istio\",\n       \"domainTemplate\": \"{{ .Name }}-{{ .Namespace }}.{{ .IngressDomain }}\",\n       \"urlScheme\": \"http\",\n       \"disableIstioVirtualHost\": false,\n       \"disableIngressCreation\": false\n   }\n ingress: |-\n   {\n       # ingressGateway specifies the ingress gateway to serve external traffic.\n       # The gateway should be specified in format <gateway namespace>/<gateway name>\n       # NOTE: This configuration only applicable for serverless deployment with Istio configured as network layer.\n       \"ingressGateway\" : \"knative-serving/knative-ingress-gateway\",\n \n       # ingressService specifies the hostname of the ingress service.\n       # NOTE: This configuration only applicable for serverless deployment with Istio configured as network layer.\n       \"ingressService\" : \"istio-ingressgateway.istio-system.svc.cluster.local\",\n \n       # localGateway specifies the gateway which handles the network traffic within the cluster.\n       # NOTE: This configuration only applicable for serverless deployment with Istio configured as network layer.\n       \"localGateway\" : \"knative-serving/knative-local-gateway\",\n \n       # localGatewayService specifies the hostname of the local gateway service.\n       # NOTE: This configuration only applicable for serverless deployment with Istio configured as network layer.\n       \"localGatewayService\" : \"knative-local-gateway.istio-system.svc.cluster.local\",\n \n       # ingressDomain specifies the domain name which is used for creating the url.\n       # If ingressDomain is empty then example.com is used as default domain.\n       # NOTE: This configuration only applicable for raw deployment.\n       \"ingressDomain\"  : \"example.com\",\n\n       # additionalIngressDomains specifies the additional domain names which are used for creating the url.\n       \"additionalIngressDomains\": [\"additional-example.com\", \"additional-example-1.com\"]\n\n       # ingressClassName specifies the ingress controller to use for ingress traffic.\n       # This is optional and if omitted the default ingress in the cluster is used.\n       # https://kubernetes.io/docs/concepts/services-networking/ingress/#default-ingress-class\n       # NOTE: This configuration only applicable for raw deployment.\n       \"ingressClassName\" : \"istio\",\n \n       # domainTemplate specifies the template for generating domain/url for each inference service by combining variable from:\n       # Name of the inference service  ( {{ .Name}} )\n       # Namespace of the inference service ( {{ .Namespace }} )\n       # Annotation of the inference service ( {{ .Annotations.key }} )\n       # Label of the inference service ( {{ .Labels.key }} )\n       # IngressDomain ( {{ .IngressDomain }} )\n       # If domain template is empty the default template {{ .Name }}-{{ .Namespace }}.{{ .IngressDomain }} is used.\n       # NOTE: This configuration only applicable for raw deployment.\n       \"domainTemplate\": \"{{ .Name }}-{{ .Namespace }}.{{ .IngressDomain }}\",\n \n       # urlScheme specifies the url scheme to use for inference service and inference graph.\n       # If urlScheme is empty then by default http is used.\n       \"urlScheme\": \"http\",\n \n       # disableIstioVirtualHost controls whether to use istio as network layer.\n       # By default istio is used as the network layer. When DisableIstioVirtualHost is true, KServe does not\n       # create the top level virtual service thus Istio is no longer required for serverless mode.\n       # By setting this field to true, user can use other networking layers supported by knative.\n       # For more info https://github.com/kserve/kserve/pull/2380, https://kserve.github.io/website/master/admin/serverless/kourier_networking/.\n       # NOTE: This configuration is only applicable to serverless deployment.\n       \"disableIstioVirtualHost\": false,\n\n       # disableIngressCreation controls whether to disable ingress creation for raw deployment mode.\n       \"disableIngressCreation\": false,\n \n       # pathTemplate specifies the template for generating path based url for each inference service.\n       # The following variables can be used in the template for generating url.\n       # Name of the inference service  ( {{ .Name}} )\n       # Namespace of the inference service ( {{ .Namespace }} )\n       # For more info https://github.com/kserve/kserve/issues/2257.\n       # NOTE: This configuration only applicable to serverless deployment.\n       \"pathTemplate\": \"/serving/{{ .Namespace }}/{{ .Name }}\"\n   }\n \n # ====================================== LOGGER CONFIGURATION ======================================\n # Example\n logger: |-\n   {\n       \"image\" : \"kserve/agent:v0.13.0\",\n       \"memoryRequest\": \"100Mi\",\n       \"memoryLimit\": \"1Gi\",\n       \"cpuRequest\": \"100m\",\n       \"cpuLimit\": \"1\",\n       \"defaultUrl\": \"http://default-broker\"\n   }\n logger: |-\n   {\n       # image contains the default logger image uri.\n       \"image\" : \"kserve/agent:v0.13.0\",\n   \n       # memoryRequest is the requests.memory to set for the logger container.\n       \"memoryRequest\": \"100Mi\",\n       \n       # memoryLimit is the limits.memory to set for the logger container.\n       \"memoryLimit\": \"1Gi\",\n       \n       # cpuRequest is the requests.cpu to set for the logger container.\n       \"cpuRequest\": \"100m\",\n       \n       # cpuLimit is the limits.cpu to set for the logger container.\n       \"cpuLimit\": \"1\",\n       \n       # defaultUrl specifies the default logger url. If logger is not specified in the resource this url is used.\n       \"defaultUrl\": \"http://default-broker\"\n   }\n \n # ====================================== BATCHER CONFIGURATION ======================================\n # Example\n batcher: |-\n   {\n       \"image\" : \"kserve/agent:v0.13.0\",\n       \"memoryRequest\": \"1Gi\",\n       \"memoryLimit\": \"1Gi\",\n       \"cpuRequest\": \"1\",\n       \"cpuLimit\": \"1\",\n       \"maxBatchSize\": \"32\",\n       \"maxLatency\": \"5000\"\n   }\n batcher: |-\n   {\n       # image contains the default batcher image uri.\n       \"image\" : \"kserve/agent:v0.13.0\",\n       \n       # memoryRequest is the requests.memory to set for the batcher container.\n       \"memoryRequest\": \"1Gi\",\n   \n       # memoryLimit is the limits.memory to set for the batcher container.\n       \"memoryLimit\": \"1Gi\",\n       \n       # cpuRequest is the requests.cpu to set for the batcher container.\n       \"cpuRequest\": \"1\",\n       \n       # cpuLimit is the limits.cpu to set for the batcher container.\n       \"cpuLimit\": \"1\"\n\n       # maxBatchSize is the default maximum batch size for batcher.\n       \"maxBatchSize\": \"32\",\n\n       # maxLatency is the default maximum latency in milliseconds for batcher to wait and collect the batch.\n       \"maxLatency\": \"5000\"\n   }\n \n # ====================================== AGENT CONFIGURATION ======================================\n # Example\n agent: |-\n   {\n       \"image\" : \"kserve/agent:v0.13.0\",\n       \"memoryRequest\": \"100Mi\",\n       \"memoryLimit\": \"1Gi\",\n       \"cpuRequest\": \"100m\",\n       \"cpuLimit\": \"1\"\n   }\n agent: |-\n   {\n       # image contains the default agent image uri.\n       \"image\" : \"kserve/agent:v0.13.0\",\n   \n       # memoryRequest is the requests.memory to set for the agent container.\n       \"memoryRequest\": \"100Mi\",\n   \n       # memoryLimit is the limits.memory to set for the agent container.\n       \"memoryLimit\": \"1Gi\",\n       \n       # cpuRequest is the requests.cpu to set for the agent container.\n       \"cpuRequest\": \"100m\",\n       \n       # cpuLimit is the limits.cpu to set for the agent container.\n       \"cpuLimit\": \"1\"\n   }\n \n # ====================================== ROUTER CONFIGURATION ======================================\n # Example\n router: |-\n   {\n       \"image\" : \"kserve/router:v0.13.0\",\n       \"memoryRequest\": \"100Mi\",\n       \"memoryLimit\": \"1Gi\",\n       \"cpuRequest\": \"100m\",\n       \"cpuLimit\": \"1\",\n       \"headers\": {\n         \"propagate\": []\n       }\n   }\n # router is the implementation of inference graph.\n router: |-\n   {\n       # image contains the default router image uri.\n       \"image\" : \"kserve/router:v0.13.0\",\n       \n       # memoryRequest is the requests.memory to set for the router container.\n       \"memoryRequest\": \"100Mi\",\n       \n       # memoryLimit is the limits.memory to set for the router container.\n       \"memoryLimit\": \"1Gi\",\n       \n       # cpuRequest is the requests.cpu to set for the router container.\n       \"cpuRequest\": \"100m\",\n       \n       # cpuLimit is the limits.cpu to set for the router container.\n       \"cpuLimit\": \"1\",\n       \n       # Propagate the specified headers to all the steps specified in an InferenceGraph. \n       # You can either specify the exact header names or use [Golang supported regex patterns]\n       # (https://pkg.go.dev/regexp/syntax@go1.21.3#hdr-Syntax) to propagate multiple headers.\n       \"headers\": {\n         \"propagate\": [\n            \"Authorization\",\n            \"Test-Header-*\",\n            \"*Trace-Id*\"\n         ]\n       }\n   }\n \n # ====================================== DEPLOYMENT CONFIGURATION ======================================\n # Example\n deploy: |-\n   {\n     \"defaultDeploymentMode\": \"Serverless\"\n   }\n deploy: |-\n   {\n     # defaultDeploymentMode specifies the default deployment mode of the kserve. The supported values are\n     # Serverless, RawDeployment and ModelMesh. Users can override the deployment mode at service level\n     # by adding the annotation serving.kserve.io/deploymentMode.For more info on deployment mode visit\n     # Serverless https://kserve.github.io/website/master/admin/serverless/serverless/\n     # RawDeployment https://kserve.github.io/website/master/admin/kubernetes_deployment/\n     # ModelMesh https://kserve.github.io/website/master/admin/modelmesh/\n     \"defaultDeploymentMode\": \"Serverless\"\n   }\n \n # ====================================== METRICS CONFIGURATION ======================================\n # Example\n metricsAggregator: |-\n   {\n     \"enableMetricAggregation\": \"false\",\n     \"enablePrometheusScraping\" : \"false\"\n   }\n # For more info see https://github.com/kserve/kserve/blob/master/qpext/README.md\n metricsAggregator: |-\n   {\n     # enableMetricAggregation configures metric aggregation annotation. This adds the annotation serving.kserve.io/enable-metric-aggregation to every\n     # service with the specified boolean value. If true enables metric aggregation in queue-proxy by setting env vars in the queue proxy container\n     # to configure scraping ports.\n     \"enableMetricAggregation\": \"false\",\n     \n     # enablePrometheusScraping configures metric aggregation annotation. This adds the annotation serving.kserve.io/enable-metric-aggregation to every\n     # service with the specified boolean value. If true, prometheus annotations are added to the pod. If serving.kserve.io/enable-metric-aggregation is false,\n     # the prometheus port is set with the default prometheus scraping port 9090, otherwise the prometheus port annotation is set with the metric aggregation port.\n     \"enablePrometheusScraping\" : \"false\"\n   }"
   agent: |-
     {
-        "image" : "kserve/agent:v0.12.1",
+        "image" : "kserve/agent:v0.13.0",
         "memoryRequest": "100Mi",
         "memoryLimit": "1Gi",
         "cpuRequest": "100m",
@@ -21994,7 +21399,7 @@ data:
     }
   batcher: |-
     {
-        "image" : "kserve/agent:v0.12.1",
+        "image" : "kserve/agent:v0.13.0",
         "memoryRequest": "1Gi",
         "memoryLimit": "1Gi",
         "cpuRequest": "1",
@@ -22028,10 +21433,6 @@ data:
     }
   explainers: |-
     {
-        "alibi": {
-            "image" : "kserve/alibi-explainer",
-            "defaultImageVersion": "latest"
-        },
         "art": {
             "image" : "kserve/art-explainer",
             "defaultImageVersion": "latest"
@@ -22052,7 +21453,7 @@ data:
     }
   logger: |-
     {
-        "image" : "kserve/agent:v0.12.1",
+        "image" : "kserve/agent:v0.13.0",
         "memoryRequest": "100Mi",
         "memoryLimit": "1Gi",
         "cpuRequest": "100m",
@@ -22066,7 +21467,7 @@ data:
     }
   router: |-
     {
-        "image" : "kserve/router:v0.12.1",
+        "image" : "kserve/router:v0.13.0",
         "memoryRequest": "100Mi",
         "memoryLimit": "1Gi",
         "cpuRequest": "100m",
@@ -22074,7 +21475,7 @@ data:
     }
   storageInitializer: |-
     {
-        "image" : "kserve/storage-initializer:v0.12.1",
+        "image" : "kserve/storage-initializer:v0.13.0",
         "memoryRequest": "100Mi",
         "memoryLimit": "1Gi",
         "cpuRequest": "100m",
@@ -22207,7 +21608,7 @@ spec:
                   fieldPath: metadata.namespace
             - name: SECRET_NAME
               value: kserve-webhook-server-cert
-          image: kserve/kserve-controller:v0.12.1
+          image: kserve/kserve-controller:v0.13.0
           imagePullPolicy: Always
           livenessProbe:
             failureThreshold: 5

--- a/hack/sync-kserve-kserve-manifests.sh
+++ b/hack/sync-kserve-kserve-manifests.sh
@@ -15,8 +15,8 @@
 set -euxo pipefail
 IFS=$'\n\t'
 
-KSERVE_VERSION="v0.12.1"
-COMMIT="0.12.1" # You can use tags as well
+KSERVE_VERSION="v0.13.0"
+COMMIT="0.13.0" # You can use tags as well
 SRC_DIR=${SRC_DIR:=/tmp/kserve}
 BRANCH=${BRANCH:=sync-kserve-manifests-${COMMIT?}}
 


### PR DESCRIPTION
Updates kserve to v0.13.0 from v0.12.1

This update was generated using the procedure from contrib/kserve/UPGRADE.md, not using hacks/sync-kserve-kserve-manifests.sh, because kserve [appears to have forgotten to add 0.13.0 to their `install/` directory](https://github.com/kserve/kserve/tree/v0.13.0/install/v0.13.0).  Instead, the manifests here have been pulled directly from [the 0.13.0 release assets](https://github.com/kserve/kserve/releases/tag/v0.13.0)