### PR TITLE
Add security patches to delete insecure LLMInferenceServiceConfig resources

### DIFF
--- a/applications/kserve/kserve/kustomization.yaml
+++ b/applications/kserve/kserve/kustomization.yaml
@@ -40,3 +40,56 @@ patches:
           securityContext:
             seccompProfile:
               type: RuntimeDefault
+
+# Security patches: Delete insecure LLMInferenceServiceConfig resources
+# These resources have dangerous capabilities (IPC_LOCK, SYS_RAWIO, NET_RAW)
+# and runAsNonRoot: false settings. See PR #3290 for details.
+# Ref: https://github.com/kubeflow/manifests/pull/3290
+
+- patch: |
+     apiVersion: serving.kserve.io/v1alpha1
+     kind: LLMInferenceServiceConfig
+     metadata:
+       name: kserve-config-llm-decode-template
+       namespace: kserve
+     $patch: delete
+
+- patch: |
+     apiVersion: serving.kserve.io/v1alpha1
+     kind: LLMInferenceServiceConfig
+     metadata:
+       name: kserve-config-llm-decode-worker-data-parallel
+       namespace: kserve
+     $patch: delete
+
+- patch: |
+     apiVersion: serving.kserve.io/v1alpha1
+     kind: LLMInferenceServiceConfig
+     metadata:
+       name: kserve-config-llm-worker-data-parallel
+       namespace: kserve
+     $patch: delete
+
+- patch: |
+     apiVersion: serving.kserve.io/v1alpha1
+     kind: LLMInferenceServiceConfig
+     metadata:
+       name: kserve-config-llm-template
+       namespace: kserve
+     $patch: delete
+
+- patch: |
+     apiVersion: serving.kserve.io/v1alpha1
+     kind: LLMInferenceServiceConfig
+     metadata:
+       name: kserve-config-llm-scheduler
+       namespace: kserve
+     $patch: delete
+
+- patch: |
+     apiVersion: serving.kserve.io/v1alpha1
+     kind: LLMInferenceServiceConfig
+     metadata:
+       name: kserve-config-llm-router-route
+       namespace: kserve
+     $patch: delete


### PR DESCRIPTION
# Pull Request Template for Kubeflow Manifests

## ✏️ Summary of Changes
This PR adds kustomize overlay patches to delete insecure `LLMInferenceServiceConfig` resources, effectively addressing the security concerns identified in #3290.

The following resources are **deleted** via patches because they define dangerous capabilities (`IPC_LOCK`, `SYS_RAWIO`, `NET_RAW`), set `runAsNonRoot: false`, and `readOnlyRootFilesystem: false`:
- `kserve-config-llm-decode-template`
- `kserve-config-llm-decode-worker-data-parallel`
- `kserve-config-llm-worker-data-parallel`
- `kserve-config-llm-template`
- `kserve-config-llm-scheduler`
- `kserve-config-llm-router-route`

## 📦 Dependencies
- This PR targets the `synchronize-kserve-manifests-v0.16.0` branch (PR #3290) instead of master, as requested by @juliusvonkohout.

## 🐛 Related Issues
- Related to #3290
- Replaces #3327

## ✅ Contributor Checklist
  - [x] I have tested these changes with kustomize. See [Installation Prerequisites](https://github.com/kubeflow/manifests#prerequisites).
  - [x] All commits are [_signed-off_](https://github.com/kubeflow/community/tree/master/dco-signoff-hook#signing-off-commits) to satisfy the DCO check.
  - [ ] I have considered adding my company to the adopters page to support Kubeflow and help the community, since I expect help from the community for my issue (see [1.](https://github.com/kubeflow/community/issues/833) and [2.](https://github.com/kubeflow/community/blob/master/ADOPTERS.md#adopters-of-kubeflow-platform)).

---     
 
> You can join the CNCF Slack and access our meetings at the [Kubeflow Community](https://www.kubeflow.org/docs/about/community/) website. Our channel on the CNCF Slack is here [**#kubeflow-platform**](https://app.slack.com/client/T08PSQ7BQ/C073W572LA2).