### PR TITLE
feat: synchronize kubeflow model registry manifests to v0.2.10

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ This repo periodically syncs all official Kubeflow components from their respect
 | KServe | contrib/kserve/kserve | [v0.14.0](https://github.com/kserve/kserve/releases/tag/v0.14.0/install/v0.14.0) |
 | KServe Models Web App | contrib/kserve/models-web-app | [0.13.0](https://github.com/kserve/models-web-app/tree/0.13.0/config) |
 | Kubeflow Pipelines | apps/pipeline/upstream | [2.3.0](https://github.com/kubeflow/pipelines/tree/2.3.0/manifests/kustomize) |
-| Kubeflow Model Registry | apps/model-registry/upstream | [v0.2.9](https://github.com/kubeflow/model-registry/tree/v0.2.9/manifests/kustomize) |
+| Kubeflow Model Registry | apps/model-registry/upstream | [v0.2.10](https://github.com/kubeflow/model-registry/tree/v0.2.10/manifests/kustomize) |
 
 The following is also a matrix with versions from common components that are
 used from the different projects of Kubeflow:

--- a/apps/model-registry/upstream/base/kustomization.yaml
+++ b/apps/model-registry/upstream/base/kustomization.yaml
@@ -8,4 +8,4 @@ resources:
 images:
 - name: kubeflow/model-registry
   newName: kubeflow/model-registry
-  newTag: v0.2.9
+  newTag: v0.2.10

--- a/apps/model-registry/upstream/options/csi/clusterstoragecontainer.yaml
+++ b/apps/model-registry/upstream/options/csi/clusterstoragecontainer.yaml
@@ -1,0 +1,20 @@
+apiVersion: "serving.kserve.io/v1alpha1"
+kind: ClusterStorageContainer
+metadata:
+  name: model-registry-storage-initializer
+spec:
+  container:
+    name: storage-initializer
+    image: kubeflow/model-registry-storage-initializer:latest
+    env:
+    - name: MODEL_REGISTRY_BASE_URL
+      value: "model-registry-service.kubeflow.svc.cluster.local:8080"
+    resources:
+      requests:
+        memory: 100Mi
+        cpu: 100m
+      limits:
+        memory: 1Gi
+        cpu: "1"
+  supportedUriFormats:
+    - prefix: model-registry://

--- a/apps/model-registry/upstream/options/csi/kustomization.yaml
+++ b/apps/model-registry/upstream/options/csi/kustomization.yaml
@@ -1,0 +1,10 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+namespace: kubeflow
+
+resources:
+- clusterstoragecontainer.yaml
+images:
+- name: kubeflow/model-registry-storage-initializer
+  newName: kubeflow/model-registry-storage-initializer
+  newTag: v0.2.10

--- a/hack/synchronize-model-registry-manifests.sh
+++ b/hack/synchronize-model-registry-manifests.sh
@@ -15,7 +15,7 @@
 set -euxo pipefail
 IFS=$'\n\t'
 
-COMMIT="v0.2.9" # You can use tags as well
+COMMIT="v0.2.10" # You can use tags as well
 DEV_MODE=${DEV_MODE:=false}
 SRC_DIR=${SRC_DIR:=/tmp/kubeflow-model-registry}
 BRANCH=${BRANCH:=synchronize-kubeflow-model-registry-manifests-${COMMIT?}}


### PR DESCRIPTION
# Pull Request Template for Kubeflow manifests Issues

## ✏️ A brief description of the changes
> I upgraded model registry to v0.2.10

## 📦 List any dependencies that are required for this change
> My PR depends on #

## 🐛 If this PR is related to an issue, please put the link to the issue here.
> The following issues are related, because ...

## ✅ Contributor checklist
  - Make sure you have tested with kustomize. See [Installation Prerequisites](https://github.com/kubeflow/manifests#prerequisites)
  - All the commits have been [_signed-off_](https://github.com/kubeflow/community/tree/master/dco-signoff-hook#signing-off-commits)  (To pass the `DCO` check)

---     
 
> You can join the CNCF Slack and access our meetings at the [Kubeflow Community](https://www.kubeflow.org/docs/about/community/) website. Our channel on the CNCF Slack is here [**#kubeflow-platform**](https://app.slack.com/client/T08PSQ7BQ/C073W572LA2).
  
