### PR TITLE
Add istio virtualservice to katib external-db

### DIFF
--- a/applications/katib/upstream/installs/katib-external-db/kustomization.yaml
+++ b/applications/katib/upstream/installs/katib-external-db/kustomization.yaml
@@ -14,6 +14,8 @@ resources:
 - ../../components/ui/
 # Katib webhooks.
 - ../../components/webhook/
+# Kubeflow istio virtual service.
+- ui-virtual-service.yaml
 images:
 - name: ghcr.io/kubeflow/katib/katib-controller
   newName: ghcr.io/kubeflow/katib/katib-controller

--- a/applications/katib/upstream/installs/katib-external-db/ui-virtual-service.yaml
+++ b/applications/katib/upstream/installs/katib-external-db/ui-virtual-service.yaml
@@ -1,0 +1,22 @@
+---
+apiVersion: networking.istio.io/v1alpha3
+kind: VirtualService
+metadata:
+  name: katib-ui
+  namespace: kubeflow
+spec:
+  gateways:
+    - kubeflow-gateway
+  hosts:
+    - "*"
+  http:
+    - match:
+        - uri:
+            prefix: /katib/
+      rewrite:
+        uri: /katib/
+      route:
+        - destination:
+            host: katib-ui.kubeflow.svc.cluster.local
+            port:
+              number: 80


### PR DESCRIPTION
# Pull Request Template for Kubeflow Manifests

## ✏️ Summary of Changes
> Describe the changes you have made, including any refactoring or feature additions.

Add ui-virtual-service.yaml to katib-external-db install profile to enable Istio routing for Katib UI (/katib/ path). Cherry-picked from katib-with-kubeflow/ui-virtual-service.yaml to fix "Sorry, /katib/ is not a valid page" error when using external database deployment.

Changes:

- Add ui-virtual-service.yaml at installs/katib-external-db/ root
- Update kustomization.yaml to include the VirtualService
- No breaking changes - preserves existing flat structure and functionality

## 📦 Dependencies
> List any dependencies or related PRs (e.g., "Depends on #123").

## 🐛 Related Issues
> Link any issues that are resolved or affected by this PR.
- https://github.com/kubeflow/katib/issues/714

## ✅ Contributor Checklist
  - [ ] I have tested these changes with kustomize. See [Installation Prerequisites](https://github.com/kubeflow/manifests#prerequisites).
  - [ ] All commits are [_signed-off_](https://github.com/kubeflow/community/tree/master/dco-signoff-hook#signing-off-commits) to satisfy the DCO check.
  - [ ] I have considered adding my company to the adopters page to support Kubeflow and help the community, since I expect help from the community for my issue (see [1.](https://github.com/kubeflow/community/issues/833) and [2.](https://github.com/kubeflow/community/blob/master/ADOPTERS.md#adopters-of-kubeflow-platform)).

---     
 
> You can join the CNCF Slack and access our meetings at the [Kubeflow Community](https://www.kubeflow.org/docs/about/community/) website. Our channel on the CNCF Slack is here [**#kubeflow-platform**](https://app.slack.com/client/T08PSQ7BQ/C073W572LA2).
  
