### PR TITLE
networkpolicy for training operator

### DIFF
--- a/common/networkpolicies/base/kustomization.yaml
+++ b/common/networkpolicies/base/kustomization.yaml
@@ -20,5 +20,6 @@ resources:
   - poddefaults.yaml
   - pvcviewer-webhook.yaml
   - seldon.yaml
-  - volumes-web-app.yaml
   - tensorboards-web-app.yaml
+  - training-operator-webhook.yaml
+  - volumes-web-app.yaml

--- a/common/networkpolicies/base/training-operator-webhook.yaml
+++ b/common/networkpolicies/base/training-operator-webhook.yaml
@@ -1,0 +1,20 @@
+kind: NetworkPolicy
+apiVersion: networking.k8s.io/v1
+metadata:
+  name: training-operator-webhook
+  namespace: kubeflow
+spec:
+  podSelector:
+    matchExpressions:
+    - key: control-plane
+      operator: In
+      values:
+      - kubeflow-training-operator
+  # https://www.elastic.co/guide/en/cloud-on-k8s/1.1/k8s-webhook-network-policies.html
+  # The kubernetes api server must reach the webhook
+  ingress:
+    - ports:
+        - protocol: TCP
+          port: 9443
+  policyTypes:
+    - Ingress


### PR DESCRIPTION
I moved the networkpolicies from https://github.com/kubeflow/manifests/pull/2779 into this PR to have it ready for 1.9