### PR TITLE
fix(profiles): migrate deprecated kustomize fields to v5 syntax

### DIFF
--- a/applications/profiles/upstream/base/kustomization.yaml
+++ b/applications/profiles/upstream/base/kustomization.yaml
@@ -6,8 +6,8 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
 - ../default
-patchesStrategicMerge:
-- patches/manager.yaml
+patches:
+- path: patches/manager.yaml
 
 images:
 - name: ghcr.io/kubeflow/kubeflow/profile-controller

--- a/applications/profiles/upstream/crd/kustomization.yaml
+++ b/applications/profiles/upstream/crd/kustomization.yaml
@@ -5,11 +5,11 @@ resources:
 - bases/kubeflow.org_profiles.yaml
 #+kubebuilder:scaffold:crdkustomizeresource
 
-patchesStrategicMerge:
-- patches/trivial_conversion_patch.yaml
+patches:
+- path: patches/trivial_conversion_patch.yaml
 # [WEBHOOK] To enable webhook, uncomment all the sections with [WEBHOOK] prefix.
 # patches here are for enabling the conversion webhook for each CRD
-#- patches/webhook_in_profiles.yaml
+#- path: patches/webhook_in_profiles.yaml
 #+kubebuilder:scaffold:crdkustomizewebhookpatch
 
 # [CERTMANAGER] To enable cert-manager, uncomment all the sections with [CERTMANAGER] prefix.

--- a/applications/profiles/upstream/default/kustomization.yaml
+++ b/applications/profiles/upstream/default/kustomization.yaml
@@ -9,10 +9,12 @@ namespace: profiles-system
 namePrefix: profiles-
 
 # Labels to add to all resources and selectors.
-commonLabels:
-  kustomize.component: profiles
+labels:
+- includeSelectors: true
+  pairs:
+    kustomize.component: profiles
 
-bases:
+resources:
 - ../crd
 - ../rbac
 - ../manager
@@ -24,26 +26,26 @@ bases:
 # [PROMETHEUS] To enable prometheus monitor, uncomment all sections with 'PROMETHEUS'.
 #- ../prometheus
 
-patchesStrategicMerge:
+patches:
 # Protect the /metrics endpoint by putting it behind auth.
 # If you want your controller-manager to expose the /metrics
 # endpoint w/o any authn/z, please comment the following line.
-# - manager_auth_proxy_patch.yaml
+# - path: manager_auth_proxy_patch.yaml
   # If you want your controller-manager to expose the /metrics
   # endpoint w/o any authn/z, uncomment the following line and
   # comment manager_auth_proxy_patch.yaml.
   # Only one of manager_auth_proxy_patch.yaml and
   # manager_prometheus_metrics_patch.yaml should be enabled.
-#- manager_prometheus_metrics_patch.yaml
+#- path: manager_prometheus_metrics_patch.yaml
 
 # [WEBHOOK] To enable webhook, uncomment all the sections with [WEBHOOK] prefix including the one in
 # crd/kustomization.yaml
-#- manager_webhook_patch.yaml
+#- path: manager_webhook_patch.yaml
 
 # [CERTMANAGER] To enable cert-manager, uncomment all sections with 'CERTMANAGER'.
 # Uncomment 'CERTMANAGER' sections in crd/kustomization.yaml to enable the CA injection in the admission webhooks.
 # 'CERTMANAGER' needs to be enabled to use ca injection
-#- webhookcainjection_patch.yaml
+#- path: webhookcainjection_patch.yaml
 
 # the following config is for teaching kustomize how to do var substitution
 vars:

--- a/applications/profiles/upstream/overlays/kubeflow/kustomization.yaml
+++ b/applications/profiles/upstream/overlays/kubeflow/kustomization.yaml
@@ -7,12 +7,14 @@ resources:
 - virtual-service.yaml
 - authorizationpolicy.yaml
 
-commonLabels:
-  kustomize.component: profiles
+labels:
+- includeSelectors: true
+  pairs:
+    kustomize.component: profiles
 
-patchesStrategicMerge:
-- patches/kfam.yaml
-- patches/remove-namespace.yaml
+patches:
+- path: patches/kfam.yaml
+- path: patches/remove-namespace.yaml
 
 configurations:
 - params.yaml


### PR DESCRIPTION
## ✏️ Summary of Changes

Migrates deprecated kustomize fields in the profiles component to kustomize v5 compatible syntax:

| Deprecated Field | New Field | Files |
|---|---|---|
| `commonLabels` | `labels` with `includeSelectors: true` | `default/kustomization.yaml`, `overlays/kubeflow/kustomization.yaml` |
| `bases` | `resources` | `default/kustomization.yaml` |
| `patchesStrategicMerge` | `patches` | `base/kustomization.yaml`, `default/kustomization.yaml`, `crd/kustomization.yaml`, `overlays/kubeflow/kustomization.yaml` |

**Note:** `vars` → `replacements` migration is intentionally excluded — the kubeflow overlay has an active `vars` entry (`PROFILES_NAMESPACE`) used for VirtualService host substitution. The `default/kustomization.yaml` has fully commented-out `vars` which were preserved as-is. This will be addressed in a follow-up PR to reduce risk.

## 📦 Dependencies
No dependencies.

## 🐛 Related Issues
Part of #2991

/cc @juliusvonkohout

## ✅ Contributor Checklist
- [x] I have tested these changes with kustomize. See [Installation Prerequisites](https://github.com/kubeflow/manifests#prerequisites).
- [x] All commits are signed-off to satisfy the DCO check.
- [ ] I have considered adding my company to the [adopters page](https://github.com/kubeflow/community/blob/master/ADOPTERS.md).