### PR TITLE
Disable the GKE metadata endpoints on Pipelines by default

### DIFF
--- a/apps/pipeline/upstream/base/pipeline/ml-pipeline-ui-deployment.yaml
+++ b/apps/pipeline/upstream/base/pipeline/ml-pipeline-ui-deployment.yaml
@@ -48,6 +48,8 @@ spec:
                 key: secretkey
           - name: ALLOW_CUSTOM_VISUALIZATIONS
             value: "true"
+          - name: DISABLE_GKE_METADATA
+            value: "true"
           - name: FRONTEND_SERVER_NAMESPACE
             valueFrom:
               fieldRef:


### PR DESCRIPTION
# Pull Request Template for Kubeflow manifests Issues

## ✏️ A brief description of the changes

When not explicitly set, the Pipelines UI queries the /pipeline/system/cluster-name and /pipeline/system/project-id endpoints, which cause the ml-pipeline-ui pods to crash when it's not deployed on GKE.

---     
 
> You can join the CNCF Slack and access our meetings at the [Kubeflow Community](https://www.kubeflow.org/docs/about/community/) website. Our channel on the CNCF Slack is here [**#kubeflow-platform**](https://app.slack.com/client/T08PSQ7BQ/C073W572LA2).
  
