### PR TITLE
Pipelines MySQL volume permissions fix

### DIFF
--- a/apps/pipeline/upstream/third-party/mysql/base/mysql-deployment.yaml
+++ b/apps/pipeline/upstream/third-party/mysql/base/mysql-deployment.yaml
@@ -67,9 +67,9 @@ spec:
         - mountPath: /var/lib/mysql
           name: mysql-persistent-storage
         resources:
-            requests:
-              cpu: 100m
-              memory: 800Mi
+          requests:
+            cpu: 100m
+            memory: 800Mi
       volumes:
       - name: mysql-persistent-storage
         persistentVolumeClaim:

--- a/apps/pipeline/upstream/third-party/mysql/base/mysql-deployment.yaml
+++ b/apps/pipeline/upstream/third-party/mysql/base/mysql-deployment.yaml
@@ -58,8 +58,8 @@ spec:
           seccompProfile:
             type: RuntimeDefault
           runAsNonRoot: true
-          runAsUser: 1000
-          runAsGroup: 0
+          runAsUser: 999
+          runAsGroup: 999
           capabilities:
             drop:
             - ALL
@@ -70,6 +70,9 @@ spec:
           requests:
             cpu: 100m
             memory: 800Mi
+      securityContext:
+        fsGroup: 999
+        fsGroupChangePolicy: OnRootMismatch
       volumes:
       - name: mysql-persistent-storage
         persistentVolumeClaim:


### PR DESCRIPTION
# Pull Request Template for Kubeflow Manifests

## ✏️ Summary of Changes

* Add a pod `securityContext` that sets `fsGroup` and `fsGroupChangePolicy` so that volumes from previous versions of Kubeflow have their file permissions seamlessly changed to match the security context on upgrade.
* Change `runAsUser` and `runAsGroup` to 999 to match `mysql` user in container.

## 📦 Dependencies
> List any dependencies or related PRs (e.g., "Depends on #123").

## 🐛 Related Issues
Fixes #3018.

## ✅ Contributor Checklist
  - [X] I have tested these changes with kustomize. See [Installation Prerequisites](https://github.com/kubeflow/manifests#prerequisites).
  - [X] All commits are [_signed-off_](https://github.com/kubeflow/community/tree/master/dco-signoff-hook#signing-off-commits) to satisfy the DCO check.

---     
 
> You can join the CNCF Slack and access our meetings at the [Kubeflow Community](https://www.kubeflow.org/docs/about/community/) website. Our channel on the CNCF Slack is here [**#kubeflow-platform**](https://app.slack.com/client/T08PSQ7BQ/C073W572LA2).
  
