### PR TITLE
Update trivy_scan.py

### DIFF
--- a/tests/trivy_install.sh
+++ b/tests/trivy_install.sh
@@ -1,4 +1,4 @@
 #!/bin/bash
 set -e
 
-curl -sfL https://raw.githubusercontent.com/aquasecurity/trivy/main/contrib/install.sh | sudo sh -s -- -b /usr/local/bin v0.48.3
+curl -sfL https://raw.githubusercontent.com/aquasecurity/trivy/main/contrib/install.sh | sudo sh -s -- -b /usr/local/bin v0.63.0

--- a/tests/trivy_scan.py
+++ b/tests/trivy_scan.py
@@ -25,7 +25,7 @@ wg_dirs = {
     "manifests": "../common/cert-manager/cert-manager/base ../common/cert-manager/kubeflow-issuer/base ../common/istio-1-24/istio-crds/base ../common/istio-1-24/istio-namespace/base ../common/istio-1-24/istio-install/overlays/oauth2-proxy ../common/oauth2-proxy/overlays/m2m-self-signed ../common/dex/overlays/oauth2-proxy ../common/knative/knative-serving/overlays/gateways ../common/knative/knative-eventing/base ../common/istio-1-24/cluster-local-gateway/base ../common/kubeflow-namespace/base ../common/kubeflow-roles/base ../common/istio-1-24/kubeflow-istio-resources/base",
     "workbenches": "../apps/pvcviewer-controller/upstream/base ../apps/admission-webhook/upstream/overlays ../apps/centraldashboard/overlays ../apps/jupyter/jupyter-web-app/upstream/overlays ../apps/volumes-web-app/upstream/overlays ../apps/tensorboard/tensorboards-web-app/upstream/overlays ../apps/profiles/upstream/overlays ../apps/jupyter/notebook-controller/upstream/overlays ../apps/tensorboard/tensorboard-controller/upstream/overlays",
     "kserve": "../apps/kserve - ../apps/kserve/models-web-app/overlays/kubeflow",
-    "model-registry": "../apps/model-registry/upstream",
+    "model-registry": "../apps/model-registry/upstream/overlays/db ../apps/model-registry/upstream/options/istio ../apps/model-registry/upstream/options/ui/overlays/istio",
     "spark": "../apps/spark/spark-operator/overlays/kubeflow",
 }
 


### PR DESCRIPTION
this should fix

```
Scanning  ghcr.io/kubeflow/model-registry/controller:latest
Error scanning ghcr.io/kubeflow/model-registry/controller:latest
2025-06-04T13:04:29.790Z	INFO	Vulnerability scanning is enabled
2025-06-04T13:04:29.790Z	INFO	Secret scanning is enabled
2025-06-04T13:04:29.790Z	INFO	If your scanning is slow, please try '--scanners vuln' to disable secret scanning
2025-06-04T13:04:29.790Z	INFO	Please see also https://aquasecurity.github.io/trivy/v0.48/docs/scanner/secret/#recommendation for faster secret detection
2025-06-04T13:04:29.849Z	FATAL	image scan error: scan error: unable to initialize a scanner: unable to initialize an image scanner: 4 errors occurred:
	* docker error: unable to inspect the image (ghcr.io/kubeflow/model-registry/controller:latest): Error response from daemon: No such image: ghcr.io/kubeflow/model-registry/controller:latest
	* containerd error: failed to initialize a containerd client: failed to dial "/run/containerd/containerd.sock": connection error: desc = "transport: error while dialing: dial unix /run/containerd/containerd.sock: connect: permission denied"
	* podman error: unable to initialize Podman client: no podman socket found: stat /run/user/1001/podman/podman.sock: no such file or directory
	* remote error: GET https://ghcr.io/token?scope=repository%3Akubeflow%2Fmodel-registry%2Fcontroller%3Apull&service=ghcr.io: DENIED: requested access to the resource is denied
```