### PR TITLE
fix cert-manager wrong path in standalone installation section

### DIFF
--- a/README.md
+++ b/README.md
@@ -185,7 +185,7 @@ admission webhooks.
 Install cert-manager:
 
 ```sh
-kustomize build common/cert-manager/cert-manager/base | kubectl apply -f -
+kustomize build common/cert-manager/base | kubectl apply -f -
 kustomize build common/cert-manager/kubeflow-issuer/base | kubectl apply -f -
 echo "Waiting for cert-manager to be ready ..."
 kubectl wait --for=condition=ready pod -l 'app in (cert-manager,webhook)' --timeout=180s -n cert-manager


### PR DESCRIPTION
# fix cert-manager wrong path in standalone installation section

## ✏️ A brief description of the changes
> I changed the README, single component installation section and corrected the bash script for cert-manager component. 

## 📦 List any dependencies that are required for this change
> it does not depend on anything.

## 🐛 If this PR is related to an issue, please put the link to the issue here.
> No related issue or PR.

## ✅ Contributor checklist
  - Make sure you have tested with kustomize. See [Installation Prerequisites](https://github.com/kubeflow/manifests#prerequisites)
  - All the commits have been [_signed-off_](https://github.com/kubeflow/community/tree/master/dco-signoff-hook#signing-off-commits)  (To pass the `DCO` check)

---     
 
> You can join the CNCF Slack and access our meetings at the [Kubeflow Community](https://www.kubeflow.org/docs/about/community/) website. Our channel on the CNCF Slack is here [**#kubeflow-platform**](https://app.slack.com/client/T08PSQ7BQ/C073W572LA2).
  
