### PR TITLE
Deny All Network Policies for the namespaces knative-serving oauth2-proxy cert-manager istio-system auth

### DIFF
--- a/common/networkpolicies/base/cert-manager-webhook.yaml
+++ b/common/networkpolicies/base/cert-manager-webhook.yaml
@@ -1,0 +1,24 @@
+kind: NetworkPolicy
+apiVersion: networking.k8s.io/v1
+metadata:
+  name: cert-manager-webhook
+  namespace: cert-manager
+spec:
+  podSelector:
+    matchExpressions:
+    - key: app.kubernetes.io/name
+      operator: In
+      values:
+      - webhook
+    - key: app.kubernetes.io/component
+      operator: In
+      values:
+      - "webhook"
+  # https://www.elastic.co/guide/en/cloud-on-k8s/1.1/k8s-webhook-network-policies.html
+  # The kubernetes api server must reach the webhook
+  ingress:
+  - ports:
+    - protocol: TCP
+      port: 10250
+  policyTypes:
+  - Ingress

--- a/common/networkpolicies/base/default-allow-same-namespace-auth.yaml
+++ b/common/networkpolicies/base/default-allow-same-namespace-auth.yaml
@@ -1,0 +1,12 @@
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: default-allow-same-namespace-auth
+  namespace: auth
+spec:
+  podSelector: {}
+  ingress:
+  - from:
+    - podSelector: {}
+  policyTypes:
+  - Ingress

--- a/common/networkpolicies/base/default-allow-same-namespace-cert-manager.yaml
+++ b/common/networkpolicies/base/default-allow-same-namespace-cert-manager.yaml
@@ -1,0 +1,12 @@
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: default-allow-same-namespace-cert-manager
+  namespace: cert-manager
+spec:
+  podSelector: {}
+  ingress:
+  - from:
+    - podSelector: {}
+  policyTypes:
+  - Ingress

--- a/common/networkpolicies/base/default-allow-same-namespace-istio-system.yaml
+++ b/common/networkpolicies/base/default-allow-same-namespace-istio-system.yaml
@@ -1,0 +1,12 @@
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: default-allow-same-namespace-istio-system
+  namespace: istio-system
+spec:
+  podSelector: {}
+  ingress:
+  - from:
+    - podSelector: {}
+  policyTypes:
+  - Ingress

--- a/common/networkpolicies/base/default-allow-same-namespace-knative-serving.yaml
+++ b/common/networkpolicies/base/default-allow-same-namespace-knative-serving.yaml
@@ -1,0 +1,12 @@
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: default-allow-same-namespace-knative-serving
+  namespace: knative-serving
+spec:
+  podSelector: {}
+  ingress:
+  - from:
+    - podSelector: {}
+  policyTypes:
+  - Ingress

--- a/common/networkpolicies/base/default-allow-same-namespace-oauth2-proxy.yaml
+++ b/common/networkpolicies/base/default-allow-same-namespace-oauth2-proxy.yaml
@@ -1,0 +1,12 @@
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: default-allow-same-namespace-oauth2-proxy
+  namespace: oauth2-proxy
+spec:
+  podSelector: {}
+  ingress:
+  - from:
+    - podSelector: {}
+  policyTypes:
+  - Ingress

--- a/common/networkpolicies/base/kustomization.yaml
+++ b/common/networkpolicies/base/kustomization.yaml
@@ -6,6 +6,11 @@ resources:
 - centraldashboard.yaml
 - default-allow-same-namespace.yaml
 - default-allow-same-namespace-kubeflow-system.yaml
+- default-allow-same-namespace-knative-serving.yaml
+- default-allow-same-namespace-cert-manager.yaml
+- default-allow-same-namespace-istio-system.yaml
+- default-allow-same-namespace-oauth2-proxy.yaml
+- default-allow-same-namespace-auth.yaml
 - jupyter-web-app.yaml
 - katib-controller.yaml
 - katib-db-manager.yaml

--- a/common/networkpolicies/base/kustomization.yaml
+++ b/common/networkpolicies/base/kustomization.yaml
@@ -4,6 +4,7 @@ namespace: kubeflow
 resources:
 - cache-server.yaml
 - centraldashboard.yaml
+- cert-manager-webhook.yaml
 - default-allow-same-namespace.yaml
 - default-allow-same-namespace-kubeflow-system.yaml
 - default-allow-same-namespace-knative-serving.yaml


### PR DESCRIPTION
# Pull Request Template for Kubeflow Manifests

## ✏️ Summary of Changes
> Add Default Deny All the NetworkPolicy for rest of namespaces like knative-serving, oauth2-proxy, cert-manager, auth, istio-system similar to already implemented kubeflow and kubeflow-system.


## 🐛 Related Issues
> #3227 

## ✅ Contributor Checklist
  - [ ] I have tested these changes with kustomize. See [Installation Prerequisites](https://github.com/kubeflow/manifests#prerequisites).
  - [x] All commits are [_signed-off_](https://github.com/kubeflow/community/tree/master/dco-signoff-hook#signing-off-commits) to satisfy the DCO check.
  - [ ] I have considered adding my company to the adopters page to support Kubeflow and help the community, since I expect help from the community for my issue (see [1.](https://github.com/kubeflow/community/issues/833) and [2.](https://github.com/kubeflow/community/blob/master/ADOPTERS.md#adopters-of-kubeflow-platform)).

---     
 
> You can join the CNCF Slack and access our meetings at the [Kubeflow Community](https://www.kubeflow.org/docs/about/community/) website. Our channel on the CNCF Slack is here [**#kubeflow-platform**](https://app.slack.com/client/T08PSQ7BQ/C073W572LA2).
  
