### PR TITLE
Add security context to ml-pipeline-ui-artifact and ml-pipeline-visualizationserver deployments

### DIFF
--- a/apps/pipeline/upstream/base/installs/multi-user/pipelines-profile-controller/sync.py
+++ b/apps/pipeline/upstream/base/installs/multi-user/pipelines-profile-controller/sync.py
@@ -197,6 +197,9 @@ def server_factory(visualization_server_image,
                                             "cpu": "500m",
                                             "memory": "1Gi"
                                         },
+                                    },
+                                    "securityContext": {
+                                        "allowPrivilegeEscalation": False                                        
                                     }
                                 }],
                                 "serviceAccountName":
@@ -327,6 +330,9 @@ def server_factory(visualization_server_image,
                                             "cpu": "100m",
                                             "memory": "500Mi"
                                         },
+                                    },
+                                    "securityContext": {
+                                        "allowPrivilegeEscalation": False
                                     }
                                 }],
                                 "serviceAccountName":


### PR DESCRIPTION
Add security context to ml-pipeline-ui-artifact and ml-pipeline-visualizationserver deployments

# Pull Request Template for Kubeflow Manifests

## ✏️ Summary of Changes
Added SecurityContext for ml-pipeline-ui-artifact and ml-pipeline-visualizationserver deployments. Set allowPrivilegeEscalation to false to prevent containers from gaining additional privileges beyond their initial grants.

## 📦 Dependencies
none

## 🐛 Related Issues
none

## ✅ Contributor Checklist
  - [x] I have tested these changes with kustomize. See [Installation Prerequisites](https://github.com/kubeflow/manifests#prerequisites).
  - [x] All commits are [_signed-off_](https://github.com/kubeflow/community/tree/master/dco-signoff-hook#signing-off-commits) to satisfy the DCO check.

---     
 
> You can join the CNCF Slack and access our meetings at the [Kubeflow Community](https://www.kubeflow.org/docs/about/community/) website. Our channel on the CNCF Slack is here [**#kubeflow-platform**](https://app.slack.com/client/T08PSQ7BQ/C073W572LA2).
  
