### PR TITLE
fix: update kind config

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,7 +122,7 @@ nodes:
     kind: ClusterConfiguration
     apiServer:
       extraArgs:
-        "service-account-issuer": "kubernetes.default.svc"
+        "service-account-issuer": "https://kubernetes.default.svc"
         "service-account-signing-key-file": "/etc/kubernetes/pki/sa.key"
 EOF
 ```

--- a/tests/gh-actions/install_KinD_create_KinD_cluster_install_kustomize.sh
+++ b/tests/gh-actions/install_KinD_create_KinD_cluster_install_kustomize.sh
@@ -45,7 +45,7 @@ kubeadmConfigPatches:
       name: config
     apiServer:
       extraArgs:
-        \"service-account-issuer\": \"kubernetes.default.svc\"
+        \"service-account-issuer\": \"https://kubernetes.default.svc\"
         \"service-account-signing-key-file\": \"/etc/kubernetes/pki/sa.key\"
 nodes:
 - role: control-plane


### PR DESCRIPTION
# Fix kind config in the install instructions 

## ✏️ A brief description of the changes
Follow the install instructions  👉🏻： https://github.com/kubeflow/manifests?tab=readme-ov-file#install-with-a-single-command
but the `cluster-jwks-proxy` not works due to the wrong config for kind cluster, the `kubernetes.default.svc` issuer should be corrected as `https://kubernetes.default.svc`

## 📦 List any dependencies that are required for this change
> My PR depends on #

None

## 🐛 If this PR is related to an issue, please put the link to the issue here.
> The following issues are related, because ...

#2963 

## ✅ Contributor checklist
  - Make sure you have tested with kustomize. See [Installation Prerequisites](https://github.com/kubeflow/manifests#prerequisites)
  - All the commits have been [_signed-off_](https://github.com/kubeflow/community/tree/master/dco-signoff-hook#signing-off-commits)  (To pass the `DCO` check)

---     
 
> You can join the CNCF Slack and access our meetings at the [Kubeflow Community](https://www.kubeflow.org/docs/about/community/) website. Our channel on the CNCF Slack is here [**#kubeflow-platform**](https://app.slack.com/client/T08PSQ7BQ/C073W572LA2).
  
