### PR TITLE
Expose Ray and Seldon to example kustomization.yaml file

### DIFF
--- a/example/kustomization.yaml
+++ b/example/kustomization.yaml
@@ -90,6 +90,15 @@ resources:
 - ../contrib/kserve/kserve
 - ../contrib/kserve/models-web-app/overlays/kubeflow
 
+# Ray and Seldon resources (commented out by default)
+# Ray does not support Istio yet and integration is in alpha state.
+# Here is the documentation for Ray: https://docs.ray.io/en/latest/
+# - ../contrib/ray/kuberay-operator/overlays/kubeflow
+#
+# Seldon integration notes: Seldon may have specific requirements and limitations.
+# Documentation for Seldon: https://docs.seldon.io/projects/seldon-core/en/latest/
+# - ../contrib/seldon/seldon-core-operator/overlays/application
+
 components:
 # Pod Security Standards
 # https://kubernetes.io/docs/concepts/security/pod-security-standards/

--- a/example/kustomization.yaml
+++ b/example/kustomization.yaml
@@ -93,10 +93,12 @@ resources:
 # Ray and Seldon resources (commented out by default)
 # Ray does not support Istio yet and integration is in alpha state.
 # Here is the documentation for Ray: https://docs.ray.io/en/latest/
+# Here is the internal documentation for Ray: - ../contrib/ray/README.md
 # - ../contrib/ray/kuberay-operator/overlays/kubeflow
 #
 # Seldon integration notes: Seldon may have specific requirements and limitations.
 # Documentation for Seldon: https://docs.seldon.io/projects/seldon-core/en/latest/
+# Here is the internal documentation for Seldon: - ../contrib/seldon/README.md
 # - ../contrib/seldon/seldon-core-operator/overlays/application
 
 components:


### PR DESCRIPTION
# Pull Request Template for Kubeflow manifests Issues

## ✏️ A brief description of the changes
> I added ray and Seldon into kustomization.yaml file

## ✅ Contributor checklist
  - Make sure you have tested with kustomize. See [Installation Prerequisites](https://github.com/kubeflow/manifests#prerequisites)
  - All the commits have been _signed-off_  (To pass the `DCO` check)
  - Submit the [Contributor License Agreements](https://cla.developers.google.com/clas) (To pass the `cla/google` check)

---     
 
> You can join the CNCF Slack and access our meetings at the [Kubeflow Community](https://www.kubeflow.org/docs/about/community/) website. Our channel on the CNCF Slack is here [**#kubeflow-platform**](https://app.slack.com/client/T08PSQ7BQ/C073W572LA2).
  
