### PR TITLE
fix: add trainedmodels custom resource to kubeflow-kserve clusterroles

### DIFF
--- a/contrib/kserve/kserve/kserve_kubeflow.yaml
+++ b/contrib/kserve/kserve/kserve_kubeflow.yaml
@@ -31604,6 +31604,7 @@ rules:
     resources:
       - inferenceservices
       - servingruntimes
+      - trainedmodels
     verbs:
       - get
       - list
@@ -31648,6 +31649,7 @@ rules:
     resources:
       - inferenceservices
       - servingruntimes
+      - trainedmodels
     verbs:
       - get
       - list


### PR DESCRIPTION
# Pull Request Template for Kubeflow manifests Issues

## ✏️ A brief description of the changes
> Added the `trainedmodels` custom resource to the `kubeflow-kserve-edit` and `kubeflow-kserve-view` cluster roles so that users can create/view `TrainedModel` type resources. 

## 📦 List any dependencies that are required for this change
> No other changes are required, I have built the custom manifest and tested on my kubeflow cluster.

## 🐛 If this PR is related to an issue, please put the link to the issue here.
> This closes issue https://github.com/kubeflow/manifests/issues/2974

## ✅ Contributor checklist
  - Make sure you have tested with kustomize. See [Installation Prerequisites](https://github.com/kubeflow/manifests#prerequisites)
  - All the commits have been [_signed-off_](https://github.com/kubeflow/community/tree/master/dco-signoff-hook#signing-off-commits)  (To pass the `DCO` check)

---     
 
> You can join the CNCF Slack and access our meetings at the [Kubeflow Community](https://www.kubeflow.org/docs/about/community/) website. Our channel on the CNCF Slack is here [**#kubeflow-platform**](https://app.slack.com/client/T08PSQ7BQ/C073W572LA2).
  
