### PR TITLE
Fixing issues running v2 pipeline

### DIFF
--- a/apps/pipeline/upstream/base/installs/multi-user/view-edit-cluster-roles.yaml
+++ b/apps/pipeline/upstream/base/installs/multi-user/view-edit-cluster-roles.yaml
@@ -97,6 +97,7 @@ rules:
   - workflows/finalizers
   - workfloweventbindings
   - workflowtemplates
+  - workflowtaskresults
 
 ---
 


### PR DESCRIPTION
# Fixing V2 pipeline RBAC issues related to `ParallelFor`

Running v2 pipelines using `ParallelFor` in Kubeflow 1.8.1 and 1.9.0 results in an RBAC error. This issue is due to a missing resource in the `aggregate-to-kubeflow-pipelines-edit` `ClusterRole`. As a result, `ParallelFor` pipelines compiled with KFP 2.8.0 fail while executing them on the Kubeflow cluster. 

```bash
time="2024-07-25T10:11:07.236Z" level=info msg="Create workflowtaskresults 403"
error="workflowtaskresults.argoproj.io is forbidden: User \"system:serviceaccount:dummyusernamespace:default-editor\" cannot create resource \"workflowtaskresults\" in API group \"argoproj.io\" in the namespace \"dummyusernamespace\""
```

After making this changes I successfully ran V2 pipeline's `ParallelFor` functionality. 

