### PR TITLE
updating readme for oauth2

### DIFF
--- a/README.md
+++ b/README.md
@@ -227,8 +227,14 @@ echo "Installing oauth2-proxy..."
 kustomize build common/oauth2-proxy/overlays/m2m-self-signed/ | kubectl apply -f -
 kubectl wait --for=condition=ready pod -l 'app.kubernetes.io/name=oauth2-proxy' --timeout=180s -n oauth2-proxy
 ```
-
 It supports user sessions as well as proper token-based machine to machine atuhhentication.
+
+:warning: Using default [example.yaml](https://github.com/kubeflow/manifests/blob/master/example/kustomization.yaml) in clusters that don't have support `/.well-known/openid-configuration` endpoints will cause issues for users trying to communicate to Kubeflow pipelines via Notebooks.
+
+You can overwrite the M2M token issuer [here](https://github.com/kubeflow/manifests/blob/afc358d6d473a24029149f2a0ca21671af4aca6d/common/oauth2-proxy/overlays/m2m/component-overwrite-m2m-token-issuer/kustomization.yaml#L8).
+
+For EKS clusters, please check [here](https://github.com/kubeflow/manifests/blob/master/common/oauth2-proxy/overlays/m2m/README.md).
+
 
 #### Dex
 


### PR DESCRIPTION
# Pull Request Template for Kubeflow manifests Issues

## ✏️ A brief description of the changes
> I changed the readme based on #2850 

## 📦 List any dependencies that are required for this change
> None

## 🐛 If this PR is related to an issue, please put the link to the issue here.
> #2850 

## ✅ Contributor checklist
  - Make sure you have tested with kustomize. See [Installation Prerequisites](https://github.com/kubeflow/manifests#prerequisites)
  - All the commits have been [_signed-off_](https://github.com/kubeflow/community/tree/master/dco-signoff-hook#signing-off-commits)  (To pass the `DCO` check)

---     
 
> You can join the CNCF Slack and access our meetings at the [Kubeflow Community](https://www.kubeflow.org/docs/about/community/) website. Our channel on the CNCF Slack is here [**#kubeflow-platform**](https://app.slack.com/client/T08PSQ7BQ/C073W572LA2).
  
