### PR TITLE
Enforce failure on PSS baseline test violations

### DIFF
--- a/apps/kserve/kserve/kustomization.yaml
+++ b/apps/kserve/kserve/kustomization.yaml
@@ -1,6 +1,16 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
-  # Install Kserve in kubeflow namespace
-  - kserve_kubeflow.yaml
-  - kserve-cluster-resources.yaml
+# Install Kserve in kubeflow namespace
+- kserve_kubeflow.yaml
+- kserve-cluster-resources.yaml
+
+# Patch to delete the kserve-localmodelnode-agent DaemonSet
+patches:
+- patch: |
+     apiVersion: apps/v1
+     kind: DaemonSet
+     metadata:
+       name: kserve-localmodelnode-agent
+       namespace: kubeflow
+     $patch: delete

--- a/tests/gh-actions/enable_baseline_PSS.sh
+++ b/tests/gh-actions/enable_baseline_PSS.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+set -euxo pipefail
 
 NAMESPACES=("istio-system" "auth" "cert-manager" "oauth2-proxy" "kubeflow")
 
@@ -13,3 +14,10 @@ for NAMESPACE in "${NAMESPACES[@]}"; do
         fi
     fi
 done
+
+VIOLATIONS=$(kubectl get pods --all-namespaces -o json | jq -r '.items[] | select(.metadata.namespace as $ns | ["istio-system", "auth", "cert-manager", "oauth2-proxy", "kubeflow"] | index($ns) != null) | select(.status.message != null and .status.message | contains("violate PodSecurity"))')
+
+if [ -n "$VIOLATIONS" ]; then
+    echo "$VIOLATIONS" | jq -r '.metadata.namespace + "/" + .metadata.name + ": " + .status.message'
+    exit 1
+fi

--- a/tests/gh-actions/enable_baseline_PSS.sh
+++ b/tests/gh-actions/enable_baseline_PSS.sh
@@ -14,8 +14,6 @@ for NAMESPACE in "${NAMESPACES[@]}"; do
                 echo "CRITICAL: PSS baseline violations detected in namespace $NAMESPACE"
                 HAS_VIOLATIONS=true
             fi
-        else
-            echo "Patch file for namespace $NAMESPACE not found, skipping..."
         fi
     fi
 done
@@ -23,7 +21,6 @@ done
 FAILING_PODS=$(kubectl get pods --all-namespaces --field-selector=status.phase=Failed -o json | jq -r '.items[] | select(.metadata.namespace as $ns | ["istio-system", "auth", "cert-manager", "oauth2-proxy", "kubeflow"] | index($ns) != null) | .metadata.namespace + "/" + .metadata.name')
 
 if [ -n "$FAILING_PODS" ]; then
-    echo "CRITICAL: Failed pods detected after applying PSS baseline:"
     echo "$FAILING_PODS"
     exit 1
 fi

--- a/tests/gh-actions/enable_baseline_PSS.sh
+++ b/tests/gh-actions/enable_baseline_PSS.sh
@@ -15,7 +15,7 @@ for NAMESPACE in "${NAMESPACES[@]}"; do
     fi
 done
 
-VIOLATIONS=$(kubectl get pods --all-namespaces -o json | jq -r '.items[] | select(.metadata.namespace as $ns | ["istio-system", "auth", "cert-manager", "oauth2-proxy", "kubeflow"] | index($ns) != null) | select(.status.message != null and .status.message | contains("violate PodSecurity"))')
+VIOLATIONS=$(kubectl get pods --all-namespaces -o json | jq -r '.items[] | select(.metadata.namespace as $ns | ["istio-system", "auth", "cert-manager", "oauth2-proxy", "kubeflow"] | index($ns) != null) | select(.status.message != null and ((.status.message | type) == "string") and (.status.message | contains("violate PodSecurity")))')
 
 if [ -n "$VIOLATIONS" ]; then
     echo "$VIOLATIONS" | jq -r '.metadata.namespace + "/" + .metadata.name + ": " + .status.message'

--- a/tests/gh-actions/enable_baseline_PSS.sh
+++ b/tests/gh-actions/enable_baseline_PSS.sh
@@ -5,19 +5,30 @@ NAMESPACES=("istio-system" "auth" "cert-manager" "oauth2-proxy" "kubeflow")
 
 for NAMESPACE in "${NAMESPACES[@]}"; do
     if kubectl get namespace "$NAMESPACE" >/dev/null 2>&1; then
-        # Check if the patch file exists
         if [ -f "./experimental/security/PSS/static/baseline/patches/${NAMESPACE}-labels.yaml" ]; then
             echo "Patching the PSS-baseline labels for namespace $NAMESPACE..."
-            kubectl patch namespace $NAMESPACE --patch-file ./experimental/security/PSS/static/baseline/patches/${NAMESPACE}-labels.yaml
+            PATCH_OUTPUT=$(kubectl patch namespace $NAMESPACE --patch-file ./experimental/security/PSS/static/baseline/patches/${NAMESPACE}-labels.yaml 2>&1)
+            echo "$PATCH_OUTPUT"
+            
+            if echo "$PATCH_OUTPUT" | grep -q "violate the new PodSecurity"; then
+                echo "CRITICAL: PSS baseline violations detected in namespace $NAMESPACE"
+                HAS_VIOLATIONS=true
+            fi
         else
             echo "Patch file for namespace $NAMESPACE not found, skipping..."
         fi
     fi
 done
 
-VIOLATIONS=$(kubectl get pods --all-namespaces -o json | jq -r '.items[] | select(.metadata.namespace as $ns | ["istio-system", "auth", "cert-manager", "oauth2-proxy", "kubeflow"] | index($ns) != null) | select(.status.message != null and ((.status.message | type) == "string") and (.status.message | contains("violate PodSecurity")))')
+FAILING_PODS=$(kubectl get pods --all-namespaces --field-selector=status.phase=Failed -o json | jq -r '.items[] | select(.metadata.namespace as $ns | ["istio-system", "auth", "cert-manager", "oauth2-proxy", "kubeflow"] | index($ns) != null) | .metadata.namespace + "/" + .metadata.name')
 
-if [ -n "$VIOLATIONS" ]; then
-    echo "$VIOLATIONS" | jq -r '.metadata.namespace + "/" + .metadata.name + ": " + .status.message'
+if [ -n "$FAILING_PODS" ]; then
+    echo "CRITICAL: Failed pods detected after applying PSS baseline:"
+    echo "$FAILING_PODS"
+    exit 1
+fi
+
+if [ "${HAS_VIOLATIONS:-false}" = true ]; then
+    echo "CRITICAL: PSS baseline violations detected in one or more namespaces"
     exit 1
 fi

--- a/tests/gh-actions/enable_baseline_PSS.sh
+++ b/tests/gh-actions/enable_baseline_PSS.sh
@@ -6,26 +6,10 @@ NAMESPACES=("istio-system" "auth" "cert-manager" "oauth2-proxy" "kubeflow")
 for NAMESPACE in "${NAMESPACES[@]}"; do
     if kubectl get namespace "$NAMESPACE" >/dev/null 2>&1; then
         if [ -f "./experimental/security/PSS/static/baseline/patches/${NAMESPACE}-labels.yaml" ]; then
-            echo "Patching the PSS-baseline labels for namespace $NAMESPACE..."
             PATCH_OUTPUT=$(kubectl patch namespace $NAMESPACE --patch-file ./experimental/security/PSS/static/baseline/patches/${NAMESPACE}-labels.yaml 2>&1)
-            echo "$PATCH_OUTPUT"
-            
             if echo "$PATCH_OUTPUT" | grep -q "violate the new PodSecurity"; then
-                echo "CRITICAL: PSS baseline violations detected in namespace $NAMESPACE"
-                HAS_VIOLATIONS=true
+                exit 1
             fi
         fi
     fi
 done
-
-FAILING_PODS=$(kubectl get pods --all-namespaces --field-selector=status.phase=Failed -o json | jq -r '.items[] | select(.metadata.namespace as $ns | ["istio-system", "auth", "cert-manager", "oauth2-proxy", "kubeflow"] | index($ns) != null) | .metadata.namespace + "/" + .metadata.name')
-
-if [ -n "$FAILING_PODS" ]; then
-    echo "$FAILING_PODS"
-    exit 1
-fi
-
-if [ "${HAS_VIOLATIONS:-false}" = true ]; then
-    echo "CRITICAL: PSS baseline violations detected in one or more namespaces"
-    exit 1
-fi

--- a/tests/gh-actions/enable_restricted_PSS.sh
+++ b/tests/gh-actions/enable_restricted_PSS.sh
@@ -14,8 +14,6 @@ for NAMESPACE in "${NAMESPACES[@]}"; do
                 echo "CRITICAL: PSS restricted violations detected in namespace $NAMESPACE"
                 HAS_VIOLATIONS=true
             fi
-        else
-            echo "Patch file for namespace $NAMESPACE not found, skipping..."
         fi
     fi
 done
@@ -23,7 +21,6 @@ done
 FAILING_PODS=$(kubectl get pods --all-namespaces --field-selector=status.phase=Failed -o json | jq -r '.items[] | select(.metadata.namespace as $ns | ["istio-system", "auth", "cert-manager", "oauth2-proxy", "kubeflow"] | index($ns) != null) | .metadata.namespace + "/" + .metadata.name')
 
 if [ -n "$FAILING_PODS" ]; then
-    echo "CRITICAL: Failed pods detected after applying PSS restricted:"
     echo "$FAILING_PODS"
     exit 1
 fi

--- a/tests/gh-actions/enable_restricted_PSS.sh
+++ b/tests/gh-actions/enable_restricted_PSS.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+set -euxo pipefail
 
 NAMESPACES=("istio-system" "auth" "cert-manager" "oauth2-proxy" "kubeflow")
 
@@ -13,3 +14,10 @@ for NAMESPACE in "${NAMESPACES[@]}"; do
         fi
     fi
 done
+
+VIOLATIONS=$(kubectl get pods --all-namespaces -o json | jq -r '.items[] | select(.metadata.namespace as $ns | ["istio-system", "auth", "cert-manager", "oauth2-proxy", "kubeflow"] | index($ns) != null) | select(.status.message != null and .status.message | contains("violate PodSecurity"))')
+
+if [ -n "$VIOLATIONS" ]; then
+    echo "$VIOLATIONS" | jq -r '.metadata.namespace + "/" + .metadata.name + ": " + .status.message'
+    exit 1
+fi

--- a/tests/gh-actions/enable_restricted_PSS.sh
+++ b/tests/gh-actions/enable_restricted_PSS.sh
@@ -15,7 +15,7 @@ for NAMESPACE in "${NAMESPACES[@]}"; do
     fi
 done
 
-VIOLATIONS=$(kubectl get pods --all-namespaces -o json | jq -r '.items[] | select(.metadata.namespace as $ns | ["istio-system", "auth", "cert-manager", "oauth2-proxy", "kubeflow"] | index($ns) != null) | select(.status.message != null and .status.message | contains("violate PodSecurity"))')
+VIOLATIONS=$(kubectl get pods --all-namespaces -o json | jq -r '.items[] | select(.metadata.namespace as $ns | ["istio-system", "auth", "cert-manager", "oauth2-proxy", "kubeflow"] | index($ns) != null) | select(.status.message != null and ((.status.message | type) == "string") and (.status.message | contains("violate PodSecurity")))')
 
 if [ -n "$VIOLATIONS" ]; then
     echo "$VIOLATIONS" | jq -r '.metadata.namespace + "/" + .metadata.name + ": " + .status.message'

--- a/tests/gh-actions/enable_restricted_PSS.sh
+++ b/tests/gh-actions/enable_restricted_PSS.sh
@@ -1,5 +1,4 @@
 #!/bin/bash
-set -euxo pipefail
 
 NAMESPACES=("istio-system" "auth" "cert-manager" "oauth2-proxy" "kubeflow")
 
@@ -7,25 +6,9 @@ for NAMESPACE in "${NAMESPACES[@]}"; do
     if kubectl get namespace "$NAMESPACE" >/dev/null 2>&1; then
         if [ -f "./experimental/security/PSS/static/restricted/patches/${NAMESPACE}-labels.yaml" ]; then
             echo "Patching the PSS-restricted labels for namespace $NAMESPACE..."
-            PATCH_OUTPUT=$(kubectl patch namespace $NAMESPACE --patch-file ./experimental/security/PSS/static/restricted/patches/${NAMESPACE}-labels.yaml 2>&1)
-            echo "$PATCH_OUTPUT"
-            
-            if echo "$PATCH_OUTPUT" | grep -q "violate the new PodSecurity"; then
-                echo "CRITICAL: PSS restricted violations detected in namespace $NAMESPACE"
-                HAS_VIOLATIONS=true
-            fi
+            kubectl patch namespace $NAMESPACE --patch-file ./experimental/security/PSS/static/restricted/patches/${NAMESPACE}-labels.yaml
+        else
+            echo "Patch file for namespace $NAMESPACE not found, skipping..."
         fi
     fi
 done
-
-FAILING_PODS=$(kubectl get pods --all-namespaces --field-selector=status.phase=Failed -o json | jq -r '.items[] | select(.metadata.namespace as $ns | ["istio-system", "auth", "cert-manager", "oauth2-proxy", "kubeflow"] | index($ns) != null) | .metadata.namespace + "/" + .metadata.name')
-
-if [ -n "$FAILING_PODS" ]; then
-    echo "$FAILING_PODS"
-    exit 1
-fi
-
-if [ "${HAS_VIOLATIONS:-false}" = true ]; then
-    echo "CRITICAL: PSS restricted violations detected in one or more namespaces"
-    exit 1
-fi

--- a/tests/gh-actions/enable_restricted_PSS.sh
+++ b/tests/gh-actions/enable_restricted_PSS.sh
@@ -5,19 +5,30 @@ NAMESPACES=("istio-system" "auth" "cert-manager" "oauth2-proxy" "kubeflow")
 
 for NAMESPACE in "${NAMESPACES[@]}"; do
     if kubectl get namespace "$NAMESPACE" >/dev/null 2>&1; then
-        # Check if the patch file exists
         if [ -f "./experimental/security/PSS/static/restricted/patches/${NAMESPACE}-labels.yaml" ]; then
             echo "Patching the PSS-restricted labels for namespace $NAMESPACE..."
-            kubectl patch namespace $NAMESPACE --patch-file ./experimental/security/PSS/static/restricted/patches/${NAMESPACE}-labels.yaml
+            PATCH_OUTPUT=$(kubectl patch namespace $NAMESPACE --patch-file ./experimental/security/PSS/static/restricted/patches/${NAMESPACE}-labels.yaml 2>&1)
+            echo "$PATCH_OUTPUT"
+            
+            if echo "$PATCH_OUTPUT" | grep -q "violate the new PodSecurity"; then
+                echo "CRITICAL: PSS restricted violations detected in namespace $NAMESPACE"
+                HAS_VIOLATIONS=true
+            fi
         else
             echo "Patch file for namespace $NAMESPACE not found, skipping..."
         fi
     fi
 done
 
-VIOLATIONS=$(kubectl get pods --all-namespaces -o json | jq -r '.items[] | select(.metadata.namespace as $ns | ["istio-system", "auth", "cert-manager", "oauth2-proxy", "kubeflow"] | index($ns) != null) | select(.status.message != null and ((.status.message | type) == "string") and (.status.message | contains("violate PodSecurity")))')
+FAILING_PODS=$(kubectl get pods --all-namespaces --field-selector=status.phase=Failed -o json | jq -r '.items[] | select(.metadata.namespace as $ns | ["istio-system", "auth", "cert-manager", "oauth2-proxy", "kubeflow"] | index($ns) != null) | .metadata.namespace + "/" + .metadata.name')
 
-if [ -n "$VIOLATIONS" ]; then
-    echo "$VIOLATIONS" | jq -r '.metadata.namespace + "/" + .metadata.name + ": " + .status.message'
+if [ -n "$FAILING_PODS" ]; then
+    echo "CRITICAL: Failed pods detected after applying PSS restricted:"
+    echo "$FAILING_PODS"
+    exit 1
+fi
+
+if [ "${HAS_VIOLATIONS:-false}" = true ]; then
+    echo "CRITICAL: PSS restricted violations detected in one or more namespaces"
     exit 1
 fi

--- a/tests/gh-actions/enable_restricted_PSS.sh
+++ b/tests/gh-actions/enable_restricted_PSS.sh
@@ -5,9 +5,9 @@ NAMESPACES=("istio-system" "auth" "cert-manager" "oauth2-proxy" "kubeflow")
 for NAMESPACE in "${NAMESPACES[@]}"; do
     if kubectl get namespace "$NAMESPACE" >/dev/null 2>&1; then
         if [ -f "./experimental/security/PSS/static/restricted/patches/${NAMESPACE}-labels.yaml" ]; then
-            PATCH_OUTPUT=$(kubectl patch namespace $NAMESPACE --patch-file ./experimental/security/PSS/static/baseline/patches/${NAMESPACE}-labels.yaml 2>&1)
+            PATCH_OUTPUT=$(kubectl patch namespace $NAMESPACE --patch-file ./experimental/security/PSS/static/restricted/patches/${NAMESPACE}-labels.yaml 2>&1)
             if echo "$PATCH_OUTPUT" | grep -q "violate the new PodSecurity"; then
-                echo "\nWARNING PSS VIOLATED\n"
+                exit 1
             fi
         fi
     fi

--- a/tests/gh-actions/enable_restricted_PSS.sh
+++ b/tests/gh-actions/enable_restricted_PSS.sh
@@ -7,7 +7,7 @@ for NAMESPACE in "${NAMESPACES[@]}"; do
         if [ -f "./experimental/security/PSS/static/restricted/patches/${NAMESPACE}-labels.yaml" ]; then
             PATCH_OUTPUT=$(kubectl patch namespace $NAMESPACE --patch-file ./experimental/security/PSS/static/restricted/patches/${NAMESPACE}-labels.yaml 2>&1)
             if echo "$PATCH_OUTPUT" | grep -q "violate the new PodSecurity"; then
-                exit 1
+                echo "\nWARNING PSS VIOLATED\n"
             fi
         fi
     fi

--- a/tests/gh-actions/enable_restricted_PSS.sh
+++ b/tests/gh-actions/enable_restricted_PSS.sh
@@ -1,14 +1,14 @@
 #!/bin/bash
+set -euxo pipefail
 
 NAMESPACES=("istio-system" "auth" "cert-manager" "oauth2-proxy" "kubeflow")
-
 for NAMESPACE in "${NAMESPACES[@]}"; do
     if kubectl get namespace "$NAMESPACE" >/dev/null 2>&1; then
         if [ -f "./experimental/security/PSS/static/restricted/patches/${NAMESPACE}-labels.yaml" ]; then
-            echo "Patching the PSS-restricted labels for namespace $NAMESPACE..."
-            kubectl patch namespace $NAMESPACE --patch-file ./experimental/security/PSS/static/restricted/patches/${NAMESPACE}-labels.yaml
-        else
-            echo "Patch file for namespace $NAMESPACE not found, skipping..."
+            PATCH_OUTPUT=$(kubectl patch namespace $NAMESPACE --patch-file ./experimental/security/PSS/static/baseline/patches/${NAMESPACE}-labels.yaml 2>&1)
+            if echo "$PATCH_OUTPUT" | grep -q "violate the new PodSecurity"; then
+                echo "\nWARNING PSS VIOLATED\n"
+            fi
         fi
     fi
 done

--- a/tests/gh-actions/install_kserve.sh
+++ b/tests/gh-actions/install_kserve.sh
@@ -13,8 +13,6 @@ for ((i=1; i<=3; i++)); do
 done
 set -e
 
-kubectl -n kubeflow delete DaemonSet kserve-localmodelnode-agent # TODO https://github.com/kserve/kserve/issues/4402
-
 kubectl wait --for condition=established --timeout=30s crd/clusterservingruntimes.serving.kserve.io
 kustomize build kserve | kubectl apply --server-side --force-conflicts -f -
 


### PR DESCRIPTION
# Pull Request Template for Kubeflow Manifests

## ✏️ Summary of Changes
> Updates the behavior of the PSS (Pod Security Standards) baseline  tests. 
> The tests will now fail immediately upon detecting a policy violation.

## ✅ Contributor Checklist
  - [ ] I have tested these changes with kustomize. See [Installation Prerequisites](https://github.com/kubeflow/manifests#prerequisites).
  - [x] All commits are [_signed-off_](https://github.com/kubeflow/community/tree/master/dco-signoff-hook#signing-off-commits) to satisfy the DCO check.

---     
 
> You can join the CNCF Slack and access our meetings at the [Kubeflow Community](https://www.kubeflow.org/docs/about/community/) website. Our channel on the CNCF Slack is here [**#kubeflow-platform**](https://app.slack.com/client/T08PSQ7BQ/C073W572LA2).
  
