### PR TITLE
Update Dex and oauth2-proxy to 2.41.1 and 7.7.1

### DIFF
--- a/common/dex/base/deployment.yaml
+++ b/common/dex/base/deployment.yaml
@@ -16,7 +16,7 @@ spec:
     spec:
       serviceAccountName: dex
       containers:
-      - image: ghcr.io/dexidp/dex:v2.39.1
+      - image: ghcr.io/dexidp/dex:v2.41.1
         name: dex
         command: ["dex", "serve", "/etc/dex/cfg/config.yaml"]
         ports:
@@ -35,6 +35,11 @@ spec:
             valueFrom:
               fieldRef:
                 fieldPath: metadata.namespace
+        readinessProbe:
+          httpGet:
+            path: /healthz
+            port: 5556
+            scheme: HTTPS
       volumes:
       - name: config
         configMap:

--- a/common/dex/base/deployment.yaml
+++ b/common/dex/base/deployment.yaml
@@ -8,7 +8,7 @@ spec:
   replicas: 1
   selector:
     matchLabels:
-        app: dex
+      app: dex
   template:
     metadata:
       labels:
@@ -26,20 +26,20 @@ spec:
         - name: config
           mountPath: /etc/dex/cfg
         envFrom:
-          - secretRef:
-              name: dex-oidc-client
-          - secretRef:
-              name: dex-passwords
+        - secretRef:
+            name: dex-oidc-client
+        - secretRef:
+            name: dex-passwords
         env:
-          - name: KUBERNETES_POD_NAMESPACE
-            valueFrom:
-              fieldRef:
-                fieldPath: metadata.namespace
-        readinessProbe:
-          httpGet:
-            path: /healthz
-            port: 5556
-            scheme: HTTPS
+        - name: KUBERNETES_POD_NAMESPACE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace
+        #readinessProbe:
+        #  httpGet:
+        #    path: /healthz
+        #    port: 5556
+        #    scheme: HTTPS
       volumes:
       - name: config
         configMap:

--- a/common/oauth2-proxy/base/kustomization.yaml
+++ b/common/oauth2-proxy/base/kustomization.yaml
@@ -92,4 +92,4 @@ replacements:
 images:
 - name: quay.io/oauth2-proxy/oauth2-proxy
   newName: quay.io/oauth2-proxy/oauth2-proxy
-  newTag: v7.6.0
+  newTag: v7.7.1


### PR DESCRIPTION
@tarekabouzeid for /lgtm


- https://github.com/oauth2-proxy/oauth2-proxy/releases/tag/v7.7.1
- https://github.com/dexidp/dex/releases/tag/v2.41.1
- https://github.com/dexidp/dex/blob/master/examples/k8s/dex.yaml
- https://github.com/dexidp/dex/pkgs/container/dex/254808321?tag=v2.41.1
- https://quay.io/repository/oauth2-proxy/oauth2-proxy?tab=tags&tag=v7.7.1
- https://github.com/kubeflow/manifests/pull/2710/files
  
