### PR TITLE
Update kubeflow/pipelines manifests from 2.3.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ This repo periodically syncs all official Kubeflow components from their respect
 | Katib | apps/katib/upstream | [v0.17.0](https://github.com/kubeflow/katib/tree/v0.17.0/manifests/v1beta1) |
 | KServe | contrib/kserve/kserve | [0.13.0](https://github.com/kserve/kserve/releases/tag/v0.13.0) |
 | KServe Models Web App | contrib/kserve/models-web-app | [0.13.0](https://github.com/kserve/models-web-app/tree/0.13.0/config) |
-| Kubeflow Pipelines | apps/pipeline/upstream | [2.2.0](https://github.com/kubeflow/pipelines/tree/2.2.0/manifests/kustomize) |
+| Kubeflow Pipelines | apps/pipeline/upstream | [2.3.0](https://github.com/kubeflow/pipelines/tree/2.3.0/manifests/kustomize) |
 | Kubeflow Tekton Pipelines | apps/kfp-tekton/upstream | [2.0.5](https://github.com/kubeflow/kfp-tekton/tree/2.0.5/manifests/kustomize) |
 | Kubeflow Model Registry | apps/model-registry/upstream | [v0.2.1-alpha](https://github.com/kubeflow/model-registry/tree/v0.2.1-alpha/manifests/kustomize) |
 

--- a/apps/pipeline/upstream/README.md
+++ b/apps/pipeline/upstream/README.md
@@ -18,9 +18,9 @@ Install:
 
 ```bash
 KFP_ENV=platform-agnostic
-kubectl apply -k cluster-scoped-resources/
+kustomize build cluster-scoped-resources/ | kubectl apply -f -
 kubectl wait crd/applications.app.k8s.io --for condition=established --timeout=60s
-kubectl apply -k "env/${KFP_ENV}/"
+kustomize build "env/${KFP_ENV}/" | kubectl apply -f -
 kubectl wait pods -l application-crd-id=kubeflow-pipelines -n kubeflow --for condition=Ready --timeout=1800s
 kubectl port-forward -n kubeflow svc/ml-pipeline-ui 8080:80
 ```

--- a/apps/pipeline/upstream/base/cache-deployer/kustomization.yaml
+++ b/apps/pipeline/upstream/base/cache-deployer/kustomization.yaml
@@ -8,4 +8,4 @@ commonLabels:
   app: cache-deployer
 images:
   - name: gcr.io/ml-pipeline/cache-deployer
-    newTag: 2.2.0
+    newTag: 2.3.0

--- a/apps/pipeline/upstream/base/cache/kustomization.yaml
+++ b/apps/pipeline/upstream/base/cache/kustomization.yaml
@@ -10,4 +10,4 @@ commonLabels:
   app: cache-server
 images:
   - name: gcr.io/ml-pipeline/cache-server
-    newTag: 2.2.0
+    newTag: 2.3.0

--- a/apps/pipeline/upstream/base/installs/generic/pipeline-install-config.yaml
+++ b/apps/pipeline/upstream/base/installs/generic/pipeline-install-config.yaml
@@ -11,7 +11,7 @@ data:
     until the changes take effect. A quick way to restart all deployments in a
     namespace: `kubectl rollout restart deployment -n <your-namespace>`.
   appName: pipeline
-  appVersion: 2.2.0
+  appVersion: 2.3.0
   dbHost: mysql # relic to be removed after release
   dbPort: "3306" # relic to be removed after release
   dbType: mysql

--- a/apps/pipeline/upstream/base/installs/multi-user/istio-authorization-config.yaml
+++ b/apps/pipeline/upstream/base/installs/multi-user/istio-authorization-config.yaml
@@ -32,6 +32,10 @@ spec:
         - cluster.local/ns/kubeflow/sa/ml-pipeline-scheduledworkflow
         - cluster.local/ns/kubeflow/sa/ml-pipeline-viewer-crd-service-account
         - cluster.local/ns/kubeflow/sa/kubeflow-pipelines-cache
+  # allow access by any trusted principal
+  - from:
+    - source:
+        requestPrincipals: ["*"]
   # For user workloads, which cannot user http headers for authentication
   - when:
     - key: request.headers[kubeflow-userid]

--- a/apps/pipeline/upstream/base/installs/multi-user/istio-authorization-config.yaml
+++ b/apps/pipeline/upstream/base/installs/multi-user/istio-authorization-config.yaml
@@ -32,10 +32,6 @@ spec:
         - cluster.local/ns/kubeflow/sa/ml-pipeline-scheduledworkflow
         - cluster.local/ns/kubeflow/sa/ml-pipeline-viewer-crd-service-account
         - cluster.local/ns/kubeflow/sa/kubeflow-pipelines-cache
-  # allow access by any trusted principal
-  - from:
-    - source:
-        requestPrincipals: ["*"]
   # For user workloads, which cannot user http headers for authentication
   - when:
     - key: request.headers[kubeflow-userid]

--- a/apps/pipeline/upstream/base/installs/multi-user/view-edit-cluster-roles.yaml
+++ b/apps/pipeline/upstream/base/installs/multi-user/view-edit-cluster-roles.yaml
@@ -97,6 +97,7 @@ rules:
   - workflows/finalizers
   - workfloweventbindings
   - workflowtemplates
+  - workflowtaskresults
 
 ---
 

--- a/apps/pipeline/upstream/base/metadata/base/kustomization.yaml
+++ b/apps/pipeline/upstream/base/metadata/base/kustomization.yaml
@@ -10,4 +10,4 @@ resources:
   - metadata-grpc-sa.yaml
 images:
   - name: gcr.io/ml-pipeline/metadata-envoy
-    newTag: 2.2.0
+    newTag: 2.3.0

--- a/apps/pipeline/upstream/base/pipeline/kustomization.yaml
+++ b/apps/pipeline/upstream/base/pipeline/kustomization.yaml
@@ -36,14 +36,14 @@ resources:
   - kfp-launcher-configmap.yaml
 images:
   - name: gcr.io/ml-pipeline/api-server
-    newTag: 2.2.0
+    newTag: 2.3.0
   - name: gcr.io/ml-pipeline/persistenceagent
-    newTag: 2.2.0
+    newTag: 2.3.0
   - name: gcr.io/ml-pipeline/scheduledworkflow
-    newTag: 2.2.0
+    newTag: 2.3.0
   - name: gcr.io/ml-pipeline/frontend
-    newTag: 2.2.0
+    newTag: 2.3.0
   - name: gcr.io/ml-pipeline/viewer-crd-controller
-    newTag: 2.2.0
+    newTag: 2.3.0
   - name: gcr.io/ml-pipeline/visualization-server
-    newTag: 2.2.0
+    newTag: 2.3.0

--- a/apps/pipeline/upstream/base/pipeline/metadata-writer/kustomization.yaml
+++ b/apps/pipeline/upstream/base/pipeline/metadata-writer/kustomization.yaml
@@ -7,4 +7,4 @@ resources:
   - metadata-writer-sa.yaml
 images:
   - name: gcr.io/ml-pipeline/metadata-writer
-    newTag: 2.2.0
+    newTag: 2.3.0

--- a/apps/pipeline/upstream/base/pipeline/ml-pipeline-ui-deployment.yaml
+++ b/apps/pipeline/upstream/base/pipeline/ml-pipeline-ui-deployment.yaml
@@ -48,6 +48,10 @@ spec:
                 key: secretkey
           - name: ALLOW_CUSTOM_VISUALIZATIONS
             value: "true"
+          - name: FRONTEND_SERVER_NAMESPACE
+            valueFrom:
+              fieldRef:
+                fieldPath: metadata.namespace
         readinessProbe:
           exec:
             command:

--- a/apps/pipeline/upstream/env/aws/README.md
+++ b/apps/pipeline/upstream/env/aws/README.md
@@ -38,13 +38,13 @@ Follow this [doc](https://awslabs.github.io/kubeflow-manifests/docs/deployment/r
 5. Install
 
 ```
-kubectl apply -k ../../cluster-scoped-resources
+kustomize build ../../cluster-scoped-resources | kubectl apply -f -
 # If upper one action got failed, e.x. you used wrong value, try delete, fix and apply again
 # kubectl delete -k ../../cluster-scoped-resources
 
 kubectl wait crd/applications.app.k8s.io --for condition=established --timeout=60s
 
-kubectl apply -k ./
+kustomize build ./ | kubectl apply -f -
 # If upper one action got failed, e.x. you used wrong value, try delete, fix and apply again
 # kubectl delete -k ./
 

--- a/apps/pipeline/upstream/env/gcp/inverse-proxy/kustomization.yaml
+++ b/apps/pipeline/upstream/env/gcp/inverse-proxy/kustomization.yaml
@@ -2,7 +2,7 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 images:
   - name: gcr.io/ml-pipeline/inverse-proxy-agent
-    newTag: 2.2.0
+    newTag: 2.3.0
 resources:
   - proxy-configmap.yaml
   - proxy-deployment.yaml

--- a/apps/pipeline/upstream/env/platform-agnostic-multi-user-legacy/kustomization.yaml
+++ b/apps/pipeline/upstream/env/platform-agnostic-multi-user-legacy/kustomization.yaml
@@ -2,6 +2,7 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 
 resources:
+  - ../../third-party/metacontroller/base
   - ../../base/installs/multi-user
   - ../../base/metadata/overlays/db
   - ../../base/metadata/options/istio
@@ -10,7 +11,6 @@ resources:
   - ../../third-party/mysql/options/istio
   - ../../third-party/minio/base
   - ../../third-party/minio/options/istio
-  - ../../third-party/metacontroller/base
 
 # Identifier for application manager to apply ownerReference.
 # The ownerReference ensures the resources get garbage collected

--- a/apps/pipeline/upstream/env/platform-agnostic-multi-user/kustomization.yaml
+++ b/apps/pipeline/upstream/env/platform-agnostic-multi-user/kustomization.yaml
@@ -2,6 +2,7 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 
 resources:
+  - ../../third-party/metacontroller/base
   - ../../base/installs/multi-user
   - ../../base/metadata/base
   - ../../base/metadata/options/istio
@@ -10,7 +11,6 @@ resources:
   - ../../third-party/mysql/options/istio
   - ../../third-party/minio/base
   - ../../third-party/minio/options/istio
-  - ../../third-party/metacontroller/base
 
 # Identifier for application manager to apply ownerReference.
 # The ownerReference ensures the resources get garbage collected

--- a/apps/pipeline/upstream/hack/presubmit.sh
+++ b/apps/pipeline/upstream/hack/presubmit.sh
@@ -21,23 +21,31 @@ set -ex
 DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" > /dev/null && pwd)"
 TMP="$(mktemp -d)"
 
-pushd "${TMP}"
-# Install Kustomize
-KUSTOMIZE_VERSION=5.2.1
-# Reference: https://kubectl.docs.kubernetes.io/installation/kustomize/binaries/
-curl -s -O "https://raw.githubusercontent.com/\
-kubernetes-sigs/kustomize/master/hack/install_kustomize.sh"
-chmod +x install_kustomize.sh
-./install_kustomize.sh "${KUSTOMIZE_VERSION}" /usr/local/bin/
+# Add TMP to PATH
+PATH="$TMP:$PATH"
 
+pushd "${TMP}"
+
+# Install kustomize
+KUSTOMIZE_VERSION=5.2.1
+# Reference: https://github.com/kubernetes-sigs/kustomize/releases/tag/kustomize%2Fv5.2.1
+curl -s -LO "https://github.com/kubernetes-sigs/kustomize/releases/download/kustomize%2Fv${KUSTOMIZE_VERSION}/kustomize_v${KUSTOMIZE_VERSION}_linux_amd64.tar.gz"
+tar -xzf kustomize_v${KUSTOMIZE_VERSION}_linux_amd64.tar.gz
+chmod +x kustomize
+
+# Install yq
 # Reference: https://github.com/mikefarah/yq/releases/tag/3.4.1
 curl -s -LO "https://github.com/mikefarah/yq/releases/download/3.4.1/yq_linux_amd64"
 chmod +x yq_linux_amd64
-mv yq_linux_amd64 /usr/local/bin/yq
-popd
+mv yq_linux_amd64 yq
 
-# kpt and kubectl should already be installed in gcr.io/google.com/cloudsdktool/cloud-sdk:latest
-# so we do not need to install them here
+# Install kpt
+KPT_VERSION=1.0.0-beta.54
+# Reference: https://github.com/kptdev/kpt/releases/tag/v1.0.0-beta.54
+curl -s -LO "https://github.com/kptdev/kpt/releases/download/v${KPT_VERSION}/kpt_linux_amd64"
+chmod +x kpt_linux_amd64
+mv kpt_linux_amd64 kpt
+popd
 
 # trigger real unit tests
 ${DIR}/test.sh

--- a/apps/pipeline/upstream/sample/README.md
+++ b/apps/pipeline/upstream/sample/README.md
@@ -63,11 +63,11 @@ gsutil mb -p myProjectId gs://myBucketName/
 6. Install
 
 ```
-kubectl apply -k sample/cluster-scoped-resources/
+kustomize build sample/cluster-scoped-resources/ | kubectl apply -f -
 
 kubectl wait crd/applications.app.k8s.io --for condition=established --timeout=60s
 
-kubectl apply -k sample/
+kustomize build sample/ | kubectl apply -f -
 # If upper one action got failed, e.x. you used wrong value, try delete, fix and apply again
 # kubectl delete -k sample/
 

--- a/apps/pipeline/upstream/sample/kustomization.yaml
+++ b/apps/pipeline/upstream/sample/kustomization.yaml
@@ -34,5 +34,5 @@ namespace: kubeflow
 #### Customization ###
 # 1. Change values in params.env file
 # 2. Change values in params-db-secret.env file for CloudSQL username and password
-# 3. kubectl apply -k ./
+# 3. kustomize build ./ | kubectl apply -f -
 ####

--- a/apps/pipeline/upstream/third-party/argo/base/workflow-controller-configmap-patch.yaml
+++ b/apps/pipeline/upstream/third-party/argo/base/workflow-controller-configmap-patch.yaml
@@ -4,9 +4,9 @@ metadata:
   name: workflow-controller-configmap
 data:
   # References:
-  # * https://github.com/argoproj/argo-workflows/blob/v3.4.16/config/config.go
-  # * https://github.com/argoproj/argo-workflows/blob/v3.4.16/docs/workflow-controller-configmap.md
-  # * https://github.com/argoproj/argo-workflows/blob/v3.4.16/docs/workflow-controller-configmap.yaml
+  # * https://github.com/argoproj/argo-workflows/blob/v3.4.17/config/config.go
+  # * https://github.com/argoproj/argo-workflows/blob/v3.4.17/docs/workflow-controller-configmap.md
+  # * https://github.com/argoproj/argo-workflows/blob/v3.4.17/docs/workflow-controller-configmap.yaml
 
   # In artifactRepository.s3.endpoint, $(kfp-namespace) is needed, because in multi-user mode, pipelines may run in other namespaces.
   artifactRepository: |

--- a/apps/pipeline/upstream/third-party/argo/base/workflow-controller-deployment-patch.yaml
+++ b/apps/pipeline/upstream/third-party/argo/base/workflow-controller-deployment-patch.yaml
@@ -7,12 +7,12 @@ spec:
     spec:
       containers:
         - name: workflow-controller
-          image: gcr.io/ml-pipeline/workflow-controller:v3.4.16-license-compliance
+          image: gcr.io/ml-pipeline/workflow-controller:v3.4.17-license-compliance
           args:
             - --configmap
             - workflow-controller-configmap
             - --executor-image
-            - gcr.io/ml-pipeline/argoexec:v3.4.16-license-compliance
+            - gcr.io/ml-pipeline/argoexec:v3.4.17-license-compliance
           resources:
             requests:
               cpu: 100m

--- a/apps/pipeline/upstream/third-party/argo/upstream/manifests/Kptfile
+++ b/apps/pipeline/upstream/third-party/argo/upstream/manifests/Kptfile
@@ -7,12 +7,12 @@ upstream:
   git:
     repo: https://github.com/argoproj/argo-workflows
     directory: /manifests
-    ref: v3.4.16
+    ref: v3.4.17
   updateStrategy: resource-merge
 upstreamLock:
   type: git
   git:
     repo: https://github.com/argoproj/argo-workflows
     directory: /manifests
-    ref: v3.4.16
-    commit: 910a9aabce5de6568b54350c181a431f8263605a
+    ref: v3.4.17
+    commit: 89cbdb53361cbe59fbe81b887ee82722cce5de54

--- a/apps/pipeline/upstream/third-party/argo/upstream/manifests/namespace-install/kustomization.yaml
+++ b/apps/pipeline/upstream/third-party/argo/upstream/manifests/namespace-install/kustomization.yaml
@@ -4,16 +4,16 @@ resources:
   - ../base
   - ./argo-server-rbac
   - ./workflow-controller-rbac
-patches:
-  - path: ./overlays/workflow-controller-deployment.yaml
-    target:
+patchesJson6902:
+  - target:
+      version: v1
       group: apps
       kind: Deployment
       name: workflow-controller
+    path: ./overlays/workflow-controller-deployment.yaml
+  - target:
       version: v1
-  - path: ./overlays/argo-server-deployment.yaml
-    target:
       group: apps
       kind: Deployment
       name: argo-server
-      version: v1
+    path: ./overlays/argo-server-deployment.yaml

--- a/apps/pipeline/upstream/third-party/argo/upstream/manifests/quick-start/base/kustomization.yaml
+++ b/apps/pipeline/upstream/third-party/argo/upstream/manifests/quick-start/base/kustomization.yaml
@@ -19,6 +19,6 @@ resources:
   - artifactgc-default-rolebinding.yaml
   - cluster-workflow-template-rbac.yaml
   - artifact-repositories-configmap.yaml
-patches:
-  - path: overlays/workflow-controller-configmap.yaml
-  - path: overlays/argo-server-deployment.yaml
+patchesStrategicMerge:
+  - overlays/workflow-controller-configmap.yaml
+  - overlays/argo-server-deployment.yaml

--- a/apps/pipeline/upstream/third-party/argo/upstream/manifests/quick-start/minimal/kustomization.yaml
+++ b/apps/pipeline/upstream/third-party/argo/upstream/manifests/quick-start/minimal/kustomization.yaml
@@ -2,5 +2,5 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
   - ../base
-patches:
-  - path: overlays/workflow-controller-configmap.yaml
+patchesStrategicMerge:
+  - overlays/workflow-controller-configmap.yaml

--- a/apps/pipeline/upstream/third-party/argo/upstream/manifests/quick-start/mysql/kustomization.yaml
+++ b/apps/pipeline/upstream/third-party/argo/upstream/manifests/quick-start/mysql/kustomization.yaml
@@ -5,5 +5,5 @@ resources:
   - argo-mysql-config-secret.yaml
   - mysql-deployment.yaml
   - mysql-service.yaml
-patches:
-  - path: overlays/workflow-controller-configmap.yaml
+patchesStrategicMerge:
+  - overlays/workflow-controller-configmap.yaml

--- a/apps/pipeline/upstream/third-party/argo/upstream/manifests/quick-start/postgres/kustomization.yaml
+++ b/apps/pipeline/upstream/third-party/argo/upstream/manifests/quick-start/postgres/kustomization.yaml
@@ -5,5 +5,5 @@ resources:
   - argo-postgres-config-secret.yaml
   - postgres-deployment.yaml
   - postgres-service.yaml
-patches:
-  - path: overlays/workflow-controller-configmap.yaml
+patchesStrategicMerge:
+  - overlays/workflow-controller-configmap.yaml

--- a/apps/pipeline/upstream/third-party/argo/upstream/manifests/quick-start/sso/kustomization.yaml
+++ b/apps/pipeline/upstream/third-party/argo/upstream/manifests/quick-start/sso/kustomization.yaml
@@ -3,6 +3,6 @@ kind: Kustomization
 resources:
   - ../base
   - dex
-patches:
-  - path: overlays/workflow-controller-configmap.yaml
-  - path: overlays/argo-server-sa.yaml
+patchesStrategicMerge:
+  - overlays/workflow-controller-configmap.yaml
+  - overlays/argo-server-sa.yaml

--- a/hack/synchronize-pipelines-manifests.sh
+++ b/hack/synchronize-pipelines-manifests.sh
@@ -15,7 +15,7 @@
 set -euxo pipefail
 IFS=$'\n\t'
 
-COMMIT="2.2.0" # You can use tags as well
+COMMIT="2.3.0" # You can use tags as well
 SRC_DIR=${SRC_DIR:=/tmp/kubeflow-pipelines}
 BRANCH=${BRANCH:=synchronize-kubeflow-pipelines-manifests-${COMMIT?}}
 


### PR DESCRIPTION
# Pull Request Template for Kubeflow manifests Issues

## ✏️ A brief description of the changes
> I changed KFP version to 2.3.0

## 📦 List any dependencies that are required for this change
> My PR depends on #

## 🐛 If this PR is related to an issue, please put the link to the issue here.
> The following issues are related, because synchronizing manifests with KFP 2.3.0

## ✅ Contributor checklist
  - Make sure you have tested with kustomize. See [Installation Prerequisites](https://github.com/kubeflow/manifests#prerequisites)
  - All the commits have been [_signed-off_](https://github.com/kubeflow/community/tree/master/dco-signoff-hook#signing-off-commits)  (To pass the `DCO` check)

---     
 
> You can join the CNCF Slack and access our meetings at the [Kubeflow Community](https://www.kubeflow.org/docs/about/community/) website. Our channel on the CNCF Slack is here [**#kubeflow-platform**](https://app.slack.com/client/T08PSQ7BQ/C073W572LA2).
  
