### PR TITLE
Add a section for pre-commit in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@
 
 ## Overview of the Kubeflow Platform
 
-This repository is owned by the [Manifests Working Group](https://github.com/kubeflow/community/blob/master/wg-manifests/charter.md).
+This repository is owned by the [Platform/Manifests Working Group](https://github.com/kubeflow/community/blob/master/wg-manifests/charter.md).
 If you are a contributor authoring or editing the packages please see [Best Practices](https://kubectl.docs.kubernetes.io/references/kustomize/).
 You can join the CNCF Slack and access our meetings at the [Kubeflow Community](https://www.kubeflow.org/docs/about/community/) website. Our channel on the CNCF Slack is here [**#kubeflow-platform**](https://app.slack.com/client/T08PSQ7BQ/C073W572LA2). You can also find there our [biweekly meetings](https://bit.ly/kf-wg-manifests-meet), including the commentable [Agenda](https://bit.ly/kf-wg-manifests-notes).
 
@@ -74,7 +74,9 @@ used from the different projects of Kubeflow:
 
 This is for the installation from scratch. For the in-place upgrade guide please jump to the [Upgrading and extending](#upgrading-and-extending) section.
 
-The Manifests WG provides two options for installing Kubeflow official components and common services with kustomize. The aim is to help end users install easily and to help distribution owners build their opinionated distributions from a tested starting point:
+Although our master branch has extended automated test and is already quite stable,please consider using a stable [release tag / branch](https://github.com/kubeflow/manifests/releases) if you want a more conservative experience.
+
+We provide two options for installing Kubeflow official components and common services with kustomize. The aim is to help end users install easily and to help distribution owners build their opinionated distributions from a tested starting point:
 
 1. Single-command installation of all components under `apps` and `common`
 2. Multi-command, individual components installation for `apps` and `common`

--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ This is for the installation from scratch. For the in-place upgrade guide please
 
 Although our master branch has extended automated test and is already quite stable,please consider using a stable [release tag / branch](https://github.com/kubeflow/manifests/releases) if you want a more conservative experience.
 
-We provide two options for installing Kubeflow official components and common services with kustomize. The aim is to help end users install easily and to help distribution owners build their opinionated distributions from a tested starting point:
+We provide two options for installing the offii Kubeflow components and common services with kustomize. The aim is to help end users install easily and to help distribution owners build their opinionated distributions from a tested starting point:
 
 1. Single-command installation of all components under `apps` and `common`
 2. Multi-command, individual components installation for `apps` and `common`

--- a/README.md
+++ b/README.md
@@ -74,7 +74,7 @@ used from the different projects of Kubeflow:
 
 This is for the installation from scratch. For the in-place upgrade guide please jump to the [Upgrading and extending](#upgrading-and-extending) section.
 
-Although our master branch has extended automated test and is already quite stable,please consider using a stable [release tag / branch](https://github.com/kubeflow/manifests/releases) if you want a more conservative experience.
+Although our master branch has extended automated tests and is already quite stable, please consider using a stable [release tag / branch](https://github.com/kubeflow/manifests/releases) if you want a more conservative experience.
 
 We provide two options for installing the offii Kubeflow components and common services with kustomize. The aim is to help end users install easily and to help distribution owners build their opinionated distributions from a tested starting point:
 

--- a/README.md
+++ b/README.md
@@ -7,15 +7,16 @@
 - [Overview of the Kubeflow Platform](#overview-of-the-kubeflow-platform)
 - [Kubeflow components versions](#kubeflow-components-versions)
 - [Installation](#installation)
-  * [Prerequisites](#prerequisites)
-  * [Install with a single command](#install-with-a-single-command)
-  * [Install individual components](#install-individual-components)
-  * [Connect to your Kubeflow Cluster](#connect-to-your-kubeflow-cluster)
-  * [Change default user name](#change-default-user-name)
-  * [Change default user password](#change-default-user-password)
+  - [Prerequisites](#prerequisites)
+  - [Install with a single command](#install-with-a-single-command)
+  - [Install individual components](#install-individual-components)
+  - [Connect to your Kubeflow Cluster](#connect-to-your-kubeflow-cluster)
+  - [Change default user name](#change-default-user-name)
+  - [Change default user password](#change-default-user-password)
 - [Upgrading and extending](#upgrading-and-extending)
 - [Release process](#release-process)
 - [CVE Scanning](#cve-scanning)
+- [Pre-commit Hooks](#pre-commit-hooks)
 - [Frequently Asked Questions](#frequently-asked-questions)
 
 <!-- tocstop -->
@@ -172,7 +173,7 @@ ensure CRDs are installed first
 ```
 
 This is because a kustomization applies both a CRD and a CR very quickly, and the CRD
-hasn't become [`Established`](https://github.com/kubernetes/apiextensions-apiserver/blob/a7ee7f91a2d0805f729998b85680a20cfba208d2/pkg/apis/apiextensions/types.go#L276-L279) yet. You can learn more about this in https://github.com/kubernetes/kubectl/issues/1117 and https://github.com/helm/helm/issues/4925.
+hasn't become [`Established`](https://github.com/kubernetes/apiextensions-apiserver/blob/a7ee7f91a2d0805f729998b85680a20cfba208d2/pkg/apis/apiextensions/types.go#L276-L279) yet. You can learn more about this in <https://github.com/kubernetes/kubectl/issues/1117> and <https://github.com/helm/helm/issues/4925>.
 
 If you bump into this error we advise to re-apply the kustomization of the component.
 
@@ -199,7 +200,7 @@ Error from server (InternalError): error when creating "STDIN": Internal error o
 ```
 This is because the webhook is not yet ready to receive requests. Wait a couple of seconds and retry applying the manifests.
 
-For more troubleshooting info also check out https://cert-manager.io/docs/troubleshooting/webhook/
+For more troubleshooting info also check out <https://cert-manager.io/docs/troubleshooting/webhook/>
 
 #### Istio
 
@@ -280,9 +281,9 @@ kustomize build common/dex/overlays/oauth2-proxy | kubectl apply -f -
 kubectl wait --for=condition=ready pods --all --timeout=180s -n auth
 ```
 
-To connect to your desired identity providers (LDAP,GitHub,Google,Microsoft,OIDC,SAML,GitLab) please take a look at https://dexidp.io/docs/connectors/oidc/.
+To connect to your desired identity providers (LDAP,GitHub,Google,Microsoft,OIDC,SAML,GitLab) please take a look at <https://dexidp.io/docs/connectors/oidc/>.
 We recommend to use OIDC in general, since it is compatible with most providers as for example azure in the following example.
-You need to modify https://github.com/kubeflow/manifests/blob/master/common/dex/overlays/oauth2-proxy/config-map.yaml and add some environment variables in https://github.com/kubeflow/manifests/blob/master/common/dex/base/deployment.yaml by adding a patch section in your main Kustomization file. For guidance please check out [Upgrading and extending](#upgrading-and-extending).
+You need to modify <https://github.com/kubeflow/manifests/blob/master/common/dex/overlays/oauth2-proxy/config-map.yaml> and add some environment variables in <https://github.com/kubeflow/manifests/blob/master/common/dex/base/deployment.yaml> by adding a patch section in your main Kustomization file. For guidance please check out [Upgrading and extending](#upgrading-and-extending).
 
 ```yaml
 apiVersion: v1
@@ -655,6 +656,36 @@ The Kubeflow security working group follows a responsible disclosure policy for 
   - Notify the maintainers and contributors
   - Try to provide a fix or mitigation strategy
   - Publicly disclose the CVE details
+
+## Pre-commit Hooks
+
+This repository uses pre-commit hooks to ensure code quality and consistency. The following hooks are configured:
+
+1. **Black** - Python code formatter
+
+2. **Yamllint** - YAML file linter
+
+3. **Shellcheck** - Shell script static analysis
+
+To use these hooks:
+
+1. Install pre-commit:
+
+   ```bash
+   pip install pre-commit
+   ```
+
+2. Install the git hooks:
+
+   ```bash
+   pre-commit install
+   ```
+
+The hooks will run automatically on `git commit`. You can also run them manually:
+
+```bash
+pre-commit run
+```
 
 ## Frequently Asked Questions
 

--- a/README.md
+++ b/README.md
@@ -175,7 +175,7 @@ ensure CRDs are installed first
 ```
 
 This is because a kustomization applies both a CRD and a CR very quickly, and the CRD
-hasn't become [`Established`](https://github.com/kubernetes/apiextensions-apiserver/blob/a7ee7f91a2d0805f729998b85680a20cfba208d2/pkg/apis/apiextensions/types.go#L276-L279) yet. You can learn more about this in <https://github.com/kubernetes/kubectl/issues/1117> and <https://github.com/helm/helm/issues/4925>.
+has not yet become [`Established`](https://github.com/kubernetes/apiextensions-apiserver/blob/a7ee7f91a2d0805f729998b85680a20cfba208d2/pkg/apis/apiextensions/types.go#L276-L279) yet. You can learn more about this in <https://github.com/kubernetes/kubectl/issues/1117> and <https://github.com/helm/helm/issues/4925>.
 
 If you bump into this error we advise to re-apply the kustomization of the component.
 

--- a/README.md
+++ b/README.md
@@ -177,7 +177,7 @@ ensure CRDs are installed first
 This is because a kustomization applies both a CRD and a CR very quickly, and the CRD
 has not yet become [`Established`](https://github.com/kubernetes/apiextensions-apiserver/blob/a7ee7f91a2d0805f729998b85680a20cfba208d2/pkg/apis/apiextensions/types.go#L276-L279) yet. You can learn more about this in <https://github.com/kubernetes/kubectl/issues/1117> and <https://github.com/helm/helm/issues/4925>.
 
-If you bump into this error we advise to re-apply the kustomization of the component.
+If you bump into this error, we advise to re-apply the manifests of the component.
 
 ---
 


### PR DESCRIPTION
# Pull Request Template for Kubeflow Manifests

## ✏️ Summary of Changes
- added a section for pre-commit in the README
- made some minor improvements in README

## 📦 Dependencies


## 🐛 Related Issues
- https://github.com/kubeflow/manifests/pull/3001#issuecomment-2666067349

## ✅ Contributor Checklist
  - [ ] I have tested these changes with kustomize. See [Installation Prerequisites](https://github.com/kubeflow/manifests#prerequisites).
  - [x] All commits are [_signed-off_](https://github.com/kubeflow/community/tree/master/dco-signoff-hook#signing-off-commits) to satisfy the DCO check.

---     
 
> You can join the CNCF Slack and access our meetings at the [Kubeflow Community](https://www.kubeflow.org/docs/about/community/) website. Our channel on the CNCF Slack is here [**#kubeflow-platform**](https://app.slack.com/client/T08PSQ7BQ/C073W572LA2).
  
