### PR TITLE
fix: update /models/ to /kserve-endpoints/ for kserve models web app …

### DIFF
--- a/apps/centraldashboard/upstream/overlays/kserve/patches/configmap.yaml
+++ b/apps/centraldashboard/upstream/overlays/kserve/patches/configmap.yaml
@@ -33,7 +33,7 @@ data:
             },
             {
                 "type": "item",
-                "link": "/models/",
+                "link": "/kserve-endpoints/",
                 "text": "KServe Endpoints",
                 "icon": "kubeflow:models"
             },


### PR DESCRIPTION
Fix KServe model endpoints webapp Url.

## Description
> Update   [`centraldashboard-config`](https://github.com/kubeflow/manifests/blob/master/apps/centraldashboard/upstream/overlays/kserve/patches/configmap.yaml#L36) **_ConfigMap_** to point to the right link based on this [VirtualService](https://github.com/kubeflow/manifests/blob/master/contrib/kserve/models-web-app/base/istio.yaml#L14)

> Using `/models/` will result in the following screen when deploying Kubeflow

![models-invalid](https://github.com/kubeflow/manifests/assets/39798912/72cc190b-6108-4010-8996-9f5fd4d492ed)

  

> After Updating the **_ConfigMap_** to use  `/kserve-endpoints/`, the Models endpoint will show correctly: 

![kserve-fixed](https://github.com/kubeflow/manifests/assets/39798912/7207daf6-da8c-448e-82a9-2602a60d0a6a)




> Note: Instead of updating the ConfigMap [`centraldashboard-config`](https://github.com/kubeflow/manifests/blob/master/apps/centraldashboard/upstream/overlays/kserve/patches/configmap.yaml#L36)  we can update the actual [VirtualService](https://github.com/kubeflow/manifests/blob/master/contrib/kserve/models-web-app/base/istio.yaml#L14) to use `/models/` instead also.

  