### PR TITLE
fix: remove broken multi-document patch from katib-cert-manager kusto…

### DIFF
--- a/applications/katib/upstream/installs/katib-cert-manager/kustomization.yaml
+++ b/applications/katib/upstream/installs/katib-cert-manager/kustomization.yaml
@@ -41,8 +41,6 @@ configMapGenerator:
   name: katib-config
   options:
     disableNameSuffixHash: true
-patches:
-- path: patches/katib-cert-injection.yaml
 replacements:
 - source:
     fieldPath: metadata.namespace


### PR DESCRIPTION
…mization

The katib-cert-injection.yaml patch file contains two YAML documents (ValidatingWebhookConfiguration and MutatingWebhookConfiguration) separated by '---', which kustomize cannot parse as a single patch.

This patch is redundant because the replacements section already handles injecting the cert-manager.io/inject-ca-from annotation on both webhook configurations using 'create: true'.

Fixes kustomize build error introduced in katib v0.19.0 sync (#3288).

https://claude.ai/code/session_017aG6oVWgytSZt4q6U8LSdX

# Pull Request Template for Kubeflow Manifests

## ✏️ Summary of Changes
> Describe the changes you have made, including any refactoring or feature additions.

## 📦 Dependencies
> List any dependencies or related PRs (e.g., "Depends on #123").

## 🐛 Related Issues
> Link any issues that are resolved or affected by this PR.

## ✅ Contributor Checklist
  - [ ] I have tested these changes with kustomize. See [Installation Prerequisites](https://github.com/kubeflow/manifests#prerequisites).
  - [ ] All commits are [_signed-off_](https://github.com/kubeflow/community/tree/master/dco-signoff-hook#signing-off-commits) to satisfy the DCO check.
  - [ ] I have considered adding my company to the adopters page to support Kubeflow and help the community, since I expect help from the community for my issue (see [1.](https://github.com/kubeflow/community/issues/833) and [2.](https://github.com/kubeflow/community/blob/master/ADOPTERS.md#adopters-of-kubeflow-platform)).

---     
 
> You can join the CNCF Slack and access our meetings at the [Kubeflow Community](https://www.kubeflow.org/docs/about/community/) website. Our channel on the CNCF Slack is here [**#kubeflow-platform**](https://app.slack.com/client/T08PSQ7BQ/C073W572LA2).
  
