### PR TITLE
Change ml-pipeline-api-server image reference

### DIFF
--- a/applications/pipeline/upstream/env/cert-manager/platform-agnostic-multi-user-k8s-native/patches/deployment.yaml
+++ b/applications/pipeline/upstream/env/cert-manager/platform-agnostic-multi-user-k8s-native/patches/deployment.yaml
@@ -10,7 +10,6 @@ spec:
           ports:
           - containerPort: 8443
             name: webhook
-          image: domain.local/apiserver:local
           command:
             - "/bin/apiserver"
           args:


### PR DESCRIPTION
Removed the wrong image from the patch "domain.local/apiserver:local"

# Pull Request Template for Kubeflow Manifests

## ✏️ Summary of Changes
> Describe the changes you have made, including any refactoring or feature additions.


## ✅ Contributor Checklist
  - [x] I have tested these changes with kustomize. See [Installation Prerequisites](https://github.com/kubeflow/manifests#prerequisites).
  - [x] All commits are [_signed-off_](https://github.com/kubeflow/community/tree/master/dco-signoff-hook#signing-off-commits) to satisfy the DCO check.
  - [x] I have considered adding my company to the adopters page to support Kubeflow and help the community, since I expect help from the community for my issue (see [1.](https://github.com/kubeflow/community/issues/833) and [2.](https://github.com/kubeflow/community/blob/master/ADOPTERS.md#adopters-of-kubeflow-platform)).

---     
 
> You can join the CNCF Slack and access our meetings at the [Kubeflow Community](https://www.kubeflow.org/docs/about/community/) website. Our channel on the CNCF Slack is here [**#kubeflow-platform**](https://app.slack.com/client/T08PSQ7BQ/C073W572LA2).
  
