### PR TITLE
KServe Path-Based Routing Implementation

### DIFF
--- a/tests/kserve_test.sh
+++ b/tests/kserve_test.sh
@@ -78,14 +78,7 @@ spec:
       serving.knative.dev/service: test-sklearn-predictor
 EOF
 
-sleep 40
-
-kubectl get authorizationpolicy -A | grep -E "(ALLOW|istio-system)"
-kubectl get authorizationpolicy -n istio-system -o yaml
-kubectl get requestauthentication -n istio-system -o yaml
-kubectl get pods -n istio-system | grep cluster-jwks-proxy
-kubectl get pods --all-namespaces
-kubectl get svc -n istio-system | grep cluster-jwks-proxy
+sleep 300
 
 echo "Testing path-based access with valid token..."
 curl -v --fail --show-error \

--- a/tests/kserve_test.sh
+++ b/tests/kserve_test.sh
@@ -68,11 +68,13 @@ spec:
       serving.knative.dev/service: test-sklearn-predictor
 EOF
 
+kubectl delete virtualservice test-sklearn-path -n ${NAMESPACE} --ignore-not-found=true
+
 cat <<EOF | kubectl apply -f -
 apiVersion: networking.istio.io/v1beta1
 kind: VirtualService
 metadata:
-  name: test-sklearn-external
+  name: test-sklearn-path
   namespace: ${NAMESPACE}
 spec:
   gateways:

--- a/tests/kserve_test.sh
+++ b/tests/kserve_test.sh
@@ -45,6 +45,9 @@ spec:
    - kserve-path.${NAMESPACE}.example.com
 EOF
 
+kubectl wait --for=condition=Ready gateway/kserve-path-gateway -n ${NAMESPACE} --timeout=60s || true
+kubectl get gateway kserve-path-gateway -n ${NAMESPACE} -o yaml
+
 echo "=== Setting up path-based routing VirtualService ==="
 cat <<EOF | kubectl apply -f -
 apiVersion: networking.istio.io/v1beta1

--- a/tests/kserve_test.sh
+++ b/tests/kserve_test.sh
@@ -5,35 +5,44 @@ NAMESPACE=${1:-kubeflow-user-example-com}
 SCRIPT_DIRECTORY="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 TEST_DIRECTORY="${SCRIPT_DIRECTORY}/kserve"
 
-echo "=== Creating dedicated Gateway for path-based routing ==="
+if ! command -v pytest &> /dev/null; then
+  echo "Installing test dependencies..."
+  pip install -r ${TEST_DIRECTORY}/requirements.txt
+fi
+
+kubectl delete inferenceservice isvc-sklearn -n ${NAMESPACE} --ignore-not-found=true --timeout=60s
+kubectl delete virtualservice isvc-sklearn-external -n ${NAMESPACE} --ignore-not-found=true
+kubectl delete authorizationpolicy allow-kserve-access -n ${NAMESPACE} --ignore-not-found=true
+
+export KSERVE_INGRESS_HOST_PORT=${KSERVE_INGRESS_HOST_PORT:-localhost:8080}
+export KSERVE_M2M_TOKEN="$(kubectl -n ${NAMESPACE} create token default-editor)"
+export KSERVE_TEST_NAMESPACE=${NAMESPACE}
+
+echo "=== Creating AuthorizationPolicy for KServe access ==="
 cat <<EOF | kubectl apply -f -
-apiVersion: networking.istio.io/v1beta1
-kind: Gateway
+apiVersion: security.istio.io/v1beta1
+kind: AuthorizationPolicy
 metadata:
- name: kserve-path-gateway
- namespace: ${NAMESPACE}
+  name: allow-kserve-access
+  namespace: ${NAMESPACE}
 spec:
- selector:
-   istio: ingressgateway
- servers:
- - port:
-     number: 80
-     name: http
-     protocol: HTTP
-   hosts:
-   - kserve-path.${NAMESPACE}.example.com
+  action: ALLOW
+  rules:
+  - {}
+  selector:
+    matchLabels:
+      serving.knative.dev/service: isvc-sklearn-predictor
 EOF
 
-kubectl wait --for=condition=Ready gateway/kserve-path-gateway -n ${NAMESPACE} --timeout=60s || true
-kubectl get gateway kserve-path-gateway -n ${NAMESPACE} -o yaml
+cd ${TEST_DIRECTORY} && pytest . -vs --log-level info
 
-echo "=== Setting up path-based routing VirtualService ==="
+echo "=== Setting up path-based routing VirtualService (no dedicated Gateway) ==="
 cat <<EOF | kubectl apply -f -
 apiVersion: networking.istio.io/v1beta1
 kind: VirtualService
 metadata:
- name: kserve-path-routing
- namespace: ${NAMESPACE}
+  name: isvc-sklearn-external
+  namespace: ${NAMESPACE}
 spec:
   gateways:
     - kubeflow/kubeflow-gateway
@@ -56,67 +65,19 @@ spec:
       timeout: 300s
 EOF
 
-if ! command -v pytest &> /dev/null; then
-  echo "Installing test dependencies..."
-  pip install -r ${TEST_DIRECTORY}/requirements.txt
-fi
-
-kubectl delete inferenceservice isvc-sklearn -n ${NAMESPACE} --ignore-not-found=true --timeout=60s
-
-kubectl delete authorizationpolicy allow-kserve-access -n ${NAMESPACE} --ignore-not-found=true
-
-export KSERVE_INGRESS_HOST_PORT=${KSERVE_INGRESS_HOST_PORT:-localhost:8080}
-export KSERVE_M2M_TOKEN="$(kubectl -n ${NAMESPACE} create token default-editor)"
-export KSERVE_TEST_NAMESPACE=${NAMESPACE}
-
-cat <<EOF | kubectl apply -f -
-apiVersion: security.istio.io/v1beta1
-kind: AuthorizationPolicy
-metadata:
-  name: allow-kserve-access
-  namespace: ${NAMESPACE}
-spec:
-  action: ALLOW
-  rules:
-  - {}
-  selector:
-    matchLabels:
-      serving.knative.dev/service: isvc-sklearn-predictor
-EOF
-
-cd ${TEST_DIRECTORY} && pytest . -vs --log-level info
-
-echo "=== InferenceService for additional tests ==="
-cat <<EOF | kubectl apply -f -
-apiVersion: "serving.kserve.io/v1beta1"
-kind: "InferenceService"
-metadata:
-  name: "isvc-sklearn"
-  namespace: ${NAMESPACE}
-spec:
-  predictor:
-    sklearn:
-      storageUri: "gs://kfserving-examples/models/sklearn/1.0/model"
-EOF
-
-kubectl wait --for=condition=Ready inferenceservice/isvc-sklearn -n ${NAMESPACE} --timeout=300s
-
-
+sleep 10
 
 kubectl get pods -n ${NAMESPACE} -l serving.knative.dev/service=isvc-sklearn-predictor --show-labels
-echo "=== Testing path-based routing functionality ==="
 
 echo "Testing path-based access with valid token..."
 curl --fail --show-error \
- -H "Host: kserve-path.${NAMESPACE}.example.com" \
  -H "Authorization: Bearer ${KSERVE_M2M_TOKEN}" \
  -H "Content-Type: application/json" \
- "http://${KSERVE_INGRESS_HOST_PORT}/serving/${NAMESPACE}/isvc-sklearn/v1/models/isvc-sklearn:predict" \
+ "http://${KSERVE_INGRESS_HOST_PORT}/kserve/${NAMESPACE}/isvc-sklearn/v1/models/isvc-sklearn:predict" \
  -d '{"instances": [[6.8, 2.8, 4.8, 1.4], [6.0, 3.4, 4.5, 1.6]]}'
 
 echo "Testing 404 for incorrect path..."
 RESPONSE=$(curl -s -o /dev/null -w "%{http_code}" \
- -H "Host: kserve-path.${NAMESPACE}.example.com" \
  -H "Authorization: Bearer ${KSERVE_M2M_TOKEN}" \
  -H "Content-Type: application/json" \
  "http://${KSERVE_INGRESS_HOST_PORT}/wrong-path/${NAMESPACE}/isvc-sklearn/v1/models/isvc-sklearn:predict" \

--- a/tests/kserve_test.sh
+++ b/tests/kserve_test.sh
@@ -80,6 +80,9 @@ EOF
 
 sleep 10
 
+kubectl get authorizationpolicy -A | grep -E "(ALLOW|istio-system)"
+kubectl get authorizationpolicy -n istio-system -o yaml
+
 echo "Testing path-based access with valid token..."
 curl --fail --show-error \
  -H "Authorization: Bearer ${KSERVE_M2M_TOKEN}" \
@@ -110,6 +113,8 @@ spec:
     matchLabels:
       serving.knative.dev/service: isvc-sklearn-predictor
 EOF
+
+kubectl delete inferenceservice isvc-sklearn -n ${NAMESPACE} --ignore-not-found=true
 
 cd ${TEST_DIRECTORY} && pytest . -vs --log-level info
 

--- a/tests/kserve_test.sh
+++ b/tests/kserve_test.sh
@@ -63,6 +63,8 @@ fi
 
 kubectl delete inferenceservice isvc-sklearn -n ${NAMESPACE} --ignore-not-found=true --timeout=60s
 
+kubectl delete authorizationpolicy allow-kserve-access -n ${NAMESPACE} --ignore-not-found=true
+
 export KSERVE_INGRESS_HOST_PORT=${KSERVE_INGRESS_HOST_PORT:-localhost:8080}
 export KSERVE_M2M_TOKEN="$(kubectl -n ${NAMESPACE} create token default-editor)"
 export KSERVE_TEST_NAMESPACE=${NAMESPACE}

--- a/tests/kserve_test.sh
+++ b/tests/kserve_test.sh
@@ -78,11 +78,14 @@ spec:
       serving.knative.dev/service: test-sklearn-predictor
 EOF
 
-sleep 30
+sleep 40
 
 kubectl get authorizationpolicy -A | grep -E "(ALLOW|istio-system)"
 kubectl get authorizationpolicy -n istio-system -o yaml
 kubectl get requestauthentication -n istio-system -o yaml
+kubectl get pods -n istio-system | grep cluster-jwks-proxy
+kubectl get pods --all-namespaces
+kubectl get svc -n istio-system | grep cluster-jwks-proxy
 
 echo "Testing path-based access with valid token..."
 curl -v --fail --show-error \

--- a/tests/kserve_test.sh
+++ b/tests/kserve_test.sh
@@ -18,7 +18,7 @@ cat <<EOF | kubectl apply -f -
 apiVersion: security.istio.io/v1beta1
 kind: AuthorizationPolicy
 metadata:
-  name: allow-test-sklearn
+  name: allow-isvc-sklearn
   namespace: ${NAMESPACE}
 spec:
   action: ALLOW
@@ -26,9 +26,10 @@ spec:
   - {}
   selector:
     matchLabels:
-      serving.knative.dev/service: test-sklearn-predictor
+      serving.knative.dev/service: isvc-sklearn-predictor
 EOF
 
+# Run pytest first (creates and cleans up isvc-sklearn)
 cd ${TEST_DIRECTORY} && pytest . -vs --log-level info
 
 cat <<EOF | kubectl apply -f -
@@ -51,6 +52,21 @@ spec:
 EOF
 
 kubectl wait --for=condition=Ready inferenceservice/test-sklearn -n ${NAMESPACE} --timeout=300s
+
+cat <<EOF | kubectl apply -f -
+apiVersion: security.istio.io/v1beta1
+kind: AuthorizationPolicy
+metadata:
+  name: allow-test-sklearn
+  namespace: ${NAMESPACE}
+spec:
+  action: ALLOW
+  rules:
+  - {}
+  selector:
+    matchLabels:
+      serving.knative.dev/service: test-sklearn-predictor
+EOF
 
 cat <<EOF | kubectl apply -f -
 apiVersion: networking.istio.io/v1beta1

--- a/tests/kserve_test.sh
+++ b/tests/kserve_test.sh
@@ -10,20 +10,39 @@ if ! command -v pytest &> /dev/null; then
   pip install -r ${TEST_DIRECTORY}/requirements.txt
 fi
 
-kubectl delete inferenceservice isvc-sklearn -n ${NAMESPACE} --ignore-not-found=true --timeout=60s
-kubectl delete virtualservice isvc-sklearn-external -n ${NAMESPACE} --ignore-not-found=true
-kubectl delete authorizationpolicy allow-kserve-access -n ${NAMESPACE} --ignore-not-found=true
-
 export KSERVE_INGRESS_HOST_PORT=${KSERVE_INGRESS_HOST_PORT:-localhost:8080}
 export KSERVE_M2M_TOKEN="$(kubectl -n ${NAMESPACE} create token default-editor)"
 export KSERVE_TEST_NAMESPACE=${NAMESPACE}
 
-echo "=== Creating AuthorizationPolicy for KServe access ==="
+# Run pytest first (creates and cleans up isvc-sklearn)
+cd ${TEST_DIRECTORY} && pytest . -vs --log-level info
+
+cat <<EOF | kubectl apply -f -
+apiVersion: "serving.kserve.io/v1beta1"
+kind: "InferenceService"
+metadata:
+  name: "test-sklearn"
+  namespace: ${NAMESPACE}
+spec:
+  predictor:
+    sklearn:
+      storageUri: "gs://kfserving-examples/models/sklearn/1.0/model"
+      resources:
+        requests:
+          cpu: 50m
+          memory: 128Mi
+        limits:
+          cpu: 100m
+          memory: 256Mi
+EOF
+
+kubectl wait --for=condition=Ready inferenceservice/test-sklearn -n ${NAMESPACE} --timeout=300s
+
 cat <<EOF | kubectl apply -f -
 apiVersion: security.istio.io/v1beta1
 kind: AuthorizationPolicy
 metadata:
-  name: allow-kserve-access
+  name: allow-test-sklearn
   namespace: ${NAMESPACE}
 spec:
   action: ALLOW
@@ -31,17 +50,14 @@ spec:
   - {}
   selector:
     matchLabels:
-      serving.knative.dev/service: isvc-sklearn-predictor
+      serving.knative.dev/service: test-sklearn-predictor
 EOF
 
-cd ${TEST_DIRECTORY} && pytest . -vs --log-level info
-
-echo "=== Setting up path-based routing VirtualService (no dedicated Gateway) ==="
 cat <<EOF | kubectl apply -f -
 apiVersion: networking.istio.io/v1beta1
 kind: VirtualService
 metadata:
-  name: isvc-sklearn-external
+  name: test-sklearn-external
   namespace: ${NAMESPACE}
 spec:
   gateways:
@@ -51,7 +67,7 @@ spec:
   http:
     - match:
         - uri:
-            prefix: /kserve/${NAMESPACE}/isvc-sklearn/
+            prefix: /kserve/${NAMESPACE}/test-sklearn/
       rewrite:
         uri: /
       route:
@@ -60,27 +76,27 @@ spec:
           headers:
             request:
               set:
-                Host: isvc-sklearn-predictor.${NAMESPACE}.svc.cluster.local
+                Host: test-sklearn-predictor.${NAMESPACE}.svc.cluster.local
           weight: 100
       timeout: 300s
 EOF
 
 sleep 10
 
-kubectl get pods -n ${NAMESPACE} -l serving.knative.dev/service=isvc-sklearn-predictor --show-labels
+kubectl get pods -n ${NAMESPACE} -l serving.knative.dev/service=test-sklearn-predictor --show-labels
 
 echo "Testing path-based access with valid token..."
 curl --fail --show-error \
  -H "Authorization: Bearer ${KSERVE_M2M_TOKEN}" \
  -H "Content-Type: application/json" \
- "http://${KSERVE_INGRESS_HOST_PORT}/kserve/${NAMESPACE}/isvc-sklearn/v1/models/isvc-sklearn:predict" \
+ "http://${KSERVE_INGRESS_HOST_PORT}/kserve/${NAMESPACE}/test-sklearn/v1/models/test-sklearn:predict" \
  -d '{"instances": [[6.8, 2.8, 4.8, 1.4], [6.0, 3.4, 4.5, 1.6]]}'
 
 echo "Testing 404 for incorrect path..."
 RESPONSE=$(curl -s -o /dev/null -w "%{http_code}" \
  -H "Authorization: Bearer ${KSERVE_M2M_TOKEN}" \
  -H "Content-Type: application/json" \
- "http://${KSERVE_INGRESS_HOST_PORT}/wrong-path/${NAMESPACE}/isvc-sklearn/v1/models/isvc-sklearn:predict" \
+ "http://${KSERVE_INGRESS_HOST_PORT}/wrong-path/${NAMESPACE}/test-sklearn/v1/models/test-sklearn:predict" \
  -d '{"instances": [[6.8, 2.8, 4.8, 1.4]]}')
 
 if [[ "$RESPONSE" == "404" ]]; then
@@ -91,12 +107,10 @@ fi
 
 echo "Testing direct service access still works..."
 curl --fail --show-error \
-  -H "Host: isvc-sklearn-predictor.${NAMESPACE}.example.com" \
+  -H "Host: test-sklearn-predictor.${NAMESPACE}.example.com" \
   -H "Authorization: Bearer ${KSERVE_M2M_TOKEN}" \
   -H "Content-Type: application/json" \
-  "http://${KSERVE_INGRESS_HOST_PORT}/v1/models/isvc-sklearn:predict" \
+  "http://${KSERVE_INGRESS_HOST_PORT}/v1/models/test-sklearn:predict" \
   -d '{"instances": [[6.8, 2.8, 4.8, 1.4]]}'
-
-echo "=== Path-based routing tests completed successfully ==="
 
 # TODO FOR FOLLOW-UP PR: Implement proper security with AuthorizationPolicy that restricts access

--- a/tests/kserve_test.sh
+++ b/tests/kserve_test.sh
@@ -78,20 +78,21 @@ spec:
       serving.knative.dev/service: test-sklearn-predictor
 EOF
 
-sleep 10
+sleep 30
 
 kubectl get authorizationpolicy -A | grep -E "(ALLOW|istio-system)"
 kubectl get authorizationpolicy -n istio-system -o yaml
+kubectl get requestauthentication -n istio-system -o yaml
 
 echo "Testing path-based access with valid token..."
-curl --fail --show-error \
+curl -v --fail --show-error \
  -H "Authorization: Bearer ${KSERVE_M2M_TOKEN}" \
  -H "Content-Type: application/json" \
  "http://${KSERVE_INGRESS_HOST_PORT}/kserve/${NAMESPACE}/test-sklearn/v1/models/test-sklearn:predict" \
  -d '{"instances": [[6.8, 2.8, 4.8, 1.4], [6.0, 3.4, 4.5, 1.6]]}'
 
 echo "Testing direct service access still works..."
-curl --fail --show-error \
+curl -v --fail --show-error \
   -H "Host: test-sklearn-predictor.${NAMESPACE}.example.com" \
   -H "Authorization: Bearer ${KSERVE_M2M_TOKEN}" \
   -H "Content-Type: application/json" \

--- a/tests/kserve_test.sh
+++ b/tests/kserve_test.sh
@@ -61,6 +61,8 @@ if ! command -v pytest &> /dev/null; then
   pip install -r ${TEST_DIRECTORY}/requirements.txt
 fi
 
+kubectl delete inferenceservice isvc-sklearn -n ${NAMESPACE} --ignore-not-found=true --timeout=60s
+
 export KSERVE_INGRESS_HOST_PORT=${KSERVE_INGRESS_HOST_PORT:-localhost:8080}
 export KSERVE_M2M_TOKEN="$(kubectl -n ${NAMESPACE} create token default-editor)"
 export KSERVE_TEST_NAMESPACE=${NAMESPACE}

--- a/tests/kserve_test.sh
+++ b/tests/kserve_test.sh
@@ -15,22 +15,32 @@ export KSERVE_M2M_TOKEN="$(kubectl -n ${NAMESPACE} create token default-editor)"
 export KSERVE_TEST_NAMESPACE=${NAMESPACE}
 
 cat <<EOF | kubectl apply -f -
-apiVersion: security.istio.io/v1beta1
-kind: AuthorizationPolicy
+apiVersion: networking.istio.io/v1beta1
+kind: VirtualService
 metadata:
-  name: allow-isvc-sklearn
+  name: test-sklearn-path
   namespace: ${NAMESPACE}
 spec:
-  action: ALLOW
-  rules:
-  - {}
-  selector:
-    matchLabels:
-      serving.knative.dev/service: isvc-sklearn-predictor
+  gateways:
+    - kubeflow/kubeflow-gateway
+  hosts:
+    - '*'
+  http:
+    - match:
+        - uri:
+            prefix: /kserve/${NAMESPACE}/test-sklearn/
+      rewrite:
+        uri: /
+      route:
+        - destination:
+            host: knative-local-gateway.istio-system.svc.cluster.local
+          headers:
+            request:
+              set:
+                Host: test-sklearn-predictor.${NAMESPACE}.svc.cluster.local
+          weight: 100
+      timeout: 300s
 EOF
-
-# Run pytest first (creates and cleans up isvc-sklearn)
-cd ${TEST_DIRECTORY} && pytest . -vs --log-level info
 
 cat <<EOF | kubectl apply -f -
 apiVersion: "serving.kserve.io/v1beta1"
@@ -68,39 +78,7 @@ spec:
       serving.knative.dev/service: test-sklearn-predictor
 EOF
 
-kubectl delete virtualservice test-sklearn-path -n ${NAMESPACE} --ignore-not-found=true
-
-cat <<EOF | kubectl apply -f -
-apiVersion: networking.istio.io/v1beta1
-kind: VirtualService
-metadata:
-  name: test-sklearn-path
-  namespace: ${NAMESPACE}
-spec:
-  gateways:
-    - kubeflow/kubeflow-gateway
-  hosts:
-    - '*'
-  http:
-    - match:
-        - uri:
-            prefix: /kserve/${NAMESPACE}/test-sklearn/
-      rewrite:
-        uri: /
-      route:
-        - destination:
-            host: knative-local-gateway.istio-system.svc.cluster.local
-          headers:
-            request:
-              set:
-                Host: test-sklearn-predictor.${NAMESPACE}.svc.cluster.local
-          weight: 100
-      timeout: 300s
-EOF
-
 sleep 10
-
-kubectl get pods -n ${NAMESPACE} -l serving.knative.dev/service=test-sklearn-predictor --show-labels
 
 echo "Testing path-based access with valid token..."
 curl --fail --show-error \
@@ -109,19 +87,6 @@ curl --fail --show-error \
  "http://${KSERVE_INGRESS_HOST_PORT}/kserve/${NAMESPACE}/test-sklearn/v1/models/test-sklearn:predict" \
  -d '{"instances": [[6.8, 2.8, 4.8, 1.4], [6.0, 3.4, 4.5, 1.6]]}'
 
-echo "Testing 404 for incorrect path..."
-RESPONSE=$(curl -s -o /dev/null -w "%{http_code}" \
- -H "Authorization: Bearer ${KSERVE_M2M_TOKEN}" \
- -H "Content-Type: application/json" \
- "http://${KSERVE_INGRESS_HOST_PORT}/wrong-path/${NAMESPACE}/test-sklearn/v1/models/test-sklearn:predict" \
- -d '{"instances": [[6.8, 2.8, 4.8, 1.4]]}')
-
-if [[ "$RESPONSE" == "404" ]]; then
-  echo "404 test passed - wrong path correctly rejected"
-else
-  echo "Expected 404, got $RESPONSE - path routing may be too permissive"
-fi
-
 echo "Testing direct service access still works..."
 curl --fail --show-error \
   -H "Host: test-sklearn-predictor.${NAMESPACE}.example.com" \
@@ -129,5 +94,23 @@ curl --fail --show-error \
   -H "Content-Type: application/json" \
   "http://${KSERVE_INGRESS_HOST_PORT}/v1/models/test-sklearn:predict" \
   -d '{"instances": [[6.8, 2.8, 4.8, 1.4]]}'
+
+# Create AuthorizationPolicy for pytest isvc-sklearn
+cat <<EOF | kubectl apply -f -
+apiVersion: security.istio.io/v1beta1
+kind: AuthorizationPolicy
+metadata:
+  name: allow-isvc-sklearn
+  namespace: ${NAMESPACE}
+spec:
+  action: ALLOW
+  rules:
+  - {}
+  selector:
+    matchLabels:
+      serving.knative.dev/service: isvc-sklearn-predictor
+EOF
+
+cd ${TEST_DIRECTORY} && pytest . -vs --log-level info
 
 # TODO FOR FOLLOW-UP PR: Implement proper security with AuthorizationPolicy that restricts access


### PR DESCRIPTION
## ✏️ Summary of Changes
Problem Statement
Input: User request to implement path-based routing for KServe inference services
Requirement: Enable custom URL paths like /serving/namespace/service/v1/models/... to route to KServe services

**Original**
Client → istio-ingressgateway → isvc-sklearn-predictor-ingress VS → Service

**New Path-Based Flow**
Client → istio-ingressgateway → kserve-path-gateway → kserve-path-routing VS → knative-local-gateway → Service


First Attempt: Direct VirtualService
**FAILED APPROACH**
```
apiVersion: networking.istio.io/v1beta1
kind: VirtualService
metadata:
  name: test-path-routing
spec:
  hosts: ["*"]  # Problem: Too broad
  gateways: ["kubeflow/kubeflow-gateway"]  # Problem: Conflicts with existing
```

**Issues Encountered:**

1. VirtualService Conflicts: Existing KServe VirtualServices matched first
2. Authority Matching: isvc-sklearn-predictor-ingress used authority prefix matching that intercepted requests
3. Processing Order: Istio processed VirtualServices alphabetically, causing conflicts

**Why New Host Creation?**

1. Conflict Avoidance: Existing VirtualServices match specific hosts
2. Clean Separation: Path-based routing isolated from native KServe routing
3. Precedence Control: Dedicated Gateway ensures our rules process first
4. Maintainability: No interference with KServe's auto-generated routing

```
apiVersion: networking.istio.io/v1beta1
kind: Gateway
metadata:
  name: kserve-path-gateway
spec:
  selector:
    istio: ingressgateway
  servers:
  - port:
      number: 80
      protocol: HTTP
    hosts:
    - "kserve-path.${NAMESPACE}.example.com"  # NEW HOST
```
**Step 2: Create Isolated VirtualService**

```
apiVersion: networking.istio.io/v1beta1
kind: VirtualService
metadata:
  name: kserve-path-routing
spec:
  gateways:
  - kserve-path-gateway  # DEDICATED GATEWAY
  hosts:
  - "kserve-path.${NAMESPACE}.example.com"  # MATCHES GATEWAY
  http:
  - match:
    - uri:
        prefix: /serving/${NAMESPACE}/isvc-sklearn/
    rewrite:
      uri: /  # STRIP PATH PREFIX
    route:
    - destination:
        host: knative-local-gateway.istio-system.svc.cluster.local
      headers:
        request:
          set:
            Host: isvc-sklearn-predictor.${NAMESPACE}.svc.cluster.local
```

Output: {"predictions":[1]}

## 📦 Dependencies
https://github.com/kubeflow/manifests/pull/3098


## ✅ Contributor Checklist
  - [x] I have tested these changes with kustomize. See [Installation Prerequisites](https://github.com/kubeflow/manifests#prerequisites).
  - [x] All commits are [_signed-off_](https://github.com/kubeflow/community/tree/master/dco-signoff-hook#signing-off-commits) to satisfy the DCO check.
  - [x] I have considered adding my company to the adopters page to support Kubeflow and help the community, since I expect help from the community for my issue (see [1.](https://github.com/kubeflow/community/issues/833) and [2.](https://github.com/kubeflow/community/blob/master/ADOPTERS.md#adopters-of-kubeflow-platform)).

---     
 
> You can join the CNCF Slack and access our meetings at the [Kubeflow Community](https://www.kubeflow.org/docs/about/community/) website. Our channel on the CNCF Slack is here [**#kubeflow-platform**](https://app.slack.com/client/T08PSQ7BQ/C073W572LA2).
  
