### PR TITLE
Fix: Revert OAuth2 authentication policy for cluster-local-gateway

### DIFF
--- a/common/istio-1-24/cluster-local-gateway/base/gateway-authorizationpolicy.yaml
+++ b/common/istio-1-24/cluster-local-gateway/base/gateway-authorizationpolicy.yaml
@@ -1,12 +1,10 @@
-# Enforce OAuth2-proxy authentication for cluster-local-gateway
+# Allow all traffic to the cluster-local-gateway
 apiVersion: security.istio.io/v1beta1
 kind: AuthorizationPolicy
 metadata:
-  name: cluster-local-gateway-oauth2-proxy
+  name: cluster-local-gateway
 spec:
-  action: CUSTOM
-  provider:
-    name: oauth2-proxy
+  action: ALLOW
   selector:
     # Same as the cluster-local-gateway Service selector
     matchLabels:

--- a/common/istio-cni-1-24/cluster-local-gateway/base/gateway-authorizationpolicy.yaml
+++ b/common/istio-cni-1-24/cluster-local-gateway/base/gateway-authorizationpolicy.yaml
@@ -1,12 +1,10 @@
-# Enforce OAuth2-proxy authentication for cluster-local-gateway
+# Allow all traffic to the cluster-local-gateway
 apiVersion: security.istio.io/v1beta1
 kind: AuthorizationPolicy
 metadata:
-  name: cluster-local-gateway-oauth2-proxy
+  name: cluster-local-gateway
 spec:
-  action: CUSTOM
-  provider:
-    name: oauth2-proxy
+  action: ALLOW
   selector:
     # Same as the cluster-local-gateway Service selector
     matchLabels:


### PR DESCRIPTION
# Pull Request Template for Kubeflow Manifests

## ✏️ Summary of Changes
Revert OAuth2 authentication policy for cluster-local-gateway
## 📦 Dependencies

## 🐛 Related Issues

## ✅ Contributor Checklist
  - [x] I have tested these changes with kustomize. See [Installation Prerequisites](https://github.com/kubeflow/manifests#prerequisites).
  - [x] All commits are [_signed-off_](https://github.com/kubeflow/community/tree/master/dco-signoff-hook#signing-off-commits) to satisfy the DCO check.

---     
 
> You can join the CNCF Slack and access our meetings at the [Kubeflow Community](https://www.kubeflow.org/docs/about/community/) website. Our channel on the CNCF Slack is here [**#kubeflow-platform**](https://app.slack.com/client/T08PSQ7BQ/C073W572LA2).
  
