### PR TITLE
Removed KServe DNS patches from GitHub Actions tests

### DIFF
--- a/.github/workflows/kserve_m2m_test.yaml
+++ b/.github/workflows/kserve_m2m_test.yaml
@@ -13,7 +13,7 @@ on:
     - common/cert-manager/**
     - tests/gh-actions/install_cert_manager.sh
     - common/knative/**
-    - tests/gh-actions/install_knative.sh
+    - tests/gh-actions/install_knative*.sh
 
 jobs:
   build:

--- a/apps/kserve/tests/utils.py
+++ b/apps/kserve/tests/utils.py
@@ -91,7 +91,7 @@ def predict_str(
     # temporary sleep until this is fixed https://github.com/kserve/kserve/issues/604
     time.sleep(10)
     cluster_ip = get_cluster_ip()
-    host = urlparse(isvc["status"]["url"]).netloc
+    host = f"{service_name}.{KSERVE_TEST_NAMESPACE}.example.com"
     headers = {
         "Host": host,
         "Content-Type": "application/json",

--- a/common/knative/knative-serving/overlays/gateways/patches/config-domain.yaml
+++ b/common/knative/knative-serving/overlays/gateways/patches/config-domain.yaml
@@ -4,4 +4,4 @@ metadata:
   name: config-domain
   namespace: knative-serving
 data:
-  example.com: ""
+  svc.cluster.local: ""

--- a/common/knative/knative-serving/overlays/gateways/patches/config-domain.yaml
+++ b/common/knative/knative-serving/overlays/gateways/patches/config-domain.yaml
@@ -4,4 +4,4 @@ metadata:
   name: config-domain
   namespace: knative-serving
 data:
-  svc.cluster.local: ""
+  example.com: ""

--- a/tests/gh-actions/install_knative-cni.sh
+++ b/tests/gh-actions/install_knative-cni.sh
@@ -6,7 +6,7 @@ echo "Installing KNative with Istio-CNI ..."
 # Retry mechanism for applying Knative manifests
 set +e
 for _ in {1..5}; do
-    if kustomize build common/knative/knative-serving/base | kubectl apply -f -; then
+    if kustomize build common/knative/knative-serving/overlays/gateways | kubectl apply -f -; then
         break
     fi
     echo "Retrying in 30 seconds..."

--- a/tests/gh-actions/install_knative-cni.sh
+++ b/tests/gh-actions/install_knative-cni.sh
@@ -22,5 +22,4 @@ kubectl wait --for=condition=Available deployment/activator -n knative-serving -
 kubectl wait --for=condition=Available deployment/autoscaler -n knative-serving --timeout=10s
 kubectl wait --for=condition=Available deployment/controller -n knative-serving --timeout=10s
 kubectl wait --for=condition=Available deployment/webhook -n knative-serving --timeout=10s
-kubectl patch cm config-domain --patch '{"data":{"example.com":""}}' -n knative-serving
 kubectl get deployment -n knative-serving

--- a/tests/gh-actions/install_knative.sh
+++ b/tests/gh-actions/install_knative.sh
@@ -6,7 +6,7 @@ echo "Installing KNative ..."
 # Retry mechanism for applying Knative manifests
 set +e
 for _ in {1..5}; do
-    if kustomize build common/knative/knative-serving/base | kubectl apply -f -; then
+    if kustomize build common/knative/knative-serving/overlays/gateways | kubectl apply -f -; then
         break
     fi
     echo "Retrying in 30 seconds..."
@@ -22,5 +22,4 @@ kubectl wait --for=condition=Available deployment/activator -n knative-serving -
 kubectl wait --for=condition=Available deployment/autoscaler -n knative-serving --timeout=10s
 kubectl wait --for=condition=Available deployment/controller -n knative-serving --timeout=10s
 kubectl wait --for=condition=Available deployment/webhook -n knative-serving --timeout=10s
-kubectl patch cm config-domain --patch '{"data":{"example.com":""}}' -n knative-serving # TODO this will be moved into the manifests in https://github.com/kubeflow/manifests/pull/3084
 kubectl get deployment -n knative-serving


### PR DESCRIPTION
## ✏️ Summary of Changes

Removed KServe DNS patches from GitHub Actions tests, as they were already added as a patch, see https://github.com/kubeflow/manifests/pull/3084

## 📦 Related PR
Follow up to PR: https://github.com/kubeflow/manifests/pull/3084

## 🐛 Related Issues
none

## ✅ Contributor Checklist
  - [x] I have tested these changes with kustomize. See [Installation Prerequisites](https://github.com/kubeflow/manifests#prerequisites).
  - [x] All commits are [_signed-off_](https://github.com/kubeflow/community/tree/master/dco-signoff-hook#signing-off-commits) to satisfy the DCO check.

---     
 
> You can join the CNCF Slack and access our meetings at the [Kubeflow Community](https://www.kubeflow.org/docs/about/community/) website. Our channel on the CNCF Slack is here [**#kubeflow-platform**](https://app.slack.com/client/T08PSQ7BQ/C073W572LA2).
  
