### PR TITLE
fix(admission-webhook): migrate deprecated kustomize fields to v5 syntax

### DIFF
--- a/applications/admission-webhook/upstream/base/kustomization.yaml
+++ b/applications/admission-webhook/upstream/base/kustomization.yaml
@@ -8,11 +8,13 @@ resources:
 - service-account.yaml
 - service.yaml
 - crd.yaml
-commonLabels:
-  app: poddefaults
-  kustomize.component: poddefaults
-  app.kubernetes.io/component: poddefaults
-  app.kubernetes.io/name: poddefaults
+labels:
+- includeSelectors: true
+  pairs:
+    app: poddefaults
+    kustomize.component: poddefaults
+    app.kubernetes.io/component: poddefaults
+    app.kubernetes.io/name: poddefaults
 images:
 - name: ghcr.io/kubeflow/kubeflow/poddefaults-webhook
   newName: ghcr.io/kubeflow/kubeflow/poddefaults-webhook

--- a/applications/admission-webhook/upstream/overlays/cert-manager/kustomization.yaml
+++ b/applications/admission-webhook/upstream/overlays/cert-manager/kustomization.yaml
@@ -4,25 +4,25 @@
 # the certificate.
 # TODO(jlewi): We should eventually refactor the manifests to delete
 # bootstrap and use certmanager by default.
-bases:
-- ../../base
-
 resources:
+- ../../base
 - certificate.yaml
 
 namespace: kubeflow
 
 namePrefix: admission-webhook-
 
-commonLabels:
-  app: poddefaults
-  kustomize.component: poddefaults
-  app.kubernetes.io/component: poddefaults
-  app.kubernetes.io/name: poddefaults
+labels:
+- includeSelectors: true
+  pairs:
+    app: poddefaults
+    kustomize.component: poddefaults
+    app.kubernetes.io/component: poddefaults
+    app.kubernetes.io/name: poddefaults
 
-patchesStrategicMerge:
-- mutating-webhook-configuration.yaml
-- deployment.yaml
+patches:
+- path: mutating-webhook-configuration.yaml
+- path: deployment.yaml
 
 generatorOptions:
   disableNameSuffixHash: true


### PR DESCRIPTION
## ✏️ Summary of Changes

Migrates deprecated kustomize fields in `admission-webhook` upstream manifests to kustomize v5 compatible syntax:

| Deprecated Field | New Field | File |
|---|---|---|
| `commonLabels` | `labels` with `includeSelectors: true` | [base/kustomization.yaml](cci:7://file:///c:/Users/asus%20vivoBook/Desktop/New%20folder%20%282%29/kubeflow-manifests/applications/admission-webhook/upstream/base/kustomization.yaml:0:0-0:0) |
| `commonLabels` | `labels` with `includeSelectors: true` | [overlays/cert-manager/kustomization.yaml](cci:7://file:///c:/Users/asus%20vivoBook/Desktop/New%20folder%20%282%29/kubeflow-manifests/applications/admission-webhook/upstream/overlays/cert-manager/kustomization.yaml:0:0-0:0) |
| `bases` | `resources` | [overlays/cert-manager/kustomization.yaml](cci:7://file:///c:/Users/asus%20vivoBook/Desktop/New%20folder%20%282%29/kubeflow-manifests/applications/admission-webhook/upstream/overlays/cert-manager/kustomization.yaml:0:0-0:0) |
| `patchesStrategicMerge` | `patches` | [overlays/cert-manager/kustomization.yaml](cci:7://file:///c:/Users/asus%20vivoBook/Desktop/New%20folder%20%282%29/kubeflow-manifests/applications/admission-webhook/upstream/overlays/cert-manager/kustomization.yaml:0:0-0:0) |

> **Note:** `vars` → `replacements` migration is intentionally excluded — it requires careful source/target mapping for the `$(podDefaultsDeploymentName)` substitution in the MutatingWebhookConfiguration. This will be addressed in a follow-up PR to reduce risk.

## 📦 Dependencies

No dependencies.

## 🐛 Related Issues

Part of #2991

/cc @juliusvonkohout

## ✅ Contributor Checklist
  - [x] I have tested these changes with kustomize. See [Installation Prerequisites](https://github.com/kubeflow/manifests#prerequisites).
  - [x] All commits are [_signed-off_](https://github.com/kubeflow/community/tree/master/dco-signoff-hook#signing-off-commits) to satisfy the DCO check.
  - [ ] I have considered adding my company to the adopters page to support Kubeflow and help the community, since I expect help from the community for my issue (see [1.](https://github.com/kubeflow/community/issues/833) and [2.](https://github.com/kubeflow/community/blob/master/ADOPTERS.md#adopters-of-kubeflow-platform)).

---

> You can join the CNCF Slack and access our meetings at the [Kubeflow Community](https://www.kubeflow.org/docs/about/community/) website. Our channel on the CNCF Slack is here [**#kubeflow-platform**](https://app.slack.com/client/T08PSQ7BQ/C073W572LA2).