### PR TITLE
Integrates the Spark Operator as a dependency for the models-web-app

### DIFF
--- a/apps/kserve/models-web-app/base/kustomization.yaml
+++ b/apps/kserve/models-web-app/base/kustomization.yaml
@@ -1,3 +1,5 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
 resources:
 - rbac.yaml
 - service.yaml
@@ -15,8 +17,17 @@ configMapGenerator:
 - literals:
   - APP_DISABLE_AUTH="True"
   name: kserve-models-web-app-config
-apiVersion: kustomize.config.k8s.io/v1beta1
-kind: Kustomization
+helmCharts:
+- name: spark-operator
+  repo: https://kubeflow.github.io/spark-operator
+  version: 2.1.1
+  releaseName: spark-operator
+  includeCRDs: true
+  valuesInline:
+    spark.jobNamespaces: {} # To match the synchronize script
+    webhook.enable: true
+    webhook.port: 9443
+
 labels:
 - includeSelectors: true
   pairs:


### PR DESCRIPTION
# Pull Request Template for Kubeflow Manifests

## ✏️ Summary of Changes
> The goal was to integrate the Spark Operator with the `models-web-app` using its official Helm chart via Kustomize.
>  Modifies apps/kserve/models-web-app/base/kustomization.yaml to include the official Spark Operator Helm chart. This allows the models-web-app to utilize Spark Operator functionality, rendered and managed directly through Kustomize.

## ✅ Contributor Checklist
  - [ ] I have tested these changes with kustomize. See [Installation Prerequisites](https://github.com/kubeflow/manifests#prerequisites).
  - [ ] All commits are [_signed-off_](https://github.com/kubeflow/community/tree/master/dco-signoff-hook#signing-off-commits) to satisfy the DCO check.
  - [ ] I have considered adding my company to the adopters page to support Kubeflow and help the community, since I expect help from the community for my issue (see [1.](https://github.com/kubeflow/community/issues/833) and [2.](https://github.com/kubeflow/community/blob/master/ADOPTERS.md#adopters-of-kubeflow-platform)).

---     
 
> You can join the CNCF Slack and access our meetings at the [Kubeflow Community](https://www.kubeflow.org/docs/about/community/) website. Our channel on the CNCF Slack is here [**#kubeflow-platform**](https://app.slack.com/client/T08PSQ7BQ/C073W572LA2).
  
