### PR TITLE
Migrate busybox image to ghcr

### DIFF
--- a/common/istio/istio-install/base/kustomization.yaml
+++ b/common/istio/istio-install/base/kustomization.yaml
@@ -20,4 +20,4 @@ patches:
 
 images:
 - name: busybox
-  newName: registry.k8s.io/busybox
+  newName: ghcr.io/containerd/busybox


### PR DESCRIPTION
# Pull Request Template for Kubeflow Manifests

## ✏️ Summary of Changes
- Migrated busybox image form `registry.k8s.io/busybox` to `ghcr.io/containerd/busybox`

## 📦 Dependencies
> List any dependencies or related PRs (e.g., "Depends on #123").

## 🐛 Related Issues
- https://github.com/kubeflow/manifests/issues/3171

## ✅ Contributor Checklist
  - [ ] I have tested these changes with kustomize. See [Installation Prerequisites](https://github.com/kubeflow/manifests#prerequisites).
  - [ ] All commits are [_signed-off_](https://github.com/kubeflow/community/tree/master/dco-signoff-hook#signing-off-commits) to satisfy the DCO check.
  - [ ] I have considered adding my company to the adopters page to support Kubeflow and help the community, since I expect help from the community for my issue (see [1.](https://github.com/kubeflow/community/issues/833) and [2.](https://github.com/kubeflow/community/blob/master/ADOPTERS.md#adopters-of-kubeflow-platform)).

---     
 
> You can join the CNCF Slack and access our meetings at the [Kubeflow Community](https://www.kubeflow.org/docs/about/community/) website. Our channel on the CNCF Slack is here [**#kubeflow-platform**](https://app.slack.com/client/T08PSQ7BQ/C073W572LA2).
  
