### PR TITLE
Add KFP V1 Pipeline Test to CI Workflow

### DIFF
--- a/.github/workflows/full_kubeflow_integration_test.yaml
+++ b/.github/workflows/full_kubeflow_integration_test.yaml
@@ -115,7 +115,6 @@ jobs:
     - name: V1 Pipeline Test
       run: |
         pip3 install "kfp>=1.8.22,<2.0.0"
-        KF_PROFILE=kubeflow-user-example-com
         TOKEN="$(kubectl -n $KF_PROFILE create token default-editor)"
         python3 tests/gh-actions/test_pipeline_v1.py "${TOKEN}" "${KF_PROFILE}"
 

--- a/.github/workflows/full_kubeflow_integration_test.yaml
+++ b/.github/workflows/full_kubeflow_integration_test.yaml
@@ -100,9 +100,6 @@ jobs:
     - name: Wait for All Pods to be Ready
       run: kubectl wait --for=condition=Ready pods --all --all-namespaces --timeout 60s --field-selector=status.phase!=Succeeded
 
-    - name: Install Dependencies
-      run: pip install pytest kubernetes kfp==2.13.0 kserve pytest-timeout pyyaml requests
-
     - name: Port-forward the istio-ingress gateway
       run: ./tests/gh-actions/port_forward_gateway.sh
 
@@ -112,13 +109,19 @@ jobs:
     - name: Test Dex Login
       run: |
         pip3 install -q requests
-
         python3 tests/gh-actions/test_dex_login.py
-
         echo "Dex login test completed successfully."
+        
+    - name: V1 Pipeline Test
+      run: |
+        pip3 install "kfp>=1.8.22,<2.0.0"
+        KF_PROFILE=kubeflow-user-example-com
+        TOKEN="$(kubectl -n $KF_PROFILE create token default-editor)"
+        python3 tests/gh-actions/test_pipeline_v1.py "${TOKEN}" "${KF_PROFILE}"
 
     - name: V2 Pipeline Test
       run: |
+        pip3 install -U "kfp>=2.13.0"
         TOKEN="$(kubectl -n $KF_PROFILE create token default-editor)"
         python3 tests/gh-actions/test_pipeline.py run_pipeline "${TOKEN}" "${KF_PROFILE}"
 

--- a/.github/workflows/full_kubeflow_integration_test.yaml
+++ b/.github/workflows/full_kubeflow_integration_test.yaml
@@ -117,7 +117,7 @@ jobs:
 
         echo "Dex login test completed successfully."
 
-    - name: Test Pipeline Access with Authorized Token
+    - name: V2 Pipeline Test
       run: |
         TOKEN="$(kubectl -n $KF_PROFILE create token default-editor)"
         python3 tests/gh-actions/test_pipeline.py run_pipeline "${TOKEN}" "${KF_PROFILE}"

--- a/.github/workflows/full_kubeflow_integration_test.yaml
+++ b/.github/workflows/full_kubeflow_integration_test.yaml
@@ -111,7 +111,7 @@ jobs:
         pip3 install -q requests
         python3 tests/gh-actions/test_dex_login.py
         echo "Dex login test completed successfully."
-        
+
     - name: V1 Pipeline Test
       run: |
         pip3 install "kfp>=1.8.22,<2.0.0"

--- a/.github/workflows/pipeline_test.yaml
+++ b/.github/workflows/pipeline_test.yaml
@@ -15,6 +15,9 @@ on:
     - tests/gh-actions/test_pipeline_v1.py
     - experimental/security/PSS/*
 
+env:
+  KF_PROFILE: kubeflow-user-example-com
+
 jobs:
   build:
     timeout-minutes: 15
@@ -68,14 +71,12 @@ jobs:
     - name: V1 Pipeline Test
       run: |
         pip3 install "kfp>=1.8.22,<2.0.0"
-        KF_PROFILE=kubeflow-user-example-com
         TOKEN="$(kubectl -n $KF_PROFILE create token default-editor)"
         python3 tests/gh-actions/test_pipeline_v1.py "${TOKEN}" "${KF_PROFILE}"
 
     - name: List and deploy test pipeline with authorized ServiceAccount Token
       run: |
         pip3 install kfp==2.13.0
-        KF_PROFILE=kubeflow-user-example-com
         TOKEN="$(kubectl -n $KF_PROFILE create token default-editor)"
         python3 tests/gh-actions/test_pipeline.py run_pipeline "${TOKEN}" "${KF_PROFILE}"
 

--- a/.github/workflows/pipeline_test.yaml
+++ b/.github/workflows/pipeline_test.yaml
@@ -58,7 +58,6 @@ jobs:
 
     - name: Verify Pipeline Integration
       run: |
-        KF_PROFILE=kubeflow-user-example-com
         if ! kubectl get secret mlpipeline-minio-artifact -n $KF_PROFILE > /dev/null 2>&1; then
           echo "Error: Secret mlpipeline-minio-artifact not found in namespace $KF_PROFILE"
           exit 1
@@ -76,14 +75,13 @@ jobs:
 
     - name: List and deploy test pipeline with authorized ServiceAccount Token
       run: |
-        pip3 install kfp==2.13.0
+        pip3 install -U kfp==2.13.0
         TOKEN="$(kubectl -n $KF_PROFILE create token default-editor)"
         python3 tests/gh-actions/test_pipeline.py run_pipeline "${TOKEN}" "${KF_PROFILE}"
 
     - name: Fail to list pipelines with unauthorized ServiceAccount Token
       run: |
-        pip3 install kfp==2.13.0
-        KF_PROFILE=kubeflow-user-example-com
+        pip3 install -U kfp==2.13.0
         TOKEN="$(kubectl -n default create token default)"
         python3 tests/gh-actions/test_pipeline.py test_unauthorized_access "${TOKEN}" "${KF_PROFILE}"
         echo "Test succeeded. Token from unauthorized ServiceAccount cannot list pipelines in $KF_PROFILE namespace."

--- a/.github/workflows/pipeline_test.yaml
+++ b/.github/workflows/pipeline_test.yaml
@@ -73,7 +73,7 @@ jobs:
         TOKEN="$(kubectl -n $KF_PROFILE create token default-editor)"
         python3 tests/gh-actions/test_pipeline_v1.py "${TOKEN}" "${KF_PROFILE}"
 
-    - name: List and deploy test pipeline with authorized ServiceAccount Token
+    - name: V2 Pipeline Test
       run: |
         pip3 install -U kfp==2.13.0
         TOKEN="$(kubectl -n $KF_PROFILE create token default-editor)"

--- a/.github/workflows/pipeline_test.yaml
+++ b/.github/workflows/pipeline_test.yaml
@@ -3,9 +3,9 @@ on:
   pull_request:
     paths:
     - tests/gh-actions/install_KinD_create_KinD_cluster_install_kustomize.sh
-    - .github/workflows/test_pipeline.yaml
+    - .github/workflows/pipeline_test.yaml
     - apps/pipeline/upstream/**
-    - tests/gh-actions/install_istio.sh
+    - tests/gh-actions/install_istio*.sh
     - tests/gh-actions/install_cert_manager.sh
     - tests/gh-actions/install_oauth2-proxy.sh
     - common/cert-manager/**

--- a/.github/workflows/pipeline_test.yaml
+++ b/.github/workflows/pipeline_test.yaml
@@ -12,6 +12,7 @@ on:
     - common/oauth2-proxy/**
     - common/istio*/**
     - tests/gh-actions/test_pipeline.py
+    - tests/gh-actions/test_pipeline_v1.py
     - experimental/security/PSS/*
 
 jobs:
@@ -63,6 +64,13 @@ jobs:
 
     - name: Port forward
       run: ./tests/gh-actions/port_forward_gateway.sh
+
+    - name: Run V1 Pipeline Test
+      run: |
+        pip3 install "kfp>=1.8.22,<2.0.0"
+        KF_PROFILE=kubeflow-user-example-com
+        TOKEN="$(kubectl -n $KF_PROFILE create token default-editor)"
+        python3 tests/gh-actions/test_pipeline_v1.py "${TOKEN}" "${KF_PROFILE}"
 
     - name: List and deploy test pipeline with authorized ServiceAccount Token
       run: |

--- a/.github/workflows/pipeline_test.yaml
+++ b/.github/workflows/pipeline_test.yaml
@@ -101,4 +101,3 @@ jobs:
 
     - name: Applying Pod Security Standards restricted levels for static namespaces
       run: ./tests/gh-actions/enable_restricted_PSS.sh
-

--- a/.github/workflows/pipeline_test.yaml
+++ b/.github/workflows/pipeline_test.yaml
@@ -65,7 +65,7 @@ jobs:
     - name: Port forward
       run: ./tests/gh-actions/port_forward_gateway.sh
 
-    - name: Run V1 Pipeline Test
+    - name: V1 Pipeline Test
       run: |
         pip3 install "kfp>=1.8.22,<2.0.0"
         KF_PROFILE=kubeflow-user-example-com

--- a/tests/gh-actions/kserve/requirements.txt
+++ b/tests/gh-actions/kserve/requirements.txt
@@ -1,4 +1,4 @@
 pytest>=7.0.0
-kserve>=0.14.1
+kserve>=0.15.0
 kubernetes>=18.20.0
 requests>=2.18.4

--- a/tests/gh-actions/test_pipeline_v1.py
+++ b/tests/gh-actions/test_pipeline_v1.py
@@ -3,19 +3,19 @@
 import kfp
 import sys
 import time
-from kfp import dsl
 
-@dsl.component
-def hello_world():
-    print("Hello World from Kubeflow Pipelines V1!")
-    return "Hello World"
+def hello_world_op():
+    from kfp.components import func_to_container_op
+    
+    def hello_world():
+        print("Hello World from Kubeflow Pipelines V1!")
+        return "Hello World"
+    
+    return func_to_container_op(hello_world)
 
-@dsl.pipeline(
-    name="Hello World V1 Pipeline",
-    description="A simple pipeline that prints Hello World"
-)
 def hello_world_pipeline():
-    hello_world()
+    hello_op = hello_world_op()
+    hello_op()
 
 def run_v1_pipeline(token, namespace):
     client = kfp.Client(host="http://localhost:8080/pipeline", existing_token=token)

--- a/tests/gh-actions/test_pipeline_v1.py
+++ b/tests/gh-actions/test_pipeline_v1.py
@@ -26,7 +26,8 @@ def run_v1_pipeline(token, namespace):
         hello_world_pipeline,
         experiment_name=experiment.name,
         run_name="v1-hello-world",
-        namespace=namespace
+        namespace=namespace,
+        arguments={}
     )
     
     for iteration in range(15):

--- a/tests/gh-actions/test_pipeline_v1.py
+++ b/tests/gh-actions/test_pipeline_v1.py
@@ -1,0 +1,48 @@
+#!/usr/bin/env python3
+
+import kfp
+import sys
+import time
+from kfp import dsl
+
+@dsl.component
+def hello_world():
+    print("Hello World from Kubeflow Pipelines V1!")
+    return "Hello World"
+
+@dsl.pipeline(
+    name="Hello World V1 Pipeline",
+    description="A simple pipeline that prints Hello World"
+)
+def hello_world_pipeline():
+    hello_world()
+
+def run_v1_pipeline(token, namespace):
+    client = kfp.Client(host="http://localhost:8080/pipeline", existing_token=token)
+    
+    experiment = client.create_experiment("v1-pipeline-test", namespace=namespace)
+    
+    pipeline_run = client.create_run_from_pipeline_func(
+        hello_world_pipeline,
+        experiment_name=experiment.name,
+        run_name="v1-hello-world",
+        namespace=namespace
+    )
+    
+    for iteration in range(15):
+        pipeline_status = client.get_run(pipeline_run.run_id).run.status
+        
+        if pipeline_status == "Succeeded":
+            return
+        elif pipeline_status not in ["Running", "Pending"]:
+            sys.exit(1)
+            
+        time.sleep(10)
+    
+    sys.exit(1)
+
+if __name__ == "__main__":
+    if len(sys.argv) != 3:
+        sys.exit(1)
+        
+    run_v1_pipeline(sys.argv[1], sys.argv[2]) 


### PR DESCRIPTION
## ✏️ Summary of Changes
> Added KFP v1 SDK (>=1.8.22,<2.0.0) pipeline test to CI workflow
> Create simple hello world V1 pipeline test script


## ✅ Contributor Checklist
  - [ ] I have tested these changes with kustomize. See [Installation Prerequisites](https://github.com/kubeflow/manifests#prerequisites).
  - [x] All commits are [_signed-off_](https://github.com/kubeflow/community/tree/master/dco-signoff-hook#signing-off-commits) to satisfy the DCO check.
  - [ ] I have considered adding my company to the adopters page to support Kubeflow and help the community, since I expect help from the community for my issue (see [1.](https://github.com/kubeflow/community/issues/833) and [2.](https://github.com/kubeflow/community/blob/master/ADOPTERS.md#adopters-of-kubeflow-platform)).

---     
 
> You can join the CNCF Slack and access our meetings at the [Kubeflow Community](https://www.kubeflow.org/docs/about/community/) website. Our channel on the CNCF Slack is here [**#kubeflow-platform**](https://app.slack.com/client/T08PSQ7BQ/C073W572LA2).
  
