### PR TITLE
Added securityContext profiles for deployments failing PSS restricted level

### DIFF
--- a/common/oauth2-proxy/components/configure-self-signed-kubernetes-oidc-issuer/cronjob.kubeflow-m2m-oidc-configurator.yaml
+++ b/common/oauth2-proxy/components/configure-self-signed-kubernetes-oidc-issuer/cronjob.kubeflow-m2m-oidc-configurator.yaml
@@ -29,6 +29,14 @@ spec:
               name: script
               subPath: script.sh
             resources: {}
+            securityContext:
+              allowPrivilegeEscalation: false
+              seccompProfile:
+                type: RuntimeDefault
+              runAsNonRoot: true
+              capabilities:
+                drop:
+                - ALL
           volumes:
           - name: script
             configMap:

--- a/common/oauth2-proxy/components/configure-self-signed-kubernetes-oidc-issuer/cronjob.kubeflow-m2m-oidc-configurator.yaml
+++ b/common/oauth2-proxy/components/configure-self-signed-kubernetes-oidc-issuer/cronjob.kubeflow-m2m-oidc-configurator.yaml
@@ -29,14 +29,6 @@ spec:
               name: script
               subPath: script.sh
             resources: {}
-            securityContext:
-              allowPrivilegeEscalation: false
-              seccompProfile:
-                type: RuntimeDefault
-              runAsNonRoot: true
-              capabilities:
-                drop:
-                - ALL
           volumes:
           - name: script
             configMap:

--- a/contrib/security/PSS/patches/cache-server.yaml
+++ b/contrib/security/PSS/patches/cache-server.yaml
@@ -1,0 +1,17 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: cache-server
+spec:
+  template:
+    spec:
+      containers:
+      - name: server
+        securityContext:
+          allowPrivilegeEscalation: false
+          seccompProfile:
+            type: RuntimeDefault
+          runAsNonRoot: true
+          capabilities:
+            drop:
+            - ALL

--- a/contrib/security/PSS/patches/cluster-local-gateway.yaml
+++ b/contrib/security/PSS/patches/cluster-local-gateway.yaml
@@ -1,0 +1,12 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: cluster-local-gateway
+spec:
+  template:
+    spec:
+      containers:
+      - name: istio-proxy
+        securityContext:
+          seccompProfile:
+            type: RuntimeDefault

--- a/contrib/security/PSS/patches/dex.yaml
+++ b/contrib/security/PSS/patches/dex.yaml
@@ -1,0 +1,17 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: dex
+spec:
+  template:
+    spec:
+      containers:
+      - name: dex
+        securityContext:
+          allowPrivilegeEscalation: false
+          seccompProfile:
+            type: RuntimeDefault
+          runAsNonRoot: true
+          capabilities:
+            drop:
+            - ALL

--- a/contrib/security/PSS/patches/kfam.yaml
+++ b/contrib/security/PSS/patches/kfam.yaml
@@ -11,3 +11,7 @@ spec:
           allowPrivilegeEscalation: false
           seccompProfile:
             type: RuntimeDefault
+          runAsNonRoot: true
+          capabilities:
+            drop:
+            - ALL

--- a/contrib/security/PSS/patches/kfam.yaml
+++ b/contrib/security/PSS/patches/kfam.yaml
@@ -1,0 +1,13 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: profiles-deployment
+spec:
+  template:
+    spec:
+      containers:
+      - name: kfam
+        securityContext:
+          allowPrivilegeEscalation: false
+          seccompProfile:
+            type: RuntimeDefault

--- a/contrib/security/PSS/patches/kubeflow-pipelines-profile-controller.yaml
+++ b/contrib/security/PSS/patches/kubeflow-pipelines-profile-controller.yaml
@@ -1,0 +1,17 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: kubeflow-pipelines-profile-controller
+spec:
+  template:
+    spec:
+      containers:
+      - name: profile-controller
+        securityContext:
+          allowPrivilegeEscalation: false
+          seccompProfile:
+            type: RuntimeDefault
+          runAsNonRoot: true
+          capabilities:
+            drop:
+            - ALL

--- a/contrib/security/PSS/patches/manager.yaml
+++ b/contrib/security/PSS/patches/manager.yaml
@@ -11,3 +11,7 @@ spec:
           allowPrivilegeEscalation: false
           seccompProfile:
             type: RuntimeDefault
+          runAsNonRoot: true
+          capabilities:
+            drop:
+            - ALL

--- a/contrib/security/PSS/patches/manager.yaml
+++ b/contrib/security/PSS/patches/manager.yaml
@@ -1,0 +1,13 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: profiles-deployment
+spec:
+  template:
+    spec:
+      containers:
+      - name: manager
+        securityContext:
+          allowPrivilegeEscalation: false
+          seccompProfile:
+            type: RuntimeDefault

--- a/contrib/security/PSS/patches/metadata-envoy-deployment.yaml
+++ b/contrib/security/PSS/patches/metadata-envoy-deployment.yaml
@@ -1,0 +1,17 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: metadata-envoy-deployment
+spec:
+  template:
+    spec:
+      containers:
+      - name: container
+        securityContext:
+          allowPrivilegeEscalation: false
+          seccompProfile:
+            type: RuntimeDefault
+          runAsNonRoot: true
+          capabilities:
+            drop:
+            - ALL

--- a/contrib/security/PSS/patches/metadata-grpc-deployment.yaml
+++ b/contrib/security/PSS/patches/metadata-grpc-deployment.yaml
@@ -1,0 +1,17 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: metadata-grpc-deployment
+spec:
+  template:
+    spec:
+      containers:
+      - name: container
+        securityContext:
+          allowPrivilegeEscalation: false
+          seccompProfile:
+            type: RuntimeDefault
+          runAsNonRoot: true
+          capabilities:
+            drop:
+            - ALL

--- a/contrib/security/PSS/patches/metadata-writer.yaml
+++ b/contrib/security/PSS/patches/metadata-writer.yaml
@@ -1,0 +1,17 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: metadata-writer
+spec:
+  template:
+    spec:
+      containers:
+      - name: main
+        securityContext:
+          allowPrivilegeEscalation: false
+          seccompProfile:
+            type: RuntimeDefault
+          runAsNonRoot: true
+          capabilities:
+            drop:
+            - ALL

--- a/contrib/security/PSS/patches/minio.yaml
+++ b/contrib/security/PSS/patches/minio.yaml
@@ -1,0 +1,17 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: minio
+spec:
+  template:
+    spec:
+      containers:
+      - name: minio
+        securityContext:
+          allowPrivilegeEscalation: false
+          seccompProfile:
+            type: RuntimeDefault
+          runAsNonRoot: true
+          capabilities:
+            drop:
+            - ALL

--- a/contrib/security/PSS/patches/ml-pipeline-persistenceagent.yaml
+++ b/contrib/security/PSS/patches/ml-pipeline-persistenceagent.yaml
@@ -1,0 +1,17 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: ml-pipeline-persistenceagent
+spec:
+  template:
+    spec:
+      containers:
+      - name: ml-pipeline-persistenceagent
+        securityContext:
+          allowPrivilegeEscalation: false
+          seccompProfile:
+            type: RuntimeDefault
+          runAsNonRoot: true
+          capabilities:
+            drop:
+            - ALL

--- a/contrib/security/PSS/patches/ml-pipeline-scheduledworkflow.yaml
+++ b/contrib/security/PSS/patches/ml-pipeline-scheduledworkflow.yaml
@@ -1,0 +1,17 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: ml-pipeline-scheduledworkflow
+spec:
+  template:
+    spec:
+      containers:
+      - name: ml-pipeline-scheduledworkflow
+        securityContext:
+          allowPrivilegeEscalation: false
+          seccompProfile:
+            type: RuntimeDefault
+          runAsNonRoot: true
+          capabilities:
+            drop:
+            - ALL

--- a/contrib/security/PSS/patches/ml-pipeline-ui.yaml
+++ b/contrib/security/PSS/patches/ml-pipeline-ui.yaml
@@ -1,0 +1,17 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: ml-pipeline-ui
+spec:
+  template:
+    spec:
+      containers:
+      - name: ml-pipeline-ui
+        securityContext:
+          allowPrivilegeEscalation: false
+          seccompProfile:
+            type: RuntimeDefault
+          runAsNonRoot: true
+          capabilities:
+            drop:
+            - ALL

--- a/contrib/security/PSS/patches/ml-pipeline-viewer-crd.yaml
+++ b/contrib/security/PSS/patches/ml-pipeline-viewer-crd.yaml
@@ -1,0 +1,17 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: ml-pipeline-viewer-crd
+spec:
+  template:
+    spec:
+      containers:
+      - name: ml-pipeline-viewer-crd
+        securityContext:
+          allowPrivilegeEscalation: false
+          seccompProfile:
+            type: RuntimeDefault
+          runAsNonRoot: true
+          capabilities:
+            drop:
+            - ALL

--- a/contrib/security/PSS/patches/ml-pipeline-visualizationserver.yaml
+++ b/contrib/security/PSS/patches/ml-pipeline-visualizationserver.yaml
@@ -1,0 +1,17 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: ml-pipeline-visualizationserver
+spec:
+  template:
+    spec:
+      containers:
+      - name: ml-pipeline-visualizationserver
+        securityContext:
+          allowPrivilegeEscalation: false
+          seccompProfile:
+            type: RuntimeDefault
+          runAsNonRoot: true
+          capabilities:
+            drop:
+            - ALL

--- a/contrib/security/PSS/patches/ml-pipeline.yaml
+++ b/contrib/security/PSS/patches/ml-pipeline.yaml
@@ -1,0 +1,17 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: ml-pipeline
+spec:
+  template:
+    spec:
+      containers:
+      - name: ml-pipeline-api-server
+        securityContext:
+          allowPrivilegeEscalation: false
+          seccompProfile:
+            type: RuntimeDefault
+          runAsNonRoot: true
+          capabilities:
+            drop:
+            - ALL

--- a/contrib/security/PSS/patches/mysql.yaml
+++ b/contrib/security/PSS/patches/mysql.yaml
@@ -1,0 +1,17 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: mysql
+spec:
+  template:
+    spec:
+      containers:
+      - name: mysql
+        securityContext:
+          allowPrivilegeEscalation: false
+          seccompProfile:
+            type: RuntimeDefault
+          runAsNonRoot: true
+          capabilities:
+            drop:
+            - ALL

--- a/contrib/security/PSS/patches/oauth2-proxy.yaml
+++ b/contrib/security/PSS/patches/oauth2-proxy.yaml
@@ -1,0 +1,18 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: oauth2-proxy
+spec:
+  replicas: 2
+  template:
+    spec:
+      containers:
+      - name: oauth2-proxy
+        securityContext:
+          allowPrivilegeEscalation: false
+          seccompProfile:
+            type: RuntimeDefault
+          runAsNonRoot: true
+          capabilities:
+            drop:
+            - ALL


### PR DESCRIPTION
# Pull Request Template for Kubeflow manifests Issues

## ✏️ A brief description of the changes
> I added securityContext for profile-controller containers kfam and manager.
## 📦 List any dependencies that are required for this change
> My PR depends on #

## 🐛 If this PR is related to an issue, please put the link to the issue here.
> The following issues are related, because ...

## ✅ Contributor checklist
  - Make sure you have tested with kustomize. See [Installation Prerequisites](https://github.com/kubeflow/manifests#prerequisites)
  - All the commits have been _signed-off_  (To pass the `DCO` check)
  - Submit the [Contributor License Agreements](https://cla.developers.google.com/clas) (To pass the `cla/google` check)

---     
 
> You can join the CNCF Slack and access our meetings at the [Kubeflow Community](https://www.kubeflow.org/docs/about/community/) website. Our channel on the CNCF Slack is here [**#kubeflow-platform**](https://app.slack.com/client/T08PSQ7BQ/C073W572LA2).
  
