### PR TITLE
v1.10-branch: fix bitnami deprecation

### DIFF
--- a/common/oauth2-proxy/components/cluster-jwks-proxy/kustomization.yaml
+++ b/common/oauth2-proxy/components/cluster-jwks-proxy/kustomization.yaml
@@ -6,5 +6,5 @@ resources:
 
 images:
 - name: docker.io/bitnami/kubectl
-  newName: docker.io/bitnami/kubectl
-  newTag: 1.30.4
+  newName: docker.io/bitnamisecure/kubectl
+  newTag: latest


### PR DESCRIPTION
(cherry picked from commit 5298caa76d65f866a9f2cf629b5d50360812c68f)

# Pull Request Template for Kubeflow Manifests

## ✏️ Summary of Changes
> Describe the changes you have made, including any refactoring or feature additions.

Backport the already merged and deployed changes from Julius to `v1.10-branch` to fix the ImagePullBackOff error that it causes:
```
Back-off pulling image "docker.io/bitnami/kubectl:1.30.4": ErrImagePull: rpc error: code = NotFound desc = failed to pull and unpack image "docker.io/bitnami/kubectl:1.30.4": failed to resolve reference "docker.io/bitnami/kubectl:1.30.4": docker.io/bitnami/kubectl:1.30.4: not found
```


## 📦 Dependencies
> List any dependencies or related PRs (e.g., "Depends on #123").

## 🐛 Related Issues
> Link any issues that are resolved or affected by this PR.
 (#3235)

## ✅ Contributor Checklist
  - [x] I have tested these changes with kustomize. See [Installation Prerequisites](https://github.com/kubeflow/manifests#prerequisites).
  - [x] All commits are [_signed-off_](https://github.com/kubeflow/community/tree/master/dco-signoff-hook#signing-off-commits) to satisfy the DCO check.
  - [x] I have considered adding my company to the adopters page to support Kubeflow and help the community, since I expect help from the community for my issue (see [1.](https://github.com/kubeflow/community/issues/833) and [2.](https://github.com/kubeflow/community/blob/master/ADOPTERS.md#adopters-of-kubeflow-platform)).

---     
 
> You can join the CNCF Slack and access our meetings at the [Kubeflow Community](https://www.kubeflow.org/docs/about/community/) website. Our channel on the CNCF Slack is here [**#kubeflow-platform**](https://app.slack.com/client/T08PSQ7BQ/C073W572LA2).
  
