### PR TITLE
fix: override dex deployment with custom image and env specific for c42 env

### DIFF
--- a/common/dex/overlays/oauth2-proxy/kustomization.yaml
+++ b/common/dex/overlays/oauth2-proxy/kustomization.yaml
@@ -11,4 +11,10 @@ patches:
       kind: ConfigMap
       name: dex
       namespace: auth
+  - path: patch-deployment.yaml
+    target:
+      version: v1
+      kind: Deployment
+      name: dex
+      namespace: auth
 

--- a/common/dex/overlays/oauth2-proxy/patch-deployment.yaml
+++ b/common/dex/overlays/oauth2-proxy/patch-deployment.yaml
@@ -1,0 +1,14 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: dex
+  namespace: auth
+spec:
+  template:
+    spec:
+      containers:
+      - name: dex
+        image: avnshrai/dex-with-ca:v1
+        env:
+        - name: SSL_CERT_FILE
+          value: /etc/ssl/certs/ca-certificates.crt


### PR DESCRIPTION
### Summary
- Added new overlay patch (`patch-deployment.yaml`) in `common/dex/overlays/oauth2-proxy` to:
  - Override Dex container image with `avnshrai/dex-with-ca:v1`
  - Add `SSL_CERT_FILE=/etc/ssl/certs/ca-certificates.crt`

- Updated `kustomization.yaml` in the same overlay to include this patch.

### Why
- Ensures Dex uses the custom image and required SSL_CERT_FILE env var across all installs.
- Prevents drift when uninstalling/reinstalling Kubeflow.
