### PR TITLE
knative and cluster-local-gateway confusion

### DIFF
--- a/common/istio/cluster-local-gateway/README.md
+++ b/common/istio/cluster-local-gateway/README.md
@@ -27,9 +27,10 @@ When investigating the gateway architecture, you'll notice that:
 
 ### Why This Design?
 
-- **Backward Compatibility**: KServe has hardcoded references to `knative-local-gateway` throughout its configuration
-- **Abstraction Layer**: This allows the underlying implementation to change without breaking KServe
-- **Single Gateway**: Reduces resource usage by having one set of gateway pods handle both names
+- **KServe Configuration**: KServe's ingress configuration explicitly references `knative-local-gateway` in its ConfigMap
+- **Knative Integration**: Knative Serving creates the `knative-local-gateway` service by default
+- **Resource Optimization**: Instead of running separate gateway pods, Kubeflow redirects the service to use existing `cluster-local-gateway` pods
+- **Abstraction Layer**: This allows KServe to use its expected service name while leveraging Kubeflow's gateway infrastructure
 
 ### Verification
 


### PR DESCRIPTION
## ✏️ Summary of Changes
  The investigation confirms that:
  1. The knative-local-gateway service intentionally routes to cluster-local-gateway pods
  2. This is a design choice for backward compatibility with KServe
  3. No changes to the code are needed - the architecture is working as intended

  The documentation explains this potentially confusing architecture for future contributors.
## 📦 Dependencies
none
## 🐛 Related Issues
 https://github.com/kubeflow/manifests/pull/3098
## ✅ Contributor Checklist
  - [x] I have tested these changes with kustomize. See [Installation Prerequisites](https://github.com/kubeflow/manifests#prerequisites).
  - [x] All commits are [_signed-off_](https://github.com/kubeflow/community/tree/master/dco-signoff-hook#signing-off-commits) to satisfy the DCO check.
  - [x] I have considered adding my company to the adopters page to support Kubeflow and help the community, since I expect help from the community for my issue (see [1.](https://github.com/kubeflow/community/issues/833) and [2.](https://github.com/kubeflow/community/blob/master/ADOPTERS.md#adopters-of-kubeflow-platform)).

---     
 
> You can join the CNCF Slack and access our meetings at the [Kubeflow Community](https://www.kubeflow.org/docs/about/community/) website. Our channel on the CNCF Slack is here [**#kubeflow-platform**](https://app.slack.com/client/T08PSQ7BQ/C073W572LA2).
  
