### PR TITLE
Update kubeflow/training-operator manifests from v1.8.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ This repo periodically syncs all official Kubeflow components from their respect
 
 | Component | Local Manifests Path | Upstream Revision |
 | - | - | - |
-| Training Operator | apps/training-operator/upstream | [v1.8.0-rc.1](https://github.com/kubeflow/training-operator/tree/v1.8.0-rc.1/manifests) |
+| Training Operator | apps/training-operator/upstream | [v1.8.0](https://github.com/kubeflow/training-operator/tree/v1.8.0/manifests) |
 | Notebook Controller | apps/jupyter/notebook-controller/upstream | [v1.9.0-rc.2](https://github.com/kubeflow/kubeflow/tree/v1.9.0-rc.2/components/notebook-controller/config) |
 | PVC Viewer Controller | apps/pvcviewer-roller/upstream | [v1.9.0-rc.2](https://github.com/kubeflow/kubeflow/tree/v1.9.0-rc.2/components/pvcviewer-controller/config) |
 | Tensorboard Controller | apps/tensorboard/tensorboard-controller/upstream | [v1.9.0-rc.2](https://github.com/kubeflow/kubeflow/tree/v1.9.0-rc.2/components/tensorboard-controller/config) |

--- a/apps/training-operator/upstream/overlays/kubeflow/kustomization.yaml
+++ b/apps/training-operator/upstream/overlays/kubeflow/kustomization.yaml
@@ -6,7 +6,7 @@ resources:
   - kubeflow-training-roles.yaml
 images:
   - name: kubeflow/training-operator
-    newTag: "v1-4485b0a"
+    newTag: "v1-9e52eb7"
 # TODO (tenzen-y): Once we support cert-manager, we need to remove this secret generation.
 # REF: https://github.com/kubeflow/training-operator/issues/2049
 secretGenerator:

--- a/apps/training-operator/upstream/overlays/standalone/kustomization.yaml
+++ b/apps/training-operator/upstream/overlays/standalone/kustomization.yaml
@@ -6,7 +6,7 @@ resources:
   - namespace.yaml
 images:
   - name: kubeflow/training-operator
-    newTag: "v1-4485b0a"
+    newTag: "v1-9e52eb7"
 secretGenerator:
   - name: training-operator-webhook-cert
     options:


### PR DESCRIPTION
# Pull Request Template for Kubeflow manifests Issues

## ✏️ A brief description of the changes
As part of the Kubeflow 1.9 release, this PR bumps Training Operator manifests to v1.8.0

## 📦 List any dependencies that are required for this change
N/A

## 🐛 If this PR is related to an issue, please put the link to the issue here.
N/A

## ✅ Contributor checklist
  - Make sure you have tested with kustomize. See [Installation Prerequisites](https://github.com/kubeflow/manifests#prerequisites)
  - All the commits have been _signed-off_  (To pass the `DCO` check)
  - Submit the [Contributor License Agreements](https://cla.developers.google.com/clas) (To pass the `cla/google` check)

---     
 
> You can join the CNCF Slack and access our meetings at the [Kubeflow Community](https://www.kubeflow.org/docs/about/community/) website. Our channel on the CNCF Slack is here [**#kubeflow-platform**](https://app.slack.com/client/T08PSQ7BQ/C073W572LA2).
  
