### PR TITLE
update PR template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -11,8 +11,7 @@
 
 ## ✅ Contributor checklist
   - Make sure you have tested with kustomize. See [Installation Prerequisites](https://github.com/kubeflow/manifests#prerequisites)
-  - All the commits have been _signed-off_  (To pass the `DCO` check)
-  - Submit the [Contributor License Agreements](https://cla.developers.google.com/clas) (To pass the `cla/google` check)
+  - All the commits have been [_signed-off_](https://wiki.linuxfoundation.org/dco)  (To pass the `DCO` check)
 
 ---     
  

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -11,7 +11,7 @@
 
 ## ✅ Contributor checklist
   - Make sure you have tested with kustomize. See [Installation Prerequisites](https://github.com/kubeflow/manifests#prerequisites)
-  - All the commits have been [_signed-off_](https://wiki.linuxfoundation.org/dco)  (To pass the `DCO` check)
+  - All the commits have been [_signed-off_](https://github.com/kubeflow/community/tree/master/dco-signoff-hook#signing-off-commits)  (To pass the `DCO` check)
 
 ---     
  


### PR DESCRIPTION


# Pull Request Template for Kubeflow manifests Issues

## ✏️ A brief description of the changes
follow-up to #2793
- add link to sign-off/DCO (I found this link helpful to share with contributors while explain it/answering the newcomer the question about DCO)
- CLA is no longer required

## 📦 List any dependencies that are required for this change
none

## 🐛 If this PR is related to an issue, please put the link to the issue here.
none

## ✅ Contributor checklist
  - Make sure you have tested with kustomize. See [Installation Prerequisites](https://github.com/kubeflow/manifests#prerequisites)
  - All the commits have been _signed-off_  (To pass the `DCO` check)

---     
 
> You can join the CNCF Slack and access our meetings at the [Kubeflow Community](https://www.kubeflow.org/docs/about/community/) website. Our channel on the CNCF Slack is here [**#kubeflow-platform**](https://app.slack.com/client/T08PSQ7BQ/C073W572LA2).
  
wdyt?