### PR TITLE
Synchronize kubeflow model registry manifests v0.2.9

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ This repo periodically syncs all official Kubeflow components from their respect
 | KServe Models Web App | contrib/kserve/models-web-app | [0.13.0](https://github.com/kserve/models-web-app/tree/0.13.0/config) |
 | Kubeflow Pipelines | apps/pipeline/upstream | [2.3.0](https://github.com/kubeflow/pipelines/tree/2.3.0/manifests/kustomize) |
 | Kubeflow Tekton Pipelines | apps/kfp-tekton/upstream | [2.0.5](https://github.com/kubeflow/kfp-tekton/tree/2.0.5/manifests/kustomize) |
-| Kubeflow Model Registry | apps/model-registry/upstream | [v0.2.5-alpha](https://github.com/kubeflow/model-registry/tree/v0.2.5-alpha/manifests/kustomize) |
+| Kubeflow Model Registry | apps/model-registry/upstream | [v0.2.9](https://github.com/kubeflow/model-registry/tree/v0.2.9/manifests/kustomize) |
 
 The following is also a matrix with versions from common components that are
 used from the different projects of Kubeflow:

--- a/apps/model-registry/upstream/base/kustomization.yaml
+++ b/apps/model-registry/upstream/base/kustomization.yaml
@@ -1,7 +1,11 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
-  - model-registry-configmap.yaml
-  - model-registry-deployment.yaml
-  - model-registry-service.yaml
-  - model-registry-sa.yaml
+- model-registry-configmap.yaml
+- model-registry-deployment.yaml
+- model-registry-service.yaml
+- model-registry-sa.yaml
+images:
+- name: kubeflow/model-registry
+  newName: kubeflow/model-registry
+  newTag: v0.2.9

--- a/hack/synchronize-model-registry-manifests.sh
+++ b/hack/synchronize-model-registry-manifests.sh
@@ -15,7 +15,7 @@
 set -euxo pipefail
 IFS=$'\n\t'
 
-COMMIT="v0.2.5-alpha" # You can use tags as well
+COMMIT="v0.2.9" # You can use tags as well
 DEV_MODE=${DEV_MODE:=false}
 SRC_DIR=${SRC_DIR:=/tmp/kubeflow-model-registry}
 BRANCH=${BRANCH:=synchronize-kubeflow-model-registry-manifests-${COMMIT?}}


### PR DESCRIPTION
# Pull Request Template for Kubeflow manifests Issues

## ✏️ A brief description of the changes
> I upgraded model registry to v0.2.9

## 📦 List any dependencies that are required for this change
> My PR depends on #

## 🐛 If this PR is related to an issue, please put the link to the issue here.
> The following issues are related, because ...

## ✅ Contributor checklist
  - Make sure you have tested with kustomize. See [Installation Prerequisites](https://github.com/kubeflow/manifests#prerequisites)
  - All the commits have been [_signed-off_](https://github.com/kubeflow/community/tree/master/dco-signoff-hook#signing-off-commits)  (To pass the `DCO` check)

---     
 
> You can join the CNCF Slack and access our meetings at the [Kubeflow Community](https://www.kubeflow.org/docs/about/community/) website. Our channel on the CNCF Slack is here [**#kubeflow-platform**](https://app.slack.com/client/T08PSQ7BQ/C073W572LA2).
  
