### PR TITLE
fix: make again script runnable on Mac OSX

### DIFF
--- a/scripts/library.sh
+++ b/scripts/library.sh
@@ -78,7 +78,11 @@ update_readme() {
   local source_text="$2"
   local destination_text="$3"
   
-  sed -i "s|$source_text|$destination_text|g" "${manifests_directory}/README.md"
+  if [[ "$OSTYPE" == "darwin"* ]]; then
+    sed -i "" "s|$source_text|$destination_text|g" "${manifests_directory}/README.md" # BSD sed of Mac OSX
+  else
+    sed -i "s|$source_text|$destination_text|g" "${manifests_directory}/README.md" # GNU sed of Linux
+  fi
 }
 
 # Commit changes to git repository


### PR DESCRIPTION
# Pull Request Template for Kubeflow Manifests

## ✏️ Summary of Changes
Previously, we updated the sync script to run effectively on Mac OSX, ie BSD `sed`:

https://github.com/kubeflow/manifests/blob/c1ae849873a36199af43c4e14d113bd60fc695d7/scripts/synchronize-model-registry-manifests.sh#L64

since the refactor to use a "common library", here:

https://github.com/kubeflow/manifests/blob/53724ce69fca11951158c2a5374e5a4b2fa15b08/scripts/library.sh#L81

the missing extension to the `-i` parameter works for GNU `sed`, but making it fail again for BSD `sed`.

Kindly consider this modification which shall be compatible for both.

## 📦 Dependencies
none applicable

## 🐛 Related Issues
none applicable

## ✅ Contributor Checklist
  - [n/a] I have tested these changes with kustomize. See [Installation Prerequisites](https://github.com/kubeflow/manifests#prerequisites).
  - [x] All commits are [_signed-off_](https://github.com/kubeflow/community/tree/master/dco-signoff-hook#signing-off-commits) to satisfy the DCO check.
  - [ ] I have considered adding my company to the adopters page to support Kubeflow and help the community, since I expect help from the community for my issue (see [1.](https://github.com/kubeflow/community/issues/833) and [2.](https://github.com/kubeflow/community/blob/master/ADOPTERS.md#adopters-of-kubeflow-platform)).

---     
 
> You can join the CNCF Slack and access our meetings at the [Kubeflow Community](https://www.kubeflow.org/docs/about/community/) website. Our channel on the CNCF Slack is here [**#kubeflow-platform**](https://app.slack.com/client/T08PSQ7BQ/C073W572LA2).
  
