### PR TITLE
Update kubeflow/model-registry manifests from v0.2.15.3

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ This repository periodically synchronizes all official Kubeflow components from 
 | KServe | apps/kserve/kserve | [v0.14.1](https://github.com/kserve/kserve/releases/tag/v0.14.1/install/v0.14.1) |
 | KServe Models Web App | apps/kserve/models-web-app | [v0.14.0-rc.0](https://github.com/kserve/models-web-app/tree/v0.14.0-rc.0/config) |
 | Kubeflow Pipelines | apps/pipeline/upstream | [2.4.1](https://github.com/kubeflow/pipelines/tree/2.4.1/manifests/kustomize) |
-| Kubeflow Model Registry | apps/model-registry/upstream | [v0.2.15](https://github.com/kubeflow/model-registry/tree/v0.2.15/manifests/kustomize) |
+| Kubeflow Model Registry | apps/model-registry/upstream | [v0.2.15.3](https://github.com/kubeflow/model-registry/tree/v0.2.15.3/manifests/kustomize) |
 
 The following matrix shows the versions of common components used across different Kubeflow projects:
 

--- a/apps/model-registry/upstream/base/kustomization.yaml
+++ b/apps/model-registry/upstream/base/kustomization.yaml
@@ -6,6 +6,6 @@ resources:
 - model-registry-service.yaml
 - model-registry-sa.yaml
 images:
-- name: kubeflow/model-registry
-  newName: kubeflow/model-registry
-  newTag: v0.2.15
+- name: ghcr.io/kubeflow/model-registry/server
+  newName: ghcr.io/kubeflow/model-registry/server
+  newTag: v0.2.15.3

--- a/apps/model-registry/upstream/base/model-registry-deployment.yaml
+++ b/apps/model-registry/upstream/base/model-registry-deployment.yaml
@@ -11,9 +11,8 @@ spec:
       component: model-registry-server
   template:
     metadata:
-      annotations:
-        sidecar.istio.io/inject: "true"
       labels:
+        sidecar.istio.io/inject: "true"
         component: model-registry-server
     spec:
       securityContext:
@@ -30,7 +29,7 @@ spec:
           command:
             - /model-registry
             - proxy
-          image: kubeflow/model-registry:latest
+          image: ghcr.io/kubeflow/model-registry/server:latest
           # empty placeholder environment for patching
           env: []
           ports:

--- a/apps/model-registry/upstream/options/csi/clusterstoragecontainer.yaml
+++ b/apps/model-registry/upstream/options/csi/clusterstoragecontainer.yaml
@@ -5,7 +5,7 @@ metadata:
 spec:
   container:
     name: storage-initializer
-    image: kubeflow/model-registry-storage-initializer:latest
+    image: ghcr.io/kubeflow/model-registry/storage-initializer:latest
     env:
     - name: MODEL_REGISTRY_BASE_URL
       value: "model-registry-service.kubeflow.svc.cluster.local:8080"

--- a/apps/model-registry/upstream/options/csi/kustomization.yaml
+++ b/apps/model-registry/upstream/options/csi/kustomization.yaml
@@ -5,6 +5,6 @@ namespace: kubeflow
 resources:
 - clusterstoragecontainer.yaml
 images:
-- name: kubeflow/model-registry-storage-initializer
-  newName: kubeflow/model-registry-storage-initializer
-  newTag: v0.2.15
+- name: ghcr.io/kubeflow/model-registry/storage-initializer
+  newName: ghcr.io/kubeflow/model-registry/storage-initializer
+  newTag: v0.2.15.3

--- a/apps/model-registry/upstream/options/ui/base/kustomization.yaml
+++ b/apps/model-registry/upstream/options/ui/base/kustomization.yaml
@@ -9,5 +9,5 @@ resources:
 
 images:
 - name: model-registry-ui
-  newName: docker.io/kubeflow/model-registry-ui
-  newTag: v0.2.15
+  newName: ghcr.io/kubeflow/model-registry/ui
+  newTag: v0.2.15.3

--- a/apps/model-registry/upstream/overlays/db/model-registry-db-deployment.yaml
+++ b/apps/model-registry/upstream/overlays/db/model-registry-db-deployment.yaml
@@ -16,7 +16,6 @@ spec:
       name: db
       labels:
         component: db
-      annotations:
         sidecar.istio.io/inject: "false"
     spec:
       securityContext:

--- a/apps/model-registry/upstream/overlays/postgres/model-registry-db-deployment.yaml
+++ b/apps/model-registry/upstream/overlays/postgres/model-registry-db-deployment.yaml
@@ -16,7 +16,6 @@ spec:
       name: db
       labels:
         component: db
-      annotations:
         sidecar.istio.io/inject: "false"
     spec:
       securityContext:


### PR DESCRIPTION
# Pull Request Template for Kubeflow Manifests

## ✏️ Summary of Changes
Followup [nano v0.2.15.3 release](https://github.com/kubeflow/model-registry/releases/tag/v0.2.15.3) to support the migration to `ghcr.io` as requested, it also include the istio label change requested.
Special thanks to @madmecodes , @mahdikhashan , for their contributions.

## 📦 Dependencies
n/a

## 🐛 Related Issues
- https://github.com/kubeflow/manifests/issues/3010
- https://github.com/kubeflow/manifests/issues/2798

## ✅ Contributor Checklist
  - [x] I have tested these changes with kustomize (ci via GHA). See [Installation Prerequisites](https://github.com/kubeflow/manifests#prerequisites).
  - [x] All commits are [_signed-off_](https://github.com/kubeflow/community/tree/master/dco-signoff-hook#signing-off-commits) to satisfy the DCO check.

---     
 
> You can join the CNCF Slack and access our meetings at the [Kubeflow Community](https://www.kubeflow.org/docs/about/community/) website. Our channel on the CNCF Slack is here [**#kubeflow-platform**](https://app.slack.com/client/T08PSQ7BQ/C073W572LA2).
  
this superseeds https://github.com/kubeflow/manifests/pull/3065