### PR TITLE
fix wrong path for `cert-manager` in single component installation se…

### DIFF
--- a/README.md
+++ b/README.md
@@ -185,7 +185,7 @@ admission webhooks.
 Install cert-manager:
 
 ```sh
-kustomize build common/cert-manager/cert-manager/base | kubectl apply -f -
+kustomize build common/cert-manager/base | kubectl apply -f -
 kustomize build common/cert-manager/kubeflow-issuer/base | kubectl apply -f -
 echo "Waiting for cert-manager to be ready ..."
 kubectl wait --for=condition=ready pod -l 'app in (cert-manager,webhook)' --timeout=180s -n cert-manager


### PR DESCRIPTION
# fix wrong path for cert-manager in single component installation

## ✏️ A brief description of the changes
> I changed the the script for cert-manager installation as a single component, the path was wrong.

## 📦 List any dependencies that are required for this change
> There are no dependencies.

## 🐛 If this PR is related to an issue, please put the link to the issue here.
> There are no related issues.

## ✅ Contributor checklist
  - Make sure you have tested with kustomize. See [Installation Prerequisites](https://github.com/kubeflow/manifests#prerequisites)
  - All the commits have been [_signed-off_](https://github.com/kubeflow/community/tree/master/dco-signoff-hook#signing-off-commits)  (To pass the `DCO` check)

---     
 
> You can join the CNCF Slack and access our meetings at the [Kubeflow Community](https://www.kubeflow.org/docs/about/community/) website. Our channel on the CNCF Slack is here [**#kubeflow-platform**](https://app.slack.com/client/T08PSQ7BQ/C073W572LA2).
  
