### PR TITLE
 Deprecate optional Knative Eventing components

### DIFF
--- a/example/kustomization.yaml
+++ b/example/kustomization.yaml
@@ -46,7 +46,8 @@ resources:
 - ../common/dex/overlays/oauth2-proxy
 # KNative
 - ../common/knative/knative-serving/overlays/gateways
-- ../common/knative/knative-eventing/base
+# Uncomment the following line if `knative-eventing` is required
+# - ../common/knative/knative-eventing/base
 - ../common/istio-1-22/cluster-local-gateway/base
 # Kubeflow namespace
 - ../common/kubeflow-namespace/base


### PR DESCRIPTION
# Pull Request Template for Kubeflow manifests Issues

- Please include a summary of changes and the related issue. 
- List any dependencies that are required for this change. 
- Please delete the options that are not relevant.
- The following checklist will help you to satisfy the requirements.



## ✏️ A brief description of the changes
> I commented out the   _../common/knative/knative-eventing/base_ in [Kustomization.yaml](https://github.com/kubeflow/manifests/blob/master/example/kustomization.yaml) file to deprecate optional Knative Eventing components from common manifests


## 🐛 If this PR is related to an issue, please put the link of the issue here.
> [#2685](https://github.com/kubeflow/manifests/issues/2685)


 
## ✅ Contributor checklist
  - [X] All the commits have been _signed-off_  (To pass the `DCO` check)
  - [X] Submit the [Contributor License Agreements](https://cla.developers.google.com/clas) (To pass the `cla/google` check)


---     
 
> You can join the CNCF Slack and access our meetings at the [Kubeflow Community](https://www.kubeflow.org/docs/about/community/) website. Our channel on the CNCF Slack is here [**#kubeflow-platform**](https://app.slack.com/client/T08PSQ7BQ/C073W572LA2).
  