### PR TITLE
feat: add PDB patches to fix node drain with single replicas

### DIFF
--- a/common/knative/knative-eventing/base/kustomization.yaml
+++ b/common/knative/knative-eventing/base/kustomization.yaml
@@ -15,3 +15,4 @@ labels:
     kustomize.component: knative
 patches:
 - path: patches/clusterrole-patch.yaml
+- path: patches/pdb-node-drain.yaml

--- a/common/knative/knative-eventing/base/patches/pdb-node-drain.yaml
+++ b/common/knative/knative-eventing/base/patches/pdb-node-drain.yaml
@@ -1,0 +1,17 @@
+# Patch PodDisruptionBudget to allow node drain with single replica deployments
+# By Kubeflow convention, minAvailable is set to 0 to allow safe drain operations.
+#
+# Problem: PDBs with minAvailable: 80% block node drain when replicas=1
+# since ceil(0.8 * 1) = 1, meaning 100% of pods must remain available.
+#
+# Solution: Set minAvailable to 0 so node drain can proceed.
+# The HPA will maintain availability by scaling up as needed.
+#
+# Ref: https://github.com/kubeflow/manifests/issues/3313
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: eventing-webhook
+  namespace: knative-eventing
+spec:
+  minAvailable: 0

--- a/common/knative/knative-serving/base/kustomization.yaml
+++ b/common/knative/knative-serving/base/kustomization.yaml
@@ -21,3 +21,4 @@ patches:
     kind: Deployment
     namespace: knative-serving
     name: "(autoscaler|activator|controller|net-istio-webhook|webhook|net-istio-controller)"
+- path: patches/pdb-node-drain.yaml

--- a/common/knative/knative-serving/base/patches/pdb-node-drain.yaml
+++ b/common/knative/knative-serving/base/patches/pdb-node-drain.yaml
@@ -1,0 +1,25 @@
+# Patch PodDisruptionBudgets to allow node drain with single replica deployments
+# By Kubeflow convention, minAvailable is set to 0 to allow safe drain operations.
+#
+# Problem: PDBs with minAvailable: 80% block node drain when replicas=1
+# since ceil(0.8 * 1) = 1, meaning 100% of pods must remain available.
+#
+# Solution: Set minAvailable to 0 so node drain can proceed.
+# The HPA will maintain availability by scaling up as needed.
+#
+# Ref: https://github.com/kubeflow/manifests/issues/3313
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: activator-pdb
+  namespace: knative-serving
+spec:
+  minAvailable: 0
+---
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: webhook-pdb
+  namespace: knative-serving
+spec:
+  minAvailable: 0


### PR DESCRIPTION
Add strategic merge patches for Knative PodDisruptionBudgets to set minAvailable to 0 instead of 80%. This fixes issues where node drain operations would be blocked when running Knative components with a single replica (the default).

With minAvailable: 80%, a single replica deployment requires ceil(0.8 * 1) = 1 pod to remain available. This prevents node drain. With minAvailable: 0, the HPA can still maintain availability while allowing necessary drain operations.

Affected PDBs:
- knative-serving/activator-pdb
- knative-serving/webhook-pdb
- knative-eventing/eventing-webhook

Fixes: kubeflow/manifests#3313
Related: kubeflow/manifests#3317

# Pull Request Template for Kubeflow Manifests

## ✏️ Summary of Changes
Added strategic merge patches in `base/patches/` for Knative PodDisruptionBudgets:
- [common/knative/knative-serving/base/patches/pdb-node-drain.yaml](cci:7://file:///c:/Users/asus%20vivoBook/Desktop/New%20folder%20%282%29/manifests-fix/common/knative/knative-serving/base/patches/pdb-node-drain.yaml:0:0-0:0) - patches activator-pdb and webhook-pdb
- [common/knative/knative-eventing/base/patches/pdb-node-drain.yaml](cci:7://file:///c:/Users/asus%20vivoBook/Desktop/New%20folder%20%282%29/manifests-fix/common/knative/knative-eventing/base/patches/pdb-node-drain.yaml:0:0-0:0) - patches eventing-webhook
- Updated both [base/kustomization.yaml](cci:7://file:///c:/Users/asus%20vivoBook/Desktop/New%20folder%20%282%29/manifests-fix/common/knative/knative-serving/base/kustomization.yaml:0:0-0:0) files to include the new patches

## 📦 Dependencies
None

## 🐛 Related Issues
- Fixes #3313 (Knative PDB blocks node drain when only one replica is running)
- Supersedes #3317 (implements the fix using overlays/patches as requested by maintainer)

## ✅ Contributor Checklist
  - [x] I have tested these changes with kustomize. See [Installation Prerequisites](https://github.com/kubeflow/manifests#prerequisites).
  - [x] All commits are [_signed-off_](https://github.com/kubeflow/community/tree/master/dco-signoff-hook#signing-off-commits) to satisfy the DCO check.
  - [ ] I have considered adding my company to the adopters page to support Kubeflow and help the community, since I expect help from the community for my issue (see [1.](https://github.com/kubeflow/community/issues/833) and [2.](https://github.com/kubeflow/community/blob/master/ADOPTERS.md#adopters-of-kubeflow-platform)).

---     
 
> You can join the CNCF Slack and access our meetings at the [Kubeflow Community](https://www.kubeflow.org/docs/about/community/) website. Our channel on the CNCF Slack is here [**#kubeflow-platform**](https://app.slack.com/client/T08PSQ7BQ/C073W572LA2).