### PR TITLE
Restrict webhook access to kube-system API server

### DIFF
--- a/common/networkpolicies/base/kserve.yaml
+++ b/common/networkpolicies/base/kserve.yaml
@@ -6,15 +6,22 @@ metadata:
 spec:
   podSelector:
     matchExpressions:
-      - key: control-plane
-        operator: In
-        values:
-          - kserve-controller-manager # mutating webhook
+    - key: control-plane
+      operator: In
+      values:
+      - kserve-controller-manager  # mutating webhook
   # https://www.elastic.co/guide/en/cloud-on-k8s/1.1/k8s-webhook-network-policies.html
   # The kubernetes api server must reach the webhook
   ingress:
-    - ports:
-        - protocol: TCP
-          port: 9443
+  - from:
+    - podSelector:
+        matchLabels:
+          component: kube-apiserver
+      namespaceSelector:
+        matchLabels:
+          kubernetes.io/metadata.name: kube-system
+    ports:
+    - protocol: TCP
+      port: 9443
   policyTypes:
-    - Ingress
+  - Ingress

--- a/common/networkpolicies/base/pvcviewer-webhook.yaml
+++ b/common/networkpolicies/base/pvcviewer-webhook.yaml
@@ -6,15 +6,22 @@ metadata:
 spec:
   podSelector:
     matchExpressions:
-      - key: app
-        operator: In
-        values:
-          - pvcviewer
+    - key: app
+      operator: In
+      values:
+      - pvcviewer
   # https://www.elastic.co/guide/en/cloud-on-k8s/1.1/k8s-webhook-network-policies.html
   # The kubernetes api server must reach the webhook
   ingress:
-    - ports:
-        - protocol: TCP
-          port: 9443
+  - from:
+    - podSelector:
+        matchLabels:
+          component: kube-apiserver
+      namespaceSelector:
+        matchLabels:
+          kubernetes.io/metadata.name: kube-system
+    ports:
+    - protocol: TCP
+      port: 9443
   policyTypes:
-    - Ingress
+  - Ingress

--- a/common/networkpolicies/base/spark-operator-webhook.yaml
+++ b/common/networkpolicies/base/spark-operator-webhook.yaml
@@ -17,7 +17,14 @@ spec:
   # https://www.elastic.co/guide/en/cloud-on-k8s/1.1/k8s-webhook-network-policies.html
   # The kubernetes api server must reach the webhook
   ingress:
-  - ports:
+  - from:
+    - podSelector:
+        matchLabels:
+          component: kube-apiserver
+      namespaceSelector:
+        matchLabels:
+          kubernetes.io/metadata.name: kube-system
+    ports:
     - protocol: TCP
       port: 9443
   policyTypes:

--- a/common/networkpolicies/base/training-operator-webhook.yaml
+++ b/common/networkpolicies/base/training-operator-webhook.yaml
@@ -13,7 +13,14 @@ spec:
   # https://www.elastic.co/guide/en/cloud-on-k8s/1.1/k8s-webhook-network-policies.html
   # The kubernetes api server must reach the webhook
   ingress:
-  - ports:
+  - from:
+    - podSelector:
+        matchLabels:
+          component: kube-apiserver
+      namespaceSelector:
+        matchLabels:
+          kubernetes.io/metadata.name: kube-system
+    ports:
     - protocol: TCP
       port: 9443
   policyTypes:


### PR DESCRIPTION
# Pull Request Template for Kubeflow Manifests

## ✏️ Summary of Changes
Modified the below files in the `common/networkpolicies/base` directory
- `kserve.yaml`
- `pvcviewer-webhook.yaml`
- `spark-operator-webhook.yaml`
- `training-operator-webhook.yaml`

Added the necessary restriction to allow access only from the apiserver namespace kube-system for webhooks.

Fixed YAML indentation issues that were previously undetected, as the workflow was not triggered on commits modifying the  `kserve.yaml`,  `pvcviewer-webhook.yaml` file.

## 📦 Dependencies
> List any dependencies or related PRs (e.g., "Depends on #123").

## 🐛 Related Issues
- Fixes #2928

## ✅ Contributor Checklist
  - [x] I have tested these changes with kustomize. See [Installation Prerequisites](https://github.com/kubeflow/manifests#prerequisites).
  - [x] All commits are [_signed-off_](https://github.com/kubeflow/community/tree/master/dco-signoff-hook#signing-off-commits) to satisfy the DCO check.

---     
 
> You can join the CNCF Slack and access our meetings at the [Kubeflow Community](https://www.kubeflow.org/docs/about/community/) website. Our channel on the CNCF Slack is here [**#kubeflow-platform**](https://app.slack.com/client/T08PSQ7BQ/C073W572LA2).
  
