### PR TITLE
Fix knative-serving PSS warnings

### DIFF
--- a/apps/kserve/kserve/kustomization.yaml
+++ b/apps/kserve/kserve/kustomization.yaml
@@ -27,3 +27,16 @@ patches:
           securityContext:
             seccompProfile:
               type: RuntimeDefault
+
+- patch: | 
+     apiVersion: apps/v1
+     kind: Deployment
+     metadata:
+       name: kserve-localmodel-controller-manager
+       namespace: kubeflow
+     spec:
+      template:
+        spec:
+          securityContext:
+            seccompProfile:
+              type: RuntimeDefault

--- a/apps/kserve/kserve/kustomization.yaml
+++ b/apps/kserve/kserve/kustomization.yaml
@@ -14,3 +14,16 @@ patches:
        name: kserve-localmodelnode-agent
        namespace: kubeflow
      $patch: delete
+
+- patch: | 
+     apiVersion: apps/v1
+     kind: Deployment
+     metadata:
+       name: kserve-controller-manager
+       namespace: kubeflow
+     spec:
+      template:
+        spec:
+          securityContext:
+            seccompProfile:
+              type: RuntimeDefault

--- a/common/knative/knative-serving/base/kustomization.yaml
+++ b/common/knative/knative-serving/base/kustomization.yaml
@@ -16,3 +16,8 @@ patches:
 - path: patches/knative-serving-namespaced-view.yaml
 - path: patches/service-labels.yaml
 - path: patches/remove-gateway.yaml
+- path: patches/seccomp.yaml
+  target:
+    kind: Deployment
+    namespace: knative-serving
+    name: "(autoscaler|activator|controller|net-istio-webhook|webhook)"

--- a/common/knative/knative-serving/base/patches/seccomp.yaml
+++ b/common/knative/knative-serving/base/patches/seccomp.yaml
@@ -1,0 +1,11 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: placeholder
+  namespace: knative-serving
+spec:
+  template:
+    spec:
+      securityContext:
+        seccompProfile:
+          type: RuntimeDefault


### PR DESCRIPTION
# Pull Request Template for Kubeflow Manifests

## ✏️ Summary of Changes
- Added patch to insert `seccompProfile` in several knative-serving deployments

## 📦 Dependencies
> List any dependencies or related PRs (e.g., "Depends on #123").

## 🐛 Related Issues
- #3015

## ✅ Contributor Checklist
  - [ ] I have tested these changes with kustomize. See [Installation Prerequisites](https://github.com/kubeflow/manifests#prerequisites).
  - [ ] All commits are [_signed-off_](https://github.com/kubeflow/community/tree/master/dco-signoff-hook#signing-off-commits) to satisfy the DCO check.
  - [ ] I have considered adding my company to the adopters page to support Kubeflow and help the community, since I expect help from the community for my issue (see [1.](https://github.com/kubeflow/community/issues/833) and [2.](https://github.com/kubeflow/community/blob/master/ADOPTERS.md#adopters-of-kubeflow-platform)).

---     
 
> You can join the CNCF Slack and access our meetings at the [Kubeflow Community](https://www.kubeflow.org/docs/about/community/) website. Our channel on the CNCF Slack is here [**#kubeflow-platform**](https://app.slack.com/client/T08PSQ7BQ/C073W572LA2).
  
