### PR TITLE
Modernize logger interface

### DIFF
--- a/tests/kserve/utils.py
+++ b/tests/kserve/utils.py
@@ -102,7 +102,7 @@ def predict_str(
         headers.update({"Authorization": f"Bearer {token}"})
         logging.info("M2M Token Found.")
     except M2mTokenNotAvailable:
-        logging.warn("M2M Token Not found, client authentication disabled.")
+        logging.warning("M2M Token Not found, client authentication disabled.")
 
     if model_name is None:
         model_name = service_name


### PR DESCRIPTION
# Pull Request Template for Kubeflow Manifests

## ✏️ Summary of Changes
The `logger.warn()` method is deprecated since Python2.7 and replaced with `logger.warning()`. It leads to those warnings:
```python
DeprecationWarning: The 'warn' method is deprecated, use 'warning' instead
```

## 📦 Dependencies

## 🐛 Related Issues

## ✅ Contributor Checklist
  - [x] I have tested these changes with kustomize. See [Installation Prerequisites](https://github.com/kubeflow/manifests#prerequisites).
  - [x] All commits are [_signed-off_](https://github.com/kubeflow/community/tree/master/dco-signoff-hook#signing-off-commits) to satisfy the DCO check.
  - [x] I have considered adding my company to the adopters page to support Kubeflow and help the community, since I expect help from the community for my issue (see [1.](https://github.com/kubeflow/community/issues/833) and [2.](https://github.com/kubeflow/community/blob/master/ADOPTERS.md#adopters-of-kubeflow-platform)).

---     
 
> You can join the CNCF Slack and access our meetings at the [Kubeflow Community](https://www.kubeflow.org/docs/about/community/) website. Our channel on the CNCF Slack is here [**#kubeflow-platform**](https://app.slack.com/client/T08PSQ7BQ/C073W572LA2).
  
