### PR TITLE
Add swfs test to full_kubeflow_integration_test.yaml

### DIFF
--- a/.github/workflows/full_kubeflow_integration_test.yaml
+++ b/.github/workflows/full_kubeflow_integration_test.yaml
@@ -58,7 +58,7 @@ jobs:
     - name: Install KServe
       run: ./tests/kserve_install.sh
 
-    - name: Install Pipelines
+    - name: Install Pipelines with SeaweedFS
       run: ./tests/pipelines_swfs_install.sh
 
     - name: Create KF Profile

--- a/.github/workflows/full_kubeflow_integration_test.yaml
+++ b/.github/workflows/full_kubeflow_integration_test.yaml
@@ -59,7 +59,7 @@ jobs:
       run: ./tests/kserve_install.sh
 
     - name: Install Pipelines
-      run: ./tests/pipelines_install.sh
+      run: ./tests/pipelines_swfs_install.sh
 
     - name: Create KF Profile
       run: ./tests/kubeflow_profile_install.sh
@@ -111,6 +111,15 @@ jobs:
         pip3 install -q requests
         python3 tests/dex_login_test.py
         echo "Dex login test completed successfully."
+        
+    - name: Verify Pipeline Integration
+      run: |
+        KF_PROFILE=kubeflow-user-example-com
+        if ! kubectl get secret mlpipeline-minio-artifact -n $KF_PROFILE > /dev/null 2>&1; then
+          echo "Error: Secret mlpipeline-minio-artifact not found in namespace $KF_PROFILE"
+          exit 1
+        fi
+        kubectl get secret mlpipeline-minio-artifact -n "$KF_PROFILE" -o json | jq -r '.data | keys[] as $k | "\($k): \(. | .[$k] | @base64d)"' | tr '\n' ' '
 
     - name: V1 Pipeline Test
       run: |
@@ -130,6 +139,9 @@ jobs:
         kubectl create serviceaccount test-unauthorized -n test-unauthorized
         UNAUTHORIZED_TOKEN=$(kubectl -n test-unauthorized create token test-unauthorized)
         python3 tests/pipeline_v2_test.py test_unauthorized_access "$UNAUTHORIZED_TOKEN" "${KF_PROFILE}"
+
+    - name: Test SeaweedFS Namespace Isolation
+      run: ./tests/swfs_namespace_isolation_test.sh
 
     - name: Test Volumes Web Application API
       run: ./tests/volumes_web_application_test.sh "${KF_PROFILE}"

--- a/.github/workflows/full_kubeflow_integration_test.yaml
+++ b/.github/workflows/full_kubeflow_integration_test.yaml
@@ -58,6 +58,9 @@ jobs:
     - name: Install KServe
       run: ./tests/kserve_install.sh
 
+    #- name: Install Pipelines
+    #  run: ./tests/pipelines_install.sh
+
     - name: Install Pipelines with SeaweedFS
       run: ./tests/pipelines_swfs_install.sh
 

--- a/.github/workflows/full_kubeflow_integration_test.yaml
+++ b/.github/workflows/full_kubeflow_integration_test.yaml
@@ -111,7 +111,7 @@ jobs:
         pip3 install -q requests
         python3 tests/dex_login_test.py
         echo "Dex login test completed successfully."
-        
+
     - name: Verify Pipeline Integration
       run: |
         KF_PROFILE=kubeflow-user-example-com


### PR DESCRIPTION
# Pull Request Template for Kubeflow Manifests

## ✏️ Summary of Changes
- Add pipelines swfs test to full_kubeflow_integration_test.yaml

## 📦 Dependencies
> List any dependencies or related PRs (e.g., "Depends on #123").

## 🐛 Related Issues
- part of https://github.com/kubeflow/manifests/issues/3119

## ✅ Contributor Checklist
  - [ ] I have tested these changes with kustomize. See [Installation Prerequisites](https://github.com/kubeflow/manifests#prerequisites).
  - [ ] All commits are [_signed-off_](https://github.com/kubeflow/community/tree/master/dco-signoff-hook#signing-off-commits) to satisfy the DCO check.
  - [ ] I have considered adding my company to the adopters page to support Kubeflow and help the community, since I expect help from the community for my issue (see [1.](https://github.com/kubeflow/community/issues/833) and [2.](https://github.com/kubeflow/community/blob/master/ADOPTERS.md#adopters-of-kubeflow-platform)).

---     
 
> You can join the CNCF Slack and access our meetings at the [Kubeflow Community](https://www.kubeflow.org/docs/about/community/) website. Our channel on the CNCF Slack is here [**#kubeflow-platform**](https://app.slack.com/client/T08PSQ7BQ/C073W572LA2).
  
