### PR TITLE
fix: replace deprecated gcr.io minio image with docker.io in v1.9.1

### DIFF
--- a/apps/pipeline/upstream/third-party/minio/base/minio-deployment.yaml
+++ b/apps/pipeline/upstream/third-party/minio/base/minio-deployment.yaml
@@ -30,7 +30,7 @@ spec:
             secretKeyRef:
               name: mlpipeline-minio-artifact
               key: secretkey
-        image: minio/minio:RELEASE.2019-08-14T20-37-41Z
+        image: docker.io/minio/minio:RELEASE.2019-08-14T20-37-41Z
         name: minio
         ports:
         - containerPort: 9000


### PR DESCRIPTION
## Problem
The image `gcr.io/ml-pipeline/minio:RELEASE.2019-08-14T20-37-41Z-license-compliance` is no longer available on gcr.io, causing `minio` pod to fail with `ImagePullBackOff` on fresh installs of v1.9.1.

## Fix
Replace with the equivalent official image from Docker Hub:
`minio/minio:RELEASE.2019-08-14T20-37-41Z`

## Testing
Verified working on a local kind cluster running Kubeflow v1.9.1.