### PR TITLE
Fixed the cert manager readiness for kserve

### DIFF
--- a/tests/gh-actions/install_kserve.sh
+++ b/tests/gh-actions/install_kserve.sh
@@ -12,12 +12,7 @@ kubectl wait --for condition=established --timeout=30s crd/clusterservingruntime
 kustomize build kserve | kubectl apply --server-side --force-conflicts -f -
 
 kubectl wait --for=condition=Ready certificate/serving-cert -n kubeflow --timeout=60s
-
-kubectl get secret kserve-webhook-server-cert -n kubeflow -o name || {
-  echo "Secret kserve-webhook-server-cert not found. Waiting additional time..."
-  sleep 30
-  kubectl get secret kserve-webhook-server-cert -n kubeflow -o name || echo "Warning: Secret still not found after waiting."
-}
+kubectl get secret kserve-webhook-server-cert -n kubeflow -o name
 
 kustomize build models-web-app/overlays/kubeflow | kubectl apply --server-side --force-conflicts -f -
 kubectl wait --for=condition=Ready pods --all --all-namespaces --timeout=600s \


### PR DESCRIPTION
# Pull Request Template for Kubeflow Manifests

## ✏️ Summary of Changes
> Added a check to wait for the Certificate resource for the kserve


## ✅ Contributor Checklist
  - [ ] I have tested these changes with kustomize. See [Installation Prerequisites](https://github.com/kubeflow/manifests#prerequisites).
  - [x] All commits are [_signed-off_](https://github.com/kubeflow/community/tree/master/dco-signoff-hook#signing-off-commits) to satisfy the DCO check.

---     
 
> You can join the CNCF Slack and access our meetings at the [Kubeflow Community](https://www.kubeflow.org/docs/about/community/) website. Our channel on the CNCF Slack is here [**#kubeflow-platform**](https://app.slack.com/client/T08PSQ7BQ/C073W572LA2).
  
