### PR TITLE
Update common/knative manifests to v1.16.2/v1.16.4.

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ used from the different projects of Kubeflow:
 | Component | Local Manifests Path | Upstream Revision |
 | - | - | - |
 | Istio | common/istio-1-24 | [1.24.2](https://github.com/istio/istio/releases/tag/1.24.2) |
-| Knative | common/knative/knative-serving <br /> common/knative/knative-eventing | [v1.16.0](https://github.com/knative/serving/releases/tag/knative-v1.16.0) <br /> [v1.16.1](https://github.com/knative/eventing/releases/tag/knative-v1.16.1) |
+| Knative | common/knative/knative-serving <br /> common/knative/knative-eventing | [v1.16.2](https://github.com/knative/serving/releases/tag/knative-v1.16.2) <br /> [v1.16.4](https://github.com/knative/eventing/releases/tag/knative-v1.16.4) |
 | Cert Manager | common/cert-manager | [1.16.1](https://github.com/cert-manager/cert-manager/releases/tag/v1.16.1) |
 
 ## Installation

--- a/common/knative/README.md
+++ b/common/knative/README.md
@@ -4,7 +4,7 @@
 
 The manifests for Knative Serving are based off the following:
 
-  - [Knative serving (v1.16.0)](https://github.com/knative/serving/releases/tag/knative-v1.16.0)
+  - [Knative serving (v1.16.2)](https://github.com/knative/serving/releases/tag/knative-v1.16.2)
   - [Knative ingress controller for Istio (v1.16.0)](https://github.com/knative-extensions/net-istio/releases/tag/knative-v1.16.0)
 
 1. Download the knative-serving manifests with the following commands:
@@ -54,7 +54,7 @@ The manifests for Knative Serving are based off the following:
 
 ## Knative-Eventing
 
-The manifests for Knative Eventing are based off the [v1.16.1 release](https://github.com/knative/eventing/releases/tag/knative-v1.16.1).
+The manifests for Knative Eventing are based off the [v1.16.4 release](https://github.com/knative/eventing/releases/tag/knative-v1.16.4).
 
   - [Eventing Core](https://github.com/knative/eventing/releases/download/knative-v1.12.6/eventing-core.yaml)
   - [In-Memory Channel](https://github.com/knative/eventing/releases/download/knative-v1.12.6/in-memory-channel.yaml)

--- a/common/knative/knative-eventing-post-install-jobs/base/eventing-post-install.yaml
+++ b/common/knative/knative-eventing-post-install-jobs/base/eventing-post-install.yaml
@@ -7,7 +7,7 @@ metadata:
     app: "storage-version-migration-eventing"
     app.kubernetes.io/name: knative-eventing
     app.kubernetes.io/component: storage-version-migration-job
-    app.kubernetes.io/version: "1.16.1"
+    app.kubernetes.io/version: "1.16.4"
   name: storage-version-migration-eventing
 spec:
   ttlSecondsAfterFinished: 600
@@ -18,7 +18,7 @@ spec:
         app: "storage-version-migration-eventing"
         app.kubernetes.io/name: knative-eventing
         app.kubernetes.io/component: storage-version-migration-job
-        app.kubernetes.io/version: "1.16.1"
+        app.kubernetes.io/version: "1.16.4"
         sidecar.istio.io/inject: "false"
       annotations:
         sidecar.istio.io/inject: "false"
@@ -26,28 +26,28 @@ spec:
       serviceAccountName: knative-eventing-post-install-job
       restartPolicy: OnFailure
       containers:
-      - name: migrate
-        image: gcr.io/knative-releases/knative.dev/pkg/apiextensions/storageversion/cmd/migrate@sha256:f1786ed71c979b93e3fba02c4cfb3df33d97be0cce2c9ef994bfba4cc15a5558
-        args:
-        - "apiserversources.sources.knative.dev"
-        - "brokers.eventing.knative.dev"
-        - "channels.messaging.knative.dev"
-        - "containersources.sources.knative.dev"
-        - "eventtypes.eventing.knative.dev"
-        - "inmemorychannels.messaging.knative.dev"
-        - "parallels.flows.knative.dev"
-        - "pingsources.sources.knative.dev"
-        - "sequences.flows.knative.dev"
-        - "sinkbindings.sources.knative.dev"
-        - "subscriptions.messaging.knative.dev"
-        - "triggers.eventing.knative.dev"
-        - "jobsinks.sinks.knative.dev"
-        securityContext:
-          allowPrivilegeEscalation: false
-          readOnlyRootFilesystem: true
-          runAsNonRoot: true
-          capabilities:
-            drop:
-            - ALL
-          seccompProfile:
-            type: RuntimeDefault
+        - name: migrate
+          image: gcr.io/knative-releases/knative.dev/pkg/apiextensions/storageversion/cmd/migrate@sha256:c6baaa8b2a882ff9269ebfe14b54dcba29efc060dfafc06971001b89b084667b
+          args:
+            - "apiserversources.sources.knative.dev"
+            - "brokers.eventing.knative.dev"
+            - "channels.messaging.knative.dev"
+            - "containersources.sources.knative.dev"
+            - "eventtypes.eventing.knative.dev"
+            - "inmemorychannels.messaging.knative.dev"
+            - "parallels.flows.knative.dev"
+            - "pingsources.sources.knative.dev"
+            - "sequences.flows.knative.dev"
+            - "sinkbindings.sources.knative.dev"
+            - "subscriptions.messaging.knative.dev"
+            - "triggers.eventing.knative.dev"
+            - "jobsinks.sinks.knative.dev"
+          securityContext:
+            allowPrivilegeEscalation: false
+            readOnlyRootFilesystem: true
+            runAsNonRoot: true
+            capabilities:
+              drop:
+                - ALL
+            seccompProfile:
+              type: RuntimeDefault

--- a/common/knative/knative-eventing-post-install-jobs/base/eventing-post-install.yaml
+++ b/common/knative/knative-eventing-post-install-jobs/base/eventing-post-install.yaml
@@ -26,28 +26,28 @@ spec:
       serviceAccountName: knative-eventing-post-install-job
       restartPolicy: OnFailure
       containers:
-        - name: migrate
-          image: gcr.io/knative-releases/knative.dev/pkg/apiextensions/storageversion/cmd/migrate@sha256:c6baaa8b2a882ff9269ebfe14b54dcba29efc060dfafc06971001b89b084667b
-          args:
-            - "apiserversources.sources.knative.dev"
-            - "brokers.eventing.knative.dev"
-            - "channels.messaging.knative.dev"
-            - "containersources.sources.knative.dev"
-            - "eventtypes.eventing.knative.dev"
-            - "inmemorychannels.messaging.knative.dev"
-            - "parallels.flows.knative.dev"
-            - "pingsources.sources.knative.dev"
-            - "sequences.flows.knative.dev"
-            - "sinkbindings.sources.knative.dev"
-            - "subscriptions.messaging.knative.dev"
-            - "triggers.eventing.knative.dev"
-            - "jobsinks.sinks.knative.dev"
-          securityContext:
-            allowPrivilegeEscalation: false
-            readOnlyRootFilesystem: true
-            runAsNonRoot: true
-            capabilities:
-              drop:
-                - ALL
-            seccompProfile:
-              type: RuntimeDefault
+      - name: migrate
+        image: gcr.io/knative-releases/knative.dev/pkg/apiextensions/storageversion/cmd/migrate@sha256:c6baaa8b2a882ff9269ebfe14b54dcba29efc060dfafc06971001b89b084667b
+        args:
+        - "apiserversources.sources.knative.dev"
+        - "brokers.eventing.knative.dev"
+        - "channels.messaging.knative.dev"
+        - "containersources.sources.knative.dev"
+        - "eventtypes.eventing.knative.dev"
+        - "inmemorychannels.messaging.knative.dev"
+        - "parallels.flows.knative.dev"
+        - "pingsources.sources.knative.dev"
+        - "sequences.flows.knative.dev"
+        - "sinkbindings.sources.knative.dev"
+        - "subscriptions.messaging.knative.dev"
+        - "triggers.eventing.knative.dev"
+        - "jobsinks.sinks.knative.dev"
+        securityContext:
+          allowPrivilegeEscalation: false
+          readOnlyRootFilesystem: true
+          runAsNonRoot: true
+          capabilities:
+            drop:
+            - ALL
+          seccompProfile:
+            type: RuntimeDefault

--- a/common/knative/knative-eventing/base/upstream/eventing-core.yaml
+++ b/common/knative/knative-eventing/base/upstream/eventing-core.yaml
@@ -3,7 +3,7 @@ kind: Namespace
 metadata:
   name: knative-eventing
   labels:
-    app.kubernetes.io/version: "1.16.1"
+    app.kubernetes.io/version: "1.16.4"
     app.kubernetes.io/name: knative-eventing
 ---
 apiVersion: v1
@@ -12,7 +12,7 @@ metadata:
   name: eventing-controller
   namespace: knative-eventing
   labels:
-    app.kubernetes.io/version: "1.16.1"
+    app.kubernetes.io/version: "1.16.4"
     app.kubernetes.io/name: knative-eventing
 ---
 apiVersion: rbac.authorization.k8s.io/v1
@@ -20,7 +20,7 @@ kind: ClusterRoleBinding
 metadata:
   name: eventing-controller
   labels:
-    app.kubernetes.io/version: "1.16.1"
+    app.kubernetes.io/version: "1.16.4"
     app.kubernetes.io/name: knative-eventing
 subjects:
   - kind: ServiceAccount
@@ -36,7 +36,7 @@ kind: ClusterRoleBinding
 metadata:
   name: eventing-controller-resolver
   labels:
-    app.kubernetes.io/version: "1.16.1"
+    app.kubernetes.io/version: "1.16.4"
     app.kubernetes.io/name: knative-eventing
 subjects:
   - kind: ServiceAccount
@@ -52,7 +52,7 @@ kind: ClusterRoleBinding
 metadata:
   name: eventing-controller-source-observer
   labels:
-    app.kubernetes.io/version: "1.16.1"
+    app.kubernetes.io/version: "1.16.4"
     app.kubernetes.io/name: knative-eventing
 subjects:
   - kind: ServiceAccount
@@ -68,7 +68,7 @@ kind: ClusterRoleBinding
 metadata:
   name: eventing-controller-sources-controller
   labels:
-    app.kubernetes.io/version: "1.16.1"
+    app.kubernetes.io/version: "1.16.4"
     app.kubernetes.io/name: knative-eventing
 subjects:
   - kind: ServiceAccount
@@ -84,7 +84,7 @@ kind: ClusterRoleBinding
 metadata:
   name: eventing-controller-manipulator
   labels:
-    app.kubernetes.io/version: "1.16.1"
+    app.kubernetes.io/version: "1.16.4"
     app.kubernetes.io/name: knative-eventing
 subjects:
   - kind: ServiceAccount
@@ -100,7 +100,7 @@ kind: ClusterRoleBinding
 metadata:
   name: eventing-controller-crossnamespace-subscriber
   labels:
-    app.kubernetes.io/version: "1.16.1"
+    app.kubernetes.io/version: "1.16.4"
     app.kubernetes.io/name: knative-eventing
 subjects:
   - kind: ServiceAccount
@@ -117,7 +117,7 @@ metadata:
   name: job-sink
   namespace: knative-eventing
   labels:
-    app.kubernetes.io/version: "1.16.1"
+    app.kubernetes.io/version: "1.16.4"
     app.kubernetes.io/name: knative-eventing
 ---
 apiVersion: rbac.authorization.k8s.io/v1
@@ -125,7 +125,7 @@ kind: ClusterRoleBinding
 metadata:
   name: knative-eventing-job-sink
   labels:
-    app.kubernetes.io/version: "1.16.1"
+    app.kubernetes.io/version: "1.16.4"
     app.kubernetes.io/name: knative-eventing
 subjects:
   - kind: ServiceAccount
@@ -142,7 +142,7 @@ metadata:
   name: pingsource-mt-adapter
   namespace: knative-eventing
   labels:
-    app.kubernetes.io/version: "1.16.1"
+    app.kubernetes.io/version: "1.16.4"
     app.kubernetes.io/name: knative-eventing
 ---
 apiVersion: rbac.authorization.k8s.io/v1
@@ -150,7 +150,7 @@ kind: ClusterRoleBinding
 metadata:
   name: knative-eventing-pingsource-mt-adapter
   labels:
-    app.kubernetes.io/version: "1.16.1"
+    app.kubernetes.io/version: "1.16.4"
     app.kubernetes.io/name: knative-eventing
 subjects:
   - kind: ServiceAccount
@@ -167,7 +167,7 @@ metadata:
   name: eventing-webhook
   namespace: knative-eventing
   labels:
-    app.kubernetes.io/version: "1.16.1"
+    app.kubernetes.io/version: "1.16.4"
     app.kubernetes.io/name: knative-eventing
 ---
 apiVersion: rbac.authorization.k8s.io/v1
@@ -175,7 +175,7 @@ kind: ClusterRoleBinding
 metadata:
   name: eventing-webhook
   labels:
-    app.kubernetes.io/version: "1.16.1"
+    app.kubernetes.io/version: "1.16.4"
     app.kubernetes.io/name: knative-eventing
 subjects:
   - kind: ServiceAccount
@@ -192,7 +192,7 @@ metadata:
   namespace: knative-eventing
   name: eventing-webhook
   labels:
-    app.kubernetes.io/version: "1.16.1"
+    app.kubernetes.io/version: "1.16.4"
     app.kubernetes.io/name: knative-eventing
 subjects:
   - kind: ServiceAccount
@@ -208,7 +208,7 @@ kind: ClusterRoleBinding
 metadata:
   name: eventing-webhook-resolver
   labels:
-    app.kubernetes.io/version: "1.16.1"
+    app.kubernetes.io/version: "1.16.4"
     app.kubernetes.io/name: knative-eventing
 subjects:
   - kind: ServiceAccount
@@ -224,7 +224,7 @@ kind: ClusterRoleBinding
 metadata:
   name: eventing-webhook-podspecable-binding
   labels:
-    app.kubernetes.io/version: "1.16.1"
+    app.kubernetes.io/version: "1.16.4"
     app.kubernetes.io/name: knative-eventing
 subjects:
   - kind: ServiceAccount
@@ -241,7 +241,7 @@ metadata:
   name: config-br-default-channel
   namespace: knative-eventing
   labels:
-    app.kubernetes.io/version: "1.16.1"
+    app.kubernetes.io/version: "1.16.4"
     app.kubernetes.io/name: knative-eventing
 data:
   channel-template-spec: |
@@ -254,7 +254,7 @@ metadata:
   name: config-br-defaults
   namespace: knative-eventing
   labels:
-    app.kubernetes.io/version: "1.16.1"
+    app.kubernetes.io/version: "1.16.4"
     app.kubernetes.io/name: knative-eventing
 data:
   default-br-config: |
@@ -275,7 +275,7 @@ metadata:
   name: default-ch-webhook
   namespace: knative-eventing
   labels:
-    app.kubernetes.io/version: "1.16.1"
+    app.kubernetes.io/version: "1.16.4"
     app.kubernetes.io/name: knative-eventing
 data:
   default-ch-config: |
@@ -294,7 +294,7 @@ metadata:
   namespace: knative-eventing
   annotations:
     knative.dev/example-checksum: "9185c153"
-    app.kubernetes.io/version: "1.16.1"
+    app.kubernetes.io/version: "1.16.4"
     app.kubernetes.io/name: knative-eventing
 data:
   _example: |
@@ -325,7 +325,7 @@ metadata:
   labels:
     knative.dev/config-propagation: original
     knative.dev/config-category: eventing
-    app.kubernetes.io/version: "1.16.1"
+    app.kubernetes.io/version: "1.16.4"
     app.kubernetes.io/name: knative-eventing
 data:
   kreference-group: "disabled"
@@ -378,7 +378,7 @@ metadata:
   name: config-leader-election
   namespace: knative-eventing
   labels:
-    app.kubernetes.io/version: "1.16.1"
+    app.kubernetes.io/version: "1.16.4"
     app.kubernetes.io/name: knative-eventing
   annotations:
     knative.dev/example-checksum: "f7948630"
@@ -426,7 +426,7 @@ metadata:
   labels:
     knative.dev/config-propagation: original
     knative.dev/config-category: eventing
-    app.kubernetes.io/version: "1.16.1"
+    app.kubernetes.io/version: "1.16.4"
     app.kubernetes.io/name: knative-eventing
 data:
   zap-logger-config: |
@@ -461,7 +461,7 @@ metadata:
   labels:
     knative.dev/config-propagation: original
     knative.dev/config-category: eventing
-    app.kubernetes.io/version: "1.16.1"
+    app.kubernetes.io/version: "1.16.4"
     app.kubernetes.io/name: knative-eventing
   annotations:
     knative.dev/example-checksum: "f46cf09d"
@@ -520,7 +520,7 @@ metadata:
   name: config-sugar
   namespace: knative-eventing
   labels:
-    app.kubernetes.io/version: "1.16.1"
+    app.kubernetes.io/version: "1.16.4"
     app.kubernetes.io/name: knative-eventing
   annotations:
     knative.dev/example-checksum: "62dfac6f"
@@ -564,7 +564,7 @@ metadata:
   labels:
     knative.dev/config-propagation: original
     knative.dev/config-category: eventing
-    app.kubernetes.io/version: "1.16.1"
+    app.kubernetes.io/version: "1.16.4"
     app.kubernetes.io/name: knative-eventing
   annotations:
     knative.dev/example-checksum: "0492ceb0"
@@ -606,7 +606,7 @@ metadata:
   labels:
     knative.dev/high-availability: "true"
     app.kubernetes.io/component: eventing-controller
-    app.kubernetes.io/version: "1.16.1"
+    app.kubernetes.io/version: "1.16.4"
     app.kubernetes.io/name: knative-eventing
     bindings.knative.dev/exclude: "true"
 spec:
@@ -618,7 +618,7 @@ spec:
       labels:
         app: eventing-controller
         app.kubernetes.io/component: eventing-controller
-        app.kubernetes.io/version: "1.16.1"
+        app.kubernetes.io/version: "1.16.4"
         app.kubernetes.io/name: knative-eventing
     spec:
       affinity:
@@ -635,7 +635,7 @@ spec:
       containers:
         - name: eventing-controller
           terminationMessagePolicy: FallbackToLogsOnError
-          image: gcr.io/knative-releases/knative.dev/eventing/cmd/controller@sha256:8157c2d59c69b2fc658bad9f795aa8b5d9b72b052916ba3c5b83921e4230cecf
+          image: gcr.io/knative-releases/knative.dev/eventing/cmd/controller@sha256:806330a39dfac379cd39a771c2e42f3a9998d0f214fe38f28bcb101c554a5a7a
           resources:
             requests:
               cpu: 100m
@@ -652,7 +652,7 @@ spec:
             - name: METRICS_DOMAIN
               value: knative.dev/eventing
             - name: APISERVER_RA_IMAGE
-              value: gcr.io/knative-releases/knative.dev/eventing/cmd/apiserver_receive_adapter@sha256:f3b6e75a19a1d7c2d2de15d15a5d3a5efac3a10120f2289584de2b139ea6b01a
+              value: gcr.io/knative-releases/knative.dev/eventing/cmd/apiserver_receive_adapter@sha256:681680716067c6466511f391822e35e0fd5c4eaf97405b058532ca082f3a8ba4
             - name: POD_NAME
               valueFrom:
                 fieldRef:
@@ -697,7 +697,7 @@ metadata:
   namespace: knative-eventing
   labels:
     app.kubernetes.io/component: job-sink
-    app.kubernetes.io/version: "1.16.1"
+    app.kubernetes.io/version: "1.16.4"
     app.kubernetes.io/name: knative-eventing
 spec:
   replicas: 1
@@ -709,7 +709,7 @@ spec:
       labels:
         sinks.knative.dev/sink: job-sink
         app.kubernetes.io/component: job-sink
-        app.kubernetes.io/version: "1.16.1"
+        app.kubernetes.io/version: "1.16.4"
         app.kubernetes.io/name: knative-eventing
     spec:
       affinity:
@@ -725,7 +725,7 @@ spec:
       containers:
         - name: job-sink
           terminationMessagePolicy: FallbackToLogsOnError
-          image: gcr.io/knative-releases/knative.dev/eventing/cmd/jobsink@sha256:e9a6e5ba3d6838f9feb26197b0f521e503cb313aba38732fc876364fc7d72dac
+          image: gcr.io/knative-releases/knative.dev/eventing/cmd/jobsink@sha256:3e5270924afeeccc8dfe31142a1c7f7e3ec3489df11b4c81f69f352a788ad207
           env:
             - name: SYSTEM_NAMESPACE
               valueFrom:
@@ -807,7 +807,7 @@ metadata:
   labels:
     sinks.knative.dev/sink: job-sink
     app.kubernetes.io/component: job-sink
-    app.kubernetes.io/version: "1.16.1"
+    app.kubernetes.io/version: "1.16.4"
     app.kubernetes.io/name: knative-eventing
   name: job-sink
   namespace: knative-eventing
@@ -835,7 +835,7 @@ metadata:
   namespace: knative-eventing
   labels:
     app.kubernetes.io/component: pingsource-mt-adapter
-    app.kubernetes.io/version: "1.16.1"
+    app.kubernetes.io/version: "1.16.4"
     app.kubernetes.io/name: knative-eventing
     bindings.knative.dev/exclude: "true"
 spec:
@@ -850,7 +850,7 @@ spec:
         eventing.knative.dev/source: ping-source-controller
         sources.knative.dev/role: adapter
         app.kubernetes.io/component: pingsource-mt-adapter
-        app.kubernetes.io/version: "1.16.1"
+        app.kubernetes.io/version: "1.16.4"
         app.kubernetes.io/name: knative-eventing
     spec:
       affinity:
@@ -866,7 +866,7 @@ spec:
       enableServiceLinks: false
       containers:
         - name: dispatcher
-          image: gcr.io/knative-releases/knative.dev/eventing/cmd/mtping@sha256:f242272f0224da5704adf9922138acfaa971d32a03130b2f24057995032c3698
+          image: gcr.io/knative-releases/knative.dev/eventing/cmd/mtping@sha256:1ccb821e1a4edf4cb6b35449e1ec9d03c9098d9a19361a06c0e8f6fc6dd2117a
           env:
             - name: SYSTEM_NAMESPACE
               value: ''
@@ -923,7 +923,7 @@ metadata:
   namespace: knative-eventing
   labels:
     app.kubernetes.io/component: eventing-webhook
-    app.kubernetes.io/version: "1.16.1"
+    app.kubernetes.io/version: "1.16.4"
     app.kubernetes.io/name: knative-eventing
 spec:
   scaleTargetRef:
@@ -947,7 +947,7 @@ metadata:
   namespace: knative-eventing
   labels:
     app.kubernetes.io/component: eventing-webhook
-    app.kubernetes.io/version: "1.16.1"
+    app.kubernetes.io/version: "1.16.4"
     app.kubernetes.io/name: knative-eventing
 spec:
   minAvailable: 80%
@@ -962,7 +962,7 @@ metadata:
   namespace: knative-eventing
   labels:
     app.kubernetes.io/component: eventing-webhook
-    app.kubernetes.io/version: "1.16.1"
+    app.kubernetes.io/version: "1.16.4"
     app.kubernetes.io/name: knative-eventing
     bindings.knative.dev/exclude: "true"
 spec:
@@ -976,7 +976,7 @@ spec:
         app: eventing-webhook
         role: eventing-webhook
         app.kubernetes.io/component: eventing-webhook
-        app.kubernetes.io/version: "1.16.1"
+        app.kubernetes.io/version: "1.16.4"
         app.kubernetes.io/name: knative-eventing
     spec:
       affinity:
@@ -993,7 +993,7 @@ spec:
       containers:
         - name: eventing-webhook
           terminationMessagePolicy: FallbackToLogsOnError
-          image: gcr.io/knative-releases/knative.dev/eventing/cmd/webhook@sha256:09f4923e016940fb87875a8d85b6d504ee3c696f45ffb3d4720cfa9b3b67cfca
+          image: gcr.io/knative-releases/knative.dev/eventing/cmd/webhook@sha256:be90d7813786da265dbda2408742b4783e4f69e73719cb3b6e2c103d631ed721
           resources:
             requests:
               cpu: 100m
@@ -1061,7 +1061,7 @@ metadata:
   labels:
     role: eventing-webhook
     app.kubernetes.io/component: eventing-webhook
-    app.kubernetes.io/version: "1.16.1"
+    app.kubernetes.io/version: "1.16.4"
     app.kubernetes.io/name: knative-eventing
   name: eventing-webhook
   namespace: knative-eventing
@@ -1081,7 +1081,7 @@ metadata:
     eventing.knative.dev/source: "true"
     duck.knative.dev/source: "true"
     knative.dev/crd-install: "true"
-    app.kubernetes.io/version: "1.16.1"
+    app.kubernetes.io/version: "1.16.4"
     app.kubernetes.io/name: knative-eventing
   annotations:
     registry.knative.dev/eventTypes: |
@@ -1352,7 +1352,7 @@ metadata:
   labels:
     knative.dev/crd-install: "true"
     duck.knative.dev/addressable: "true"
-    app.kubernetes.io/version: "1.16.1"
+    app.kubernetes.io/version: "1.16.4"
     app.kubernetes.io/name: knative-eventing
 spec:
   group: eventing.knative.dev
@@ -1552,7 +1552,7 @@ metadata:
     knative.dev/crd-install: "true"
     messaging.knative.dev/subscribable: "true"
     duck.knative.dev/addressable: "true"
-    app.kubernetes.io/version: "1.16.1"
+    app.kubernetes.io/version: "1.16.4"
     app.kubernetes.io/name: knative-eventing
 spec:
   group: messaging.knative.dev
@@ -1895,7 +1895,7 @@ metadata:
     eventing.knative.dev/source: "true"
     duck.knative.dev/source: "true"
     knative.dev/crd-install: "true"
-    app.kubernetes.io/version: "1.16.1"
+    app.kubernetes.io/version: "1.16.4"
     app.kubernetes.io/name: knative-eventing
   name: containersources.sources.knative.dev
 spec:
@@ -2055,7 +2055,7 @@ metadata:
   name: eventpolicies.eventing.knative.dev
   labels:
     knative.dev/crd-install: "true"
-    app.kubernetes.io/version: "1.16.1"
+    app.kubernetes.io/version: "1.16.4"
     app.kubernetes.io/name: knative-eventing
 spec:
   group: eventing.knative.dev
@@ -2245,14 +2245,6 @@ spec:
       - knative
       - eventing
   scope: Namespaced
-  conversion:
-    strategy: Webhook
-    webhook:
-      conversionReviewVersions: ["v1", "v1beta1"]
-      clientConfig:
-        service:
-          name: eventing-webhook
-          namespace: knative-eventing
 ---
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
@@ -2260,7 +2252,7 @@ metadata:
   name: eventtypes.eventing.knative.dev
   labels:
     knative.dev/crd-install: "true"
-    app.kubernetes.io/version: "1.16.1"
+    app.kubernetes.io/version: "1.16.4"
     app.kubernetes.io/name: knative-eventing
 spec:
   group: eventing.knative.dev
@@ -2634,7 +2626,7 @@ metadata:
   labels:
     knative.dev/crd-install: "true"
     duck.knative.dev/addressable: "true"
-    app.kubernetes.io/version: "1.16.1"
+    app.kubernetes.io/version: "1.16.4"
     app.kubernetes.io/name: knative-eventing
 spec:
   group: sinks.knative.dev
@@ -2709,10 +2701,6 @@ spec:
                       name:
                         description: The name of the applied EventPolicy
                         type: string
-                observedGeneration:
-                  description: ObservedGeneration is the 'Generation' of the Service that was last processed by the controller.
-                  type: integer
-                  format: int64
                 conditions:
                   description: Conditions the latest available observations of a resource's current state.
                   type: array
@@ -2775,7 +2763,7 @@ metadata:
   labels:
     knative.dev/crd-install: "true"
     duck.knative.dev/addressable: "true"
-    app.kubernetes.io/version: "1.16.1"
+    app.kubernetes.io/version: "1.16.4"
     app.kubernetes.io/name: knative-eventing
 spec:
   group: flows.knative.dev
@@ -3288,7 +3276,7 @@ metadata:
     eventing.knative.dev/source: "true"
     duck.knative.dev/source: "true"
     knative.dev/crd-install: "true"
-    app.kubernetes.io/version: "1.16.1"
+    app.kubernetes.io/version: "1.16.4"
     app.kubernetes.io/name: knative-eventing
   annotations:
     registry.knative.dev/eventTypes: |
@@ -3641,7 +3629,7 @@ metadata:
   labels:
     knative.dev/crd-install: "true"
     duck.knative.dev/addressable: "true"
-    app.kubernetes.io/version: "1.16.1"
+    app.kubernetes.io/version: "1.16.4"
     app.kubernetes.io/name: knative-eventing
 spec:
   group: flows.knative.dev
@@ -4010,7 +3998,7 @@ metadata:
     duck.knative.dev/source: "true"
     duck.knative.dev/binding: "true"
     knative.dev/crd-install: "true"
-    app.kubernetes.io/version: "1.16.1"
+    app.kubernetes.io/version: "1.16.4"
     app.kubernetes.io/name: knative-eventing
   name: sinkbindings.sources.knative.dev
 spec:
@@ -4211,7 +4199,7 @@ metadata:
   name: subscriptions.messaging.knative.dev
   labels:
     knative.dev/crd-install: "true"
-    app.kubernetes.io/version: "1.16.1"
+    app.kubernetes.io/version: "1.16.4"
     app.kubernetes.io/name: knative-eventing
 spec:
   group: messaging.knative.dev
@@ -4458,7 +4446,7 @@ metadata:
   name: triggers.eventing.knative.dev
   labels:
     knative.dev/crd-install: "true"
-    app.kubernetes.io/version: "1.16.1"
+    app.kubernetes.io/version: "1.16.4"
     app.kubernetes.io/name: knative-eventing
 spec:
   group: eventing.knative.dev
@@ -4718,7 +4706,7 @@ kind: ClusterRole
 metadata:
   name: addressable-resolver
   labels:
-    app.kubernetes.io/version: "1.16.1"
+    app.kubernetes.io/version: "1.16.4"
     app.kubernetes.io/name: knative-eventing
 aggregationRule:
   clusterRoleSelectors:
@@ -4732,7 +4720,7 @@ metadata:
   name: service-addressable-resolver
   labels:
     duck.knative.dev/addressable: "true"
-    app.kubernetes.io/version: "1.16.1"
+    app.kubernetes.io/version: "1.16.4"
     app.kubernetes.io/name: knative-eventing
 rules:
   - apiGroups:
@@ -4750,7 +4738,7 @@ metadata:
   name: serving-addressable-resolver
   labels:
     duck.knative.dev/addressable: "true"
-    app.kubernetes.io/version: "1.16.1"
+    app.kubernetes.io/version: "1.16.4"
     app.kubernetes.io/name: knative-eventing
 rules:
   - apiGroups:
@@ -4771,7 +4759,7 @@ metadata:
   name: channel-addressable-resolver
   labels:
     duck.knative.dev/addressable: "true"
-    app.kubernetes.io/version: "1.16.1"
+    app.kubernetes.io/version: "1.16.4"
     app.kubernetes.io/name: knative-eventing
 rules:
   - apiGroups:
@@ -4796,7 +4784,7 @@ metadata:
   name: broker-addressable-resolver
   labels:
     duck.knative.dev/addressable: "true"
-    app.kubernetes.io/version: "1.16.1"
+    app.kubernetes.io/version: "1.16.4"
     app.kubernetes.io/name: knative-eventing
 rules:
   - apiGroups:
@@ -4815,7 +4803,7 @@ metadata:
   name: flows-addressable-resolver
   labels:
     duck.knative.dev/addressable: "true"
-    app.kubernetes.io/version: "1.16.1"
+    app.kubernetes.io/version: "1.16.4"
     app.kubernetes.io/name: knative-eventing
 rules:
   - apiGroups:
@@ -4830,12 +4818,31 @@ rules:
       - list
       - watch
 ---
+kind: ClusterRole
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: jobsinks-addressable-resolver
+  labels:
+    duck.knative.dev/addressable: "true"
+    app.kubernetes.io/version: "1.16.4"
+    app.kubernetes.io/name: knative-eventing
+rules:
+  - apiGroups:
+      - sinks.knative.dev
+    resources:
+      - jobsinks
+      - jobsinks/status
+    verbs:
+      - get
+      - list
+      - watch
+---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   name: eventing-broker-filter
   labels:
-    app.kubernetes.io/version: "1.16.1"
+    app.kubernetes.io/version: "1.16.4"
     app.kubernetes.io/name: knative-eventing
 rules:
   - apiGroups:
@@ -4861,7 +4868,7 @@ kind: ClusterRole
 metadata:
   name: eventing-broker-ingress
   labels:
-    app.kubernetes.io/version: "1.16.1"
+    app.kubernetes.io/version: "1.16.4"
     app.kubernetes.io/name: knative-eventing
 rules:
   - apiGroups:
@@ -4878,7 +4885,7 @@ kind: ClusterRole
 metadata:
   name: eventing-config-reader
   labels:
-    app.kubernetes.io/version: "1.16.1"
+    app.kubernetes.io/version: "1.16.4"
     app.kubernetes.io/name: knative-eventing
 rules:
   - apiGroups:
@@ -4895,7 +4902,7 @@ kind: ClusterRole
 metadata:
   name: channelable-manipulator
   labels:
-    app.kubernetes.io/version: "1.16.1"
+    app.kubernetes.io/version: "1.16.4"
     app.kubernetes.io/name: knative-eventing
 aggregationRule:
   clusterRoleSelectors:
@@ -4909,7 +4916,7 @@ metadata:
   name: meta-channelable-manipulator
   labels:
     duck.knative.dev/channelable: "true"
-    app.kubernetes.io/version: "1.16.1"
+    app.kubernetes.io/version: "1.16.4"
     app.kubernetes.io/name: knative-eventing
 rules:
   - apiGroups:
@@ -4932,7 +4939,7 @@ metadata:
   name: knative-eventing-namespaced-admin
   labels:
     rbac.authorization.k8s.io/aggregate-to-admin: "true"
-    app.kubernetes.io/version: "1.16.1"
+    app.kubernetes.io/version: "1.16.4"
     app.kubernetes.io/name: knative-eventing
 rules:
   - apiGroups: ["eventing.knative.dev"]
@@ -4945,7 +4952,7 @@ metadata:
   name: knative-messaging-namespaced-admin
   labels:
     rbac.authorization.k8s.io/aggregate-to-admin: "true"
-    app.kubernetes.io/version: "1.16.1"
+    app.kubernetes.io/version: "1.16.4"
     app.kubernetes.io/name: knative-eventing
 rules:
   - apiGroups: ["messaging.knative.dev"]
@@ -4958,7 +4965,7 @@ metadata:
   name: knative-flows-namespaced-admin
   labels:
     rbac.authorization.k8s.io/aggregate-to-admin: "true"
-    app.kubernetes.io/version: "1.16.1"
+    app.kubernetes.io/version: "1.16.4"
     app.kubernetes.io/name: knative-eventing
 rules:
   - apiGroups: ["flows.knative.dev"]
@@ -4971,7 +4978,7 @@ metadata:
   name: knative-sources-namespaced-admin
   labels:
     rbac.authorization.k8s.io/aggregate-to-admin: "true"
-    app.kubernetes.io/version: "1.16.1"
+    app.kubernetes.io/version: "1.16.4"
     app.kubernetes.io/name: knative-eventing
 rules:
   - apiGroups: ["sources.knative.dev"]
@@ -4984,7 +4991,7 @@ metadata:
   name: knative-bindings-namespaced-admin
   labels:
     rbac.authorization.k8s.io/aggregate-to-admin: "true"
-    app.kubernetes.io/version: "1.16.1"
+    app.kubernetes.io/version: "1.16.4"
     app.kubernetes.io/name: knative-eventing
 rules:
   - apiGroups: ["bindings.knative.dev"]
@@ -4994,13 +5001,26 @@ rules:
 kind: ClusterRole
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
+  name: knative-sinks-namespaced-admin
+  labels:
+    rbac.authorization.k8s.io/aggregate-to-admin: "true"
+    app.kubernetes.io/version: "1.16.4"
+    app.kubernetes.io/name: knative-eventing
+rules:
+  - apiGroups: ["sinks.knative.dev"]
+    resources: ["*"]
+    verbs: ["*"]
+---
+kind: ClusterRole
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
   name: knative-eventing-namespaced-edit
   labels:
     rbac.authorization.k8s.io/aggregate-to-edit: "true"
-    app.kubernetes.io/version: "1.16.1"
+    app.kubernetes.io/version: "1.16.4"
     app.kubernetes.io/name: knative-eventing
 rules:
-  - apiGroups: ["eventing.knative.dev", "messaging.knative.dev", "sources.knative.dev", "flows.knative.dev", "bindings.knative.dev"]
+  - apiGroups: ["eventing.knative.dev", "messaging.knative.dev", "sources.knative.dev", "flows.knative.dev", "bindings.knative.dev", "sinks.knative.dev"]
     resources: ["*"]
     verbs: ["create", "update", "patch", "delete"]
 ---
@@ -5010,10 +5030,10 @@ metadata:
   name: knative-eventing-namespaced-view
   labels:
     rbac.authorization.k8s.io/aggregate-to-view: "true"
-    app.kubernetes.io/version: "1.16.1"
+    app.kubernetes.io/version: "1.16.4"
     app.kubernetes.io/name: knative-eventing
 rules:
-  - apiGroups: ["eventing.knative.dev", "messaging.knative.dev", "sources.knative.dev", "flows.knative.dev", "bindings.knative.dev"]
+  - apiGroups: ["eventing.knative.dev", "messaging.knative.dev", "sources.knative.dev", "flows.knative.dev", "bindings.knative.dev", "sinks.knative.dev"]
     resources: ["*"]
     verbs: ["get", "list", "watch"]
 ---
@@ -5022,7 +5042,7 @@ kind: ClusterRole
 metadata:
   name: knative-eventing-controller
   labels:
-    app.kubernetes.io/version: "1.16.1"
+    app.kubernetes.io/version: "1.16.4"
     app.kubernetes.io/name: knative-eventing
 rules:
   - apiGroups:
@@ -5204,7 +5224,7 @@ kind: ClusterRole
 metadata:
   name: crossnamespace-subscriber
   labels:
-    app.kubernetes.io/version: "1.16.1"
+    app.kubernetes.io/version: "1.16.4"
     app.kubernetes.io/name: knative-eventing
 aggregationRule:
   clusterRoleSelectors:
@@ -5218,7 +5238,7 @@ metadata:
   name: channel-subscriber
   labels:
     duck.knative.dev/crossnamespace-subscribable: "true"
-    app.kubernetes.io/version: "1.16.1"
+    app.kubernetes.io/version: "1.16.4"
     app.kubernetes.io/name: knative-eventing
 rules:
   - apiGroups:
@@ -5234,7 +5254,7 @@ metadata:
   name: broker-subscriber
   labels:
     duck.knative.dev/crossnamespace-subscribable: "true"
-    app.kubernetes.io/version: "1.16.1"
+    app.kubernetes.io/version: "1.16.4"
     app.kubernetes.io/name: knative-eventing
 rules:
   - apiGroups:
@@ -5249,7 +5269,7 @@ kind: ClusterRole
 metadata:
   name: knative-eventing-job-sink
   labels:
-    app.kubernetes.io/version: "1.16.1"
+    app.kubernetes.io/version: "1.16.4"
     app.kubernetes.io/name: knative-eventing
 rules:
   - apiGroups:
@@ -5328,7 +5348,7 @@ kind: ClusterRole
 metadata:
   name: knative-eventing-pingsource-mt-adapter
   labels:
-    app.kubernetes.io/version: "1.16.1"
+    app.kubernetes.io/version: "1.16.4"
     app.kubernetes.io/name: knative-eventing
 rules:
   - apiGroups:
@@ -5385,7 +5405,7 @@ kind: ClusterRole
 metadata:
   name: podspecable-binding
   labels:
-    app.kubernetes.io/version: "1.16.1"
+    app.kubernetes.io/version: "1.16.4"
     app.kubernetes.io/name: knative-eventing
 aggregationRule:
   clusterRoleSelectors:
@@ -5399,7 +5419,7 @@ metadata:
   name: builtin-podspecable-binding
   labels:
     duck.knative.dev/podspecable: "true"
-    app.kubernetes.io/version: "1.16.1"
+    app.kubernetes.io/version: "1.16.4"
     app.kubernetes.io/name: knative-eventing
 rules:
   - apiGroups:
@@ -5427,7 +5447,7 @@ kind: ClusterRole
 metadata:
   name: source-observer
   labels:
-    app.kubernetes.io/version: "1.16.1"
+    app.kubernetes.io/version: "1.16.4"
     app.kubernetes.io/name: knative-eventing
 aggregationRule:
   clusterRoleSelectors:
@@ -5441,7 +5461,7 @@ metadata:
   name: eventing-sources-source-observer
   labels:
     duck.knative.dev/source: "true"
-    app.kubernetes.io/version: "1.16.1"
+    app.kubernetes.io/version: "1.16.4"
     app.kubernetes.io/name: knative-eventing
 rules:
   - apiGroups:
@@ -5461,7 +5481,7 @@ kind: ClusterRole
 metadata:
   name: knative-eventing-sources-controller
   labels:
-    app.kubernetes.io/version: "1.16.1"
+    app.kubernetes.io/version: "1.16.4"
     app.kubernetes.io/name: knative-eventing
 rules:
   - apiGroups:
@@ -5561,7 +5581,7 @@ kind: ClusterRole
 metadata:
   name: knative-eventing-webhook
   labels:
-    app.kubernetes.io/version: "1.16.1"
+    app.kubernetes.io/version: "1.16.4"
     app.kubernetes.io/name: knative-eventing
 rules:
   - apiGroups:
@@ -5710,7 +5730,7 @@ metadata:
   namespace: knative-eventing
   name: knative-eventing-webhook
   labels:
-    app.kubernetes.io/version: "1.16.1"
+    app.kubernetes.io/version: "1.16.4"
     app.kubernetes.io/name: knative-eventing
 rules:
   - apiGroups:
@@ -5730,7 +5750,7 @@ kind: ValidatingWebhookConfiguration
 metadata:
   name: config.webhook.eventing.knative.dev
   labels:
-    app.kubernetes.io/version: "1.16.1"
+    app.kubernetes.io/version: "1.16.4"
     app.kubernetes.io/name: knative-eventing
 webhooks:
   - admissionReviewVersions: ["v1", "v1beta1"]
@@ -5753,7 +5773,7 @@ kind: MutatingWebhookConfiguration
 metadata:
   name: webhook.eventing.knative.dev
   labels:
-    app.kubernetes.io/version: "1.16.1"
+    app.kubernetes.io/version: "1.16.4"
     app.kubernetes.io/name: knative-eventing
 webhooks:
   - admissionReviewVersions: ["v1", "v1beta1"]
@@ -5771,7 +5791,7 @@ kind: ValidatingWebhookConfiguration
 metadata:
   name: validation.webhook.eventing.knative.dev
   labels:
-    app.kubernetes.io/version: "1.16.1"
+    app.kubernetes.io/version: "1.16.4"
     app.kubernetes.io/name: knative-eventing
 webhooks:
   - admissionReviewVersions: ["v1", "v1beta1"]
@@ -5790,7 +5810,7 @@ metadata:
   name: eventing-webhook-certs
   namespace: knative-eventing
   labels:
-    app.kubernetes.io/version: "1.16.1"
+    app.kubernetes.io/version: "1.16.4"
     app.kubernetes.io/name: knative-eventing
 ---
 apiVersion: admissionregistration.k8s.io/v1
@@ -5798,7 +5818,7 @@ kind: MutatingWebhookConfiguration
 metadata:
   name: sinkbindings.webhook.sources.knative.dev
   labels:
-    app.kubernetes.io/version: "1.16.1"
+    app.kubernetes.io/version: "1.16.4"
     app.kubernetes.io/name: knative-eventing
 webhooks:
   - admissionReviewVersions: ["v1", "v1beta1"]

--- a/common/knative/knative-eventing/base/upstream/in-memory-channel.yaml
+++ b/common/knative/knative-eventing/base/upstream/in-memory-channel.yaml
@@ -4,7 +4,7 @@ metadata:
   name: imc-controller
   namespace: knative-eventing
   labels:
-    app.kubernetes.io/version: "1.16.1"
+    app.kubernetes.io/version: "1.16.4"
     app.kubernetes.io/name: knative-eventing
 ---
 apiVersion: rbac.authorization.k8s.io/v1
@@ -12,7 +12,7 @@ kind: ClusterRoleBinding
 metadata:
   name: imc-controller
   labels:
-    app.kubernetes.io/version: "1.16.1"
+    app.kubernetes.io/version: "1.16.4"
     app.kubernetes.io/name: knative-eventing
 subjects:
   - kind: ServiceAccount
@@ -29,7 +29,7 @@ metadata:
   namespace: knative-eventing
   name: imc-controller
   labels:
-    app.kubernetes.io/version: "1.16.1"
+    app.kubernetes.io/version: "1.16.4"
     app.kubernetes.io/name: knative-eventing
 subjects:
   - kind: ServiceAccount
@@ -45,7 +45,7 @@ kind: ClusterRoleBinding
 metadata:
   name: imc-controller-resolver
   labels:
-    app.kubernetes.io/version: "1.16.1"
+    app.kubernetes.io/version: "1.16.4"
     app.kubernetes.io/name: knative-eventing
 subjects:
   - kind: ServiceAccount
@@ -62,7 +62,7 @@ metadata:
   name: imc-dispatcher
   namespace: knative-eventing
   labels:
-    app.kubernetes.io/version: "1.16.1"
+    app.kubernetes.io/version: "1.16.4"
     app.kubernetes.io/name: knative-eventing
 ---
 apiVersion: rbac.authorization.k8s.io/v1
@@ -70,7 +70,7 @@ kind: ClusterRoleBinding
 metadata:
   name: imc-dispatcher
   labels:
-    app.kubernetes.io/version: "1.16.1"
+    app.kubernetes.io/version: "1.16.4"
     app.kubernetes.io/name: knative-eventing
 subjects:
   - kind: ServiceAccount
@@ -117,7 +117,7 @@ metadata:
   namespace: knative-eventing
   labels:
     app.kubernetes.io/component: imc-controller
-    app.kubernetes.io/version: "1.16.1"
+    app.kubernetes.io/version: "1.16.4"
     app.kubernetes.io/name: knative-eventing
 data:
   MaxIdleConnections: "1000"
@@ -131,7 +131,7 @@ metadata:
   labels:
     knative.dev/high-availability: "true"
     app.kubernetes.io/component: imc-controller
-    app.kubernetes.io/version: "1.16.1"
+    app.kubernetes.io/version: "1.16.4"
     app.kubernetes.io/name: knative-eventing
     bindings.knative.dev/exclude: "true"
 spec:
@@ -145,7 +145,7 @@ spec:
         messaging.knative.dev/channel: in-memory-channel
         messaging.knative.dev/role: controller
         app.kubernetes.io/component: imc-controller
-        app.kubernetes.io/version: "1.16.1"
+        app.kubernetes.io/version: "1.16.4"
         app.kubernetes.io/name: knative-eventing
     spec:
       affinity:
@@ -162,7 +162,7 @@ spec:
       enableServiceLinks: false
       containers:
         - name: controller
-          image: gcr.io/knative-releases/knative.dev/eventing/cmd/in_memory/channel_controller@sha256:c4a1ea7b53b8e9084b99e41d8558e094cacd6f3c1b59d3a0f37993d53a36020f
+          image: gcr.io/knative-releases/knative.dev/eventing/cmd/in_memory/channel_controller@sha256:b71eb30909c369c1c8c07185e7ec4c75f874e36696eca563b93df70959e7a619
           env:
             - name: WEBHOOK_NAME
               value: inmemorychannel-webhook
@@ -179,7 +179,7 @@ spec:
                 fieldRef:
                   fieldPath: metadata.namespace
             - name: DISPATCHER_IMAGE
-              value: gcr.io/knative-releases/knative.dev/eventing/cmd/in_memory/channel_dispatcher@sha256:5bdef6a2eba6e4958ddda765b5d1f38ba390324cfb2aed1846b7ec58b53022a6
+              value: gcr.io/knative-releases/knative.dev/eventing/cmd/in_memory/channel_dispatcher@sha256:185f51cd8fa39e598b86463ee04a843560db40bbb235c1611e4579ebebfe9133
             - name: POD_NAME
               valueFrom:
                 fieldRef:
@@ -224,7 +224,7 @@ kind: Service
 metadata:
   labels:
     app.kubernetes.io/component: imc-controller
-    app.kubernetes.io/version: "1.16.1"
+    app.kubernetes.io/version: "1.16.4"
     app.kubernetes.io/name: knative-eventing
   name: inmemorychannel-webhook
   namespace: knative-eventing
@@ -252,7 +252,7 @@ metadata:
     messaging.knative.dev/channel: in-memory-channel
     messaging.knative.dev/role: dispatcher
     app.kubernetes.io/component: imc-dispatcher
-    app.kubernetes.io/version: "1.16.1"
+    app.kubernetes.io/version: "1.16.4"
     app.kubernetes.io/name: knative-eventing
 spec:
   selector:
@@ -279,7 +279,7 @@ metadata:
   labels:
     knative.dev/high-availability: "true"
     app.kubernetes.io/component: imc-dispatcher
-    app.kubernetes.io/version: "1.16.1"
+    app.kubernetes.io/version: "1.16.4"
     app.kubernetes.io/name: knative-eventing
     bindings.knative.dev/exclude: "true"
 spec:
@@ -293,7 +293,7 @@ spec:
         messaging.knative.dev/channel: in-memory-channel
         messaging.knative.dev/role: dispatcher
         app.kubernetes.io/component: imc-dispatcher
-        app.kubernetes.io/version: "1.16.1"
+        app.kubernetes.io/version: "1.16.4"
         app.kubernetes.io/name: knative-eventing
     spec:
       affinity:
@@ -310,7 +310,7 @@ spec:
       enableServiceLinks: false
       containers:
         - name: dispatcher
-          image: gcr.io/knative-releases/knative.dev/eventing/cmd/in_memory/channel_dispatcher@sha256:5bdef6a2eba6e4958ddda765b5d1f38ba390324cfb2aed1846b7ec58b53022a6
+          image: gcr.io/knative-releases/knative.dev/eventing/cmd/in_memory/channel_dispatcher@sha256:185f51cd8fa39e598b86463ee04a843560db40bbb235c1611e4579ebebfe9133
           readinessProbe:
             failureThreshold: 3
             httpGet:
@@ -378,7 +378,7 @@ metadata:
     knative.dev/crd-install: "true"
     messaging.knative.dev/subscribable: "true"
     duck.knative.dev/addressable: "true"
-    app.kubernetes.io/version: "1.16.1"
+    app.kubernetes.io/version: "1.16.4"
     app.kubernetes.io/name: knative-eventing
 spec:
   group: messaging.knative.dev
@@ -699,7 +699,7 @@ metadata:
   name: imc-addressable-resolver
   labels:
     duck.knative.dev/addressable: "true"
-    app.kubernetes.io/version: "1.16.1"
+    app.kubernetes.io/version: "1.16.4"
     app.kubernetes.io/name: knative-eventing
 rules:
   - apiGroups:
@@ -718,7 +718,7 @@ metadata:
   name: imc-channelable-manipulator
   labels:
     duck.knative.dev/channelable: "true"
-    app.kubernetes.io/version: "1.16.1"
+    app.kubernetes.io/version: "1.16.4"
     app.kubernetes.io/name: knative-eventing
 rules:
   - apiGroups:
@@ -740,7 +740,7 @@ kind: ClusterRole
 metadata:
   name: imc-controller
   labels:
-    app.kubernetes.io/version: "1.16.1"
+    app.kubernetes.io/version: "1.16.4"
     app.kubernetes.io/name: knative-eventing
 rules:
   - apiGroups:
@@ -889,7 +889,7 @@ metadata:
   name: imc-subscriber
   labels:
     duck.knative.dev/crossnamespace-subscribable: "true"
-    app.kubernetes.io/version: "1.16.1"
+    app.kubernetes.io/version: "1.16.4"
     app.kubernetes.io/name: knative-eventing
 rules:
   - apiGroups:
@@ -904,7 +904,7 @@ kind: ClusterRole
 metadata:
   name: imc-dispatcher
   labels:
-    app.kubernetes.io/version: "1.16.1"
+    app.kubernetes.io/version: "1.16.4"
     app.kubernetes.io/name: knative-eventing
 rules:
   - apiGroups:
@@ -978,7 +978,7 @@ metadata:
   namespace: knative-eventing
   name: knative-inmemorychannel-webhook
   labels:
-    app.kubernetes.io/version: "1.16.1"
+    app.kubernetes.io/version: "1.16.4"
     app.kubernetes.io/name: knative-eventing
 rules:
   - apiGroups:
@@ -998,7 +998,7 @@ kind: MutatingWebhookConfiguration
 metadata:
   name: inmemorychannel.eventing.knative.dev
   labels:
-    app.kubernetes.io/version: "1.16.1"
+    app.kubernetes.io/version: "1.16.4"
     app.kubernetes.io/name: knative-eventing
 webhooks:
   - admissionReviewVersions: ["v1"]
@@ -1016,7 +1016,7 @@ kind: ValidatingWebhookConfiguration
 metadata:
   name: validation.inmemorychannel.eventing.knative.dev
   labels:
-    app.kubernetes.io/version: "1.16.1"
+    app.kubernetes.io/version: "1.16.4"
     app.kubernetes.io/name: knative-eventing
 webhooks:
   - admissionReviewVersions: ["v1"]
@@ -1035,7 +1035,7 @@ metadata:
   name: inmemorychannel-webhook-certs
   namespace: knative-eventing
   labels:
-    app.kubernetes.io/version: "1.16.1"
+    app.kubernetes.io/version: "1.16.4"
     app.kubernetes.io/name: knative-eventing
 ---
 

--- a/common/knative/knative-eventing/base/upstream/mt-channel-broker.yaml
+++ b/common/knative/knative-eventing/base/upstream/mt-channel-broker.yaml
@@ -3,7 +3,7 @@ kind: ClusterRole
 metadata:
   name: knative-eventing-mt-channel-broker-controller
   labels:
-    app.kubernetes.io/version: "1.16.1"
+    app.kubernetes.io/version: "1.16.4"
     app.kubernetes.io/name: knative-eventing
 rules:
   - apiGroups:
@@ -36,7 +36,7 @@ kind: ClusterRole
 metadata:
   name: knative-eventing-mt-broker-filter
   labels:
-    app.kubernetes.io/version: "1.16.1"
+    app.kubernetes.io/version: "1.16.4"
     app.kubernetes.io/name: knative-eventing
 rules:
   - apiGroups:
@@ -104,7 +104,7 @@ metadata:
   name: mt-broker-filter
   namespace: knative-eventing
   labels:
-    app.kubernetes.io/version: "1.16.1"
+    app.kubernetes.io/version: "1.16.4"
     app.kubernetes.io/name: knative-eventing
 ---
 apiVersion: rbac.authorization.k8s.io/v1
@@ -112,7 +112,7 @@ kind: ClusterRole
 metadata:
   name: knative-eventing-mt-broker-ingress
   labels:
-    app.kubernetes.io/version: "1.16.1"
+    app.kubernetes.io/version: "1.16.4"
     app.kubernetes.io/name: knative-eventing
 rules:
   - apiGroups:
@@ -171,7 +171,7 @@ metadata:
   name: mt-broker-ingress-oidc
   namespace: knative-eventing
   labels:
-    app.kubernetes.io/version: "1.16.1"
+    app.kubernetes.io/version: "1.16.4"
     app.kubernetes.io/name: knative-eventing
 ---
 apiVersion: v1
@@ -180,7 +180,7 @@ metadata:
   name: mt-broker-ingress
   namespace: knative-eventing
   labels:
-    app.kubernetes.io/version: "1.16.1"
+    app.kubernetes.io/version: "1.16.4"
     app.kubernetes.io/name: knative-eventing
 ---
 apiVersion: rbac.authorization.k8s.io/v1
@@ -188,7 +188,7 @@ kind: ClusterRoleBinding
 metadata:
   name: eventing-mt-channel-broker-controller
   labels:
-    app.kubernetes.io/version: "1.16.1"
+    app.kubernetes.io/version: "1.16.4"
     app.kubernetes.io/name: knative-eventing
 subjects:
   - kind: ServiceAccount
@@ -204,7 +204,7 @@ kind: ClusterRoleBinding
 metadata:
   name: knative-eventing-mt-broker-filter
   labels:
-    app.kubernetes.io/version: "1.16.1"
+    app.kubernetes.io/version: "1.16.4"
     app.kubernetes.io/name: knative-eventing
 subjects:
   - kind: ServiceAccount
@@ -234,7 +234,7 @@ kind: ClusterRoleBinding
 metadata:
   name: knative-eventing-mt-broker-ingress
   labels:
-    app.kubernetes.io/version: "1.16.1"
+    app.kubernetes.io/version: "1.16.4"
     app.kubernetes.io/name: knative-eventing
 subjects:
   - kind: ServiceAccount
@@ -266,7 +266,7 @@ metadata:
   namespace: knative-eventing
   labels:
     app.kubernetes.io/component: broker-filter
-    app.kubernetes.io/version: "1.16.1"
+    app.kubernetes.io/version: "1.16.4"
     app.kubernetes.io/name: knative-eventing
     bindings.knative.dev/exclude: "true"
 spec:
@@ -278,7 +278,7 @@ spec:
       labels:
         eventing.knative.dev/brokerRole: filter
         app.kubernetes.io/component: broker-filter
-        app.kubernetes.io/version: "1.16.1"
+        app.kubernetes.io/version: "1.16.4"
         app.kubernetes.io/name: knative-eventing
     spec:
       serviceAccountName: mt-broker-filter
@@ -286,7 +286,7 @@ spec:
       containers:
         - name: filter
           terminationMessagePolicy: FallbackToLogsOnError
-          image: gcr.io/knative-releases/knative.dev/eventing/cmd/broker/filter@sha256:3fe93eca5e162e2a594911dd5ea32f9c5b0573c8725d151d21d9b773ab8fde78
+          image: gcr.io/knative-releases/knative.dev/eventing/cmd/broker/filter@sha256:71879b9320951fd245e3f0251f3dd4d77b8171e48de12daba2cad9617c4355d1
           readinessProbe:
             failureThreshold: 3
             httpGet:
@@ -364,7 +364,7 @@ metadata:
   labels:
     eventing.knative.dev/brokerRole: filter
     app.kubernetes.io/component: broker-filter
-    app.kubernetes.io/version: "1.16.1"
+    app.kubernetes.io/version: "1.16.4"
     app.kubernetes.io/name: knative-eventing
   name: broker-filter
   namespace: knative-eventing
@@ -392,7 +392,7 @@ metadata:
   namespace: knative-eventing
   labels:
     app.kubernetes.io/component: broker-ingress
-    app.kubernetes.io/version: "1.16.1"
+    app.kubernetes.io/version: "1.16.4"
     app.kubernetes.io/name: knative-eventing
     bindings.knative.dev/exclude: "true"
 spec:
@@ -404,7 +404,7 @@ spec:
       labels:
         eventing.knative.dev/brokerRole: ingress
         app.kubernetes.io/component: broker-ingress
-        app.kubernetes.io/version: "1.16.1"
+        app.kubernetes.io/version: "1.16.4"
         app.kubernetes.io/name: knative-eventing
     spec:
       serviceAccountName: mt-broker-ingress
@@ -412,7 +412,7 @@ spec:
       containers:
         - name: ingress
           terminationMessagePolicy: FallbackToLogsOnError
-          image: gcr.io/knative-releases/knative.dev/eventing/cmd/broker/ingress@sha256:e40b14c0238385afc13ecb408800a2ea2550835ef2a7627beb98fc04ed131cc8
+          image: gcr.io/knative-releases/knative.dev/eventing/cmd/broker/ingress@sha256:fc52f7e445fbf3512ed08003c5cba0b3e4d59fb1308271fa9dc1ce910f3ec71d
           readinessProbe:
             failureThreshold: 3
             httpGet:
@@ -490,7 +490,7 @@ metadata:
   labels:
     eventing.knative.dev/brokerRole: ingress
     app.kubernetes.io/component: broker-ingress
-    app.kubernetes.io/version: "1.16.1"
+    app.kubernetes.io/version: "1.16.4"
     app.kubernetes.io/name: knative-eventing
   name: broker-ingress
   namespace: knative-eventing
@@ -518,7 +518,7 @@ metadata:
   namespace: knative-eventing
   labels:
     app.kubernetes.io/component: mt-broker-controller
-    app.kubernetes.io/version: "1.16.1"
+    app.kubernetes.io/version: "1.16.4"
     app.kubernetes.io/name: knative-eventing
     bindings.knative.dev/exclude: "true"
 spec:
@@ -530,7 +530,7 @@ spec:
       labels:
         app: mt-broker-controller
         app.kubernetes.io/component: broker-controller
-        app.kubernetes.io/version: "1.16.1"
+        app.kubernetes.io/version: "1.16.4"
         app.kubernetes.io/name: knative-eventing
     spec:
       affinity:
@@ -547,7 +547,7 @@ spec:
       containers:
         - name: mt-broker-controller
           terminationMessagePolicy: FallbackToLogsOnError
-          image: gcr.io/knative-releases/knative.dev/eventing/cmd/mtchannel_broker@sha256:f76d14e43d6e907e8f50d2ebcc61cd2f14e9aa9a45f9936d1e4ae47532ad4fb4
+          image: gcr.io/knative-releases/knative.dev/eventing/cmd/mtchannel_broker@sha256:8700453a537ea6ca6cd78259335c36e7ad528abe539b593fc2bdf6e5ddf91ab0
           resources:
             requests:
               cpu: 100m
@@ -589,7 +589,7 @@ metadata:
   namespace: knative-eventing
   labels:
     app.kubernetes.io/component: broker-ingress
-    app.kubernetes.io/version: "1.16.1"
+    app.kubernetes.io/version: "1.16.4"
     app.kubernetes.io/name: knative-eventing
 spec:
   scaleTargetRef:
@@ -613,7 +613,7 @@ metadata:
   namespace: knative-eventing
   labels:
     app.kubernetes.io/component: broker-filter
-    app.kubernetes.io/version: "1.16.1"
+    app.kubernetes.io/version: "1.16.4"
     app.kubernetes.io/name: knative-eventing
 spec:
   scaleTargetRef:

--- a/common/knative/knative-serving-post-install-jobs/base/serving-post-install-jobs.yaml
+++ b/common/knative/knative-serving-post-install-jobs/base/serving-post-install-jobs.yaml
@@ -7,7 +7,7 @@ metadata:
     app: storage-version-migration-serving
     app.kubernetes.io/name: knative-serving
     app.kubernetes.io/component: storage-version-migration-job
-    app.kubernetes.io/version: "1.16.0"
+    app.kubernetes.io/version: "1.16.2"
   name: storage-version-migration-serving
 spec:
   ttlSecondsAfterFinished: 600
@@ -18,33 +18,33 @@ spec:
         app: storage-version-migration-serving
         app.kubernetes.io/name: knative-serving
         app.kubernetes.io/component: storage-version-migration-job
-        app.kubernetes.io/version: "1.16.0"
+        app.kubernetes.io/version: "1.16.2"
         sidecar.istio.io/inject: "false"
     spec:
       serviceAccountName: controller
       restartPolicy: OnFailure
       containers:
-      - name: migrate
-        image: gcr.io/knative-releases/knative.dev/pkg/apiextensions/storageversion/cmd/migrate@sha256:c2f7830569ab0b9f40ba785796d7a1d3e2069987528f5ca945ab7a339b0d96e7
-        args:
-        - "services.serving.knative.dev"
-        - "configurations.serving.knative.dev"
-        - "revisions.serving.knative.dev"
-        - "routes.serving.knative.dev"
-        - "domainmappings.serving.knative.dev"
-        resources:
-          requests:
-            cpu: 100m
-            memory: 100Mi
-          limits:
-            cpu: 1000m
-            memory: 1000Mi
-        securityContext:
-          allowPrivilegeEscalation: false
-          readOnlyRootFilesystem: true
-          runAsNonRoot: true
-          capabilities:
-            drop:
-            - ALL
-          seccompProfile:
-            type: RuntimeDefault
+        - name: migrate
+          image: gcr.io/knative-releases/knative.dev/pkg/apiextensions/storageversion/cmd/migrate@sha256:1b09bcf7e7304c400780d370c25702bf1c26291d9e431bfb3d553c4ce71b0c97
+          args:
+            - "services.serving.knative.dev"
+            - "configurations.serving.knative.dev"
+            - "revisions.serving.knative.dev"
+            - "routes.serving.knative.dev"
+            - "domainmappings.serving.knative.dev"
+          resources:
+            requests:
+              cpu: 100m
+              memory: 100Mi
+            limits:
+              cpu: 1000m
+              memory: 1000Mi
+          securityContext:
+            allowPrivilegeEscalation: false
+            readOnlyRootFilesystem: true
+            runAsNonRoot: true
+            capabilities:
+              drop:
+                - ALL
+            seccompProfile:
+              type: RuntimeDefault

--- a/common/knative/knative-serving-post-install-jobs/base/serving-post-install-jobs.yaml
+++ b/common/knative/knative-serving-post-install-jobs/base/serving-post-install-jobs.yaml
@@ -24,27 +24,27 @@ spec:
       serviceAccountName: controller
       restartPolicy: OnFailure
       containers:
-        - name: migrate
-          image: gcr.io/knative-releases/knative.dev/pkg/apiextensions/storageversion/cmd/migrate@sha256:1b09bcf7e7304c400780d370c25702bf1c26291d9e431bfb3d553c4ce71b0c97
-          args:
-            - "services.serving.knative.dev"
-            - "configurations.serving.knative.dev"
-            - "revisions.serving.knative.dev"
-            - "routes.serving.knative.dev"
-            - "domainmappings.serving.knative.dev"
-          resources:
-            requests:
-              cpu: 100m
-              memory: 100Mi
-            limits:
-              cpu: 1000m
-              memory: 1000Mi
-          securityContext:
-            allowPrivilegeEscalation: false
-            readOnlyRootFilesystem: true
-            runAsNonRoot: true
-            capabilities:
-              drop:
-                - ALL
-            seccompProfile:
-              type: RuntimeDefault
+      - name: migrate
+        image: gcr.io/knative-releases/knative.dev/pkg/apiextensions/storageversion/cmd/migrate@sha256:1b09bcf7e7304c400780d370c25702bf1c26291d9e431bfb3d553c4ce71b0c97
+        args:
+        - "services.serving.knative.dev"
+        - "configurations.serving.knative.dev"
+        - "revisions.serving.knative.dev"
+        - "routes.serving.knative.dev"
+        - "domainmappings.serving.knative.dev"
+        resources:
+          requests:
+            cpu: 100m
+            memory: 100Mi
+          limits:
+            cpu: 1000m
+            memory: 1000Mi
+        securityContext:
+          allowPrivilegeEscalation: false
+          readOnlyRootFilesystem: true
+          runAsNonRoot: true
+          capabilities:
+            drop:
+            - ALL
+          seccompProfile:
+            type: RuntimeDefault

--- a/common/knative/knative-serving/base/upstream/serving-core.yaml
+++ b/common/knative/knative-serving/base/upstream/serving-core.yaml
@@ -4,7 +4,7 @@ metadata:
   name: knative-serving
   labels:
     app.kubernetes.io/name: knative-serving
-    app.kubernetes.io/version: "1.16.0"
+    app.kubernetes.io/version: "1.16.2"
 ---
 kind: Role
 apiVersion: rbac.authorization.k8s.io/v1
@@ -13,7 +13,7 @@ metadata:
   namespace: knative-serving
   labels:
     serving.knative.dev/controller: "true"
-    app.kubernetes.io/version: "1.16.0"
+    app.kubernetes.io/version: "1.16.2"
     app.kubernetes.io/name: knative-serving
 rules:
   - apiGroups: [""]
@@ -30,7 +30,7 @@ metadata:
   name: knative-serving-activator-cluster
   labels:
     serving.knative.dev/controller: "true"
-    app.kubernetes.io/version: "1.16.0"
+    app.kubernetes.io/version: "1.16.2"
     app.kubernetes.io/name: knative-serving
 rules:
   - apiGroups: [""]
@@ -45,7 +45,7 @@ kind: ClusterRole
 metadata:
   name: knative-serving-aggregated-addressable-resolver
   labels:
-    app.kubernetes.io/version: "1.16.0"
+    app.kubernetes.io/version: "1.16.2"
     app.kubernetes.io/name: knative-serving
 aggregationRule:
   clusterRoleSelectors:
@@ -57,7 +57,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: knative-serving-addressable-resolver
   labels:
-    app.kubernetes.io/version: "1.16.0"
+    app.kubernetes.io/version: "1.16.2"
     app.kubernetes.io/name: knative-serving
     duck.knative.dev/addressable: "true"
 rules:
@@ -79,7 +79,7 @@ metadata:
   name: knative-serving-namespaced-admin
   labels:
     rbac.authorization.k8s.io/aggregate-to-admin: "true"
-    app.kubernetes.io/version: "1.16.0"
+    app.kubernetes.io/version: "1.16.2"
     app.kubernetes.io/name: knative-serving
 rules:
   - apiGroups: ["serving.knative.dev"]
@@ -95,7 +95,7 @@ metadata:
   name: knative-serving-namespaced-edit
   labels:
     rbac.authorization.k8s.io/aggregate-to-edit: "true"
-    app.kubernetes.io/version: "1.16.0"
+    app.kubernetes.io/version: "1.16.2"
     app.kubernetes.io/name: knative-serving
 rules:
   - apiGroups: ["serving.knative.dev"]
@@ -111,7 +111,7 @@ metadata:
   name: knative-serving-namespaced-view
   labels:
     rbac.authorization.k8s.io/aggregate-to-view: "true"
-    app.kubernetes.io/version: "1.16.0"
+    app.kubernetes.io/version: "1.16.2"
     app.kubernetes.io/name: knative-serving
 rules:
   - apiGroups: ["serving.knative.dev", "networking.internal.knative.dev", "autoscaling.internal.knative.dev", "caching.internal.knative.dev"]
@@ -124,7 +124,7 @@ metadata:
   name: knative-serving-core
   labels:
     serving.knative.dev/controller: "true"
-    app.kubernetes.io/version: "1.16.0"
+    app.kubernetes.io/version: "1.16.2"
     app.kubernetes.io/name: knative-serving
 rules:
   - apiGroups: [""]
@@ -173,7 +173,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: knative-serving-podspecable-binding
   labels:
-    app.kubernetes.io/version: "1.16.0"
+    app.kubernetes.io/version: "1.16.2"
     app.kubernetes.io/name: knative-serving
     duck.knative.dev/podspecable: "true"
 rules:
@@ -195,7 +195,7 @@ metadata:
   labels:
     app.kubernetes.io/component: controller
     app.kubernetes.io/name: knative-serving
-    app.kubernetes.io/version: "1.16.0"
+    app.kubernetes.io/version: "1.16.2"
 ---
 kind: ClusterRole
 apiVersion: rbac.authorization.k8s.io/v1
@@ -203,7 +203,7 @@ metadata:
   name: knative-serving-admin
   labels:
     app.kubernetes.io/name: knative-serving
-    app.kubernetes.io/version: "1.16.0"
+    app.kubernetes.io/version: "1.16.2"
 aggregationRule:
   clusterRoleSelectors:
     - matchLabels:
@@ -216,7 +216,7 @@ metadata:
   labels:
     app.kubernetes.io/component: controller
     app.kubernetes.io/name: knative-serving
-    app.kubernetes.io/version: "1.16.0"
+    app.kubernetes.io/version: "1.16.2"
 subjects:
   - kind: ServiceAccount
     name: controller
@@ -233,7 +233,7 @@ metadata:
   labels:
     app.kubernetes.io/component: controller
     app.kubernetes.io/name: knative-serving
-    app.kubernetes.io/version: "1.16.0"
+    app.kubernetes.io/version: "1.16.2"
 subjects:
   - kind: ServiceAccount
     name: controller
@@ -251,7 +251,7 @@ metadata:
   labels:
     app.kubernetes.io/component: activator
     app.kubernetes.io/name: knative-serving
-    app.kubernetes.io/version: "1.16.0"
+    app.kubernetes.io/version: "1.16.2"
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
@@ -261,7 +261,7 @@ metadata:
   labels:
     app.kubernetes.io/component: activator
     app.kubernetes.io/name: knative-serving
-    app.kubernetes.io/version: "1.16.0"
+    app.kubernetes.io/version: "1.16.2"
 subjects:
   - kind: ServiceAccount
     name: activator
@@ -278,7 +278,7 @@ metadata:
   labels:
     app.kubernetes.io/component: activator
     app.kubernetes.io/name: knative-serving
-    app.kubernetes.io/version: "1.16.0"
+    app.kubernetes.io/version: "1.16.2"
 subjects:
   - kind: ServiceAccount
     name: activator
@@ -294,7 +294,7 @@ metadata:
   name: images.caching.internal.knative.dev
   labels:
     app.kubernetes.io/name: knative-serving
-    app.kubernetes.io/version: "1.16.0"
+    app.kubernetes.io/version: "1.16.2"
     knative.dev/crd-install: "true"
 spec:
   group: caching.internal.knative.dev
@@ -456,7 +456,7 @@ metadata:
   labels:
     app.kubernetes.io/name: knative-serving
     app.kubernetes.io/component: networking
-    app.kubernetes.io/version: "1.16.0"
+    app.kubernetes.io/version: "1.16.2"
     knative.dev/crd-install: "true"
 spec:
   group: networking.internal.knative.dev
@@ -625,7 +625,7 @@ metadata:
   name: configurations.serving.knative.dev
   labels:
     app.kubernetes.io/name: knative-serving
-    app.kubernetes.io/version: "1.16.0"
+    app.kubernetes.io/version: "1.16.2"
     knative.dev/crd-install: "true"
     duck.knative.dev/podspecable: "true"
 spec:
@@ -2192,7 +2192,7 @@ metadata:
   labels:
     app.kubernetes.io/name: knative-serving
     app.kubernetes.io/component: networking
-    app.kubernetes.io/version: "1.16.0"
+    app.kubernetes.io/version: "1.16.2"
     knative.dev/crd-install: "true"
 spec:
   group: networking.internal.knative.dev
@@ -2254,7 +2254,7 @@ metadata:
   name: domainmappings.serving.knative.dev
   labels:
     app.kubernetes.io/name: knative-serving
-    app.kubernetes.io/version: "1.16.0"
+    app.kubernetes.io/version: "1.16.2"
     knative.dev/crd-install: "true"
 spec:
   group: serving.knative.dev
@@ -2453,7 +2453,7 @@ metadata:
   labels:
     app.kubernetes.io/name: knative-serving
     app.kubernetes.io/component: networking
-    app.kubernetes.io/version: "1.16.0"
+    app.kubernetes.io/version: "1.16.2"
     knative.dev/crd-install: "true"
 spec:
   group: networking.internal.knative.dev
@@ -2833,7 +2833,7 @@ metadata:
   name: metrics.autoscaling.internal.knative.dev
   labels:
     app.kubernetes.io/name: knative-serving
-    app.kubernetes.io/version: "1.16.0"
+    app.kubernetes.io/version: "1.16.2"
     knative.dev/crd-install: "true"
 spec:
   group: autoscaling.internal.knative.dev
@@ -2960,7 +2960,7 @@ metadata:
   name: podautoscalers.autoscaling.internal.knative.dev
   labels:
     app.kubernetes.io/name: knative-serving
-    app.kubernetes.io/version: "1.16.0"
+    app.kubernetes.io/version: "1.16.2"
     knative.dev/crd-install: "true"
 spec:
   group: autoscaling.internal.knative.dev
@@ -3144,7 +3144,7 @@ metadata:
   name: revisions.serving.knative.dev
   labels:
     app.kubernetes.io/name: knative-serving
-    app.kubernetes.io/version: "1.16.0"
+    app.kubernetes.io/version: "1.16.2"
     knative.dev/crd-install: "true"
 spec:
   group: serving.knative.dev
@@ -4724,7 +4724,7 @@ metadata:
   name: routes.serving.knative.dev
   labels:
     app.kubernetes.io/name: knative-serving
-    app.kubernetes.io/version: "1.16.0"
+    app.kubernetes.io/version: "1.16.2"
     knative.dev/crd-install: "true"
     duck.knative.dev/addressable: "true"
 spec:
@@ -4980,7 +4980,7 @@ metadata:
   labels:
     app.kubernetes.io/name: knative-serving
     app.kubernetes.io/component: networking
-    app.kubernetes.io/version: "1.16.0"
+    app.kubernetes.io/version: "1.16.2"
     knative.dev/crd-install: "true"
 spec:
   group: networking.internal.knative.dev
@@ -5188,7 +5188,7 @@ metadata:
   name: services.serving.knative.dev
   labels:
     app.kubernetes.io/name: knative-serving
-    app.kubernetes.io/version: "1.16.0"
+    app.kubernetes.io/version: "1.16.2"
     knative.dev/crd-install: "true"
     duck.knative.dev/addressable: "true"
     duck.knative.dev/podspecable: "true"
@@ -6906,9 +6906,9 @@ metadata:
   labels:
     app.kubernetes.io/component: queue-proxy
     app.kubernetes.io/name: knative-serving
-    app.kubernetes.io/version: "1.16.0"
+    app.kubernetes.io/version: "1.16.2"
 spec:
-  image: gcr.io/knative-releases/knative.dev/serving/cmd/queue@sha256:c61042001b1f21c5d06bdee9b42b5e4524e4370e09d4f46347226f06db29ba0f
+  image: gcr.io/knative-releases/knative.dev/serving/cmd/queue@sha256:698ef80ebc698f4d2bb93c1e85684063a0cf253a83faebcbf106cee444181d8e
 ---
 apiVersion: v1
 kind: ConfigMap
@@ -6918,7 +6918,7 @@ metadata:
   labels:
     app.kubernetes.io/component: autoscaler
     app.kubernetes.io/name: knative-serving
-    app.kubernetes.io/version: "1.16.0"
+    app.kubernetes.io/version: "1.16.2"
   annotations:
     knative.dev/example-checksum: "47c2487f"
 data:
@@ -7114,7 +7114,7 @@ metadata:
   labels:
     app.kubernetes.io/name: knative-serving
     app.kubernetes.io/component: controller
-    app.kubernetes.io/version: "1.16.0"
+    app.kubernetes.io/version: "1.16.2"
     networking.knative.dev/certificate-provider: cert-manager
   annotations:
     knative.dev/example-checksum: "b7a9a602"
@@ -7169,7 +7169,7 @@ metadata:
   labels:
     app.kubernetes.io/name: knative-serving
     app.kubernetes.io/component: controller
-    app.kubernetes.io/version: "1.16.0"
+    app.kubernetes.io/version: "1.16.2"
   annotations:
     knative.dev/example-checksum: "5b64ff5c"
 data:
@@ -7309,11 +7309,11 @@ metadata:
   labels:
     app.kubernetes.io/name: knative-serving
     app.kubernetes.io/component: controller
-    app.kubernetes.io/version: "1.16.0"
+    app.kubernetes.io/version: "1.16.2"
   annotations:
     knative.dev/example-checksum: "720ddb97"
 data:
-  queue-sidecar-image: gcr.io/knative-releases/knative.dev/serving/cmd/queue@sha256:c61042001b1f21c5d06bdee9b42b5e4524e4370e09d4f46347226f06db29ba0f
+  queue-sidecar-image: gcr.io/knative-releases/knative.dev/serving/cmd/queue@sha256:698ef80ebc698f4d2bb93c1e85684063a0cf253a83faebcbf106cee444181d8e
   _example: |-
     ################################
     #                              #
@@ -7419,7 +7419,7 @@ metadata:
   labels:
     app.kubernetes.io/name: knative-serving
     app.kubernetes.io/component: controller
-    app.kubernetes.io/version: "1.16.0"
+    app.kubernetes.io/version: "1.16.2"
   annotations:
     knative.dev/example-checksum: "26c09de5"
 data:
@@ -7469,7 +7469,7 @@ metadata:
   labels:
     app.kubernetes.io/name: knative-serving
     app.kubernetes.io/component: controller
-    app.kubernetes.io/version: "1.16.0"
+    app.kubernetes.io/version: "1.16.2"
   annotations:
     knative.dev/example-checksum: "9ff569ad"
 data:
@@ -7692,7 +7692,7 @@ metadata:
   labels:
     app.kubernetes.io/name: knative-serving
     app.kubernetes.io/component: controller
-    app.kubernetes.io/version: "1.16.0"
+    app.kubernetes.io/version: "1.16.2"
   annotations:
     knative.dev/example-checksum: "aa3813a8"
 data:
@@ -7777,7 +7777,7 @@ metadata:
   labels:
     app.kubernetes.io/name: knative-serving
     app.kubernetes.io/component: controller
-    app.kubernetes.io/version: "1.16.0"
+    app.kubernetes.io/version: "1.16.2"
   annotations:
     knative.dev/example-checksum: "f4b71f57"
 data:
@@ -7822,7 +7822,7 @@ metadata:
   name: config-logging
   namespace: knative-serving
   labels:
-    app.kubernetes.io/version: "1.16.0"
+    app.kubernetes.io/version: "1.16.2"
     app.kubernetes.io/component: logging
     app.kubernetes.io/name: knative-serving
   annotations:
@@ -7890,7 +7890,7 @@ metadata:
   labels:
     app.kubernetes.io/name: knative-serving
     app.kubernetes.io/component: networking
-    app.kubernetes.io/version: "1.16.0"
+    app.kubernetes.io/version: "1.16.2"
   annotations:
     knative.dev/example-checksum: "0573e07d"
 data:
@@ -8080,7 +8080,7 @@ metadata:
   labels:
     app.kubernetes.io/name: knative-serving
     app.kubernetes.io/component: observability
-    app.kubernetes.io/version: "1.16.0"
+    app.kubernetes.io/version: "1.16.2"
   annotations:
     knative.dev/example-checksum: "54abd711"
 data:
@@ -8185,7 +8185,7 @@ metadata:
   labels:
     app.kubernetes.io/name: knative-serving
     app.kubernetes.io/component: tracing
-    app.kubernetes.io/version: "1.16.0"
+    app.kubernetes.io/version: "1.16.2"
   annotations:
     knative.dev/example-checksum: "26614636"
 data:
@@ -8227,7 +8227,7 @@ metadata:
   labels:
     app.kubernetes.io/component: activator
     app.kubernetes.io/name: knative-serving
-    app.kubernetes.io/version: "1.16.0"
+    app.kubernetes.io/version: "1.16.2"
 spec:
   minReplicas: 1
   maxReplicas: 20
@@ -8251,7 +8251,7 @@ metadata:
   labels:
     app.kubernetes.io/component: activator
     app.kubernetes.io/name: knative-serving
-    app.kubernetes.io/version: "1.16.0"
+    app.kubernetes.io/version: "1.16.2"
 spec:
   minAvailable: 80%
   selector:
@@ -8265,7 +8265,7 @@ metadata:
   namespace: knative-serving
   labels:
     app.kubernetes.io/component: activator
-    app.kubernetes.io/version: "1.16.0"
+    app.kubernetes.io/version: "1.16.2"
     app.kubernetes.io/name: knative-serving
 spec:
   selector:
@@ -8279,7 +8279,7 @@ spec:
         role: activator
         app.kubernetes.io/component: activator
         app.kubernetes.io/name: knative-serving
-        app.kubernetes.io/version: "1.16.0"
+        app.kubernetes.io/version: "1.16.2"
     spec:
       affinity:
         podAntiAffinity:
@@ -8293,7 +8293,7 @@ spec:
       serviceAccountName: activator
       containers:
         - name: activator
-          image: gcr.io/knative-releases/knative.dev/serving/cmd/activator@sha256:24c19cbee078925b91cd2e85082b581d53b218b410c083b1005dc06dc549b1d3
+          image: gcr.io/knative-releases/knative.dev/serving/cmd/activator@sha256:cc39d40985f7b37ba384a857d194a24ac5eae7e204aac4ed9bf4ebfd8d62e721
           resources:
             requests:
               cpu: 300m
@@ -8361,7 +8361,7 @@ metadata:
   labels:
     app: activator
     app.kubernetes.io/component: activator
-    app.kubernetes.io/version: "1.16.0"
+    app.kubernetes.io/version: "1.16.2"
     app.kubernetes.io/name: knative-serving
 spec:
   selector:
@@ -8392,7 +8392,7 @@ metadata:
   labels:
     app.kubernetes.io/component: autoscaler
     app.kubernetes.io/name: knative-serving
-    app.kubernetes.io/version: "1.16.0"
+    app.kubernetes.io/version: "1.16.2"
 spec:
   replicas: 1
   selector:
@@ -8408,7 +8408,7 @@ spec:
         app: autoscaler
         app.kubernetes.io/component: autoscaler
         app.kubernetes.io/name: knative-serving
-        app.kubernetes.io/version: "1.16.0"
+        app.kubernetes.io/version: "1.16.2"
     spec:
       affinity:
         podAntiAffinity:
@@ -8422,7 +8422,7 @@ spec:
       serviceAccountName: controller
       containers:
         - name: autoscaler
-          image: gcr.io/knative-releases/knative.dev/serving/cmd/autoscaler@sha256:5e9236452d89363957d4e7e249d57740a8fcd946aed23f8518d94962bf440250
+          image: gcr.io/knative-releases/knative.dev/serving/cmd/autoscaler@sha256:59c2e7ad52cea17bedfc2aca9b9e33060bb34f04d35fd71fe61147bcbdb881e4
           resources:
             requests:
               cpu: 100m
@@ -8480,7 +8480,7 @@ metadata:
     app: autoscaler
     app.kubernetes.io/component: autoscaler
     app.kubernetes.io/name: knative-serving
-    app.kubernetes.io/version: "1.16.0"
+    app.kubernetes.io/version: "1.16.2"
   name: autoscaler
   namespace: knative-serving
 spec:
@@ -8505,7 +8505,7 @@ metadata:
   labels:
     app.kubernetes.io/component: controller
     app.kubernetes.io/name: knative-serving
-    app.kubernetes.io/version: "1.16.0"
+    app.kubernetes.io/version: "1.16.2"
 spec:
   selector:
     matchLabels:
@@ -8516,7 +8516,7 @@ spec:
         app: controller
         app.kubernetes.io/component: controller
         app.kubernetes.io/name: knative-serving
-        app.kubernetes.io/version: "1.16.0"
+        app.kubernetes.io/version: "1.16.2"
     spec:
       affinity:
         podAntiAffinity:
@@ -8530,7 +8530,7 @@ spec:
       serviceAccountName: controller
       containers:
         - name: controller
-          image: gcr.io/knative-releases/knative.dev/serving/cmd/controller@sha256:5fb22b052e6bc98a1a6bbb68c0282ddb50744702acee6d83110302bc990666e9
+          image: gcr.io/knative-releases/knative.dev/serving/cmd/controller@sha256:0e47362d044f8eac84595ed0a9fdf22e5dd5a07cc7a5df74e93eb5ad17ad4827
           resources:
             requests:
               cpu: 100m
@@ -8591,7 +8591,7 @@ metadata:
     app: controller
     app.kubernetes.io/component: controller
     app.kubernetes.io/name: knative-serving
-    app.kubernetes.io/version: "1.16.0"
+    app.kubernetes.io/version: "1.16.2"
   name: controller
   namespace: knative-serving
 spec:
@@ -8613,7 +8613,7 @@ metadata:
   labels:
     app.kubernetes.io/component: webhook
     app.kubernetes.io/name: knative-serving
-    app.kubernetes.io/version: "1.16.0"
+    app.kubernetes.io/version: "1.16.2"
 spec:
   minReplicas: 1
   maxReplicas: 5
@@ -8637,7 +8637,7 @@ metadata:
   labels:
     app.kubernetes.io/component: webhook
     app.kubernetes.io/name: knative-serving
-    app.kubernetes.io/version: "1.16.0"
+    app.kubernetes.io/version: "1.16.2"
 spec:
   minAvailable: 80%
   selector:
@@ -8651,7 +8651,7 @@ metadata:
   namespace: knative-serving
   labels:
     app.kubernetes.io/component: webhook
-    app.kubernetes.io/version: "1.16.0"
+    app.kubernetes.io/version: "1.16.2"
     app.kubernetes.io/name: knative-serving
 spec:
   selector:
@@ -8664,7 +8664,7 @@ spec:
         app: webhook
         role: webhook
         app.kubernetes.io/component: webhook
-        app.kubernetes.io/version: "1.16.0"
+        app.kubernetes.io/version: "1.16.2"
         app.kubernetes.io/name: knative-serving
     spec:
       affinity:
@@ -8679,7 +8679,7 @@ spec:
       serviceAccountName: controller
       containers:
         - name: webhook
-          image: gcr.io/knative-releases/knative.dev/serving/cmd/webhook@sha256:0fb5a4245aa4737d443658754464cd0a076de959fe14623fb9e9d31318ccce24
+          image: gcr.io/knative-releases/knative.dev/serving/cmd/webhook@sha256:d42e2f83c9018779465860fdc67ce6ada3eac8ba8c47c5c2127c0bb45f9b328a
           resources:
             requests:
               cpu: 100m
@@ -8743,7 +8743,7 @@ metadata:
     app: webhook
     role: webhook
     app.kubernetes.io/component: webhook
-    app.kubernetes.io/version: "1.16.0"
+    app.kubernetes.io/version: "1.16.2"
     app.kubernetes.io/name: knative-serving
   name: webhook
   namespace: knative-serving
@@ -8769,7 +8769,7 @@ metadata:
   labels:
     app.kubernetes.io/component: webhook
     app.kubernetes.io/name: knative-serving
-    app.kubernetes.io/version: "1.16.0"
+    app.kubernetes.io/version: "1.16.2"
 webhooks:
   - admissionReviewVersions: ["v1", "v1beta1"]
     clientConfig:
@@ -8796,7 +8796,7 @@ metadata:
   labels:
     app.kubernetes.io/component: webhook
     app.kubernetes.io/name: knative-serving
-    app.kubernetes.io/version: "1.16.0"
+    app.kubernetes.io/version: "1.16.2"
 webhooks:
   - admissionReviewVersions: ["v1", "v1beta1"]
     clientConfig:
@@ -8838,7 +8838,7 @@ metadata:
   labels:
     app.kubernetes.io/component: webhook
     app.kubernetes.io/name: knative-serving
-    app.kubernetes.io/version: "1.16.0"
+    app.kubernetes.io/version: "1.16.2"
 webhooks:
   - admissionReviewVersions: ["v1", "v1beta1"]
     clientConfig:
@@ -8882,6 +8882,6 @@ metadata:
   labels:
     app.kubernetes.io/component: webhook
     app.kubernetes.io/name: knative-serving
-    app.kubernetes.io/version: "1.16.0"
+    app.kubernetes.io/version: "1.16.2"
 ---
 

--- a/hack/synchronize-knative-manifests.sh
+++ b/hack/synchronize-knative-manifests.sh
@@ -14,9 +14,9 @@
 set -euxo pipefail
 IFS=$'\n\t'
 
-KN_SERVING_RELEASE="v1.16.0" # Must be a release
+KN_SERVING_RELEASE="v1.16.2" # Must be a release
 KN_EXTENSION_RELEASE="v1.16.0" # Must be a release
-KN_EVENTING_RELEASE="v1.16.1" # Must be a release
+KN_EVENTING_RELEASE="v1.16.4" # Must be a release
 BRANCH=${BRANCH:=synchronize-knative-manifests-${KN_SERVING_RELEASE?}}
 
 SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )


### PR DESCRIPTION
# Update common/knative manifests to v1.16.2/v1.16.4.

## ✏️ Summary of Changes

Update common/knative manifests to v1.16.2/v1.16.4.

## 📦 Dependencies
> List any dependencies or related PRs (e.g., "Depends on #123").

## 🐛 Related Issues

Fixes #3016, replaces #3020.

## ✅ Contributor Checklist
  - [X] I have tested these changes with kustomize. See [Installation Prerequisites](https://github.com/kubeflow/manifests#prerequisites).
  - [X] All commits are [_signed-off_](https://github.com/kubeflow/community/tree/master/dco-signoff-hook#signing-off-commits) to satisfy the DCO check.

---     
 
> You can join the CNCF Slack and access our meetings at the [Kubeflow Community](https://www.kubeflow.org/docs/about/community/) website. Our channel on the CNCF Slack is here [**#kubeflow-platform**](https://app.slack.com/client/T08PSQ7BQ/C073W572LA2).
  
