### PR TITLE
Correct Dex's issuer in README config example

### DIFF
--- a/README.md
+++ b/README.md
@@ -301,7 +301,7 @@ metadata:
   name: dex
 data:
   config.yaml: |
-    issuer: http://dex.auth.svc.cluster.local:5556/dex
+    issuer: https://$KUBEFLOW_INGRESS_URL/dex
     storage:
       type: kubernetes
       config:


### PR DESCRIPTION
# Pull Request Template for Kubeflow Manifests

## ✏️ Summary of Changes

This PR corrects an issue in the Dex configuration example within the [Dex section](https://github.com/kubeflow/manifests?tab=readme-ov-file#dex) of `README.md`. 

The example Dex configuration with Azure OIDC connector currently specifies:

* `issuer`: `http://dex.auth.svc.cluster.local:5556/dex`
* `connectors[0].config.redirectURI`: `https://$KUBEFLOW_INGRESS_URL/dex/callback`

This configuration creates a mismatch because Dex expects the callback URL to be `${issuer}/callback`. A typical error message resulting from this misconfiguration is:

```
connector returned error when creating callback" connector_id=azure err="expected callback URL \"http://dex.auth.svc.cluster.local:5556/dex/callback\" did not match the URL in the config \"https://$KUBEFLOW_INGRESS_URL/dex/callback\"
```

To resolve this and ensure correct operation, Dex's own `issuer` URL must align with its externally accessible endpoint, ensuring consistency with the `redirectURI` used by its connectors.

This alignment is not specific to Azure OIDC connector; it is a fundamental requirement for most Dex connectors (including Google, GitHub, etc.) to function correctly.

References:
* https://github.com/dexidp/dex/blob/v2.41.x/server/handlers.go#L261
* https://github.com/dexidp/dex/blob/v2.41.x/connector/oidc/oidc.go#L341-L343
* https://dexidp.io/docs/connectors/oidc/

## 📦 Dependencies

None.

## 🐛 Related Issues

None.

## ✅ Contributor Checklist
  - [x] I have tested these changes with kustomize. See [Installation Prerequisites](https://github.com/kubeflow/manifests#prerequisites).
  - [x] All commits are [_signed-off_](https://github.com/kubeflow/community/tree/master/dco-signoff-hook#signing-off-commits) to satisfy the DCO check.
  - [x] I have considered adding my company to the adopters page to support Kubeflow and help the community, since I expect help from the community for my issue (see [1.](https://github.com/kubeflow/community/issues/833) and [2.](https://github.com/kubeflow/community/blob/master/ADOPTERS.md#adopters-of-kubeflow-platform)).

---     
 
> You can join the CNCF Slack and access our meetings at the [Kubeflow Community](https://www.kubeflow.org/docs/about/community/) website. Our channel on the CNCF Slack is here [**#kubeflow-platform**](https://app.slack.com/client/T08PSQ7BQ/C073W572LA2).
  
