### PR TITLE
fix(pipeline): minio filesystem permission access error

### DIFF
--- a/apps/pipeline/upstream/third-party/minio/base/minio-deployment.yaml
+++ b/apps/pipeline/upstream/third-party/minio/base/minio-deployment.yaml
@@ -41,6 +41,7 @@ spec:
           runAsNonRoot: true
           runAsUser: 1000
           runAsGroup: 0
+          fsGroup: 1000
           capabilities:
             drop:
             - ALL

--- a/apps/pipeline/upstream/third-party/minio/base/minio-deployment.yaml
+++ b/apps/pipeline/upstream/third-party/minio/base/minio-deployment.yaml
@@ -17,6 +17,7 @@ spec:
     spec:
       securityContext:
         fsGroup: 1000
+        fsGroupChangePolicy: "OnRootMismatch"
       containers:
       - args:
         - server

--- a/apps/pipeline/upstream/third-party/minio/base/minio-deployment.yaml
+++ b/apps/pipeline/upstream/third-party/minio/base/minio-deployment.yaml
@@ -15,6 +15,8 @@ spec:
       labels:
         app: minio
     spec:
+      securityContext:
+        fsGroup: 1000
       containers:
       - args:
         - server
@@ -41,7 +43,6 @@ spec:
           runAsNonRoot: true
           runAsUser: 1000
           runAsGroup: 0
-          fsGroup: 1000
           capabilities:
             drop:
             - ALL


### PR DESCRIPTION
# Pull Request Template for Kubeflow Manifests

## ✏️ Summary of Changes
> Describe the changes you have made, including any refactoring or feature additions.

This change will will make Kubernetes automatically set the correct ownership of the mounted volumes to be accessible by `user 1000`
## 📦 Dependencies
> List any dependencies or related PRs (e.g., "Depends on #123").

## 🐛 Related Issues
> Link any issues that are resolved or affected by this PR.

fixes #3040 
## ✅ Contributor Checklist
  - [ ] I have tested these changes with kustomize. See [Installation Prerequisites](https://github.com/kubeflow/manifests#prerequisites).
  - [x] All commits are [_signed-off_](https://github.com/kubeflow/community/tree/master/dco-signoff-hook#signing-off-commits) to satisfy the DCO check.

---     
 
> You can join the CNCF Slack and access our meetings at the [Kubeflow Community](https://www.kubeflow.org/docs/about/community/) website. Our channel on the CNCF Slack is here [**#kubeflow-platform**](https://app.slack.com/client/T08PSQ7BQ/C073W572LA2).
  
