### PR TITLE
Fix Istio sidecar injection by moving from annotations to labels

### DIFF
--- a/apps/admission-webhook/upstream/base/deployment.yaml
+++ b/apps/admission-webhook/upstream/base/deployment.yaml
@@ -5,7 +5,7 @@ metadata:
 spec:
   template:
     metadata:
-      annotations:
+      labels:
         sidecar.istio.io/inject: "false"
     spec:
       containers:

--- a/apps/centraldashboard/upstream/base/deployment.yaml
+++ b/apps/centraldashboard/upstream/base/deployment.yaml
@@ -13,7 +13,6 @@ spec:
     metadata:
       labels:
         app: centraldashboard
-      annotations:
         sidecar.istio.io/inject: "true"
     spec:
       containers:

--- a/apps/katib/upstream/components/controller/controller.yaml
+++ b/apps/katib/upstream/components/controller/controller.yaml
@@ -15,10 +15,10 @@ spec:
     metadata:
       labels:
         katib.kubeflow.org/component: controller
+        sidecar.istio.io/inject: "false"
       annotations:
         prometheus.io/scrape: "true"
         prometheus.io/port: "8080"
-        sidecar.istio.io/inject: "false"
     spec:
       serviceAccountName: katib-controller
       containers:

--- a/apps/katib/upstream/components/db-manager/db-manager.yaml
+++ b/apps/katib/upstream/components/db-manager/db-manager.yaml
@@ -15,7 +15,6 @@ spec:
     metadata:
       labels:
         katib.kubeflow.org/component: db-manager
-      annotations:
         sidecar.istio.io/inject: "false"
     spec:
       containers:

--- a/apps/katib/upstream/components/mysql/mysql.yaml
+++ b/apps/katib/upstream/components/mysql/mysql.yaml
@@ -17,7 +17,6 @@ spec:
     metadata:
       labels:
         katib.kubeflow.org/component: mysql
-      annotations:
         sidecar.istio.io/inject: "false"
     spec:
       containers:

--- a/apps/katib/upstream/components/postgres/postgres.yaml
+++ b/apps/katib/upstream/components/postgres/postgres.yaml
@@ -17,8 +17,8 @@ spec:
     metadata:
       labels:
         katib.kubeflow.org/component: postgres
-      annotations:
         sidecar.istio.io/inject: "false"
+      annotations:
     spec:
       containers:
         - name: katib-postgres

--- a/apps/katib/upstream/components/ui/ui.yaml
+++ b/apps/katib/upstream/components/ui/ui.yaml
@@ -15,7 +15,6 @@ spec:
     metadata:
       labels:
         katib.kubeflow.org/component: ui
-      annotations:
         sidecar.istio.io/inject: "false"
     spec:
       containers:

--- a/apps/katib/upstream/installs/katib-with-kubeflow/patches/istio-sidecar-injection.yaml
+++ b/apps/katib/upstream/installs/katib-with-kubeflow/patches/istio-sidecar-injection.yaml
@@ -6,5 +6,5 @@ metadata:
 spec:
   template:
     metadata:
-      annotations:
+      labels:
         sidecar.istio.io/inject: "true"

--- a/apps/kserve/kserve/kserve_kubeflow.yaml
+++ b/apps/kserve/kserve/kserve_kubeflow.yaml
@@ -31960,12 +31960,12 @@ spec:
     metadata:
       annotations:
         kubectl.kubernetes.io/default-container: manager
-        sidecar.istio.io/inject: "false"
       labels:
         app: kserve
         app.kubernetes.io/name: kserve
         control-plane: kserve-controller-manager
         controller-tools.k8s.io: "1.0"
+        sidecar.istio.io/inject: "false"
     spec:
       containers:
         - args:

--- a/apps/kserve/models-web-app/overlays/kubeflow/patches/web-app-sidecar.yaml
+++ b/apps/kserve/models-web-app/overlays/kubeflow/patches/web-app-sidecar.yaml
@@ -6,5 +6,5 @@ metadata:
 spec:
   template:
     metadata:
-      annotations:
+      labels:
         sidecar.istio.io/inject: "true"

--- a/apps/model-registry/upstream/base/model-registry-deployment.yaml
+++ b/apps/model-registry/upstream/base/model-registry-deployment.yaml
@@ -11,9 +11,8 @@ spec:
       component: model-registry-server
   template:
     metadata:
-      annotations:
-        sidecar.istio.io/inject: "true"
       labels:
+        sidecar.istio.io/inject: "true"
         component: model-registry-server
     spec:
       securityContext:

--- a/apps/model-registry/upstream/overlays/db/model-registry-db-deployment.yaml
+++ b/apps/model-registry/upstream/overlays/db/model-registry-db-deployment.yaml
@@ -16,7 +16,6 @@ spec:
       name: db
       labels:
         component: db
-      annotations:
         sidecar.istio.io/inject: "false"
     spec:
       securityContext:

--- a/apps/model-registry/upstream/overlays/postgres/model-registry-db-deployment.yaml
+++ b/apps/model-registry/upstream/overlays/postgres/model-registry-db-deployment.yaml
@@ -16,7 +16,6 @@ spec:
       name: db
       labels:
         component: db
-      annotations:
         sidecar.istio.io/inject: "false"
     spec:
       securityContext:

--- a/apps/pipeline/upstream/base/installs/multi-user/pipelines-profile-controller/deployment.yaml
+++ b/apps/pipeline/upstream/base/installs/multi-user/pipelines-profile-controller/deployment.yaml
@@ -6,6 +6,8 @@ spec:
   replicas: 1
   template:
     metadata:
+      labels:
+        sidecar.istio.io/inject: "false"
       annotations:
         sidecar.istio.io/inject: "false"
     spec:

--- a/apps/pipeline/upstream/base/installs/multi-user/pipelines-profile-controller/deployment.yaml
+++ b/apps/pipeline/upstream/base/installs/multi-user/pipelines-profile-controller/deployment.yaml
@@ -8,8 +8,6 @@ spec:
     metadata:
       labels:
         sidecar.istio.io/inject: "false"
-      annotations:
-        sidecar.istio.io/inject: "false"
     spec:
       containers:
       - name: profile-controller
@@ -59,4 +57,3 @@ spec:
       - name: hooks
         configMap:
           name: kubeflow-pipelines-profile-controller-code
-

--- a/apps/pipeline/upstream/base/metadata/base/metadata-envoy-deployment.yaml
+++ b/apps/pipeline/upstream/base/metadata/base/metadata-envoy-deployment.yaml
@@ -14,8 +14,6 @@ spec:
       labels:
         component: metadata-envoy
         sidecar.istio.io/inject: "false"
-      annotations:
-        sidecar.istio.io/inject: "false"
     spec:
       containers:
       - name: container

--- a/apps/pipeline/upstream/base/metadata/base/metadata-envoy-deployment.yaml
+++ b/apps/pipeline/upstream/base/metadata/base/metadata-envoy-deployment.yaml
@@ -13,6 +13,7 @@ spec:
     metadata:
       labels:
         component: metadata-envoy
+        sidecar.istio.io/inject: "false"
       annotations:
         sidecar.istio.io/inject: "false"
     spec:

--- a/apps/pipeline/upstream/base/metadata/overlays/db/metadata-db-deployment.yaml
+++ b/apps/pipeline/upstream/base/metadata/overlays/db/metadata-db-deployment.yaml
@@ -17,8 +17,6 @@ spec:
       labels:
         component: db
         sidecar.istio.io/inject: "false"
-      annotations:
-        sidecar.istio.io/inject: "false"
     spec:
       containers:
       - name: db-container
@@ -50,4 +48,3 @@ spec:
       - name: metadata-mysql
         persistentVolumeClaim:
           claimName: metadata-mysql
-

--- a/apps/pipeline/upstream/base/metadata/overlays/db/metadata-db-deployment.yaml
+++ b/apps/pipeline/upstream/base/metadata/overlays/db/metadata-db-deployment.yaml
@@ -16,6 +16,7 @@ spec:
       name: db
       labels:
         component: db
+        sidecar.istio.io/inject: "false"
       annotations:
         sidecar.istio.io/inject: "false"
     spec:

--- a/apps/pipeline/upstream/base/metadata/overlays/postgres/metadata-db-deployment.yaml
+++ b/apps/pipeline/upstream/base/metadata/overlays/postgres/metadata-db-deployment.yaml
@@ -17,15 +17,13 @@ spec:
       labels:
         component: db
         sidecar.istio.io/inject: "false"
-      annotations:
-        sidecar.istio.io/inject: "false"
     spec:
       containers:
       - name: db-container
         image: postgres
         env:
-          - name: PGDATA
-            value: /var/lib/postgresql/data/pgdata
+        - name: PGDATA
+          value: /var/lib/postgresql/data/pgdata
         envFrom:
         - configMapRef:
             name: metadata-postgres-db-parameters
@@ -41,4 +39,3 @@ spec:
       - name: metadata-postgres
         persistentVolumeClaim:
           claimName: metadata-postgres
-

--- a/apps/pipeline/upstream/base/metadata/overlays/postgres/metadata-db-deployment.yaml
+++ b/apps/pipeline/upstream/base/metadata/overlays/postgres/metadata-db-deployment.yaml
@@ -16,6 +16,7 @@ spec:
       name: db
       labels:
         component: db
+        sidecar.istio.io/inject: "false"
       annotations:
         sidecar.istio.io/inject: "false"
     spec:

--- a/apps/pipeline/upstream/third-party/metacontroller/base/stateful-set.yaml
+++ b/apps/pipeline/upstream/third-party/metacontroller/base/stateful-set.yaml
@@ -14,6 +14,7 @@ spec:
     metadata:
       labels:
         app: metacontroller
+        sidecar.istio.io/inject: "false"
       annotations:
         sidecar.istio.io/inject: "false"
     spec:

--- a/apps/pipeline/upstream/third-party/metacontroller/base/stateful-set.yaml
+++ b/apps/pipeline/upstream/third-party/metacontroller/base/stateful-set.yaml
@@ -15,8 +15,6 @@ spec:
       labels:
         app: metacontroller
         sidecar.istio.io/inject: "false"
-      annotations:
-        sidecar.istio.io/inject: "false"
     spec:
       containers:
         - resources:
@@ -39,7 +37,7 @@ spec:
               port: 8081
               path: /readyz
           securityContext:
-            seccompProfile: 
+            seccompProfile:
               type: RuntimeDefault
             capabilities:
               drop:

--- a/apps/profiles/upstream/manager/manager.yaml
+++ b/apps/profiles/upstream/manager/manager.yaml
@@ -13,7 +13,7 @@ spec:
   replicas: 1
   template:
     metadata:
-      annotations:
+      labels:
         sidecar.istio.io/inject: "false"
     spec:
       containers:

--- a/apps/profiles/upstream/overlays/kubeflow/patches/kfam.yaml
+++ b/apps/profiles/upstream/overlays/kubeflow/patches/kfam.yaml
@@ -5,7 +5,7 @@ metadata:
 spec:
   template:
     metadata:
-      annotations:
+      labels:
         sidecar.istio.io/inject: "true"
     spec:
       containers:

--- a/apps/spark/spark-operator/base/kustomization.yaml
+++ b/apps/spark/spark-operator/base/kustomization.yaml
@@ -48,6 +48,8 @@ patches:
       spec:
         template:
           metadata:
+            labels:
+              sidecar.istio.io/inject: "false"
             annotations:
               sidecar.istio.io/inject: "false"
   - target:
@@ -61,5 +63,7 @@ patches:
       spec:
         template:
           metadata:
+          labels:
+              sidecar.istio.io/inject: "false"
             annotations:
               sidecar.istio.io/inject: "false"

--- a/apps/spark/spark-operator/base/kustomization.yaml
+++ b/apps/spark/spark-operator/base/kustomization.yaml
@@ -1,8 +1,8 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
-  - resources.yaml
-  - aggregated-roles.yaml
+- resources.yaml
+- aggregated-roles.yaml
 namespace: kubeflow
 patches:
   - target:
@@ -50,8 +50,6 @@ patches:
           metadata:
             labels:
               sidecar.istio.io/inject: "false"
-            annotations:
-              sidecar.istio.io/inject: "false"
   - target:
       kind: Deployment
       name: spark-operator-controller
@@ -59,11 +57,9 @@ patches:
       apiVersion: apps/v1
       kind: Deployment
       metadata:
-        name: spark-operator-webhook
+        name: spark-operator-controller
       spec:
         template:
           metadata:
-          labels:
-              sidecar.istio.io/inject: "false"
-            annotations:
+            labels:
               sidecar.istio.io/inject: "false"

--- a/apps/spark/sparkapplication_example.yaml
+++ b/apps/spark/sparkapplication_example.yaml
@@ -2,6 +2,8 @@ apiVersion: sparkoperator.k8s.io/v1beta2
 kind: SparkApplication
 metadata:
   name: spark-pi-python
+  labels:
+    sidecar.istio.io/inject: "false"
 spec:
   type: Python
   pythonVersion: "3"
@@ -14,8 +16,8 @@ spec:
     cores: 1
     memory: 512m
     serviceAccount: default-editor
-    annotations:
-      "sidecar.istio.io/inject": "false"
+    labels:
+      sidecar.istio.io/inject: "false"
     securityContext:
       capabilities:
         drop:
@@ -30,8 +32,8 @@ spec:
     instances: 1
     cores: 1
     memory: 512m
-    annotations:
-      "sidecar.istio.io/inject": "false"
+    labels:
+      sidecar.istio.io.inject: "false"
     securityContext:
       capabilities:
         drop:

--- a/apps/training-operator/upstream/base/deployment.yaml
+++ b/apps/training-operator/upstream/base/deployment.yaml
@@ -13,7 +13,6 @@ spec:
     metadata:
       labels:
         control-plane: kubeflow-training-operator
-      annotations:
         sidecar.istio.io/inject: "false"
     spec:
       containers:

--- a/common/knative/knative-serving/base/patches/sidecar-injection.yaml
+++ b/common/knative/knative-serving/base/patches/sidecar-injection.yaml
@@ -8,5 +8,3 @@ spec:
     metadata:
       labels:
         sidecar.istio.io/inject: "true"
-      annotations:
-        sidecar.istio.io/inject: "true"

--- a/common/knative/knative-serving/base/patches/sidecar-injection.yaml
+++ b/common/knative/knative-serving/base/patches/sidecar-injection.yaml
@@ -6,5 +6,7 @@ metadata:
 spec:
   template:
     metadata:
+      labels:
+        sidecar.istio.io/inject: "true"
       annotations:
         sidecar.istio.io/inject: "true"

--- a/tests/gh-actions/kf-objects/training_operator_job.yaml
+++ b/tests/gh-actions/kf-objects/training_operator_job.yaml
@@ -15,13 +15,13 @@ spec:
             sidecar.istio.io/inject: "false"
         spec:
           containers:
-            - name: pytorch
-              image: docker.io/kubeflowkatib/pytorch-mnist:v1beta1-45c5727
-              imagePullPolicy: Always
-              command:
-                - "python3"
-                - "/opt/pytorch-mnist/mnist.py"
-                - "--epochs=1"
+          - name: pytorch
+            image: docker.io/kubeflowkatib/pytorch-mnist:v1beta1-45c5727
+            imagePullPolicy: Always
+            command:
+            - "python3"
+            - "/opt/pytorch-mnist/mnist.py"
+            - "--epochs=1"
     Worker:
       replicas: 1
       restartPolicy: OnFailure
@@ -31,10 +31,10 @@ spec:
             sidecar.istio.io/inject: "false"
         spec:
           containers:
-            - name: pytorch
-              image: docker.io/kubeflowkatib/pytorch-mnist:v1beta1-45c5727
-              imagePullPolicy: Always
-              command:
-                - "python3"
-                - "/opt/pytorch-mnist/mnist.py"
-                - "--epochs=1"
+          - name: pytorch
+            image: docker.io/kubeflowkatib/pytorch-mnist:v1beta1-45c5727
+            imagePullPolicy: Always
+            command:
+            - "python3"
+            - "/opt/pytorch-mnist/mnist.py"
+            - "--epochs=1"

--- a/tests/gh-actions/kf-objects/training_operator_job.yaml
+++ b/tests/gh-actions/kf-objects/training_operator_job.yaml
@@ -11,7 +11,7 @@ spec:
       restartPolicy: OnFailure
       template:
         metadata:
-          annotations:
+          labels:
             sidecar.istio.io/inject: "false"
         spec:
           containers:
@@ -27,7 +27,7 @@ spec:
       restartPolicy: OnFailure
       template:
         metadata:
-          annotations:
+          labels:
             sidecar.istio.io/inject: "false"
         spec:
           containers:


### PR DESCRIPTION
# Pull Request Template for Kubeflow Manifests

## ✏️ Summary of Changes

This PR fixes Istio sidecar injection by moving control from annotations to labels across all manifests, following Istio best practices documentation.

## 📦 Dependencies

No dependencies on other PRs.

## 🐛 Related Issues

Fixes #2798

## ✅ Contributor Checklist
  - [x] I have tested these changes with kustomize. See [Installation Prerequisites](https://github.com/kubeflow/manifests#prerequisites).
  - [x] All commits are [_signed-off_](https://github.com/kubeflow/community/tree/master/dco-signoff-hook#signing-off-commits) to satisfy the DCO check.

---     
 
> You can join the CNCF Slack and access our meetings at the [Kubeflow Community](https://www.kubeflow.org/docs/about/community/) website. Our channel on the CNCF Slack is here [**#kubeflow-platform**](https://app.slack.com/client/T08PSQ7BQ/C073W572LA2).
  
