### PR TITLE
Update common/knative manifests to v1.17.0/v1.17.2.

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ used from the different projects of Kubeflow:
 | Component | Local Manifests Path | Upstream Revision |
 | - | - | - |
 | Istio | common/istio-1-24 | [1.24.2](https://github.com/istio/istio/releases/tag/1.24.2) |
-| Knative | common/knative/knative-serving <br /> common/knative/knative-eventing | [v1.16.0](https://github.com/knative/serving/releases/tag/knative-v1.16.0) <br /> [v1.16.1](https://github.com/knative/eventing/releases/tag/knative-v1.16.1) |
+| Knative | common/knative/knative-serving <br /> common/knative/knative-eventing | [v1.17.0](https://github.com/knative/serving/releases/tag/knative-v1.17.0) <br /> [v1.17.2](https://github.com/knative/eventing/releases/tag/knative-v1.17.2) |
 | Cert Manager | common/cert-manager | [1.16.1](https://github.com/cert-manager/cert-manager/releases/tag/v1.16.1) |
 
 ## Installation

--- a/common/knative/README.md
+++ b/common/knative/README.md
@@ -4,8 +4,8 @@
 
 The manifests for Knative Serving are based off the following:
 
-  - [Knative serving (v1.16.0)](https://github.com/knative/serving/releases/tag/knative-v1.16.0)
-  - [Knative ingress controller for Istio (v1.16.0)](https://github.com/knative-extensions/net-istio/releases/tag/knative-v1.16.0)
+  - [Knative serving (v1.17.0)](https://github.com/knative/serving/releases/tag/knative-v1.17.0)
+  - [Knative ingress controller for Istio (v1.17.0)](https://github.com/knative-extensions/net-istio/releases/tag/knative-v1.17.0)
 
 1. Download the knative-serving manifests with the following commands:
 
@@ -54,7 +54,7 @@ The manifests for Knative Serving are based off the following:
 
 ## Knative-Eventing
 
-The manifests for Knative Eventing are based off the [v1.16.1 release](https://github.com/knative/eventing/releases/tag/knative-v1.16.1).
+The manifests for Knative Eventing are based off the [v1.17.2 release](https://github.com/knative/eventing/releases/tag/knative-v1.17.2).
 
   - [Eventing Core](https://github.com/knative/eventing/releases/download/knative-v1.12.6/eventing-core.yaml)
   - [In-Memory Channel](https://github.com/knative/eventing/releases/download/knative-v1.12.6/in-memory-channel.yaml)

--- a/common/knative/knative-eventing-post-install-jobs/base/eventing-post-install.yaml
+++ b/common/knative/knative-eventing-post-install-jobs/base/eventing-post-install.yaml
@@ -7,7 +7,7 @@ metadata:
     app: "storage-version-migration-eventing"
     app.kubernetes.io/name: knative-eventing
     app.kubernetes.io/component: storage-version-migration-job
-    app.kubernetes.io/version: "1.16.1"
+    app.kubernetes.io/version: "1.17.2"
   name: storage-version-migration-eventing
 spec:
   ttlSecondsAfterFinished: 600
@@ -18,7 +18,7 @@ spec:
         app: "storage-version-migration-eventing"
         app.kubernetes.io/name: knative-eventing
         app.kubernetes.io/component: storage-version-migration-job
-        app.kubernetes.io/version: "1.16.1"
+        app.kubernetes.io/version: "1.17.2"
         sidecar.istio.io/inject: "false"
       annotations:
         sidecar.istio.io/inject: "false"
@@ -26,28 +26,31 @@ spec:
       serviceAccountName: knative-eventing-post-install-job
       restartPolicy: OnFailure
       containers:
-      - name: migrate
-        image: gcr.io/knative-releases/knative.dev/pkg/apiextensions/storageversion/cmd/migrate@sha256:f1786ed71c979b93e3fba02c4cfb3df33d97be0cce2c9ef994bfba4cc15a5558
-        args:
-        - "apiserversources.sources.knative.dev"
-        - "brokers.eventing.knative.dev"
-        - "channels.messaging.knative.dev"
-        - "containersources.sources.knative.dev"
-        - "eventtypes.eventing.knative.dev"
-        - "inmemorychannels.messaging.knative.dev"
-        - "parallels.flows.knative.dev"
-        - "pingsources.sources.knative.dev"
-        - "sequences.flows.knative.dev"
-        - "sinkbindings.sources.knative.dev"
-        - "subscriptions.messaging.knative.dev"
-        - "triggers.eventing.knative.dev"
-        - "jobsinks.sinks.knative.dev"
-        securityContext:
-          allowPrivilegeEscalation: false
-          readOnlyRootFilesystem: true
-          runAsNonRoot: true
-          capabilities:
-            drop:
-            - ALL
-          seccompProfile:
-            type: RuntimeDefault
+        - name: migrate
+          image: gcr.io/knative-releases/knative.dev/pkg/apiextensions/storageversion/cmd/migrate@sha256:861978f6cb0e531059f5d1ae307f99a0241f402ddd5ba103b8501e3780866cba
+          args:
+            - "apiserversources.sources.knative.dev"
+            - "brokers.eventing.knative.dev"
+            - "channels.messaging.knative.dev"
+            - "containersources.sources.knative.dev"
+            - "eventtypes.eventing.knative.dev"
+            - "inmemorychannels.messaging.knative.dev"
+            - "parallels.flows.knative.dev"
+            - "pingsources.sources.knative.dev"
+            - "sequences.flows.knative.dev"
+            - "sinkbindings.sources.knative.dev"
+            - "subscriptions.messaging.knative.dev"
+            - "triggers.eventing.knative.dev"
+            - "jobsinks.sinks.knative.dev"
+            - "eventpolicies.eventing.knative.dev"
+            - "integrationsources.sources.knative.dev"
+            - "integrationsinks.sinks.knative.dev"
+          securityContext:
+            allowPrivilegeEscalation: false
+            readOnlyRootFilesystem: true
+            runAsNonRoot: true
+            capabilities:
+              drop:
+                - ALL
+            seccompProfile:
+              type: RuntimeDefault

--- a/common/knative/knative-eventing/base/upstream/eventing-core.yaml
+++ b/common/knative/knative-eventing/base/upstream/eventing-core.yaml
@@ -3,7 +3,7 @@ kind: Namespace
 metadata:
   name: knative-eventing
   labels:
-    app.kubernetes.io/version: "1.16.1"
+    app.kubernetes.io/version: "1.17.2"
     app.kubernetes.io/name: knative-eventing
 ---
 apiVersion: v1
@@ -12,7 +12,7 @@ metadata:
   name: eventing-controller
   namespace: knative-eventing
   labels:
-    app.kubernetes.io/version: "1.16.1"
+    app.kubernetes.io/version: "1.17.2"
     app.kubernetes.io/name: knative-eventing
 ---
 apiVersion: rbac.authorization.k8s.io/v1
@@ -20,7 +20,7 @@ kind: ClusterRoleBinding
 metadata:
   name: eventing-controller
   labels:
-    app.kubernetes.io/version: "1.16.1"
+    app.kubernetes.io/version: "1.17.2"
     app.kubernetes.io/name: knative-eventing
 subjects:
   - kind: ServiceAccount
@@ -36,7 +36,7 @@ kind: ClusterRoleBinding
 metadata:
   name: eventing-controller-resolver
   labels:
-    app.kubernetes.io/version: "1.16.1"
+    app.kubernetes.io/version: "1.17.2"
     app.kubernetes.io/name: knative-eventing
 subjects:
   - kind: ServiceAccount
@@ -52,7 +52,7 @@ kind: ClusterRoleBinding
 metadata:
   name: eventing-controller-source-observer
   labels:
-    app.kubernetes.io/version: "1.16.1"
+    app.kubernetes.io/version: "1.17.2"
     app.kubernetes.io/name: knative-eventing
 subjects:
   - kind: ServiceAccount
@@ -68,7 +68,7 @@ kind: ClusterRoleBinding
 metadata:
   name: eventing-controller-sources-controller
   labels:
-    app.kubernetes.io/version: "1.16.1"
+    app.kubernetes.io/version: "1.17.2"
     app.kubernetes.io/name: knative-eventing
 subjects:
   - kind: ServiceAccount
@@ -84,7 +84,7 @@ kind: ClusterRoleBinding
 metadata:
   name: eventing-controller-manipulator
   labels:
-    app.kubernetes.io/version: "1.16.1"
+    app.kubernetes.io/version: "1.17.2"
     app.kubernetes.io/name: knative-eventing
 subjects:
   - kind: ServiceAccount
@@ -100,7 +100,7 @@ kind: ClusterRoleBinding
 metadata:
   name: eventing-controller-crossnamespace-subscriber
   labels:
-    app.kubernetes.io/version: "1.16.1"
+    app.kubernetes.io/version: "1.17.2"
     app.kubernetes.io/name: knative-eventing
 subjects:
   - kind: ServiceAccount
@@ -117,7 +117,7 @@ metadata:
   name: job-sink
   namespace: knative-eventing
   labels:
-    app.kubernetes.io/version: "1.16.1"
+    app.kubernetes.io/version: "1.17.2"
     app.kubernetes.io/name: knative-eventing
 ---
 apiVersion: rbac.authorization.k8s.io/v1
@@ -125,7 +125,7 @@ kind: ClusterRoleBinding
 metadata:
   name: knative-eventing-job-sink
   labels:
-    app.kubernetes.io/version: "1.16.1"
+    app.kubernetes.io/version: "1.17.2"
     app.kubernetes.io/name: knative-eventing
 subjects:
   - kind: ServiceAccount
@@ -142,7 +142,7 @@ metadata:
   name: pingsource-mt-adapter
   namespace: knative-eventing
   labels:
-    app.kubernetes.io/version: "1.16.1"
+    app.kubernetes.io/version: "1.17.2"
     app.kubernetes.io/name: knative-eventing
 ---
 apiVersion: rbac.authorization.k8s.io/v1
@@ -150,7 +150,7 @@ kind: ClusterRoleBinding
 metadata:
   name: knative-eventing-pingsource-mt-adapter
   labels:
-    app.kubernetes.io/version: "1.16.1"
+    app.kubernetes.io/version: "1.17.2"
     app.kubernetes.io/name: knative-eventing
 subjects:
   - kind: ServiceAccount
@@ -167,7 +167,7 @@ metadata:
   name: eventing-webhook
   namespace: knative-eventing
   labels:
-    app.kubernetes.io/version: "1.16.1"
+    app.kubernetes.io/version: "1.17.2"
     app.kubernetes.io/name: knative-eventing
 ---
 apiVersion: rbac.authorization.k8s.io/v1
@@ -175,7 +175,7 @@ kind: ClusterRoleBinding
 metadata:
   name: eventing-webhook
   labels:
-    app.kubernetes.io/version: "1.16.1"
+    app.kubernetes.io/version: "1.17.2"
     app.kubernetes.io/name: knative-eventing
 subjects:
   - kind: ServiceAccount
@@ -192,7 +192,7 @@ metadata:
   namespace: knative-eventing
   name: eventing-webhook
   labels:
-    app.kubernetes.io/version: "1.16.1"
+    app.kubernetes.io/version: "1.17.2"
     app.kubernetes.io/name: knative-eventing
 subjects:
   - kind: ServiceAccount
@@ -208,7 +208,7 @@ kind: ClusterRoleBinding
 metadata:
   name: eventing-webhook-resolver
   labels:
-    app.kubernetes.io/version: "1.16.1"
+    app.kubernetes.io/version: "1.17.2"
     app.kubernetes.io/name: knative-eventing
 subjects:
   - kind: ServiceAccount
@@ -224,7 +224,7 @@ kind: ClusterRoleBinding
 metadata:
   name: eventing-webhook-podspecable-binding
   labels:
-    app.kubernetes.io/version: "1.16.1"
+    app.kubernetes.io/version: "1.17.2"
     app.kubernetes.io/name: knative-eventing
 subjects:
   - kind: ServiceAccount
@@ -241,7 +241,7 @@ metadata:
   name: config-br-default-channel
   namespace: knative-eventing
   labels:
-    app.kubernetes.io/version: "1.16.1"
+    app.kubernetes.io/version: "1.17.2"
     app.kubernetes.io/name: knative-eventing
 data:
   channel-template-spec: |
@@ -254,7 +254,7 @@ metadata:
   name: config-br-defaults
   namespace: knative-eventing
   labels:
-    app.kubernetes.io/version: "1.16.1"
+    app.kubernetes.io/version: "1.17.2"
     app.kubernetes.io/name: knative-eventing
 data:
   default-br-config: |
@@ -275,7 +275,7 @@ metadata:
   name: default-ch-webhook
   namespace: knative-eventing
   labels:
-    app.kubernetes.io/version: "1.16.1"
+    app.kubernetes.io/version: "1.17.2"
     app.kubernetes.io/name: knative-eventing
 data:
   default-ch-config: |
@@ -294,7 +294,7 @@ metadata:
   namespace: knative-eventing
   annotations:
     knative.dev/example-checksum: "9185c153"
-    app.kubernetes.io/version: "1.16.1"
+    app.kubernetes.io/version: "1.17.2"
     app.kubernetes.io/name: knative-eventing
 data:
   _example: |
@@ -325,7 +325,7 @@ metadata:
   labels:
     knative.dev/config-propagation: original
     knative.dev/config-category: eventing
-    app.kubernetes.io/version: "1.16.1"
+    app.kubernetes.io/version: "1.17.2"
     app.kubernetes.io/name: knative-eventing
 data:
   kreference-group: "disabled"
@@ -378,7 +378,7 @@ metadata:
   name: config-leader-election
   namespace: knative-eventing
   labels:
-    app.kubernetes.io/version: "1.16.1"
+    app.kubernetes.io/version: "1.17.2"
     app.kubernetes.io/name: knative-eventing
   annotations:
     knative.dev/example-checksum: "f7948630"
@@ -426,7 +426,7 @@ metadata:
   labels:
     knative.dev/config-propagation: original
     knative.dev/config-category: eventing
-    app.kubernetes.io/version: "1.16.1"
+    app.kubernetes.io/version: "1.17.2"
     app.kubernetes.io/name: knative-eventing
 data:
   zap-logger-config: |
@@ -461,7 +461,7 @@ metadata:
   labels:
     knative.dev/config-propagation: original
     knative.dev/config-category: eventing
-    app.kubernetes.io/version: "1.16.1"
+    app.kubernetes.io/version: "1.17.2"
     app.kubernetes.io/name: knative-eventing
   annotations:
     knative.dev/example-checksum: "f46cf09d"
@@ -520,7 +520,7 @@ metadata:
   name: config-sugar
   namespace: knative-eventing
   labels:
-    app.kubernetes.io/version: "1.16.1"
+    app.kubernetes.io/version: "1.17.2"
     app.kubernetes.io/name: knative-eventing
   annotations:
     knative.dev/example-checksum: "62dfac6f"
@@ -564,7 +564,7 @@ metadata:
   labels:
     knative.dev/config-propagation: original
     knative.dev/config-category: eventing
-    app.kubernetes.io/version: "1.16.1"
+    app.kubernetes.io/version: "1.17.2"
     app.kubernetes.io/name: knative-eventing
   annotations:
     knative.dev/example-checksum: "0492ceb0"
@@ -606,7 +606,7 @@ metadata:
   labels:
     knative.dev/high-availability: "true"
     app.kubernetes.io/component: eventing-controller
-    app.kubernetes.io/version: "1.16.1"
+    app.kubernetes.io/version: "1.17.2"
     app.kubernetes.io/name: knative-eventing
     bindings.knative.dev/exclude: "true"
 spec:
@@ -618,7 +618,7 @@ spec:
       labels:
         app: eventing-controller
         app.kubernetes.io/component: eventing-controller
-        app.kubernetes.io/version: "1.16.1"
+        app.kubernetes.io/version: "1.17.2"
         app.kubernetes.io/name: knative-eventing
     spec:
       affinity:
@@ -635,7 +635,7 @@ spec:
       containers:
         - name: eventing-controller
           terminationMessagePolicy: FallbackToLogsOnError
-          image: gcr.io/knative-releases/knative.dev/eventing/cmd/controller@sha256:8157c2d59c69b2fc658bad9f795aa8b5d9b72b052916ba3c5b83921e4230cecf
+          image: gcr.io/knative-releases/knative.dev/eventing/cmd/controller@sha256:51121a4470ef1ac97ad66cdb86169927b2f48c370a59fd764fdf167252f79b03
           resources:
             requests:
               cpu: 100m
@@ -652,7 +652,7 @@ spec:
             - name: METRICS_DOMAIN
               value: knative.dev/eventing
             - name: APISERVER_RA_IMAGE
-              value: gcr.io/knative-releases/knative.dev/eventing/cmd/apiserver_receive_adapter@sha256:f3b6e75a19a1d7c2d2de15d15a5d3a5efac3a10120f2289584de2b139ea6b01a
+              value: gcr.io/knative-releases/knative.dev/eventing/cmd/apiserver_receive_adapter@sha256:73ac8f691e1a5c7f16c562ba0dbd3284169ee0d035f2e1ee49f45bb9dd032d1b
             - name: POD_NAME
               valueFrom:
                 fieldRef:
@@ -697,7 +697,7 @@ metadata:
   namespace: knative-eventing
   labels:
     app.kubernetes.io/component: job-sink
-    app.kubernetes.io/version: "1.16.1"
+    app.kubernetes.io/version: "1.17.2"
     app.kubernetes.io/name: knative-eventing
 spec:
   replicas: 1
@@ -709,7 +709,7 @@ spec:
       labels:
         sinks.knative.dev/sink: job-sink
         app.kubernetes.io/component: job-sink
-        app.kubernetes.io/version: "1.16.1"
+        app.kubernetes.io/version: "1.17.2"
         app.kubernetes.io/name: knative-eventing
     spec:
       affinity:
@@ -725,7 +725,7 @@ spec:
       containers:
         - name: job-sink
           terminationMessagePolicy: FallbackToLogsOnError
-          image: gcr.io/knative-releases/knative.dev/eventing/cmd/jobsink@sha256:e9a6e5ba3d6838f9feb26197b0f521e503cb313aba38732fc876364fc7d72dac
+          image: gcr.io/knative-releases/knative.dev/eventing/cmd/jobsink@sha256:49cdb60368ff9b3435ec3037a81d7ef49055fb439ac2e303ec71e0d31a184cf0
           env:
             - name: SYSTEM_NAMESPACE
               valueFrom:
@@ -807,7 +807,7 @@ metadata:
   labels:
     sinks.knative.dev/sink: job-sink
     app.kubernetes.io/component: job-sink
-    app.kubernetes.io/version: "1.16.1"
+    app.kubernetes.io/version: "1.17.2"
     app.kubernetes.io/name: knative-eventing
   name: job-sink
   namespace: knative-eventing
@@ -835,7 +835,7 @@ metadata:
   namespace: knative-eventing
   labels:
     app.kubernetes.io/component: pingsource-mt-adapter
-    app.kubernetes.io/version: "1.16.1"
+    app.kubernetes.io/version: "1.17.2"
     app.kubernetes.io/name: knative-eventing
     bindings.knative.dev/exclude: "true"
 spec:
@@ -850,7 +850,7 @@ spec:
         eventing.knative.dev/source: ping-source-controller
         sources.knative.dev/role: adapter
         app.kubernetes.io/component: pingsource-mt-adapter
-        app.kubernetes.io/version: "1.16.1"
+        app.kubernetes.io/version: "1.17.2"
         app.kubernetes.io/name: knative-eventing
     spec:
       affinity:
@@ -866,7 +866,7 @@ spec:
       enableServiceLinks: false
       containers:
         - name: dispatcher
-          image: gcr.io/knative-releases/knative.dev/eventing/cmd/mtping@sha256:f242272f0224da5704adf9922138acfaa971d32a03130b2f24057995032c3698
+          image: gcr.io/knative-releases/knative.dev/eventing/cmd/mtping@sha256:0c4ce6109be8ea85f9a484f8420f284e8076289f80bded8b2227470aab409c38
           env:
             - name: SYSTEM_NAMESPACE
               value: ''
@@ -898,6 +898,8 @@ spec:
             - containerPort: 9090
               name: metrics
               protocol: TCP
+            - name: probes
+              containerPort: 8080
           resources:
             requests:
               cpu: 125m
@@ -914,6 +916,22 @@ spec:
                 - ALL
             seccompProfile:
               type: RuntimeDefault
+          livenessProbe:
+            httpGet:
+              path: /health
+              port: probes
+              scheme: HTTP
+            initialDelaySeconds: 20
+            periodSeconds: 10
+            timeoutSeconds: 5
+          readinessProbe:
+            httpGet:
+              path: /readiness
+              port: probes
+              scheme: HTTP
+            initialDelaySeconds: 20
+            periodSeconds: 10
+            timeoutSeconds: 5
       serviceAccountName: pingsource-mt-adapter
 ---
 apiVersion: autoscaling/v2
@@ -923,7 +941,7 @@ metadata:
   namespace: knative-eventing
   labels:
     app.kubernetes.io/component: eventing-webhook
-    app.kubernetes.io/version: "1.16.1"
+    app.kubernetes.io/version: "1.17.2"
     app.kubernetes.io/name: knative-eventing
 spec:
   scaleTargetRef:
@@ -947,7 +965,7 @@ metadata:
   namespace: knative-eventing
   labels:
     app.kubernetes.io/component: eventing-webhook
-    app.kubernetes.io/version: "1.16.1"
+    app.kubernetes.io/version: "1.17.2"
     app.kubernetes.io/name: knative-eventing
 spec:
   minAvailable: 80%
@@ -962,7 +980,7 @@ metadata:
   namespace: knative-eventing
   labels:
     app.kubernetes.io/component: eventing-webhook
-    app.kubernetes.io/version: "1.16.1"
+    app.kubernetes.io/version: "1.17.2"
     app.kubernetes.io/name: knative-eventing
     bindings.knative.dev/exclude: "true"
 spec:
@@ -976,7 +994,7 @@ spec:
         app: eventing-webhook
         role: eventing-webhook
         app.kubernetes.io/component: eventing-webhook
-        app.kubernetes.io/version: "1.16.1"
+        app.kubernetes.io/version: "1.17.2"
         app.kubernetes.io/name: knative-eventing
     spec:
       affinity:
@@ -993,7 +1011,7 @@ spec:
       containers:
         - name: eventing-webhook
           terminationMessagePolicy: FallbackToLogsOnError
-          image: gcr.io/knative-releases/knative.dev/eventing/cmd/webhook@sha256:09f4923e016940fb87875a8d85b6d504ee3c696f45ffb3d4720cfa9b3b67cfca
+          image: gcr.io/knative-releases/knative.dev/eventing/cmd/webhook@sha256:093bedc3f7063cf3a566ea0c109440ec7f2297c155bbe26052ebc6e2edc98c67
           resources:
             requests:
               cpu: 100m
@@ -1061,7 +1079,7 @@ metadata:
   labels:
     role: eventing-webhook
     app.kubernetes.io/component: eventing-webhook
-    app.kubernetes.io/version: "1.16.1"
+    app.kubernetes.io/version: "1.17.2"
     app.kubernetes.io/name: knative-eventing
   name: eventing-webhook
   namespace: knative-eventing
@@ -1081,7 +1099,7 @@ metadata:
     eventing.knative.dev/source: "true"
     duck.knative.dev/source: "true"
     knative.dev/crd-install: "true"
-    app.kubernetes.io/version: "1.16.1"
+    app.kubernetes.io/version: "1.17.2"
     app.kubernetes.io/name: knative-eventing
   annotations:
     registry.knative.dev/eventTypes: |
@@ -1352,7 +1370,7 @@ metadata:
   labels:
     knative.dev/crd-install: "true"
     duck.knative.dev/addressable: "true"
-    app.kubernetes.io/version: "1.16.1"
+    app.kubernetes.io/version: "1.17.2"
     app.kubernetes.io/name: knative-eventing
 spec:
   group: eventing.knative.dev
@@ -1552,7 +1570,7 @@ metadata:
     knative.dev/crd-install: "true"
     messaging.knative.dev/subscribable: "true"
     duck.knative.dev/addressable: "true"
-    app.kubernetes.io/version: "1.16.1"
+    app.kubernetes.io/version: "1.17.2"
     app.kubernetes.io/name: knative-eventing
 spec:
   group: messaging.knative.dev
@@ -1895,7 +1913,7 @@ metadata:
     eventing.knative.dev/source: "true"
     duck.knative.dev/source: "true"
     knative.dev/crd-install: "true"
-    app.kubernetes.io/version: "1.16.1"
+    app.kubernetes.io/version: "1.17.2"
     app.kubernetes.io/name: knative-eventing
   name: containersources.sources.knative.dev
 spec:
@@ -2055,7 +2073,7 @@ metadata:
   name: eventpolicies.eventing.knative.dev
   labels:
     knative.dev/crd-install: "true"
-    app.kubernetes.io/version: "1.16.1"
+    app.kubernetes.io/version: "1.17.2"
     app.kubernetes.io/name: knative-eventing
 spec:
   group: eventing.knative.dev
@@ -2245,14 +2263,6 @@ spec:
       - knative
       - eventing
   scope: Namespaced
-  conversion:
-    strategy: Webhook
-    webhook:
-      conversionReviewVersions: ["v1", "v1beta1"]
-      clientConfig:
-        service:
-          name: eventing-webhook
-          namespace: knative-eventing
 ---
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
@@ -2260,7 +2270,7 @@ metadata:
   name: eventtypes.eventing.knative.dev
   labels:
     knative.dev/crd-install: "true"
-    app.kubernetes.io/version: "1.16.1"
+    app.kubernetes.io/version: "1.17.2"
     app.kubernetes.io/name: knative-eventing
 spec:
   group: eventing.knative.dev
@@ -2630,11 +2640,761 @@ spec:
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
+  name: integrationsinks.sinks.knative.dev
+  labels:
+    knative.dev/crd-install: "true"
+    duck.knative.dev/addressable: "true"
+    app.kubernetes.io/version: "1.17.2"
+    app.kubernetes.io/name: knative-eventing
+spec:
+  group: sinks.knative.dev
+  versions:
+    - name: v1alpha1
+      served: true
+      storage: true
+      subresources:
+        status: {}
+      schema:
+        openAPIV3Schema:
+          description: 'IntegrationSink sends events to generic event sink'
+          type: object
+          properties:
+            spec:
+              description: Spec defines the desired state of the IntegrationSink.
+              type: object
+              properties:
+                log:
+                  type: object
+                  properties:
+                    loggerName:
+                      type: string
+                      title: Logger Name
+                      description: Name of the logging category to use
+                      default: log-sink
+                    level:
+                      type: string
+                      title: Log Level
+                      description: Logging level to use
+                      default: INFO
+                    logMask:
+                      type: boolean
+                      title: Log Mask
+                      description: Mask sensitive information like password or passphrase in the log
+                      default: false
+                    marker:
+                      type: string
+                      title: Marker
+                      description: An optional Marker name to use
+                    multiline:
+                      type: boolean
+                      title: Multiline
+                      description: If enabled then each information is outputted on a newline
+                      default: false
+                    showAllProperties:
+                      type: boolean
+                      title: Show All Properties
+                      description: Show all of the exchange properties (both internal and custom)
+                      default: false
+                    showBody:
+                      type: boolean
+                      title: Show Body
+                      description: Show the message body
+                      default: true
+                    showBodyType:
+                      type: boolean
+                      title: Show Body Type
+                      description: Show the body Java type
+                      default: true
+                    showExchangePattern:
+                      type: boolean
+                      title: Show Exchange Pattern
+                      description: Shows the Message Exchange Pattern (or MEP for short)
+                      default: true
+                    showHeaders:
+                      type: boolean
+                      title: Show Headers
+                      description: Show the headers received
+                      default: false
+                    showProperties:
+                      type: boolean
+                      title: Show Properties
+                      description: Show the exchange properties (only custom). Use showAllProperties to show both internal and custom properties.
+                      default: false
+                    showStreams:
+                      type: boolean
+                      title: Show Streams
+                      description: Show the stream bodies (they may not be available in following steps)
+                      default: false
+                    showCachedStreams:
+                      type: boolean
+                      title: Show Cached Streams
+                      description: Whether Camel should show cached stream bodies or not.
+                      default: true
+                aws:
+                  type: object
+                  properties:
+                    s3:
+                      type: object
+                      properties:
+                        arn:
+                          type: string
+                          title: Bucket Name
+                          description: The S3 Bucket name or Amazon Resource Name (ARN).
+                        deleteAfterRead:
+                          type: boolean
+                          title: Auto-delete Objects
+                          description: Specifies to delete objects after consuming them.
+                          default: true
+                        moveAfterRead:
+                          type: boolean
+                          title: Move Objects After Delete
+                          description: Move objects from S3 bucket to a different bucket after they have been retrieved.
+                          default: false
+                        destinationBucket:
+                          type: string
+                          title: Destination Bucket
+                          description: Define the destination bucket where an object must be moved when moveAfterRead is set to true.
+                        destinationBucketPrefix:
+                          type: string
+                          title: Destination Bucket Prefix
+                          description: Define the destination bucket prefix to use when an object must be moved, and moveAfterRead is set to true.
+                        destinationBucketSuffix:
+                          type: string
+                          title: Destination Bucket Suffix
+                          description: Define the destination bucket suffix to use when an object must be moved, and moveAfterRead is set to true.
+                        region:
+                          type: string
+                          title: AWS Region
+                          description: The AWS region to access.
+                        autoCreateBucket:
+                          type: boolean
+                          title: Autocreate Bucket
+                          description: Specifies to automatically create the S3 bucket.
+                          default: false
+                        prefix:
+                          type: string
+                          title: Prefix
+                          description: The AWS S3 bucket prefix to consider while searching.
+                          example: folder/
+                        ignoreBody:
+                          type: boolean
+                          title: Ignore Body
+                          description: If true, the S3 Object body is ignored. Setting this to true overrides any behavior defined by the `includeBody` option. If false, the S3 object is put in the body.
+                          default: false
+                        uriEndpointOverride:
+                          type: string
+                          title: Overwrite Endpoint URI
+                          description: The overriding endpoint URI. To use this option, you must also select the `overrideEndpoint` option.
+                        overrideEndpoint:
+                          type: boolean
+                          title: Endpoint Overwrite
+                          description: Select this option to override the endpoint URI. To use this option, you must also provide a URI for the `uriEndpointOverride` option.
+                          default: false
+                        forcePathStyle:
+                          type: boolean
+                          title: Force Path Style
+                          description: Forces path style when accessing AWS S3 buckets.
+                          default: false
+                        delay:
+                          type: integer
+                          title: Delay
+                          description: The number of milliseconds before the next poll of the selected bucket.
+                          default: 500
+                        maxMessagesPerPoll:
+                          type: integer
+                          title: Max Messages Per Poll
+                          description: Gets the maximum number of messages as a limit to poll at each polling. Gets the maximum number of messages as a limit to poll at each polling. The default value is 10. Use 0 or a negative number to set it as unlimited.
+                          default: 10
+                    sqs:
+                      type: object
+                      properties:
+                        arn:
+                          type: string
+                          title: Queue Name
+                          description: The SQS Queue Name or ARN
+                        deleteAfterRead:
+                          type: boolean
+                          title: Auto-delete Messages
+                          description: Delete messages after consuming them
+                          default: true
+                        region:
+                          type: string
+                          title: AWS Region
+                          description: The AWS region to access.
+                        autoCreateQueue:
+                          type: boolean
+                          title: Autocreate Queue
+                          description: Setting the autocreation of the SQS queue.
+                          default: false
+                        host:
+                          type: string
+                          title: AWS Host
+                          description: The hostname of the Amazon AWS cloud.
+                          default: amazonaws.com
+                        protocol:
+                          type: string
+                          title: Protocol
+                          description: The underlying protocol used to communicate with SQS
+                          default: https
+                          example: http or https
+                        queueURL:
+                          type: string
+                          title: Queue URL
+                          description: The full SQS Queue URL (required if using KEDA)
+                        uriEndpointOverride:
+                          type: string
+                          title: Overwrite Endpoint URI
+                          description: The overriding endpoint URI. To use this option, you must also select the `overrideEndpoint` option.
+                        overrideEndpoint:
+                          type: boolean
+                          title: Endpoint Overwrite
+                          description: Select this option to override the endpoint URI. To use this option, you must also provide a URI for the `uriEndpointOverride` option.
+                          default: false
+                        delay:
+                          type: integer
+                          title: Delay
+                          description: The number of milliseconds before the next poll of the selected stream
+                          default: 500
+                        greedy:
+                          type: boolean
+                          title: Greedy Scheduler
+                          description: If greedy is enabled, then the polling will happen immediately again, if the previous run polled 1 or more messages.
+                          default: false
+                        maxMessagesPerPoll:
+                          type: integer
+                          title: Max Messages Per Poll
+                          description: The maximum number of messages to return. Amazon SQS never returns more messages than this value (however, fewer messages might be returned). Valid values 1 to 10. Default 1.
+                          default: 1
+                        waitTimeSeconds:
+                          type: integer
+                          title: Wait Time Seconds
+                          description: The duration (in seconds) for which the call waits for a message to arrive in the queue before returning. If a message is available, the call returns sooner than WaitTimeSeconds. If no messages are available and the wait time expires, the call does not return a message list.
+                        visibilityTimeout:
+                          type: integer
+                          title: Visibility Timeout
+                          description: The duration (in seconds) that the received messages are hidden from subsequent retrieve requests after being retrieved by a ReceiveMessage request.
+                    sns:
+                      type: object
+                      properties:
+                        arn:
+                          type: string
+                          title: Topic Name
+                          description: The SNS topic name name or Amazon Resource Name (ARN).
+                        region:
+                          type: string
+                          title: AWS Region
+                          description: The AWS region to access.
+                        autoCreateTopic:
+                          type: boolean
+                          title: Autocreate Topic
+                          description: Setting the autocreation of the SNS topic.
+                          default: false
+                        uriEndpointOverride:
+                          type: string
+                          title: Overwrite Endpoint URI
+                          description: The overriding endpoint URI. To use this option, you must also select the `overrideEndpoint` option.
+                        overrideEndpoint:
+                          type: boolean
+                          title: Endpoint Overwrite
+                          description: Select this option to override the endpoint URI. To use this option, you must also provide a URI for the `uriEndpointOverride` option.
+                          default: false
+                    auth:
+                      description: 'Auth configurations'
+                      type: object
+                      properties:
+                        secret:
+                          description: 'Auth secret'
+                          type: object
+                          properties:
+                            ref:
+                              description: |
+                                Secret reference.
+                              type: object
+                              required:
+                                - name
+                              properties:
+                                name:
+                                  description: 'Secret name'
+                                  type: string
+            status:
+              description: Status represents the current state of the IntegrationSink. This data may be out of date.
+              type: object
+              properties:
+                address:
+                  description: IntegrationSink is Addressable. It exposes the endpoints as URIs to get events delivered into the used Kamelet.
+                  type: object
+                  properties:
+                    name:
+                      type: string
+                    url:
+                      type: string
+                    CACerts:
+                      type: string
+                    audience:
+                      type: string
+                addresses:
+                  description: IntegrationSink is Addressable. It exposes the endpoints as URIs to get events delivered into the used Kamelet.
+                  type: array
+                  items:
+                    type: object
+                    properties:
+                      name:
+                        type: string
+                      url:
+                        type: string
+                      CACerts:
+                        type: string
+                      audience:
+                        type: string
+                annotations:
+                  description: Annotations is additional Status fields for the Resource to save some additional State as well as convey more information to the user. This is roughly akin to Annotations on any k8s resource, just the reconciler conveying richer information outwards.
+                  type: object
+                  x-kubernetes-preserve-unknown-fields: true
+                policies:
+                  description: List of applied EventPolicies
+                  type: array
+                  items:
+                    type: object
+                    properties:
+                      apiVersion:
+                        description: The API version of the applied EventPolicy. This indicates, which version of EventPolicy is supported by the resource.
+                        type: string
+                      name:
+                        description: The name of the applied EventPolicy
+                        type: string
+                conditions:
+                  description: Conditions the latest available observations of a resource's current state.
+                  type: array
+                  items:
+                    type: object
+                    required:
+                      - type
+                      - status
+                    properties:
+                      lastTransitionTime:
+                        description: 'LastTransitionTime is the last time the condition transitioned from one status to another. We use VolatileTime in place of metav1.Time to exclude this from creating equality.Semantic differences (all other things held constant).'
+                        type: string
+                      message:
+                        description: 'A human readable message indicating details about the transition.'
+                        type: string
+                      reason:
+                        description: 'The reason for the condition''s last transition.'
+                        type: string
+                      severity:
+                        description: 'Severity with which to treat failures of this type of condition. When this is not specified, it defaults to Error.'
+                        type: string
+                      status:
+                        description: 'Status of the condition, one of True, False, Unknown.'
+                        type: string
+                      type:
+                        description: 'Type of condition.'
+                        type: string
+                observedGeneration:
+                  description: ObservedGeneration is the 'Generation' of the Service that was last processed by the controller.
+                  type: integer
+                  format: int64
+      additionalPrinterColumns:
+        - name: URL
+          type: string
+          jsonPath: .status.address.url
+        - name: Age
+          type: date
+          jsonPath: .metadata.creationTimestamp
+        - name: Ready
+          type: string
+          jsonPath: ".status.conditions[?(@.type==\"Ready\")].status"
+        - name: Reason
+          type: string
+          jsonPath: ".status.conditions[?(@.type==\"Ready\")].reason"
+  names:
+    kind: IntegrationSink
+    plural: integrationsinks
+    singular: integrationsink
+    categories:
+      - all
+      - knative
+      - eventing
+      - sink
+  scope: Namespaced
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  labels:
+    eventing.knative.dev/source: "true"
+    duck.knative.dev/source: "true"
+    knative.dev/crd-install: "true"
+    app.kubernetes.io/version: "1.17.2"
+    app.kubernetes.io/name: knative-eventing
+  name: integrationsources.sources.knative.dev
+spec:
+  group: sources.knative.dev
+  versions:
+    - name: v1alpha1
+      served: true
+      storage: true
+      subresources:
+        status: {}
+      schema:
+        openAPIV3Schema:
+          description: 'IntegrationSource is an event source that starts a container image which generates events under certain situations and sends messages to a sink URI'
+          type: object
+          properties:
+            spec:
+              type: object
+              properties:
+                ceOverrides:
+                  description: CloudEventOverrides defines overrides to control the output format and modifications of the event sent to the sink.
+                  type: object
+                  properties:
+                    extensions:
+                      description: Extensions specify what attribute are added or overridden on the outbound event. Each `Extensions` key-value pair are set on the event as an attribute extension independently.
+                      type: object
+                      x-kubernetes-preserve-unknown-fields: true
+                sink:
+                  description: Sink is a reference to an object that will resolve to a uri to use as the sink.
+                  type: object
+                  properties:
+                    ref:
+                      description: Ref points to an Addressable.
+                      type: object
+                      properties:
+                        apiVersion:
+                          description: API version of the referent.
+                          type: string
+                        kind:
+                          description: 'Kind of the referent. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+                          type: string
+                        name:
+                          description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                          type: string
+                        namespace:
+                          description: 'Namespace of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/ This is optional field, it gets defaulted to the object holding it if left out.'
+                          type: string
+                    uri:
+                      description: URI can be an absolute URL(non-empty scheme and non-empty host) pointing to the target or a relative URI. Relative URIs will be resolved using the base URI retrieved from Ref.
+                      type: string
+                    CACerts:
+                      description: CACerts is the Certification Authority (CA) certificates in PEM format that the source trusts when sending events to the sink.
+                      type: string
+                    audience:
+                      description: Audience is the OIDC audience. This only needs to be set if the target is not an Addressable and thus the Audience can't be received from the target itself. If specified, it takes precedence over the target's Audience.
+                      type: string
+                timer:
+                  type: object
+                  properties:
+                    period:
+                      type: integer
+                      title: Period
+                      description: The interval (in milliseconds) to wait between producing the next message.
+                      default: 1000
+                    message:
+                      type: string
+                      title: Message
+                      description: The message to generate.
+                      example: hello world
+                    contentType:
+                      type: string
+                      title: Content Type
+                      description: The content type of the generated message.
+                      default: text/plain
+                    repeatCount:
+                      type: integer
+                      title: Repeat Count
+                      description: Specifies a maximum limit of number of fires
+                aws:
+                  type: object
+                  properties:
+                    s3:
+                      type: object
+                      properties:
+                        arn:
+                          type: string
+                          title: Bucket Name
+                          description: The S3 Bucket name or Amazon Resource Name (ARN).
+                        deleteAfterRead:
+                          type: boolean
+                          title: Auto-delete Objects
+                          description: Specifies to delete objects after consuming them.
+                          default: true
+                        moveAfterRead:
+                          type: boolean
+                          title: Move Objects After Delete
+                          description: Move objects from S3 bucket to a different bucket after they have been retrieved.
+                          default: false
+                        destinationBucket:
+                          type: string
+                          title: Destination Bucket
+                          description: Define the destination bucket where an object must be moved when moveAfterRead is set to true.
+                        destinationBucketPrefix:
+                          type: string
+                          title: Destination Bucket Prefix
+                          description: Define the destination bucket prefix to use when an object must be moved, and moveAfterRead is set to true.
+                        destinationBucketSuffix:
+                          type: string
+                          title: Destination Bucket Suffix
+                          description: Define the destination bucket suffix to use when an object must be moved, and moveAfterRead is set to true.
+                        region:
+                          type: string
+                          title: AWS Region
+                          description: The AWS region to access.
+                        autoCreateBucket:
+                          type: boolean
+                          title: Autocreate Bucket
+                          description: Specifies to automatically create the S3 bucket.
+                          default: false
+                        prefix:
+                          type: string
+                          title: Prefix
+                          description: The AWS S3 bucket prefix to consider while searching.
+                          example: folder/
+                        ignoreBody:
+                          type: boolean
+                          title: Ignore Body
+                          description: If true, the S3 Object body is ignored. Setting this to true overrides any behavior defined by the `includeBody` option. If false, the S3 object is put in the body.
+                          default: false
+                        uriEndpointOverride:
+                          type: string
+                          title: Overwrite Endpoint URI
+                          description: The overriding endpoint URI. To use this option, you must also select the `overrideEndpoint` option.
+                        overrideEndpoint:
+                          type: boolean
+                          title: Endpoint Overwrite
+                          description: Select this option to override the endpoint URI. To use this option, you must also provide a URI for the `uriEndpointOverride` option.
+                          default: false
+                        forcePathStyle:
+                          type: boolean
+                          title: Force Path Style
+                          description: Forces path style when accessing AWS S3 buckets.
+                          default: false
+                        delay:
+                          type: integer
+                          title: Delay
+                          description: The number of milliseconds before the next poll of the selected bucket.
+                          default: 500
+                        maxMessagesPerPoll:
+                          type: integer
+                          title: Max Messages Per Poll
+                          description: Gets the maximum number of messages as a limit to poll at each polling. Gets the maximum number of messages as a limit to poll at each polling. The default value is 10. Use 0 or a negative number to set it as unlimited.
+                          default: 10
+                    sqs:
+                      type: object
+                      properties:
+                        arn:
+                          type: string
+                          title: Queue Name
+                          description: The SQS Queue Name or ARN
+                        deleteAfterRead:
+                          type: boolean
+                          title: Auto-delete Messages
+                          description: Delete messages after consuming them
+                          default: true
+                        region:
+                          type: string
+                          title: AWS Region
+                          description: The AWS region to access.
+                        autoCreateQueue:
+                          type: boolean
+                          title: Autocreate Queue
+                          description: Setting the autocreation of the SQS queue.
+                          default: false
+                        host:
+                          type: string
+                          title: AWS Host
+                          description: The hostname of the Amazon AWS cloud.
+                          default: amazonaws.com
+                        protocol:
+                          type: string
+                          title: Protocol
+                          description: The underlying protocol used to communicate with SQS
+                          default: https
+                          example: http or https
+                        queueURL:
+                          type: string
+                          title: Queue URL
+                          description: The full SQS Queue URL (required if using KEDA)
+                        uriEndpointOverride:
+                          type: string
+                          title: Overwrite Endpoint URI
+                          description: The overriding endpoint URI. To use this option, you must also select the `overrideEndpoint` option.
+                        overrideEndpoint:
+                          type: boolean
+                          title: Endpoint Overwrite
+                          description: Select this option to override the endpoint URI. To use this option, you must also provide a URI for the `uriEndpointOverride` option.
+                          default: false
+                        delay:
+                          type: integer
+                          title: Delay
+                          description: The number of milliseconds before the next poll of the selected stream
+                          default: 500
+                        greedy:
+                          type: boolean
+                          title: Greedy Scheduler
+                          description: If greedy is enabled, then the polling will happen immediately again, if the previous run polled 1 or more messages.
+                          default: false
+                        maxMessagesPerPoll:
+                          type: integer
+                          title: Max Messages Per Poll
+                          description: The maximum number of messages to return. Amazon SQS never returns more messages than this value (however, fewer messages might be returned). Valid values 1 to 10. Default 1.
+                          default: 1
+                        waitTimeSeconds:
+                          type: integer
+                          title: Wait Time Seconds
+                          description: The duration (in seconds) for which the call waits for a message to arrive in the queue before returning. If a message is available, the call returns sooner than WaitTimeSeconds. If no messages are available and the wait time expires, the call does not return a message list.
+                        visibilityTimeout:
+                          type: integer
+                          title: Visibility Timeout
+                          description: The duration (in seconds) that the received messages are hidden from subsequent retrieve requests after being retrieved by a ReceiveMessage request.
+                    ddbStreams:
+                      type: object
+                      properties:
+                        table:
+                          type: string
+                          title: Table
+                          description: The name of the DynamoDB table.
+                        region:
+                          type: string
+                          title: AWS Region
+                          description: The AWS region to access.
+                        streamIteratorType:
+                          type: string
+                          title: Stream Iterator Type
+                          description: Defines where in the DynamoDB stream to start getting records. There are two enums and the value can be one of FROM_LATEST and FROM_START. Note that using FROM_START can cause a significant delay before the stream has caught up to real-time.
+                          default: FROM_LATEST
+                        uriEndpointOverride:
+                          type: string
+                          title: Overwrite Endpoint URI
+                          description: The overriding endpoint URI. To use this option, you must also select the `overrideEndpoint` option.
+                        overrideEndpoint:
+                          type: boolean
+                          title: Endpoint Overwrite
+                          description: Select this option to override the endpoint URI. To use this option, you must also provide a URI for the `uriEndpointOverride` option.
+                          default: false
+                        delay:
+                          type: integer
+                          title: Delay
+                          description: The number of milliseconds before the next poll from the database.
+                          default: 500
+                    auth:
+                      description: 'Auth configurations'
+                      type: object
+                      properties:
+                        secret:
+                          description: 'Auth secret'
+                          type: object
+                          properties:
+                            ref:
+                              description: |
+                                Secret reference.
+                              type: object
+                              required:
+                                - name
+                              properties:
+                                name:
+                                  description: 'Secret name'
+                                  type: string
+            status:
+              type: object
+              properties:
+                annotations:
+                  description: Annotations is additional Status fields for the Resource to save some additional State as well as convey more information to the user. This is roughly akin to Annotations on any k8s resource, just the reconciler conveying richer information outwards.
+                  type: object
+                  x-kubernetes-preserve-unknown-fields: true
+                auth:
+                  description: Auth provides the relevant information for OIDC authentication.
+                  type: object
+                  properties:
+                    serviceAccountName:
+                      description: ServiceAccountName is the name of the generated service account used for this components OIDC authentication.
+                      type: string
+                    serviceAccountNames:
+                      description: ServiceAccountNames is the list of names of the generated service accounts used for this components OIDC authentication.
+                      type: array
+                      items:
+                        type: string
+                ceAttributes:
+                  description: CloudEventAttributes are the specific attributes that the Source uses as part of its CloudEvents.
+                  type: array
+                  items:
+                    type: object
+                    properties:
+                      source:
+                        description: Source is the CloudEvents source attribute.
+                        type: string
+                      type:
+                        description: Type refers to the CloudEvent type attribute.
+                        type: string
+                conditions:
+                  description: Conditions the latest available observations of a resource's current state.
+                  type: array
+                  items:
+                    type: object
+                    required:
+                      - type
+                      - status
+                    properties:
+                      lastTransitionTime:
+                        description: LastTransitionTime is the last time the condition transitioned from one status to another. We use VolatileTime in place of metav1.Time to exclude this from creating equality.Semantic differences (all other things held constant).
+                        type: string
+                      message:
+                        description: A human readable message indicating details about the transition.
+                        type: string
+                      reason:
+                        description: The reason for the condition's last transition.
+                        type: string
+                      severity:
+                        description: Severity with which to treat failures of this type of condition. When this is not specified, it defaults to Error.
+                        type: string
+                      status:
+                        description: Status of the condition, one of True, False, Unknown.
+                        type: string
+                      type:
+                        description: Type of condition.
+                        type: string
+                observedGeneration:
+                  description: ObservedGeneration is the 'Generation' of the Service that was last processed by the controller.
+                  type: integer
+                  format: int64
+                sinkUri:
+                  description: SinkURI is the current active sink URI that has been configured for the Source.
+                  type: string
+                sinkCACerts:
+                  description: CACerts is the Certification Authority (CA) certificates in PEM format that the source trusts when sending events to the sink.
+                  type: string
+                sinkAudience:
+                  description: Audience is the OIDC audience of the sink.
+                  type: string
+      additionalPrinterColumns:
+        - name: Sink
+          type: string
+          jsonPath: ".status.sinkUri"
+        - name: Age
+          type: date
+          jsonPath: .metadata.creationTimestamp
+        - name: Ready
+          type: string
+          jsonPath: ".status.conditions[?(@.type==\"Ready\")].status"
+        - name: Reason
+          type: string
+          jsonPath: ".status.conditions[?(@.type=='Ready')].reason"
+  names:
+    categories:
+      - all
+      - knative
+      - sources
+    kind: IntegrationSource
+    plural: integrationsources
+    singular: integrationsource
+  scope: Namespaced
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
   name: jobsinks.sinks.knative.dev
   labels:
     knative.dev/crd-install: "true"
     duck.knative.dev/addressable: "true"
-    app.kubernetes.io/version: "1.16.1"
+    app.kubernetes.io/version: "1.17.2"
     app.kubernetes.io/name: knative-eventing
 spec:
   group: sinks.knative.dev
@@ -2709,10 +3469,6 @@ spec:
                       name:
                         description: The name of the applied EventPolicy
                         type: string
-                observedGeneration:
-                  description: ObservedGeneration is the 'Generation' of the Service that was last processed by the controller.
-                  type: integer
-                  format: int64
                 conditions:
                   description: Conditions the latest available observations of a resource's current state.
                   type: array
@@ -2775,7 +3531,7 @@ metadata:
   labels:
     knative.dev/crd-install: "true"
     duck.knative.dev/addressable: "true"
-    app.kubernetes.io/version: "1.16.1"
+    app.kubernetes.io/version: "1.17.2"
     app.kubernetes.io/name: knative-eventing
 spec:
   group: flows.knative.dev
@@ -3288,7 +4044,7 @@ metadata:
     eventing.knative.dev/source: "true"
     duck.knative.dev/source: "true"
     knative.dev/crd-install: "true"
-    app.kubernetes.io/version: "1.16.1"
+    app.kubernetes.io/version: "1.17.2"
     app.kubernetes.io/name: knative-eventing
   annotations:
     registry.knative.dev/eventTypes: |
@@ -3637,11 +4393,211 @@ spec:
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
+  name: requestreplies.eventing.knative.dev
+  labels:
+    knative.dev/crd-install: "true"
+    app.kubernetes.io/version: "1.17.2"
+    app.kubernetes.io/name: knative-eventing
+spec:
+  group: eventing.knative.dev
+  versions:
+    - name: v1alpha1
+      served: true
+      storage: true
+      subresources:
+        status: {}
+      schema:
+        openAPIV3Schema:
+          type: object
+          properties:
+            spec:
+              description: Spec defines the desired state of the RequestReply.
+              type: object
+              properties:
+                brokerRef:
+                  description: A KReference referring to the broker this RequestReply forwards events to. CrossNamespace references are not allowed.
+                  type: object
+                  properties:
+                    apiVersion:
+                      description: API Version of the broker.
+                      type: string
+                    kind:
+                      description: 'Kind of the broker. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+                      type: string
+                    name:
+                      description: 'Name of the broker. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                      type: string
+                correlationAttribute:
+                  description: The name of the cloudevent attribute where the correlation id will be set on new events.
+                  type: string
+                replyAttribute:
+                  description: The name of the cloudevents attribute which will hold the correlation id for an event which will be treated as a reply.
+                  type: string
+                secrets:
+                  description: A list of the names of one or more secrets used to sign the correlation ids and reply ids. The secrets must be in the same namespace as the requestreply resource.
+                  type: array
+                  items:
+                    type: string
+                timeout:
+                  description: A ISO8601 string representing how long RequestReply holds onto an incoming request before it times out without a reply.
+                  type: string
+                delivery:
+                  description: Delivery contains the delivery spec for each trigger to this Broker. Each trigger delivery spec, if any, overrides this global delivery spec.
+                  type: object
+                  properties:
+                    backoffDelay:
+                      description: 'BackoffDelay is the delay before retrying. More information on Duration format: - https://www.iso.org/iso-8601-date-and-time-format.html - https://en.wikipedia.org/wiki/ISO_8601  For linear policy, backoff delay is backoffDelay*<numberOfRetries>. For exponential policy, backoff delay is backoffDelay*2^<numberOfRetries>.'
+                      type: string
+                    backoffPolicy:
+                      description: BackoffPolicy is the retry backoff policy (linear, exponential).
+                      type: string
+                    deadLetterSink:
+                      description: DeadLetterSink is the sink receiving event that could not be sent to a destination.
+                      type: object
+                      properties:
+                        ref:
+                          description: Ref points to an Addressable.
+                          type: object
+                          properties:
+                            apiVersion:
+                              description: API version of the referent.
+                              type: string
+                            kind:
+                              description: 'Kind of the referent. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+                              type: string
+                            name:
+                              description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                              type: string
+                            namespace:
+                              description: 'Namespace of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/ This is optional field, it gets defaulted to the object holding it if left out.'
+                              type: string
+                        uri:
+                          description: URI can be an absolute URL(non-empty scheme and non-empty host) pointing to the target or a relative URI. Relative URIs will be resolved using the base URI retrieved from Ref.
+                          type: string
+                        CACerts:
+                          description: Certification Authority (CA) certificates in PEM format that the source trusts when sending events to the sink.
+                          type: string
+                        audience:
+                          description: Audience is the OIDC audience. This only needs to be set if the target is not an Addressable and thus the Audience can't be received from the target itself. If specified, it takes precedence over the target's Audience.
+                          type: string
+                    retry:
+                      description: Retry is the minimum number of retries the sender should attempt when sending an event before moving it to the dead letter sink.
+                      type: integer
+                      format: int32
+                  x-kubernetes-preserve-unknown-fields: true
+            status:
+              description: Status represents the current state of the RequestReply. This data may be out of date.
+              type: object
+              properties:
+                annotations:
+                  description: Annotations is additional Status fields for the Resource to save some additional State as well as convey more information to the user. This is roughly akin to Annotations on any k8s resource, just the reconciler conveying richer information outwards.
+                  type: object
+                  x-kubernetes-preserve-unknown-fields: true
+                conditions:
+                  description: Conditions the latest available observations of a resource's current state.
+                  type: array
+                  items:
+                    type: object
+                    required:
+                      - type
+                      - status
+                    properties:
+                      lastTransitionTime:
+                        description: LastTransitionTime is the last time the condition transitioned from one status to another. We use VolatileTime in place of metav1.Time to exclude this from creating equality.Semantic differences (all other things held constant).
+                        type: string
+                      message:
+                        description: A human readable message indicating details about the transition.
+                        type: string
+                      reason:
+                        description: The reason for the condition's last transition.
+                        type: string
+                      severity:
+                        description: Severity with which to treat failures of this type of condition. When this is not specified, it defaults to Error.
+                        type: string
+                      status:
+                        description: Status of the condition, one of True, False, Unknown.
+                        type: string
+                      type:
+                        description: Type of condition.
+                        type: string
+                address:
+                  description: RequestReply is Addressable. It exposes the endpoint as an URI to get events delivered.
+                  type: object
+                  properties:
+                    name:
+                      type: string
+                    url:
+                      type: string
+                    CACerts:
+                      type: string
+                    audience:
+                      type: string
+                addresses:
+                  description: RequestReply is Addressable. It exposes the endpoints as URIs to get events delivered.
+                  type: array
+                  items:
+                    type: object
+                    properties:
+                      name:
+                        type: string
+                      url:
+                        type: string
+                      CACerts:
+                        type: string
+                      audience:
+                        type: string
+                policies:
+                  description: List of applied EventPolicies
+                  type: array
+                  items:
+                    type: object
+                    properties:
+                      apiVersion:
+                        description: The API version of the applied EventPolicy. This indicates whichversion of EventPolicy is supported by the resource.
+                        type: string
+                      name:
+                        description: The name of the applied EventPolicy
+                        type: string
+                observedGeneration:
+                  description: ObservedGeneration is the 'Generation' of the Service that was last processed by the controller.
+                  type: integer
+                  format: int64
+      additionalPrinterColumns:
+        - name: URL
+          type: string
+          jsonPath: ".status.address.url"
+        - name: Ready
+          type: string
+          jsonPath: ".status.conditions[?(@.type==\"Ready\")].status"
+        - name: Reason
+          type: string
+          jsonPath: ".status.conditions[?(@.type==\"Ready\")].reason"
+  names:
+    kind: RequestReply
+    plural: requestreplies
+    singular: requestreply
+    categories:
+      - all
+      - knative
+      - eventing
+  scope: Namespaced
+  conversion:
+    strategy: Webhook
+    webhook:
+      conversionReviewVersions: ["v1", "v1beta1"]
+      clientConfig:
+        service:
+          name: eventing-webhook
+          namespace: knative-eventing
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
   name: sequences.flows.knative.dev
   labels:
     knative.dev/crd-install: "true"
     duck.knative.dev/addressable: "true"
-    app.kubernetes.io/version: "1.16.1"
+    app.kubernetes.io/version: "1.17.2"
     app.kubernetes.io/name: knative-eventing
 spec:
   group: flows.knative.dev
@@ -4010,7 +4966,7 @@ metadata:
     duck.knative.dev/source: "true"
     duck.knative.dev/binding: "true"
     knative.dev/crd-install: "true"
-    app.kubernetes.io/version: "1.16.1"
+    app.kubernetes.io/version: "1.17.2"
     app.kubernetes.io/name: knative-eventing
   name: sinkbindings.sources.knative.dev
 spec:
@@ -4211,7 +5167,7 @@ metadata:
   name: subscriptions.messaging.knative.dev
   labels:
     knative.dev/crd-install: "true"
-    app.kubernetes.io/version: "1.16.1"
+    app.kubernetes.io/version: "1.17.2"
     app.kubernetes.io/name: knative-eventing
 spec:
   group: messaging.knative.dev
@@ -4458,7 +5414,7 @@ metadata:
   name: triggers.eventing.knative.dev
   labels:
     knative.dev/crd-install: "true"
-    app.kubernetes.io/version: "1.16.1"
+    app.kubernetes.io/version: "1.17.2"
     app.kubernetes.io/name: knative-eventing
 spec:
   group: eventing.knative.dev
@@ -4718,7 +5674,7 @@ kind: ClusterRole
 metadata:
   name: addressable-resolver
   labels:
-    app.kubernetes.io/version: "1.16.1"
+    app.kubernetes.io/version: "1.17.2"
     app.kubernetes.io/name: knative-eventing
 aggregationRule:
   clusterRoleSelectors:
@@ -4732,7 +5688,7 @@ metadata:
   name: service-addressable-resolver
   labels:
     duck.knative.dev/addressable: "true"
-    app.kubernetes.io/version: "1.16.1"
+    app.kubernetes.io/version: "1.17.2"
     app.kubernetes.io/name: knative-eventing
 rules:
   - apiGroups:
@@ -4750,7 +5706,7 @@ metadata:
   name: serving-addressable-resolver
   labels:
     duck.knative.dev/addressable: "true"
-    app.kubernetes.io/version: "1.16.1"
+    app.kubernetes.io/version: "1.17.2"
     app.kubernetes.io/name: knative-eventing
 rules:
   - apiGroups:
@@ -4771,7 +5727,7 @@ metadata:
   name: channel-addressable-resolver
   labels:
     duck.knative.dev/addressable: "true"
-    app.kubernetes.io/version: "1.16.1"
+    app.kubernetes.io/version: "1.17.2"
     app.kubernetes.io/name: knative-eventing
 rules:
   - apiGroups:
@@ -4796,7 +5752,7 @@ metadata:
   name: broker-addressable-resolver
   labels:
     duck.knative.dev/addressable: "true"
-    app.kubernetes.io/version: "1.16.1"
+    app.kubernetes.io/version: "1.17.2"
     app.kubernetes.io/name: knative-eventing
 rules:
   - apiGroups:
@@ -4815,7 +5771,7 @@ metadata:
   name: flows-addressable-resolver
   labels:
     duck.knative.dev/addressable: "true"
-    app.kubernetes.io/version: "1.16.1"
+    app.kubernetes.io/version: "1.17.2"
     app.kubernetes.io/name: knative-eventing
 rules:
   - apiGroups:
@@ -4830,12 +5786,50 @@ rules:
       - list
       - watch
 ---
+kind: ClusterRole
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: jobsinks-addressable-resolver
+  labels:
+    duck.knative.dev/addressable: "true"
+    app.kubernetes.io/version: "1.17.2"
+    app.kubernetes.io/name: knative-eventing
+rules:
+  - apiGroups:
+      - sinks.knative.dev
+    resources:
+      - jobsinks
+      - jobsinks/status
+    verbs:
+      - get
+      - list
+      - watch
+---
+kind: ClusterRole
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: integrationsinks-addressable-resolver
+  labels:
+    duck.knative.dev/addressable: "true"
+    app.kubernetes.io/version: "1.17.2"
+    app.kubernetes.io/name: knative-eventing
+rules:
+  - apiGroups:
+      - sinks.knative.dev
+    resources:
+      - integrationsinks
+      - integrationsinks/status
+    verbs:
+      - get
+      - list
+      - watch
+---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   name: eventing-broker-filter
   labels:
-    app.kubernetes.io/version: "1.16.1"
+    app.kubernetes.io/version: "1.17.2"
     app.kubernetes.io/name: knative-eventing
 rules:
   - apiGroups:
@@ -4861,7 +5855,7 @@ kind: ClusterRole
 metadata:
   name: eventing-broker-ingress
   labels:
-    app.kubernetes.io/version: "1.16.1"
+    app.kubernetes.io/version: "1.17.2"
     app.kubernetes.io/name: knative-eventing
 rules:
   - apiGroups:
@@ -4878,7 +5872,7 @@ kind: ClusterRole
 metadata:
   name: eventing-config-reader
   labels:
-    app.kubernetes.io/version: "1.16.1"
+    app.kubernetes.io/version: "1.17.2"
     app.kubernetes.io/name: knative-eventing
 rules:
   - apiGroups:
@@ -4895,7 +5889,7 @@ kind: ClusterRole
 metadata:
   name: channelable-manipulator
   labels:
-    app.kubernetes.io/version: "1.16.1"
+    app.kubernetes.io/version: "1.17.2"
     app.kubernetes.io/name: knative-eventing
 aggregationRule:
   clusterRoleSelectors:
@@ -4909,7 +5903,7 @@ metadata:
   name: meta-channelable-manipulator
   labels:
     duck.knative.dev/channelable: "true"
-    app.kubernetes.io/version: "1.16.1"
+    app.kubernetes.io/version: "1.17.2"
     app.kubernetes.io/name: knative-eventing
 rules:
   - apiGroups:
@@ -4932,7 +5926,7 @@ metadata:
   name: knative-eventing-namespaced-admin
   labels:
     rbac.authorization.k8s.io/aggregate-to-admin: "true"
-    app.kubernetes.io/version: "1.16.1"
+    app.kubernetes.io/version: "1.17.2"
     app.kubernetes.io/name: knative-eventing
 rules:
   - apiGroups: ["eventing.knative.dev"]
@@ -4945,7 +5939,7 @@ metadata:
   name: knative-messaging-namespaced-admin
   labels:
     rbac.authorization.k8s.io/aggregate-to-admin: "true"
-    app.kubernetes.io/version: "1.16.1"
+    app.kubernetes.io/version: "1.17.2"
     app.kubernetes.io/name: knative-eventing
 rules:
   - apiGroups: ["messaging.knative.dev"]
@@ -4958,7 +5952,7 @@ metadata:
   name: knative-flows-namespaced-admin
   labels:
     rbac.authorization.k8s.io/aggregate-to-admin: "true"
-    app.kubernetes.io/version: "1.16.1"
+    app.kubernetes.io/version: "1.17.2"
     app.kubernetes.io/name: knative-eventing
 rules:
   - apiGroups: ["flows.knative.dev"]
@@ -4971,7 +5965,7 @@ metadata:
   name: knative-sources-namespaced-admin
   labels:
     rbac.authorization.k8s.io/aggregate-to-admin: "true"
-    app.kubernetes.io/version: "1.16.1"
+    app.kubernetes.io/version: "1.17.2"
     app.kubernetes.io/name: knative-eventing
 rules:
   - apiGroups: ["sources.knative.dev"]
@@ -4984,7 +5978,7 @@ metadata:
   name: knative-bindings-namespaced-admin
   labels:
     rbac.authorization.k8s.io/aggregate-to-admin: "true"
-    app.kubernetes.io/version: "1.16.1"
+    app.kubernetes.io/version: "1.17.2"
     app.kubernetes.io/name: knative-eventing
 rules:
   - apiGroups: ["bindings.knative.dev"]
@@ -4994,13 +5988,26 @@ rules:
 kind: ClusterRole
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
+  name: knative-sinks-namespaced-admin
+  labels:
+    rbac.authorization.k8s.io/aggregate-to-admin: "true"
+    app.kubernetes.io/version: "1.17.2"
+    app.kubernetes.io/name: knative-eventing
+rules:
+  - apiGroups: ["sinks.knative.dev"]
+    resources: ["*"]
+    verbs: ["*"]
+---
+kind: ClusterRole
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
   name: knative-eventing-namespaced-edit
   labels:
     rbac.authorization.k8s.io/aggregate-to-edit: "true"
-    app.kubernetes.io/version: "1.16.1"
+    app.kubernetes.io/version: "1.17.2"
     app.kubernetes.io/name: knative-eventing
 rules:
-  - apiGroups: ["eventing.knative.dev", "messaging.knative.dev", "sources.knative.dev", "flows.knative.dev", "bindings.knative.dev"]
+  - apiGroups: ["eventing.knative.dev", "messaging.knative.dev", "sources.knative.dev", "flows.knative.dev", "bindings.knative.dev", "sinks.knative.dev"]
     resources: ["*"]
     verbs: ["create", "update", "patch", "delete"]
 ---
@@ -5010,10 +6017,10 @@ metadata:
   name: knative-eventing-namespaced-view
   labels:
     rbac.authorization.k8s.io/aggregate-to-view: "true"
-    app.kubernetes.io/version: "1.16.1"
+    app.kubernetes.io/version: "1.17.2"
     app.kubernetes.io/name: knative-eventing
 rules:
-  - apiGroups: ["eventing.knative.dev", "messaging.knative.dev", "sources.knative.dev", "flows.knative.dev", "bindings.knative.dev"]
+  - apiGroups: ["eventing.knative.dev", "messaging.knative.dev", "sources.knative.dev", "flows.knative.dev", "bindings.knative.dev", "sinks.knative.dev"]
     resources: ["*"]
     verbs: ["get", "list", "watch"]
 ---
@@ -5022,7 +6029,7 @@ kind: ClusterRole
 metadata:
   name: knative-eventing-controller
   labels:
-    app.kubernetes.io/version: "1.16.1"
+    app.kubernetes.io/version: "1.17.2"
     app.kubernetes.io/name: knative-eventing
 rules:
   - apiGroups:
@@ -5108,6 +6115,8 @@ rules:
     resources:
       - "jobsinks"
       - "jobsinks/status"
+      - "integrationsinks"
+      - "integrationsinks/status"
     verbs:
       - "get"
       - "list"
@@ -5127,6 +6136,7 @@ rules:
       - "sinks.knative.dev"
     resources:
       - "jobsinks/finalizers"
+      - "integrationsinks/finalizers"
     verbs:
       - "update"
   - apiGroups:
@@ -5204,7 +6214,7 @@ kind: ClusterRole
 metadata:
   name: crossnamespace-subscriber
   labels:
-    app.kubernetes.io/version: "1.16.1"
+    app.kubernetes.io/version: "1.17.2"
     app.kubernetes.io/name: knative-eventing
 aggregationRule:
   clusterRoleSelectors:
@@ -5218,7 +6228,7 @@ metadata:
   name: channel-subscriber
   labels:
     duck.knative.dev/crossnamespace-subscribable: "true"
-    app.kubernetes.io/version: "1.16.1"
+    app.kubernetes.io/version: "1.17.2"
     app.kubernetes.io/name: knative-eventing
 rules:
   - apiGroups:
@@ -5234,7 +6244,7 @@ metadata:
   name: broker-subscriber
   labels:
     duck.knative.dev/crossnamespace-subscribable: "true"
-    app.kubernetes.io/version: "1.16.1"
+    app.kubernetes.io/version: "1.17.2"
     app.kubernetes.io/name: knative-eventing
 rules:
   - apiGroups:
@@ -5249,7 +6259,7 @@ kind: ClusterRole
 metadata:
   name: knative-eventing-job-sink
   labels:
-    app.kubernetes.io/version: "1.16.1"
+    app.kubernetes.io/version: "1.17.2"
     app.kubernetes.io/name: knative-eventing
 rules:
   - apiGroups:
@@ -5328,7 +6338,7 @@ kind: ClusterRole
 metadata:
   name: knative-eventing-pingsource-mt-adapter
   labels:
-    app.kubernetes.io/version: "1.16.1"
+    app.kubernetes.io/version: "1.17.2"
     app.kubernetes.io/name: knative-eventing
 rules:
   - apiGroups:
@@ -5385,7 +6395,7 @@ kind: ClusterRole
 metadata:
   name: podspecable-binding
   labels:
-    app.kubernetes.io/version: "1.16.1"
+    app.kubernetes.io/version: "1.17.2"
     app.kubernetes.io/name: knative-eventing
 aggregationRule:
   clusterRoleSelectors:
@@ -5399,7 +6409,7 @@ metadata:
   name: builtin-podspecable-binding
   labels:
     duck.knative.dev/podspecable: "true"
-    app.kubernetes.io/version: "1.16.1"
+    app.kubernetes.io/version: "1.17.2"
     app.kubernetes.io/name: knative-eventing
 rules:
   - apiGroups:
@@ -5427,7 +6437,7 @@ kind: ClusterRole
 metadata:
   name: source-observer
   labels:
-    app.kubernetes.io/version: "1.16.1"
+    app.kubernetes.io/version: "1.17.2"
     app.kubernetes.io/name: knative-eventing
 aggregationRule:
   clusterRoleSelectors:
@@ -5441,7 +6451,7 @@ metadata:
   name: eventing-sources-source-observer
   labels:
     duck.knative.dev/source: "true"
-    app.kubernetes.io/version: "1.16.1"
+    app.kubernetes.io/version: "1.17.2"
     app.kubernetes.io/name: knative-eventing
 rules:
   - apiGroups:
@@ -5451,6 +6461,7 @@ rules:
       - pingsources
       - sinkbindings
       - containersources
+      - integrationsources
     verbs:
       - get
       - list
@@ -5461,7 +6472,7 @@ kind: ClusterRole
 metadata:
   name: knative-eventing-sources-controller
   labels:
-    app.kubernetes.io/version: "1.16.1"
+    app.kubernetes.io/version: "1.17.2"
     app.kubernetes.io/name: knative-eventing
 rules:
   - apiGroups:
@@ -5505,6 +6516,9 @@ rules:
       - "containersources"
       - "containersources/status"
       - "containersources/finalizers"
+      - "integrationsources"
+      - "integrationsources/status"
+      - "integrationsources/finalizers"
     verbs:
       - "get"
       - "list"
@@ -5561,7 +6575,7 @@ kind: ClusterRole
 metadata:
   name: knative-eventing-webhook
   labels:
-    app.kubernetes.io/version: "1.16.1"
+    app.kubernetes.io/version: "1.17.2"
     app.kubernetes.io/name: knative-eventing
 rules:
   - apiGroups:
@@ -5710,7 +6724,7 @@ metadata:
   namespace: knative-eventing
   name: knative-eventing-webhook
   labels:
-    app.kubernetes.io/version: "1.16.1"
+    app.kubernetes.io/version: "1.17.2"
     app.kubernetes.io/name: knative-eventing
 rules:
   - apiGroups:
@@ -5730,7 +6744,7 @@ kind: ValidatingWebhookConfiguration
 metadata:
   name: config.webhook.eventing.knative.dev
   labels:
-    app.kubernetes.io/version: "1.16.1"
+    app.kubernetes.io/version: "1.17.2"
     app.kubernetes.io/name: knative-eventing
 webhooks:
   - admissionReviewVersions: ["v1", "v1beta1"]
@@ -5753,7 +6767,7 @@ kind: MutatingWebhookConfiguration
 metadata:
   name: webhook.eventing.knative.dev
   labels:
-    app.kubernetes.io/version: "1.16.1"
+    app.kubernetes.io/version: "1.17.2"
     app.kubernetes.io/name: knative-eventing
 webhooks:
   - admissionReviewVersions: ["v1", "v1beta1"]
@@ -5771,7 +6785,7 @@ kind: ValidatingWebhookConfiguration
 metadata:
   name: validation.webhook.eventing.knative.dev
   labels:
-    app.kubernetes.io/version: "1.16.1"
+    app.kubernetes.io/version: "1.17.2"
     app.kubernetes.io/name: knative-eventing
 webhooks:
   - admissionReviewVersions: ["v1", "v1beta1"]
@@ -5790,7 +6804,7 @@ metadata:
   name: eventing-webhook-certs
   namespace: knative-eventing
   labels:
-    app.kubernetes.io/version: "1.16.1"
+    app.kubernetes.io/version: "1.17.2"
     app.kubernetes.io/name: knative-eventing
 ---
 apiVersion: admissionregistration.k8s.io/v1
@@ -5798,7 +6812,7 @@ kind: MutatingWebhookConfiguration
 metadata:
   name: sinkbindings.webhook.sources.knative.dev
   labels:
-    app.kubernetes.io/version: "1.16.1"
+    app.kubernetes.io/version: "1.17.2"
     app.kubernetes.io/name: knative-eventing
 webhooks:
   - admissionReviewVersions: ["v1", "v1beta1"]

--- a/common/knative/knative-eventing/base/upstream/in-memory-channel.yaml
+++ b/common/knative/knative-eventing/base/upstream/in-memory-channel.yaml
@@ -4,7 +4,7 @@ metadata:
   name: imc-controller
   namespace: knative-eventing
   labels:
-    app.kubernetes.io/version: "1.16.1"
+    app.kubernetes.io/version: "1.17.2"
     app.kubernetes.io/name: knative-eventing
 ---
 apiVersion: rbac.authorization.k8s.io/v1
@@ -12,7 +12,7 @@ kind: ClusterRoleBinding
 metadata:
   name: imc-controller
   labels:
-    app.kubernetes.io/version: "1.16.1"
+    app.kubernetes.io/version: "1.17.2"
     app.kubernetes.io/name: knative-eventing
 subjects:
   - kind: ServiceAccount
@@ -29,7 +29,7 @@ metadata:
   namespace: knative-eventing
   name: imc-controller
   labels:
-    app.kubernetes.io/version: "1.16.1"
+    app.kubernetes.io/version: "1.17.2"
     app.kubernetes.io/name: knative-eventing
 subjects:
   - kind: ServiceAccount
@@ -45,7 +45,7 @@ kind: ClusterRoleBinding
 metadata:
   name: imc-controller-resolver
   labels:
-    app.kubernetes.io/version: "1.16.1"
+    app.kubernetes.io/version: "1.17.2"
     app.kubernetes.io/name: knative-eventing
 subjects:
   - kind: ServiceAccount
@@ -62,7 +62,7 @@ metadata:
   name: imc-dispatcher
   namespace: knative-eventing
   labels:
-    app.kubernetes.io/version: "1.16.1"
+    app.kubernetes.io/version: "1.17.2"
     app.kubernetes.io/name: knative-eventing
 ---
 apiVersion: rbac.authorization.k8s.io/v1
@@ -70,7 +70,7 @@ kind: ClusterRoleBinding
 metadata:
   name: imc-dispatcher
   labels:
-    app.kubernetes.io/version: "1.16.1"
+    app.kubernetes.io/version: "1.17.2"
     app.kubernetes.io/name: knative-eventing
 subjects:
   - kind: ServiceAccount
@@ -117,7 +117,7 @@ metadata:
   namespace: knative-eventing
   labels:
     app.kubernetes.io/component: imc-controller
-    app.kubernetes.io/version: "1.16.1"
+    app.kubernetes.io/version: "1.17.2"
     app.kubernetes.io/name: knative-eventing
 data:
   MaxIdleConnections: "1000"
@@ -131,7 +131,7 @@ metadata:
   labels:
     knative.dev/high-availability: "true"
     app.kubernetes.io/component: imc-controller
-    app.kubernetes.io/version: "1.16.1"
+    app.kubernetes.io/version: "1.17.2"
     app.kubernetes.io/name: knative-eventing
     bindings.knative.dev/exclude: "true"
 spec:
@@ -145,7 +145,7 @@ spec:
         messaging.knative.dev/channel: in-memory-channel
         messaging.knative.dev/role: controller
         app.kubernetes.io/component: imc-controller
-        app.kubernetes.io/version: "1.16.1"
+        app.kubernetes.io/version: "1.17.2"
         app.kubernetes.io/name: knative-eventing
     spec:
       affinity:
@@ -162,7 +162,7 @@ spec:
       enableServiceLinks: false
       containers:
         - name: controller
-          image: gcr.io/knative-releases/knative.dev/eventing/cmd/in_memory/channel_controller@sha256:c4a1ea7b53b8e9084b99e41d8558e094cacd6f3c1b59d3a0f37993d53a36020f
+          image: gcr.io/knative-releases/knative.dev/eventing/cmd/in_memory/channel_controller@sha256:1b9168f8cf92e7fa821b6c684a4148259d3cbb3b28872ad8e54b270e3366d93f
           env:
             - name: WEBHOOK_NAME
               value: inmemorychannel-webhook
@@ -179,7 +179,7 @@ spec:
                 fieldRef:
                   fieldPath: metadata.namespace
             - name: DISPATCHER_IMAGE
-              value: gcr.io/knative-releases/knative.dev/eventing/cmd/in_memory/channel_dispatcher@sha256:5bdef6a2eba6e4958ddda765b5d1f38ba390324cfb2aed1846b7ec58b53022a6
+              value: gcr.io/knative-releases/knative.dev/eventing/cmd/in_memory/channel_dispatcher@sha256:18c575d5bfc7cd2152641b44f65b412ea39e9e630df474b7ba723704cd253a7b
             - name: POD_NAME
               valueFrom:
                 fieldRef:
@@ -224,7 +224,7 @@ kind: Service
 metadata:
   labels:
     app.kubernetes.io/component: imc-controller
-    app.kubernetes.io/version: "1.16.1"
+    app.kubernetes.io/version: "1.17.2"
     app.kubernetes.io/name: knative-eventing
   name: inmemorychannel-webhook
   namespace: knative-eventing
@@ -252,7 +252,7 @@ metadata:
     messaging.knative.dev/channel: in-memory-channel
     messaging.knative.dev/role: dispatcher
     app.kubernetes.io/component: imc-dispatcher
-    app.kubernetes.io/version: "1.16.1"
+    app.kubernetes.io/version: "1.17.2"
     app.kubernetes.io/name: knative-eventing
 spec:
   selector:
@@ -279,7 +279,7 @@ metadata:
   labels:
     knative.dev/high-availability: "true"
     app.kubernetes.io/component: imc-dispatcher
-    app.kubernetes.io/version: "1.16.1"
+    app.kubernetes.io/version: "1.17.2"
     app.kubernetes.io/name: knative-eventing
     bindings.knative.dev/exclude: "true"
 spec:
@@ -293,7 +293,7 @@ spec:
         messaging.knative.dev/channel: in-memory-channel
         messaging.knative.dev/role: dispatcher
         app.kubernetes.io/component: imc-dispatcher
-        app.kubernetes.io/version: "1.16.1"
+        app.kubernetes.io/version: "1.17.2"
         app.kubernetes.io/name: knative-eventing
     spec:
       affinity:
@@ -310,7 +310,7 @@ spec:
       enableServiceLinks: false
       containers:
         - name: dispatcher
-          image: gcr.io/knative-releases/knative.dev/eventing/cmd/in_memory/channel_dispatcher@sha256:5bdef6a2eba6e4958ddda765b5d1f38ba390324cfb2aed1846b7ec58b53022a6
+          image: gcr.io/knative-releases/knative.dev/eventing/cmd/in_memory/channel_dispatcher@sha256:18c575d5bfc7cd2152641b44f65b412ea39e9e630df474b7ba723704cd253a7b
           readinessProbe:
             failureThreshold: 3
             httpGet:
@@ -378,7 +378,7 @@ metadata:
     knative.dev/crd-install: "true"
     messaging.knative.dev/subscribable: "true"
     duck.knative.dev/addressable: "true"
-    app.kubernetes.io/version: "1.16.1"
+    app.kubernetes.io/version: "1.17.2"
     app.kubernetes.io/name: knative-eventing
 spec:
   group: messaging.knative.dev
@@ -699,7 +699,7 @@ metadata:
   name: imc-addressable-resolver
   labels:
     duck.knative.dev/addressable: "true"
-    app.kubernetes.io/version: "1.16.1"
+    app.kubernetes.io/version: "1.17.2"
     app.kubernetes.io/name: knative-eventing
 rules:
   - apiGroups:
@@ -718,7 +718,7 @@ metadata:
   name: imc-channelable-manipulator
   labels:
     duck.knative.dev/channelable: "true"
-    app.kubernetes.io/version: "1.16.1"
+    app.kubernetes.io/version: "1.17.2"
     app.kubernetes.io/name: knative-eventing
 rules:
   - apiGroups:
@@ -740,7 +740,7 @@ kind: ClusterRole
 metadata:
   name: imc-controller
   labels:
-    app.kubernetes.io/version: "1.16.1"
+    app.kubernetes.io/version: "1.17.2"
     app.kubernetes.io/name: knative-eventing
 rules:
   - apiGroups:
@@ -889,7 +889,7 @@ metadata:
   name: imc-subscriber
   labels:
     duck.knative.dev/crossnamespace-subscribable: "true"
-    app.kubernetes.io/version: "1.16.1"
+    app.kubernetes.io/version: "1.17.2"
     app.kubernetes.io/name: knative-eventing
 rules:
   - apiGroups:
@@ -904,7 +904,7 @@ kind: ClusterRole
 metadata:
   name: imc-dispatcher
   labels:
-    app.kubernetes.io/version: "1.16.1"
+    app.kubernetes.io/version: "1.17.2"
     app.kubernetes.io/name: knative-eventing
 rules:
   - apiGroups:
@@ -978,7 +978,7 @@ metadata:
   namespace: knative-eventing
   name: knative-inmemorychannel-webhook
   labels:
-    app.kubernetes.io/version: "1.16.1"
+    app.kubernetes.io/version: "1.17.2"
     app.kubernetes.io/name: knative-eventing
 rules:
   - apiGroups:
@@ -998,7 +998,7 @@ kind: MutatingWebhookConfiguration
 metadata:
   name: inmemorychannel.eventing.knative.dev
   labels:
-    app.kubernetes.io/version: "1.16.1"
+    app.kubernetes.io/version: "1.17.2"
     app.kubernetes.io/name: knative-eventing
 webhooks:
   - admissionReviewVersions: ["v1"]
@@ -1016,7 +1016,7 @@ kind: ValidatingWebhookConfiguration
 metadata:
   name: validation.inmemorychannel.eventing.knative.dev
   labels:
-    app.kubernetes.io/version: "1.16.1"
+    app.kubernetes.io/version: "1.17.2"
     app.kubernetes.io/name: knative-eventing
 webhooks:
   - admissionReviewVersions: ["v1"]
@@ -1035,7 +1035,7 @@ metadata:
   name: inmemorychannel-webhook-certs
   namespace: knative-eventing
   labels:
-    app.kubernetes.io/version: "1.16.1"
+    app.kubernetes.io/version: "1.17.2"
     app.kubernetes.io/name: knative-eventing
 ---
 

--- a/common/knative/knative-eventing/base/upstream/mt-channel-broker.yaml
+++ b/common/knative/knative-eventing/base/upstream/mt-channel-broker.yaml
@@ -3,7 +3,7 @@ kind: ClusterRole
 metadata:
   name: knative-eventing-mt-channel-broker-controller
   labels:
-    app.kubernetes.io/version: "1.16.1"
+    app.kubernetes.io/version: "1.17.2"
     app.kubernetes.io/name: knative-eventing
 rules:
   - apiGroups:
@@ -36,7 +36,7 @@ kind: ClusterRole
 metadata:
   name: knative-eventing-mt-broker-filter
   labels:
-    app.kubernetes.io/version: "1.16.1"
+    app.kubernetes.io/version: "1.17.2"
     app.kubernetes.io/name: knative-eventing
 rules:
   - apiGroups:
@@ -104,7 +104,7 @@ metadata:
   name: mt-broker-filter
   namespace: knative-eventing
   labels:
-    app.kubernetes.io/version: "1.16.1"
+    app.kubernetes.io/version: "1.17.2"
     app.kubernetes.io/name: knative-eventing
 ---
 apiVersion: rbac.authorization.k8s.io/v1
@@ -112,7 +112,7 @@ kind: ClusterRole
 metadata:
   name: knative-eventing-mt-broker-ingress
   labels:
-    app.kubernetes.io/version: "1.16.1"
+    app.kubernetes.io/version: "1.17.2"
     app.kubernetes.io/name: knative-eventing
 rules:
   - apiGroups:
@@ -171,7 +171,7 @@ metadata:
   name: mt-broker-ingress-oidc
   namespace: knative-eventing
   labels:
-    app.kubernetes.io/version: "1.16.1"
+    app.kubernetes.io/version: "1.17.2"
     app.kubernetes.io/name: knative-eventing
 ---
 apiVersion: v1
@@ -180,7 +180,7 @@ metadata:
   name: mt-broker-ingress
   namespace: knative-eventing
   labels:
-    app.kubernetes.io/version: "1.16.1"
+    app.kubernetes.io/version: "1.17.2"
     app.kubernetes.io/name: knative-eventing
 ---
 apiVersion: rbac.authorization.k8s.io/v1
@@ -188,7 +188,7 @@ kind: ClusterRoleBinding
 metadata:
   name: eventing-mt-channel-broker-controller
   labels:
-    app.kubernetes.io/version: "1.16.1"
+    app.kubernetes.io/version: "1.17.2"
     app.kubernetes.io/name: knative-eventing
 subjects:
   - kind: ServiceAccount
@@ -204,7 +204,7 @@ kind: ClusterRoleBinding
 metadata:
   name: knative-eventing-mt-broker-filter
   labels:
-    app.kubernetes.io/version: "1.16.1"
+    app.kubernetes.io/version: "1.17.2"
     app.kubernetes.io/name: knative-eventing
 subjects:
   - kind: ServiceAccount
@@ -234,7 +234,7 @@ kind: ClusterRoleBinding
 metadata:
   name: knative-eventing-mt-broker-ingress
   labels:
-    app.kubernetes.io/version: "1.16.1"
+    app.kubernetes.io/version: "1.17.2"
     app.kubernetes.io/name: knative-eventing
 subjects:
   - kind: ServiceAccount
@@ -266,7 +266,7 @@ metadata:
   namespace: knative-eventing
   labels:
     app.kubernetes.io/component: broker-filter
-    app.kubernetes.io/version: "1.16.1"
+    app.kubernetes.io/version: "1.17.2"
     app.kubernetes.io/name: knative-eventing
     bindings.knative.dev/exclude: "true"
 spec:
@@ -278,7 +278,7 @@ spec:
       labels:
         eventing.knative.dev/brokerRole: filter
         app.kubernetes.io/component: broker-filter
-        app.kubernetes.io/version: "1.16.1"
+        app.kubernetes.io/version: "1.17.2"
         app.kubernetes.io/name: knative-eventing
     spec:
       serviceAccountName: mt-broker-filter
@@ -286,7 +286,7 @@ spec:
       containers:
         - name: filter
           terminationMessagePolicy: FallbackToLogsOnError
-          image: gcr.io/knative-releases/knative.dev/eventing/cmd/broker/filter@sha256:3fe93eca5e162e2a594911dd5ea32f9c5b0573c8725d151d21d9b773ab8fde78
+          image: gcr.io/knative-releases/knative.dev/eventing/cmd/broker/filter@sha256:664b3f99009600824252b3a9e6acec24ff32f6a3363a06adea4e3dad558c1e9c
           readinessProbe:
             failureThreshold: 3
             httpGet:
@@ -364,7 +364,7 @@ metadata:
   labels:
     eventing.knative.dev/brokerRole: filter
     app.kubernetes.io/component: broker-filter
-    app.kubernetes.io/version: "1.16.1"
+    app.kubernetes.io/version: "1.17.2"
     app.kubernetes.io/name: knative-eventing
   name: broker-filter
   namespace: knative-eventing
@@ -392,7 +392,7 @@ metadata:
   namespace: knative-eventing
   labels:
     app.kubernetes.io/component: broker-ingress
-    app.kubernetes.io/version: "1.16.1"
+    app.kubernetes.io/version: "1.17.2"
     app.kubernetes.io/name: knative-eventing
     bindings.knative.dev/exclude: "true"
 spec:
@@ -404,7 +404,7 @@ spec:
       labels:
         eventing.knative.dev/brokerRole: ingress
         app.kubernetes.io/component: broker-ingress
-        app.kubernetes.io/version: "1.16.1"
+        app.kubernetes.io/version: "1.17.2"
         app.kubernetes.io/name: knative-eventing
     spec:
       serviceAccountName: mt-broker-ingress
@@ -412,7 +412,7 @@ spec:
       containers:
         - name: ingress
           terminationMessagePolicy: FallbackToLogsOnError
-          image: gcr.io/knative-releases/knative.dev/eventing/cmd/broker/ingress@sha256:e40b14c0238385afc13ecb408800a2ea2550835ef2a7627beb98fc04ed131cc8
+          image: gcr.io/knative-releases/knative.dev/eventing/cmd/broker/ingress@sha256:3154a294a406ea95da0e346f878fac4ab856bc671dbfc8a8d57fa80a88f3897f
           readinessProbe:
             failureThreshold: 3
             httpGet:
@@ -490,7 +490,7 @@ metadata:
   labels:
     eventing.knative.dev/brokerRole: ingress
     app.kubernetes.io/component: broker-ingress
-    app.kubernetes.io/version: "1.16.1"
+    app.kubernetes.io/version: "1.17.2"
     app.kubernetes.io/name: knative-eventing
   name: broker-ingress
   namespace: knative-eventing
@@ -518,7 +518,7 @@ metadata:
   namespace: knative-eventing
   labels:
     app.kubernetes.io/component: mt-broker-controller
-    app.kubernetes.io/version: "1.16.1"
+    app.kubernetes.io/version: "1.17.2"
     app.kubernetes.io/name: knative-eventing
     bindings.knative.dev/exclude: "true"
 spec:
@@ -530,7 +530,7 @@ spec:
       labels:
         app: mt-broker-controller
         app.kubernetes.io/component: broker-controller
-        app.kubernetes.io/version: "1.16.1"
+        app.kubernetes.io/version: "1.17.2"
         app.kubernetes.io/name: knative-eventing
     spec:
       affinity:
@@ -547,7 +547,7 @@ spec:
       containers:
         - name: mt-broker-controller
           terminationMessagePolicy: FallbackToLogsOnError
-          image: gcr.io/knative-releases/knative.dev/eventing/cmd/mtchannel_broker@sha256:f76d14e43d6e907e8f50d2ebcc61cd2f14e9aa9a45f9936d1e4ae47532ad4fb4
+          image: gcr.io/knative-releases/knative.dev/eventing/cmd/mtchannel_broker@sha256:e16dff986c9e461791c250a072f73ed7e7c7363b6d4d4c6445f6369a37686b9c
           resources:
             requests:
               cpu: 100m
@@ -576,11 +576,29 @@ spec:
                 - ALL
             seccompProfile:
               type: RuntimeDefault
+          livenessProbe:
+            httpGet:
+              path: /health
+              port: probes
+              scheme: HTTP
+            initialDelaySeconds: 20
+            periodSeconds: 10
+            timeoutSeconds: 5
+          readinessProbe:
+            httpGet:
+              path: /readiness
+              port: probes
+              scheme: HTTP
+            initialDelaySeconds: 20
+            periodSeconds: 10
+            timeoutSeconds: 5
           ports:
             - name: metrics
               containerPort: 9090
             - name: profiling
               containerPort: 8008
+            - name: probes
+              containerPort: 8080
 ---
 apiVersion: autoscaling/v2
 kind: HorizontalPodAutoscaler
@@ -589,7 +607,7 @@ metadata:
   namespace: knative-eventing
   labels:
     app.kubernetes.io/component: broker-ingress
-    app.kubernetes.io/version: "1.16.1"
+    app.kubernetes.io/version: "1.17.2"
     app.kubernetes.io/name: knative-eventing
 spec:
   scaleTargetRef:
@@ -613,7 +631,7 @@ metadata:
   namespace: knative-eventing
   labels:
     app.kubernetes.io/component: broker-filter
-    app.kubernetes.io/version: "1.16.1"
+    app.kubernetes.io/version: "1.17.2"
     app.kubernetes.io/name: knative-eventing
 spec:
   scaleTargetRef:

--- a/common/knative/knative-serving-post-install-jobs/base/serving-post-install-jobs.yaml
+++ b/common/knative/knative-serving-post-install-jobs/base/serving-post-install-jobs.yaml
@@ -7,7 +7,7 @@ metadata:
     app: storage-version-migration-serving
     app.kubernetes.io/name: knative-serving
     app.kubernetes.io/component: storage-version-migration-job
-    app.kubernetes.io/version: "1.16.0"
+    app.kubernetes.io/version: "1.17.0"
   name: storage-version-migration-serving
 spec:
   ttlSecondsAfterFinished: 600
@@ -18,33 +18,33 @@ spec:
         app: storage-version-migration-serving
         app.kubernetes.io/name: knative-serving
         app.kubernetes.io/component: storage-version-migration-job
-        app.kubernetes.io/version: "1.16.0"
+        app.kubernetes.io/version: "1.17.0"
         sidecar.istio.io/inject: "false"
     spec:
       serviceAccountName: controller
       restartPolicy: OnFailure
       containers:
-      - name: migrate
-        image: gcr.io/knative-releases/knative.dev/pkg/apiextensions/storageversion/cmd/migrate@sha256:c2f7830569ab0b9f40ba785796d7a1d3e2069987528f5ca945ab7a339b0d96e7
-        args:
-        - "services.serving.knative.dev"
-        - "configurations.serving.knative.dev"
-        - "revisions.serving.knative.dev"
-        - "routes.serving.knative.dev"
-        - "domainmappings.serving.knative.dev"
-        resources:
-          requests:
-            cpu: 100m
-            memory: 100Mi
-          limits:
-            cpu: 1000m
-            memory: 1000Mi
-        securityContext:
-          allowPrivilegeEscalation: false
-          readOnlyRootFilesystem: true
-          runAsNonRoot: true
-          capabilities:
-            drop:
-            - ALL
-          seccompProfile:
-            type: RuntimeDefault
+        - name: migrate
+          image: gcr.io/knative-releases/knative.dev/pkg/apiextensions/storageversion/cmd/migrate@sha256:c7ae2bf09e8f4236fad16705aa2ec69ab69e0f31ebd53159a6b0d734039538b4
+          args:
+            - "services.serving.knative.dev"
+            - "configurations.serving.knative.dev"
+            - "revisions.serving.knative.dev"
+            - "routes.serving.knative.dev"
+            - "domainmappings.serving.knative.dev"
+          resources:
+            requests:
+              cpu: 100m
+              memory: 100Mi
+            limits:
+              cpu: 1000m
+              memory: 1000Mi
+          securityContext:
+            allowPrivilegeEscalation: false
+            readOnlyRootFilesystem: true
+            runAsNonRoot: true
+            capabilities:
+              drop:
+                - ALL
+            seccompProfile:
+              type: RuntimeDefault

--- a/common/knative/knative-serving/base/upstream/net-istio.yaml
+++ b/common/knative/knative-serving/base/upstream/net-istio.yaml
@@ -5,7 +5,7 @@ metadata:
   labels:
     app.kubernetes.io/component: net-istio
     app.kubernetes.io/name: knative-serving
-    app.kubernetes.io/version: "1.16.0"
+    app.kubernetes.io/version: "1.17.0"
     serving.knative.dev/controller: "true"
     networking.knative.dev/ingress-provider: istio
 rules:
@@ -21,7 +21,7 @@ metadata:
   labels:
     app.kubernetes.io/component: net-istio
     app.kubernetes.io/name: knative-serving
-    app.kubernetes.io/version: "1.16.0"
+    app.kubernetes.io/version: "1.17.0"
     networking.knative.dev/ingress-provider: istio
 spec:
   selector:
@@ -42,7 +42,7 @@ metadata:
   labels:
     app.kubernetes.io/component: net-istio
     app.kubernetes.io/name: knative-serving
-    app.kubernetes.io/version: "1.16.0"
+    app.kubernetes.io/version: "1.17.0"
     networking.knative.dev/ingress-provider: istio
 spec:
   selector:
@@ -63,7 +63,7 @@ metadata:
   labels:
     app.kubernetes.io/component: net-istio
     app.kubernetes.io/name: knative-serving
-    app.kubernetes.io/version: "1.16.0"
+    app.kubernetes.io/version: "1.17.0"
     networking.knative.dev/ingress-provider: istio
     experimental.istio.io/disable-gateway-port-translation: "true"
 spec:
@@ -86,7 +86,7 @@ metadata:
   labels:
     app.kubernetes.io/component: net-istio
     app.kubernetes.io/name: knative-serving
-    app.kubernetes.io/version: "1.16.0"
+    app.kubernetes.io/version: "1.17.0"
     networking.knative.dev/ingress-provider: istio
 data:
   _example: |
@@ -192,7 +192,7 @@ metadata:
   labels:
     app.kubernetes.io/component: net-istio
     app.kubernetes.io/name: knative-serving
-    app.kubernetes.io/version: "1.16.0"
+    app.kubernetes.io/version: "1.17.0"
     networking.knative.dev/ingress-provider: istio
 spec:
   selector:
@@ -210,7 +210,7 @@ metadata:
   labels:
     app.kubernetes.io/component: net-istio
     app.kubernetes.io/name: knative-serving
-    app.kubernetes.io/version: "1.16.0"
+    app.kubernetes.io/version: "1.17.0"
     networking.knative.dev/ingress-provider: istio
 spec:
   selector:
@@ -228,7 +228,7 @@ metadata:
   labels:
     app.kubernetes.io/component: net-istio
     app.kubernetes.io/name: knative-serving
-    app.kubernetes.io/version: "1.16.0"
+    app.kubernetes.io/version: "1.17.0"
     networking.knative.dev/ingress-provider: istio
 spec:
   selector:
@@ -241,12 +241,12 @@ spec:
         app: net-istio-controller
         app.kubernetes.io/component: net-istio
         app.kubernetes.io/name: knative-serving
-        app.kubernetes.io/version: "1.16.0"
+        app.kubernetes.io/version: "1.17.0"
     spec:
       serviceAccountName: controller
       containers:
         - name: controller
-          image: gcr.io/knative-releases/knative.dev/net-istio/cmd/controller@sha256:e70bc675f97778da144157f125b3001124ba7a5903b85dab9e77776352fea1c7
+          image: gcr.io/knative-releases/knative.dev/net-istio/cmd/controller@sha256:781a242ee3f5fcf79264b98c65aff8185427404c51ab8ff723e2ebfaf085c593
           resources:
             requests:
               cpu: 30m
@@ -306,7 +306,7 @@ metadata:
   labels:
     app.kubernetes.io/component: net-istio
     app.kubernetes.io/name: knative-serving
-    app.kubernetes.io/version: "1.16.0"
+    app.kubernetes.io/version: "1.17.0"
     networking.knative.dev/ingress-provider: istio
 spec:
   selector:
@@ -320,12 +320,12 @@ spec:
         role: net-istio-webhook
         app.kubernetes.io/component: net-istio
         app.kubernetes.io/name: knative-serving
-        app.kubernetes.io/version: "1.16.0"
+        app.kubernetes.io/version: "1.17.0"
     spec:
       serviceAccountName: controller
       containers:
         - name: webhook
-          image: gcr.io/knative-releases/knative.dev/net-istio/cmd/webhook@sha256:7d76a6d42d139ed53aae3ca2dfd600b1c776eb85a17af64dd1b604176a4b132a
+          image: gcr.io/knative-releases/knative.dev/net-istio/cmd/webhook@sha256:846e3e40ac21966cbaa4e2aeaa856f0faa8fb26cfaf8e23baada1bad4087be8e
           resources:
             requests:
               cpu: 20m
@@ -385,7 +385,7 @@ metadata:
   labels:
     app.kubernetes.io/component: net-istio
     app.kubernetes.io/name: knative-serving
-    app.kubernetes.io/version: "1.16.0"
+    app.kubernetes.io/version: "1.17.0"
     networking.knative.dev/ingress-provider: istio
 ---
 apiVersion: v1
@@ -397,7 +397,7 @@ metadata:
     role: net-istio-webhook
     app.kubernetes.io/component: net-istio
     app.kubernetes.io/name: knative-serving
-    app.kubernetes.io/version: "1.16.0"
+    app.kubernetes.io/version: "1.17.0"
     networking.knative.dev/ingress-provider: istio
 spec:
   ports:
@@ -420,7 +420,7 @@ metadata:
   labels:
     app.kubernetes.io/component: net-istio
     app.kubernetes.io/name: knative-serving
-    app.kubernetes.io/version: "1.16.0"
+    app.kubernetes.io/version: "1.17.0"
     networking.knative.dev/ingress-provider: istio
 webhooks:
   - admissionReviewVersions:
@@ -444,7 +444,7 @@ metadata:
   labels:
     app.kubernetes.io/component: net-istio
     app.kubernetes.io/name: knative-serving
-    app.kubernetes.io/version: "1.16.0"
+    app.kubernetes.io/version: "1.17.0"
     networking.knative.dev/ingress-provider: istio
 webhooks:
   - admissionReviewVersions:

--- a/common/knative/knative-serving/base/upstream/serving-core.yaml
+++ b/common/knative/knative-serving/base/upstream/serving-core.yaml
@@ -4,7 +4,7 @@ metadata:
   name: knative-serving
   labels:
     app.kubernetes.io/name: knative-serving
-    app.kubernetes.io/version: "1.16.0"
+    app.kubernetes.io/version: "1.17.0"
 ---
 kind: Role
 apiVersion: rbac.authorization.k8s.io/v1
@@ -13,7 +13,7 @@ metadata:
   namespace: knative-serving
   labels:
     serving.knative.dev/controller: "true"
-    app.kubernetes.io/version: "1.16.0"
+    app.kubernetes.io/version: "1.17.0"
     app.kubernetes.io/name: knative-serving
 rules:
   - apiGroups: [""]
@@ -30,7 +30,7 @@ metadata:
   name: knative-serving-activator-cluster
   labels:
     serving.knative.dev/controller: "true"
-    app.kubernetes.io/version: "1.16.0"
+    app.kubernetes.io/version: "1.17.0"
     app.kubernetes.io/name: knative-serving
 rules:
   - apiGroups: [""]
@@ -45,7 +45,7 @@ kind: ClusterRole
 metadata:
   name: knative-serving-aggregated-addressable-resolver
   labels:
-    app.kubernetes.io/version: "1.16.0"
+    app.kubernetes.io/version: "1.17.0"
     app.kubernetes.io/name: knative-serving
 aggregationRule:
   clusterRoleSelectors:
@@ -57,7 +57,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: knative-serving-addressable-resolver
   labels:
-    app.kubernetes.io/version: "1.16.0"
+    app.kubernetes.io/version: "1.17.0"
     app.kubernetes.io/name: knative-serving
     duck.knative.dev/addressable: "true"
 rules:
@@ -79,7 +79,7 @@ metadata:
   name: knative-serving-namespaced-admin
   labels:
     rbac.authorization.k8s.io/aggregate-to-admin: "true"
-    app.kubernetes.io/version: "1.16.0"
+    app.kubernetes.io/version: "1.17.0"
     app.kubernetes.io/name: knative-serving
 rules:
   - apiGroups: ["serving.knative.dev"]
@@ -95,7 +95,7 @@ metadata:
   name: knative-serving-namespaced-edit
   labels:
     rbac.authorization.k8s.io/aggregate-to-edit: "true"
-    app.kubernetes.io/version: "1.16.0"
+    app.kubernetes.io/version: "1.17.0"
     app.kubernetes.io/name: knative-serving
 rules:
   - apiGroups: ["serving.knative.dev"]
@@ -111,7 +111,7 @@ metadata:
   name: knative-serving-namespaced-view
   labels:
     rbac.authorization.k8s.io/aggregate-to-view: "true"
-    app.kubernetes.io/version: "1.16.0"
+    app.kubernetes.io/version: "1.17.0"
     app.kubernetes.io/name: knative-serving
 rules:
   - apiGroups: ["serving.knative.dev", "networking.internal.knative.dev", "autoscaling.internal.knative.dev", "caching.internal.knative.dev"]
@@ -124,7 +124,7 @@ metadata:
   name: knative-serving-core
   labels:
     serving.knative.dev/controller: "true"
-    app.kubernetes.io/version: "1.16.0"
+    app.kubernetes.io/version: "1.17.0"
     app.kubernetes.io/name: knative-serving
 rules:
   - apiGroups: [""]
@@ -173,7 +173,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: knative-serving-podspecable-binding
   labels:
-    app.kubernetes.io/version: "1.16.0"
+    app.kubernetes.io/version: "1.17.0"
     app.kubernetes.io/name: knative-serving
     duck.knative.dev/podspecable: "true"
 rules:
@@ -195,7 +195,7 @@ metadata:
   labels:
     app.kubernetes.io/component: controller
     app.kubernetes.io/name: knative-serving
-    app.kubernetes.io/version: "1.16.0"
+    app.kubernetes.io/version: "1.17.0"
 ---
 kind: ClusterRole
 apiVersion: rbac.authorization.k8s.io/v1
@@ -203,7 +203,7 @@ metadata:
   name: knative-serving-admin
   labels:
     app.kubernetes.io/name: knative-serving
-    app.kubernetes.io/version: "1.16.0"
+    app.kubernetes.io/version: "1.17.0"
 aggregationRule:
   clusterRoleSelectors:
     - matchLabels:
@@ -216,7 +216,7 @@ metadata:
   labels:
     app.kubernetes.io/component: controller
     app.kubernetes.io/name: knative-serving
-    app.kubernetes.io/version: "1.16.0"
+    app.kubernetes.io/version: "1.17.0"
 subjects:
   - kind: ServiceAccount
     name: controller
@@ -233,7 +233,7 @@ metadata:
   labels:
     app.kubernetes.io/component: controller
     app.kubernetes.io/name: knative-serving
-    app.kubernetes.io/version: "1.16.0"
+    app.kubernetes.io/version: "1.17.0"
 subjects:
   - kind: ServiceAccount
     name: controller
@@ -251,7 +251,7 @@ metadata:
   labels:
     app.kubernetes.io/component: activator
     app.kubernetes.io/name: knative-serving
-    app.kubernetes.io/version: "1.16.0"
+    app.kubernetes.io/version: "1.17.0"
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
@@ -261,7 +261,7 @@ metadata:
   labels:
     app.kubernetes.io/component: activator
     app.kubernetes.io/name: knative-serving
-    app.kubernetes.io/version: "1.16.0"
+    app.kubernetes.io/version: "1.17.0"
 subjects:
   - kind: ServiceAccount
     name: activator
@@ -278,7 +278,7 @@ metadata:
   labels:
     app.kubernetes.io/component: activator
     app.kubernetes.io/name: knative-serving
-    app.kubernetes.io/version: "1.16.0"
+    app.kubernetes.io/version: "1.17.0"
 subjects:
   - kind: ServiceAccount
     name: activator
@@ -294,7 +294,7 @@ metadata:
   name: images.caching.internal.knative.dev
   labels:
     app.kubernetes.io/name: knative-serving
-    app.kubernetes.io/version: "1.16.0"
+    app.kubernetes.io/version: "1.17.0"
     knative.dev/crd-install: "true"
 spec:
   group: caching.internal.knative.dev
@@ -362,9 +362,7 @@ spec:
                           This field is effectively required, but due to backwards compatibility is
                           allowed to be empty. Instances of this type with an empty value here are
                           almost certainly wrong.
-                          TODO: Add other useful fields. apiVersion, kind, uid?
                           More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                          TODO: Drop `kubebuilder:default` when controller-gen doesn't need it https://github.com/kubernetes-sigs/kubebuilder/issues/3896.
                         type: string
                         default: ""
                     x-kubernetes-map-type: atomic
@@ -456,7 +454,7 @@ metadata:
   labels:
     app.kubernetes.io/name: knative-serving
     app.kubernetes.io/component: networking
-    app.kubernetes.io/version: "1.16.0"
+    app.kubernetes.io/version: "1.17.0"
     knative.dev/crd-install: "true"
 spec:
   group: networking.internal.knative.dev
@@ -625,7 +623,7 @@ metadata:
   name: configurations.serving.knative.dev
   labels:
     app.kubernetes.io/name: knative-serving
-    app.kubernetes.io/version: "1.16.0"
+    app.kubernetes.io/version: "1.17.0"
     knative.dev/crd-install: "true"
     duck.knative.dev/podspecable: "true"
 spec:
@@ -821,9 +819,7 @@ spec:
                                                 This field is effectively required, but due to backwards compatibility is
                                                 allowed to be empty. Instances of this type with an empty value here are
                                                 almost certainly wrong.
-                                                TODO: Add other useful fields. apiVersion, kind, uid?
                                                 More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                                TODO: Drop `kubebuilder:default` when controller-gen doesn't need it https://github.com/kubernetes-sigs/kubebuilder/issues/3896.
                                               type: string
                                               default: ""
                                             optional:
@@ -831,15 +827,17 @@ spec:
                                               type: boolean
                                           x-kubernetes-map-type: atomic
                                         fieldRef:
-                                          description: This is accessible behind a feature flag - kubernetes.podspec-fieldref
+                                          description: |-
+                                            This is accessible behind a feature flag - kubernetes.podspec-fieldref
                                           type: object
-                                          x-kubernetes-preserve-unknown-fields: true
                                           x-kubernetes-map-type: atomic
+                                          x-kubernetes-preserve-unknown-fields: true
                                         resourceFieldRef:
-                                          description: This is accessible behind a feature flag - kubernetes.podspec-fieldref
+                                          description: |-
+                                            This is accessible behind a feature flag - kubernetes.podspec-fieldref
                                           type: object
-                                          x-kubernetes-preserve-unknown-fields: true
                                           x-kubernetes-map-type: atomic
+                                          x-kubernetes-preserve-unknown-fields: true
                                         secretKeyRef:
                                           description: Selects a key of a secret in the pod's namespace
                                           type: object
@@ -855,9 +853,7 @@ spec:
                                                 This field is effectively required, but due to backwards compatibility is
                                                 allowed to be empty. Instances of this type with an empty value here are
                                                 almost certainly wrong.
-                                                TODO: Add other useful fields. apiVersion, kind, uid?
                                                 More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                                TODO: Drop `kubebuilder:default` when controller-gen doesn't need it https://github.com/kubernetes-sigs/kubebuilder/issues/3896.
                                               type: string
                                               default: ""
                                             optional:
@@ -890,9 +886,7 @@ spec:
                                             This field is effectively required, but due to backwards compatibility is
                                             allowed to be empty. Instances of this type with an empty value here are
                                             almost certainly wrong.
-                                            TODO: Add other useful fields. apiVersion, kind, uid?
                                             More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                            TODO: Drop `kubebuilder:default` when controller-gen doesn't need it https://github.com/kubernetes-sigs/kubebuilder/issues/3896.
                                           type: string
                                           default: ""
                                         optional:
@@ -912,9 +906,7 @@ spec:
                                             This field is effectively required, but due to backwards compatibility is
                                             allowed to be empty. Instances of this type with an empty value here are
                                             almost certainly wrong.
-                                            TODO: Add other useful fields. apiVersion, kind, uid?
                                             More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                            TODO: Drop `kubebuilder:default` when controller-gen doesn't need it https://github.com/kubernetes-sigs/kubebuilder/issues/3896.
                                           type: string
                                           default: ""
                                         optional:
@@ -969,8 +961,6 @@ spec:
                                   grpc:
                                     description: GRPC specifies an action involving a GRPC port.
                                     type: object
-                                    required:
-                                      - port
                                     properties:
                                       port:
                                         description: Port number of the gRPC service. Number must be in the range 1 to 65535.
@@ -981,9 +971,9 @@ spec:
                                           Service is the name of the service to place in the gRPC HealthCheckRequest
                                           (see https://github.com/grpc/grpc/blob/master/doc/health-checking.md).
 
-
                                           If this is not specified, the default behavior is defined by gRPC.
                                         type: string
+                                        default: ""
                                   httpGet:
                                     description: HTTPGet specifies the http request to perform.
                                     type: object
@@ -1036,7 +1026,8 @@ spec:
                                     type: integer
                                     format: int32
                                   periodSeconds:
-                                    description: How often (in seconds) to perform the probe.
+                                    description: |-
+                                      How often (in seconds) to perform the probe.
                                     type: integer
                                     format: int32
                                   successThreshold:
@@ -1087,8 +1078,6 @@ spec:
                                 items:
                                   description: ContainerPort represents a network port in a single container.
                                   type: object
-                                  required:
-                                    - containerPort
                                   properties:
                                     containerPort:
                                       description: |-
@@ -1108,10 +1097,6 @@ spec:
                                         Defaults to "TCP".
                                       type: string
                                       default: TCP
-                                x-kubernetes-list-map-keys:
-                                  - containerPort
-                                  - protocol
-                                x-kubernetes-list-type: map
                               readinessProbe:
                                 description: |-
                                   Periodic probe of container service readiness.
@@ -1144,8 +1129,6 @@ spec:
                                   grpc:
                                     description: GRPC specifies an action involving a GRPC port.
                                     type: object
-                                    required:
-                                      - port
                                     properties:
                                       port:
                                         description: Port number of the gRPC service. Number must be in the range 1 to 65535.
@@ -1156,9 +1139,9 @@ spec:
                                           Service is the name of the service to place in the gRPC HealthCheckRequest
                                           (see https://github.com/grpc/grpc/blob/master/doc/health-checking.md).
 
-
                                           If this is not specified, the default behavior is defined by gRPC.
                                         type: string
+                                        default: ""
                                   httpGet:
                                     description: HTTPGet specifies the http request to perform.
                                     type: object
@@ -1211,7 +1194,8 @@ spec:
                                     type: integer
                                     format: int32
                                   periodSeconds:
-                                    description: How often (in seconds) to perform the probe.
+                                    description: |-
+                                      How often (in seconds) to perform the probe.
                                     type: integer
                                     format: int32
                                   successThreshold:
@@ -1250,33 +1234,6 @@ spec:
                                   More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
                                 type: object
                                 properties:
-                                  claims:
-                                    description: |-
-                                      Claims lists the names of resources, defined in spec.resourceClaims,
-                                      that are used by this container.
-
-
-                                      This is an alpha field and requires enabling the
-                                      DynamicResourceAllocation feature gate.
-
-
-                                      This field is immutable. It can only be set for containers.
-                                    type: array
-                                    items:
-                                      description: ResourceClaim references one entry in PodSpec.ResourceClaims.
-                                      type: object
-                                      required:
-                                        - name
-                                      properties:
-                                        name:
-                                          description: |-
-                                            Name must match the name of one entry in pod.spec.resourceClaims of
-                                            the Pod where this field is used. It makes that resource available
-                                            inside a container.
-                                          type: string
-                                    x-kubernetes-list-map-keys:
-                                      - name
-                                    x-kubernetes-list-type: map
                                   limits:
                                     description: |-
                                       Limits describes the maximum amount of compute resources allowed.
@@ -1339,6 +1296,10 @@ spec:
                                           description: Capability represent POSIX capabilities type
                                           type: string
                                         x-kubernetes-list-type: atomic
+                                  privileged:
+                                    description: |-
+                                      Run container in privileged mode. This can only be set to explicitly to 'false'
+                                    type: boolean
                                   readOnlyRootFilesystem:
                                     description: |-
                                       Whether this container has a read-only root filesystem.
@@ -1394,7 +1355,6 @@ spec:
                                           type indicates which kind of seccomp profile will be applied.
                                           Valid options are:
 
-
                                           Localhost - a profile defined in a file on the node should be used.
                                           RuntimeDefault - the container runtime default profile should be used.
                                           Unconfined - no profile should be applied.
@@ -1434,8 +1394,6 @@ spec:
                                   grpc:
                                     description: GRPC specifies an action involving a GRPC port.
                                     type: object
-                                    required:
-                                      - port
                                     properties:
                                       port:
                                         description: Port number of the gRPC service. Number must be in the range 1 to 65535.
@@ -1446,9 +1404,9 @@ spec:
                                           Service is the name of the service to place in the gRPC HealthCheckRequest
                                           (see https://github.com/grpc/grpc/blob/master/doc/health-checking.md).
 
-
                                           If this is not specified, the default behavior is defined by gRPC.
                                         type: string
+                                        default: ""
                                   httpGet:
                                     description: HTTPGet specifies the http request to perform.
                                     type: object
@@ -1501,7 +1459,8 @@ spec:
                                     type: integer
                                     format: int32
                                   periodSeconds:
-                                    description: How often (in seconds) to perform the probe.
+                                    description: |-
+                                      How often (in seconds) to perform the probe.
                                     type: integer
                                     format: int32
                                   successThreshold:
@@ -1594,34 +1553,39 @@ spec:
                                   Cannot be updated.
                                 type: string
                         dnsConfig:
-                          description: This is accessible behind a feature flag - kubernetes.podspec-dnsconfig
+                          description: |-
+                            This is accessible behind a feature flag - kubernetes.podspec-dnsconfig
                           type: object
                           x-kubernetes-preserve-unknown-fields: true
                         dnsPolicy:
-                          description: This is accessible behind a feature flag - kubernetes.podspec-dnspolicy
+                          description: |-
+                            This is accessible behind a feature flag - kubernetes.podspec-dnspolicy
                           type: string
                         enableServiceLinks:
-                          description: 'EnableServiceLinks indicates whether information about services should be injected into pod''s environment variables, matching the syntax of Docker links. Optional: Knative defaults this to false.'
+                          description: |-
+                            EnableServiceLinks indicates whether information aboutservices should be injected into pod's environment variables, matching the syntax of Docker links. Optional: Knative defaults this to false.
                           type: boolean
                         hostAliases:
-                          description: This is accessible behind a feature flag - kubernetes.podspec-hostaliases
+                          description: |-
+                            This is accessible behind a feature flag - kubernetes.podspec-hostaliases
                           type: array
                           items:
-                            description: This is accessible behind a feature flag - kubernetes.podspec-hostaliases
+                            description: |-
+                              This is accessible behind a feature flag - kubernetes.podspec-hostaliases
                             type: object
                             x-kubernetes-preserve-unknown-fields: true
                         hostIPC:
-                          description: This is accessible behind a feature flag - kubernetes.podspec-hostipc
+                          description: |-
+                            This is accessible behind a feature flag - kubernetes.podspec-hostipc
                           type: boolean
-                          x-kubernetes-preserve-unknown-fields: true
                         hostNetwork:
-                          description: This is accessible behind a feature flag - kubernetes.podspec-hostnetwork
+                          description: |-
+                            This is accessible behind a feature flag - kubernetes.podspec-hostnetwork
                           type: boolean
-                          x-kubernetes-preserve-unknown-fields: true
                         hostPID:
-                          description: This is accessible behind a feature flag - kubernetes.podspec-hostpid
+                          description: |-
+                            This is accessible behind a feature flag - kubernetes.podspec-hostpid
                           type: boolean
-                          x-kubernetes-preserve-unknown-fields: true
                         idleTimeoutSeconds:
                           description: |-
                             IdleTimeoutSeconds is the maximum duration in seconds a request will be allowed
@@ -1647,9 +1611,7 @@ spec:
                                   This field is effectively required, but due to backwards compatibility is
                                   allowed to be empty. Instances of this type with an empty value here are
                                   almost certainly wrong.
-                                  TODO: Add other useful fields. apiVersion, kind, uid?
                                   More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                  TODO: Drop `kubebuilder:default` when controller-gen doesn't need it https://github.com/kubernetes-sigs/kubebuilder/issues/3896.
                                 type: string
                                 default: ""
                             x-kubernetes-map-type: atomic
@@ -1658,33 +1620,23 @@ spec:
                           x-kubernetes-list-type: map
                         initContainers:
                           description: |-
-                            List of initialization containers belonging to the pod.
-                            Init containers are executed in order prior to containers being started. If any
-                            init container fails, the pod is considered to have failed and is handled according
-                            to its restartPolicy. The name for an init container or normal container must be
-                            unique among all containers.
-                            Init containers may not have Lifecycle actions, Readiness probes, Liveness probes, or Startup probes.
-                            The resourceRequirements of an init container are taken into account during scheduling
-                            by finding the highest request/limit for each resource type, and then using the max of
-                            of that value or the sum of the normal containers. Limits are applied to init containers
-                            in a similar fashion.
-                            Init containers cannot currently be added or removed.
-                            Cannot be updated.
-                            More info: https://kubernetes.io/docs/concepts/workloads/pods/init-containers/
+                            This is accessible behind a feature flag - kubernetes.podspec-init-containers
                           type: array
                           items:
                             description: This is accessible behind a feature flag - kubernetes.podspec-init-containers
                             type: object
                             x-kubernetes-preserve-unknown-fields: true
                         nodeSelector:
-                          description: This is accessible behind a feature flag - kubernetes.podspec-nodeselector
+                          description: |-
+                            This is accessible behind a feature flag - kubernetes.podspec-nodeselector
                           type: object
-                          x-kubernetes-preserve-unknown-fields: true
+                          additionalProperties:
+                            type: string
                           x-kubernetes-map-type: atomic
                         priorityClassName:
-                          description: This is accessible behind a feature flag - kubernetes.podspec-priorityclassname
+                          description: |-
+                            This is accessible behind a feature flag - kubernetes.podspec-priorityclassname
                           type: string
-                          x-kubernetes-preserve-unknown-fields: true
                         responseStartTimeoutSeconds:
                           description: |-
                             ResponseStartTimeoutSeconds is the maximum duration in seconds that the request
@@ -1693,15 +1645,16 @@ spec:
                           type: integer
                           format: int64
                         runtimeClassName:
-                          description: This is accessible behind a feature flag - kubernetes.podspec-runtimeclassname
+                          description: |-
+                            This is accessible behind a feature flag - kubernetes.podspec-runtimeclassname
                           type: string
-                          x-kubernetes-preserve-unknown-fields: true
                         schedulerName:
-                          description: This is accessible behind a feature flag - kubernetes.podspec-schedulername
+                          description: |-
+                            This is accessible behind a feature flag - kubernetes.podspec-schedulername
                           type: string
-                          x-kubernetes-preserve-unknown-fields: true
                         securityContext:
-                          description: This is accessible behind a feature flag - kubernetes.podspec-securitycontext
+                          description: |-
+                            This is accessible behind a feature flag - kubernetes.podspec-securitycontext
                           type: object
                           x-kubernetes-preserve-unknown-fields: true
                         serviceAccountName:
@@ -1710,9 +1663,9 @@ spec:
                             More info: https://kubernetes.io/docs/tasks/configure-pod-container/configure-service-account/
                           type: string
                         shareProcessNamespace:
-                          description: This is accessible behind a feature flag - kubernetes.podspec-shareproccessnamespace
+                          description: |-
+                            This is accessible behind a feature flag - kubernetes.podspec-shareprocessnamespace
                           type: boolean
-                          x-kubernetes-preserve-unknown-fields: true
                         timeoutSeconds:
                           description: |-
                             TimeoutSeconds is the maximum duration in seconds that the request instance
@@ -1724,12 +1677,13 @@ spec:
                           description: This is accessible behind a feature flag - kubernetes.podspec-tolerations
                           type: array
                           items:
-                            description: This is accessible behind a feature flag - kubernetes.podspec-tolerations
+                            description: |-
+                              This is accessible behind a feature flag - kubernetes.podspec-tolerations
                             type: object
                             x-kubernetes-preserve-unknown-fields: true
-                          x-kubernetes-list-type: atomic
                         topologySpreadConstraints:
-                          description: This is accessible behind a feature flag - kubernetes.podspec-topologyspreadconstraints
+                          description: |-
+                            This is accessible behind a feature flag - kubernetes.podspec-topologyspreadconstraints
                           type: array
                           items:
                             description: This is accessible behind a feature flag - kubernetes.podspec-topologyspreadconstraints
@@ -1805,9 +1759,7 @@ spec:
                                       This field is effectively required, but due to backwards compatibility is
                                       allowed to be empty. Instances of this type with an empty value here are
                                       almost certainly wrong.
-                                      TODO: Add other useful fields. apiVersion, kind, uid?
                                       More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                      TODO: Drop `kubebuilder:default` when controller-gen doesn't need it https://github.com/kubernetes-sigs/kubebuilder/issues/3896.
                                     type: string
                                     default: ""
                                   optional:
@@ -1815,7 +1767,13 @@ spec:
                                     type: boolean
                                 x-kubernetes-map-type: atomic
                               emptyDir:
-                                description: This is accessible behind a feature flag - kubernetes.podspec-emptydir
+                                description: |-
+                                  This is accessible behind a feature flag - kubernetes.podspec-volumes-emptydir
+                                type: object
+                                x-kubernetes-preserve-unknown-fields: true
+                              hostPath:
+                                description: |-
+                                  This is accessible behind a feature flag - kubernetes.podspec-volumes-hostpath
                                 type: object
                                 x-kubernetes-preserve-unknown-fields: true
                               name:
@@ -1825,7 +1783,8 @@ spec:
                                   More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
                                 type: string
                               persistentVolumeClaim:
-                                description: This is accessible behind a feature flag - kubernetes.podspec-persistent-volume-claim
+                                description: |-
+                                  This is accessible behind a feature flag - kubernetes.podspec-persistent-volume-claim
                                 type: object
                                 x-kubernetes-preserve-unknown-fields: true
                               projected:
@@ -1843,10 +1802,14 @@ spec:
                                     type: integer
                                     format: int32
                                   sources:
-                                    description: sources is the list of volume projections
+                                    description: |-
+                                      sources is the list of volume projections. Each entry in this list
+                                      handles one source.
                                     type: array
                                     items:
-                                      description: Projection that may be projected along with other supported volume types
+                                      description: |-
+                                        Projection that may be projected along with other supported volume types.
+                                        Exactly one of these fields must be set.
                                       type: object
                                       properties:
                                         configMap:
@@ -1897,9 +1860,7 @@ spec:
                                                 This field is effectively required, but due to backwards compatibility is
                                                 allowed to be empty. Instances of this type with an empty value here are
                                                 almost certainly wrong.
-                                                TODO: Add other useful fields. apiVersion, kind, uid?
                                                 More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                                TODO: Drop `kubebuilder:default` when controller-gen doesn't need it https://github.com/kubernetes-sigs/kubebuilder/issues/3896.
                                               type: string
                                               default: ""
                                             optional:
@@ -2016,9 +1977,7 @@ spec:
                                                 This field is effectively required, but due to backwards compatibility is
                                                 allowed to be empty. Instances of this type with an empty value here are
                                                 almost certainly wrong.
-                                                TODO: Add other useful fields. apiVersion, kind, uid?
                                                 More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                                TODO: Drop `kubebuilder:default` when controller-gen doesn't need it https://github.com/kubernetes-sigs/kubebuilder/issues/3896.
                                               type: string
                                               default: ""
                                             optional:
@@ -2192,7 +2151,7 @@ metadata:
   labels:
     app.kubernetes.io/name: knative-serving
     app.kubernetes.io/component: networking
-    app.kubernetes.io/version: "1.16.0"
+    app.kubernetes.io/version: "1.17.0"
     knative.dev/crd-install: "true"
 spec:
   group: networking.internal.knative.dev
@@ -2254,7 +2213,7 @@ metadata:
   name: domainmappings.serving.knative.dev
   labels:
     app.kubernetes.io/name: knative-serving
-    app.kubernetes.io/version: "1.16.0"
+    app.kubernetes.io/version: "1.17.0"
     knative.dev/crd-install: "true"
 spec:
   group: serving.knative.dev
@@ -2308,12 +2267,10 @@ spec:
                   description: |-
                     Ref specifies the target of the Domain Mapping.
 
-
                     The object identified by the Ref must be an Addressable with a URL of the
                     form `{name}.{namespace}.{domain}` where `{domain}` is the cluster domain,
                     and `{name}` and `{namespace}` are the name and namespace of a Kubernetes
                     Service.
-
 
                     This contract is satisfied by Knative types such as Knative Services and
                     Knative Routes, and by Kubernetes Services.
@@ -2453,7 +2410,7 @@ metadata:
   labels:
     app.kubernetes.io/name: knative-serving
     app.kubernetes.io/component: networking
-    app.kubernetes.io/version: "1.16.0"
+    app.kubernetes.io/version: "1.17.0"
     knative.dev/crd-install: "true"
 spec:
   group: networking.internal.knative.dev
@@ -2469,7 +2426,6 @@ spec:
             Ingress is a collection of rules that allow inbound connections to reach the endpoints defined
             by a backend. An Ingress can be configured to give services externally-reachable URLs, load
             balance traffic, offer name based virtual hosting, etc.
-
 
             This is heavily based on K8s Ingress https://godoc.org/k8s.io/api/networking/v1beta1#Ingress
             which some highlighted modifications.
@@ -2542,7 +2498,6 @@ spec:
                             description: |-
                               A collection of paths that map requests to backends.
 
-
                               If they are multiple matching paths, the first match takes precedence.
                             type: array
                             items:
@@ -2557,7 +2512,6 @@ spec:
                                   description: |-
                                     AppendHeaders allow specifying additional HTTP headers to add
                                     before forwarding a request to the destination service.
-
 
                                     NOTE: This differs from K8s Ingress which doesn't allow header appending.
                                   type: object
@@ -2593,7 +2547,6 @@ spec:
                                   description: |-
                                     RewriteHost rewrites the incoming request's host header.
 
-
                                     This field is currently experimental and not supported by all Ingress
                                     implementations.
                                   type: string
@@ -2615,7 +2568,6 @@ spec:
                                           AppendHeaders allow specifying additional HTTP headers to add
                                           before forwarding a request to the destination service.
 
-
                                           NOTE: This differs from K8s Ingress which doesn't allow header appending.
                                         type: object
                                         additionalProperties:
@@ -2625,7 +2577,6 @@ spec:
                                           Specifies the split percentage, a number between 0 and 100.  If
                                           only one split is specified, we default to 100.
 
-
                                           NOTE: This differs from K8s Ingress to allow percentage split.
                                         type: integer
                                       serviceName:
@@ -2634,7 +2585,6 @@ spec:
                                       serviceNamespace:
                                         description: |-
                                           Specifies the namespace of the referenced service.
-
 
                                           NOTE: This differs from K8s Ingress to allow routing to different namespaces.
                                         type: string
@@ -2760,7 +2710,6 @@ spec:
                             description: |-
                               DomainInternal is set if there is a cluster-local DNS name to access the Ingress.
 
-
                               NOTE: This differs from K8s Ingress, since we also desire to have a cluster-local
                                     DNS name to allow routing in case of not having a mesh.
                             type: string
@@ -2795,7 +2744,6 @@ spec:
                           domainInternal:
                             description: |-
                               DomainInternal is set if there is a cluster-local DNS name to access the Ingress.
-
 
                               NOTE: This differs from K8s Ingress, since we also desire to have a cluster-local
                                     DNS name to allow routing in case of not having a mesh.
@@ -2833,7 +2781,7 @@ metadata:
   name: metrics.autoscaling.internal.knative.dev
   labels:
     app.kubernetes.io/name: knative-serving
-    app.kubernetes.io/version: "1.16.0"
+    app.kubernetes.io/version: "1.17.0"
     knative.dev/crd-install: "true"
 spec:
   group: autoscaling.internal.knative.dev
@@ -2960,7 +2908,7 @@ metadata:
   name: podautoscalers.autoscaling.internal.knative.dev
   labels:
     app.kubernetes.io/name: knative-serving
-    app.kubernetes.io/version: "1.16.0"
+    app.kubernetes.io/version: "1.17.0"
     knative.dev/crd-install: "true"
 spec:
   group: autoscaling.internal.knative.dev
@@ -3144,7 +3092,7 @@ metadata:
   name: revisions.serving.knative.dev
   labels:
     app.kubernetes.io/name: knative-serving
-    app.kubernetes.io/version: "1.16.0"
+    app.kubernetes.io/version: "1.17.0"
     knative.dev/crd-install: "true"
 spec:
   group: serving.knative.dev
@@ -3190,7 +3138,6 @@ spec:
             Revision is an immutable snapshot of code and configuration.  A revision
             references a container image. Revisions are created by updates to a
             Configuration.
-
 
             See also: https://github.com/knative/serving/blob/main/docs/spec/overview.md#revision
           type: object
@@ -3317,9 +3264,7 @@ spec:
                                         This field is effectively required, but due to backwards compatibility is
                                         allowed to be empty. Instances of this type with an empty value here are
                                         almost certainly wrong.
-                                        TODO: Add other useful fields. apiVersion, kind, uid?
                                         More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                        TODO: Drop `kubebuilder:default` when controller-gen doesn't need it https://github.com/kubernetes-sigs/kubebuilder/issues/3896.
                                       type: string
                                       default: ""
                                     optional:
@@ -3327,15 +3272,17 @@ spec:
                                       type: boolean
                                   x-kubernetes-map-type: atomic
                                 fieldRef:
-                                  description: This is accessible behind a feature flag - kubernetes.podspec-fieldref
+                                  description: |-
+                                    This is accessible behind a feature flag - kubernetes.podspec-fieldref
                                   type: object
-                                  x-kubernetes-preserve-unknown-fields: true
                                   x-kubernetes-map-type: atomic
+                                  x-kubernetes-preserve-unknown-fields: true
                                 resourceFieldRef:
-                                  description: This is accessible behind a feature flag - kubernetes.podspec-fieldref
+                                  description: |-
+                                    This is accessible behind a feature flag - kubernetes.podspec-fieldref
                                   type: object
-                                  x-kubernetes-preserve-unknown-fields: true
                                   x-kubernetes-map-type: atomic
+                                  x-kubernetes-preserve-unknown-fields: true
                                 secretKeyRef:
                                   description: Selects a key of a secret in the pod's namespace
                                   type: object
@@ -3351,9 +3298,7 @@ spec:
                                         This field is effectively required, but due to backwards compatibility is
                                         allowed to be empty. Instances of this type with an empty value here are
                                         almost certainly wrong.
-                                        TODO: Add other useful fields. apiVersion, kind, uid?
                                         More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                        TODO: Drop `kubebuilder:default` when controller-gen doesn't need it https://github.com/kubernetes-sigs/kubebuilder/issues/3896.
                                       type: string
                                       default: ""
                                     optional:
@@ -3386,9 +3331,7 @@ spec:
                                     This field is effectively required, but due to backwards compatibility is
                                     allowed to be empty. Instances of this type with an empty value here are
                                     almost certainly wrong.
-                                    TODO: Add other useful fields. apiVersion, kind, uid?
                                     More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                    TODO: Drop `kubebuilder:default` when controller-gen doesn't need it https://github.com/kubernetes-sigs/kubebuilder/issues/3896.
                                   type: string
                                   default: ""
                                 optional:
@@ -3408,9 +3351,7 @@ spec:
                                     This field is effectively required, but due to backwards compatibility is
                                     allowed to be empty. Instances of this type with an empty value here are
                                     almost certainly wrong.
-                                    TODO: Add other useful fields. apiVersion, kind, uid?
                                     More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                    TODO: Drop `kubebuilder:default` when controller-gen doesn't need it https://github.com/kubernetes-sigs/kubebuilder/issues/3896.
                                   type: string
                                   default: ""
                                 optional:
@@ -3465,8 +3406,6 @@ spec:
                           grpc:
                             description: GRPC specifies an action involving a GRPC port.
                             type: object
-                            required:
-                              - port
                             properties:
                               port:
                                 description: Port number of the gRPC service. Number must be in the range 1 to 65535.
@@ -3477,9 +3416,9 @@ spec:
                                   Service is the name of the service to place in the gRPC HealthCheckRequest
                                   (see https://github.com/grpc/grpc/blob/master/doc/health-checking.md).
 
-
                                   If this is not specified, the default behavior is defined by gRPC.
                                 type: string
+                                default: ""
                           httpGet:
                             description: HTTPGet specifies the http request to perform.
                             type: object
@@ -3532,7 +3471,8 @@ spec:
                             type: integer
                             format: int32
                           periodSeconds:
-                            description: How often (in seconds) to perform the probe.
+                            description: |-
+                              How often (in seconds) to perform the probe.
                             type: integer
                             format: int32
                           successThreshold:
@@ -3583,8 +3523,6 @@ spec:
                         items:
                           description: ContainerPort represents a network port in a single container.
                           type: object
-                          required:
-                            - containerPort
                           properties:
                             containerPort:
                               description: |-
@@ -3604,10 +3542,6 @@ spec:
                                 Defaults to "TCP".
                               type: string
                               default: TCP
-                        x-kubernetes-list-map-keys:
-                          - containerPort
-                          - protocol
-                        x-kubernetes-list-type: map
                       readinessProbe:
                         description: |-
                           Periodic probe of container service readiness.
@@ -3640,8 +3574,6 @@ spec:
                           grpc:
                             description: GRPC specifies an action involving a GRPC port.
                             type: object
-                            required:
-                              - port
                             properties:
                               port:
                                 description: Port number of the gRPC service. Number must be in the range 1 to 65535.
@@ -3652,9 +3584,9 @@ spec:
                                   Service is the name of the service to place in the gRPC HealthCheckRequest
                                   (see https://github.com/grpc/grpc/blob/master/doc/health-checking.md).
 
-
                                   If this is not specified, the default behavior is defined by gRPC.
                                 type: string
+                                default: ""
                           httpGet:
                             description: HTTPGet specifies the http request to perform.
                             type: object
@@ -3707,7 +3639,8 @@ spec:
                             type: integer
                             format: int32
                           periodSeconds:
-                            description: How often (in seconds) to perform the probe.
+                            description: |-
+                              How often (in seconds) to perform the probe.
                             type: integer
                             format: int32
                           successThreshold:
@@ -3746,33 +3679,6 @@ spec:
                           More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
                         type: object
                         properties:
-                          claims:
-                            description: |-
-                              Claims lists the names of resources, defined in spec.resourceClaims,
-                              that are used by this container.
-
-
-                              This is an alpha field and requires enabling the
-                              DynamicResourceAllocation feature gate.
-
-
-                              This field is immutable. It can only be set for containers.
-                            type: array
-                            items:
-                              description: ResourceClaim references one entry in PodSpec.ResourceClaims.
-                              type: object
-                              required:
-                                - name
-                              properties:
-                                name:
-                                  description: |-
-                                    Name must match the name of one entry in pod.spec.resourceClaims of
-                                    the Pod where this field is used. It makes that resource available
-                                    inside a container.
-                                  type: string
-                            x-kubernetes-list-map-keys:
-                              - name
-                            x-kubernetes-list-type: map
                           limits:
                             description: |-
                               Limits describes the maximum amount of compute resources allowed.
@@ -3835,6 +3741,10 @@ spec:
                                   description: Capability represent POSIX capabilities type
                                   type: string
                                 x-kubernetes-list-type: atomic
+                          privileged:
+                            description: |-
+                              Run container in privileged mode. This can only be set to explicitly to 'false'
+                            type: boolean
                           readOnlyRootFilesystem:
                             description: |-
                               Whether this container has a read-only root filesystem.
@@ -3890,7 +3800,6 @@ spec:
                                   type indicates which kind of seccomp profile will be applied.
                                   Valid options are:
 
-
                                   Localhost - a profile defined in a file on the node should be used.
                                   RuntimeDefault - the container runtime default profile should be used.
                                   Unconfined - no profile should be applied.
@@ -3930,8 +3839,6 @@ spec:
                           grpc:
                             description: GRPC specifies an action involving a GRPC port.
                             type: object
-                            required:
-                              - port
                             properties:
                               port:
                                 description: Port number of the gRPC service. Number must be in the range 1 to 65535.
@@ -3942,9 +3849,9 @@ spec:
                                   Service is the name of the service to place in the gRPC HealthCheckRequest
                                   (see https://github.com/grpc/grpc/blob/master/doc/health-checking.md).
 
-
                                   If this is not specified, the default behavior is defined by gRPC.
                                 type: string
+                                default: ""
                           httpGet:
                             description: HTTPGet specifies the http request to perform.
                             type: object
@@ -3997,7 +3904,8 @@ spec:
                             type: integer
                             format: int32
                           periodSeconds:
-                            description: How often (in seconds) to perform the probe.
+                            description: |-
+                              How often (in seconds) to perform the probe.
                             type: integer
                             format: int32
                           successThreshold:
@@ -4090,34 +3998,39 @@ spec:
                           Cannot be updated.
                         type: string
                 dnsConfig:
-                  description: This is accessible behind a feature flag - kubernetes.podspec-dnsconfig
+                  description: |-
+                    This is accessible behind a feature flag - kubernetes.podspec-dnsconfig
                   type: object
                   x-kubernetes-preserve-unknown-fields: true
                 dnsPolicy:
-                  description: This is accessible behind a feature flag - kubernetes.podspec-dnspolicy
+                  description: |-
+                    This is accessible behind a feature flag - kubernetes.podspec-dnspolicy
                   type: string
                 enableServiceLinks:
-                  description: 'EnableServiceLinks indicates whether information about services should be injected into pod''s environment variables, matching the syntax of Docker links. Optional: Knative defaults this to false.'
+                  description: |-
+                    EnableServiceLinks indicates whether information aboutservices should be injected into pod's environment variables, matching the syntax of Docker links. Optional: Knative defaults this to false.
                   type: boolean
                 hostAliases:
-                  description: This is accessible behind a feature flag - kubernetes.podspec-hostaliases
+                  description: |-
+                    This is accessible behind a feature flag - kubernetes.podspec-hostaliases
                   type: array
                   items:
-                    description: This is accessible behind a feature flag - kubernetes.podspec-hostaliases
+                    description: |-
+                      This is accessible behind a feature flag - kubernetes.podspec-hostaliases
                     type: object
                     x-kubernetes-preserve-unknown-fields: true
                 hostIPC:
-                  description: This is accessible behind a feature flag - kubernetes.podspec-hostipc
+                  description: |-
+                    This is accessible behind a feature flag - kubernetes.podspec-hostipc
                   type: boolean
-                  x-kubernetes-preserve-unknown-fields: true
                 hostNetwork:
-                  description: This is accessible behind a feature flag - kubernetes.podspec-hostnetwork
+                  description: |-
+                    This is accessible behind a feature flag - kubernetes.podspec-hostnetwork
                   type: boolean
-                  x-kubernetes-preserve-unknown-fields: true
                 hostPID:
-                  description: This is accessible behind a feature flag - kubernetes.podspec-hostpid
+                  description: |-
+                    This is accessible behind a feature flag - kubernetes.podspec-hostpid
                   type: boolean
-                  x-kubernetes-preserve-unknown-fields: true
                 idleTimeoutSeconds:
                   description: |-
                     IdleTimeoutSeconds is the maximum duration in seconds a request will be allowed
@@ -4143,9 +4056,7 @@ spec:
                           This field is effectively required, but due to backwards compatibility is
                           allowed to be empty. Instances of this type with an empty value here are
                           almost certainly wrong.
-                          TODO: Add other useful fields. apiVersion, kind, uid?
                           More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                          TODO: Drop `kubebuilder:default` when controller-gen doesn't need it https://github.com/kubernetes-sigs/kubebuilder/issues/3896.
                         type: string
                         default: ""
                     x-kubernetes-map-type: atomic
@@ -4154,33 +4065,23 @@ spec:
                   x-kubernetes-list-type: map
                 initContainers:
                   description: |-
-                    List of initialization containers belonging to the pod.
-                    Init containers are executed in order prior to containers being started. If any
-                    init container fails, the pod is considered to have failed and is handled according
-                    to its restartPolicy. The name for an init container or normal container must be
-                    unique among all containers.
-                    Init containers may not have Lifecycle actions, Readiness probes, Liveness probes, or Startup probes.
-                    The resourceRequirements of an init container are taken into account during scheduling
-                    by finding the highest request/limit for each resource type, and then using the max of
-                    of that value or the sum of the normal containers. Limits are applied to init containers
-                    in a similar fashion.
-                    Init containers cannot currently be added or removed.
-                    Cannot be updated.
-                    More info: https://kubernetes.io/docs/concepts/workloads/pods/init-containers/
+                    This is accessible behind a feature flag - kubernetes.podspec-init-containers
                   type: array
                   items:
                     description: This is accessible behind a feature flag - kubernetes.podspec-init-containers
                     type: object
                     x-kubernetes-preserve-unknown-fields: true
                 nodeSelector:
-                  description: This is accessible behind a feature flag - kubernetes.podspec-nodeselector
+                  description: |-
+                    This is accessible behind a feature flag - kubernetes.podspec-nodeselector
                   type: object
-                  x-kubernetes-preserve-unknown-fields: true
+                  additionalProperties:
+                    type: string
                   x-kubernetes-map-type: atomic
                 priorityClassName:
-                  description: This is accessible behind a feature flag - kubernetes.podspec-priorityclassname
+                  description: |-
+                    This is accessible behind a feature flag - kubernetes.podspec-priorityclassname
                   type: string
-                  x-kubernetes-preserve-unknown-fields: true
                 responseStartTimeoutSeconds:
                   description: |-
                     ResponseStartTimeoutSeconds is the maximum duration in seconds that the request
@@ -4189,15 +4090,16 @@ spec:
                   type: integer
                   format: int64
                 runtimeClassName:
-                  description: This is accessible behind a feature flag - kubernetes.podspec-runtimeclassname
+                  description: |-
+                    This is accessible behind a feature flag - kubernetes.podspec-runtimeclassname
                   type: string
-                  x-kubernetes-preserve-unknown-fields: true
                 schedulerName:
-                  description: This is accessible behind a feature flag - kubernetes.podspec-schedulername
+                  description: |-
+                    This is accessible behind a feature flag - kubernetes.podspec-schedulername
                   type: string
-                  x-kubernetes-preserve-unknown-fields: true
                 securityContext:
-                  description: This is accessible behind a feature flag - kubernetes.podspec-securitycontext
+                  description: |-
+                    This is accessible behind a feature flag - kubernetes.podspec-securitycontext
                   type: object
                   x-kubernetes-preserve-unknown-fields: true
                 serviceAccountName:
@@ -4206,9 +4108,9 @@ spec:
                     More info: https://kubernetes.io/docs/tasks/configure-pod-container/configure-service-account/
                   type: string
                 shareProcessNamespace:
-                  description: This is accessible behind a feature flag - kubernetes.podspec-shareproccessnamespace
+                  description: |-
+                    This is accessible behind a feature flag - kubernetes.podspec-shareprocessnamespace
                   type: boolean
-                  x-kubernetes-preserve-unknown-fields: true
                 timeoutSeconds:
                   description: |-
                     TimeoutSeconds is the maximum duration in seconds that the request instance
@@ -4220,12 +4122,13 @@ spec:
                   description: This is accessible behind a feature flag - kubernetes.podspec-tolerations
                   type: array
                   items:
-                    description: This is accessible behind a feature flag - kubernetes.podspec-tolerations
+                    description: |-
+                      This is accessible behind a feature flag - kubernetes.podspec-tolerations
                     type: object
                     x-kubernetes-preserve-unknown-fields: true
-                  x-kubernetes-list-type: atomic
                 topologySpreadConstraints:
-                  description: This is accessible behind a feature flag - kubernetes.podspec-topologyspreadconstraints
+                  description: |-
+                    This is accessible behind a feature flag - kubernetes.podspec-topologyspreadconstraints
                   type: array
                   items:
                     description: This is accessible behind a feature flag - kubernetes.podspec-topologyspreadconstraints
@@ -4301,9 +4204,7 @@ spec:
                               This field is effectively required, but due to backwards compatibility is
                               allowed to be empty. Instances of this type with an empty value here are
                               almost certainly wrong.
-                              TODO: Add other useful fields. apiVersion, kind, uid?
                               More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                              TODO: Drop `kubebuilder:default` when controller-gen doesn't need it https://github.com/kubernetes-sigs/kubebuilder/issues/3896.
                             type: string
                             default: ""
                           optional:
@@ -4311,7 +4212,13 @@ spec:
                             type: boolean
                         x-kubernetes-map-type: atomic
                       emptyDir:
-                        description: This is accessible behind a feature flag - kubernetes.podspec-emptydir
+                        description: |-
+                          This is accessible behind a feature flag - kubernetes.podspec-volumes-emptydir
+                        type: object
+                        x-kubernetes-preserve-unknown-fields: true
+                      hostPath:
+                        description: |-
+                          This is accessible behind a feature flag - kubernetes.podspec-volumes-hostpath
                         type: object
                         x-kubernetes-preserve-unknown-fields: true
                       name:
@@ -4321,7 +4228,8 @@ spec:
                           More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
                         type: string
                       persistentVolumeClaim:
-                        description: This is accessible behind a feature flag - kubernetes.podspec-persistent-volume-claim
+                        description: |-
+                          This is accessible behind a feature flag - kubernetes.podspec-persistent-volume-claim
                         type: object
                         x-kubernetes-preserve-unknown-fields: true
                       projected:
@@ -4339,10 +4247,14 @@ spec:
                             type: integer
                             format: int32
                           sources:
-                            description: sources is the list of volume projections
+                            description: |-
+                              sources is the list of volume projections. Each entry in this list
+                              handles one source.
                             type: array
                             items:
-                              description: Projection that may be projected along with other supported volume types
+                              description: |-
+                                Projection that may be projected along with other supported volume types.
+                                Exactly one of these fields must be set.
                               type: object
                               properties:
                                 configMap:
@@ -4393,9 +4305,7 @@ spec:
                                         This field is effectively required, but due to backwards compatibility is
                                         allowed to be empty. Instances of this type with an empty value here are
                                         almost certainly wrong.
-                                        TODO: Add other useful fields. apiVersion, kind, uid?
                                         More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                        TODO: Drop `kubebuilder:default` when controller-gen doesn't need it https://github.com/kubernetes-sigs/kubebuilder/issues/3896.
                                       type: string
                                       default: ""
                                     optional:
@@ -4512,9 +4422,7 @@ spec:
                                         This field is effectively required, but due to backwards compatibility is
                                         allowed to be empty. Instances of this type with an empty value here are
                                         almost certainly wrong.
-                                        TODO: Add other useful fields. apiVersion, kind, uid?
                                         More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                        TODO: Drop `kubebuilder:default` when controller-gen doesn't need it https://github.com/kubernetes-sigs/kubebuilder/issues/3896.
                                       type: string
                                       default: ""
                                     optional:
@@ -4724,7 +4632,7 @@ metadata:
   name: routes.serving.knative.dev
   labels:
     app.kubernetes.io/name: knative-serving
-    app.kubernetes.io/version: "1.16.0"
+    app.kubernetes.io/version: "1.17.0"
     knative.dev/crd-install: "true"
     duck.knative.dev/addressable: "true"
 spec:
@@ -4980,7 +4888,7 @@ metadata:
   labels:
     app.kubernetes.io/name: knative-serving
     app.kubernetes.io/component: networking
-    app.kubernetes.io/version: "1.16.0"
+    app.kubernetes.io/version: "1.17.0"
     knative.dev/crd-install: "true"
 spec:
   group: networking.internal.knative.dev
@@ -5053,7 +4961,6 @@ spec:
                         the event) or if no container name is specified "spec.containers[2]" (container with
                         index 2 in this pod). This syntax is chosen only to have some well-defined way of
                         referencing a part of an object.
-                        TODO: this design is not final and this field is subject to change in the future.
                       type: string
                     kind:
                       description: |-
@@ -5188,7 +5095,7 @@ metadata:
   name: services.serving.knative.dev
   labels:
     app.kubernetes.io/name: knative-serving
-    app.kubernetes.io/version: "1.16.0"
+    app.kubernetes.io/version: "1.17.0"
     knative.dev/crd-install: "true"
     duck.knative.dev/addressable: "true"
     duck.knative.dev/podspecable: "true"
@@ -5239,10 +5146,8 @@ spec:
             underlying Routes and Configurations (much as a kubernetes Deployment
             orchestrates ReplicaSets), and its usage is optional but recommended.
 
-
             The Service's controller will track the statuses of its owned Configuration
             and Route, reflecting their statuses and conditions as its own.
-
 
             See also: https://github.com/knative/serving/blob/main/docs/spec/overview.md#service
           type: object
@@ -5404,9 +5309,7 @@ spec:
                                                 This field is effectively required, but due to backwards compatibility is
                                                 allowed to be empty. Instances of this type with an empty value here are
                                                 almost certainly wrong.
-                                                TODO: Add other useful fields. apiVersion, kind, uid?
                                                 More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                                TODO: Drop `kubebuilder:default` when controller-gen doesn't need it https://github.com/kubernetes-sigs/kubebuilder/issues/3896.
                                               type: string
                                               default: ""
                                             optional:
@@ -5414,15 +5317,17 @@ spec:
                                               type: boolean
                                           x-kubernetes-map-type: atomic
                                         fieldRef:
-                                          description: This is accessible behind a feature flag - kubernetes.podspec-fieldref
+                                          description: |-
+                                            This is accessible behind a feature flag - kubernetes.podspec-fieldref
                                           type: object
-                                          x-kubernetes-preserve-unknown-fields: true
                                           x-kubernetes-map-type: atomic
+                                          x-kubernetes-preserve-unknown-fields: true
                                         resourceFieldRef:
-                                          description: This is accessible behind a feature flag - kubernetes.podspec-fieldref
+                                          description: |-
+                                            This is accessible behind a feature flag - kubernetes.podspec-fieldref
                                           type: object
-                                          x-kubernetes-preserve-unknown-fields: true
                                           x-kubernetes-map-type: atomic
+                                          x-kubernetes-preserve-unknown-fields: true
                                         secretKeyRef:
                                           description: Selects a key of a secret in the pod's namespace
                                           type: object
@@ -5438,9 +5343,7 @@ spec:
                                                 This field is effectively required, but due to backwards compatibility is
                                                 allowed to be empty. Instances of this type with an empty value here are
                                                 almost certainly wrong.
-                                                TODO: Add other useful fields. apiVersion, kind, uid?
                                                 More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                                TODO: Drop `kubebuilder:default` when controller-gen doesn't need it https://github.com/kubernetes-sigs/kubebuilder/issues/3896.
                                               type: string
                                               default: ""
                                             optional:
@@ -5473,9 +5376,7 @@ spec:
                                             This field is effectively required, but due to backwards compatibility is
                                             allowed to be empty. Instances of this type with an empty value here are
                                             almost certainly wrong.
-                                            TODO: Add other useful fields. apiVersion, kind, uid?
                                             More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                            TODO: Drop `kubebuilder:default` when controller-gen doesn't need it https://github.com/kubernetes-sigs/kubebuilder/issues/3896.
                                           type: string
                                           default: ""
                                         optional:
@@ -5495,9 +5396,7 @@ spec:
                                             This field is effectively required, but due to backwards compatibility is
                                             allowed to be empty. Instances of this type with an empty value here are
                                             almost certainly wrong.
-                                            TODO: Add other useful fields. apiVersion, kind, uid?
                                             More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                            TODO: Drop `kubebuilder:default` when controller-gen doesn't need it https://github.com/kubernetes-sigs/kubebuilder/issues/3896.
                                           type: string
                                           default: ""
                                         optional:
@@ -5552,8 +5451,6 @@ spec:
                                   grpc:
                                     description: GRPC specifies an action involving a GRPC port.
                                     type: object
-                                    required:
-                                      - port
                                     properties:
                                       port:
                                         description: Port number of the gRPC service. Number must be in the range 1 to 65535.
@@ -5564,9 +5461,9 @@ spec:
                                           Service is the name of the service to place in the gRPC HealthCheckRequest
                                           (see https://github.com/grpc/grpc/blob/master/doc/health-checking.md).
 
-
                                           If this is not specified, the default behavior is defined by gRPC.
                                         type: string
+                                        default: ""
                                   httpGet:
                                     description: HTTPGet specifies the http request to perform.
                                     type: object
@@ -5619,7 +5516,8 @@ spec:
                                     type: integer
                                     format: int32
                                   periodSeconds:
-                                    description: How often (in seconds) to perform the probe.
+                                    description: |-
+                                      How often (in seconds) to perform the probe.
                                     type: integer
                                     format: int32
                                   successThreshold:
@@ -5670,8 +5568,6 @@ spec:
                                 items:
                                   description: ContainerPort represents a network port in a single container.
                                   type: object
-                                  required:
-                                    - containerPort
                                   properties:
                                     containerPort:
                                       description: |-
@@ -5691,10 +5587,6 @@ spec:
                                         Defaults to "TCP".
                                       type: string
                                       default: TCP
-                                x-kubernetes-list-map-keys:
-                                  - containerPort
-                                  - protocol
-                                x-kubernetes-list-type: map
                               readinessProbe:
                                 description: |-
                                   Periodic probe of container service readiness.
@@ -5727,8 +5619,6 @@ spec:
                                   grpc:
                                     description: GRPC specifies an action involving a GRPC port.
                                     type: object
-                                    required:
-                                      - port
                                     properties:
                                       port:
                                         description: Port number of the gRPC service. Number must be in the range 1 to 65535.
@@ -5739,9 +5629,9 @@ spec:
                                           Service is the name of the service to place in the gRPC HealthCheckRequest
                                           (see https://github.com/grpc/grpc/blob/master/doc/health-checking.md).
 
-
                                           If this is not specified, the default behavior is defined by gRPC.
                                         type: string
+                                        default: ""
                                   httpGet:
                                     description: HTTPGet specifies the http request to perform.
                                     type: object
@@ -5794,7 +5684,8 @@ spec:
                                     type: integer
                                     format: int32
                                   periodSeconds:
-                                    description: How often (in seconds) to perform the probe.
+                                    description: |-
+                                      How often (in seconds) to perform the probe.
                                     type: integer
                                     format: int32
                                   successThreshold:
@@ -5833,33 +5724,6 @@ spec:
                                   More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
                                 type: object
                                 properties:
-                                  claims:
-                                    description: |-
-                                      Claims lists the names of resources, defined in spec.resourceClaims,
-                                      that are used by this container.
-
-
-                                      This is an alpha field and requires enabling the
-                                      DynamicResourceAllocation feature gate.
-
-
-                                      This field is immutable. It can only be set for containers.
-                                    type: array
-                                    items:
-                                      description: ResourceClaim references one entry in PodSpec.ResourceClaims.
-                                      type: object
-                                      required:
-                                        - name
-                                      properties:
-                                        name:
-                                          description: |-
-                                            Name must match the name of one entry in pod.spec.resourceClaims of
-                                            the Pod where this field is used. It makes that resource available
-                                            inside a container.
-                                          type: string
-                                    x-kubernetes-list-map-keys:
-                                      - name
-                                    x-kubernetes-list-type: map
                                   limits:
                                     description: |-
                                       Limits describes the maximum amount of compute resources allowed.
@@ -5922,6 +5786,10 @@ spec:
                                           description: Capability represent POSIX capabilities type
                                           type: string
                                         x-kubernetes-list-type: atomic
+                                  privileged:
+                                    description: |-
+                                      Run container in privileged mode. This can only be set to explicitly to 'false'
+                                    type: boolean
                                   readOnlyRootFilesystem:
                                     description: |-
                                       Whether this container has a read-only root filesystem.
@@ -5977,7 +5845,6 @@ spec:
                                           type indicates which kind of seccomp profile will be applied.
                                           Valid options are:
 
-
                                           Localhost - a profile defined in a file on the node should be used.
                                           RuntimeDefault - the container runtime default profile should be used.
                                           Unconfined - no profile should be applied.
@@ -6017,8 +5884,6 @@ spec:
                                   grpc:
                                     description: GRPC specifies an action involving a GRPC port.
                                     type: object
-                                    required:
-                                      - port
                                     properties:
                                       port:
                                         description: Port number of the gRPC service. Number must be in the range 1 to 65535.
@@ -6029,9 +5894,9 @@ spec:
                                           Service is the name of the service to place in the gRPC HealthCheckRequest
                                           (see https://github.com/grpc/grpc/blob/master/doc/health-checking.md).
 
-
                                           If this is not specified, the default behavior is defined by gRPC.
                                         type: string
+                                        default: ""
                                   httpGet:
                                     description: HTTPGet specifies the http request to perform.
                                     type: object
@@ -6084,7 +5949,8 @@ spec:
                                     type: integer
                                     format: int32
                                   periodSeconds:
-                                    description: How often (in seconds) to perform the probe.
+                                    description: |-
+                                      How often (in seconds) to perform the probe.
                                     type: integer
                                     format: int32
                                   successThreshold:
@@ -6177,34 +6043,39 @@ spec:
                                   Cannot be updated.
                                 type: string
                         dnsConfig:
-                          description: This is accessible behind a feature flag - kubernetes.podspec-dnsconfig
+                          description: |-
+                            This is accessible behind a feature flag - kubernetes.podspec-dnsconfig
                           type: object
                           x-kubernetes-preserve-unknown-fields: true
                         dnsPolicy:
-                          description: This is accessible behind a feature flag - kubernetes.podspec-dnspolicy
+                          description: |-
+                            This is accessible behind a feature flag - kubernetes.podspec-dnspolicy
                           type: string
                         enableServiceLinks:
-                          description: 'EnableServiceLinks indicates whether information about services should be injected into pod''s environment variables, matching the syntax of Docker links. Optional: Knative defaults this to false.'
+                          description: |-
+                            EnableServiceLinks indicates whether information aboutservices should be injected into pod's environment variables, matching the syntax of Docker links. Optional: Knative defaults this to false.
                           type: boolean
                         hostAliases:
-                          description: This is accessible behind a feature flag - kubernetes.podspec-hostaliases
+                          description: |-
+                            This is accessible behind a feature flag - kubernetes.podspec-hostaliases
                           type: array
                           items:
-                            description: This is accessible behind a feature flag - kubernetes.podspec-hostaliases
+                            description: |-
+                              This is accessible behind a feature flag - kubernetes.podspec-hostaliases
                             type: object
                             x-kubernetes-preserve-unknown-fields: true
                         hostIPC:
-                          description: This is accessible behind a feature flag - kubernetes.podspec-hostipc
+                          description: |-
+                            This is accessible behind a feature flag - kubernetes.podspec-hostipc
                           type: boolean
-                          x-kubernetes-preserve-unknown-fields: true
                         hostNetwork:
-                          description: This is accessible behind a feature flag - kubernetes.podspec-hostnetwork
+                          description: |-
+                            This is accessible behind a feature flag - kubernetes.podspec-hostnetwork
                           type: boolean
-                          x-kubernetes-preserve-unknown-fields: true
                         hostPID:
-                          description: This is accessible behind a feature flag - kubernetes.podspec-hostpid
+                          description: |-
+                            This is accessible behind a feature flag - kubernetes.podspec-hostpid
                           type: boolean
-                          x-kubernetes-preserve-unknown-fields: true
                         idleTimeoutSeconds:
                           description: |-
                             IdleTimeoutSeconds is the maximum duration in seconds a request will be allowed
@@ -6230,9 +6101,7 @@ spec:
                                   This field is effectively required, but due to backwards compatibility is
                                   allowed to be empty. Instances of this type with an empty value here are
                                   almost certainly wrong.
-                                  TODO: Add other useful fields. apiVersion, kind, uid?
                                   More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                  TODO: Drop `kubebuilder:default` when controller-gen doesn't need it https://github.com/kubernetes-sigs/kubebuilder/issues/3896.
                                 type: string
                                 default: ""
                             x-kubernetes-map-type: atomic
@@ -6241,33 +6110,23 @@ spec:
                           x-kubernetes-list-type: map
                         initContainers:
                           description: |-
-                            List of initialization containers belonging to the pod.
-                            Init containers are executed in order prior to containers being started. If any
-                            init container fails, the pod is considered to have failed and is handled according
-                            to its restartPolicy. The name for an init container or normal container must be
-                            unique among all containers.
-                            Init containers may not have Lifecycle actions, Readiness probes, Liveness probes, or Startup probes.
-                            The resourceRequirements of an init container are taken into account during scheduling
-                            by finding the highest request/limit for each resource type, and then using the max of
-                            of that value or the sum of the normal containers. Limits are applied to init containers
-                            in a similar fashion.
-                            Init containers cannot currently be added or removed.
-                            Cannot be updated.
-                            More info: https://kubernetes.io/docs/concepts/workloads/pods/init-containers/
+                            This is accessible behind a feature flag - kubernetes.podspec-init-containers
                           type: array
                           items:
                             description: This is accessible behind a feature flag - kubernetes.podspec-init-containers
                             type: object
                             x-kubernetes-preserve-unknown-fields: true
                         nodeSelector:
-                          description: This is accessible behind a feature flag - kubernetes.podspec-nodeselector
+                          description: |-
+                            This is accessible behind a feature flag - kubernetes.podspec-nodeselector
                           type: object
-                          x-kubernetes-preserve-unknown-fields: true
+                          additionalProperties:
+                            type: string
                           x-kubernetes-map-type: atomic
                         priorityClassName:
-                          description: This is accessible behind a feature flag - kubernetes.podspec-priorityclassname
+                          description: |-
+                            This is accessible behind a feature flag - kubernetes.podspec-priorityclassname
                           type: string
-                          x-kubernetes-preserve-unknown-fields: true
                         responseStartTimeoutSeconds:
                           description: |-
                             ResponseStartTimeoutSeconds is the maximum duration in seconds that the request
@@ -6276,15 +6135,16 @@ spec:
                           type: integer
                           format: int64
                         runtimeClassName:
-                          description: This is accessible behind a feature flag - kubernetes.podspec-runtimeclassname
+                          description: |-
+                            This is accessible behind a feature flag - kubernetes.podspec-runtimeclassname
                           type: string
-                          x-kubernetes-preserve-unknown-fields: true
                         schedulerName:
-                          description: This is accessible behind a feature flag - kubernetes.podspec-schedulername
+                          description: |-
+                            This is accessible behind a feature flag - kubernetes.podspec-schedulername
                           type: string
-                          x-kubernetes-preserve-unknown-fields: true
                         securityContext:
-                          description: This is accessible behind a feature flag - kubernetes.podspec-securitycontext
+                          description: |-
+                            This is accessible behind a feature flag - kubernetes.podspec-securitycontext
                           type: object
                           x-kubernetes-preserve-unknown-fields: true
                         serviceAccountName:
@@ -6293,9 +6153,9 @@ spec:
                             More info: https://kubernetes.io/docs/tasks/configure-pod-container/configure-service-account/
                           type: string
                         shareProcessNamespace:
-                          description: This is accessible behind a feature flag - kubernetes.podspec-shareproccessnamespace
+                          description: |-
+                            This is accessible behind a feature flag - kubernetes.podspec-shareprocessnamespace
                           type: boolean
-                          x-kubernetes-preserve-unknown-fields: true
                         timeoutSeconds:
                           description: |-
                             TimeoutSeconds is the maximum duration in seconds that the request instance
@@ -6307,12 +6167,13 @@ spec:
                           description: This is accessible behind a feature flag - kubernetes.podspec-tolerations
                           type: array
                           items:
-                            description: This is accessible behind a feature flag - kubernetes.podspec-tolerations
+                            description: |-
+                              This is accessible behind a feature flag - kubernetes.podspec-tolerations
                             type: object
                             x-kubernetes-preserve-unknown-fields: true
-                          x-kubernetes-list-type: atomic
                         topologySpreadConstraints:
-                          description: This is accessible behind a feature flag - kubernetes.podspec-topologyspreadconstraints
+                          description: |-
+                            This is accessible behind a feature flag - kubernetes.podspec-topologyspreadconstraints
                           type: array
                           items:
                             description: This is accessible behind a feature flag - kubernetes.podspec-topologyspreadconstraints
@@ -6388,9 +6249,7 @@ spec:
                                       This field is effectively required, but due to backwards compatibility is
                                       allowed to be empty. Instances of this type with an empty value here are
                                       almost certainly wrong.
-                                      TODO: Add other useful fields. apiVersion, kind, uid?
                                       More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                      TODO: Drop `kubebuilder:default` when controller-gen doesn't need it https://github.com/kubernetes-sigs/kubebuilder/issues/3896.
                                     type: string
                                     default: ""
                                   optional:
@@ -6398,7 +6257,13 @@ spec:
                                     type: boolean
                                 x-kubernetes-map-type: atomic
                               emptyDir:
-                                description: This is accessible behind a feature flag - kubernetes.podspec-emptydir
+                                description: |-
+                                  This is accessible behind a feature flag - kubernetes.podspec-volumes-emptydir
+                                type: object
+                                x-kubernetes-preserve-unknown-fields: true
+                              hostPath:
+                                description: |-
+                                  This is accessible behind a feature flag - kubernetes.podspec-volumes-hostpath
                                 type: object
                                 x-kubernetes-preserve-unknown-fields: true
                               name:
@@ -6408,7 +6273,8 @@ spec:
                                   More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
                                 type: string
                               persistentVolumeClaim:
-                                description: This is accessible behind a feature flag - kubernetes.podspec-persistent-volume-claim
+                                description: |-
+                                  This is accessible behind a feature flag - kubernetes.podspec-persistent-volume-claim
                                 type: object
                                 x-kubernetes-preserve-unknown-fields: true
                               projected:
@@ -6426,10 +6292,14 @@ spec:
                                     type: integer
                                     format: int32
                                   sources:
-                                    description: sources is the list of volume projections
+                                    description: |-
+                                      sources is the list of volume projections. Each entry in this list
+                                      handles one source.
                                     type: array
                                     items:
-                                      description: Projection that may be projected along with other supported volume types
+                                      description: |-
+                                        Projection that may be projected along with other supported volume types.
+                                        Exactly one of these fields must be set.
                                       type: object
                                       properties:
                                         configMap:
@@ -6480,9 +6350,7 @@ spec:
                                                 This field is effectively required, but due to backwards compatibility is
                                                 allowed to be empty. Instances of this type with an empty value here are
                                                 almost certainly wrong.
-                                                TODO: Add other useful fields. apiVersion, kind, uid?
                                                 More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                                TODO: Drop `kubebuilder:default` when controller-gen doesn't need it https://github.com/kubernetes-sigs/kubebuilder/issues/3896.
                                               type: string
                                               default: ""
                                             optional:
@@ -6599,9 +6467,7 @@ spec:
                                                 This field is effectively required, but due to backwards compatibility is
                                                 allowed to be empty. Instances of this type with an empty value here are
                                                 almost certainly wrong.
-                                                TODO: Add other useful fields. apiVersion, kind, uid?
                                                 More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                                TODO: Drop `kubebuilder:default` when controller-gen doesn't need it https://github.com/kubernetes-sigs/kubebuilder/issues/3896.
                                               type: string
                                               default: ""
                                             optional:
@@ -6906,9 +6772,9 @@ metadata:
   labels:
     app.kubernetes.io/component: queue-proxy
     app.kubernetes.io/name: knative-serving
-    app.kubernetes.io/version: "1.16.0"
+    app.kubernetes.io/version: "1.17.0"
 spec:
-  image: gcr.io/knative-releases/knative.dev/serving/cmd/queue@sha256:c61042001b1f21c5d06bdee9b42b5e4524e4370e09d4f46347226f06db29ba0f
+  image: gcr.io/knative-releases/knative.dev/serving/cmd/queue@sha256:4682baab5634dca1917cdde5ea64e830181d745acb3cc88bd271618170f422db
 ---
 apiVersion: v1
 kind: ConfigMap
@@ -6918,7 +6784,7 @@ metadata:
   labels:
     app.kubernetes.io/component: autoscaler
     app.kubernetes.io/name: knative-serving
-    app.kubernetes.io/version: "1.16.0"
+    app.kubernetes.io/version: "1.17.0"
   annotations:
     knative.dev/example-checksum: "47c2487f"
 data:
@@ -7114,7 +6980,7 @@ metadata:
   labels:
     app.kubernetes.io/name: knative-serving
     app.kubernetes.io/component: controller
-    app.kubernetes.io/version: "1.16.0"
+    app.kubernetes.io/version: "1.17.0"
     networking.knative.dev/certificate-provider: cert-manager
   annotations:
     knative.dev/example-checksum: "b7a9a602"
@@ -7169,7 +7035,7 @@ metadata:
   labels:
     app.kubernetes.io/name: knative-serving
     app.kubernetes.io/component: controller
-    app.kubernetes.io/version: "1.16.0"
+    app.kubernetes.io/version: "1.17.0"
   annotations:
     knative.dev/example-checksum: "5b64ff5c"
 data:
@@ -7309,11 +7175,11 @@ metadata:
   labels:
     app.kubernetes.io/name: knative-serving
     app.kubernetes.io/component: controller
-    app.kubernetes.io/version: "1.16.0"
+    app.kubernetes.io/version: "1.17.0"
   annotations:
     knative.dev/example-checksum: "720ddb97"
 data:
-  queue-sidecar-image: gcr.io/knative-releases/knative.dev/serving/cmd/queue@sha256:c61042001b1f21c5d06bdee9b42b5e4524e4370e09d4f46347226f06db29ba0f
+  queue-sidecar-image: gcr.io/knative-releases/knative.dev/serving/cmd/queue@sha256:4682baab5634dca1917cdde5ea64e830181d745acb3cc88bd271618170f422db
   _example: |-
     ################################
     #                              #
@@ -7419,7 +7285,7 @@ metadata:
   labels:
     app.kubernetes.io/name: knative-serving
     app.kubernetes.io/component: controller
-    app.kubernetes.io/version: "1.16.0"
+    app.kubernetes.io/version: "1.17.0"
   annotations:
     knative.dev/example-checksum: "26c09de5"
 data:
@@ -7469,9 +7335,9 @@ metadata:
   labels:
     app.kubernetes.io/name: knative-serving
     app.kubernetes.io/component: controller
-    app.kubernetes.io/version: "1.16.0"
+    app.kubernetes.io/version: "1.17.0"
   annotations:
-    knative.dev/example-checksum: "9ff569ad"
+    knative.dev/example-checksum: "63a13754"
 data:
   _example: |-
     ################################
@@ -7649,6 +7515,14 @@ data:
     # 2. Disabled: disabling EmptyDir volume support
     kubernetes.podspec-volumes-emptydir: "enabled"
 
+    # Controls whether volume support for HostPath is enabled or not.
+    # WARNING: Cannot safely be disabled once enabled.
+    # WARNING: If you can avoid using a hostPath volume, you should.
+    # Please read https://kubernetes.io/docs/concepts/storage/volumes/#hostpath before enabling this feature.
+    # 1. Enabled: enabling HostPath volume support
+    # 2. Disabled: disabling HostPath volume support
+    kubernetes.podspec-volumes-hostpath: "disabled"
+
     # Controls whether init containers support is enabled or not.
     # 1. Enabled: enabling init containers support
     # 2. Disabled: disabling init containers support
@@ -7692,7 +7566,7 @@ metadata:
   labels:
     app.kubernetes.io/name: knative-serving
     app.kubernetes.io/component: controller
-    app.kubernetes.io/version: "1.16.0"
+    app.kubernetes.io/version: "1.17.0"
   annotations:
     knative.dev/example-checksum: "aa3813a8"
 data:
@@ -7777,7 +7651,7 @@ metadata:
   labels:
     app.kubernetes.io/name: knative-serving
     app.kubernetes.io/component: controller
-    app.kubernetes.io/version: "1.16.0"
+    app.kubernetes.io/version: "1.17.0"
   annotations:
     knative.dev/example-checksum: "f4b71f57"
 data:
@@ -7822,7 +7696,7 @@ metadata:
   name: config-logging
   namespace: knative-serving
   labels:
-    app.kubernetes.io/version: "1.16.0"
+    app.kubernetes.io/version: "1.17.0"
     app.kubernetes.io/component: logging
     app.kubernetes.io/name: knative-serving
   annotations:
@@ -7890,7 +7764,7 @@ metadata:
   labels:
     app.kubernetes.io/name: knative-serving
     app.kubernetes.io/component: networking
-    app.kubernetes.io/version: "1.16.0"
+    app.kubernetes.io/version: "1.17.0"
   annotations:
     knative.dev/example-checksum: "0573e07d"
 data:
@@ -8080,7 +7954,7 @@ metadata:
   labels:
     app.kubernetes.io/name: knative-serving
     app.kubernetes.io/component: observability
-    app.kubernetes.io/version: "1.16.0"
+    app.kubernetes.io/version: "1.17.0"
   annotations:
     knative.dev/example-checksum: "54abd711"
 data:
@@ -8185,7 +8059,7 @@ metadata:
   labels:
     app.kubernetes.io/name: knative-serving
     app.kubernetes.io/component: tracing
-    app.kubernetes.io/version: "1.16.0"
+    app.kubernetes.io/version: "1.17.0"
   annotations:
     knative.dev/example-checksum: "26614636"
 data:
@@ -8227,7 +8101,7 @@ metadata:
   labels:
     app.kubernetes.io/component: activator
     app.kubernetes.io/name: knative-serving
-    app.kubernetes.io/version: "1.16.0"
+    app.kubernetes.io/version: "1.17.0"
 spec:
   minReplicas: 1
   maxReplicas: 20
@@ -8251,7 +8125,7 @@ metadata:
   labels:
     app.kubernetes.io/component: activator
     app.kubernetes.io/name: knative-serving
-    app.kubernetes.io/version: "1.16.0"
+    app.kubernetes.io/version: "1.17.0"
 spec:
   minAvailable: 80%
   selector:
@@ -8265,7 +8139,7 @@ metadata:
   namespace: knative-serving
   labels:
     app.kubernetes.io/component: activator
-    app.kubernetes.io/version: "1.16.0"
+    app.kubernetes.io/version: "1.17.0"
     app.kubernetes.io/name: knative-serving
 spec:
   selector:
@@ -8279,7 +8153,7 @@ spec:
         role: activator
         app.kubernetes.io/component: activator
         app.kubernetes.io/name: knative-serving
-        app.kubernetes.io/version: "1.16.0"
+        app.kubernetes.io/version: "1.17.0"
     spec:
       affinity:
         podAntiAffinity:
@@ -8293,7 +8167,7 @@ spec:
       serviceAccountName: activator
       containers:
         - name: activator
-          image: gcr.io/knative-releases/knative.dev/serving/cmd/activator@sha256:24c19cbee078925b91cd2e85082b581d53b218b410c083b1005dc06dc549b1d3
+          image: gcr.io/knative-releases/knative.dev/serving/cmd/activator@sha256:cd4bb3af998f4199ea760718a309f50d1bcc9d5c4a1c5446684a6a0115a7aad5
           resources:
             requests:
               cpu: 300m
@@ -8361,7 +8235,7 @@ metadata:
   labels:
     app: activator
     app.kubernetes.io/component: activator
-    app.kubernetes.io/version: "1.16.0"
+    app.kubernetes.io/version: "1.17.0"
     app.kubernetes.io/name: knative-serving
 spec:
   selector:
@@ -8392,7 +8266,7 @@ metadata:
   labels:
     app.kubernetes.io/component: autoscaler
     app.kubernetes.io/name: knative-serving
-    app.kubernetes.io/version: "1.16.0"
+    app.kubernetes.io/version: "1.17.0"
 spec:
   replicas: 1
   selector:
@@ -8408,7 +8282,7 @@ spec:
         app: autoscaler
         app.kubernetes.io/component: autoscaler
         app.kubernetes.io/name: knative-serving
-        app.kubernetes.io/version: "1.16.0"
+        app.kubernetes.io/version: "1.17.0"
     spec:
       affinity:
         podAntiAffinity:
@@ -8422,7 +8296,7 @@ spec:
       serviceAccountName: controller
       containers:
         - name: autoscaler
-          image: gcr.io/knative-releases/knative.dev/serving/cmd/autoscaler@sha256:5e9236452d89363957d4e7e249d57740a8fcd946aed23f8518d94962bf440250
+          image: gcr.io/knative-releases/knative.dev/serving/cmd/autoscaler@sha256:ac1a83ba7c278ce9482b7bbfffe00e266f657b7d2356daed88ffe666bc68978e
           resources:
             requests:
               cpu: 100m
@@ -8480,7 +8354,7 @@ metadata:
     app: autoscaler
     app.kubernetes.io/component: autoscaler
     app.kubernetes.io/name: knative-serving
-    app.kubernetes.io/version: "1.16.0"
+    app.kubernetes.io/version: "1.17.0"
   name: autoscaler
   namespace: knative-serving
 spec:
@@ -8505,7 +8379,7 @@ metadata:
   labels:
     app.kubernetes.io/component: controller
     app.kubernetes.io/name: knative-serving
-    app.kubernetes.io/version: "1.16.0"
+    app.kubernetes.io/version: "1.17.0"
 spec:
   selector:
     matchLabels:
@@ -8516,7 +8390,7 @@ spec:
         app: controller
         app.kubernetes.io/component: controller
         app.kubernetes.io/name: knative-serving
-        app.kubernetes.io/version: "1.16.0"
+        app.kubernetes.io/version: "1.17.0"
     spec:
       affinity:
         podAntiAffinity:
@@ -8530,7 +8404,7 @@ spec:
       serviceAccountName: controller
       containers:
         - name: controller
-          image: gcr.io/knative-releases/knative.dev/serving/cmd/controller@sha256:5fb22b052e6bc98a1a6bbb68c0282ddb50744702acee6d83110302bc990666e9
+          image: gcr.io/knative-releases/knative.dev/serving/cmd/controller@sha256:df24c6d3e20bc22a691fcd8db6df25a66c67498abd38a8a56e8847cb6bfb875b
           resources:
             requests:
               cpu: 100m
@@ -8591,7 +8465,7 @@ metadata:
     app: controller
     app.kubernetes.io/component: controller
     app.kubernetes.io/name: knative-serving
-    app.kubernetes.io/version: "1.16.0"
+    app.kubernetes.io/version: "1.17.0"
   name: controller
   namespace: knative-serving
 spec:
@@ -8613,7 +8487,7 @@ metadata:
   labels:
     app.kubernetes.io/component: webhook
     app.kubernetes.io/name: knative-serving
-    app.kubernetes.io/version: "1.16.0"
+    app.kubernetes.io/version: "1.17.0"
 spec:
   minReplicas: 1
   maxReplicas: 5
@@ -8637,7 +8511,7 @@ metadata:
   labels:
     app.kubernetes.io/component: webhook
     app.kubernetes.io/name: knative-serving
-    app.kubernetes.io/version: "1.16.0"
+    app.kubernetes.io/version: "1.17.0"
 spec:
   minAvailable: 80%
   selector:
@@ -8651,7 +8525,7 @@ metadata:
   namespace: knative-serving
   labels:
     app.kubernetes.io/component: webhook
-    app.kubernetes.io/version: "1.16.0"
+    app.kubernetes.io/version: "1.17.0"
     app.kubernetes.io/name: knative-serving
 spec:
   selector:
@@ -8664,7 +8538,7 @@ spec:
         app: webhook
         role: webhook
         app.kubernetes.io/component: webhook
-        app.kubernetes.io/version: "1.16.0"
+        app.kubernetes.io/version: "1.17.0"
         app.kubernetes.io/name: knative-serving
     spec:
       affinity:
@@ -8679,7 +8553,7 @@ spec:
       serviceAccountName: controller
       containers:
         - name: webhook
-          image: gcr.io/knative-releases/knative.dev/serving/cmd/webhook@sha256:0fb5a4245aa4737d443658754464cd0a076de959fe14623fb9e9d31318ccce24
+          image: gcr.io/knative-releases/knative.dev/serving/cmd/webhook@sha256:d842f05a1b05b1805021b9c0657783b4721e79dc96c5b58dc206998c7062d9d9
           resources:
             requests:
               cpu: 100m
@@ -8743,7 +8617,7 @@ metadata:
     app: webhook
     role: webhook
     app.kubernetes.io/component: webhook
-    app.kubernetes.io/version: "1.16.0"
+    app.kubernetes.io/version: "1.17.0"
     app.kubernetes.io/name: knative-serving
   name: webhook
   namespace: knative-serving
@@ -8769,7 +8643,7 @@ metadata:
   labels:
     app.kubernetes.io/component: webhook
     app.kubernetes.io/name: knative-serving
-    app.kubernetes.io/version: "1.16.0"
+    app.kubernetes.io/version: "1.17.0"
 webhooks:
   - admissionReviewVersions: ["v1", "v1beta1"]
     clientConfig:
@@ -8796,7 +8670,7 @@ metadata:
   labels:
     app.kubernetes.io/component: webhook
     app.kubernetes.io/name: knative-serving
-    app.kubernetes.io/version: "1.16.0"
+    app.kubernetes.io/version: "1.17.0"
 webhooks:
   - admissionReviewVersions: ["v1", "v1beta1"]
     clientConfig:
@@ -8838,7 +8712,7 @@ metadata:
   labels:
     app.kubernetes.io/component: webhook
     app.kubernetes.io/name: knative-serving
-    app.kubernetes.io/version: "1.16.0"
+    app.kubernetes.io/version: "1.17.0"
 webhooks:
   - admissionReviewVersions: ["v1", "v1beta1"]
     clientConfig:
@@ -8882,6 +8756,6 @@ metadata:
   labels:
     app.kubernetes.io/component: webhook
     app.kubernetes.io/name: knative-serving
-    app.kubernetes.io/version: "1.16.0"
+    app.kubernetes.io/version: "1.17.0"
 ---
 

--- a/hack/synchronize-knative-manifests.sh
+++ b/hack/synchronize-knative-manifests.sh
@@ -14,9 +14,9 @@
 set -euxo pipefail
 IFS=$'\n\t'
 
-KN_SERVING_RELEASE="v1.16.0" # Must be a release
-KN_EXTENSION_RELEASE="v1.16.0" # Must be a release
-KN_EVENTING_RELEASE="v1.16.1" # Must be a release
+KN_SERVING_RELEASE="v1.17.0" # Must be a release
+KN_EXTENSION_RELEASE="v1.17.0" # Must be a release
+KN_EVENTING_RELEASE="v1.17.2" # Must be a release
 BRANCH=${BRANCH:=synchronize-knative-manifests-${KN_SERVING_RELEASE?}}
 
 SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )


### PR DESCRIPTION
# Update common/knative manifests to v1.17.0/v1.17.2.

## ✏️ Summary of Changes

Update common/knative manifests to v1.17.0/v1.17.2.

## 📦 Dependencies
> List any dependencies or related PRs (e.g., "Depends on #123").

## 🐛 Related Issues

Fixes #3016, replaces #3017.

## ✅ Contributor Checklist
  - [X] I have tested these changes with kustomize. See [Installation Prerequisites](https://github.com/kubeflow/manifests#prerequisites).
  - [X] All commits are [_signed-off_](https://github.com/kubeflow/community/tree/master/dco-signoff-hook#signing-off-commits) to satisfy the DCO check.

---     
 
> You can join the CNCF Slack and access our meetings at the [Kubeflow Community](https://www.kubeflow.org/docs/about/community/) website. Our channel on the CNCF Slack is here [**#kubeflow-platform**](https://app.slack.com/client/T08PSQ7BQ/C073W572LA2).
  
