### PR TITLE
TrainJob support to Katib Trial Templates

### DIFF
--- a/applications/katib/upstream/components/controller/rbac.yaml
+++ b/applications/katib/upstream/components/controller/rbac.yaml
@@ -91,6 +91,16 @@ rules:
       - "create"
       - "delete"
   - apiGroups:
+    - trainer.kubeflow.org
+    resources:
+    - trainjobs
+    verbs:
+    - "get"
+    - "list"
+    - "watch"
+    - "create"
+    - "delete"
+  - apiGroups:
       - kubeflow.org
     resources:
       - tfjobs

--- a/experimental/helm/charts/katib/templates/controller/rbac.yaml
+++ b/experimental/helm/charts/katib/templates/controller/rbac.yaml
@@ -93,6 +93,16 @@ rules:
   - "create"
   - "delete"
 - apiGroups:
+  - trainer.kubeflow.org
+  resources:
+  - trainjobs
+  verbs:
+  - "get"
+  - "list"
+  - "watch"
+  - "create"
+  - "delete"
+- apiGroups:
   - kubeflow.org
   resources:
   - tfjobs


### PR DESCRIPTION
# Pull Request Template for Kubeflow Manifests

## ✏️ Summary of Changes
> Describe the changes you have made, including any refactoring or feature additions.

Adding TrainJob support to Katib Trial Templates.
https://github.com/kubeflow/katib/pull/2560

## 📦 Dependencies
> List any dependencies or related PRs (e.g., "Depends on #123").

## 🐛 Related Issues
> Link any issues that are resolved or affected by this PR.

## ✅ Contributor Checklist
  - [x] I have tested these changes with kustomize. See [Installation Prerequisites](https://github.com/kubeflow/manifests#prerequisites).
  - [x] All commits are [_signed-off_](https://github.com/kubeflow/community/tree/master/dco-signoff-hook#signing-off-commits) to satisfy the DCO check.
  - [x] I have considered adding my company to the adopters page to support Kubeflow and help the community, since I expect help from the community for my issue (see [1.](https://github.com/kubeflow/community/issues/833) and [2.](https://github.com/kubeflow/community/blob/master/ADOPTERS.md#adopters-of-kubeflow-platform)).

---     
 
> You can join the CNCF Slack and access our meetings at the [Kubeflow Community](https://www.kubeflow.org/docs/about/community/) website. Our channel on the CNCF Slack is here [**#kubeflow-platform**](https://app.slack.com/client/T08PSQ7BQ/C073W572LA2).
  
