### PR TITLE
The test_pipeline.py has been changed to test_pipeline_v2.py

### DIFF
--- a/.github/workflows/pipeline_swfs_test.yaml
+++ b/.github/workflows/pipeline_swfs_test.yaml
@@ -79,14 +79,6 @@ jobs:
         TOKEN="$(kubectl -n $KF_PROFILE create token default-editor)"
         python3 tests/gh-actions/test_pipeline_v2.py run_pipeline "${TOKEN}" "${KF_PROFILE}"
 
-    - name: Fail to list pipelines with unauthorized ServiceAccount Token (V1 API)
-      run: |
-        pip3 install "kfp>=1.8.22,<2.0.0"
-        KF_PROFILE=kubeflow-user-example-com
-        TOKEN="$(kubectl -n default create token default)"
-        python3 tests/gh-actions/test_pipeline_v1.py test_unauthorized_access "${TOKEN}" "${KF_PROFILE}"
-        echo "Test succeeded. Token from unauthorized ServiceAccount cannot list pipelines in $KF_PROFILE namespace using V1 API."
-
     - name: Fail to list pipelines with unauthorized ServiceAccount Token (V2 API)
       run: |
         pip3 install kfp==2.13.0

--- a/.github/workflows/pipeline_swfs_test.yaml
+++ b/.github/workflows/pipeline_swfs_test.yaml
@@ -70,14 +70,14 @@ jobs:
         pip3 install kfp==2.13.0
         KF_PROFILE=kubeflow-user-example-com
         TOKEN="$(kubectl -n $KF_PROFILE create token default-editor)"
-        python3 tests/gh-actions/test_pipeline.py run_pipeline "${TOKEN}" "${KF_PROFILE}"
+        python3 tests/gh-actions/test_pipeline_v2.py run_pipeline "${TOKEN}" "${KF_PROFILE}"
 
     - name: Fail to list pipelines with unauthorized ServiceAccount Token
       run: |
         pip3 install kfp==2.13.0
         KF_PROFILE=kubeflow-user-example-com
         TOKEN="$(kubectl -n default create token default)"
-        python3 tests/gh-actions/test_pipeline.py test_unauthorized_access "${TOKEN}" "${KF_PROFILE}"
+        python3 tests/gh-actions/test_pipeline_v2.py test_unauthorized_access "${TOKEN}" "${KF_PROFILE}"
         echo "Test succeeded. Token from unauthorized ServiceAccount cannot list pipelines in $KF_PROFILE namespace."
 
 

--- a/.github/workflows/pipeline_swfs_test.yaml
+++ b/.github/workflows/pipeline_swfs_test.yaml
@@ -65,14 +65,29 @@ jobs:
     - name: Port forward
       run: ./tests/gh-actions/port_forward_gateway.sh
 
-    - name: List and deploy test pipeline with authorized ServiceAccount Token
+    - name: List and deploy test pipeline with V1 API
+      run: |
+        pip3 install "kfp>=1.8.22,<2.0.0"
+        KF_PROFILE=kubeflow-user-example-com
+        TOKEN="$(kubectl -n $KF_PROFILE create token default-editor)"
+        python3 tests/gh-actions/test_pipeline_v1.py "${TOKEN}" "${KF_PROFILE}"
+
+    - name: List and deploy test pipeline with V2 API
       run: |
         pip3 install kfp==2.13.0
         KF_PROFILE=kubeflow-user-example-com
         TOKEN="$(kubectl -n $KF_PROFILE create token default-editor)"
         python3 tests/gh-actions/test_pipeline_v2.py run_pipeline "${TOKEN}" "${KF_PROFILE}"
 
-    - name: Fail to list pipelines with unauthorized ServiceAccount Token
+    - name: Fail to list pipelines with unauthorized ServiceAccount Token (V1 API)
+      run: |
+        pip3 install "kfp>=1.8.22,<2.0.0"
+        KF_PROFILE=kubeflow-user-example-com
+        TOKEN="$(kubectl -n default create token default)"
+        python3 tests/gh-actions/test_pipeline_v1.py test_unauthorized_access "${TOKEN}" "${KF_PROFILE}"
+        echo "Test succeeded. Token from unauthorized ServiceAccount cannot list pipelines in $KF_PROFILE namespace using V1 API."
+
+    - name: Fail to list pipelines with unauthorized ServiceAccount Token (V2 API)
       run: |
         pip3 install kfp==2.13.0
         KF_PROFILE=kubeflow-user-example-com


### PR DESCRIPTION
The test_pipeline.py has been changed to test_pipeline_v2.py in https://github.com/kubeflow/manifests/pull/3129

## ✅ Contributor Checklist
  - [x] I have tested these changes with kustomize. See [Installation Prerequisites](https://github.com/kubeflow/manifests#prerequisites).
  - [x] All commits are [_signed-off_](https://github.com/kubeflow/community/tree/master/dco-signoff-hook#signing-off-commits) to satisfy the DCO check.
  - [x] I have considered adding my company to the adopters page to support Kubeflow and help the community, since I expect help from the community for my issue (see [1.](https://github.com/kubeflow/community/issues/833) and [2.](https://github.com/kubeflow/community/blob/master/ADOPTERS.md#adopters-of-kubeflow-platform)).

---     
 
> You can join the CNCF Slack and access our meetings at the [Kubeflow Community](https://www.kubeflow.org/docs/about/community/) website. Our channel on the CNCF Slack is here [**#kubeflow-platform**](https://app.slack.com/client/T08PSQ7BQ/C073W572LA2).
  
