### PR TITLE
Update Kind and test Kubernetes 1.29-1.32

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,7 +115,7 @@ The `example` directory contains an example kustomization for the single command
 #### Prerequisites
 - 16 GB of RAM recommended.
 - 8 CPU cores recommended.
-- `kind` version 0.26+.
+- `kind` version 0.27+.
 - `docker` or a more modern tool such as `podman` to run the OCI images for the Kind cluster.
 - Linux kernel subsystem changes to support many pods:
     - `sudo sysctl fs.inotify.max_user_instances=2280`

--- a/common/istio-cni-1-24/istio-install/base/install.yaml
+++ b/common/istio-cni-1-24/istio-install/base/install.yaml
@@ -3316,7 +3316,7 @@ spec:
         - 30m
         env:
         - name: ENABLE_NATIVE_SIDECARS
-          value: 'false'
+          value: 'true'
         - name: REVISION
           value: default
         - name: PILOT_CERT_PROVIDER

--- a/common/istio-cni-1-24/istio-install/base/install.yaml
+++ b/common/istio-cni-1-24/istio-install/base/install.yaml
@@ -3316,7 +3316,7 @@ spec:
         - 30m
         env:
         - name: ENABLE_NATIVE_SIDECARS
-          value: 'true'
+          value: 'false'
         - name: REVISION
           value: default
         - name: PILOT_CERT_PROVIDER

--- a/tests/gh-actions/install_KinD_create_KinD_cluster_install_kustomize.sh
+++ b/tests/gh-actions/install_KinD_create_KinD_cluster_install_kustomize.sh
@@ -49,11 +49,11 @@ kubeadmConfigPatches:
         \"service-account-signing-key-file\": \"/etc/kubernetes/pki/sa.key\"
 nodes:
 - role: control-plane
-  image: kindest/node:v1.29.14@sha256:8703bd94ee24e51b778d5556ae310c6c0fa67d761fae6379c8e0bb480e6fea29
+  image: kindest/node:v1.30.10@sha256:4de75d0e82481ea846c0ed1de86328d821c1e6a6a91ac37bf804e5313670e507
 - role: worker
-  image: kindest/node:v1.29.14@sha256:8703bd94ee24e51b778d5556ae310c6c0fa67d761fae6379c8e0bb480e6fea29
+  image: kindest/node:v1.30.10@sha256:4de75d0e82481ea846c0ed1de86328d821c1e6a6a91ac37bf804e5313670e507
 - role: worker
-  image: kindest/node:v1.29.14@sha256:8703bd94ee24e51b778d5556ae310c6c0fa67d761fae6379c8e0bb480e6fea29
+  image: kindest/node:v1.30.10@sha256:4de75d0e82481ea846c0ed1de86328d821c1e6a6a91ac37bf804e5313670e507
 " | kind create cluster --config -
 
 

--- a/tests/gh-actions/install_KinD_create_KinD_cluster_install_kustomize.sh
+++ b/tests/gh-actions/install_KinD_create_KinD_cluster_install_kustomize.sh
@@ -48,13 +48,12 @@ kubeadmConfigPatches:
         \"service-account-issuer\": \"https://kubernetes.default.svc\"
         \"service-account-signing-key-file\": \"/etc/kubernetes/pki/sa.key\"
 nodes:
-# test according to https://github.com/kubernetes-sigs/kind/releases/tag/v0.27.0
 - role: control-plane
-  image: v1.31.6: kindest/node:v1.31.6@sha256:28b7cbb993dfe093c76641a0c95807637213c9109b761f1d422c2400e22b8e87
+  image: kindest/node:v1.31.6@sha256:28b7cbb993dfe093c76641a0c95807637213c9109b761f1d422c2400e22b8e87
 - role: worker
-  image: v1.31.6: kindest/node:v1.31.6@sha256:28b7cbb993dfe093c76641a0c95807637213c9109b761f1d422c2400e22b8e87
+  image: kindest/node:v1.31.6@sha256:28b7cbb993dfe093c76641a0c95807637213c9109b761f1d422c2400e22b8e87
 - role: worker
-  image: v1.31.6: kindest/node:v1.31.6@sha256:28b7cbb993dfe093c76641a0c95807637213c9109b761f1d422c2400e22b8e87
+  image: kindest/node:v1.31.6@sha256:28b7cbb993dfe093c76641a0c95807637213c9109b761f1d422c2400e22b8e87
 " | kind create cluster --config -
 
 

--- a/tests/gh-actions/install_KinD_create_KinD_cluster_install_kustomize.sh
+++ b/tests/gh-actions/install_KinD_create_KinD_cluster_install_kustomize.sh
@@ -49,11 +49,11 @@ kubeadmConfigPatches:
         \"service-account-signing-key-file\": \"/etc/kubernetes/pki/sa.key\"
 nodes:
 - role: control-plane
-  image: kindest/node:v1.31.6@sha256:28b7cbb993dfe093c76641a0c95807637213c9109b761f1d422c2400e22b8e87
+  image: kindest/node:v1.29.14@sha256:8703bd94ee24e51b778d5556ae310c6c0fa67d761fae6379c8e0bb480e6fea29
 - role: worker
-  image: kindest/node:v1.31.6@sha256:28b7cbb993dfe093c76641a0c95807637213c9109b761f1d422c2400e22b8e87
+  image: kindest/node:v1.29.14@sha256:8703bd94ee24e51b778d5556ae310c6c0fa67d761fae6379c8e0bb480e6fea29
 - role: worker
-  image: kindest/node:v1.31.6@sha256:28b7cbb993dfe093c76641a0c95807637213c9109b761f1d422c2400e22b8e87
+  image: kindest/node:v1.29.14@sha256:8703bd94ee24e51b778d5556ae310c6c0fa67d761fae6379c8e0bb480e6fea29
 " | kind create cluster --config -
 
 

--- a/tests/gh-actions/install_KinD_create_KinD_cluster_install_kustomize.sh
+++ b/tests/gh-actions/install_KinD_create_KinD_cluster_install_kustomize.sh
@@ -20,7 +20,7 @@ if [ -e /swapfile ]; then
 fi
 
 {
-    curl -Lo ./kind https://kind.sigs.k8s.io/dl/v0.26.0/kind-linux-amd64
+    curl -Lo ./kind https://kind.sigs.k8s.io/dl/v0.27.0/kind-linux-amd64
     chmod +x ./kind
     sudo mv kind /usr/local/bin
 } || { echo "Failed to install KinD"; exit 1; }
@@ -48,12 +48,13 @@ kubeadmConfigPatches:
         \"service-account-issuer\": \"https://kubernetes.default.svc\"
         \"service-account-signing-key-file\": \"/etc/kubernetes/pki/sa.key\"
 nodes:
+# test according to https://github.com/kubernetes-sigs/kind/releases/tag/v0.27.0
 - role: control-plane
-  image: kindest/node:v1.32.0@sha256:c48c62eac5da28cdadcf560d1d8616cfa6783b58f0d94cf63ad1bf49600cb027
+  image: kindest/node:v1.30.10@sha256:4de75d0e82481ea846c0ed1de86328d821c1e6a6a91ac37bf804e5313670e507
 - role: worker
-  image: kindest/node:v1.32.0@sha256:c48c62eac5da28cdadcf560d1d8616cfa6783b58f0d94cf63ad1bf49600cb027
+  image: kindest/node:v1.30.10@sha256:4de75d0e82481ea846c0ed1de86328d821c1e6a6a91ac37bf804e5313670e507
 - role: worker
-  image: kindest/node:v1.32.0@sha256:c48c62eac5da28cdadcf560d1d8616cfa6783b58f0d94cf63ad1bf49600cb027
+  image: kindest/node:v1.30.10@sha256:4de75d0e82481ea846c0ed1de86328d821c1e6a6a91ac37bf804e5313670e507
 " | kind create cluster --config -
 
 

--- a/tests/gh-actions/install_KinD_create_KinD_cluster_install_kustomize.sh
+++ b/tests/gh-actions/install_KinD_create_KinD_cluster_install_kustomize.sh
@@ -50,11 +50,11 @@ kubeadmConfigPatches:
 nodes:
 # test according to https://github.com/kubernetes-sigs/kind/releases/tag/v0.27.0
 - role: control-plane
-  image: kindest/node:v1.30.10@sha256:4de75d0e82481ea846c0ed1de86328d821c1e6a6a91ac37bf804e5313670e507
+  image: v1.31.6: kindest/node:v1.31.6@sha256:28b7cbb993dfe093c76641a0c95807637213c9109b761f1d422c2400e22b8e87
 - role: worker
-  image: kindest/node:v1.30.10@sha256:4de75d0e82481ea846c0ed1de86328d821c1e6a6a91ac37bf804e5313670e507
+  image: v1.31.6: kindest/node:v1.31.6@sha256:28b7cbb993dfe093c76641a0c95807637213c9109b761f1d422c2400e22b8e87
 - role: worker
-  image: kindest/node:v1.30.10@sha256:4de75d0e82481ea846c0ed1de86328d821c1e6a6a91ac37bf804e5313670e507
+  image: v1.31.6: kindest/node:v1.31.6@sha256:28b7cbb993dfe093c76641a0c95807637213c9109b761f1d422c2400e22b8e87
 " | kind create cluster --config -
 
 

--- a/tests/gh-actions/install_KinD_create_KinD_cluster_install_kustomize.sh
+++ b/tests/gh-actions/install_KinD_create_KinD_cluster_install_kustomize.sh
@@ -49,11 +49,11 @@ kubeadmConfigPatches:
         \"service-account-signing-key-file\": \"/etc/kubernetes/pki/sa.key\"
 nodes:
 - role: control-plane
-  image: kindest/node:v1.30.10@sha256:4de75d0e82481ea846c0ed1de86328d821c1e6a6a91ac37bf804e5313670e507
+  image: kindest/node:v1.32.2@sha256:f226345927d7e348497136874b6d207e0b32cc52154ad8323129352923a3142f
 - role: worker
-  image: kindest/node:v1.30.10@sha256:4de75d0e82481ea846c0ed1de86328d821c1e6a6a91ac37bf804e5313670e507
+  image: kindest/node:v1.32.2@sha256:f226345927d7e348497136874b6d207e0b32cc52154ad8323129352923a3142f
 - role: worker
-  image: kindest/node:v1.30.10@sha256:4de75d0e82481ea846c0ed1de86328d821c1e6a6a91ac37bf804e5313670e507
+  image: kindest/node:v1.32.2@sha256:f226345927d7e348497136874b6d207e0b32cc52154ad8323129352923a3142f
 " | kind create cluster --config -
 
 


### PR DESCRIPTION
Kind 0.27 https://github.com/kubernetes-sigs/kind/releases/tag/v0.27.0 with

- [x] update kind everywhere in the documentation
- [x]   v1.32.2: kindest/node:v1.32.2@sha256:f226345927d7e348497136874b6d207e0b32cc52154ad8323129352923a3142f
- [x]   v1.31.6: kindest/node:v1.31.6@sha256:28b7cbb993dfe093c76641a0c95807637213c9109b761f1d422c2400e22b8e87 - all tests successful
- [x]   v1.30.10: kindest/node:v1.30.10@sha256:4de75d0e82481ea846c0ed1de86328d821c1e6a6a91ac37bf804e5313670e507 - dex is the only test failing, works with `ENABLE_NATIVE_SIDECARS: false`
![image](https://github.com/user-attachments/assets/feb403bd-c4b8-4158-8b5a-a1d663f2acdf)
- [x]   v1.29.14: kindest/node:v1.29.14@sha256:8703bd94ee24e51b778d5556ae310c6c0fa67d761fae6379c8e0bb480e6fea29 - dex is the only test failing, works with `ENABLE_NATIVE_SIDECARS: false`
![image](https://github.com/user-attachments/assets/feb403bd-c4b8-4158-8b5a-a1d663f2acdf)
- [x] We support Kubernetes 1.31-1.33 directly. For Kubernetes 1.29-1.30 you might have to either enable the native sidecars [feature gate](https://kubernetes.io/docs/reference/command-line-tools-reference/feature-gates/) on your Kubernetes cluster or you need to disable `NATIVE_SIDECARS ` here https://github.com/kubeflow/manifests/blob/421ffcd46899d4916972d39949a6ea0c8fe97ff2/common/istio-1-24/istio-install/base/install.yaml#L3006-L3007 or here https://github.com/kubeflow/manifests/blob/421ffcd46899d4916972d39949a6ea0c8fe97ff2/common/istio-cni-1-24/istio-install/base/install.yaml#L3318-L3319.
But Kubernetes 1.30 is already [End of Life](https://kubernetes.io/releases/#release-history) by 2025-06-28, so we strongly recommend to upgrade to 1.31+. We also tested that native sidecars work on AKS and GKE 1.31+. Kubernetes 1.33 is planned for release on April 23 2025, so we would support 1.31-1.33 and down to 1.29 with native sidecars workarounds.

  
