### PR TITLE
Fix: kubectl wait condition case from ready to Ready

### DIFF
--- a/.github/workflows/dex_oauth2-proxy_test.yaml
+++ b/.github/workflows/dex_oauth2-proxy_test.yaml
@@ -45,7 +45,7 @@ jobs:
         kustomize build ./common/dex/overlays/oauth2-proxy | kubectl apply -f -
 
         echo "Waiting for pods in auth namespace to become ready..."
-        kubectl wait --for=condition=ready pods --all --timeout=180s -n auth
+        kubectl wait --for=condition=Ready pods --all --timeout=180s -n auth
 
     - name: Install central-dashboard
       run: |

--- a/README.md
+++ b/README.md
@@ -197,7 +197,7 @@ Install cert-manager:
 kustomize build common/cert-manager/base | kubectl apply -f -
 kustomize build common/cert-manager/kubeflow-issuer/base | kubectl apply -f -
 echo "Waiting for cert-manager to be ready ..."
-kubectl wait --for=condition=ready pod -l 'app in (cert-manager,webhook)' --timeout=180s -n cert-manager
+kubectl wait --for=condition=Ready pod -l 'app in (cert-manager,webhook)' --timeout=180s -n cert-manager
 kubectl wait --for=jsonpath='{.subsets[0].addresses[0].targetRef.kind}'=Pod endpoints -l 'app in (cert-manager,webhook)' --timeout=180s -n cert-manager
 ```
 
@@ -239,7 +239,7 @@ echo "Installing oauth2-proxy..."
 #           tokens to be used from outside the cluster via the Istio ingress-gateway.
 #
 kustomize build common/oauth2-proxy/overlays/m2m-dex-only/ | kubectl apply -f -
-kubectl wait --for=condition=ready pod -l 'app.kubernetes.io/name=oauth2-proxy' --timeout=180s -n oauth2-proxy
+kubectl wait --for=condition=Ready pod -l 'app.kubernetes.io/name=oauth2-proxy' --timeout=180s -n oauth2-proxy
 
 # Option 2: works on Kind, K3D, Rancher, GKE, and many other clusters with the proper configuration, and allows K8s service account tokens to be used
 #           from outside the cluster via the Istio ingress-gateway. For example, for automation with GitHub Actions.
@@ -250,15 +250,15 @@ kubectl wait --for=condition=ready pod -l 'app.kubernetes.io/name=oauth2-proxy' 
 #           from a pod in the cluster should provide you with the issuer of your cluster.
 # 
 #kustomize build common/oauth2-proxy/overlays/m2m-dex-and-kind/ | kubectl apply -f -
-#kubectl wait --for=condition=ready pod -l 'app.kubernetes.io/name=oauth2-proxy' --timeout=180s -n oauth2-proxy
-#kubectl wait --for=condition=ready pod -l 'app.kubernetes.io/name=cluster-jwks-proxy' --timeout=180s -n istio-system
+#kubectl wait --for=condition=Ready pod -l 'app.kubernetes.io/name=oauth2-proxy' --timeout=180s -n oauth2-proxy
+#kubectl wait --for=condition=Ready pod -l 'app.kubernetes.io/name=cluster-jwks-proxy' --timeout=180s -n istio-system
 
 # OPTION 3: works on most EKS clusters with K8s service account
 #           tokens to be used from outside the cluster via the Istio ingress-gateway.
 #           You have to adjust AWS_REGION and CLUSTER_ID in common/oauth2-proxy/overlays/m2m-dex-and-eks/ first.
 #
 #kustomize build common/oauth2-proxy/overlays/m2m-dex-and-eks/ | kubectl apply -f -
-#kubectl wait --for=condition=ready pod -l 'app.kubernetes.io/name=oauth2-proxy' --timeout=180s -n oauth2-proxy
+#kubectl wait --for=condition=Ready pod -l 'app.kubernetes.io/name=oauth2-proxy' --timeout=180s -n oauth2-proxy
 ```
 
 If and after you finish the installation with Kubernetes service account token support, you should be able to create and use the tokens:
@@ -280,7 +280,7 @@ Install Dex:
 ```sh
 echo "Installing Dex..."
 kustomize build common/dex/overlays/oauth2-proxy | kubectl apply -f -
-kubectl wait --for=condition=ready pods --all --timeout=180s -n auth
+kubectl wait --for=condition=Ready pods --all --timeout=180s -n auth
 ```
 
 To connect to your desired identity providers (LDAP, GitHub, Google, Microsoft, OIDC, SAML, GitLab), please take a look at <https://dexidp.io/docs/connectors/oidc/>. We recommend using OIDC in general since it is compatible with most providers. For example, Azure in the following example. You need to modify <https://github.com/kubeflow/manifests/blob/master/common/dex/overlays/oauth2-proxy/config-map.yaml> and add some environment variables in <https://github.com/kubeflow/manifests/blob/master/common/dex/base/deployment.yaml> by adding a patch section in your main Kustomization file. For guidance, please check out [Upgrading and Extending](#upgrading-and-extending).

--- a/experimental/ray/test.sh
+++ b/experimental/ray/test.sh
@@ -44,7 +44,7 @@ kubectl -n $NAMESPACE apply -f raycluster_example.yaml
 
 # Wait for the RayCluster to be ready.
 sleep 5
-kubectl -n $NAMESPACE wait --for=condition=ready pod -l ray.io/cluster=kubeflow-raycluster --timeout=900s
+kubectl -n $NAMESPACE wait --for=condition=Ready pod -l ray.io/cluster=kubeflow-raycluster --timeout=900s
 kubectl -n $NAMESPACE logs -l ray.io/cluster=kubeflow-raycluster,ray.io/node-type=head
 
 # Forward the port of Dashboard

--- a/tests/gh-actions/install_cert_manager.sh
+++ b/tests/gh-actions/install_cert_manager.sh
@@ -6,7 +6,7 @@ kubectl create namespace cert-manager
 kustomize build base | kubectl apply -f -
 
 echo "Waiting for cert-manager to be ready ..."
-kubectl wait --for=condition=ready pod -l 'app in (cert-manager,webhook)' --timeout=180s -n cert-manager
+kubectl wait --for=condition=Ready pod -l 'app in (cert-manager,webhook)' --timeout=180s -n cert-manager
 kubectl wait --for=jsonpath='{.subsets[0].addresses[0].targetRef.kind}'=Pod endpoints -l 'app in (cert-manager,webhook)' --timeout=180s -n cert-manager
 
 echo "Deploy clusterissuer.cert-manager.io/kubeflow-self-signing-issuer"

--- a/tests/gh-actions/install_oauth2-proxy.sh
+++ b/tests/gh-actions/install_oauth2-proxy.sh
@@ -6,7 +6,7 @@ cd common/
 kustomize build oauth2-proxy/overlays/m2m-dex-and-kind/ | kubectl apply -f -
 
 echo "Waiting for all oauth2-proxy pods to become ready..."
-kubectl wait --for=condition=ready pod -l 'app.kubernetes.io/name=oauth2-proxy' --timeout=180s -n oauth2-proxy
+kubectl wait --for=condition=Ready pod -l 'app.kubernetes.io/name=oauth2-proxy' --timeout=180s -n oauth2-proxy
 
 echo "Waiting for all cluster-jwks-proxy pods to become ready..."
-kubectl wait --for=condition=ready pod -l 'app.kubernetes.io/name=cluster-jwks-proxy' --timeout=180s -n istio-system
+kubectl wait --for=condition=Ready pod -l 'app.kubernetes.io/name=cluster-jwks-proxy' --timeout=180s -n istio-system


### PR DESCRIPTION
## ✏️ Summary of Changes
Kubernetes API conditions are case-sensitive and standard
pod conditions use capitalized names. This changes all
instances of "--for=condition=ready" to "--for=condition=Ready"
to ensure consistent behavior across installation scripts.

## 📦 Dependencies
none
## 🐛 Related Issues
none
## ✅ Contributor Checklist
  - [x] I have tested these changes with kustomize. See [Installation Prerequisites](https://github.com/kubeflow/manifests#prerequisites).
  - [x] All commits are [_signed-off_](https://github.com/kubeflow/community/tree/master/dco-signoff-hook#signing-off-commits) to satisfy the DCO check.

---     
 
> You can join the CNCF Slack and access our meetings at the [Kubeflow Community](https://www.kubeflow.org/docs/about/community/) website. Our channel on the CNCF Slack is here [**#kubeflow-platform**](https://app.slack.com/client/T08PSQ7BQ/C073W572LA2).
  
