### PR TITLE
set CNCF slack channel in README file

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@
 
 This repository is owned by the [Manifests Working Group](https://github.com/kubeflow/community/blob/master/wg-manifests/charter.md).
 If you are a contributor authoring or editing the packages please see [Best Practices](./docs/KustomizeBestPractices.md).
-Our Slack channel is wg-manifests which you can join here https://www.kubeflow.org/docs/about/community/. You can also find there our [biweekly meetings](https://bit.ly/kf-wg-manifests-meet), including the commentable [Agenda](https://bit.ly/kf-wg-manifests-notes)
+Our CNCF Slack channel is kubeflow-platform which you can join here https://app.slack.com/client/T08PSQ7BQ/C073W572LA2. You can also find there our [biweekly meetings](https://bit.ly/kf-wg-manifests-meet), including the commentable [Agenda](https://bit.ly/kf-wg-manifests-notes)
 
 The Kubeflow Manifests repository is organized under three main directories, which include manifests for installing:
 

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@
 
 This repository is owned by the [Manifests Working Group](https://github.com/kubeflow/community/blob/master/wg-manifests/charter.md).
 If you are a contributor authoring or editing the packages please see [Best Practices](./docs/KustomizeBestPractices.md).
-Our CNCF Slack channel is kubeflow-platform which you can join here https://app.slack.com/client/T08PSQ7BQ/C073W572LA2. You can also find there our [biweekly meetings](https://bit.ly/kf-wg-manifests-meet), including the commentable [Agenda](https://bit.ly/kf-wg-manifests-notes)
+.You can join the CNCF Slack and access our meetings at the [Kubeflow Community](https://www.kubeflow.org/docs/about/community/) website. Our channel on the CNCF Slack is here [**#kubeflow-platform**](https://app.slack.com/client/T08PSQ7BQ/C073W572LA2). You can also find there our [biweekly meetings](https://bit.ly/kf-wg-manifests-meet), including the commentable [Agenda](https://bit.ly/kf-wg-manifests-notes)
 
 The Kubeflow Manifests repository is organized under three main directories, which include manifests for installing:
 


### PR DESCRIPTION
# Pull Request Template for Kubeflow manifests Issues

- Please include a summary of changes and the related issue. 
- List any dependencies that are required for this change. 
- Please delete the options that are not relevant.
- The following checklist will help you to satisfy the requirements.


## ✏️ A brief description of the changes
> I changed the slack channel to CNCF slack channel


## ✅ Contributor checklist
  - [X] All the commits have been _signed-off_  (To pass the `DCO` check)
  - [X] Submit the [Contributor License Agreements](https://cla.developers.google.com/clas) (To pass the `cla/google` check)


---     
 
> You can join the CNCF Slack and access our meetings at the [Kubeflow Community](https://www.kubeflow.org/docs/about/community/) website. Our channel on the CNCF Slack is here [**#kubeflow-platform**](https://app.slack.com/client/T08PSQ7BQ/C073W572LA2).
  