### PR TITLE
Apply pss labels from diectly PSS enable scripts

### DIFF
--- a/common/knative/knative-serving/base/kustomization.yaml
+++ b/common/knative/knative-serving/base/kustomization.yaml
@@ -20,4 +20,4 @@ patches:
   target:
     kind: Deployment
     namespace: knative-serving
-    name: "(autoscaler|activator|controller|net-istio-webhook|webhook)"
+    name: "(autoscaler|activator|controller|net-istio-webhook|webhook|net-istio-controller)"

--- a/tests/gh-actions/enable_restricted_PSS.sh
+++ b/tests/gh-actions/enable_restricted_PSS.sh
@@ -1,14 +1,15 @@
 #!/bin/bash
-set -euxo pipefail
+set -euo pipefail
 
 NAMESPACES=("istio-system" "auth" "cert-manager" "oauth2-proxy" "kubeflow" "knative-serving")
 for NAMESPACE in "${NAMESPACES[@]}"; do
     if kubectl get namespace "$NAMESPACE" >/dev/null 2>&1; then
-        if [ -f "./experimental/security/PSS/static/restricted/patches/${NAMESPACE}-labels.yaml" ]; then
-            PATCH_OUTPUT=$(kubectl patch namespace $NAMESPACE --patch-file ./experimental/security/PSS/static/restricted/patches/${NAMESPACE}-labels.yaml 2>&1)
-            if echo "$PATCH_OUTPUT" | grep -q "violate the new PodSecurity"; then
-                echo "\nWARNING PSS VIOLATED\n"
-            fi
+        PATCH_OUTPUT=$(kubectl label namespace $NAMESPACE pod-security.kubernetes.io/enforce=restricted --overwrite 2>&1)
+        if echo "$PATCH_OUTPUT" | grep -q "violate the new PodSecurity"; then
+            echo "WARNING: PSS violation detected for namespace $NAMESPACE"
+            echo "$PATCH_OUTPUT" | grep -A 5 "violate the new PodSecurity"
+        else
+            echo "✅ Namespace '$NAMESPACE' labeled successfully."
         fi
     fi
 done


### PR DESCRIPTION
# Pull Request Template for Kubeflow Manifests

## ✏️ Summary of Changes
- Modified PSS enable scripts to apply pss labels from diectly PSS enable scripts
- working on fixing `knative-serving` pss warning

## 📦 Dependencies
> List any dependencies or related PRs (e.g., "Depends on #123").

## 🐛 Related Issues
> Link any issues that are resolved or affected by this PR.

## ✅ Contributor Checklist
  - [ ] I have tested these changes with kustomize. See [Installation Prerequisites](https://github.com/kubeflow/manifests#prerequisites).
  - [ ] All commits are [_signed-off_](https://github.com/kubeflow/community/tree/master/dco-signoff-hook#signing-off-commits) to satisfy the DCO check.
  - [ ] I have considered adding my company to the adopters page to support Kubeflow and help the community, since I expect help from the community for my issue (see [1.](https://github.com/kubeflow/community/issues/833) and [2.](https://github.com/kubeflow/community/blob/master/ADOPTERS.md#adopters-of-kubeflow-platform)).

---     
 
> You can join the CNCF Slack and access our meetings at the [Kubeflow Community](https://www.kubeflow.org/docs/about/community/) website. Our channel on the CNCF Slack is here [**#kubeflow-platform**](https://app.slack.com/client/T08PSQ7BQ/C073W572LA2).
  
