### PR TITLE
fix: disable GHA in forked repo

### DIFF
--- a/.github/workflows/full_kubeflow_integration_test.yaml
+++ b/.github/workflows/full_kubeflow_integration_test.yaml
@@ -14,6 +14,7 @@ env:
 jobs:
   kubeflow-integration:
     name: Kubeflow Installation and Testing
+    if: ${{ github.repository == 'kubeflow/manifests' }}
     runs-on:
       labels: ubuntu-latest-16-cores
     timeout-minutes: 60

--- a/.github/workflows/manifests_example_test.yaml
+++ b/.github/workflows/manifests_example_test.yaml
@@ -7,6 +7,7 @@ on:
 jobs:
   build:
     name: Test
+    if: ${{ github.repository == 'kubeflow/manifests' }}
     runs-on: ubuntu-latest
 
     steps:

--- a/.github/workflows/stale.yaml
+++ b/.github/workflows/stale.yaml
@@ -11,6 +11,7 @@ on:
 
 jobs:
   stale:
+    if: ${{ github.repository == 'kubeflow/manifests' }}
     runs-on: ubuntu-latest
     permissions:
       issues: write

--- a/.github/workflows/trivy.yaml
+++ b/.github/workflows/trivy.yaml
@@ -11,6 +11,7 @@ on:
 
 jobs:
   image-extraction-and-security-scan:
+    if: ${{ github.repository == 'kubeflow/manifests' }}
     runs-on: ubuntu-latest
     steps:
     - name: Checkout code


### PR DESCRIPTION
# Pull Request Template for Kubeflow Manifests

## ✏️ Summary of Changes
> Describe the changes you have made, including any refactoring or feature additions.

disables the GHA runs in forked repo
## 📦 Dependencies
> List any dependencies or related PRs (e.g., "Depends on #123").

## 🐛 Related Issues
> Link any issues that are resolved or affected by this PR.

fixes #3095 
## ✅ Contributor Checklist
  - [ ] I have tested these changes with kustomize. See [Installation Prerequisites](https://github.com/kubeflow/manifests#prerequisites).
  - [x] All commits are [_signed-off_](https://github.com/kubeflow/community/tree/master/dco-signoff-hook#signing-off-commits) to satisfy the DCO check.

---     
 
> You can join the CNCF Slack and access our meetings at the [Kubeflow Community](https://www.kubeflow.org/docs/about/community/) website. Our channel on the CNCF Slack is here [**#kubeflow-platform**](https://app.slack.com/client/T08PSQ7BQ/C073W572LA2).
  
