### PR TITLE
feat: Add a Makefile for quick installation of Kubeflow.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,18 @@
+
+KUSTOMIZE = $(shell pwd)/bin/kustomize
+
+# Define the target
+.PHONY: install
+install: kustomize ## Install Kubeflow into the K8s cluster specified in ~/.kube/config.
+	@echo "Applying Kubernetes resources using Kustomize"
+	@while ! $(KUSTOMIZE) build example | kubectl apply -f -; do \
+		echo "Retrying to apply resources"; \
+		sleep 20; \
+	done
+
+
+PROJECT_DIR := $(shell dirname $(abspath $(lastword $(MAKEFILE_LIST))))
+
+.PHONY: kustomize
+kustomize: ## Download kustomize locally if necessary.
+	GOBIN=$(PROJECT_DIR)/bin go install sigs.k8s.io/kustomize/kustomize/v5@v5.2.1

--- a/README.md
+++ b/README.md
@@ -146,7 +146,7 @@ kubectl create secret generic regcred \
 You can install all Kubeflow official components (residing under `apps`) and all common services (residing under `common`) using the following command:
 
 ```sh
-while ! kustomize build example | kubectl apply -f -; do echo "Retrying to apply resources"; sleep 20; done
+make install
 ```
 
 Once, everything is installed successfully, you can access the Kubeflow Central Dashboard [by logging in to your cluster](#connect-to-your-kubeflow-cluster).


### PR DESCRIPTION
# Pull Request Template for Kubeflow manifests Issues

## ✏️ A brief description of the changes
1.  Add a Makefile for quick installation of Kubeflow.
2. Different open-source projects may have inconsistent requirements for the kustomize version. Using a standalone kustomize version in the Makefile will not affect the user's default installed kustomize version.

## 📦 List any dependencies that are required for this change


## 🐛 If this PR is related to an issue, please put the link to the issue here.
> The following issues are related, because ...

## ✅ Contributor checklist
  - Make sure you have tested with kustomize. See [Installation Prerequisites](https://github.com/kubeflow/manifests#prerequisites)
  - All the commits have been _signed-off_  (To pass the `DCO` check)
  - Submit the [Contributor License Agreements](https://cla.developers.google.com/clas) (To pass the `cla/google` check)

---     
 
> You can join the CNCF Slack and access our meetings at the [Kubeflow Community](https://www.kubeflow.org/docs/about/community/) website. Our channel on the CNCF Slack is here [**#kubeflow-platform**](https://app.slack.com/client/T08PSQ7BQ/C073W572LA2).
  
