### PR TITLE
Added the GHA permissions

### DIFF
--- a/.github/workflows/admission_webhook_test.yaml
+++ b/.github/workflows/admission_webhook_test.yaml
@@ -9,6 +9,10 @@ on:
     - common/cert-manager/**
     - common/istio*/**
 
+permissions:
+  contents: read
+  actions: read
+
 jobs:
   build:
     runs-on: ubuntu-latest

--- a/.github/workflows/centraldashboard_test.yaml
+++ b/.github/workflows/centraldashboard_test.yaml
@@ -8,6 +8,10 @@ on:
     - tests/istio*
     - common/istio*/**
 
+permissions:
+  contents: read
+  actions: read
+
 jobs:
   build:
     runs-on: ubuntu-latest

--- a/.github/workflows/dex_oauth2-proxy_test.yaml
+++ b/.github/workflows/dex_oauth2-proxy_test.yaml
@@ -12,6 +12,10 @@ on:
     - tests/istio*
     - tests/dex_login_test.py
 
+permissions:
+  contents: read
+  actions: read
+
 jobs:
   build:
     runs-on: ubuntu-latest

--- a/.github/workflows/full_kubeflow_integration_test.yaml
+++ b/.github/workflows/full_kubeflow_integration_test.yaml
@@ -8,6 +8,10 @@ on:
     branches:
     - master
 
+permissions:
+  contents: read
+  actions: read
+
 env:
   KF_PROFILE: kubeflow-user-example-com
 

--- a/.github/workflows/istio_validation.yaml
+++ b/.github/workflows/istio_validation.yaml
@@ -9,6 +9,10 @@ on:
     - common/istio/**
     - common/cert-manager/**
 
+permissions:
+  contents: read
+  actions: read
+
 env:
   KF_PROFILE: kubeflow-user-example-com
 

--- a/.github/workflows/jupyter_web_application_test.yaml
+++ b/.github/workflows/jupyter_web_application_test.yaml
@@ -8,6 +8,10 @@ on:
     - tests/istio*
     - common/istio*/**
 
+permissions:
+  contents: read
+  actions: read
+
 jobs:
   build:
     runs-on: ubuntu-latest

--- a/.github/workflows/katib_test.yaml
+++ b/.github/workflows/katib_test.yaml
@@ -11,6 +11,10 @@ on:
     - common/cert-manager/**
     - experimental/security/PSS/*
 
+permissions:
+  contents: read
+  actions: read
+
 env:
   KF_PROFILE: kubeflow-user-example-com
 

--- a/.github/workflows/kserve_test.yaml
+++ b/.github/workflows/kserve_test.yaml
@@ -16,6 +16,10 @@ on:
     - common/knative/**
     - tests/knative-cni_install.sh
 
+permissions:
+  contents: read
+  actions: read
+
 jobs:
   build:
     runs-on: ubuntu-latest

--- a/.github/workflows/linting_bash_python_yaml_files.yaml
+++ b/.github/workflows/linting_bash_python_yaml_files.yaml
@@ -2,6 +2,10 @@ name: Proper linting on Bash, Python, and YAML files
 
 on: [pull_request]
 
+permissions:
+  contents: read
+  actions: read
+
 jobs:
   format_python_files:
     runs-on: ubuntu-latest

--- a/.github/workflows/manifests_example_test.yaml
+++ b/.github/workflows/manifests_example_test.yaml
@@ -4,6 +4,10 @@ on:
 - push
 - pull_request
 
+permissions:
+  contents: read
+  actions: read
+
 jobs:
   build:
     name: Test

--- a/.github/workflows/model_registry_test.yaml
+++ b/.github/workflows/model_registry_test.yaml
@@ -10,6 +10,10 @@ on:
     - tests/istio*
     - common/istio*/**
 
+permissions:
+  contents: read
+  actions: read
+
 jobs:
   build-kfmr:
     runs-on: ubuntu-latest

--- a/.github/workflows/notebook_controller_test.yaml
+++ b/.github/workflows/notebook_controller_test.yaml
@@ -11,6 +11,10 @@ on:
     - tests/oauth2-proxy_install.sh
     - tests/multi_tenancy_install.sh
 
+permissions:
+  contents: read
+  actions: read
+
 jobs:
   build:
     runs-on: ubuntu-latest

--- a/.github/workflows/pipeline_run_from_notebook.yaml
+++ b/.github/workflows/pipeline_run_from_notebook.yaml
@@ -13,6 +13,9 @@ on:
     - common/kubeflow-namespace/**
     - applications/jupyter/**
 
+permissions:
+  contents: read
+  actions: read
 jobs:
   build:
     runs-on: ubuntu-latest

--- a/.github/workflows/pipeline_swfs_test.yaml
+++ b/.github/workflows/pipeline_swfs_test.yaml
@@ -15,6 +15,9 @@ on:
     - tests/swfs_namespace_isolation_test.sh
     - tests/s3_helper_test.py
 
+permissions:
+  contents: read
+  actions: read
 jobs:
   build:
     timeout-minutes: 15

--- a/.github/workflows/pipeline_test.yaml
+++ b/.github/workflows/pipeline_test.yaml
@@ -14,6 +14,9 @@ on:
     - tests/pipeline_v2_test.py
     - experimental/security/PSS/*
 
+permissions:
+  contents: read
+  actions: read
 env:
   KF_PROFILE: kubeflow-user-example-com
 

--- a/.github/workflows/profiles_test.yaml
+++ b/.github/workflows/profiles_test.yaml
@@ -8,6 +8,9 @@ on:
     - tests/istio*
     - common/istio*/**
 
+permissions:
+  contents: read
+  actions: read
 jobs:
   build:
     runs-on: ubuntu-latest

--- a/.github/workflows/ray_test.yaml
+++ b/.github/workflows/ray_test.yaml
@@ -11,6 +11,9 @@ on:
     - common/oauth2-proxy/**
     - common/istio*/**
 
+permissions:
+  contents: read
+  actions: read
 jobs:
   build:
     runs-on: ubuntu-latest

--- a/.github/workflows/spark_test.yaml
+++ b/.github/workflows/spark_test.yaml
@@ -12,6 +12,10 @@ on:
     - common/oauth2-proxy/**
     - common/istio*/**
 
+permissions:
+  contents: read
+  actions: read
+
 jobs:
   build:
     runs-on: ubuntu-latest

--- a/.github/workflows/tensorboard_controller_test.yaml
+++ b/.github/workflows/tensorboard_controller_test.yaml
@@ -8,6 +8,10 @@ on:
     - tests/istio*
     - common/istio*/**
 
+permissions:
+  contents: read
+  actions: read
+
 jobs:
   build:
     runs-on: ubuntu-latest

--- a/.github/workflows/tensorboards_web_application_test.yaml
+++ b/.github/workflows/tensorboards_web_application_test.yaml
@@ -8,6 +8,10 @@ on:
     - tests/istio*
     - common/istio*/**
 
+permissions:
+  contents: read
+  actions: read
+
 jobs:
   build:
     runs-on: ubuntu-latest

--- a/.github/workflows/training_operator_test.yaml
+++ b/.github/workflows/training_operator_test.yaml
@@ -13,6 +13,10 @@ on:
     - common/istio*/**
     - experimental/security/PSS/*
 
+permissions:
+  contents: read
+  actions: read
+
 env:
   KF_PROFILE: kubeflow-user-example-com
 

--- a/.github/workflows/trivy.yaml
+++ b/.github/workflows/trivy.yaml
@@ -9,6 +9,10 @@ on:
     - '.github/workflows/trivy.yaml'
     - 'tests/trivy_scan.py'
 
+permissions:
+  contents: read
+  actions: read
+
 jobs:
   image-extraction-and-security-scan:
     if: ${{ github.repository == 'kubeflow/manifests' }}

--- a/.github/workflows/volumes_web_application_test.yaml
+++ b/.github/workflows/volumes_web_application_test.yaml
@@ -13,6 +13,10 @@ on:
     - tests/volumes_web_application_install.sh
     - tests/volumes_web_application_test.sh
 
+permissions:
+  contents: read
+  actions: read
+
 env:
   KF_PROFILE: kubeflow-user-example-com
 


### PR DESCRIPTION
# Pull Request Template for Kubeflow Manifests

## ✏️ Summary of Changes
> Added the permissions to the gha workflows.

## ✅ Contributor Checklist
  - [ ] I have tested these changes with kustomize. See [Installation Prerequisites](https://github.com/kubeflow/manifests#prerequisites).
  - [x] All commits are [_signed-off_](https://github.com/kubeflow/community/tree/master/dco-signoff-hook#signing-off-commits) to satisfy the DCO check.
  - [ ] I have considered adding my company to the adopters page to support Kubeflow and help the community, since I expect help from the community for my issue (see [1.](https://github.com/kubeflow/community/issues/833) and [2.](https://github.com/kubeflow/community/blob/master/ADOPTERS.md#adopters-of-kubeflow-platform)).

---     
 
> You can join the CNCF Slack and access our meetings at the [Kubeflow Community](https://www.kubeflow.org/docs/about/community/) website. Our channel on the CNCF Slack is here [**#kubeflow-platform**](https://app.slack.com/client/T08PSQ7BQ/C073W572LA2).
  
