### PR TITLE
Disable init container injection for ray

### DIFF
--- a/contrib/ray/kuberay-operator/overlays/kubeflow/disable-injection.yaml
+++ b/contrib/ray/kuberay-operator/overlays/kubeflow/disable-injection.yaml
@@ -1,0 +1,13 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: kuberay-operator
+  namespace: kubeflow
+spec:
+  template:
+    spec:
+      containers:
+      - name: kuberay-operator
+        env:
+        - name: ENABLE_INIT_CONTAINER_INJECTION
+          value: "false"

--- a/contrib/ray/kuberay-operator/overlays/kubeflow/kustomization.yaml
+++ b/contrib/ray/kuberay-operator/overlays/kubeflow/kustomization.yaml
@@ -1,3 +1,6 @@
 namespace: kubeflow
 resources:
 - ../../base
+
+patches:
+- path: disable-injection.yaml

--- a/contrib/ray/test.sh
+++ b/contrib/ray/test.sh
@@ -33,7 +33,7 @@ kubectl label namespace $NAMESPACE istio-injection=enabled
 kubectl get namespaces --selector=istio-injection=enabled
 
 # Install KubeRay operator
-kustomize build kuberay-operator/overlays/standalone | kubectl -n kubeflow apply --server-side -f -
+kustomize build kuberay-operator/overlays/kubeflow | kubectl -n kubeflow apply --server-side -f -
 
 # Wait for the operator to be ready.
 kubectl -n kubeflow wait --for=condition=available --timeout=600s deploy/kuberay-operator


### PR DESCRIPTION
The kuberay-operator needs to disable the init container injection as specified here:
https://docs.ray.io/en/latest/cluster/kubernetes/k8s-ecosystem/istio.html#step-3-optional-enable-istio-mtls-strict-mode

from @fraenkel based on https://github.com/kubeflow/manifests/pull/2907#issuecomment-2532171819 and the commit in the PR.

@tarekabouzeid @biswajit-9776  for /lgtm