### PR TITLE
fix: Fixes issue where service account tokens fail with: "Jwt issuer is not configured" error.

### DIFF
--- a/common/oauth2-proxy/overlays/m2m-dex-and-kind/kustomization.yaml
+++ b/common/oauth2-proxy/overlays/m2m-dex-and-kind/kustomization.yaml
@@ -33,3 +33,25 @@ patches:
     kind: RequestAuthentication
     name: m2m-token-issuer
     namespace: istio-system
+
+- patch: |-
+    - op: add
+      path: /spec/jwtRules/-
+      value:
+        issuer: "https://kubernetes.default.svc"
+        jwksUri: "http://cluster-jwks-proxy.istio-system.svc.cluster.local/openid/v1/jwks"
+        forwardOriginalToken: true
+        outputClaimToHeaders:
+        - header: kubeflow-userid
+          claim: sub
+        - header: kubeflow-groups
+          claim: groups
+        fromHeaders:
+        - name: Authorization
+          prefix: "Bearer "
+  target:
+    group: security.istio.io
+    version: v1beta1
+    kind: RequestAuthentication
+    name: m2m-token-issuer
+    namespace: istio-system


### PR DESCRIPTION
## ✏️ Summary of Changes

Different Kubernetes distributions and configurations may use
either format for service account tokens. This fix ensures
M2M authentication works across all environments by adding
a second JWT rule to the RequestAuthentication.

This change adds support for both JWT issuer formats:
- https://kubernetes.default.svc.cluster.local
- https://kubernetes.default.svc

Fixes issue where service account tokens fail with:
**"Jwt issuer is not configured" error.**

I was facing this issue, in my kind cluster, default _kubectl apply -k common/oauth2-proxy/overlays/m2m-dex-and-kind_ was using kubernetes.default.svc.cluster.local as issuer giving me Jwt issuer is not configured" error on curl, 

fixed by adding this as issuer, in patch of kustomizatin https://kubernetes.default.svc and fixed the issue.

**Step1: Verifying Token issuer**

<img width="1467" alt="Screenshot 2025-03-30 at 8 37 08 PM" src="https://github.com/user-attachments/assets/7ad3acbe-9082-4c59-8019-ddfb77e06ca1" />

**Step2: My m2m-token-issuer**

<img width="500" alt="Screenshot 2025-03-30 at 8 38 15 PM" src="https://github.com/user-attachments/assets/45ce7244-f371-4328-a4ff-61cea21cb4b3" />

**Step3: Jwt issuer is not configured" error Issue**

<img width="500" alt="Screenshot 2025-03-30 at 8 39 39 PM" src="https://github.com/user-attachments/assets/caf97c34-f6ac-4467-bc45-ccf9d94d7468" />

Step4: Applied the PR changes, Now RequestAuthentication uses both

<img width="500" alt="Screenshot 2025-03-30 at 8 49 35 PM" src="https://github.com/user-attachments/assets/03a0998f-3caf-4472-a4c8-28f7e91e5ccf" />


Step5: curl working now

<img width="500" alt="Screenshot 2025-03-30 at 8 49 47 PM" src="https://github.com/user-attachments/assets/06c0a2be-6ae8-4fed-9bf7-8a379b96bfc4" />


## 📦 Dependencies
none

## 🐛 Related Issues
none

## ✅ Contributor Checklist
  - [x] I have tested these changes with kustomize. See [Installation Prerequisites](https://github.com/kubeflow/manifests#prerequisites).
  - [x] All commits are [_signed-off_](https://github.com/kubeflow/community/tree/master/dco-signoff-hook#signing-off-commits) to satisfy the DCO check.

---     
 
> You can join the CNCF Slack and access our meetings at the [Kubeflow Community](https://www.kubeflow.org/docs/about/community/) website. Our channel on the CNCF Slack is here [**#kubeflow-platform**](https://app.slack.com/client/T08PSQ7BQ/C073W572LA2).
  
