### PR TITLE
fix: update README for user namespace installation using KF_PROFILE script

### DIFF
--- a/README.md
+++ b/README.md
@@ -571,12 +571,19 @@ kustomize build applications/spark/spark-operator/overlays/kubeflow | kubectl ap
 
 **Note:** The Ray component in the experimental folder is configured to disable Istio sidecar injection for its head and worker pods to ensure compatibility with Istio CNI.
 
-#### User Namespaces
+#### User Namespaces 
+
+> **Note**  
+> The installation steps below are continuously verified by the Kubeflow
+> full integration test workflow, which runs on every commit to the `master`
+> branch:
+> https://github.com/kubeflow/manifests/blob/master/.github/workflows/full_kubeflow_integration_test.yaml
 
 Finally, create a new namespace for the default user (named `kubeflow-user-example-com`).
 
 ```sh
-kustomize build common/user-namespace/base | kubectl apply -f -
+export KF_PROFILE=kubeflow-user-example-com
+./tests/kubeflow_profile_install.sh
 ```
 
 ### Connect to Your Kubeflow Cluster


### PR DESCRIPTION
## ✏️ Summary of Changes
Updated the README to replace the direct `kustomize` command for creating the user namespace with the recommended KF_PROFILE script approach:
- Added export of KF_PROFILE environment variable.
- Ran ./tests/kubeflow_profile_install.sh to install user namespace.

## 📦 Dependencies
No external dependencies.

## 🐛 Related Issues
Fixes #3315 - Kubeflow profile creation error in default KIND configuration.

## ✅ Contributor Checklist
  - [x] Tested changes locally using kustomize and KIND cluster.
  - [x] All commits are signed-off to satisfy DCO check.
  - [x] Considered community guidelines for documentation changes.
