### PR TITLE
PSS test for knative-serving

### DIFF
--- a/experimental/security/PSS/static/baseline/kustomization.yaml
+++ b/experimental/security/PSS/static/baseline/kustomization.yaml
@@ -7,3 +7,4 @@ patches:
 - path: patches/cert-manager-labels.yaml
 - path: patches/auth-labels.yaml
 - path: patches/oauth2-proxy-labels.yaml
+- path: patches/knative-serving-labels.yaml

--- a/experimental/security/PSS/static/baseline/patches/knative-serving-labels.yaml
+++ b/experimental/security/PSS/static/baseline/patches/knative-serving-labels.yaml
@@ -1,0 +1,6 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: knative-serving
+  labels:
+    pod-security.kubernetes.io/enforce: baseline

--- a/experimental/security/PSS/static/restricted/kustomization.yaml
+++ b/experimental/security/PSS/static/restricted/kustomization.yaml
@@ -7,3 +7,4 @@ patches:
 - path: patches/cert-manager-labels.yaml
 - path: patches/auth-labels.yaml
 - path: patches/oauth2-proxy-labels.yaml
+- path: patches/knative-serving-labels.yaml

--- a/experimental/security/PSS/static/restricted/patches/knative-serving-labels.yaml
+++ b/experimental/security/PSS/static/restricted/patches/knative-serving-labels.yaml
@@ -1,0 +1,6 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: knative-serving
+  labels:
+    pod-security.kubernetes.io/enforce: restricted

--- a/tests/gh-actions/enable_baseline_PSS.sh
+++ b/tests/gh-actions/enable_baseline_PSS.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 set -euxo pipefail
 
-NAMESPACES=("istio-system" "auth" "cert-manager" "oauth2-proxy" "kubeflow")
+NAMESPACES=("istio-system" "auth" "cert-manager" "oauth2-proxy" "kubeflow" "knative-serving")
 
 for NAMESPACE in "${NAMESPACES[@]}"; do
     if kubectl get namespace "$NAMESPACE" >/dev/null 2>&1; then

--- a/tests/gh-actions/enable_restricted_PSS.sh
+++ b/tests/gh-actions/enable_restricted_PSS.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 set -euxo pipefail
 
-NAMESPACES=("istio-system" "auth" "cert-manager" "oauth2-proxy" "kubeflow")
+NAMESPACES=("istio-system" "auth" "cert-manager" "oauth2-proxy" "kubeflow" "knative-serving")
 for NAMESPACE in "${NAMESPACES[@]}"; do
     if kubectl get namespace "$NAMESPACE" >/dev/null 2>&1; then
         if [ -f "./experimental/security/PSS/static/restricted/patches/${NAMESPACE}-labels.yaml" ]; then


### PR DESCRIPTION
# Pull Request Template for Kubeflow Manifests

## ✏️ Summary of Changes
> Added the knative-serving namespace to the PSS tests.



## ✅ Contributor Checklist
  - [ ] I have tested these changes with kustomize. See [Installation Prerequisites](https://github.com/kubeflow/manifests#prerequisites).
  - [x] All commits are [_signed-off_](https://github.com/kubeflow/community/tree/master/dco-signoff-hook#signing-off-commits) to satisfy the DCO check.
  - [ ] I have considered adding my company to the adopters page to support Kubeflow and help the community, since I expect help from the community for my issue (see [1.](https://github.com/kubeflow/community/issues/833) and [2.](https://github.com/kubeflow/community/blob/master/ADOPTERS.md#adopters-of-kubeflow-platform)).

---     
 
> You can join the CNCF Slack and access our meetings at the [Kubeflow Community](https://www.kubeflow.org/docs/about/community/) website. Our channel on the CNCF Slack is here [**#kubeflow-platform**](https://app.slack.com/client/T08PSQ7BQ/C073W572LA2).
  
