### PR TITLE
Update kubeflow/katib manifests from v0.17.0

### DIFF
--- a/apps/katib/upstream/components/controller/trial-templates.yaml
+++ b/apps/katib/upstream/components/controller/trial-templates.yaml
@@ -15,7 +15,7 @@ data:
         spec:
           containers:
             - name: training-container
-              image: docker.io/kubeflowkatib/pytorch-mnist-cpu:v0.17.0-rc.1
+              image: docker.io/kubeflowkatib/pytorch-mnist-cpu:v0.17.0
               command:
                 - "python3"
                 - "/opt/pytorch-mnist/mnist.py"
@@ -33,7 +33,7 @@ data:
         spec:
           containers:
             - name: training-container
-              image: docker.io/kubeflowkatib/enas-cnn-cifar10-cpu:v0.17.0-rc.1
+              image: docker.io/kubeflowkatib/enas-cnn-cifar10-cpu:v0.17.0
               command:
                 - python3
                 - -u
@@ -54,7 +54,7 @@ data:
             spec:
               containers:
                 - name: pytorch
-                  image: docker.io/kubeflowkatib/pytorch-mnist-cpu:v0.17.0-rc.1
+                  image: docker.io/kubeflowkatib/pytorch-mnist-cpu:v0.17.0
                   command:
                     - "python3"
                     - "/opt/pytorch-mnist/mnist.py"
@@ -68,7 +68,7 @@ data:
             spec:
               containers:
                 - name: pytorch
-                  image: docker.io/kubeflowkatib/pytorch-mnist-cpu:v0.17.0-rc.1
+                  image: docker.io/kubeflowkatib/pytorch-mnist-cpu:v0.17.0
                   command:
                     - "python3"
                     - "/opt/pytorch-mnist/mnist.py"

--- a/apps/katib/upstream/installs/katib-cert-manager/katib-config.yaml
+++ b/apps/katib/upstream/installs/katib-cert-manager/katib-config.yaml
@@ -14,40 +14,40 @@ init:
 runtime:
   metricsCollectors:
     - kind: StdOut
-      image: docker.io/kubeflowkatib/file-metrics-collector:v0.17.0-rc.1
+      image: docker.io/kubeflowkatib/file-metrics-collector:v0.17.0
     - kind: File
-      image: docker.io/kubeflowkatib/file-metrics-collector:v0.17.0-rc.1
+      image: docker.io/kubeflowkatib/file-metrics-collector:v0.17.0
     - kind: TensorFlowEvent
-      image: docker.io/kubeflowkatib/tfevent-metrics-collector:v0.17.0-rc.1
+      image: docker.io/kubeflowkatib/tfevent-metrics-collector:v0.17.0
       resources:
         limits:
           memory: 1Gi
   suggestions:
     - algorithmName: random
-      image: docker.io/kubeflowkatib/suggestion-hyperopt:v0.17.0-rc.1
+      image: docker.io/kubeflowkatib/suggestion-hyperopt:v0.17.0
     - algorithmName: tpe
-      image: docker.io/kubeflowkatib/suggestion-hyperopt:v0.17.0-rc.1
+      image: docker.io/kubeflowkatib/suggestion-hyperopt:v0.17.0
     - algorithmName: grid
-      image: docker.io/kubeflowkatib/suggestion-optuna:v0.17.0-rc.1
+      image: docker.io/kubeflowkatib/suggestion-optuna:v0.17.0
     - algorithmName: hyperband
-      image: docker.io/kubeflowkatib/suggestion-hyperband:v0.17.0-rc.1
+      image: docker.io/kubeflowkatib/suggestion-hyperband:v0.17.0
     - algorithmName: bayesianoptimization
-      image: docker.io/kubeflowkatib/suggestion-skopt:v0.17.0-rc.1
+      image: docker.io/kubeflowkatib/suggestion-skopt:v0.17.0
     - algorithmName: cmaes
-      image: docker.io/kubeflowkatib/suggestion-goptuna:v0.17.0-rc.1
+      image: docker.io/kubeflowkatib/suggestion-goptuna:v0.17.0
     - algorithmName: sobol
-      image: docker.io/kubeflowkatib/suggestion-goptuna:v0.17.0-rc.1
+      image: docker.io/kubeflowkatib/suggestion-goptuna:v0.17.0
     - algorithmName: multivariate-tpe
-      image: docker.io/kubeflowkatib/suggestion-optuna:v0.17.0-rc.1
+      image: docker.io/kubeflowkatib/suggestion-optuna:v0.17.0
     - algorithmName: enas
-      image: docker.io/kubeflowkatib/suggestion-enas:v0.17.0-rc.1
+      image: docker.io/kubeflowkatib/suggestion-enas:v0.17.0
       resources:
         limits:
           memory: 400Mi
     - algorithmName: darts
-      image: docker.io/kubeflowkatib/suggestion-darts:v0.17.0-rc.1
+      image: docker.io/kubeflowkatib/suggestion-darts:v0.17.0
     - algorithmName: pbt
-      image: docker.io/kubeflowkatib/suggestion-pbt:v0.17.0-rc.1
+      image: docker.io/kubeflowkatib/suggestion-pbt:v0.17.0
       persistentVolumeClaimSpec:
         accessModes:
           - ReadWriteMany
@@ -56,4 +56,4 @@ runtime:
             storage: 5Gi
   earlyStoppings:
     - algorithmName: medianstop
-      image: docker.io/kubeflowkatib/earlystopping-medianstop:v0.17.0-rc.1
+      image: docker.io/kubeflowkatib/earlystopping-medianstop:v0.17.0

--- a/apps/katib/upstream/installs/katib-cert-manager/kustomization.yaml
+++ b/apps/katib/upstream/installs/katib-cert-manager/kustomization.yaml
@@ -22,13 +22,13 @@ resources:
 images:
   - name: docker.io/kubeflowkatib/katib-controller
     newName: docker.io/kubeflowkatib/katib-controller
-    newTag: v0.17.0-rc.1
+    newTag: v0.17.0
   - name: docker.io/kubeflowkatib/katib-db-manager
     newName: docker.io/kubeflowkatib/katib-db-manager
-    newTag: v0.17.0-rc.1
+    newTag: v0.17.0
   - name: docker.io/kubeflowkatib/katib-ui
     newName: docker.io/kubeflowkatib/katib-ui
-    newTag: v0.17.0-rc.1
+    newTag: v0.17.0
 
 patchesStrategicMerge:
   - patches/katib-cert-injection.yaml

--- a/apps/katib/upstream/installs/katib-external-db/katib-config.yaml
+++ b/apps/katib/upstream/installs/katib-external-db/katib-config.yaml
@@ -16,40 +16,40 @@ init:
 runtime:
   metricsCollectors:
     - kind: StdOut
-      image: docker.io/kubeflowkatib/file-metrics-collector:v0.17.0-rc.1
+      image: docker.io/kubeflowkatib/file-metrics-collector:v0.17.0
     - kind: File
-      image: docker.io/kubeflowkatib/file-metrics-collector:v0.17.0-rc.1
+      image: docker.io/kubeflowkatib/file-metrics-collector:v0.17.0
     - kind: TensorFlowEvent
-      image: docker.io/kubeflowkatib/tfevent-metrics-collector:v0.17.0-rc.1
+      image: docker.io/kubeflowkatib/tfevent-metrics-collector:v0.17.0
       resources:
         limits:
           memory: 1Gi
   suggestions:
     - algorithmName: random
-      image: docker.io/kubeflowkatib/suggestion-hyperopt:v0.17.0-rc.1
+      image: docker.io/kubeflowkatib/suggestion-hyperopt:v0.17.0
     - algorithmName: tpe
-      image: docker.io/kubeflowkatib/suggestion-hyperopt:v0.17.0-rc.1
+      image: docker.io/kubeflowkatib/suggestion-hyperopt:v0.17.0
     - algorithmName: grid
-      image: docker.io/kubeflowkatib/suggestion-optuna:v0.17.0-rc.1
+      image: docker.io/kubeflowkatib/suggestion-optuna:v0.17.0
     - algorithmName: hyperband
-      image: docker.io/kubeflowkatib/suggestion-hyperband:v0.17.0-rc.1
+      image: docker.io/kubeflowkatib/suggestion-hyperband:v0.17.0
     - algorithmName: bayesianoptimization
-      image: docker.io/kubeflowkatib/suggestion-skopt:v0.17.0-rc.1
+      image: docker.io/kubeflowkatib/suggestion-skopt:v0.17.0
     - algorithmName: cmaes
-      image: docker.io/kubeflowkatib/suggestion-goptuna:v0.17.0-rc.1
+      image: docker.io/kubeflowkatib/suggestion-goptuna:v0.17.0
     - algorithmName: sobol
-      image: docker.io/kubeflowkatib/suggestion-goptuna:v0.17.0-rc.1
+      image: docker.io/kubeflowkatib/suggestion-goptuna:v0.17.0
     - algorithmName: multivariate-tpe
-      image: docker.io/kubeflowkatib/suggestion-optuna:v0.17.0-rc.1
+      image: docker.io/kubeflowkatib/suggestion-optuna:v0.17.0
     - algorithmName: enas
-      image: docker.io/kubeflowkatib/suggestion-enas:v0.17.0-rc.1
+      image: docker.io/kubeflowkatib/suggestion-enas:v0.17.0
       resources:
         limits:
           memory: 400Mi
     - algorithmName: darts
-      image: docker.io/kubeflowkatib/suggestion-darts:v0.17.0-rc.1
+      image: docker.io/kubeflowkatib/suggestion-darts:v0.17.0
     - algorithmName: pbt
-      image: docker.io/kubeflowkatib/suggestion-pbt:v0.17.0-rc.1
+      image: docker.io/kubeflowkatib/suggestion-pbt:v0.17.0
       persistentVolumeClaimSpec:
         accessModes:
           - ReadWriteMany
@@ -58,4 +58,4 @@ runtime:
             storage: 5Gi
   earlyStoppings:
     - algorithmName: medianstop
-      image: docker.io/kubeflowkatib/earlystopping-medianstop:v0.17.0-rc.1
+      image: docker.io/kubeflowkatib/earlystopping-medianstop:v0.17.0

--- a/apps/katib/upstream/installs/katib-external-db/kustomization.yaml
+++ b/apps/katib/upstream/installs/katib-external-db/kustomization.yaml
@@ -18,13 +18,13 @@ resources:
 images:
   - name: docker.io/kubeflowkatib/katib-controller
     newName: docker.io/kubeflowkatib/katib-controller
-    newTag: v0.17.0-rc.1
+    newTag: v0.17.0
   - name: docker.io/kubeflowkatib/katib-db-manager
     newName: docker.io/kubeflowkatib/katib-db-manager
-    newTag: v0.17.0-rc.1
+    newTag: v0.17.0
   - name: docker.io/kubeflowkatib/katib-ui
     newName: docker.io/kubeflowkatib/katib-ui
-    newTag: v0.17.0-rc.1
+    newTag: v0.17.0
 patchesStrategicMerge:
   - patches/db-manager.yaml
 # Modify katib-mysql-secrets with parameters for the DB.

--- a/apps/katib/upstream/installs/katib-leader-election/katib-config.yaml
+++ b/apps/katib/upstream/installs/katib-leader-election/katib-config.yaml
@@ -17,40 +17,40 @@ init:
 runtime:
   metricsCollectors:
     - kind: StdOut
-      image: docker.io/kubeflowkatib/file-metrics-collector:v0.17.0-rc.1
+      image: docker.io/kubeflowkatib/file-metrics-collector:v0.17.0
     - kind: File
-      image: docker.io/kubeflowkatib/file-metrics-collector:v0.17.0-rc.1
+      image: docker.io/kubeflowkatib/file-metrics-collector:v0.17.0
     - kind: TensorFlowEvent
-      image: docker.io/kubeflowkatib/tfevent-metrics-collector:v0.17.0-rc.1
+      image: docker.io/kubeflowkatib/tfevent-metrics-collector:v0.17.0
       resources:
         limits:
           memory: 1Gi
   suggestions:
     - algorithmName: random
-      image: docker.io/kubeflowkatib/suggestion-hyperopt:v0.17.0-rc.1
+      image: docker.io/kubeflowkatib/suggestion-hyperopt:v0.17.0
     - algorithmName: tpe
-      image: docker.io/kubeflowkatib/suggestion-hyperopt:v0.17.0-rc.1
+      image: docker.io/kubeflowkatib/suggestion-hyperopt:v0.17.0
     - algorithmName: grid
-      image: docker.io/kubeflowkatib/suggestion-optuna:v0.17.0-rc.1
+      image: docker.io/kubeflowkatib/suggestion-optuna:v0.17.0
     - algorithmName: hyperband
-      image: docker.io/kubeflowkatib/suggestion-hyperband:v0.17.0-rc.1
+      image: docker.io/kubeflowkatib/suggestion-hyperband:v0.17.0
     - algorithmName: bayesianoptimization
-      image: docker.io/kubeflowkatib/suggestion-skopt:v0.17.0-rc.1
+      image: docker.io/kubeflowkatib/suggestion-skopt:v0.17.0
     - algorithmName: cmaes
-      image: docker.io/kubeflowkatib/suggestion-goptuna:v0.17.0-rc.1
+      image: docker.io/kubeflowkatib/suggestion-goptuna:v0.17.0
     - algorithmName: sobol
-      image: docker.io/kubeflowkatib/suggestion-goptuna:v0.17.0-rc.1
+      image: docker.io/kubeflowkatib/suggestion-goptuna:v0.17.0
     - algorithmName: multivariate-tpe
-      image: docker.io/kubeflowkatib/suggestion-optuna:v0.17.0-rc.1
+      image: docker.io/kubeflowkatib/suggestion-optuna:v0.17.0
     - algorithmName: enas
-      image: docker.io/kubeflowkatib/suggestion-enas:v0.17.0-rc.1
+      image: docker.io/kubeflowkatib/suggestion-enas:v0.17.0
       resources:
         limits:
           memory: 400Mi
     - algorithmName: darts
-      image: docker.io/kubeflowkatib/suggestion-darts:v0.17.0-rc.1
+      image: docker.io/kubeflowkatib/suggestion-darts:v0.17.0
     - algorithmName: pbt
-      image: docker.io/kubeflowkatib/suggestion-pbt:v0.17.0-rc.1
+      image: docker.io/kubeflowkatib/suggestion-pbt:v0.17.0
       persistentVolumeClaimSpec:
         accessModes:
           - ReadWriteMany
@@ -59,4 +59,4 @@ runtime:
             storage: 5Gi
   earlyStoppings:
     - algorithmName: medianstop
-      image: docker.io/kubeflowkatib/earlystopping-medianstop:v0.17.0-rc.1
+      image: docker.io/kubeflowkatib/earlystopping-medianstop:v0.17.0

--- a/apps/katib/upstream/installs/katib-openshift/katib-config.yaml
+++ b/apps/katib/upstream/installs/katib-openshift/katib-config.yaml
@@ -14,40 +14,40 @@ init:
 runtime:
   metricsCollectors:
     - kind: StdOut
-      image: docker.io/kubeflowkatib/file-metrics-collector:v0.17.0-rc.1
+      image: docker.io/kubeflowkatib/file-metrics-collector:v0.17.0
     - kind: File
-      image: docker.io/kubeflowkatib/file-metrics-collector:v0.17.0-rc.1
+      image: docker.io/kubeflowkatib/file-metrics-collector:v0.17.0
     - kind: TensorFlowEvent
-      image: docker.io/kubeflowkatib/tfevent-metrics-collector:v0.17.0-rc.1
+      image: docker.io/kubeflowkatib/tfevent-metrics-collector:v0.17.0
       resources:
         limits:
           memory: 1Gi
   suggestions:
     - algorithmName: random
-      image: docker.io/kubeflowkatib/suggestion-hyperopt:v0.17.0-rc.1
+      image: docker.io/kubeflowkatib/suggestion-hyperopt:v0.17.0
     - algorithmName: tpe
-      image: docker.io/kubeflowkatib/suggestion-hyperopt:v0.17.0-rc.1
+      image: docker.io/kubeflowkatib/suggestion-hyperopt:v0.17.0
     - algorithmName: grid
-      image: docker.io/kubeflowkatib/suggestion-optuna:v0.17.0-rc.1
+      image: docker.io/kubeflowkatib/suggestion-optuna:v0.17.0
     - algorithmName: hyperband
-      image: docker.io/kubeflowkatib/suggestion-hyperband:v0.17.0-rc.1
+      image: docker.io/kubeflowkatib/suggestion-hyperband:v0.17.0
     - algorithmName: bayesianoptimization
-      image: docker.io/kubeflowkatib/suggestion-skopt:v0.17.0-rc.1
+      image: docker.io/kubeflowkatib/suggestion-skopt:v0.17.0
     - algorithmName: cmaes
-      image: docker.io/kubeflowkatib/suggestion-goptuna:v0.17.0-rc.1
+      image: docker.io/kubeflowkatib/suggestion-goptuna:v0.17.0
     - algorithmName: sobol
-      image: docker.io/kubeflowkatib/suggestion-goptuna:v0.17.0-rc.1
+      image: docker.io/kubeflowkatib/suggestion-goptuna:v0.17.0
     - algorithmName: multivariate-tpe
-      image: docker.io/kubeflowkatib/suggestion-optuna:v0.17.0-rc.1
+      image: docker.io/kubeflowkatib/suggestion-optuna:v0.17.0
     - algorithmName: enas
-      image: docker.io/kubeflowkatib/suggestion-enas:v0.17.0-rc.1
+      image: docker.io/kubeflowkatib/suggestion-enas:v0.17.0
       resources:
         limits:
           memory: 400Mi
     - algorithmName: darts
-      image: docker.io/kubeflowkatib/suggestion-darts:v0.17.0-rc.1
+      image: docker.io/kubeflowkatib/suggestion-darts:v0.17.0
     - algorithmName: pbt
-      image: docker.io/kubeflowkatib/suggestion-pbt:v0.17.0-rc.1
+      image: docker.io/kubeflowkatib/suggestion-pbt:v0.17.0
       persistentVolumeClaimSpec:
         accessModes:
           - ReadWriteMany
@@ -56,4 +56,4 @@ runtime:
             storage: 5Gi
   earlyStoppings:
     - algorithmName: medianstop
-      image: docker.io/kubeflowkatib/earlystopping-medianstop:v0.17.0-rc.1
+      image: docker.io/kubeflowkatib/earlystopping-medianstop:v0.17.0

--- a/apps/katib/upstream/installs/katib-openshift/kustomization.yaml
+++ b/apps/katib/upstream/installs/katib-openshift/kustomization.yaml
@@ -30,13 +30,13 @@ resources:
 images:
   - name: docker.io/kubeflowkatib/katib-controller
     newName: docker.io/kubeflowkatib/katib-controller
-    newTag: v0.17.0-rc.1
+    newTag: v0.17.0
   - name: docker.io/kubeflowkatib/katib-db-manager
     newName: docker.io/kubeflowkatib/katib-db-manager
-    newTag: v0.17.0-rc.1
+    newTag: v0.17.0
   - name: docker.io/kubeflowkatib/katib-ui
     newName: docker.io/kubeflowkatib/katib-ui
-    newTag: v0.17.0-rc.1
+    newTag: v0.17.0
 
 patchesJson6902:
   # Annotate Service to delegate TLS-secret generation to OpenShift service controller

--- a/apps/katib/upstream/installs/katib-standalone-postgres/katib-config.yaml
+++ b/apps/katib/upstream/installs/katib-standalone-postgres/katib-config.yaml
@@ -16,40 +16,40 @@ init:
 runtime:
   metricsCollectors:
     - kind: StdOut
-      image: docker.io/kubeflowkatib/file-metrics-collector:v0.17.0-rc.1
+      image: docker.io/kubeflowkatib/file-metrics-collector:v0.17.0
     - kind: File
-      image: docker.io/kubeflowkatib/file-metrics-collector:v0.17.0-rc.1
+      image: docker.io/kubeflowkatib/file-metrics-collector:v0.17.0
     - kind: TensorFlowEvent
-      image: docker.io/kubeflowkatib/tfevent-metrics-collector:v0.17.0-rc.1
+      image: docker.io/kubeflowkatib/tfevent-metrics-collector:v0.17.0
       resources:
         limits:
           memory: 1Gi
   suggestions:
     - algorithmName: random
-      image: docker.io/kubeflowkatib/suggestion-hyperopt:v0.17.0-rc.1
+      image: docker.io/kubeflowkatib/suggestion-hyperopt:v0.17.0
     - algorithmName: tpe
-      image: docker.io/kubeflowkatib/suggestion-hyperopt:v0.17.0-rc.1
+      image: docker.io/kubeflowkatib/suggestion-hyperopt:v0.17.0
     - algorithmName: grid
-      image: docker.io/kubeflowkatib/suggestion-optuna:v0.17.0-rc.1
+      image: docker.io/kubeflowkatib/suggestion-optuna:v0.17.0
     - algorithmName: hyperband
-      image: docker.io/kubeflowkatib/suggestion-hyperband:v0.17.0-rc.1
+      image: docker.io/kubeflowkatib/suggestion-hyperband:v0.17.0
     - algorithmName: bayesianoptimization
-      image: docker.io/kubeflowkatib/suggestion-skopt:v0.17.0-rc.1
+      image: docker.io/kubeflowkatib/suggestion-skopt:v0.17.0
     - algorithmName: cmaes
-      image: docker.io/kubeflowkatib/suggestion-goptuna:v0.17.0-rc.1
+      image: docker.io/kubeflowkatib/suggestion-goptuna:v0.17.0
     - algorithmName: sobol
-      image: docker.io/kubeflowkatib/suggestion-goptuna:v0.17.0-rc.1
+      image: docker.io/kubeflowkatib/suggestion-goptuna:v0.17.0
     - algorithmName: multivariate-tpe
-      image: docker.io/kubeflowkatib/suggestion-optuna:v0.17.0-rc.1
+      image: docker.io/kubeflowkatib/suggestion-optuna:v0.17.0
     - algorithmName: enas
-      image: docker.io/kubeflowkatib/suggestion-enas:v0.17.0-rc.1
+      image: docker.io/kubeflowkatib/suggestion-enas:v0.17.0
       resources:
         limits:
           memory: 400Mi
     - algorithmName: darts
-      image: docker.io/kubeflowkatib/suggestion-darts:v0.17.0-rc.1
+      image: docker.io/kubeflowkatib/suggestion-darts:v0.17.0
     - algorithmName: pbt
-      image: docker.io/kubeflowkatib/suggestion-pbt:v0.17.0-rc.1
+      image: docker.io/kubeflowkatib/suggestion-pbt:v0.17.0
       persistentVolumeClaimSpec:
         accessModes:
           - ReadWriteMany
@@ -58,4 +58,4 @@ runtime:
             storage: 5Gi
   earlyStoppings:
     - algorithmName: medianstop
-      image: docker.io/kubeflowkatib/earlystopping-medianstop:v0.17.0-rc.1
+      image: docker.io/kubeflowkatib/earlystopping-medianstop:v0.17.0

--- a/apps/katib/upstream/installs/katib-standalone-postgres/kustomization.yaml
+++ b/apps/katib/upstream/installs/katib-standalone-postgres/kustomization.yaml
@@ -20,13 +20,13 @@ resources:
 images:
   - name: docker.io/kubeflowkatib/katib-controller
     newName: docker.io/kubeflowkatib/katib-controller
-    newTag: v0.17.0-rc.1
+    newTag: v0.17.0
   - name: docker.io/kubeflowkatib/katib-db-manager
     newName: docker.io/kubeflowkatib/katib-db-manager
-    newTag: v0.17.0-rc.1
+    newTag: v0.17.0
   - name: docker.io/kubeflowkatib/katib-ui
     newName: docker.io/kubeflowkatib/katib-ui
-    newTag: v0.17.0-rc.1
+    newTag: v0.17.0
 patchesJson6902:
   - target:
       group: apps

--- a/apps/katib/upstream/installs/katib-standalone/katib-config.yaml
+++ b/apps/katib/upstream/installs/katib-standalone/katib-config.yaml
@@ -16,40 +16,40 @@ init:
 runtime:
   metricsCollectors:
     - kind: StdOut
-      image: docker.io/kubeflowkatib/file-metrics-collector:v0.17.0-rc.1
+      image: docker.io/kubeflowkatib/file-metrics-collector:v0.17.0
     - kind: File
-      image: docker.io/kubeflowkatib/file-metrics-collector:v0.17.0-rc.1
+      image: docker.io/kubeflowkatib/file-metrics-collector:v0.17.0
     - kind: TensorFlowEvent
-      image: docker.io/kubeflowkatib/tfevent-metrics-collector:v0.17.0-rc.1
+      image: docker.io/kubeflowkatib/tfevent-metrics-collector:v0.17.0
       resources:
         limits:
           memory: 1Gi
   suggestions:
     - algorithmName: random
-      image: docker.io/kubeflowkatib/suggestion-hyperopt:v0.17.0-rc.1
+      image: docker.io/kubeflowkatib/suggestion-hyperopt:v0.17.0
     - algorithmName: tpe
-      image: docker.io/kubeflowkatib/suggestion-hyperopt:v0.17.0-rc.1
+      image: docker.io/kubeflowkatib/suggestion-hyperopt:v0.17.0
     - algorithmName: grid
-      image: docker.io/kubeflowkatib/suggestion-optuna:v0.17.0-rc.1
+      image: docker.io/kubeflowkatib/suggestion-optuna:v0.17.0
     - algorithmName: hyperband
-      image: docker.io/kubeflowkatib/suggestion-hyperband:v0.17.0-rc.1
+      image: docker.io/kubeflowkatib/suggestion-hyperband:v0.17.0
     - algorithmName: bayesianoptimization
-      image: docker.io/kubeflowkatib/suggestion-skopt:v0.17.0-rc.1
+      image: docker.io/kubeflowkatib/suggestion-skopt:v0.17.0
     - algorithmName: cmaes
-      image: docker.io/kubeflowkatib/suggestion-goptuna:v0.17.0-rc.1
+      image: docker.io/kubeflowkatib/suggestion-goptuna:v0.17.0
     - algorithmName: sobol
-      image: docker.io/kubeflowkatib/suggestion-goptuna:v0.17.0-rc.1
+      image: docker.io/kubeflowkatib/suggestion-goptuna:v0.17.0
     - algorithmName: multivariate-tpe
-      image: docker.io/kubeflowkatib/suggestion-optuna:v0.17.0-rc.1
+      image: docker.io/kubeflowkatib/suggestion-optuna:v0.17.0
     - algorithmName: enas
-      image: docker.io/kubeflowkatib/suggestion-enas:v0.17.0-rc.1
+      image: docker.io/kubeflowkatib/suggestion-enas:v0.17.0
       resources:
         limits:
           memory: 400Mi
     - algorithmName: darts
-      image: docker.io/kubeflowkatib/suggestion-darts:v0.17.0-rc.1
+      image: docker.io/kubeflowkatib/suggestion-darts:v0.17.0
     - algorithmName: pbt
-      image: docker.io/kubeflowkatib/suggestion-pbt:v0.17.0-rc.1
+      image: docker.io/kubeflowkatib/suggestion-pbt:v0.17.0
       persistentVolumeClaimSpec:
         accessModes:
           - ReadWriteMany
@@ -58,4 +58,4 @@ runtime:
             storage: 5Gi
   earlyStoppings:
     - algorithmName: medianstop
-      image: docker.io/kubeflowkatib/earlystopping-medianstop:v0.17.0-rc.1
+      image: docker.io/kubeflowkatib/earlystopping-medianstop:v0.17.0

--- a/apps/katib/upstream/installs/katib-standalone/kustomization.yaml
+++ b/apps/katib/upstream/installs/katib-standalone/kustomization.yaml
@@ -20,13 +20,13 @@ resources:
 images:
   - name: docker.io/kubeflowkatib/katib-controller
     newName: docker.io/kubeflowkatib/katib-controller
-    newTag: v0.17.0-rc.1
+    newTag: v0.17.0
   - name: docker.io/kubeflowkatib/katib-db-manager
     newName: docker.io/kubeflowkatib/katib-db-manager
-    newTag: v0.17.0-rc.1
+    newTag: v0.17.0
   - name: docker.io/kubeflowkatib/katib-ui
     newName: docker.io/kubeflowkatib/katib-ui
-    newTag: v0.17.0-rc.1
+    newTag: v0.17.0
 configMapGenerator:
   - name: katib-config
     behavior: create

--- a/apps/katib/upstream/installs/katib-with-kubeflow/kustomization.yaml
+++ b/apps/katib/upstream/installs/katib-with-kubeflow/kustomization.yaml
@@ -11,13 +11,13 @@ resources:
 images:
   - name: docker.io/kubeflowkatib/katib-controller
     newName: docker.io/kubeflowkatib/katib-controller
-    newTag: v0.17.0-rc.1
+    newTag: v0.17.0
   - name: docker.io/kubeflowkatib/katib-db-manager
     newName: docker.io/kubeflowkatib/katib-db-manager
-    newTag: v0.17.0-rc.1
+    newTag: v0.17.0
   - name: docker.io/kubeflowkatib/katib-ui
     newName: docker.io/kubeflowkatib/katib-ui
-    newTag: v0.17.0-rc.1
+    newTag: v0.17.0
 
 patchesStrategicMerge:
   - patches/remove-namespace.yaml


### PR DESCRIPTION
# Pull Request Template for Kubeflow manifests Issues

## ✏️ A brief description of the changes
As part of Kubeflow 1.9 release, this PR is bumping Katib manifests to v0.17.0

## 📦 List any dependencies that are required for this change
N/A

## 🐛 If this PR is related to an issue, please put the link to the issue here.
N/A

## ✅ Contributor checklist
  - Make sure you have tested with kustomize. See [Installation Prerequisites](https://github.com/kubeflow/manifests#prerequisites)
  - All the commits have been _signed-off_  (To pass the `DCO` check)
  - Submit the [Contributor License Agreements](https://cla.developers.google.com/clas) (To pass the `cla/google` check)

---     
 
> You can join the CNCF Slack and access our meetings at the [Kubeflow Community](https://www.kubeflow.org/docs/about/community/) website. Our channel on the CNCF Slack is here [**#kubeflow-platform**](https://app.slack.com/client/T08PSQ7BQ/C073W572LA2).
  
