### PR TITLE
KSERVE: update the kserve m2m test with real Kubeflow namespaces

### DIFF
--- a/.github/workflows/kserve_m2m_test.yaml
+++ b/.github/workflows/kserve_m2m_test.yaml
@@ -43,11 +43,17 @@ jobs:
     - name: Install knative
       run: ./tests/gh-actions/install_knative.sh
 
-    - name: Build & Apply manifests
+    - name: Install KServe
       run: ./tests/gh-actions/install_kserve.sh
 
-    - name: Create test namespace
-      run: kubectl create ns kserve-test
+    - name: Install KF Multi Tenancy
+      run: ./tests/gh-actions/install_multi_tenancy.sh
+
+    - name: Install kubeflow-istio-resources
+      run: kustomize build common/istio-1-23/kubeflow-istio-resources/base | kubectl apply -f -
+
+    - name: Create KF Profile
+      run: kustomize build common/user-namespace/base | kubectl apply -f -
 
     - name: Setup python 3.9
       uses: actions/setup-python@v4
@@ -63,10 +69,10 @@ jobs:
         nohup kubectl port-forward --namespace istio-system svc/${INGRESS_GATEWAY_SERVICE} 8080:80 &
         while ! curl localhost:8080; do echo waiting for port-forwarding; sleep 1; done; echo port-forwarding ready
 
-    - name: Run kserve tests with m2m token from SA default/default
+    - name: Run kserve tests with m2m token from SA kubeflow-user-example-com/default-editor
       run: |
         export KSERVE_INGRESS_HOST_PORT=localhost:8080
-        export KSERVE_M2M_TOKEN="$(kubectl -n default create token default)"
+        export KSERVE_M2M_TOKEN="$(kubectl -n kubeflow-user-example-com create token default-editor)"
         cd ./contrib/kserve/tests && pytest . -vs --log-level info
 
     - name: Run and fail kserve tests without kserve m2m token

--- a/.github/workflows/kserve_test.yaml
+++ b/.github/workflows/kserve_test.yaml
@@ -37,7 +37,7 @@ jobs:
       run: ./tests/gh-actions/install_kserve.sh
 
     - name: Create test namespace
-      run: kubectl create ns kserve-test
+      run: kubectl create ns kubeflow-user-example-com # warning, this is not a real KF profile
 
     - name: Setup python 3.9
       uses: actions/setup-python@v4

--- a/contrib/kserve/tests/utils.py
+++ b/contrib/kserve/tests/utils.py
@@ -26,7 +26,7 @@ from kserve import constants
 logging.basicConfig(level=logging.INFO)
 
 KSERVE_NAMESPACE = "kserve"
-KSERVE_TEST_NAMESPACE = "kserve-test"
+KSERVE_TEST_NAMESPACE = "kubeflow-user-example-com"
 MODEL_CLASS_NAME = "modelClass"
 
 


### PR DESCRIPTION
# Pull Request Template for Kubeflow manifests Issues

## ✏️ A brief description of the changes
> I changed the kserve test to test at least the m2m part in real KF user namespaces

## 📦 List any dependencies that are required for this change
> My PR depends on #

## 🐛 If this PR is related to an issue, please put the link to the issue here.
> The following issues are related, because ...
https://github.com/kubeflow/manifests/pull/2907
https://github.com/kubeflow/manifests/issues/2811

## ✅ Contributor checklist
  - Make sure you have tested with kustomize. See [Installation Prerequisites](https://github.com/kubeflow/manifests#prerequisites)
  - All the commits have been [_signed-off_](https://github.com/kubeflow/community/tree/master/dco-signoff-hook#signing-off-commits)  (To pass the `DCO` check)

---     
 
> You can join the CNCF Slack and access our meetings at the [Kubeflow Community](https://www.kubeflow.org/docs/about/community/) website. Our channel on the CNCF Slack is here [**#kubeflow-platform**](https://app.slack.com/client/T08PSQ7BQ/C073W572LA2).
  
