### PR TITLE
docs: fix Dex Keycloak OIDC config parameters

### DIFF
--- a/common/dex/README.md
+++ b/common/dex/README.md
@@ -82,15 +82,14 @@ data:
         # Override JWKS endpoint: Dex will fetch Keycloak's JWKs from here.
         # This is useful when issuer discovery fails or when the IdP uses
         # self-signed / internal-only certificates.
-        # Keycloak's certs endpoint (official): /realms/{realm}/protocol/openid-connect/certs. See Keycloak docs.
-        # https://www.keycloak.org/docs/latest/securing_apps/index.html#certificate-endpoint
+        # Keycloak's endpoint /realms/{realm}/protocol/openid-connect/certs. See the Keycloak documentation here https://www.keycloak.org/docs/latest/securing_apps/index.html#certificate-endpoint
         jwksUri: $KEYCLOAK_JWKS_URI
         clientID: $CLIENT_ID
         clientSecret: $CLIENT_SECRET
         redirectURI: $REDIRECT_URI
         insecureSkipVerify: true 
         # Disable TLS certificate verification when connecting to the issuer.
-        # This is required for test or on-prem installations using self-signed
+        # This is required for test or on-premises installations using self-signed
         # certificates.
         # Dex does not support an `insecure` field. TLS verification is controlled
         # via `insecureSkipVerify`, which is implemented in the Dex OIDC connector.


### PR DESCRIPTION
# Pull Request Template for Kubeflow Manifests

## ✏️ Summary of Changes
### Specific changes:

- Replaced the invalid insecure: false parameter with `insecureSkipVerify: true` in the Dex connector config.

- Added the `jwksUri` parameter to explicitly define the key location.

- Updated the config-map.yaml example to use a variable `KEYCLOAK_JWKS_URI` for better usability.


## 🐛 Related Issues
> #3244 
## ✅ Contributor Checklist
  - [ ] I have tested these changes with kustomize. See [Installation Prerequisites](https://github.com/kubeflow/manifests#prerequisites).
  - [X] All commits are [_signed-off_](https://github.com/kubeflow/community/tree/master/dco-signoff-hook#signing-off-commits) to satisfy the DCO check.
  - [X] I have considered adding my company to the adopters page to support Kubeflow and help the community, since I expect help from the community for my issue (see [1.](https://github.com/kubeflow/community/issues/833) and [2.](https://github.com/kubeflow/community/blob/master/ADOPTERS.md#adopters-of-kubeflow-platform)).

---     
 
> You can join the CNCF Slack and access our meetings at the [Kubeflow Community](https://www.kubeflow.org/docs/about/community/) website. Our channel on the CNCF Slack is here [**#kubeflow-platform**](https://app.slack.com/client/T08PSQ7BQ/C073W572LA2).
  
