### PR TITLE
Add synchronization scripts for Dex and OAuth2-Proxy manifests

### DIFF
--- a/scripts/synchronize-dex-manifests.sh
+++ b/scripts/synchronize-dex-manifests.sh
@@ -1,0 +1,42 @@
+#!/usr/bin/env bash
+# This script helps to create a PR to update the Dex manifests
+
+SCRIPT_DIRECTORY=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
+source "${SCRIPT_DIRECTORY}/library.sh"
+
+setup_error_handling
+
+COMPONENT_NAME="dex"
+DEX_RELEASE="v2.41.1" # Must be a release
+BRANCH_NAME=${BRANCH_NAME:=synchronize-${COMPONENT_NAME}-manifests-${DEX_RELEASE?}}
+
+MANIFESTS_DIRECTORY=$(dirname $SCRIPT_DIRECTORY)
+DESTINATION_DIRECTORY=$MANIFESTS_DIRECTORY/common/${COMPONENT_NAME}
+
+create_branch "$BRANCH_NAME"
+
+check_uncommitted_changes
+
+echo "Updating Dex image tag to ${DEX_RELEASE}..."
+
+if [[ "$OSTYPE" == "darwin"* ]]; then
+    sed -i "" "s|ghcr.io/dexidp/dex:v[0-9.]*|ghcr.io/dexidp/dex:${DEX_RELEASE}|g" \
+        $DESTINATION_DIRECTORY/base/deployment.yaml
+else
+    sed -i "s|ghcr.io/dexidp/dex:v[0-9.]*|ghcr.io/dexidp/dex:${DEX_RELEASE}|g" \
+        $DESTINATION_DIRECTORY/base/deployment.yaml
+fi
+
+if [[ "$OSTYPE" == "darwin"* ]]; then
+    sed -i "" '/| Dex | common\/dex |/s|\[.*\](https://github.com/dexidp/dex/releases/tag/v.*)|['"${DEX_RELEASE#v}"'](https://github.com/dexidp/dex/releases/tag/'"${DEX_RELEASE}"')|' \
+        ${MANIFESTS_DIRECTORY}/README.md
+else
+    sed -i '/| Dex | common\/dex |/s|\[.*\](https://github.com/dexidp/dex/releases/tag/v.*)|['"${DEX_RELEASE#v}"'](https://github.com/dexidp/dex/releases/tag/'"${DEX_RELEASE}"')|' \
+        ${MANIFESTS_DIRECTORY}/README.md
+fi
+
+commit_changes "$MANIFESTS_DIRECTORY" "Update common/dex manifests to ${DEX_RELEASE}" \
+  "$DESTINATION_DIRECTORY" \
+  "README.md"
+
+echo "Synchronization completed successfully." 

--- a/scripts/synchronize-oauth2-proxy-manifests.sh
+++ b/scripts/synchronize-oauth2-proxy-manifests.sh
@@ -1,0 +1,42 @@
+#!/usr/bin/env bash
+# This script helps to create a PR to update the OAuth2-Proxy manifests
+
+SCRIPT_DIRECTORY=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
+source "${SCRIPT_DIRECTORY}/library.sh"
+
+setup_error_handling
+
+COMPONENT_NAME="oauth2-proxy"
+OAUTH2_PROXY_RELEASE="v7.7.1" # Must be a release
+BRANCH_NAME=${BRANCH_NAME:=synchronize-${COMPONENT_NAME}-manifests-${OAUTH2_PROXY_RELEASE?}}
+
+MANIFESTS_DIRECTORY=$(dirname $SCRIPT_DIRECTORY)
+DESTINATION_DIRECTORY=$MANIFESTS_DIRECTORY/common/${COMPONENT_NAME}
+
+create_branch "$BRANCH_NAME"
+
+check_uncommitted_changes
+
+echo "Updating OAuth2-Proxy image tag to ${OAUTH2_PROXY_RELEASE}..."
+
+if [[ "$OSTYPE" == "darwin"* ]]; then
+    sed -i "" "s|quay.io/oauth2-proxy/oauth2-proxy:.*|quay.io/oauth2-proxy/oauth2-proxy:${OAUTH2_PROXY_RELEASE}|g" \
+        $DESTINATION_DIRECTORY/base/deployment.yaml
+else
+    sed -i "s|quay.io/oauth2-proxy/oauth2-proxy:.*|quay.io/oauth2-proxy/oauth2-proxy:${OAUTH2_PROXY_RELEASE}|g" \
+        $DESTINATION_DIRECTORY/base/deployment.yaml
+fi
+
+if [[ "$OSTYPE" == "darwin"* ]]; then
+    sed -i "" '/| OAuth2-Proxy | common\/oauth2-proxy |/s|\[.*\](https://github.com/oauth2-proxy/oauth2-proxy/releases/tag/v.*)|['"${OAUTH2_PROXY_RELEASE#v}"'](https://github.com/oauth2-proxy/oauth2-proxy/releases/tag/'"${OAUTH2_PROXY_RELEASE}"')|' \
+        ${MANIFESTS_DIRECTORY}/README.md
+else
+    sed -i '/| OAuth2-Proxy | common\/oauth2-proxy |/s|\[.*\](https://github.com/oauth2-proxy/oauth2-proxy/releases/tag/v.*)|['"${OAUTH2_PROXY_RELEASE#v}"'](https://github.com/oauth2-proxy/oauth2-proxy/releases/tag/'"${OAUTH2_PROXY_RELEASE}"')|' \
+        ${MANIFESTS_DIRECTORY}/README.md
+fi
+
+commit_changes "$MANIFESTS_DIRECTORY" "Update common/oauth2-proxy manifests to ${OAUTH2_PROXY_RELEASE}" \
+  "$DESTINATION_DIRECTORY" \
+  "README.md"
+
+echo "Synchronization completed successfully." 


### PR DESCRIPTION
# Pull Request Template for Kubeflow Manifests

## ✏️ Summary of Changes
- Created scripts/synchronize-dex-manifests.sh to update Dex image tags and documentation
- Created scripts/synchronize-oauth2-proxy-manifests.sh for OAuth2-Proxy version management

## ✅ Contributor Checklist
  - [ ] I have tested these changes with kustomize. See [Installation Prerequisites](https://github.com/kubeflow/manifests#prerequisites).
  - [ ] All commits are [_signed-off_](https://github.com/kubeflow/community/tree/master/dco-signoff-hook#signing-off-commits) to satisfy the DCO check.
  - [ ] I have considered adding my company to the adopters page to support Kubeflow and help the community, since I expect help from the community for my issue (see [1.](https://github.com/kubeflow/community/issues/833) and [2.](https://github.com/kubeflow/community/blob/master/ADOPTERS.md#adopters-of-kubeflow-platform)).

---     
 
> You can join the CNCF Slack and access our meetings at the [Kubeflow Community](https://www.kubeflow.org/docs/about/community/) website. Our channel on the CNCF Slack is here [**#kubeflow-platform**](https://app.slack.com/client/T08PSQ7BQ/C073W572LA2).
  
