### PR TITLE
Add model registry ui network policy

### DIFF
--- a/common/networkpolicies/base/kustomization.yaml
+++ b/common/networkpolicies/base/kustomization.yaml
@@ -17,6 +17,7 @@ resources:
 - ml-pipeline-ui.yaml
 - ml-pipeline.yaml
 - model-registry.yaml
+- model-registry-ui.yaml
 - poddefaults.yaml
 - pvcviewer-webhook.yaml
 - spark-operator-webhook.yaml

--- a/common/networkpolicies/base/model-registry-ui.yaml
+++ b/common/networkpolicies/base/model-registry-ui.yaml
@@ -1,0 +1,23 @@
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: model-registry-ui
+  namespace: kubeflow
+spec:
+  podSelector:
+    matchExpressions:
+    - key: app
+      operator: In
+      values:
+      - model-registry-ui
+  ingress:
+  - from:
+    - namespaceSelector:
+        matchExpressions:
+        - key: kubernetes.io/metadata.name
+          operator: In
+          values:
+          - istio-system
+    - podSelector: {}
+  policyTypes:
+  - Ingress


### PR DESCRIPTION
## ✏️ Summary of Changes
This PR adds model registry ui network policy. It's a blocker to include Model Registry UI.

## 📦 Dependencies
No dependencies

## 🐛 Related Issues
No dependencies

## ✅ Contributor Checklist
  - [X] I have tested these changes with kustomize. See [Installation Prerequisites](https://github.com/kubeflow/manifests#prerequisites).
  - [X] All commits are [_signed-off_](https://github.com/kubeflow/community/tree/master/dco-signoff-hook#signing-off-commits) to satisfy the DCO check.

---     
 
> You can join the CNCF Slack and access our meetings at the [Kubeflow Community](https://www.kubeflow.org/docs/about/community/) website. Our channel on the CNCF Slack is here [**#kubeflow-platform**](https://app.slack.com/client/T08PSQ7BQ/C073W572LA2).
  
