### PR TITLE
Ensure manifests description is vendor-neutral

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,10 @@
 # Kubeflow Manifests
 
-The **Kubeflow Manifests** are a collection of community-maintained manifests for installing Kubeflow in popular Kubernetes clusters such as Kind, Minikube, Rancher, EKS, AKS, and GKE. The manifests include all Kubeflow components (Pipelines, Kserve, etc.), the **Kubeflow Central Dashboard**, and other applications that comprise the **Kubeflow Platform**. This installation is beneficial for users wanting to explore the end-to-end capabilities of the Kubeflow Platform.
+The Kubeflow Manifests are community maintained kustomize manifests which are tested to deploy a minimum-viable Kubeflow Platform on **[Kind](https://kind.sigs.k8s.io/)** clusters.
+They are aggregated by the Manifests Working Group, and are intended to be used as the base of packaged distributions and by those with Kubernetes knowledge.
+
+The manifests include all **Kubeflow Components** (Pipelines, Kserve, etc.), **Kubeflow Central Dashboard**, and other applications that comprise the [Kubeflow Platform](https://www.kubeflow.org/docs/started/introduction/#what-is-kubeflow-platform).
+This installation is beneficial for users wanting to explore the end-to-end capabilities of the Kubeflow Platform.
 
 For a stable and conservative experience, we recommend using the [latest stable release](https://github.com/kubeflow/manifests/releases). However, please consult the more up-to-date documentation in the master branch.
 


### PR DESCRIPTION
## What this PR does

For the same reasons as discussed in https://github.com/kubeflow/website/pull/4071, it's is critical that the description of the manifests remain vendor-neutral and true to what we provide as a community.

This PR proposes an update to the manifests introduction paragraph that clarifies what the manifests actually are.

See [diff](xxxx) for the current proposal, but it updates to use the same wording as in https://github.com/kubeflow/website/pull/4071.

## Motivation

@kubeflow/kubeflow-steering-committee  Up until 30 days ago (PR: https://github.com/kubeflow/manifests/pull/3030), the main README of `kubeflow/manifests` did not include any statements that implied support for specific (kubernetes) distributions by the manifests.

However, the README now includes the following introduction:

> The **Kubeflow Manifests** are a collection of community-maintained manifests for installing Kubeflow in popular Kubernetes clusters such as Kind, Minikube, Rancher, EKS, AKS, and GKE. 
> The manifests include all Kubeflow components (Pipelines, Kserve, etc.), the **Kubeflow Central Dashboard**, and other applications that comprise the **Kubeflow Platform**.
> This installation is beneficial for users wanting to explore the end-to-end capabilities of the Kubeflow Platform.

The wording of the first sentence is misleading, as the manifests are currently only tested to deploy a minimum-viable Kubeflow Platform on Kind, with no guarantees for other platforms.

It's also important to note that the [Manifests WG charter](https://github.com/kubeflow/community/blob/master/wg-manifests/charter.md#out-of-scope) explicitly prohibits the inclusion of (kubernetes) distribution-specific manifests, so even mentioning specific distributions verges on violating the charter.
