### PR TITLE
Fix command for PVC Viewer Controller in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -465,7 +465,7 @@ It is still in development.
 Install the PVC Viewer Controller official Kubeflow component:
 
 ```sh
-kustomize build apps/pvcviewer-controller/upstream/default | kubectl apply -f -
+kustomize build apps/pvcviewer-controller/upstream/base | kubectl apply -f -
 ```
 
 #### Profiles + KFAM


### PR DESCRIPTION
# Pull Request Template for Kubeflow manifests Issues

## ✏️ A brief description of the changes
This fixes the installation command for PVC Viewer Controller in README.md.

## 📦 List any dependencies that are required for this change
This does not depend on anything.

## 🐛 If this PR is related to an issue, please put the link to the issue here.
This fixes #2945 .

## ✅ Contributor checklist
  - Make sure you have tested with kustomize. See [Installation Prerequisites](https://github.com/kubeflow/manifests#prerequisites)
  - All the commits have been [_signed-off_](https://github.com/kubeflow/community/tree/master/dco-signoff-hook#signing-off-commits)  (To pass the `DCO` check)

---     
 
> You can join the CNCF Slack and access our meetings at the [Kubeflow Community](https://www.kubeflow.org/docs/about/community/) website. Our channel on the CNCF Slack is here [**#kubeflow-platform**](https://app.slack.com/client/T08PSQ7BQ/C073W572LA2).
  
