### PR TITLE
Update Kind and Kubernetes version to latest

### DIFF
--- a/tests/install_KinD_create_KinD_cluster_install_kustomize.sh
+++ b/tests/install_KinD_create_KinD_cluster_install_kustomize.sh
@@ -20,7 +20,7 @@ if [ -e /swapfile ]; then
 fi
 
 {
-    curl -Lo ./kind https://kind.sigs.k8s.io/dl/v0.27.0/kind-linux-amd64
+    curl -Lo ./kind https://kind.sigs.k8s.io/dl/v0.29.0/kind-linux-amd64
     chmod +x ./kind
     sudo mv kind /usr/local/bin
 } || { echo "Failed to install KinD"; exit 1; }
@@ -49,11 +49,11 @@ kubeadmConfigPatches:
         \"service-account-signing-key-file\": \"/etc/kubernetes/pki/sa.key\"
 nodes:
 - role: control-plane
-  image: kindest/node:v1.32.2@sha256:f226345927d7e348497136874b6d207e0b32cc52154ad8323129352923a3142f
+  image: kindest/node:v1.33.1@sha256:050072256b9a903bd914c0b2866828150cb229cea0efe5892e2b644d5dd3b34f
 - role: worker
-  image: kindest/node:v1.32.2@sha256:f226345927d7e348497136874b6d207e0b32cc52154ad8323129352923a3142f
+  image: kindest/node:v1.33.1@sha256:050072256b9a903bd914c0b2866828150cb229cea0efe5892e2b644d5dd3b34f
 - role: worker
-  image: kindest/node:v1.32.2@sha256:f226345927d7e348497136874b6d207e0b32cc52154ad8323129352923a3142f
+  image: kindest/node:v1.33.1@sha256:050072256b9a903bd914c0b2866828150cb229cea0efe5892e2b644d5dd3b34f
 " | kind create cluster --config - --wait 120s
 
 kubectl cluster-info


### PR DESCRIPTION
# Pull Request Template for Kubeflow Manifests

## ✏️ Summary of Changes
> Update Kind to v0.29.0
> Update Kubernetes 1.33.1


## ✅ Contributor Checklist
  - [ ] I have tested these changes with kustomize. See [Installation Prerequisites](https://github.com/kubeflow/manifests#prerequisites).
  - [x] All commits are [_signed-off_](https://github.com/kubeflow/community/tree/master/dco-signoff-hook#signing-off-commits) to satisfy the DCO check.
  - [ ] I have considered adding my company to the adopters page to support Kubeflow and help the community, since I expect help from the community for my issue (see [1.](https://github.com/kubeflow/community/issues/833) and [2.](https://github.com/kubeflow/community/blob/master/ADOPTERS.md#adopters-of-kubeflow-platform)).

---     
 
> You can join the CNCF Slack and access our meetings at the [Kubeflow Community](https://www.kubeflow.org/docs/about/community/) website. Our channel on the CNCF Slack is here [**#kubeflow-platform**](https://app.slack.com/client/T08PSQ7BQ/C073W572LA2).
  
