### PR TITLE
Running command in README errors, upstream folder does not exist

### DIFF
--- a/README.md
+++ b/README.md
@@ -372,7 +372,7 @@ kustomize build apps/katib/upstream/installs/katib-with-kubeflow | kubectl apply
 Install the Central Dashboard official Kubeflow component:
 
 ```sh
-kustomize build apps/centraldashboard/upstream/overlays/oauth2-proxy | kubectl apply -f -
+kustomize build apps/centraldashboard/overlays/oauth2-proxy | kubectl apply -f -
 ```
 
 #### Admission Webhook


### PR DESCRIPTION
# Pull Request Template for Kubeflow manifests Issues

## ✏️ A brief description of the changes
> I changed the README file to update the Central Dashboard component installation dir

## 📦 List any dependencies that are required for this change
> N/A

## 🐛 If this PR is related to an issue, please put the link to the issue here.
> N/A

## ✅ Contributor checklist
  - Make sure you have tested with kustomize. See [Installation Prerequisites](https://github.com/kubeflow/manifests#prerequisites)
  - All the commits have been [_signed-off_](https://github.com/kubeflow/community/tree/master/dco-signoff-hook#signing-off-commits)  (To pass the `DCO` check)

---     
 
> You can join the CNCF Slack and access our meetings at the [Kubeflow Community](https://www.kubeflow.org/docs/about/community/) website. Our channel on the CNCF Slack is here [**#kubeflow-platform**](https://app.slack.com/client/T08PSQ7BQ/C073W572LA2).
  
