### PR TITLE
test: fix name, debug hooks

### DIFF
--- a/.github/workflows/model_registry_test.yaml
+++ b/.github/workflows/model_registry_test.yaml
@@ -72,11 +72,15 @@ jobs:
             exit 1
         fi
         kubectl wait --for=condition=available -n kubeflow deployment/model-registry-deployment --timeout=600s
-    - name: Test KF Model Registry deployment
+    - name: Test KF Model Registry UI deployment
       run: |
         echo "Waiting for all Model Registry UI Pods to become ready..."
-        kubectl wait --for=condition=available -n kubeflow deployment/model-registry-ui --timeout=600s
-
+        if ! kubectl wait --for=condition=available -n kubeflow deployment/model-registry-ui --timeout=600s ; then
+            kubectl events -A
+            kubectl describe deployment/model-registry-ui -n kubeflow
+            kubectl logs deployment/model-registry-ui -n kubeflow
+            exit 1
+        fi
     - name: Dry-run KF Model Registry API directly
       run: |
         echo "Dry-run KF Model Registry API directly..."


### PR DESCRIPTION


# Pull Request Template for Kubeflow Manifests

## ✏️ Summary of Changes
amend the existing dry-run testing,
by fixing to avoid a duplicate step name,
by having a "debug hook" in case one await fails
so to get some indications on the reasons for the
awaited failure

## 📦 Dependencies
n/a

## 🐛 Related Issues
n/a
## ✅ Contributor Checklist
  - [n/a] I have tested these changes with kustomize. See [Installation Prerequisites](https://github.com/kubeflow/manifests#prerequisites).
  - [x] All commits are [_signed-off_](https://github.com/kubeflow/community/tree/master/dco-signoff-hook#signing-off-commits) to satisfy the DCO check.

---     
 
> You can join the CNCF Slack and access our meetings at the [Kubeflow Community](https://www.kubeflow.org/docs/about/community/) website. Our channel on the CNCF Slack is here [**#kubeflow-platform**](https://app.slack.com/client/T08PSQ7BQ/C073W572LA2).
  
cc @lucferbux @Al-Pragliola 