### PR TITLE
Adjust the Trivy scanning workflow to upload artifacts

### DIFF
--- a/.github/workflows/trivy.yaml
+++ b/.github/workflows/trivy.yaml
@@ -46,4 +46,3 @@ jobs:
       with:
         name: trivy_scanned_results
         path: image_lists/
-

--- a/.github/workflows/trivy.yaml
+++ b/.github/workflows/trivy.yaml
@@ -41,8 +41,9 @@ jobs:
         cd hack
         python3 trivy_scan.py
 
-    # - name: Upload trivy scanned_results
-    #   uses: actions/upload-artifact@v4
-    #   with:
-    #     name: trivy_scanned_results
-    #     path: image_lists/
+    - name: Upload trivy scanned_results
+      uses: actions/upload-artifact@v4
+      with:
+        name: trivy_scanned_results
+        path: image_lists/
+


### PR DESCRIPTION
# Pull Request Template for Kubeflow manifests Issues

## ✏️ A brief description of the changes
> I added the new step to upload Trivy results artifacts.
   By default, GitHub Actions artifacts are retained for 90 days before they are automatically deleted. However, you can adjust the retention period as needed. For more information, refer to the [GitHub documentation on configuring the retention period for GitHub Actions artifacts and logs](https://docs.github.com/en/organizations/managing-organization-settings/configuring-the-retention-period-for-github-actions-artifacts-and-logs-in-your-organization).

## ✅ Contributor checklist
  - Make sure you have tested with kustomize. See [Installation Prerequisites](https://github.com/kubeflow/manifests#prerequisites)
  - All the commits have been _signed-off_  (To pass the `DCO` check)
  - Submit the [Contributor License Agreements](https://cla.developers.google.com/clas) (To pass the `cla/google` check)

---     
 
> You can join the CNCF Slack and access our meetings at the [Kubeflow Community](https://www.kubeflow.org/docs/about/community/) website. Our channel on the CNCF Slack is here [**#kubeflow-platform**](https://app.slack.com/client/T08PSQ7BQ/C073W572LA2).
  
