### PR TITLE
Add VirtualService conflict troubleshooting for KServe path-based Routing

### DIFF
--- a/applications/kserve/README.md
+++ b/applications/kserve/README.md
@@ -3,3 +3,17 @@
 For KServe installation and usage, see the [GitHub Actions tests](.github/workflows/kserve_test.yaml) which demonstrate working configurations.
 
 For complete documentation, visit the [official KServe website](https://kserve.github.io/website/).
+
+## Integration with KubeFlow
+
+When using KServe with path-based routing in a KubeFlow deployment, you may encounter VirtualService conflicts that result in 404 errors when accessing KServe InferenceServices.
+
+**Common Issues:**
+- KServe InferenceServices return 404 errors when accessed via their configured domain
+- Conflicts between KubeFlow's wildcard VirtualServices and KServe's specific-host VirtualServices
+
+**Solution:** See the [Istio troubleshooting guide](../../common/istio/README.md#virtualservice-conflicts-with-kserve-path-based-routing) for detailed resolution steps.
+
+**Related Documentation:**
+- [KServe Path-Based Routing Configuration](https://kserve.github.io/website/docs/admin-guide/configurations#path-template)
+- [Upstream Istio Issue](https://github.com/istio/istio/issues/57404)


### PR DESCRIPTION
## ✏️ Summary of Changes
Documents the Istio VirtualService conflict issue that occurs when deploying KServe with path-based routing alongside KubeFlow. Adds troubleshooting guidance to resolve 404 errors caused by conflicts between KubeFlow's wildcard VirtualServices and KServe's specific-host VirtualServices. References upstream Istio issue https://github.com/istio/istio/issues/57404 and provides Gateway configuration workaround.

## 📦 Dependencies
none
## 🐛 Related Issues
none
## ✅ Contributor Checklist
  - [x] I have tested these changes with kustomize. See [Installation Prerequisites](https://github.com/kubeflow/manifests#prerequisites).
  - [x] All commits are [_signed-off_](https://github.com/kubeflow/community/tree/master/dco-signoff-hook#signing-off-commits) to satisfy the DCO check.
  - [x] I have considered adding my company to the adopters page to support Kubeflow and help the community, since I expect help from the community for my issue (see [1.](https://github.com/kubeflow/community/issues/833) and [2.](https://github.com/kubeflow/community/blob/master/ADOPTERS.md#adopters-of-kubeflow-platform)).

---     
 
> You can join the CNCF Slack and access our meetings at the [Kubeflow Community](https://www.kubeflow.org/docs/about/community/) website. Our channel on the CNCF Slack is here [**#kubeflow-platform**](https://app.slack.com/client/T08PSQ7BQ/C073W572LA2).
  
