### PR TITLE
Updated the gha workflows to use new install_katib, made changes as s…

### DIFF
--- a/.github/workflows/full_kubeflow_integration_test.yaml
+++ b/.github/workflows/full_kubeflow_integration_test.yaml
@@ -1,4 +1,4 @@
-name: Full Kubeflow End-to-End Integration Test
+name: End-to-End Integration Test
 on:
   workflow_dispatch:
   push:

--- a/.github/workflows/full_kubeflow_integration_test.yaml
+++ b/.github/workflows/full_kubeflow_integration_test.yaml
@@ -73,17 +73,7 @@ jobs:
       run: kubectl wait --for=condition=Ready pods --all --all-namespaces --timeout 300s --field-selector=status.phase!=Succeeded
 
     - name: Install Katib
-      run: |
-        sudo apt-get install -y apparmor-profiles
-        sudo apparmor_parser -R /etc/apparmor.d/usr.sbin.mysqld
-
-        cd apps/katib/upstream && kustomize build installs/katib-with-kubeflow | kubectl apply -f - && cd ../../../
-
-        kubectl wait --for=condition=Available deployment/katib-controller -n kubeflow --timeout=300s
-
-        kubectl wait --for=condition=Available deployment/katib-mysql -n kubeflow --timeout=300s
-
-        kubectl label namespace $KF_PROFILE katib.kubeflow.org/metrics-collector-injection=enabled --overwrite
+      run: ./tests/gh-actions/install_katib.sh
 
     - name: Install Training Operator
       run: ./tests/gh-actions/install_training_operator.sh

--- a/.github/workflows/katib_test.yaml
+++ b/.github/workflows/katib_test.yaml
@@ -3,6 +3,7 @@ on:
   pull_request:
     paths:
     - tests/gh-actions/install_KinD_create_KinD_cluster_install_kustomize.sh
+    - tests/gh-actions/install_katib.sh
     - .github/workflows/katib_test.yaml
     - apps/katib/upstream/**
     - tests/gh-actions/install_istio.sh
@@ -27,19 +28,11 @@ jobs:
     - name: Install cert-manager
       run: ./tests/gh-actions/install_cert_manager.sh
 
-    # https://kind.sigs.k8s.io/docs/user/known-issues/#apparmor
-    - name: AppArmor
+    - name: Install Katib
       run: |
-        set -x
-        sudo apt-get install apparmor-profiles
-        sudo apparmor_parser -R /etc/apparmor.d/usr.sbin.mysqld
-
-    - name: Build & Apply manifests
-      run: |
-        cd apps/katib/upstream
         kubectl create ns kubeflow
-        kustomize build installs/katib-with-kubeflow | kubectl apply -f -
-        kubectl wait --for=condition=Ready pods --all -n kubeflow --timeout 300s
+        export KF_PROFILE=kubeflow-user
+        ./tests/gh-actions/install_katib.sh
 
     - name: Create katib experiment
       run: |

--- a/.github/workflows/katib_test.yaml
+++ b/.github/workflows/katib_test.yaml
@@ -28,15 +28,18 @@ jobs:
     - name: Install cert-manager
       run: ./tests/gh-actions/install_cert_manager.sh
 
-    - name: Install Katib
+    - name: Create namespaces
       run: |
         kubectl create ns kubeflow
+        kubectl create namespace kubeflow-user
+
+    - name: Install Katib
+      run: |
         export KF_PROFILE=kubeflow-user
         ./tests/gh-actions/install_katib.sh
 
     - name: Create katib experiment
       run: |
-        kubectl create namespace kubeflow-user
         kubectl label namespace kubeflow-user katib.kubeflow.org/metrics-collector-injection=enabled
         kubectl apply -f tests/gh-actions/kf-objects/katib_test.yaml
 

--- a/tests/gh-actions/install_central_dashboard.sh
+++ b/tests/gh-actions/install_central_dashboard.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-set -e
+set -euxo pipefail
 
 kustomize build apps/centraldashboard/upstream/overlays/kserve | kubectl apply -f -
 kubectl wait --for=condition=Ready pods --all -n kubeflow --timeout=180s 

--- a/tests/gh-actions/install_katib.sh
+++ b/tests/gh-actions/install_katib.sh
@@ -1,0 +1,13 @@
+#!/bin/bash
+set -euxo pipefail
+
+sudo apt-get install -y apparmor-profiles
+sudo apparmor_parser -R /etc/apparmor.d/usr.sbin.mysqld
+
+cd apps/katib/upstream && kustomize build installs/katib-with-kubeflow | kubectl apply -f - && cd ../../../
+
+kubectl wait --for=condition=Available deployment/katib-controller -n kubeflow --timeout=300s
+
+kubectl wait --for=condition=Available deployment/katib-mysql -n kubeflow --timeout=300s
+
+kubectl label namespace $KF_PROFILE katib.kubeflow.org/metrics-collector-injection=enabled --overwrite

--- a/tests/gh-actions/install_knative-cni.sh
+++ b/tests/gh-actions/install_knative-cni.sh
@@ -17,6 +17,10 @@ set -e
 kustomize build common/istio-cni-1-24/cluster-local-gateway/base | kubectl apply -f -
 kustomize build common/istio-cni-1-24/kubeflow-istio-resources/base | kubectl apply -f -
 
-kubectl wait --for=condition=Ready pods --all --all-namespaces --timeout=300s \
-  --field-selector=status.phase!=Succeeded
+kubectl wait --for=condition=Ready pods --all --all-namespaces --timeout=300s --field-selector=status.phase!=Succeeded
+kubectl wait --for=condition=Available deployment/activator -n knative-serving --timeout=10s
+kubectl wait --for=condition=Available deployment/autoscaler -n knative-serving --timeout=10s
+kubectl wait --for=condition=Available deployment/controller -n knative-serving --timeout=10s
+kubectl wait --for=condition=Available deployment/webhook -n knative-serving --timeout=10s
 kubectl patch cm config-domain --patch '{"data":{"example.com":""}}' -n knative-serving
+kubectl get deployment -n knative-serving


### PR DESCRIPTION
# Pull Request Template for Kubeflow Manifests

## ✏️ Summary of Changes
> Addd a new file for katib install, then updated 2 gha workflows to use them directly.
> Updated the  install_knative-cni.sh to be consistent with the install_knative.sh
> Follow up PR of #3077 


## 🐛 Related Issues
Fix #3054 

## ✅ Contributor Checklist
  - [ ] I have tested these changes with kustomize. See [Installation Prerequisites](https://github.com/kubeflow/manifests#prerequisites).
  - [x] All commits are [_signed-off_](https://github.com/kubeflow/community/tree/master/dco-signoff-hook#signing-off-commits) to satisfy the DCO check.

---     
 
> You can join the CNCF Slack and access our meetings at the [Kubeflow Community](https://www.kubeflow.org/docs/about/community/) website. Our channel on the CNCF Slack is here [**#kubeflow-platform**](https://app.slack.com/client/T08PSQ7BQ/C073W572LA2).
  
