### PR TITLE
Add the port name to the ml-pipeline-ui container

### DIFF
--- a/apps/pipeline/upstream/base/pipeline/ml-pipeline-ui-deployment.yaml
+++ b/apps/pipeline/upstream/base/pipeline/ml-pipeline-ui-deployment.yaml
@@ -24,7 +24,8 @@ spec:
         imagePullPolicy: IfNotPresent
         name: ml-pipeline-ui
         ports:
-        - containerPort: 3000
+        - name: http
+          containerPort: 3000
         volumeMounts:
         - name: config-volume
           mountPath: /etc/config


### PR DESCRIPTION
Without the port name, the ml-pipeline-ui Service was not working properly.