### PR TITLE
Removal of sed patch from pss_test.yaml

### DIFF
--- a/.github/workflows/pss_test.yaml
+++ b/.github/workflows/pss_test.yaml
@@ -72,7 +72,7 @@ jobs:
             kubectl patch "$KIND" "$NAME" -n "$NAMESPACE" --patch-file "$file"
           fi
         done
-        sleep 100
+        sleep 150
 
     - name: Apply Pod Security Standards baseline levels for static namespaces
       run: ./tests/gh-actions/enable_baseline_PSS.sh

--- a/.github/workflows/pss_test.yaml
+++ b/.github/workflows/pss_test.yaml
@@ -33,16 +33,6 @@ jobs:
     - name: Install Istio CNI
       run: ./tests/gh-actions/install_istio-cni.sh
 
-    - name: Configure istio init container with seccompProfile attribute
-      run: |
-        kubectl get cm istio-sidecar-injector -n istio-system -o yaml > temporary_patch.yaml
-        sed -i '0,/runAsNonRoot: true/{s//&\n              seccompProfile:\n                type: RuntimeDefault/}' temporary_patch.yaml
-        sed -i '/runAsNonRoot: true/{N; /runAsUser: {{ .ProxyUID | default "1337" }}/a\
-                      seccompProfile:\n                type: RuntimeDefault
-        }' temporary_patch.yaml
-        kubectl apply -f temporary_patch.yaml
-        rm temporary_patch.yaml
-
     - name: Install oauth2-proxy
       run: ./tests/gh-actions/install_oauth2-proxy.sh
 

--- a/.github/workflows/pss_test.yaml
+++ b/.github/workflows/pss_test.yaml
@@ -72,7 +72,9 @@ jobs:
             kubectl patch "$KIND" "$NAME" -n "$NAMESPACE" --patch-file "$file"
           fi
         done
-        sleep 300
+        kubectl get pods -n istio-system
+        kubectl get cm -n istio-system
+        kubectl describe cm istio-sidecar-injector -n istio-system
 
     - name: Apply Pod Security Standards baseline levels for static namespaces
       run: ./tests/gh-actions/enable_baseline_PSS.sh

--- a/.github/workflows/pss_test.yaml
+++ b/.github/workflows/pss_test.yaml
@@ -72,9 +72,7 @@ jobs:
             kubectl patch "$KIND" "$NAME" -n "$NAMESPACE" --patch-file "$file"
           fi
         done
-        kubectl get pods -n istio-system
-        kubectl get cm -n istio-system
-        kubectl describe cm istio-sidecar-injector -n istio-system
+        sleep 100
 
     - name: Apply Pod Security Standards baseline levels for static namespaces
       run: ./tests/gh-actions/enable_baseline_PSS.sh

--- a/contrib/security/PSS/patches/cluster-jwks-proxy.yaml
+++ b/contrib/security/PSS/patches/cluster-jwks-proxy.yaml
@@ -1,0 +1,18 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: cluster-jwks-proxy
+  namespace: istio-system
+spec:
+  template:
+    spec:
+      containers:
+      - name: kubectl-proxy
+        securityContext:
+          allowPrivilegeEscalation: false
+          seccompProfile:
+            type: RuntimeDefault
+          runAsNonRoot: true
+          capabilities:
+            drop:
+            - ALL


### PR DESCRIPTION
# Pull Request Template for Kubeflow manifests Issues

## ✏️ A brief description of the changes
> I removed the sed patch to istio-init conatiner in pss_test.yaml workflow

## 📦 List any dependencies that are required for this change
> My PR depends on #

## 🐛 If this PR is related to an issue, please put the link to the issue here.
> The following issues are related, because ...

## ✅ Contributor checklist
  - Make sure you have tested with kustomize. See [Installation Prerequisites](https://github.com/kubeflow/manifests#prerequisites)
  - All the commits have been [_signed-off_](https://github.com/kubeflow/community/tree/master/dco-signoff-hook#signing-off-commits)  (To pass the `DCO` check)

---     
 
> You can join the CNCF Slack and access our meetings at the [Kubeflow Community](https://www.kubeflow.org/docs/about/community/) website. Our channel on the CNCF Slack is here [**#kubeflow-platform**](https://app.slack.com/client/T08PSQ7BQ/C073W572LA2).
  
