### PR TITLE
docs: remove experimental/seaweedfs installation from readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ The Kubeflow Manifests repository is organized under three main directories, whi
 | - | - |
 | `applications` | Kubeflow's official components, maintained by the respective Kubeflow WGs |
 | `common` | Common services, maintained by the Manifests WG |
-| `experimental` | Third-party integrations and platform experiments (e.g., Ray, SeaweedFS, or security improvements) |
+| `experimental` | Third-party integrations and platform experiments (e.g., Ray or security improvements) |
 
 All components are deployable with `kustomize`. You can choose to deploy the entire Kubeflow platform or individual components.
 
@@ -415,17 +415,7 @@ kustomize build common/istio/kubeflow-istio-resources/base | kubectl apply -f -
 
 Kubeflow Pipelines offers two deployment options to choose from, each designed for different use cases and operational preferences. The traditional database-based approach stores pipeline definitions in an external database, while the Kubernetes native API mode leverages Kubernetes custom resources for pipeline definition storage and management.
 
-The default artifact store is now seaweedfs as explained [here](https://medium.com/@hpotpose26/kubeflow-pipelines-embraces-seaweedfs-9a7e022d5571). The single-command installation using the `example` kustomization sets SeaweedFS as the default S3-compatible artifact store for Pipelines. It replaces `minio-service` to route S3 traffic to SeaweedFS and patches the Argo Workflow controller to use it.
-If you are following the step-by-step installation and want SeaweedFS as your Pipelines artifact store, apply the following overlay instead of the MinIO-based overlays:
-
-```sh path=null start=null
-kustomize build experimental/seaweedfs/istio | kubectl apply -f -
-```
-
-To switch back to MinIO, use the standard upstream Pipelines overlays shown below.
-
-TODO MinIO Will be removed in the next releases.
-
+> The default artifact store is now seaweedfs as explained [here](https://medium.com/@hpotpose26/kubeflow-pipelines-embraces-seaweedfs-9a7e022d5571). All the overlays now sets SeaweedFS as the default S3-compatible artifact store for Pipelines. It replaces `minio-service` to route S3 traffic to SeaweedFS and patches the Argo Workflow controller to use it.
 
 ##### Pipeline Definitions Stored in the Database
 


### PR DESCRIPTION
# Pull Request Template for Kubeflow Manifests

## ✏️ Summary of Changes
SeaweedFS is now fully integrated in the overlay/ manifests so the experimental/seaweedfs installation is not needed anymore. I removed the documentation in `README.md` that required to install experimental/seaweedfs manifests for kfp.

## 📦 Dependencies
None

## 🐛 Related Issues
Related to #3328

## ✅ Contributor Checklist
  - [x] I have tested these changes with kustomize. See [Installation Prerequisites](https://github.com/kubeflow/manifests#prerequisites).
  - [x] All commits are [_signed-off_](https://github.com/kubeflow/community/tree/master/dco-signoff-hook#signing-off-commits) to satisfy the DCO check.
  - [ ] I have considered adding my company to the adopters page to support Kubeflow and help the community, since I expect help from the community for my issue (see [1.](https://github.com/kubeflow/community/issues/833) and [2.](https://github.com/kubeflow/community/blob/master/ADOPTERS.md#adopters-of-kubeflow-platform)).