### PR TITLE
Fix ml pipeline access from kfp step

### DIFF
--- a/.github/workflows/pipeline_test.yaml
+++ b/.github/workflows/pipeline_test.yaml
@@ -90,11 +90,14 @@ jobs:
 
           while True:
             status = client.get_run(run_id=run_id).state
-            if status not in ["SUCCEEDED", "FAILED", "ERROR"]:
+            if status in ["PENDING", "RUNNING"]:
               print(f"Waiting for run_id: {run_id}, status: {status}.")
               sleep(10)
             else:
               print(f"Run with id {run_id} finished with status: {status}.")
+              if status != "SUCCEEDED":
+                print("Pipeline failed")
+                raise SystemExit(1)
               break
           ' "${TOKEN}" "${KF_PROFILE}"
 

--- a/apps/kfp-tekton/upstream/base/installs/multi-user/istio-authorization-config.yaml
+++ b/apps/kfp-tekton/upstream/base/installs/multi-user/istio-authorization-config.yaml
@@ -32,6 +32,10 @@ spec:
         - cluster.local/ns/kubeflow/sa/ml-pipeline-scheduledworkflow
         - cluster.local/ns/kubeflow/sa/ml-pipeline-viewer-crd-service-account
         - cluster.local/ns/kubeflow/sa/kubeflow-pipelines-cache
+  # allow access by any trusted principal
+  - from:
+    - source:
+        requestPrincipals: ["*"]
   # For user workloads, which cannot user http headers for authentication
   - when:
     - key: request.headers[kubeflow-userid]

--- a/apps/kfp-tekton/upstream/v1/base/installs/multi-user/istio-authorization-config.yaml
+++ b/apps/kfp-tekton/upstream/v1/base/installs/multi-user/istio-authorization-config.yaml
@@ -32,6 +32,10 @@ spec:
         - cluster.local/ns/kubeflow/sa/ml-pipeline-scheduledworkflow
         - cluster.local/ns/kubeflow/sa/ml-pipeline-viewer-crd-service-account
         - cluster.local/ns/kubeflow/sa/kubeflow-pipelines-cache
+  # allow access by any trusted principal
+  - from:
+    - source:
+        requestPrincipals: ["*"]
   # For user workloads, which cannot user http headers for authentication
   - when:
     - key: request.headers[kubeflow-userid]

--- a/apps/pipeline/upstream/base/installs/multi-user/istio-authorization-config.yaml
+++ b/apps/pipeline/upstream/base/installs/multi-user/istio-authorization-config.yaml
@@ -32,9 +32,14 @@ spec:
         - cluster.local/ns/kubeflow/sa/ml-pipeline-scheduledworkflow
         - cluster.local/ns/kubeflow/sa/ml-pipeline-viewer-crd-service-account
         - cluster.local/ns/kubeflow/sa/kubeflow-pipelines-cache
+  # allow access by any trusted principal
   - from:
     - source:
-        requestPrincipals: ["*"]  # allow access by any trusted principal
+        requestPrincipals: ["*"]
+  # For user workloads, which cannot user http headers for authentication
+  - when:
+    - key: request.headers[kubeflow-userid]
+      notValues: ['*']
 ---
 apiVersion: security.istio.io/v1beta1
 kind: AuthorizationPolicy


### PR DESCRIPTION
# Fix ml pipeline access from kfp step

## ✏️ A brief description of the changes
I changed the:
* GH Action defined in `.github/workflows/pipeline_test.yaml` to fail if the KF Pipeline Run has failed,
* `AuthorizationPolicy/ml-pipeline` to allow access for both scenarios:
  * when request doesn't have `kubeflow-userid` header to allow access from KFP Steps
  * when request have a valid JWT trusted by Istio to allow programmatic access

## 📦 List any dependencies that are required for this change
N/A

## 🐛 If this PR is related to an issue, please put the link to the issue here.
https://github.com/kubeflow/manifests/issues/2794

## ✅ Contributor checklist
  - Make sure you have tested with kustomize. See [Installation Prerequisites](https://github.com/kubeflow/manifests#prerequisites)
  - All the commits have been _signed-off_  (To pass the `DCO` check)
  - Submit the [Contributor License Agreements](https://cla.developers.google.com/clas) (To pass the `cla/google` check)

@kimwnasptd , @juliusvonkohout 