### PR TITLE
Disable init container injection for ray

### DIFF
--- a/contrib/ray/kuberay-operator/overlays/kubeflow/disable-injection.yaml
+++ b/contrib/ray/kuberay-operator/overlays/kubeflow/disable-injection.yaml
@@ -1,0 +1,13 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: kuberay-operator
+  namespace: kubeflow
+spec:
+  template:
+    spec:
+      containers:
+      - name: kuberay-operator
+        env:
+        - name: ENABLE_INIT_CONTAINER_INJECTION
+          value: "false"

--- a/contrib/ray/kuberay-operator/overlays/kubeflow/kustomization.yaml
+++ b/contrib/ray/kuberay-operator/overlays/kubeflow/kustomization.yaml
@@ -1,3 +1,6 @@
 namespace: kubeflow
 resources:
 - ../../base
+
+patches:
+- path: disable-injection.yaml

--- a/contrib/ray/test.sh
+++ b/contrib/ray/test.sh
@@ -33,7 +33,7 @@ kubectl label namespace $NAMESPACE istio-injection=enabled
 kubectl get namespaces --selector=istio-injection=enabled
 
 # Install KubeRay operator
-kustomize build kuberay-operator/overlays/standalone | kubectl -n kubeflow apply --server-side -f -
+kustomize build kuberay-operator/overlays/kubeflow | kubectl -n kubeflow apply --server-side -f -
 
 # Wait for the operator to be ready.
 kubectl -n kubeflow wait --for=condition=available --timeout=600s deploy/kuberay-operator


### PR DESCRIPTION
When istio is enabled, the kuberay-operator must disable the init container injection.

See https://docs.ray.io/en/latest/cluster/kubernetes/k8s-ecosystem/istio.html#step-3-optional-enable-istio-mtls-strict-mode

# Pull Request Template for Kubeflow manifests Issues

## ✏️ A brief description of the changes
The kubeflow overlay will disable the init container injection.

## 📦 List any dependencies that are required for this change
#2907 


## ✅ Contributor checklist
  - Make sure you have tested with kustomize. See [Installation Prerequisites](https://github.com/kubeflow/manifests#prerequisites)
  - All the commits have been [_signed-off_](https://github.com/kubeflow/community/tree/master/dco-signoff-hook#signing-off-commits)  (To pass the `DCO` check)

---     
 
> You can join the CNCF Slack and access our meetings at the [Kubeflow Community](https://www.kubeflow.org/docs/about/community/) website. Our channel on the CNCF Slack is here [**#kubeflow-platform**](https://app.slack.com/client/T08PSQ7BQ/C073W572LA2).
  
