### PR TITLE
fix: wrong diagram path for kubeflow auth .

### DIFF
--- a/common/oauth2-proxy/README.md
+++ b/common/oauth2-proxy/README.md
@@ -78,7 +78,7 @@ when client calls API to list the KF Pipeline Runs:
 
 ### Auth analysis diagram for Kubeflow Pipelines
 
-![Kubeflow Auth Diagram](./kubeflow_auth_diagram.svg)
+![Kubeflow Auth Diagram](./components/kubeflow_auth_diagram.svg)
 
 ## Kubeflow Notebooks User and M2M Authentication and Authorization
 


### PR DESCRIPTION
# Pull Request Template for Kubeflow manifests Issues

## ✏️ A brief description of the changes
> I changed readme doc for oauth2 proxy; 

## 📦 List any dependencies that are required for this change
> My PR depends on #

## 🐛 If this PR is related to an issue, please put the link to the issue here.
> The following issues are related, because ...

## ✅ Contributor checklist
  - Make sure you have tested with kustomize. See [Installation Prerequisites](https://github.com/kubeflow/manifests#prerequisites)
  - All the commits have been _signed-off_  (To pass the `DCO` check)
  - Submit the [Contributor License Agreements](https://cla.developers.google.com/clas) (To pass the `cla/google` check)

---     
 
> You can join the CNCF Slack and access our meetings at the [Kubeflow Community](https://www.kubeflow.org/docs/about/community/) website. Our channel on the CNCF Slack is here [**#kubeflow-platform**](https://app.slack.com/client/T08PSQ7BQ/C073W572LA2).
  
