### PR TITLE
Feature: Add Istio Ambient Mode Support via Overlay Method

### DIFF
--- a/common/istio/istio-install/overlays/ambient-gke/gke-cni-patch.yaml
+++ b/common/istio/istio-install/overlays/ambient-gke/gke-cni-patch.yaml
@@ -1,0 +1,16 @@
+# GKE mounts `/opt/cni/bin` as read-only for security reasons, preventing the Istio CNI installer from writing the CNI binary.
+# Use the GKE-specific overlay: `kubectl apply -k common/istio/istio-install/overlays/ambient-gke`.
+# This overlay uses GKE's writable CNI directory at `/home/kubernetes/bin`.
+# For more details, see [Istio CNI Prerequisites](https://istio.io/latest/docs/setup/additional-setup/cni/#prerequisites) and [Platform Prerequisites](https://istio.io/latest/docs/ambient/install/platform-prerequisites/)
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  name: istio-cni-node
+  namespace: kube-system
+spec:
+  template:
+    spec:
+      volumes:
+      - hostPath:
+          path: /home/kubernetes/bin
+        name: cni-bin-dir

--- a/common/istio/istio-install/overlays/ambient-gke/gke-ztunnel-patch.yaml
+++ b/common/istio/istio-install/overlays/ambient-gke/gke-ztunnel-patch.yaml
@@ -1,0 +1,11 @@
+# Fix GKE priority class quota issues for ztunnel
+# Based on your ambient testing experience where you had to patch priority classes
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  name: ztunnel
+  namespace: istio-system
+spec:
+  template:
+    spec:
+      priorityClassName: ""

--- a/common/istio/istio-install/overlays/ambient-gke/istiod-ambient-patch.yaml
+++ b/common/istio/istio-install/overlays/ambient-gke/istiod-ambient-patch.yaml
@@ -1,0 +1,56 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: istiod
+  namespace: istio-system
+spec:
+  template:
+    spec:
+      containers:
+      - name: discovery
+        env:
+        - name: PILOT_ENABLE_AMBIENT
+          value: "true"
+        - name: ENABLE_NATIVE_SIDECARS
+          value: "true"
+        - name: PILOT_CERT_PROVIDER
+          value: istiod
+        - name: REVISION
+          value: default
+        - name: POD_NAME
+          valueFrom:
+            fieldRef:
+              apiVersion: v1
+              fieldPath: metadata.name
+        - name: POD_NAMESPACE
+          valueFrom:
+            fieldRef:
+              apiVersion: v1
+              fieldPath: metadata.namespace
+        - name: SERVICE_ACCOUNT
+          valueFrom:
+            fieldRef:
+              apiVersion: v1
+              fieldPath: spec.serviceAccountName
+        - name: KUBECONFIG
+          value: /var/run/secrets/remote/config
+        - name: CA_TRUSTED_NODE_ACCOUNTS
+          value: istio-system/ztunnel
+        - name: PILOT_TRACE_SAMPLING
+          value: "1"
+        - name: PILOT_ENABLE_ANALYSIS
+          value: "false"
+        - name: CLUSTER_ID
+          value: Kubernetes
+        - name: GOMEMLIMIT
+          valueFrom:
+            resourceFieldRef:
+              divisor: "1"
+              resource: limits.memory
+        - name: GOMAXPROCS
+          valueFrom:
+            resourceFieldRef:
+              divisor: "1"
+              resource: limits.cpu
+        - name: PLATFORM
+          value: ""

--- a/common/istio/istio-install/overlays/ambient-gke/kustomization.yaml
+++ b/common/istio/istio-install/overlays/ambient-gke/kustomization.yaml
@@ -1,0 +1,30 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+- ../../base
+- ztunnel.yaml
+
+patches:
+- path: istiod-ambient-patch.yaml
+  target:
+    kind: Deployment
+    name: istiod
+    namespace: istio-system
+- target:
+    kind: Namespace
+    name: kubeflow
+  patch: |-
+    - op: add
+      path: /metadata/labels/istio.io~1dataplane-mode
+      value: ambient
+- path: gke-cni-patch.yaml
+  target:
+    kind: DaemonSet
+    name: istio-cni-node
+    namespace: kube-system
+- path: gke-ztunnel-patch.yaml
+  target:
+    kind: DaemonSet
+    name: ztunnel
+    namespace: istio-system

--- a/common/istio/istio-install/overlays/ambient-gke/ztunnel.yaml
+++ b/common/istio/istio-install/overlays/ambient-gke/ztunnel.yaml
@@ -1,0 +1,180 @@
+---
+# Source: ztunnel/templates/rbac.yaml
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: ztunnel
+  namespace: istio-system
+  labels:
+    app.kubernetes.io/name: ztunnel
+    app.kubernetes.io/managed-by: "Helm"
+    app.kubernetes.io/instance: "ztunnel"
+    app.kubernetes.io/part-of: "istio"
+    app.kubernetes.io/version: "1.27.1"
+    helm.sh/chart: ztunnel-1.27.1
+
+  annotations:
+    {}
+---
+# Source: ztunnel/templates/daemonset.yaml
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  name: ztunnel
+  namespace: istio-system
+  labels:
+    app.kubernetes.io/name: ztunnel
+    app.kubernetes.io/managed-by: "Helm"
+    app.kubernetes.io/instance: "ztunnel"
+    app.kubernetes.io/part-of: "istio"
+    app.kubernetes.io/version: "1.27.1"
+    helm.sh/chart: ztunnel-1.27.1
+
+  annotations:
+    {}
+spec:
+  updateStrategy:
+    rollingUpdate:
+      maxSurge: 1
+      maxUnavailable: 0
+    type: RollingUpdate
+  selector:
+    matchLabels:
+      app: ztunnel
+  template:
+    metadata:
+      labels:
+        sidecar.istio.io/inject: "false"
+        istio.io/dataplane-mode: none
+        app: ztunnel
+        app.kubernetes.io/name: ztunnel
+        app.kubernetes.io/managed-by: "Helm"
+        app.kubernetes.io/instance: "ztunnel"
+        app.kubernetes.io/part-of: "istio"
+        app.kubernetes.io/version: "1.27.1"
+        helm.sh/chart: ztunnel-1.27.1
+
+      annotations:
+        sidecar.istio.io/inject: "false"
+        prometheus.io/port: "15020"
+        prometheus.io/scrape: "true"
+    spec:
+      nodeSelector:
+        kubernetes.io/os: linux
+      serviceAccountName: ztunnel
+      tolerations:
+      - effect: NoSchedule
+        operator: Exists
+      - key: CriticalAddonsOnly
+        operator: Exists
+      - effect: NoExecute
+        operator: Exists
+      containers:
+      - name: istio-proxy
+        image: "docker.io/istio/ztunnel:1.27.1"
+        ports:
+        - containerPort: 15020
+          name: ztunnel-stats
+          protocol: TCP
+        resources:
+          requests:
+            cpu: 200m
+            memory: 512Mi
+        securityContext:
+          # K8S docs are clear that CAP_SYS_ADMIN *or* privileged: true
+          # both force this to `true`: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/
+          # But there is a K8S validation bug that doesn't propery catch this: https://github.com/kubernetes/kubernetes/issues/119568
+          allowPrivilegeEscalation: true
+          privileged: false
+          capabilities:
+            drop:
+            - ALL
+            add: # See https://man7.org/linux/man-pages/man7/capabilities.7.html
+            - NET_ADMIN # Required for TPROXY and setsockopt
+            - SYS_ADMIN # Required for `setns` - doing things in other netns
+            - NET_RAW # Required for RAW/PACKET sockets, TPROXY
+          readOnlyRootFilesystem: true
+          runAsGroup: 1337
+          runAsNonRoot: false
+          runAsUser: 0
+        readinessProbe:
+          httpGet:
+            port: 15021
+            path: /healthz/ready
+        args:
+        - proxy
+        - ztunnel
+        env:
+        - name: CA_ADDRESS
+          value: istiod.istio-system.svc:15012
+        - name: XDS_ADDRESS
+          value: istiod.istio-system.svc:15012
+        - name: RUST_LOG
+          value: "info"
+        - name: RUST_BACKTRACE
+          value: "1"
+        - name: ISTIO_META_CLUSTER_ID
+          value: Kubernetes
+        - name: INPOD_ENABLED
+          value: "true"
+        - name: TERMINATION_GRACE_PERIOD_SECONDS
+          value: "30"
+        - name: POD_NAME
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.name
+        - name: POD_NAMESPACE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace
+        - name: NODE_NAME
+          valueFrom:
+            fieldRef:
+              fieldPath: spec.nodeName
+        - name: INSTANCE_IP
+          valueFrom:
+            fieldRef:
+              fieldPath: status.podIP
+        - name: SERVICE_ACCOUNT
+          valueFrom:
+            fieldRef:
+              fieldPath: spec.serviceAccountName
+        - name: ZTUNNEL_CPU_LIMIT
+          valueFrom:
+            resourceFieldRef:
+              resource: limits.cpu
+        volumeMounts:
+        - mountPath: /var/run/secrets/istio
+          name: istiod-ca-cert
+        - mountPath: /var/run/secrets/tokens
+          name: istio-token
+        - mountPath: /var/run/ztunnel
+          name: cni-ztunnel-sock-dir
+        - mountPath: /tmp
+          name: tmp
+      priorityClassName: system-node-critical
+      terminationGracePeriodSeconds: 30
+      volumes:
+      - name: istio-token
+        projected:
+          sources:
+          - serviceAccountToken:
+              path: istio-token
+              expirationSeconds: 43200
+              audience: istio-ca
+      - name: istiod-ca-cert
+        configMap:
+          name: istio-ca-root-cert
+      - name: cni-ztunnel-sock-dir
+        hostPath:
+          path: /var/run/ztunnel
+          type: DirectoryOrCreate # ideally this would be a socket, but istio-cni may not have started yet.
+      # pprof needs a writable /tmp, and we don't have that thanks to `readOnlyRootFilesystem: true`, so mount one
+      - name: tmp
+        emptyDir: {}
+---
+# Source: ztunnel/templates/rbac.yaml
+---
+---
+# Source: ztunnel/templates/zzz_profile.yaml
+#  Flatten globals, if defined on a per-chart basis

--- a/common/istio/istio-install/overlays/ambient-oauth2-proxy/istiod-ambient-patch.yaml
+++ b/common/istio/istio-install/overlays/ambient-oauth2-proxy/istiod-ambient-patch.yaml
@@ -1,0 +1,56 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: istiod
+  namespace: istio-system
+spec:
+  template:
+    spec:
+      containers:
+      - name: discovery
+        env:
+        - name: PILOT_ENABLE_AMBIENT
+          value: "true"
+        - name: ENABLE_NATIVE_SIDECARS
+          value: "true"
+        - name: PILOT_CERT_PROVIDER
+          value: istiod
+        - name: REVISION
+          value: default
+        - name: POD_NAME
+          valueFrom:
+            fieldRef:
+              apiVersion: v1
+              fieldPath: metadata.name
+        - name: POD_NAMESPACE
+          valueFrom:
+            fieldRef:
+              apiVersion: v1
+              fieldPath: metadata.namespace
+        - name: SERVICE_ACCOUNT
+          valueFrom:
+            fieldRef:
+              apiVersion: v1
+              fieldPath: spec.serviceAccountName
+        - name: KUBECONFIG
+          value: /var/run/secrets/remote/config
+        - name: CA_TRUSTED_NODE_ACCOUNTS
+          value: istio-system/ztunnel
+        - name: PILOT_TRACE_SAMPLING
+          value: "1"
+        - name: PILOT_ENABLE_ANALYSIS
+          value: "false"
+        - name: CLUSTER_ID
+          value: Kubernetes
+        - name: GOMEMLIMIT
+          valueFrom:
+            resourceFieldRef:
+              divisor: "1"
+              resource: limits.memory
+        - name: GOMAXPROCS
+          valueFrom:
+            resourceFieldRef:
+              divisor: "1"
+              resource: limits.cpu
+        - name: PLATFORM
+          value: ""

--- a/common/istio/istio-install/overlays/ambient-oauth2-proxy/kubeflow-namespace-ambient.yaml
+++ b/common/istio/istio-install/overlays/ambient-oauth2-proxy/kubeflow-namespace-ambient.yaml
@@ -1,0 +1,6 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: kubeflow
+  labels:
+    istio.io/dataplane-mode: ambient

--- a/common/istio/istio-install/overlays/ambient-oauth2-proxy/kustomization.yaml
+++ b/common/istio/istio-install/overlays/ambient-oauth2-proxy/kustomization.yaml
@@ -1,0 +1,17 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+- ../../base
+- ztunnel.yaml
+- kubeflow-namespace-ambient.yaml
+
+patches:
+- path: istiod-ambient-patch.yaml
+  target:
+    kind: Deployment
+    name: istiod
+    namespace: istio-system
+
+components:
+- ../../../../oauth2-proxy/components/istio-external-auth-patches

--- a/common/istio/istio-install/overlays/ambient-oauth2-proxy/ztunnel.yaml
+++ b/common/istio/istio-install/overlays/ambient-oauth2-proxy/ztunnel.yaml
@@ -1,0 +1,180 @@
+---
+# Source: ztunnel/templates/rbac.yaml
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: ztunnel
+  namespace: istio-system
+  labels:
+    app.kubernetes.io/name: ztunnel
+    app.kubernetes.io/managed-by: "Helm"
+    app.kubernetes.io/instance: "ztunnel"
+    app.kubernetes.io/part-of: "istio"
+    app.kubernetes.io/version: "1.27.1"
+    helm.sh/chart: ztunnel-1.27.1
+
+  annotations:
+    {}
+---
+# Source: ztunnel/templates/daemonset.yaml
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  name: ztunnel
+  namespace: istio-system
+  labels:
+    app.kubernetes.io/name: ztunnel
+    app.kubernetes.io/managed-by: "Helm"
+    app.kubernetes.io/instance: "ztunnel"
+    app.kubernetes.io/part-of: "istio"
+    app.kubernetes.io/version: "1.27.1"
+    helm.sh/chart: ztunnel-1.27.1
+
+  annotations:
+    {}
+spec:
+  updateStrategy:
+    rollingUpdate:
+      maxSurge: 1
+      maxUnavailable: 0
+    type: RollingUpdate
+  selector:
+    matchLabels:
+      app: ztunnel
+  template:
+    metadata:
+      labels:
+        sidecar.istio.io/inject: "false"
+        istio.io/dataplane-mode: none
+        app: ztunnel
+        app.kubernetes.io/name: ztunnel
+        app.kubernetes.io/managed-by: "Helm"
+        app.kubernetes.io/instance: "ztunnel"
+        app.kubernetes.io/part-of: "istio"
+        app.kubernetes.io/version: "1.27.1"
+        helm.sh/chart: ztunnel-1.27.1
+
+      annotations:
+        sidecar.istio.io/inject: "false"
+        prometheus.io/port: "15020"
+        prometheus.io/scrape: "true"
+    spec:
+      nodeSelector:
+        kubernetes.io/os: linux
+      serviceAccountName: ztunnel
+      tolerations:
+      - effect: NoSchedule
+        operator: Exists
+      - key: CriticalAddonsOnly
+        operator: Exists
+      - effect: NoExecute
+        operator: Exists
+      containers:
+      - name: istio-proxy
+        image: "docker.io/istio/ztunnel:1.27.1"
+        ports:
+        - containerPort: 15020
+          name: ztunnel-stats
+          protocol: TCP
+        resources:
+          requests:
+            cpu: 200m
+            memory: 512Mi
+        securityContext:
+          # K8S docs are clear that CAP_SYS_ADMIN *or* privileged: true
+          # both force this to `true`: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/
+          # But there is a K8S validation bug that doesn't propery catch this: https://github.com/kubernetes/kubernetes/issues/119568
+          allowPrivilegeEscalation: true
+          privileged: false
+          capabilities:
+            drop:
+            - ALL
+            add: # See https://man7.org/linux/man-pages/man7/capabilities.7.html
+            - NET_ADMIN # Required for TPROXY and setsockopt
+            - SYS_ADMIN # Required for `setns` - doing things in other netns
+            - NET_RAW # Required for RAW/PACKET sockets, TPROXY
+          readOnlyRootFilesystem: true
+          runAsGroup: 1337
+          runAsNonRoot: false
+          runAsUser: 0
+        readinessProbe:
+          httpGet:
+            port: 15021
+            path: /healthz/ready
+        args:
+        - proxy
+        - ztunnel
+        env:
+        - name: CA_ADDRESS
+          value: istiod.istio-system.svc:15012
+        - name: XDS_ADDRESS
+          value: istiod.istio-system.svc:15012
+        - name: RUST_LOG
+          value: "info"
+        - name: RUST_BACKTRACE
+          value: "1"
+        - name: ISTIO_META_CLUSTER_ID
+          value: Kubernetes
+        - name: INPOD_ENABLED
+          value: "true"
+        - name: TERMINATION_GRACE_PERIOD_SECONDS
+          value: "30"
+        - name: POD_NAME
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.name
+        - name: POD_NAMESPACE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace
+        - name: NODE_NAME
+          valueFrom:
+            fieldRef:
+              fieldPath: spec.nodeName
+        - name: INSTANCE_IP
+          valueFrom:
+            fieldRef:
+              fieldPath: status.podIP
+        - name: SERVICE_ACCOUNT
+          valueFrom:
+            fieldRef:
+              fieldPath: spec.serviceAccountName
+        - name: ZTUNNEL_CPU_LIMIT
+          valueFrom:
+            resourceFieldRef:
+              resource: limits.cpu
+        volumeMounts:
+        - mountPath: /var/run/secrets/istio
+          name: istiod-ca-cert
+        - mountPath: /var/run/secrets/tokens
+          name: istio-token
+        - mountPath: /var/run/ztunnel
+          name: cni-ztunnel-sock-dir
+        - mountPath: /tmp
+          name: tmp
+      priorityClassName: system-node-critical
+      terminationGracePeriodSeconds: 30
+      volumes:
+      - name: istio-token
+        projected:
+          sources:
+          - serviceAccountToken:
+              path: istio-token
+              expirationSeconds: 43200
+              audience: istio-ca
+      - name: istiod-ca-cert
+        configMap:
+          name: istio-ca-root-cert
+      - name: cni-ztunnel-sock-dir
+        hostPath:
+          path: /var/run/ztunnel
+          type: DirectoryOrCreate # ideally this would be a socket, but istio-cni may not have started yet.
+      # pprof needs a writable /tmp, and we don't have that thanks to `readOnlyRootFilesystem: true`, so mount one
+      - name: tmp
+        emptyDir: {}
+---
+# Source: ztunnel/templates/rbac.yaml
+---
+---
+# Source: ztunnel/templates/zzz_profile.yaml
+#  Flatten globals, if defined on a per-chart basis

--- a/common/istio/istio-install/overlays/ambient/istiod-ambient-patch.yaml
+++ b/common/istio/istio-install/overlays/ambient/istiod-ambient-patch.yaml
@@ -1,0 +1,56 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: istiod
+  namespace: istio-system
+spec:
+  template:
+    spec:
+      containers:
+      - name: discovery
+        env:
+        - name: PILOT_ENABLE_AMBIENT
+          value: "true"
+        - name: ENABLE_NATIVE_SIDECARS
+          value: "true"
+        - name: PILOT_CERT_PROVIDER
+          value: istiod
+        - name: REVISION
+          value: default
+        - name: POD_NAME
+          valueFrom:
+            fieldRef:
+              apiVersion: v1
+              fieldPath: metadata.name
+        - name: POD_NAMESPACE
+          valueFrom:
+            fieldRef:
+              apiVersion: v1
+              fieldPath: metadata.namespace
+        - name: SERVICE_ACCOUNT
+          valueFrom:
+            fieldRef:
+              apiVersion: v1
+              fieldPath: spec.serviceAccountName
+        - name: KUBECONFIG
+          value: /var/run/secrets/remote/config
+        - name: CA_TRUSTED_NODE_ACCOUNTS
+          value: istio-system/ztunnel
+        - name: PILOT_TRACE_SAMPLING
+          value: "1"
+        - name: PILOT_ENABLE_ANALYSIS
+          value: "false"
+        - name: CLUSTER_ID
+          value: Kubernetes
+        - name: GOMEMLIMIT
+          valueFrom:
+            resourceFieldRef:
+              divisor: "1"
+              resource: limits.memory
+        - name: GOMAXPROCS
+          valueFrom:
+            resourceFieldRef:
+              divisor: "1"
+              resource: limits.cpu
+        - name: PLATFORM
+          value: ""

--- a/common/istio/istio-install/overlays/ambient/kubeflow-namespace-ambient.yaml
+++ b/common/istio/istio-install/overlays/ambient/kubeflow-namespace-ambient.yaml
@@ -1,0 +1,8 @@
+# This file adds ambient labels to the kubeflow namespace
+# The namespace itself is created by common/kubeflow-namespace/base
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: kubeflow
+  labels:
+    istio.io/dataplane-mode: ambient

--- a/common/istio/istio-install/overlays/ambient/kustomization.yaml
+++ b/common/istio/istio-install/overlays/ambient/kustomization.yaml
@@ -1,0 +1,20 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+- ../../base
+- ztunnel.yaml
+
+patches:
+- path: istiod-ambient-patch.yaml
+  target:
+    kind: Deployment
+    name: istiod
+    namespace: istio-system
+- target:
+    kind: Namespace
+    name: kubeflow
+  patch: |-
+    - op: add
+      path: /metadata/labels/istio.io~1dataplane-mode
+      value: ambient

--- a/common/istio/istio-install/overlays/ambient/ztunnel.yaml
+++ b/common/istio/istio-install/overlays/ambient/ztunnel.yaml
@@ -1,0 +1,180 @@
+---
+# Source: ztunnel/templates/rbac.yaml
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: ztunnel
+  namespace: istio-system
+  labels:
+    app.kubernetes.io/name: ztunnel
+    app.kubernetes.io/managed-by: "Helm"
+    app.kubernetes.io/instance: "ztunnel"
+    app.kubernetes.io/part-of: "istio"
+    app.kubernetes.io/version: "1.27.1"
+    helm.sh/chart: ztunnel-1.27.1
+
+  annotations:
+    {}
+---
+# Source: ztunnel/templates/daemonset.yaml
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  name: ztunnel
+  namespace: istio-system
+  labels:
+    app.kubernetes.io/name: ztunnel
+    app.kubernetes.io/managed-by: "Helm"
+    app.kubernetes.io/instance: "ztunnel"
+    app.kubernetes.io/part-of: "istio"
+    app.kubernetes.io/version: "1.27.1"
+    helm.sh/chart: ztunnel-1.27.1
+
+  annotations:
+    {}
+spec:
+  updateStrategy:
+    rollingUpdate:
+      maxSurge: 1
+      maxUnavailable: 0
+    type: RollingUpdate
+  selector:
+    matchLabels:
+      app: ztunnel
+  template:
+    metadata:
+      labels:
+        sidecar.istio.io/inject: "false"
+        istio.io/dataplane-mode: none
+        app: ztunnel
+        app.kubernetes.io/name: ztunnel
+        app.kubernetes.io/managed-by: "Helm"
+        app.kubernetes.io/instance: "ztunnel"
+        app.kubernetes.io/part-of: "istio"
+        app.kubernetes.io/version: "1.27.1"
+        helm.sh/chart: ztunnel-1.27.1
+
+      annotations:
+        sidecar.istio.io/inject: "false"
+        prometheus.io/port: "15020"
+        prometheus.io/scrape: "true"
+    spec:
+      nodeSelector:
+        kubernetes.io/os: linux
+      serviceAccountName: ztunnel
+      tolerations:
+      - effect: NoSchedule
+        operator: Exists
+      - key: CriticalAddonsOnly
+        operator: Exists
+      - effect: NoExecute
+        operator: Exists
+      containers:
+      - name: istio-proxy
+        image: "docker.io/istio/ztunnel:1.27.1"
+        ports:
+        - containerPort: 15020
+          name: ztunnel-stats
+          protocol: TCP
+        resources:
+          requests:
+            cpu: 200m
+            memory: 512Mi
+        securityContext:
+          # K8S docs are clear that CAP_SYS_ADMIN *or* privileged: true
+          # both force this to `true`: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/
+          # But there is a K8S validation bug that doesn't propery catch this: https://github.com/kubernetes/kubernetes/issues/119568
+          allowPrivilegeEscalation: true
+          privileged: false
+          capabilities:
+            drop:
+            - ALL
+            add: # See https://man7.org/linux/man-pages/man7/capabilities.7.html
+            - NET_ADMIN # Required for TPROXY and setsockopt
+            - SYS_ADMIN # Required for `setns` - doing things in other netns
+            - NET_RAW # Required for RAW/PACKET sockets, TPROXY
+          readOnlyRootFilesystem: true
+          runAsGroup: 1337
+          runAsNonRoot: false
+          runAsUser: 0
+        readinessProbe:
+          httpGet:
+            port: 15021
+            path: /healthz/ready
+        args:
+        - proxy
+        - ztunnel
+        env:
+        - name: CA_ADDRESS
+          value: istiod.istio-system.svc:15012
+        - name: XDS_ADDRESS
+          value: istiod.istio-system.svc:15012
+        - name: RUST_LOG
+          value: "info"
+        - name: RUST_BACKTRACE
+          value: "1"
+        - name: ISTIO_META_CLUSTER_ID
+          value: Kubernetes
+        - name: INPOD_ENABLED
+          value: "true"
+        - name: TERMINATION_GRACE_PERIOD_SECONDS
+          value: "30"
+        - name: POD_NAME
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.name
+        - name: POD_NAMESPACE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace
+        - name: NODE_NAME
+          valueFrom:
+            fieldRef:
+              fieldPath: spec.nodeName
+        - name: INSTANCE_IP
+          valueFrom:
+            fieldRef:
+              fieldPath: status.podIP
+        - name: SERVICE_ACCOUNT
+          valueFrom:
+            fieldRef:
+              fieldPath: spec.serviceAccountName
+        - name: ZTUNNEL_CPU_LIMIT
+          valueFrom:
+            resourceFieldRef:
+              resource: limits.cpu
+        volumeMounts:
+        - mountPath: /var/run/secrets/istio
+          name: istiod-ca-cert
+        - mountPath: /var/run/secrets/tokens
+          name: istio-token
+        - mountPath: /var/run/ztunnel
+          name: cni-ztunnel-sock-dir
+        - mountPath: /tmp
+          name: tmp
+      priorityClassName: system-node-critical
+      terminationGracePeriodSeconds: 30
+      volumes:
+      - name: istio-token
+        projected:
+          sources:
+          - serviceAccountToken:
+              path: istio-token
+              expirationSeconds: 43200
+              audience: istio-ca
+      - name: istiod-ca-cert
+        configMap:
+          name: istio-ca-root-cert
+      - name: cni-ztunnel-sock-dir
+        hostPath:
+          path: /var/run/ztunnel
+          type: DirectoryOrCreate # ideally this would be a socket, but istio-cni may not have started yet.
+      # pprof needs a writable /tmp, and we don't have that thanks to `readOnlyRootFilesystem: true`, so mount one
+      - name: tmp
+        emptyDir: {}
+---
+# Source: ztunnel/templates/rbac.yaml
+---
+---
+# Source: ztunnel/templates/zzz_profile.yaml
+#  Flatten globals, if defined on a per-chart basis

--- a/example/kustomization.yaml
+++ b/example/kustomization.yaml
@@ -42,15 +42,19 @@ resources:
 - ../common/istio/istio-install/overlays/oauth2-proxy
 # NOTE: For Google Kubernetes Engine (GKE), use:
 # - ../common/istio/istio-install/overlays/gke
-#GKE mounts `/opt/cni/bin` as read-only for security reasons, preventing the Istio CNI installer from writing the CNI binary.
-#Use the GKE-specific overlay: `kubectl apply -k common/istio/istio-install/overlays/gke`.
-#This overlay uses GKE's writable CNI directory at `/home/kubernetes/bin`.
-#For more details, see [Istio CNI Prerequisites](https://istio.io/latest/docs/setup/additional-setup/cni/#prerequisites) and [Platform Prerequisites](https://istio.io/latest/docs/ambient/install/platform-prerequisites/)
+# NOTE: For Istio Ambient Mode, use one of:
+# - ../common/istio/istio-install/overlays/ambient                    # Basic ambient mode
+# - ../common/istio/istio-install/overlays/ambient-gke               # Ambient mode for GKE
+# - ../common/istio/istio-install/overlays/ambient-oauth2-proxy       # Ambient mode with oauth2-proxy
+# GKE mounts `/opt/cni/bin` as read-only for security reasons, preventing the Istio CNI installer from writing the CNI binary.
+# Use the GKE-specific overlay: `kubectl apply -k common/istio/istio-install/overlays/gke`.
+# This overlay uses GKE's writable CNI directory at `/home/kubernetes/bin`.
+# For more details, see [Istio CNI Prerequisites](https://istio.io/latest/docs/setup/additional-setup/cni/#prerequisites) and [Platform Prerequisites](https://istio.io/latest/docs/ambient/install/platform-prerequisites/)
 # oauth2-proxy
 # NOTE: only uncomment ONE of the following overlays, depending on your cluster type
-- ../common/oauth2-proxy/overlays/m2m-dex-only     # for all clusters
-#- ../common/oauth2-proxy/overlays/m2m-dex-and-kind # for KIND clusters (allows K8S JWTs for gateway auth)
-#- ../common/oauth2-proxy/overlays/m2m-dex-and-eks  # for EKS clusters (NOTE: requires you to configure issuer, see overlay)
+- ../common/oauth2-proxy/overlays/m2m-dex-only       # for all clusters
+# - ../common/oauth2-proxy/overlays/m2m-dex-and-kind  # for KIND clusters (allows K8S JWTs for gateway auth)
+# - ../common/oauth2-proxy/overlays/m2m-dex-and-eks   # for EKS clusters (NOTE: requires you to configure issuer, see overlay)
 # Dex
 - ../common/dex/overlays/oauth2-proxy
 # KNative
@@ -80,7 +84,7 @@ resources:
 # Notebook Controller
 - ../applications/jupyter/notebook-controller/upstream/overlays/kubeflow
 # Profiles + KFAM with PSS (Pod Security Standards)
-- ../applications/profiles/pss # TODO MUST BE UPSTREAMED
+- ../applications/profiles/pss  # TODO MUST BE UPSTREAMED
 # PVC Viewer
 - ../applications/pvcviewer-controller/upstream/base
 # Volumes Web App


### PR DESCRIPTION
# Pull Request Template for Kubeflow Manifests

## ✏️ Summary of Changes
This PR implements Istio Ambient Mode support for Kubeflow deployments using the overlay pattern within the existing istio-install structure. 

Ambient mode provides a sidecar-free service mesh solution that reduces resource overhead while maintaining full L4/L7 traffic processing capabilities.

 For Standard Deployments:
 In example/kustomization.yaml, replace:
  - ../common/istio/istio-install/overlays/oauth2-proxy
With:
  - ../common/istio/istio-install/overlays/ambient

For GKE Deployments:
In example/kustomization.yaml, use:
  - ../common/istio/istio-install/overlays/ambient-gke

For OAuth2-Proxy + Ambient:
  # In example/kustomization.yaml, use:
  - ../common/istio/istio-install/overlays/ambient-oauth2-proxy

## 📦 Dependencies
none
## 🐛 Related Issues
none
## ✅ Contributor Checklist
  - [x] I have tested these changes with kustomize. See [Installation Prerequisites](https://github.com/kubeflow/manifests#prerequisites).
  - [x] All commits are [_signed-off_](https://github.com/kubeflow/community/tree/master/dco-signoff-hook#signing-off-commits) to satisfy the DCO check.
  - [x] I have considered adding my company to the adopters page to support Kubeflow and help the community, since I expect help from the community for my issue (see [1.](https://github.com/kubeflow/community/issues/833) and [2.](https://github.com/kubeflow/community/blob/master/ADOPTERS.md#adopters-of-kubeflow-platform)).

---     
 
> You can join the CNCF Slack and access our meetings at the [Kubeflow Community](https://www.kubeflow.org/docs/about/community/) website. Our channel on the CNCF Slack is here [**#kubeflow-platform**](https://app.slack.com/client/T08PSQ7BQ/C073W572LA2).
  
