### PR TITLE
Fix sed pattern in spark-operator script

### DIFF
--- a/scripts/synchronize-spark-operator-manifests.sh
+++ b/scripts/synchronize-spark-operator-manifests.sh
@@ -45,9 +45,9 @@ echo "Successfully generated manifests."
 
 # Use OS-compatible sed command
 if [[ "$OSTYPE" == "darwin"* ]]; then
-    sed -i '' 's/Spark Operator[^|]*|[^|]*apps\/spark\/spark-operator[^|]*|[^|]*[0-9]\.[0-9]\.[0-9]/Spark Operator	|	apps\/spark\/spark-operator	|	'"${SPARK_OPERATOR_VERSION}"'/g' "${MANIFESTS_DIRECTORY}/README.md"
+    sed -i '' 's/Spark Operator[^|]*|[^|]*apps\/spark\/spark-operator[^|]*|[^|]*\[[0-9]\.[0-9]\.[0-9]\]([^)]*)/Spark Operator	|	apps\/spark\/spark-operator	|	['"${SPARK_OPERATOR_VERSION}"'](https:\/\/github.com\/kubeflow\/spark-operator\/tree\/v'"${SPARK_OPERATOR_VERSION}"')/g' "${MANIFESTS_DIRECTORY}/README.md"
 else
-    sed -i 's/Spark Operator.*|.*apps\/spark\/spark-operator[^|]*|.*[0-9]\.[0-9]\.[0-9]/Spark Operator	|	apps\/spark\/spark-operator	|	'"${SPARK_OPERATOR_VERSION}"'/g' "${MANIFESTS_DIRECTORY}/README.md"
+    sed -i 's/Spark Operator.*|.*apps\/spark\/spark-operator[^|]*|.*\[[0-9]\.[0-9]\.[0-9]\]([^)]*)/Spark Operator	|	apps\/spark\/spark-operator	|	['"${SPARK_OPERATOR_VERSION}"'](https:\/\/github.com\/kubeflow\/spark-operator\/tree\/v'"${SPARK_OPERATOR_VERSION}"')/g' "${MANIFESTS_DIRECTORY}/README.md"
 fi
 
 commit_changes "$MANIFESTS_DIRECTORY" "Update kubeflow/${COMPONENT_NAME} manifests to ${SPARK_OPERATOR_VERSION}" \


### PR DESCRIPTION
# Pull Request Template for Kubeflow Manifests

## ✏️ Summary of Changes
> Fix sed pattern in spark-operator script to properly handle markdown links in README.md

## 🐛 Related Issues
> [3146](https://github.com/kubeflow/manifests/pull/3146#discussion_r2114505041)

## ✅ Contributor Checklist
  - [ ] I have tested these changes with kustomize. See [Installation Prerequisites](https://github.com/kubeflow/manifests#prerequisites).
  - [ ] All commits are [_signed-off_](https://github.com/kubeflow/community/tree/master/dco-signoff-hook#signing-off-commits) to satisfy the DCO check.
  - [ ] I have considered adding my company to the adopters page to support Kubeflow and help the community, since I expect help from the community for my issue (see [1.](https://github.com/kubeflow/community/issues/833) and [2.](https://github.com/kubeflow/community/blob/master/ADOPTERS.md#adopters-of-kubeflow-platform)).

---     
 
> You can join the CNCF Slack and access our meetings at the [Kubeflow Community](https://www.kubeflow.org/docs/about/community/) website. Our channel on the CNCF Slack is here [**#kubeflow-platform**](https://app.slack.com/client/T08PSQ7BQ/C073W572LA2).
  
