### PR TITLE
Support Intel i915/Xe Graphics for Jupyter Notebook

### DIFF
--- a/apps/jupyter/jupyter-web-app/upstream/base/configs/spawner_ui_config.yaml
+++ b/apps/jupyter/jupyter-web-app/upstream/base/configs/spawner_ui_config.yaml
@@ -47,6 +47,7 @@ spawnerFormDefaults:
     - ghcr.io/kubeflow/kubeflow/notebook-servers/jupyter-pytorch-gaudi-full:v1.10.0
     - ghcr.io/kubeflow/kubeflow/notebook-servers/jupyter-tensorflow-full:v1.10.0
     - ghcr.io/kubeflow/kubeflow/notebook-servers/jupyter-tensorflow-cuda-full:v1.10.0
+    - docker.io/intel/intel-extension-for-pytorch:2.6.10-xpu-pip-jupyter
 
   ################################################################
   # VSCode-like Container Images (Group 1)
@@ -137,6 +138,10 @@ spawnerFormDefaults:
         uiName: "AMD"
       - limitsKey: "habana.ai/gaudi"
         uiName: "Intel Gaudi"
+      - limitsKey: "gpu.intel.com/i915"
+        uiName: "Intel i915 Graphics"
+      - limitsKey: "gpu.intel.com/xe"
+        uiName: "Intel Xe Graphics"
 
       # the default value of the limit
       # (possible values: "none", "1", "2", "4", "8")


### PR DESCRIPTION
# Pull Request Template for Kubeflow Manifests

## ✏️ Summary of Changes
> Add basic Intel i915/Xe graphics support for Jupyter Notebook by IPEX(Intel Extension for Pytorch).

## 📦 Dependencies
> Users should install driver and firmware for Intel GPUs: https://github.com/intel/intel-device-plugins-for-kubernetes/blob/main/cmd/gpu_plugin/README.md.

## ✅ Contributor Checklist
  - [x] I have tested these changes with kustomize. See [Installation Prerequisites](https://github.com/kubeflow/manifests#prerequisites).
  - [x] All commits are [_signed-off_](https://github.com/kubeflow/community/tree/master/dco-signoff-hook#signing-off-commits) to satisfy the DCO check.

## Slack Message
I have posted a message: https://cloud-native.slack.com/archives/C073W562HFY/p1741140851870119
