### PR TITLE
Make Helm Comparision Tests Non Blocking

### DIFF
--- a/.github/workflows/helm-kustomize-comparison.yml
+++ b/.github/workflows/helm-kustomize-comparison.yml
@@ -5,7 +5,6 @@ on:
     branches: [master]
     paths:
     - 'experimental/helm/charts/**'
-    - 'applications/model-registry/**'
     - 'tests/helm_kustomize_compare.py'
     - 'tests/helm_kustomize_compare.sh'
     - 'tests/helm_kustomize_compare_all.sh'


### PR DESCRIPTION
# Pull Request Template for Kubeflow Manifests

## ✏️ Summary of Changes
> Update the helm tests to be non blocking when a manifests are updated.


## 🐛 Related Issues
> #3232 

## ✅ Contributor Checklist
  - [ ] I have tested these changes with kustomize. See [Installation Prerequisites](https://github.com/kubeflow/manifests#prerequisites).
  - [ ] All commits are [_signed-off_](https://github.com/kubeflow/community/tree/master/dco-signoff-hook#signing-off-commits) to satisfy the DCO check.
  - [ ] I have considered adding my company to the adopters page to support Kubeflow and help the community, since I expect help from the community for my issue (see [1.](https://github.com/kubeflow/community/issues/833) and [2.](https://github.com/kubeflow/community/blob/master/ADOPTERS.md#adopters-of-kubeflow-platform)).

---     
 
> You can join the CNCF Slack and access our meetings at the [Kubeflow Community](https://www.kubeflow.org/docs/about/community/) website. Our channel on the CNCF Slack is here [**#kubeflow-platform**](https://app.slack.com/client/T08PSQ7BQ/C073W572LA2).
  
