### PR TITLE
Sync Script Trainer2.0

### DIFF
--- a/scripts/synchronize-training-operator-manifests.sh
+++ b/scripts/synchronize-training-operator-manifests.sh
@@ -7,10 +7,10 @@ source "${SCRIPT_DIRECTORY}/library.sh"
 setup_error_handling
 
 COMPONENT_NAME="training-operator"
-REPOSITORY_NAME="kubeflow/training-operator"
-REPOSITORY_URL="https://github.com/kubeflow/training-operator.git"
-COMMIT="v1.9.2"
-REPOSITORY_DIRECTORY="training-operator"
+REPOSITORY_NAME="kubeflow/trainer"
+REPOSITORY_URL="https://github.com/kubeflow/trainer.git"
+COMMIT="v2.0.0-rc.0"
+REPOSITORY_DIRECTORY="trainer"
 SOURCE_DIRECTORY=${SOURCE_DIRECTORY:=/tmp/kubeflow-${COMPONENT_NAME}}
 BRANCH_NAME=${BRANCH_NAME:=synchronize-${COMPONENT_NAME}-manifests-${COMMIT?}}
 


### PR DESCRIPTION
# Pull Request Template for Kubeflow Manifests

## ✏️ Summary of Changes
> Update the trainer sync script to 2.0

## ✅ Contributor Checklist
  - [ ] I have tested these changes with kustomize. See [Installation Prerequisites](https://github.com/kubeflow/manifests#prerequisites).
  - [ ] All commits are [_signed-off_](https://github.com/kubeflow/community/tree/master/dco-signoff-hook#signing-off-commits) to satisfy the DCO check.
  - [ ] I have considered adding my company to the adopters page to support Kubeflow and help the community, since I expect help from the community for my issue (see [1.](https://github.com/kubeflow/community/issues/833) and [2.](https://github.com/kubeflow/community/blob/master/ADOPTERS.md#adopters-of-kubeflow-platform)).

---     
 
> You can join the CNCF Slack and access our meetings at the [Kubeflow Community](https://www.kubeflow.org/docs/about/community/) website. Our channel on the CNCF Slack is here [**#kubeflow-platform**](https://app.slack.com/client/T08PSQ7BQ/C073W572LA2).
  
