### PR TITLE
sync(knative): bump serving/net-istio/eventing manifests

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,7 +80,7 @@ This repository periodically synchronizes all official Kubeflow components from 
 | Kubeflow Model Registry | applications/model-registry/upstream | [v0.3.6](https://github.com/kubeflow/model-registry/tree/v0.3.6/manifests/kustomize) | 510m | 2112Mi | 20GB |
 | Spark Operator	|	applications/spark/spark-operator	|	[2.4.0](https://github.com/kubeflow/spark-operator/tree/v2.4.0) | 9m | 41Mi | 0GB |
 | Istio | common/istio | [1.29.0](https://github.com/istio/istio/releases/tag/1.29.0) | 750m | 2364Mi | 0GB |
-| Knative | common/knative/knative-serving <br /> common/knative/knative-eventing | [v1.20.0](https://github.com/knative/serving/releases/tag/knative-v1.20.0) <br /> [v1.20.0](https://github.com/knative/eventing/releases/tag/knative-v1.20.0) | 1450m | 1038Mi | 0GB |
+| Knative | common/knative/knative-serving <br /> common/knative/knative-eventing | [v1.21.1](https://github.com/knative/serving/releases/tag/knative-v1.21.1) <br /> [v1.21.0](https://github.com/knative/eventing/releases/tag/knative-v1.21.0) | 1450m | 1038Mi | 0GB |
 | Cert Manager | common/cert-manager | [1.16.1](https://github.com/cert-manager/cert-manager/releases/tag/v1.16.1) | 3m | 128Mi | 0GB |
 | Dex | common/dex | [2.43.1](https://github.com/dexidp/dex/releases/tag/v2.43.1) | 3m | 27Mi | 0GB |
 | OAuth2-Proxy | common/oauth2-proxy | [7.10.0](https://github.com/oauth2-proxy/oauth2-proxy/releases/tag/v7.10.0) | 3m | 27Mi | 0GB |

--- a/common/knative/README.md
+++ b/common/knative/README.md
@@ -4,8 +4,8 @@
 
 The manifests for Knative Serving are based off the following:
 
-  - [Knative serving (v1.20.0)](https://github.com/knative/serving/releases/tag/knative-v1.20.0)
-  - [Knative ingress controller for Istio (v1.20.1)](https://github.com/knative-extensions/net-istio/releases/tag/knative-v1.20.1)
+  - [Knative serving (v1.21.1)](https://github.com/knative/serving/releases/tag/knative-v1.21.1)
+  - [Knative ingress controller for Istio (v1.21.1)](https://github.com/knative-extensions/net-istio/releases/tag/knative-v1.21.1)
 
 Please check the synchronization script under /hack.
 
@@ -18,7 +18,7 @@ Please check the synchronization script under /hack.
 
 ## Knative-Eventing
 
-The manifests for Knative Eventing are based off the [v1.20.0 release](https://github.com/knative/eventing/releases/tag/knative-v1.20.0).
+The manifests for Knative Eventing are based off the [v1.21.0 release](https://github.com/knative/eventing/releases/tag/knative-v1.21.0).
 
   - [Eventing Core](https://github.com/knative/eventing/releases/download/knative-v1.12.6/eventing-core.yaml)
   - [In-Memory Channel](https://github.com/knative/eventing/releases/download/knative-v1.12.6/in-memory-channel.yaml)

--- a/common/knative/knative-eventing-post-install-jobs/base/eventing-post-install.yaml
+++ b/common/knative/knative-eventing-post-install-jobs/base/eventing-post-install.yaml
@@ -7,7 +7,7 @@ metadata:
     app: "storage-version-migration-eventing"
     app.kubernetes.io/name: knative-eventing
     app.kubernetes.io/component: storage-version-migration-job
-    app.kubernetes.io/version: "1.20.0"
+    app.kubernetes.io/version: "1.21.0"
   name: storage-version-migration-eventing
 spec:
   ttlSecondsAfterFinished: 600
@@ -18,7 +18,7 @@ spec:
         app: "storage-version-migration-eventing"
         app.kubernetes.io/name: knative-eventing
         app.kubernetes.io/component: storage-version-migration-job
-        app.kubernetes.io/version: "1.20.0"
+        app.kubernetes.io/version: "1.21.0"
         sidecar.istio.io/inject: "false"
       annotations:
         sidecar.istio.io/inject: "false"
@@ -27,7 +27,7 @@ spec:
       restartPolicy: OnFailure
       containers:
         - name: migrate
-          image: gcr.io/knative-releases/knative.dev/pkg/apiextensions/storageversion/cmd/migrate@sha256:8f13529c6f36244b649abe820134a318fcaced35c4cf3d7aaf9a18148d8e79ce
+          image: gcr.io/knative-releases/knative.dev/pkg/apiextensions/storageversion/cmd/migrate@sha256:728a991fa5162aa82ce9a52f41e5d5b1d690ec18b2108c5726f6a82b203aa635
           env:
             - name: IGNORE_NOT_FOUND
               value: "true"

--- a/common/knative/knative-eventing/base/upstream/eventing-core.yaml
+++ b/common/knative/knative-eventing/base/upstream/eventing-core.yaml
@@ -3,7 +3,7 @@ kind: Namespace
 metadata:
   name: knative-eventing
   labels:
-    app.kubernetes.io/version: "1.20.0"
+    app.kubernetes.io/version: "1.21.0"
     app.kubernetes.io/name: knative-eventing
 ---
 apiVersion: v1
@@ -12,7 +12,7 @@ metadata:
   name: eventing-controller
   namespace: knative-eventing
   labels:
-    app.kubernetes.io/version: "1.20.0"
+    app.kubernetes.io/version: "1.21.0"
     app.kubernetes.io/name: knative-eventing
 ---
 apiVersion: rbac.authorization.k8s.io/v1
@@ -20,7 +20,7 @@ kind: ClusterRoleBinding
 metadata:
   name: eventing-controller
   labels:
-    app.kubernetes.io/version: "1.20.0"
+    app.kubernetes.io/version: "1.21.0"
     app.kubernetes.io/name: knative-eventing
 subjects:
   - kind: ServiceAccount
@@ -36,7 +36,7 @@ kind: ClusterRoleBinding
 metadata:
   name: eventing-controller-resolver
   labels:
-    app.kubernetes.io/version: "1.20.0"
+    app.kubernetes.io/version: "1.21.0"
     app.kubernetes.io/name: knative-eventing
 subjects:
   - kind: ServiceAccount
@@ -52,7 +52,7 @@ kind: ClusterRoleBinding
 metadata:
   name: eventing-controller-source-observer
   labels:
-    app.kubernetes.io/version: "1.20.0"
+    app.kubernetes.io/version: "1.21.0"
     app.kubernetes.io/name: knative-eventing
 subjects:
   - kind: ServiceAccount
@@ -68,7 +68,7 @@ kind: ClusterRoleBinding
 metadata:
   name: eventing-controller-sources-controller
   labels:
-    app.kubernetes.io/version: "1.20.0"
+    app.kubernetes.io/version: "1.21.0"
     app.kubernetes.io/name: knative-eventing
 subjects:
   - kind: ServiceAccount
@@ -84,7 +84,7 @@ kind: ClusterRoleBinding
 metadata:
   name: eventing-controller-manipulator
   labels:
-    app.kubernetes.io/version: "1.20.0"
+    app.kubernetes.io/version: "1.21.0"
     app.kubernetes.io/name: knative-eventing
 subjects:
   - kind: ServiceAccount
@@ -100,7 +100,7 @@ kind: ClusterRoleBinding
 metadata:
   name: eventing-controller-crossnamespace-subscriber
   labels:
-    app.kubernetes.io/version: "1.20.0"
+    app.kubernetes.io/version: "1.21.0"
     app.kubernetes.io/name: knative-eventing
 subjects:
   - kind: ServiceAccount
@@ -117,7 +117,7 @@ metadata:
   name: job-sink
   namespace: knative-eventing
   labels:
-    app.kubernetes.io/version: "1.20.0"
+    app.kubernetes.io/version: "1.21.0"
     app.kubernetes.io/name: knative-eventing
 ---
 apiVersion: rbac.authorization.k8s.io/v1
@@ -125,7 +125,7 @@ kind: ClusterRoleBinding
 metadata:
   name: knative-eventing-job-sink
   labels:
-    app.kubernetes.io/version: "1.20.0"
+    app.kubernetes.io/version: "1.21.0"
     app.kubernetes.io/name: knative-eventing
 subjects:
   - kind: ServiceAccount
@@ -142,7 +142,7 @@ metadata:
   name: pingsource-mt-adapter
   namespace: knative-eventing
   labels:
-    app.kubernetes.io/version: "1.20.0"
+    app.kubernetes.io/version: "1.21.0"
     app.kubernetes.io/name: knative-eventing
 ---
 apiVersion: rbac.authorization.k8s.io/v1
@@ -150,7 +150,7 @@ kind: ClusterRoleBinding
 metadata:
   name: knative-eventing-pingsource-mt-adapter
   labels:
-    app.kubernetes.io/version: "1.20.0"
+    app.kubernetes.io/version: "1.21.0"
     app.kubernetes.io/name: knative-eventing
 subjects:
   - kind: ServiceAccount
@@ -167,7 +167,7 @@ metadata:
   name: request-reply
   namespace: knative-eventing
   labels:
-    app.kubernetes.io/version: "1.20.0"
+    app.kubernetes.io/version: "1.21.0"
     app.kubernetes.io/name: knative-eventing
 ---
 apiVersion: rbac.authorization.k8s.io/v1
@@ -175,7 +175,7 @@ kind: ClusterRoleBinding
 metadata:
   name: knative-eventing-request-reply
   labels:
-    app.kubernetes.io/version: "1.20.0"
+    app.kubernetes.io/version: "1.21.0"
     app.kubernetes.io/name: knative-eventing
 subjects:
   - kind: ServiceAccount
@@ -192,7 +192,7 @@ metadata:
   name: eventing-webhook
   namespace: knative-eventing
   labels:
-    app.kubernetes.io/version: "1.20.0"
+    app.kubernetes.io/version: "1.21.0"
     app.kubernetes.io/name: knative-eventing
 ---
 apiVersion: rbac.authorization.k8s.io/v1
@@ -200,7 +200,7 @@ kind: ClusterRoleBinding
 metadata:
   name: eventing-webhook
   labels:
-    app.kubernetes.io/version: "1.20.0"
+    app.kubernetes.io/version: "1.21.0"
     app.kubernetes.io/name: knative-eventing
 subjects:
   - kind: ServiceAccount
@@ -217,7 +217,7 @@ metadata:
   namespace: knative-eventing
   name: eventing-webhook
   labels:
-    app.kubernetes.io/version: "1.20.0"
+    app.kubernetes.io/version: "1.21.0"
     app.kubernetes.io/name: knative-eventing
 subjects:
   - kind: ServiceAccount
@@ -233,7 +233,7 @@ kind: ClusterRoleBinding
 metadata:
   name: eventing-webhook-resolver
   labels:
-    app.kubernetes.io/version: "1.20.0"
+    app.kubernetes.io/version: "1.21.0"
     app.kubernetes.io/name: knative-eventing
 subjects:
   - kind: ServiceAccount
@@ -249,7 +249,7 @@ kind: ClusterRoleBinding
 metadata:
   name: eventing-webhook-podspecable-binding
   labels:
-    app.kubernetes.io/version: "1.20.0"
+    app.kubernetes.io/version: "1.21.0"
     app.kubernetes.io/name: knative-eventing
 subjects:
   - kind: ServiceAccount
@@ -266,7 +266,7 @@ metadata:
   name: config-br-default-channel
   namespace: knative-eventing
   labels:
-    app.kubernetes.io/version: "1.20.0"
+    app.kubernetes.io/version: "1.21.0"
     app.kubernetes.io/name: knative-eventing
 data:
   channel-template-spec: |
@@ -279,7 +279,7 @@ metadata:
   name: config-br-defaults
   namespace: knative-eventing
   labels:
-    app.kubernetes.io/version: "1.20.0"
+    app.kubernetes.io/version: "1.21.0"
     app.kubernetes.io/name: knative-eventing
 data:
   default-br-config: |
@@ -300,7 +300,7 @@ metadata:
   name: default-ch-webhook
   namespace: knative-eventing
   labels:
-    app.kubernetes.io/version: "1.20.0"
+    app.kubernetes.io/version: "1.21.0"
     app.kubernetes.io/name: knative-eventing
 data:
   default-ch-config: |
@@ -319,7 +319,7 @@ metadata:
   namespace: knative-eventing
   annotations:
     knative.dev/example-checksum: "9185c153"
-    app.kubernetes.io/version: "1.20.0"
+    app.kubernetes.io/version: "1.21.0"
     app.kubernetes.io/name: knative-eventing
 data:
   _example: |
@@ -348,18 +348,18 @@ metadata:
   name: eventing-integrations-images
   namespace: knative-eventing
   labels:
-    app.kubernetes.io/version: "v1.20.0"
+    app.kubernetes.io/version: "v1.21.0"
 data:
-  aws-eventbridge-sink: gcr.io/knative-releases/aws-eventbridge-sink@sha256:5443bbdb619b6bdecd210b15631202c167da1f8470267f2b61bcd01d6b7d874a
-  timer-source: gcr.io/knative-releases/timer-source@sha256:5b04a448e43e6d35a1a306bff88f859c88a433b3bd976052996cb2e0c17e1bd5
-  aws-ddb-streams-source: gcr.io/knative-releases/aws-ddb-streams-source@sha256:8e2466af77220758806d00ab925c95daaa1a02702a8d687e572abf3b5ebcaf2e
-  aws-sqs-sink: gcr.io/knative-releases/aws-sqs-sink@sha256:a3e104ec58cbdbfaaa4a1c51bebbaef299a7ea199b84ec41fc25a804aeb5e99f
-  log-sink: gcr.io/knative-releases/log-sink@sha256:5f99740693979f366027cd50746fb38b27a7fcc7dba82052322fa7d7733dff01
-  aws-s3-sink: gcr.io/knative-releases/aws-s3-sink@sha256:6a66e16b90b2c2a1ba3a0bc5ac634dda0840feba19a3f0d326964643303b6afd
-  aws-sns-sink: gcr.io/knative-releases/aws-sns-sink@sha256:89374e5fc4b686239f63a6acc2d5269b7f84a02da5cce4a2ac359ad9b134a26e
-  aws-sqs-source: gcr.io/knative-releases/aws-sqs-source@sha256:49d6ca15d2cdd10e85db88b08cb894e078bc72e982e00077a8f2edfcc43fcbbb
-  jsonata-transformer: gcr.io/knative-releases/jsonata-transformer@sha256:5a60c759a9e1730201ef9e1ad81e47432608852d129a71fd736363ceac8c7071
-  aws-s3-source: gcr.io/knative-releases/aws-s3-source@sha256:16683f90baae7aaa68d702e20c8ce97d809548a85d00aeb17673bd80b969b1b5
+  aws-eventbridge-sink: gcr.io/knative-releases/aws-eventbridge-sink@sha256:2dc612ab600c3813e48adb8e190136859ce06d21a62ea90ed2dc621e31ea74f3
+  timer-source: gcr.io/knative-releases/timer-source@sha256:1f8d9650068bf96e09a07381e0c0ac35a8e04456c9a5cfc298f7438c4b6ffe2d
+  aws-ddb-streams-source: gcr.io/knative-releases/aws-ddb-streams-source@sha256:c5110873d0a99c78aa2848a570892d01610c661e0580c20e973dd08187e5a340
+  aws-sqs-sink: gcr.io/knative-releases/aws-sqs-sink@sha256:496e8b7ca049d71189b96b6f4e0cb23f2ce93f206df53a32a05310ed0a014fbd
+  log-sink: gcr.io/knative-releases/log-sink@sha256:7dc1fa9d49f797296808928dd525005a445a7c17b18017103482453a71adfb07
+  aws-s3-sink: gcr.io/knative-releases/aws-s3-sink@sha256:10859fa6ea1823173310ad94d4cc9bd716a174fb05fc09e0f4eeae92b1742cc0
+  aws-sns-sink: gcr.io/knative-releases/aws-sns-sink@sha256:5860b307f309d4adb3e19e26a171829dc74cc9e308bc3660d8bb142cc064a6ca
+  aws-sqs-source: gcr.io/knative-releases/aws-sqs-source@sha256:08e46406ba34c0936a6e591161c84446cfc9de1152ee80bc4b71aa37ec1aae88
+  jsonata-transformer: gcr.io/knative-releases/jsonata-transformer@sha256:646c30b48edef26510fbf720189b514d758c56b9782a1f0206d08525f94ef661
+  aws-s3-source: gcr.io/knative-releases/aws-s3-source@sha256:eab34dadd20a3c418d0df0e6ec2ff8ab9f974598b7a40544b4fc40129057762b
 ---
 apiVersion: v1
 kind: ConfigMap
@@ -367,9 +367,9 @@ metadata:
   name: eventing-transformations-images
   namespace: knative-eventing
   labels:
-    app.kubernetes.io/version: "v1.20.0"
+    app.kubernetes.io/version: "v1.21.0"
 data:
-  transform-jsonata: gcr.io/knative-releases/transform-jsonata@sha256:50f78fb030d26bc8ae9c1a8dae01958c46882e1c8e9e35f8af2695d93835ee59
+  transform-jsonata: gcr.io/knative-releases/transform-jsonata@sha256:293eb9924e1e33de679181f8e932afed6947961aef2fd684e77cb7293ca3510e
 ---
 apiVersion: v1
 kind: ConfigMap
@@ -379,7 +379,7 @@ metadata:
   labels:
     knative.dev/config-propagation: original
     knative.dev/config-category: eventing
-    app.kubernetes.io/version: "1.20.0"
+    app.kubernetes.io/version: "1.21.0"
     app.kubernetes.io/name: knative-eventing
 data:
   kreference-group: "disabled"
@@ -432,7 +432,7 @@ metadata:
   name: config-leader-election
   namespace: knative-eventing
   labels:
-    app.kubernetes.io/version: "1.20.0"
+    app.kubernetes.io/version: "1.21.0"
     app.kubernetes.io/name: knative-eventing
   annotations:
     knative.dev/example-checksum: "f7948630"
@@ -480,7 +480,7 @@ metadata:
   labels:
     knative.dev/config-propagation: original
     knative.dev/config-category: eventing
-    app.kubernetes.io/version: "1.20.0"
+    app.kubernetes.io/version: "1.21.0"
     app.kubernetes.io/name: knative-eventing
 data:
   zap-logger-config: |
@@ -515,7 +515,7 @@ metadata:
   labels:
     knative.dev/config-propagation: original
     knative.dev/config-category: eventing
-    app.kubernetes.io/version: "1.20.0"
+    app.kubernetes.io/version: "1.21.0"
     app.kubernetes.io/name: knative-eventing
   annotations:
     knative.dev/example-checksum: "0270bb17"
@@ -584,7 +584,7 @@ metadata:
   name: config-sugar
   namespace: knative-eventing
   labels:
-    app.kubernetes.io/version: "1.20.0"
+    app.kubernetes.io/version: "1.21.0"
     app.kubernetes.io/name: knative-eventing
   annotations:
     knative.dev/example-checksum: "62dfac6f"
@@ -628,7 +628,7 @@ metadata:
   labels:
     knative.dev/config-propagation: original
     knative.dev/config-category: eventing
-    app.kubernetes.io/version: "1.20.0"
+    app.kubernetes.io/version: "1.21.0"
     app.kubernetes.io/name: knative-eventing
   annotations:
     knative.dev/example-checksum: "04c7e9a3"
@@ -648,7 +648,7 @@ metadata:
   labels:
     knative.dev/high-availability: "true"
     app.kubernetes.io/component: eventing-controller
-    app.kubernetes.io/version: "1.20.0"
+    app.kubernetes.io/version: "1.21.0"
     app.kubernetes.io/name: knative-eventing
     bindings.knative.dev/exclude: "true"
 spec:
@@ -660,7 +660,7 @@ spec:
       labels:
         app: eventing-controller
         app.kubernetes.io/component: eventing-controller
-        app.kubernetes.io/version: "1.20.0"
+        app.kubernetes.io/version: "1.21.0"
         app.kubernetes.io/name: knative-eventing
     spec:
       affinity:
@@ -677,7 +677,7 @@ spec:
       containers:
         - name: eventing-controller
           terminationMessagePolicy: FallbackToLogsOnError
-          image: gcr.io/knative-releases/knative.dev/eventing/cmd/controller@sha256:202f2c203154f30b642ddbd3843fad12637389a84bf097c22c216039469f704b
+          image: gcr.io/knative-releases/knative.dev/eventing/cmd/controller@sha256:363742c13076cce03c367b42c050ad47e07b327b98d4176ac1961670e12c2680
           resources:
             requests:
               cpu: 100m
@@ -694,9 +694,9 @@ spec:
             - name: METRICS_DOMAIN
               value: knative.dev/eventing
             - name: APISERVER_RA_IMAGE
-              value: gcr.io/knative-releases/knative.dev/eventing/cmd/apiserver_receive_adapter@sha256:9cf675814667090fdb72be469c0854b3480c13b3338a461cb6e11977777840b3
+              value: gcr.io/knative-releases/knative.dev/eventing/cmd/apiserver_receive_adapter@sha256:5f6f0627caa8b8d734bf1a8968c59d71c34e51403864950c0ca3e6bac8df7973
             - name: AUTH_PROXY_IMAGE
-              value: gcr.io/knative-releases/knative.dev/eventing/cmd/auth_proxy@sha256:4064ccb35793a18faed99c52665dc96ea22588193c9435ef6617255aeec1e701
+              value: gcr.io/knative-releases/knative.dev/eventing/cmd/auth_proxy@sha256:89b9ce49a216b08b443340aaaba2ea745d994a9609ce5dc4bef3e71b3a87b4ce
             - name: POD_NAME
               valueFrom:
                 fieldRef:
@@ -786,7 +786,7 @@ metadata:
   namespace: knative-eventing
   labels:
     app.kubernetes.io/component: job-sink
-    app.kubernetes.io/version: "1.20.0"
+    app.kubernetes.io/version: "1.21.0"
     app.kubernetes.io/name: knative-eventing
 spec:
   replicas: 1
@@ -798,7 +798,7 @@ spec:
       labels:
         sinks.knative.dev/sink: job-sink
         app.kubernetes.io/component: job-sink
-        app.kubernetes.io/version: "1.20.0"
+        app.kubernetes.io/version: "1.21.0"
         app.kubernetes.io/name: knative-eventing
     spec:
       affinity:
@@ -814,7 +814,7 @@ spec:
       containers:
         - name: job-sink
           terminationMessagePolicy: FallbackToLogsOnError
-          image: gcr.io/knative-releases/knative.dev/eventing/cmd/jobsink@sha256:d95c94e8b28e1cb6d6415e574679de03acf6eeb9d339edcd60e70ead8bcf8c16
+          image: gcr.io/knative-releases/knative.dev/eventing/cmd/jobsink@sha256:194e44b15a7a26adb024cdbce0ec356e7a27678aceecdde447d3986f9c43eff1
           env:
             - name: SYSTEM_NAMESPACE
               valueFrom:
@@ -896,7 +896,7 @@ metadata:
   labels:
     sinks.knative.dev/sink: job-sink
     app.kubernetes.io/component: job-sink
-    app.kubernetes.io/version: "1.20.0"
+    app.kubernetes.io/version: "1.21.0"
     app.kubernetes.io/name: knative-eventing
   name: job-sink
   namespace: knative-eventing
@@ -924,7 +924,7 @@ metadata:
   namespace: knative-eventing
   labels:
     app.kubernetes.io/component: pingsource-mt-adapter
-    app.kubernetes.io/version: "1.20.0"
+    app.kubernetes.io/version: "1.21.0"
     app.kubernetes.io/name: knative-eventing
     bindings.knative.dev/exclude: "true"
 spec:
@@ -939,7 +939,7 @@ spec:
         eventing.knative.dev/source: ping-source-controller
         sources.knative.dev/role: adapter
         app.kubernetes.io/component: pingsource-mt-adapter
-        app.kubernetes.io/version: "1.20.0"
+        app.kubernetes.io/version: "1.21.0"
         app.kubernetes.io/name: knative-eventing
     spec:
       affinity:
@@ -955,7 +955,7 @@ spec:
       enableServiceLinks: false
       containers:
         - name: dispatcher
-          image: gcr.io/knative-releases/knative.dev/eventing/cmd/mtping@sha256:8624b33e7a4126a562b410baa807ebf9f83fd057b2118e5e55b3a069111856ef
+          image: gcr.io/knative-releases/knative.dev/eventing/cmd/mtping@sha256:dbb8b1374f3871fe6637869107f803e1f6b62c50c484bb79eaf089b836415353
           env:
             - name: SYSTEM_NAMESPACE
               value: ''
@@ -1030,7 +1030,7 @@ metadata:
   namespace: knative-eventing
   labels:
     app.kubernetes.io/component: request-reply
-    app.kubernetes.io/version: "1.20.0"
+    app.kubernetes.io/version: "1.21.0"
     app.kubernetes.io/name: knative-eventing
 spec:
   replicas: 1
@@ -1042,12 +1042,12 @@ spec:
       labels:
         eventing.knative.dev/part-of: request-reply
         app.kubernetes.io/component: request-reply
-        app.kubernetes.io/version: "1.20.0"
+        app.kubernetes.io/version: "1.21.0"
         app.kubernetes.io/name: knative-eventing
     spec:
       containers:
         - name: request-reply
-          image: gcr.io/knative-releases/knative.dev/eventing/cmd/requestreply@sha256:9c39787d93c4cf81f1d131fb48ada71ee302d546e491c05572bfc30b66f0e3f5
+          image: gcr.io/knative-releases/knative.dev/eventing/cmd/requestreply@sha256:068a94cc6a2f95825dd7937c2404f4bfa85105df982f14c29d58f454c57bcfb6
           volumeMounts:
             - name: aes-keys
               mountPath: /etc/secrets
@@ -1090,7 +1090,7 @@ metadata:
   labels:
     eventing.knative.dev/part-of: request-reply
     app.kubernetes.io/component: request-reply
-    app.kubernetes.io/version: "1.20.0"
+    app.kubernetes.io/version: "1.21.0"
     app.kubernetes.io/name: knative-eventing
   name: request-reply
   namespace: knative-eventing
@@ -1113,7 +1113,7 @@ metadata:
   labels:
     eventing.knative.dev/part-of: request-reply
     app.kubernetes.io/component: request-reply
-    app.kubernetes.io/version: "1.20.0"
+    app.kubernetes.io/version: "1.21.0"
     app.kubernetes.io/name: knative-eventing
   name: request-reply-keys
   namespace: knative-eventing
@@ -1125,7 +1125,7 @@ metadata:
   namespace: knative-eventing
   labels:
     app.kubernetes.io/component: eventing-webhook
-    app.kubernetes.io/version: "1.20.0"
+    app.kubernetes.io/version: "1.21.0"
     app.kubernetes.io/name: knative-eventing
 spec:
   scaleTargetRef:
@@ -1149,7 +1149,7 @@ metadata:
   namespace: knative-eventing
   labels:
     app.kubernetes.io/component: eventing-webhook
-    app.kubernetes.io/version: "1.20.0"
+    app.kubernetes.io/version: "1.21.0"
     app.kubernetes.io/name: knative-eventing
 spec:
   minAvailable: 80%
@@ -1164,7 +1164,7 @@ metadata:
   namespace: knative-eventing
   labels:
     app.kubernetes.io/component: eventing-webhook
-    app.kubernetes.io/version: "1.20.0"
+    app.kubernetes.io/version: "1.21.0"
     app.kubernetes.io/name: knative-eventing
     bindings.knative.dev/exclude: "true"
 spec:
@@ -1178,7 +1178,7 @@ spec:
         app: eventing-webhook
         role: eventing-webhook
         app.kubernetes.io/component: eventing-webhook
-        app.kubernetes.io/version: "1.20.0"
+        app.kubernetes.io/version: "1.21.0"
         app.kubernetes.io/name: knative-eventing
     spec:
       affinity:
@@ -1195,7 +1195,7 @@ spec:
       containers:
         - name: eventing-webhook
           terminationMessagePolicy: FallbackToLogsOnError
-          image: gcr.io/knative-releases/knative.dev/eventing/cmd/webhook@sha256:b857ca0d0467c27b25b6efd555dee45281ca639eba06333c20e6adc9146002d8
+          image: gcr.io/knative-releases/knative.dev/eventing/cmd/webhook@sha256:858caa0a9e5d5f886a1f2de9f56b636e5c70ea763da3ef8792cfc0f56fce2f4b
           resources:
             requests:
               cpu: 100m
@@ -1263,7 +1263,7 @@ metadata:
   labels:
     role: eventing-webhook
     app.kubernetes.io/component: eventing-webhook
-    app.kubernetes.io/version: "1.20.0"
+    app.kubernetes.io/version: "1.21.0"
     app.kubernetes.io/name: knative-eventing
   name: eventing-webhook
   namespace: knative-eventing
@@ -1283,7 +1283,7 @@ metadata:
     eventing.knative.dev/source: "true"
     duck.knative.dev/source: "true"
     knative.dev/crd-install: "true"
-    app.kubernetes.io/version: "1.20.0"
+    app.kubernetes.io/version: "1.21.0"
     app.kubernetes.io/name: knative-eventing
   annotations:
     registry.knative.dev/eventTypes: |
@@ -1554,7 +1554,7 @@ metadata:
   labels:
     knative.dev/crd-install: "true"
     duck.knative.dev/addressable: "true"
-    app.kubernetes.io/version: "1.20.0"
+    app.kubernetes.io/version: "1.21.0"
     app.kubernetes.io/name: knative-eventing
 spec:
   group: eventing.knative.dev
@@ -1754,7 +1754,7 @@ metadata:
     knative.dev/crd-install: "true"
     messaging.knative.dev/subscribable: "true"
     duck.knative.dev/addressable: "true"
-    app.kubernetes.io/version: "1.20.0"
+    app.kubernetes.io/version: "1.21.0"
     app.kubernetes.io/name: knative-eventing
 spec:
   group: messaging.knative.dev
@@ -2097,7 +2097,7 @@ metadata:
     eventing.knative.dev/source: "true"
     duck.knative.dev/source: "true"
     knative.dev/crd-install: "true"
-    app.kubernetes.io/version: "1.20.0"
+    app.kubernetes.io/version: "1.21.0"
     app.kubernetes.io/name: knative-eventing
   name: containersources.sources.knative.dev
 spec:
@@ -2257,7 +2257,7 @@ metadata:
   name: eventpolicies.eventing.knative.dev
   labels:
     knative.dev/crd-install: "true"
-    app.kubernetes.io/version: "1.20.0"
+    app.kubernetes.io/version: "1.21.0"
     app.kubernetes.io/name: knative-eventing
 spec:
   group: eventing.knative.dev
@@ -2455,7 +2455,7 @@ metadata:
   labels:
     knative.dev/crd-install: "true"
     duck.knative.dev/addressable: "true"
-    app.kubernetes.io/version: "1.20.0"
+    app.kubernetes.io/version: "1.21.0"
     app.kubernetes.io/name: knative-eventing
 spec:
   group: eventing.knative.dev
@@ -2721,7 +2721,7 @@ metadata:
   name: eventtypes.eventing.knative.dev
   labels:
     knative.dev/crd-install: "true"
-    app.kubernetes.io/version: "1.20.0"
+    app.kubernetes.io/version: "1.21.0"
     app.kubernetes.io/name: knative-eventing
 spec:
   group: eventing.knative.dev
@@ -3095,7 +3095,7 @@ metadata:
   labels:
     knative.dev/crd-install: "true"
     duck.knative.dev/addressable: "true"
-    app.kubernetes.io/version: "1.20.0"
+    app.kubernetes.io/version: "1.21.0"
     app.kubernetes.io/name: knative-eventing
 spec:
   group: sinks.knative.dev
@@ -3478,7 +3478,7 @@ metadata:
     eventing.knative.dev/source: "true"
     duck.knative.dev/source: "true"
     knative.dev/crd-install: "true"
-    app.kubernetes.io/version: "1.20.0"
+    app.kubernetes.io/version: "1.21.0"
     app.kubernetes.io/name: knative-eventing
   name: integrationsources.sources.knative.dev
 spec:
@@ -3855,7 +3855,7 @@ metadata:
   labels:
     knative.dev/crd-install: "true"
     duck.knative.dev/addressable: "true"
-    app.kubernetes.io/version: "1.20.0"
+    app.kubernetes.io/version: "1.21.0"
     app.kubernetes.io/name: knative-eventing
 spec:
   group: sinks.knative.dev
@@ -3992,7 +3992,7 @@ metadata:
   labels:
     knative.dev/crd-install: "true"
     duck.knative.dev/addressable: "true"
-    app.kubernetes.io/version: "1.20.0"
+    app.kubernetes.io/version: "1.21.0"
     app.kubernetes.io/name: knative-eventing
 spec:
   group: flows.knative.dev
@@ -4505,7 +4505,7 @@ metadata:
     eventing.knative.dev/source: "true"
     duck.knative.dev/source: "true"
     knative.dev/crd-install: "true"
-    app.kubernetes.io/version: "1.20.0"
+    app.kubernetes.io/version: "1.21.0"
     app.kubernetes.io/name: knative-eventing
   annotations:
     registry.knative.dev/eventTypes: |
@@ -4857,7 +4857,7 @@ metadata:
   name: requestreplies.eventing.knative.dev
   labels:
     knative.dev/crd-install: "true"
-    app.kubernetes.io/version: "1.20.0"
+    app.kubernetes.io/version: "1.21.0"
     app.kubernetes.io/name: knative-eventing
 spec:
   group: eventing.knative.dev
@@ -5061,7 +5061,7 @@ metadata:
   labels:
     knative.dev/crd-install: "true"
     duck.knative.dev/addressable: "true"
-    app.kubernetes.io/version: "1.20.0"
+    app.kubernetes.io/version: "1.21.0"
     app.kubernetes.io/name: knative-eventing
 spec:
   group: flows.knative.dev
@@ -5430,7 +5430,7 @@ metadata:
     duck.knative.dev/source: "true"
     duck.knative.dev/binding: "true"
     knative.dev/crd-install: "true"
-    app.kubernetes.io/version: "1.20.0"
+    app.kubernetes.io/version: "1.21.0"
     app.kubernetes.io/name: knative-eventing
   name: sinkbindings.sources.knative.dev
 spec:
@@ -5631,7 +5631,7 @@ metadata:
   name: subscriptions.messaging.knative.dev
   labels:
     knative.dev/crd-install: "true"
-    app.kubernetes.io/version: "1.20.0"
+    app.kubernetes.io/version: "1.21.0"
     app.kubernetes.io/name: knative-eventing
 spec:
   group: messaging.knative.dev
@@ -5878,7 +5878,7 @@ metadata:
   name: triggers.eventing.knative.dev
   labels:
     knative.dev/crd-install: "true"
-    app.kubernetes.io/version: "1.20.0"
+    app.kubernetes.io/version: "1.21.0"
     app.kubernetes.io/name: knative-eventing
 spec:
   group: eventing.knative.dev
@@ -6138,7 +6138,7 @@ kind: ClusterRole
 metadata:
   name: addressable-resolver
   labels:
-    app.kubernetes.io/version: "1.20.0"
+    app.kubernetes.io/version: "1.21.0"
     app.kubernetes.io/name: knative-eventing
 aggregationRule:
   clusterRoleSelectors:
@@ -6152,7 +6152,7 @@ metadata:
   name: service-addressable-resolver
   labels:
     duck.knative.dev/addressable: "true"
-    app.kubernetes.io/version: "1.20.0"
+    app.kubernetes.io/version: "1.21.0"
     app.kubernetes.io/name: knative-eventing
 rules:
   - apiGroups:
@@ -6170,7 +6170,7 @@ metadata:
   name: serving-addressable-resolver
   labels:
     duck.knative.dev/addressable: "true"
-    app.kubernetes.io/version: "1.20.0"
+    app.kubernetes.io/version: "1.21.0"
     app.kubernetes.io/name: knative-eventing
 rules:
   - apiGroups:
@@ -6191,7 +6191,7 @@ metadata:
   name: channel-addressable-resolver
   labels:
     duck.knative.dev/addressable: "true"
-    app.kubernetes.io/version: "1.20.0"
+    app.kubernetes.io/version: "1.21.0"
     app.kubernetes.io/name: knative-eventing
 rules:
   - apiGroups:
@@ -6216,7 +6216,7 @@ metadata:
   name: broker-addressable-resolver
   labels:
     duck.knative.dev/addressable: "true"
-    app.kubernetes.io/version: "1.20.0"
+    app.kubernetes.io/version: "1.21.0"
     app.kubernetes.io/name: knative-eventing
 rules:
   - apiGroups:
@@ -6235,7 +6235,7 @@ metadata:
   name: flows-addressable-resolver
   labels:
     duck.knative.dev/addressable: "true"
-    app.kubernetes.io/version: "1.20.0"
+    app.kubernetes.io/version: "1.21.0"
     app.kubernetes.io/name: knative-eventing
 rules:
   - apiGroups:
@@ -6256,7 +6256,7 @@ metadata:
   name: jobsinks-addressable-resolver
   labels:
     duck.knative.dev/addressable: "true"
-    app.kubernetes.io/version: "1.20.0"
+    app.kubernetes.io/version: "1.21.0"
     app.kubernetes.io/name: knative-eventing
 rules:
   - apiGroups:
@@ -6275,7 +6275,7 @@ metadata:
   name: integrationsinks-addressable-resolver
   labels:
     duck.knative.dev/addressable: "true"
-    app.kubernetes.io/version: "1.20.0"
+    app.kubernetes.io/version: "1.21.0"
     app.kubernetes.io/name: knative-eventing
 rules:
   - apiGroups:
@@ -6294,7 +6294,7 @@ metadata:
   name: eventtransforms-addressable-resolver
   labels:
     duck.knative.dev/addressable: "true"
-    app.kubernetes.io/version: "1.20.0"
+    app.kubernetes.io/version: "1.21.0"
     app.kubernetes.io/name: knative-eventing
 rules:
   - apiGroups:
@@ -6313,7 +6313,7 @@ metadata:
   name: knative-eventing-auth-proxy
   namespace: knative-eventing
   labels:
-    app.kubernetes.io/version: "1.20.0"
+    app.kubernetes.io/version: "1.21.0"
     app.kubernetes.io/name: knative-eventing
 rules:
   - apiGroups:
@@ -6338,7 +6338,7 @@ kind: ClusterRole
 metadata:
   name: eventing-broker-filter
   labels:
-    app.kubernetes.io/version: "1.20.0"
+    app.kubernetes.io/version: "1.21.0"
     app.kubernetes.io/name: knative-eventing
 rules:
   - apiGroups:
@@ -6364,7 +6364,7 @@ kind: ClusterRole
 metadata:
   name: eventing-broker-ingress
   labels:
-    app.kubernetes.io/version: "1.20.0"
+    app.kubernetes.io/version: "1.21.0"
     app.kubernetes.io/name: knative-eventing
 rules:
   - apiGroups:
@@ -6381,7 +6381,7 @@ kind: ClusterRole
 metadata:
   name: eventing-config-reader
   labels:
-    app.kubernetes.io/version: "1.20.0"
+    app.kubernetes.io/version: "1.21.0"
     app.kubernetes.io/name: knative-eventing
 rules:
   - apiGroups:
@@ -6398,7 +6398,7 @@ kind: ClusterRole
 metadata:
   name: channelable-manipulator
   labels:
-    app.kubernetes.io/version: "1.20.0"
+    app.kubernetes.io/version: "1.21.0"
     app.kubernetes.io/name: knative-eventing
 aggregationRule:
   clusterRoleSelectors:
@@ -6412,7 +6412,7 @@ metadata:
   name: meta-channelable-manipulator
   labels:
     duck.knative.dev/channelable: "true"
-    app.kubernetes.io/version: "1.20.0"
+    app.kubernetes.io/version: "1.21.0"
     app.kubernetes.io/name: knative-eventing
 rules:
   - apiGroups:
@@ -6435,7 +6435,7 @@ metadata:
   name: knative-eventing-namespaced-admin
   labels:
     rbac.authorization.k8s.io/aggregate-to-admin: "true"
-    app.kubernetes.io/version: "1.20.0"
+    app.kubernetes.io/version: "1.21.0"
     app.kubernetes.io/name: knative-eventing
 rules:
   - apiGroups: ["eventing.knative.dev"]
@@ -6448,7 +6448,7 @@ metadata:
   name: knative-messaging-namespaced-admin
   labels:
     rbac.authorization.k8s.io/aggregate-to-admin: "true"
-    app.kubernetes.io/version: "1.20.0"
+    app.kubernetes.io/version: "1.21.0"
     app.kubernetes.io/name: knative-eventing
 rules:
   - apiGroups: ["messaging.knative.dev"]
@@ -6461,7 +6461,7 @@ metadata:
   name: knative-flows-namespaced-admin
   labels:
     rbac.authorization.k8s.io/aggregate-to-admin: "true"
-    app.kubernetes.io/version: "1.20.0"
+    app.kubernetes.io/version: "1.21.0"
     app.kubernetes.io/name: knative-eventing
 rules:
   - apiGroups: ["flows.knative.dev"]
@@ -6474,7 +6474,7 @@ metadata:
   name: knative-sources-namespaced-admin
   labels:
     rbac.authorization.k8s.io/aggregate-to-admin: "true"
-    app.kubernetes.io/version: "1.20.0"
+    app.kubernetes.io/version: "1.21.0"
     app.kubernetes.io/name: knative-eventing
 rules:
   - apiGroups: ["sources.knative.dev"]
@@ -6487,7 +6487,7 @@ metadata:
   name: knative-bindings-namespaced-admin
   labels:
     rbac.authorization.k8s.io/aggregate-to-admin: "true"
-    app.kubernetes.io/version: "1.20.0"
+    app.kubernetes.io/version: "1.21.0"
     app.kubernetes.io/name: knative-eventing
 rules:
   - apiGroups: ["bindings.knative.dev"]
@@ -6500,7 +6500,7 @@ metadata:
   name: knative-sinks-namespaced-admin
   labels:
     rbac.authorization.k8s.io/aggregate-to-admin: "true"
-    app.kubernetes.io/version: "1.20.0"
+    app.kubernetes.io/version: "1.21.0"
     app.kubernetes.io/name: knative-eventing
 rules:
   - apiGroups: ["sinks.knative.dev"]
@@ -6513,7 +6513,7 @@ metadata:
   name: knative-eventing-namespaced-edit
   labels:
     rbac.authorization.k8s.io/aggregate-to-edit: "true"
-    app.kubernetes.io/version: "1.20.0"
+    app.kubernetes.io/version: "1.21.0"
     app.kubernetes.io/name: knative-eventing
 rules:
   - apiGroups: ["eventing.knative.dev", "messaging.knative.dev", "sources.knative.dev", "flows.knative.dev", "bindings.knative.dev", "sinks.knative.dev"]
@@ -6526,7 +6526,7 @@ metadata:
   name: knative-eventing-namespaced-view
   labels:
     rbac.authorization.k8s.io/aggregate-to-view: "true"
-    app.kubernetes.io/version: "1.20.0"
+    app.kubernetes.io/version: "1.21.0"
     app.kubernetes.io/name: knative-eventing
 rules:
   - apiGroups: ["eventing.knative.dev", "messaging.knative.dev", "sources.knative.dev", "flows.knative.dev", "bindings.knative.dev", "sinks.knative.dev"]
@@ -6538,7 +6538,7 @@ kind: ClusterRole
 metadata:
   name: knative-eventing-controller
   labels:
-    app.kubernetes.io/version: "1.20.0"
+    app.kubernetes.io/version: "1.21.0"
     app.kubernetes.io/name: knative-eventing
 rules:
   - apiGroups:
@@ -6773,7 +6773,7 @@ kind: ClusterRole
 metadata:
   name: crossnamespace-subscriber
   labels:
-    app.kubernetes.io/version: "1.20.0"
+    app.kubernetes.io/version: "1.21.0"
     app.kubernetes.io/name: knative-eventing
 aggregationRule:
   clusterRoleSelectors:
@@ -6787,7 +6787,7 @@ metadata:
   name: channel-subscriber
   labels:
     duck.knative.dev/crossnamespace-subscribable: "true"
-    app.kubernetes.io/version: "1.20.0"
+    app.kubernetes.io/version: "1.21.0"
     app.kubernetes.io/name: knative-eventing
 rules:
   - apiGroups:
@@ -6803,7 +6803,7 @@ metadata:
   name: broker-subscriber
   labels:
     duck.knative.dev/crossnamespace-subscribable: "true"
-    app.kubernetes.io/version: "1.20.0"
+    app.kubernetes.io/version: "1.21.0"
     app.kubernetes.io/name: knative-eventing
 rules:
   - apiGroups:
@@ -6818,7 +6818,7 @@ kind: ClusterRole
 metadata:
   name: knative-eventing-job-sink
   labels:
-    app.kubernetes.io/version: "1.20.0"
+    app.kubernetes.io/version: "1.21.0"
     app.kubernetes.io/name: knative-eventing
 rules:
   - apiGroups:
@@ -6897,7 +6897,7 @@ kind: ClusterRole
 metadata:
   name: knative-eventing-pingsource-mt-adapter
   labels:
-    app.kubernetes.io/version: "1.20.0"
+    app.kubernetes.io/version: "1.21.0"
     app.kubernetes.io/name: knative-eventing
 rules:
   - apiGroups:
@@ -6954,7 +6954,7 @@ kind: ClusterRole
 metadata:
   name: podspecable-binding
   labels:
-    app.kubernetes.io/version: "1.20.0"
+    app.kubernetes.io/version: "1.21.0"
     app.kubernetes.io/name: knative-eventing
 aggregationRule:
   clusterRoleSelectors:
@@ -6968,7 +6968,7 @@ metadata:
   name: builtin-podspecable-binding
   labels:
     duck.knative.dev/podspecable: "true"
-    app.kubernetes.io/version: "1.20.0"
+    app.kubernetes.io/version: "1.21.0"
     app.kubernetes.io/name: knative-eventing
 rules:
   - apiGroups:
@@ -6996,7 +6996,7 @@ kind: ClusterRole
 metadata:
   name: knative-eventing-request-reply
   labels:
-    app.kubernetes.io/version: "1.20.0"
+    app.kubernetes.io/version: "1.21.0"
     app.kubernetes.io/name: knative-eventing
 rules:
   - apiGroups:
@@ -7050,7 +7050,7 @@ kind: ClusterRole
 metadata:
   name: source-observer
   labels:
-    app.kubernetes.io/version: "1.20.0"
+    app.kubernetes.io/version: "1.21.0"
     app.kubernetes.io/name: knative-eventing
 aggregationRule:
   clusterRoleSelectors:
@@ -7064,7 +7064,7 @@ metadata:
   name: eventing-sources-source-observer
   labels:
     duck.knative.dev/source: "true"
-    app.kubernetes.io/version: "1.20.0"
+    app.kubernetes.io/version: "1.21.0"
     app.kubernetes.io/name: knative-eventing
 rules:
   - apiGroups:
@@ -7085,7 +7085,7 @@ kind: ClusterRole
 metadata:
   name: knative-eventing-sources-controller
   labels:
-    app.kubernetes.io/version: "1.20.0"
+    app.kubernetes.io/version: "1.21.0"
     app.kubernetes.io/name: knative-eventing
 rules:
   - apiGroups:
@@ -7188,7 +7188,7 @@ kind: ClusterRole
 metadata:
   name: knative-eventing-webhook
   labels:
-    app.kubernetes.io/version: "1.20.0"
+    app.kubernetes.io/version: "1.21.0"
     app.kubernetes.io/name: knative-eventing
 rules:
   - apiGroups:
@@ -7337,7 +7337,7 @@ metadata:
   namespace: knative-eventing
   name: knative-eventing-webhook
   labels:
-    app.kubernetes.io/version: "1.20.0"
+    app.kubernetes.io/version: "1.21.0"
     app.kubernetes.io/name: knative-eventing
 rules:
   - apiGroups:
@@ -7357,7 +7357,7 @@ kind: ValidatingWebhookConfiguration
 metadata:
   name: config.webhook.eventing.knative.dev
   labels:
-    app.kubernetes.io/version: "1.20.0"
+    app.kubernetes.io/version: "1.21.0"
     app.kubernetes.io/name: knative-eventing
 webhooks:
   - admissionReviewVersions: ["v1", "v1beta1"]
@@ -7380,7 +7380,7 @@ kind: MutatingWebhookConfiguration
 metadata:
   name: webhook.eventing.knative.dev
   labels:
-    app.kubernetes.io/version: "1.20.0"
+    app.kubernetes.io/version: "1.21.0"
     app.kubernetes.io/name: knative-eventing
 webhooks:
   - admissionReviewVersions: ["v1", "v1beta1"]
@@ -7398,7 +7398,7 @@ kind: ValidatingWebhookConfiguration
 metadata:
   name: validation.webhook.eventing.knative.dev
   labels:
-    app.kubernetes.io/version: "1.20.0"
+    app.kubernetes.io/version: "1.21.0"
     app.kubernetes.io/name: knative-eventing
 webhooks:
   - admissionReviewVersions: ["v1", "v1beta1"]
@@ -7417,7 +7417,7 @@ metadata:
   name: eventing-webhook-certs
   namespace: knative-eventing
   labels:
-    app.kubernetes.io/version: "1.20.0"
+    app.kubernetes.io/version: "1.21.0"
     app.kubernetes.io/name: knative-eventing
 ---
 apiVersion: admissionregistration.k8s.io/v1
@@ -7425,7 +7425,7 @@ kind: MutatingWebhookConfiguration
 metadata:
   name: sinkbindings.webhook.sources.knative.dev
   labels:
-    app.kubernetes.io/version: "1.20.0"
+    app.kubernetes.io/version: "1.21.0"
     app.kubernetes.io/name: knative-eventing
 webhooks:
   - admissionReviewVersions: ["v1", "v1beta1"]

--- a/common/knative/knative-eventing/base/upstream/in-memory-channel.yaml
+++ b/common/knative/knative-eventing/base/upstream/in-memory-channel.yaml
@@ -4,7 +4,7 @@ metadata:
   name: imc-controller
   namespace: knative-eventing
   labels:
-    app.kubernetes.io/version: "1.20.0"
+    app.kubernetes.io/version: "1.21.0"
     app.kubernetes.io/name: knative-eventing
 ---
 apiVersion: rbac.authorization.k8s.io/v1
@@ -12,7 +12,7 @@ kind: ClusterRoleBinding
 metadata:
   name: imc-controller
   labels:
-    app.kubernetes.io/version: "1.20.0"
+    app.kubernetes.io/version: "1.21.0"
     app.kubernetes.io/name: knative-eventing
 subjects:
   - kind: ServiceAccount
@@ -29,7 +29,7 @@ metadata:
   namespace: knative-eventing
   name: imc-controller
   labels:
-    app.kubernetes.io/version: "1.20.0"
+    app.kubernetes.io/version: "1.21.0"
     app.kubernetes.io/name: knative-eventing
 subjects:
   - kind: ServiceAccount
@@ -45,7 +45,7 @@ kind: ClusterRoleBinding
 metadata:
   name: imc-controller-resolver
   labels:
-    app.kubernetes.io/version: "1.20.0"
+    app.kubernetes.io/version: "1.21.0"
     app.kubernetes.io/name: knative-eventing
 subjects:
   - kind: ServiceAccount
@@ -62,7 +62,7 @@ metadata:
   name: imc-dispatcher
   namespace: knative-eventing
   labels:
-    app.kubernetes.io/version: "1.20.0"
+    app.kubernetes.io/version: "1.21.0"
     app.kubernetes.io/name: knative-eventing
 ---
 apiVersion: rbac.authorization.k8s.io/v1
@@ -70,7 +70,7 @@ kind: ClusterRoleBinding
 metadata:
   name: imc-dispatcher
   labels:
-    app.kubernetes.io/version: "1.20.0"
+    app.kubernetes.io/version: "1.21.0"
     app.kubernetes.io/name: knative-eventing
 subjects:
   - kind: ServiceAccount
@@ -117,7 +117,7 @@ metadata:
   namespace: knative-eventing
   labels:
     app.kubernetes.io/component: imc-controller
-    app.kubernetes.io/version: "1.20.0"
+    app.kubernetes.io/version: "1.21.0"
     app.kubernetes.io/name: knative-eventing
 data:
   MaxIdleConnections: "1000"
@@ -131,7 +131,7 @@ metadata:
   labels:
     knative.dev/high-availability: "true"
     app.kubernetes.io/component: imc-controller
-    app.kubernetes.io/version: "1.20.0"
+    app.kubernetes.io/version: "1.21.0"
     app.kubernetes.io/name: knative-eventing
     bindings.knative.dev/exclude: "true"
 spec:
@@ -145,7 +145,7 @@ spec:
         messaging.knative.dev/channel: in-memory-channel
         messaging.knative.dev/role: controller
         app.kubernetes.io/component: imc-controller
-        app.kubernetes.io/version: "1.20.0"
+        app.kubernetes.io/version: "1.21.0"
         app.kubernetes.io/name: knative-eventing
     spec:
       affinity:
@@ -162,7 +162,7 @@ spec:
       enableServiceLinks: false
       containers:
         - name: controller
-          image: gcr.io/knative-releases/knative.dev/eventing/cmd/in_memory/channel_controller@sha256:2c43d1afb0b1c805a805373cfc42d903c8ce940ab72f29f32feaccdc565deb37
+          image: gcr.io/knative-releases/knative.dev/eventing/cmd/in_memory/channel_controller@sha256:c8b3a6604f270fb51af7dfbb00082443f028ad80aa4a01974f3724d36f3f0f00
           env:
             - name: WEBHOOK_NAME
               value: inmemorychannel-webhook
@@ -179,7 +179,7 @@ spec:
                 fieldRef:
                   fieldPath: metadata.namespace
             - name: DISPATCHER_IMAGE
-              value: gcr.io/knative-releases/knative.dev/eventing/cmd/in_memory/channel_dispatcher@sha256:fd95f04b6b808d18c14fe122ba9671ae2b7f0c8c54487844feb9928f2784b324
+              value: gcr.io/knative-releases/knative.dev/eventing/cmd/in_memory/channel_dispatcher@sha256:77340f4be4cd33d920538c490e9d1ff9052702da23ce019ca2c15bb4c0e1532b
             - name: POD_NAME
               valueFrom:
                 fieldRef:
@@ -224,7 +224,7 @@ kind: Service
 metadata:
   labels:
     app.kubernetes.io/component: imc-controller
-    app.kubernetes.io/version: "1.20.0"
+    app.kubernetes.io/version: "1.21.0"
     app.kubernetes.io/name: knative-eventing
   name: inmemorychannel-webhook
   namespace: knative-eventing
@@ -252,7 +252,7 @@ metadata:
     messaging.knative.dev/channel: in-memory-channel
     messaging.knative.dev/role: dispatcher
     app.kubernetes.io/component: imc-dispatcher
-    app.kubernetes.io/version: "1.20.0"
+    app.kubernetes.io/version: "1.21.0"
     app.kubernetes.io/name: knative-eventing
 spec:
   selector:
@@ -279,7 +279,7 @@ metadata:
   labels:
     knative.dev/high-availability: "true"
     app.kubernetes.io/component: imc-dispatcher
-    app.kubernetes.io/version: "1.20.0"
+    app.kubernetes.io/version: "1.21.0"
     app.kubernetes.io/name: knative-eventing
     bindings.knative.dev/exclude: "true"
 spec:
@@ -293,7 +293,7 @@ spec:
         messaging.knative.dev/channel: in-memory-channel
         messaging.knative.dev/role: dispatcher
         app.kubernetes.io/component: imc-dispatcher
-        app.kubernetes.io/version: "1.20.0"
+        app.kubernetes.io/version: "1.21.0"
         app.kubernetes.io/name: knative-eventing
     spec:
       affinity:
@@ -310,7 +310,7 @@ spec:
       enableServiceLinks: false
       containers:
         - name: dispatcher
-          image: gcr.io/knative-releases/knative.dev/eventing/cmd/in_memory/channel_dispatcher@sha256:fd95f04b6b808d18c14fe122ba9671ae2b7f0c8c54487844feb9928f2784b324
+          image: gcr.io/knative-releases/knative.dev/eventing/cmd/in_memory/channel_dispatcher@sha256:77340f4be4cd33d920538c490e9d1ff9052702da23ce019ca2c15bb4c0e1532b
           readinessProbe:
             failureThreshold: 3
             httpGet:
@@ -378,7 +378,7 @@ metadata:
     knative.dev/crd-install: "true"
     messaging.knative.dev/subscribable: "true"
     duck.knative.dev/addressable: "true"
-    app.kubernetes.io/version: "1.20.0"
+    app.kubernetes.io/version: "1.21.0"
     app.kubernetes.io/name: knative-eventing
 spec:
   group: messaging.knative.dev
@@ -699,7 +699,7 @@ metadata:
   name: imc-addressable-resolver
   labels:
     duck.knative.dev/addressable: "true"
-    app.kubernetes.io/version: "1.20.0"
+    app.kubernetes.io/version: "1.21.0"
     app.kubernetes.io/name: knative-eventing
 rules:
   - apiGroups:
@@ -718,7 +718,7 @@ metadata:
   name: imc-channelable-manipulator
   labels:
     duck.knative.dev/channelable: "true"
-    app.kubernetes.io/version: "1.20.0"
+    app.kubernetes.io/version: "1.21.0"
     app.kubernetes.io/name: knative-eventing
 rules:
   - apiGroups:
@@ -740,7 +740,7 @@ kind: ClusterRole
 metadata:
   name: imc-controller
   labels:
-    app.kubernetes.io/version: "1.20.0"
+    app.kubernetes.io/version: "1.21.0"
     app.kubernetes.io/name: knative-eventing
 rules:
   - apiGroups:
@@ -889,7 +889,7 @@ metadata:
   name: imc-subscriber
   labels:
     duck.knative.dev/crossnamespace-subscribable: "true"
-    app.kubernetes.io/version: "1.20.0"
+    app.kubernetes.io/version: "1.21.0"
     app.kubernetes.io/name: knative-eventing
 rules:
   - apiGroups:
@@ -904,7 +904,7 @@ kind: ClusterRole
 metadata:
   name: imc-dispatcher
   labels:
-    app.kubernetes.io/version: "1.20.0"
+    app.kubernetes.io/version: "1.21.0"
     app.kubernetes.io/name: knative-eventing
 rules:
   - apiGroups:
@@ -978,7 +978,7 @@ metadata:
   namespace: knative-eventing
   name: knative-inmemorychannel-webhook
   labels:
-    app.kubernetes.io/version: "1.20.0"
+    app.kubernetes.io/version: "1.21.0"
     app.kubernetes.io/name: knative-eventing
 rules:
   - apiGroups:
@@ -998,7 +998,7 @@ kind: MutatingWebhookConfiguration
 metadata:
   name: inmemorychannel.eventing.knative.dev
   labels:
-    app.kubernetes.io/version: "1.20.0"
+    app.kubernetes.io/version: "1.21.0"
     app.kubernetes.io/name: knative-eventing
 webhooks:
   - admissionReviewVersions: ["v1"]
@@ -1016,7 +1016,7 @@ kind: ValidatingWebhookConfiguration
 metadata:
   name: validation.inmemorychannel.eventing.knative.dev
   labels:
-    app.kubernetes.io/version: "1.20.0"
+    app.kubernetes.io/version: "1.21.0"
     app.kubernetes.io/name: knative-eventing
 webhooks:
   - admissionReviewVersions: ["v1"]
@@ -1035,7 +1035,7 @@ metadata:
   name: inmemorychannel-webhook-certs
   namespace: knative-eventing
   labels:
-    app.kubernetes.io/version: "1.20.0"
+    app.kubernetes.io/version: "1.21.0"
     app.kubernetes.io/name: knative-eventing
 ---
 

--- a/common/knative/knative-eventing/base/upstream/mt-channel-broker.yaml
+++ b/common/knative/knative-eventing/base/upstream/mt-channel-broker.yaml
@@ -3,7 +3,7 @@ kind: ClusterRole
 metadata:
   name: knative-eventing-mt-channel-broker-controller
   labels:
-    app.kubernetes.io/version: "1.20.0"
+    app.kubernetes.io/version: "1.21.0"
     app.kubernetes.io/name: knative-eventing
 rules:
   - apiGroups:
@@ -36,7 +36,7 @@ kind: ClusterRole
 metadata:
   name: knative-eventing-mt-broker-filter
   labels:
-    app.kubernetes.io/version: "1.20.0"
+    app.kubernetes.io/version: "1.21.0"
     app.kubernetes.io/name: knative-eventing
 rules:
   - apiGroups:
@@ -104,7 +104,7 @@ metadata:
   name: mt-broker-filter
   namespace: knative-eventing
   labels:
-    app.kubernetes.io/version: "1.20.0"
+    app.kubernetes.io/version: "1.21.0"
     app.kubernetes.io/name: knative-eventing
 ---
 apiVersion: rbac.authorization.k8s.io/v1
@@ -112,7 +112,7 @@ kind: ClusterRole
 metadata:
   name: knative-eventing-mt-broker-ingress
   labels:
-    app.kubernetes.io/version: "1.20.0"
+    app.kubernetes.io/version: "1.21.0"
     app.kubernetes.io/name: knative-eventing
 rules:
   - apiGroups:
@@ -171,7 +171,7 @@ metadata:
   name: mt-broker-ingress-oidc
   namespace: knative-eventing
   labels:
-    app.kubernetes.io/version: "1.20.0"
+    app.kubernetes.io/version: "1.21.0"
     app.kubernetes.io/name: knative-eventing
 ---
 apiVersion: v1
@@ -180,7 +180,7 @@ metadata:
   name: mt-broker-ingress
   namespace: knative-eventing
   labels:
-    app.kubernetes.io/version: "1.20.0"
+    app.kubernetes.io/version: "1.21.0"
     app.kubernetes.io/name: knative-eventing
 ---
 apiVersion: rbac.authorization.k8s.io/v1
@@ -188,7 +188,7 @@ kind: ClusterRoleBinding
 metadata:
   name: eventing-mt-channel-broker-controller
   labels:
-    app.kubernetes.io/version: "1.20.0"
+    app.kubernetes.io/version: "1.21.0"
     app.kubernetes.io/name: knative-eventing
 subjects:
   - kind: ServiceAccount
@@ -204,7 +204,7 @@ kind: ClusterRoleBinding
 metadata:
   name: knative-eventing-mt-broker-filter
   labels:
-    app.kubernetes.io/version: "1.20.0"
+    app.kubernetes.io/version: "1.21.0"
     app.kubernetes.io/name: knative-eventing
 subjects:
   - kind: ServiceAccount
@@ -234,7 +234,7 @@ kind: ClusterRoleBinding
 metadata:
   name: knative-eventing-mt-broker-ingress
   labels:
-    app.kubernetes.io/version: "1.20.0"
+    app.kubernetes.io/version: "1.21.0"
     app.kubernetes.io/name: knative-eventing
 subjects:
   - kind: ServiceAccount
@@ -266,7 +266,7 @@ metadata:
   namespace: knative-eventing
   labels:
     app.kubernetes.io/component: broker-filter
-    app.kubernetes.io/version: "1.20.0"
+    app.kubernetes.io/version: "1.21.0"
     app.kubernetes.io/name: knative-eventing
     bindings.knative.dev/exclude: "true"
 spec:
@@ -278,7 +278,7 @@ spec:
       labels:
         eventing.knative.dev/brokerRole: filter
         app.kubernetes.io/component: broker-filter
-        app.kubernetes.io/version: "1.20.0"
+        app.kubernetes.io/version: "1.21.0"
         app.kubernetes.io/name: knative-eventing
     spec:
       serviceAccountName: mt-broker-filter
@@ -286,7 +286,7 @@ spec:
       containers:
         - name: filter
           terminationMessagePolicy: FallbackToLogsOnError
-          image: gcr.io/knative-releases/knative.dev/eventing/cmd/broker/filter@sha256:b8bc6b7a6e3ec4cbe239494e64f9222e2e802415e57a841ff1023353ee8526ab
+          image: gcr.io/knative-releases/knative.dev/eventing/cmd/broker/filter@sha256:baa3253b77bde2df41a610c0c0572348a5c101463bee3cda9c1fe9ce4a62f860
           readinessProbe:
             failureThreshold: 3
             httpGet:
@@ -364,7 +364,7 @@ metadata:
   labels:
     eventing.knative.dev/brokerRole: filter
     app.kubernetes.io/component: broker-filter
-    app.kubernetes.io/version: "1.20.0"
+    app.kubernetes.io/version: "1.21.0"
     app.kubernetes.io/name: knative-eventing
   name: broker-filter
   namespace: knative-eventing
@@ -392,7 +392,7 @@ metadata:
   namespace: knative-eventing
   labels:
     app.kubernetes.io/component: broker-ingress
-    app.kubernetes.io/version: "1.20.0"
+    app.kubernetes.io/version: "1.21.0"
     app.kubernetes.io/name: knative-eventing
     bindings.knative.dev/exclude: "true"
 spec:
@@ -404,7 +404,7 @@ spec:
       labels:
         eventing.knative.dev/brokerRole: ingress
         app.kubernetes.io/component: broker-ingress
-        app.kubernetes.io/version: "1.20.0"
+        app.kubernetes.io/version: "1.21.0"
         app.kubernetes.io/name: knative-eventing
     spec:
       serviceAccountName: mt-broker-ingress
@@ -412,7 +412,7 @@ spec:
       containers:
         - name: ingress
           terminationMessagePolicy: FallbackToLogsOnError
-          image: gcr.io/knative-releases/knative.dev/eventing/cmd/broker/ingress@sha256:7d2b092284eac130f4dc002d361c46df97bd98bb34ab1d771098115030350ca6
+          image: gcr.io/knative-releases/knative.dev/eventing/cmd/broker/ingress@sha256:e77e2a916c587857d2172943996dd42a476bdccdced584216314284cf0a5a15f
           readinessProbe:
             failureThreshold: 3
             httpGet:
@@ -490,7 +490,7 @@ metadata:
   labels:
     eventing.knative.dev/brokerRole: ingress
     app.kubernetes.io/component: broker-ingress
-    app.kubernetes.io/version: "1.20.0"
+    app.kubernetes.io/version: "1.21.0"
     app.kubernetes.io/name: knative-eventing
   name: broker-ingress
   namespace: knative-eventing
@@ -518,7 +518,7 @@ metadata:
   namespace: knative-eventing
   labels:
     app.kubernetes.io/component: mt-broker-controller
-    app.kubernetes.io/version: "1.20.0"
+    app.kubernetes.io/version: "1.21.0"
     app.kubernetes.io/name: knative-eventing
     bindings.knative.dev/exclude: "true"
 spec:
@@ -530,7 +530,7 @@ spec:
       labels:
         app: mt-broker-controller
         app.kubernetes.io/component: broker-controller
-        app.kubernetes.io/version: "1.20.0"
+        app.kubernetes.io/version: "1.21.0"
         app.kubernetes.io/name: knative-eventing
     spec:
       affinity:
@@ -547,7 +547,7 @@ spec:
       containers:
         - name: mt-broker-controller
           terminationMessagePolicy: FallbackToLogsOnError
-          image: gcr.io/knative-releases/knative.dev/eventing/cmd/mtchannel_broker@sha256:59dda9835bbc01c8435cbade6b850acc7295e81d526b5b191c429b946c061a51
+          image: gcr.io/knative-releases/knative.dev/eventing/cmd/mtchannel_broker@sha256:8dde70a3c73833da379046dd839a60c986d98298315808442e67a43fc93dc92b
           resources:
             requests:
               cpu: 100m
@@ -607,7 +607,7 @@ metadata:
   namespace: knative-eventing
   labels:
     app.kubernetes.io/component: broker-ingress
-    app.kubernetes.io/version: "1.20.0"
+    app.kubernetes.io/version: "1.21.0"
     app.kubernetes.io/name: knative-eventing
 spec:
   scaleTargetRef:
@@ -631,7 +631,7 @@ metadata:
   namespace: knative-eventing
   labels:
     app.kubernetes.io/component: broker-filter
-    app.kubernetes.io/version: "1.20.0"
+    app.kubernetes.io/version: "1.21.0"
     app.kubernetes.io/name: knative-eventing
 spec:
   scaleTargetRef:

--- a/common/knative/knative-serving-post-install-jobs/base/serving-post-install-jobs.yaml
+++ b/common/knative/knative-serving-post-install-jobs/base/serving-post-install-jobs.yaml
@@ -7,7 +7,7 @@ metadata:
     app: storage-version-migration-serving
     app.kubernetes.io/name: knative-serving
     app.kubernetes.io/component: storage-version-migration-job
-    app.kubernetes.io/version: "1.20.0"
+    app.kubernetes.io/version: "1.21.1"
   name: storage-version-migration-serving
 spec:
   ttlSecondsAfterFinished: 600
@@ -18,14 +18,14 @@ spec:
         app: storage-version-migration-serving
         app.kubernetes.io/name: knative-serving
         app.kubernetes.io/component: storage-version-migration-job
-        app.kubernetes.io/version: "1.20.0"
+        app.kubernetes.io/version: "1.21.1"
         sidecar.istio.io/inject: "false"
     spec:
       serviceAccountName: controller
       restartPolicy: OnFailure
       containers:
         - name: migrate
-          image: gcr.io/knative-releases/knative.dev/pkg/apiextensions/storageversion/cmd/migrate@sha256:0bc431ff362eb453c214ea4bb30626ee9d718d66e4cbbe846272a4f4ce2a06ca
+          image: gcr.io/knative-releases/knative.dev/pkg/apiextensions/storageversion/cmd/migrate@sha256:6106427387f7f50f672218d0d68668cd20a571684cccb40da6f3cf6ae048ea1c
           args:
             - "services.serving.knative.dev"
             - "configurations.serving.knative.dev"

--- a/common/knative/knative-serving/base/upstream/net-istio.yaml
+++ b/common/knative/knative-serving/base/upstream/net-istio.yaml
@@ -5,7 +5,7 @@ metadata:
   labels:
     app.kubernetes.io/component: net-istio
     app.kubernetes.io/name: knative-serving
-    app.kubernetes.io/version: "1.20.1"
+    app.kubernetes.io/version: "1.21.1"
     serving.knative.dev/controller: "true"
     networking.knative.dev/ingress-provider: istio
 rules:
@@ -21,7 +21,7 @@ metadata:
   labels:
     app.kubernetes.io/component: net-istio
     app.kubernetes.io/name: knative-serving
-    app.kubernetes.io/version: "1.20.1"
+    app.kubernetes.io/version: "1.21.1"
     networking.knative.dev/ingress-provider: istio
 spec:
   selector:
@@ -42,7 +42,7 @@ metadata:
   labels:
     app.kubernetes.io/component: net-istio
     app.kubernetes.io/name: knative-serving
-    app.kubernetes.io/version: "1.20.1"
+    app.kubernetes.io/version: "1.21.1"
     networking.knative.dev/ingress-provider: istio
 spec:
   selector:
@@ -63,7 +63,7 @@ metadata:
   labels:
     app.kubernetes.io/component: net-istio
     app.kubernetes.io/name: knative-serving
-    app.kubernetes.io/version: "1.20.1"
+    app.kubernetes.io/version: "1.21.1"
     networking.knative.dev/ingress-provider: istio
     experimental.istio.io/disable-gateway-port-translation: "true"
 spec:
@@ -86,7 +86,7 @@ metadata:
   labels:
     app.kubernetes.io/component: net-istio
     app.kubernetes.io/name: knative-serving
-    app.kubernetes.io/version: "1.20.1"
+    app.kubernetes.io/version: "1.21.1"
     networking.knative.dev/ingress-provider: istio
 data:
   _example: |
@@ -192,7 +192,7 @@ metadata:
   labels:
     app.kubernetes.io/component: net-istio
     app.kubernetes.io/name: knative-serving
-    app.kubernetes.io/version: "1.20.1"
+    app.kubernetes.io/version: "1.21.1"
     networking.knative.dev/ingress-provider: istio
 spec:
   selector:
@@ -210,7 +210,7 @@ metadata:
   labels:
     app.kubernetes.io/component: net-istio
     app.kubernetes.io/name: knative-serving
-    app.kubernetes.io/version: "1.20.1"
+    app.kubernetes.io/version: "1.21.1"
     networking.knative.dev/ingress-provider: istio
 spec:
   selector:
@@ -228,7 +228,7 @@ metadata:
   labels:
     app.kubernetes.io/component: net-istio
     app.kubernetes.io/name: knative-serving
-    app.kubernetes.io/version: "1.20.1"
+    app.kubernetes.io/version: "1.21.1"
     networking.knative.dev/ingress-provider: istio
 spec:
   selector:
@@ -241,12 +241,12 @@ spec:
         app: net-istio-controller
         app.kubernetes.io/component: net-istio
         app.kubernetes.io/name: knative-serving
-        app.kubernetes.io/version: "1.20.1"
+        app.kubernetes.io/version: "1.21.1"
     spec:
       serviceAccountName: controller
       containers:
         - name: controller
-          image: gcr.io/knative-releases/knative.dev/net-istio/cmd/controller@sha256:52453d71844b8b0f9d23139bde9080c39e123d109f6f9aacdbf8d49321e87cfa
+          image: gcr.io/knative-releases/knative.dev/net-istio/cmd/controller@sha256:915a3a9b8caea8cceb59258ca2b941c83f0ab230aef5c1dd3b9499574ac3f379
           resources:
             requests:
               cpu: 30m
@@ -306,7 +306,7 @@ metadata:
   labels:
     app.kubernetes.io/component: net-istio
     app.kubernetes.io/name: knative-serving
-    app.kubernetes.io/version: "1.20.1"
+    app.kubernetes.io/version: "1.21.1"
     networking.knative.dev/ingress-provider: istio
 spec:
   selector:
@@ -320,12 +320,12 @@ spec:
         role: net-istio-webhook
         app.kubernetes.io/component: net-istio
         app.kubernetes.io/name: knative-serving
-        app.kubernetes.io/version: "1.20.1"
+        app.kubernetes.io/version: "1.21.1"
     spec:
       serviceAccountName: controller
       containers:
         - name: webhook
-          image: gcr.io/knative-releases/knative.dev/net-istio/cmd/webhook@sha256:dfc23229b2a377c593063cabdc0fdd6906bd0955c3a6dbd8462031b18b55e67c
+          image: gcr.io/knative-releases/knative.dev/net-istio/cmd/webhook@sha256:4d9c50245aeafb269876d05ddb95d235372abfe2b2ac1c9d8c7cd3a2ccf2d6b7
           resources:
             requests:
               cpu: 20m
@@ -385,7 +385,7 @@ metadata:
   labels:
     app.kubernetes.io/component: net-istio
     app.kubernetes.io/name: knative-serving
-    app.kubernetes.io/version: "1.20.1"
+    app.kubernetes.io/version: "1.21.1"
     networking.knative.dev/ingress-provider: istio
 ---
 apiVersion: v1
@@ -397,7 +397,7 @@ metadata:
     role: net-istio-webhook
     app.kubernetes.io/component: net-istio
     app.kubernetes.io/name: knative-serving
-    app.kubernetes.io/version: "1.20.1"
+    app.kubernetes.io/version: "1.21.1"
     networking.knative.dev/ingress-provider: istio
 spec:
   ports:
@@ -420,7 +420,7 @@ metadata:
   labels:
     app.kubernetes.io/component: net-istio
     app.kubernetes.io/name: knative-serving
-    app.kubernetes.io/version: "1.20.1"
+    app.kubernetes.io/version: "1.21.1"
     networking.knative.dev/ingress-provider: istio
 webhooks:
   - admissionReviewVersions:
@@ -444,7 +444,7 @@ metadata:
   labels:
     app.kubernetes.io/component: net-istio
     app.kubernetes.io/name: knative-serving
-    app.kubernetes.io/version: "1.20.1"
+    app.kubernetes.io/version: "1.21.1"
     networking.knative.dev/ingress-provider: istio
 webhooks:
   - admissionReviewVersions:

--- a/common/knative/knative-serving/base/upstream/serving-core.yaml
+++ b/common/knative/knative-serving/base/upstream/serving-core.yaml
@@ -4,7 +4,7 @@ metadata:
   name: knative-serving
   labels:
     app.kubernetes.io/name: knative-serving
-    app.kubernetes.io/version: "1.20.0"
+    app.kubernetes.io/version: "1.21.1"
 ---
 kind: Role
 apiVersion: rbac.authorization.k8s.io/v1
@@ -13,7 +13,7 @@ metadata:
   namespace: knative-serving
   labels:
     serving.knative.dev/controller: "true"
-    app.kubernetes.io/version: "1.20.0"
+    app.kubernetes.io/version: "1.21.1"
     app.kubernetes.io/name: knative-serving
 rules:
   - apiGroups: [""]
@@ -30,7 +30,7 @@ metadata:
   name: knative-serving-activator-cluster
   labels:
     serving.knative.dev/controller: "true"
-    app.kubernetes.io/version: "1.20.0"
+    app.kubernetes.io/version: "1.21.1"
     app.kubernetes.io/name: knative-serving
 rules:
   - apiGroups: [""]
@@ -45,7 +45,7 @@ kind: ClusterRole
 metadata:
   name: knative-serving-aggregated-addressable-resolver
   labels:
-    app.kubernetes.io/version: "1.20.0"
+    app.kubernetes.io/version: "1.21.1"
     app.kubernetes.io/name: knative-serving
 aggregationRule:
   clusterRoleSelectors:
@@ -57,7 +57,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: knative-serving-addressable-resolver
   labels:
-    app.kubernetes.io/version: "1.20.0"
+    app.kubernetes.io/version: "1.21.1"
     app.kubernetes.io/name: knative-serving
     duck.knative.dev/addressable: "true"
 rules:
@@ -79,7 +79,7 @@ metadata:
   name: knative-serving-namespaced-admin
   labels:
     rbac.authorization.k8s.io/aggregate-to-admin: "true"
-    app.kubernetes.io/version: "1.20.0"
+    app.kubernetes.io/version: "1.21.1"
     app.kubernetes.io/name: knative-serving
 rules:
   - apiGroups: ["serving.knative.dev"]
@@ -95,7 +95,7 @@ metadata:
   name: knative-serving-namespaced-edit
   labels:
     rbac.authorization.k8s.io/aggregate-to-edit: "true"
-    app.kubernetes.io/version: "1.20.0"
+    app.kubernetes.io/version: "1.21.1"
     app.kubernetes.io/name: knative-serving
 rules:
   - apiGroups: ["serving.knative.dev"]
@@ -111,7 +111,7 @@ metadata:
   name: knative-serving-namespaced-view
   labels:
     rbac.authorization.k8s.io/aggregate-to-view: "true"
-    app.kubernetes.io/version: "1.20.0"
+    app.kubernetes.io/version: "1.21.1"
     app.kubernetes.io/name: knative-serving
 rules:
   - apiGroups: ["serving.knative.dev", "networking.internal.knative.dev", "autoscaling.internal.knative.dev", "caching.internal.knative.dev"]
@@ -124,7 +124,7 @@ metadata:
   name: knative-serving-core
   labels:
     serving.knative.dev/controller: "true"
-    app.kubernetes.io/version: "1.20.0"
+    app.kubernetes.io/version: "1.21.1"
     app.kubernetes.io/name: knative-serving
 rules:
   - apiGroups: [""]
@@ -173,7 +173,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: knative-serving-podspecable-binding
   labels:
-    app.kubernetes.io/version: "1.20.0"
+    app.kubernetes.io/version: "1.21.1"
     app.kubernetes.io/name: knative-serving
     duck.knative.dev/podspecable: "true"
 rules:
@@ -195,7 +195,7 @@ metadata:
   labels:
     app.kubernetes.io/component: controller
     app.kubernetes.io/name: knative-serving
-    app.kubernetes.io/version: "1.20.0"
+    app.kubernetes.io/version: "1.21.1"
 ---
 kind: ClusterRole
 apiVersion: rbac.authorization.k8s.io/v1
@@ -203,7 +203,7 @@ metadata:
   name: knative-serving-admin
   labels:
     app.kubernetes.io/name: knative-serving
-    app.kubernetes.io/version: "1.20.0"
+    app.kubernetes.io/version: "1.21.1"
 aggregationRule:
   clusterRoleSelectors:
     - matchLabels:
@@ -216,7 +216,7 @@ metadata:
   labels:
     app.kubernetes.io/component: controller
     app.kubernetes.io/name: knative-serving
-    app.kubernetes.io/version: "1.20.0"
+    app.kubernetes.io/version: "1.21.1"
 subjects:
   - kind: ServiceAccount
     name: controller
@@ -233,7 +233,7 @@ metadata:
   labels:
     app.kubernetes.io/component: controller
     app.kubernetes.io/name: knative-serving
-    app.kubernetes.io/version: "1.20.0"
+    app.kubernetes.io/version: "1.21.1"
 subjects:
   - kind: ServiceAccount
     name: controller
@@ -251,7 +251,7 @@ metadata:
   labels:
     app.kubernetes.io/component: activator
     app.kubernetes.io/name: knative-serving
-    app.kubernetes.io/version: "1.20.0"
+    app.kubernetes.io/version: "1.21.1"
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
@@ -261,7 +261,7 @@ metadata:
   labels:
     app.kubernetes.io/component: activator
     app.kubernetes.io/name: knative-serving
-    app.kubernetes.io/version: "1.20.0"
+    app.kubernetes.io/version: "1.21.1"
 subjects:
   - kind: ServiceAccount
     name: activator
@@ -278,7 +278,7 @@ metadata:
   labels:
     app.kubernetes.io/component: activator
     app.kubernetes.io/name: knative-serving
-    app.kubernetes.io/version: "1.20.0"
+    app.kubernetes.io/version: "1.21.1"
 subjects:
   - kind: ServiceAccount
     name: activator
@@ -294,7 +294,7 @@ metadata:
   name: images.caching.internal.knative.dev
   labels:
     app.kubernetes.io/name: knative-serving
-    app.kubernetes.io/version: "1.20.0"
+    app.kubernetes.io/version: "1.21.1"
     knative.dev/crd-install: "true"
 spec:
   group: caching.internal.knative.dev
@@ -454,7 +454,7 @@ metadata:
   labels:
     app.kubernetes.io/name: knative-serving
     app.kubernetes.io/component: networking
-    app.kubernetes.io/version: "1.20.0"
+    app.kubernetes.io/version: "1.21.1"
     knative.dev/crd-install: "true"
 spec:
   group: networking.internal.knative.dev
@@ -623,7 +623,7 @@ metadata:
   name: configurations.serving.knative.dev
   labels:
     app.kubernetes.io/name: knative-serving
-    app.kubernetes.io/version: "1.20.0"
+    app.kubernetes.io/version: "1.21.1"
     knative.dev/crd-install: "true"
     duck.knative.dev/podspecable: "true"
 spec:
@@ -786,7 +786,9 @@ spec:
                                     - name
                                   properties:
                                     name:
-                                      description: Name of the environment variable. Must be a C_IDENTIFIER.
+                                      description: |-
+                                        Name of the environment variable.
+                                        May consist of any printable ASCII characters except '='.
                                       type: string
                                     value:
                                       description: |-
@@ -866,8 +868,8 @@ spec:
                               envFrom:
                                 description: |-
                                   List of sources to populate environment variables in the container.
-                                  The keys defined within a source must be a C_IDENTIFIER. All invalid keys
-                                  will be reported as an event when the container is starting. When a key exists in multiple
+                                  The keys defined within a source may consist of any printable ASCII characters except '='.
+                                  When a key exists in multiple
                                   sources, the value associated with the last source will take precedence.
                                   Values defined by an Env with a duplicate key will take precedence.
                                   Cannot be updated.
@@ -894,7 +896,9 @@ spec:
                                           type: boolean
                                       x-kubernetes-map-type: atomic
                                     prefix:
-                                      description: Optional text to prepend to the name of each environment variable. Must be a C_IDENTIFIER.
+                                      description: |-
+                                        Optional text to prepend to the name of each environment variable.
+                                        May consist of any printable ASCII characters except '='.
                                       type: string
                                     secretRef:
                                       description: The Secret to select from
@@ -2164,7 +2168,7 @@ metadata:
   labels:
     app.kubernetes.io/name: knative-serving
     app.kubernetes.io/component: networking
-    app.kubernetes.io/version: "1.20.0"
+    app.kubernetes.io/version: "1.21.1"
     knative.dev/crd-install: "true"
 spec:
   group: networking.internal.knative.dev
@@ -2226,7 +2230,7 @@ metadata:
   name: domainmappings.serving.knative.dev
   labels:
     app.kubernetes.io/name: knative-serving
-    app.kubernetes.io/version: "1.20.0"
+    app.kubernetes.io/version: "1.21.1"
     knative.dev/crd-install: "true"
 spec:
   group: serving.knative.dev
@@ -2423,7 +2427,7 @@ metadata:
   labels:
     app.kubernetes.io/name: knative-serving
     app.kubernetes.io/component: networking
-    app.kubernetes.io/version: "1.20.0"
+    app.kubernetes.io/version: "1.21.1"
     knative.dev/crd-install: "true"
 spec:
   group: networking.internal.knative.dev
@@ -2794,7 +2798,7 @@ metadata:
   name: metrics.autoscaling.internal.knative.dev
   labels:
     app.kubernetes.io/name: knative-serving
-    app.kubernetes.io/version: "1.20.0"
+    app.kubernetes.io/version: "1.21.1"
     knative.dev/crd-install: "true"
 spec:
   group: autoscaling.internal.knative.dev
@@ -2921,7 +2925,7 @@ metadata:
   name: podautoscalers.autoscaling.internal.knative.dev
   labels:
     app.kubernetes.io/name: knative-serving
-    app.kubernetes.io/version: "1.20.0"
+    app.kubernetes.io/version: "1.21.1"
     knative.dev/crd-install: "true"
 spec:
   group: autoscaling.internal.knative.dev
@@ -3105,7 +3109,7 @@ metadata:
   name: revisions.serving.knative.dev
   labels:
     app.kubernetes.io/name: knative-serving
-    app.kubernetes.io/version: "1.20.0"
+    app.kubernetes.io/version: "1.21.1"
     knative.dev/crd-install: "true"
 spec:
   group: serving.knative.dev
@@ -3244,7 +3248,9 @@ spec:
                             - name
                           properties:
                             name:
-                              description: Name of the environment variable. Must be a C_IDENTIFIER.
+                              description: |-
+                                Name of the environment variable.
+                                May consist of any printable ASCII characters except '='.
                               type: string
                             value:
                               description: |-
@@ -3324,8 +3330,8 @@ spec:
                       envFrom:
                         description: |-
                           List of sources to populate environment variables in the container.
-                          The keys defined within a source must be a C_IDENTIFIER. All invalid keys
-                          will be reported as an event when the container is starting. When a key exists in multiple
+                          The keys defined within a source may consist of any printable ASCII characters except '='.
+                          When a key exists in multiple
                           sources, the value associated with the last source will take precedence.
                           Values defined by an Env with a duplicate key will take precedence.
                           Cannot be updated.
@@ -3352,7 +3358,9 @@ spec:
                                   type: boolean
                               x-kubernetes-map-type: atomic
                             prefix:
-                              description: Optional text to prepend to the name of each environment variable. Must be a C_IDENTIFIER.
+                              description: |-
+                                Optional text to prepend to the name of each environment variable.
+                                May consist of any printable ASCII characters except '='.
                               type: string
                             secretRef:
                               description: The Secret to select from
@@ -4658,7 +4666,7 @@ metadata:
   name: routes.serving.knative.dev
   labels:
     app.kubernetes.io/name: knative-serving
-    app.kubernetes.io/version: "1.20.0"
+    app.kubernetes.io/version: "1.21.1"
     knative.dev/crd-install: "true"
     duck.knative.dev/addressable: "true"
 spec:
@@ -4914,7 +4922,7 @@ metadata:
   labels:
     app.kubernetes.io/name: knative-serving
     app.kubernetes.io/component: networking
-    app.kubernetes.io/version: "1.20.0"
+    app.kubernetes.io/version: "1.21.1"
     knative.dev/crd-install: "true"
 spec:
   group: networking.internal.knative.dev
@@ -5121,7 +5129,7 @@ metadata:
   name: services.serving.knative.dev
   labels:
     app.kubernetes.io/name: knative-serving
-    app.kubernetes.io/version: "1.20.0"
+    app.kubernetes.io/version: "1.21.1"
     knative.dev/crd-install: "true"
     duck.knative.dev/addressable: "true"
     duck.knative.dev/podspecable: "true"
@@ -5302,7 +5310,9 @@ spec:
                                     - name
                                   properties:
                                     name:
-                                      description: Name of the environment variable. Must be a C_IDENTIFIER.
+                                      description: |-
+                                        Name of the environment variable.
+                                        May consist of any printable ASCII characters except '='.
                                       type: string
                                     value:
                                       description: |-
@@ -5382,8 +5392,8 @@ spec:
                               envFrom:
                                 description: |-
                                   List of sources to populate environment variables in the container.
-                                  The keys defined within a source must be a C_IDENTIFIER. All invalid keys
-                                  will be reported as an event when the container is starting. When a key exists in multiple
+                                  The keys defined within a source may consist of any printable ASCII characters except '='.
+                                  When a key exists in multiple
                                   sources, the value associated with the last source will take precedence.
                                   Values defined by an Env with a duplicate key will take precedence.
                                   Cannot be updated.
@@ -5410,7 +5420,9 @@ spec:
                                           type: boolean
                                       x-kubernetes-map-type: atomic
                                     prefix:
-                                      description: Optional text to prepend to the name of each environment variable. Must be a C_IDENTIFIER.
+                                      description: |-
+                                        Optional text to prepend to the name of each environment variable.
+                                        May consist of any printable ASCII characters except '='.
                                       type: string
                                     secretRef:
                                       description: The Secret to select from
@@ -6811,9 +6823,9 @@ metadata:
   labels:
     app.kubernetes.io/component: queue-proxy
     app.kubernetes.io/name: knative-serving
-    app.kubernetes.io/version: "1.20.0"
+    app.kubernetes.io/version: "1.21.1"
 spec:
-  image: gcr.io/knative-releases/knative.dev/serving/cmd/queue@sha256:b78cfa015872b12cf64f01fc21f29190c6f2fa69aadbb90162fa98e843781777
+  image: gcr.io/knative-releases/knative.dev/serving/cmd/queue@sha256:40957d3ced3b185b7a78bbd771be69b0a13137dcbee5ff7f82ae738b56037d9c
 ---
 apiVersion: v1
 kind: ConfigMap
@@ -6823,7 +6835,7 @@ metadata:
   labels:
     app.kubernetes.io/component: autoscaler
     app.kubernetes.io/name: knative-serving
-    app.kubernetes.io/version: "1.20.0"
+    app.kubernetes.io/version: "1.21.1"
   annotations:
     knative.dev/example-checksum: "47c2487f"
 data:
@@ -7019,7 +7031,7 @@ metadata:
   labels:
     app.kubernetes.io/name: knative-serving
     app.kubernetes.io/component: controller
-    app.kubernetes.io/version: "1.20.0"
+    app.kubernetes.io/version: "1.21.1"
     networking.knative.dev/certificate-provider: cert-manager
   annotations:
     knative.dev/example-checksum: "b7a9a602"
@@ -7074,7 +7086,7 @@ metadata:
   labels:
     app.kubernetes.io/name: knative-serving
     app.kubernetes.io/component: controller
-    app.kubernetes.io/version: "1.20.0"
+    app.kubernetes.io/version: "1.21.1"
   annotations:
     knative.dev/example-checksum: "5b64ff5c"
 data:
@@ -7214,11 +7226,11 @@ metadata:
   labels:
     app.kubernetes.io/name: knative-serving
     app.kubernetes.io/component: controller
-    app.kubernetes.io/version: "1.20.0"
+    app.kubernetes.io/version: "1.21.1"
   annotations:
-    knative.dev/example-checksum: "720ddb97"
+    knative.dev/example-checksum: "b99000ec"
 data:
-  queue-sidecar-image: gcr.io/knative-releases/knative.dev/serving/cmd/queue@sha256:b78cfa015872b12cf64f01fc21f29190c6f2fa69aadbb90162fa98e843781777
+  queue-sidecar-image: gcr.io/knative-releases/knative.dev/serving/cmd/queue@sha256:40957d3ced3b185b7a78bbd771be69b0a13137dcbee5ff7f82ae738b56037d9c
   _example: |-
     ################################
     #                              #
@@ -7315,6 +7327,15 @@ data:
     #     selector:
     #       use-gvisor: "please"
     runtime-class-name: ""
+
+    # pod-is-always-schedulable can be used to define that Pods in the system will always be
+    # scheduled, and a Revision should not be marked unschedulable.
+    # Setting this to `true` makes sense if you have cluster-autoscaling set up for your cluster
+    # where unschedulable Pods trigger the addition of a new Node and are therefore a short and
+    # transient state.
+    #
+    # See https://github.com/knative/serving/issues/14862
+    pod-is-always-schedulable: "false"
 ---
 apiVersion: v1
 kind: ConfigMap
@@ -7324,7 +7345,7 @@ metadata:
   labels:
     app.kubernetes.io/name: knative-serving
     app.kubernetes.io/component: controller
-    app.kubernetes.io/version: "1.20.0"
+    app.kubernetes.io/version: "1.21.1"
   annotations:
     knative.dev/example-checksum: "26c09de5"
 data:
@@ -7374,7 +7395,7 @@ metadata:
   labels:
     app.kubernetes.io/name: knative-serving
     app.kubernetes.io/component: controller
-    app.kubernetes.io/version: "1.20.0"
+    app.kubernetes.io/version: "1.21.1"
   annotations:
     knative.dev/example-checksum: "9553535b"
 data:
@@ -7614,7 +7635,7 @@ metadata:
   labels:
     app.kubernetes.io/name: knative-serving
     app.kubernetes.io/component: controller
-    app.kubernetes.io/version: "1.20.0"
+    app.kubernetes.io/version: "1.21.1"
   annotations:
     knative.dev/example-checksum: "aa3813a8"
 data:
@@ -7699,7 +7720,7 @@ metadata:
   labels:
     app.kubernetes.io/name: knative-serving
     app.kubernetes.io/component: controller
-    app.kubernetes.io/version: "1.20.0"
+    app.kubernetes.io/version: "1.21.1"
   annotations:
     knative.dev/example-checksum: "f4b71f57"
 data:
@@ -7744,7 +7765,7 @@ metadata:
   name: config-logging
   namespace: knative-serving
   labels:
-    app.kubernetes.io/version: "1.20.0"
+    app.kubernetes.io/version: "1.21.1"
     app.kubernetes.io/component: logging
     app.kubernetes.io/name: knative-serving
   annotations:
@@ -7812,7 +7833,7 @@ metadata:
   labels:
     app.kubernetes.io/name: knative-serving
     app.kubernetes.io/component: networking
-    app.kubernetes.io/version: "1.20.0"
+    app.kubernetes.io/version: "1.21.1"
   annotations:
     knative.dev/example-checksum: "0573e07d"
 data:
@@ -8002,9 +8023,9 @@ metadata:
   labels:
     app.kubernetes.io/name: knative-serving
     app.kubernetes.io/component: observability
-    app.kubernetes.io/version: "1.20.0"
+    app.kubernetes.io/version: "1.21.1"
   annotations:
-    knative.dev/example-checksum: "f183bbc6"
+    knative.dev/example-checksum: "59abacb5"
 data:
   _example: |
     ################################
@@ -8062,7 +8083,7 @@ data:
     #   PodIP         string  // IP of the pod hosting the revision
     # }
     #
-    logging.request-log-template: '{"httpRequest": {"requestMethod": "{{.Request.Method}}", "requestUrl": "{{js .Request.RequestURI}}", "requestSize": "{{.Request.ContentLength}}", "status": {{.Response.Code}}, "responseSize": "{{.Response.Size}}", "userAgent": "{{js .Request.UserAgent}}", "remoteIp": "{{js .Request.RemoteAddr}}", "serverIp": "{{.Revision.PodIP}}", "referer": "{{js .Request.Referer}}", "latency": "{{.Response.Latency}}s", "protocol": "{{.Request.Proto}}"}, "traceId": "{{index .Request.Header "X-B3-Traceid"}}"}'
+    logging.request-log-template: '{"httpRequest": {"requestMethod": "{{.Request.Method}}", "requestUrl": "{{js .Request.RequestURI}}", "requestSize": "{{.Request.ContentLength}}", "status": {{.Response.Code}}, "responseSize": "{{.Response.Size}}", "userAgent": "{{js .Request.UserAgent}}", "remoteIp": "{{js .Request.RemoteAddr}}", "serverIp": "{{.Revision.PodIP}}", "referer": "{{js .Request.Referer}}", "latency": "{{.Response.Latency}}s", "protocol": "{{.Request.Proto}}"}, "traceId": "{{.TraceID}}"}'
 
     # If true, the request logging will be enabled.
     logging.enable-request-log: "false"
@@ -8135,7 +8156,7 @@ metadata:
   labels:
     app.kubernetes.io/name: knative-serving
     app.kubernetes.io/component: tracing
-    app.kubernetes.io/version: "1.20.0"
+    app.kubernetes.io/version: "1.21.1"
   annotations:
     knative.dev/example-checksum: "04c7e9a3"
 data:
@@ -8154,7 +8175,7 @@ metadata:
   labels:
     app.kubernetes.io/component: activator
     app.kubernetes.io/name: knative-serving
-    app.kubernetes.io/version: "1.20.0"
+    app.kubernetes.io/version: "1.21.1"
 spec:
   minReplicas: 1
   maxReplicas: 20
@@ -8178,7 +8199,7 @@ metadata:
   labels:
     app.kubernetes.io/component: activator
     app.kubernetes.io/name: knative-serving
-    app.kubernetes.io/version: "1.20.0"
+    app.kubernetes.io/version: "1.21.1"
 spec:
   minAvailable: 80%
   selector:
@@ -8192,7 +8213,7 @@ metadata:
   namespace: knative-serving
   labels:
     app.kubernetes.io/component: activator
-    app.kubernetes.io/version: "1.20.0"
+    app.kubernetes.io/version: "1.21.1"
     app.kubernetes.io/name: knative-serving
 spec:
   selector:
@@ -8206,7 +8227,7 @@ spec:
         role: activator
         app.kubernetes.io/component: activator
         app.kubernetes.io/name: knative-serving
-        app.kubernetes.io/version: "1.20.0"
+        app.kubernetes.io/version: "1.21.1"
     spec:
       affinity:
         podAntiAffinity:
@@ -8220,7 +8241,7 @@ spec:
       serviceAccountName: activator
       containers:
         - name: activator
-          image: gcr.io/knative-releases/knative.dev/serving/cmd/activator@sha256:701507d9c480ff87dcfa4755ca7d3d6b727438cc78c21a32164750654aa08e67
+          image: gcr.io/knative-releases/knative.dev/serving/cmd/activator@sha256:cf8d126fc08e596b742025f6e53c97abf921f7bd6394d29c200e79c1c323dc6e
           resources:
             requests:
               cpu: 300m
@@ -8286,7 +8307,7 @@ metadata:
   labels:
     app: activator
     app.kubernetes.io/component: activator
-    app.kubernetes.io/version: "1.20.0"
+    app.kubernetes.io/version: "1.21.1"
     app.kubernetes.io/name: knative-serving
 spec:
   selector:
@@ -8317,7 +8338,7 @@ metadata:
   labels:
     app.kubernetes.io/component: autoscaler
     app.kubernetes.io/name: knative-serving
-    app.kubernetes.io/version: "1.20.0"
+    app.kubernetes.io/version: "1.21.1"
 spec:
   replicas: 1
   selector:
@@ -8333,7 +8354,7 @@ spec:
         app: autoscaler
         app.kubernetes.io/component: autoscaler
         app.kubernetes.io/name: knative-serving
-        app.kubernetes.io/version: "1.20.0"
+        app.kubernetes.io/version: "1.21.1"
     spec:
       affinity:
         podAntiAffinity:
@@ -8347,7 +8368,7 @@ spec:
       serviceAccountName: controller
       containers:
         - name: autoscaler
-          image: gcr.io/knative-releases/knative.dev/serving/cmd/autoscaler@sha256:485c0a009cede9138a7ec1e5ab5a5ef22ff9ddbbc7f278571211f33c505ca596
+          image: gcr.io/knative-releases/knative.dev/serving/cmd/autoscaler@sha256:35045ef7c35c6151f0565094cc5ec240a886ba2e5a844366b22a074342af3edf
           resources:
             requests:
               cpu: 100m
@@ -8403,7 +8424,7 @@ metadata:
     app: autoscaler
     app.kubernetes.io/component: autoscaler
     app.kubernetes.io/name: knative-serving
-    app.kubernetes.io/version: "1.20.0"
+    app.kubernetes.io/version: "1.21.1"
   name: autoscaler
   namespace: knative-serving
 spec:
@@ -8428,7 +8449,7 @@ metadata:
   labels:
     app.kubernetes.io/component: controller
     app.kubernetes.io/name: knative-serving
-    app.kubernetes.io/version: "1.20.0"
+    app.kubernetes.io/version: "1.21.1"
 spec:
   selector:
     matchLabels:
@@ -8439,7 +8460,7 @@ spec:
         app: controller
         app.kubernetes.io/component: controller
         app.kubernetes.io/name: knative-serving
-        app.kubernetes.io/version: "1.20.0"
+        app.kubernetes.io/version: "1.21.1"
     spec:
       affinity:
         podAntiAffinity:
@@ -8453,7 +8474,7 @@ spec:
       serviceAccountName: controller
       containers:
         - name: controller
-          image: gcr.io/knative-releases/knative.dev/serving/cmd/controller@sha256:3718bf2e2f135ac70699db930145b22e52fb49bdd47a613b58cd0732853576da
+          image: gcr.io/knative-releases/knative.dev/serving/cmd/controller@sha256:622546def05a9b181123d35ede4e4a6e60d7751ae558ea2c5306978b30c24d5c
           resources:
             requests:
               cpu: 100m
@@ -8512,7 +8533,7 @@ metadata:
     app: controller
     app.kubernetes.io/component: controller
     app.kubernetes.io/name: knative-serving
-    app.kubernetes.io/version: "1.20.0"
+    app.kubernetes.io/version: "1.21.1"
   name: controller
   namespace: knative-serving
 spec:
@@ -8534,7 +8555,7 @@ metadata:
   labels:
     app.kubernetes.io/component: webhook
     app.kubernetes.io/name: knative-serving
-    app.kubernetes.io/version: "1.20.0"
+    app.kubernetes.io/version: "1.21.1"
 spec:
   minReplicas: 1
   maxReplicas: 5
@@ -8558,7 +8579,7 @@ metadata:
   labels:
     app.kubernetes.io/component: webhook
     app.kubernetes.io/name: knative-serving
-    app.kubernetes.io/version: "1.20.0"
+    app.kubernetes.io/version: "1.21.1"
 spec:
   minAvailable: 80%
   selector:
@@ -8572,7 +8593,7 @@ metadata:
   namespace: knative-serving
   labels:
     app.kubernetes.io/component: webhook
-    app.kubernetes.io/version: "1.20.0"
+    app.kubernetes.io/version: "1.21.1"
     app.kubernetes.io/name: knative-serving
 spec:
   selector:
@@ -8585,7 +8606,7 @@ spec:
         app: webhook
         role: webhook
         app.kubernetes.io/component: webhook
-        app.kubernetes.io/version: "1.20.0"
+        app.kubernetes.io/version: "1.21.1"
         app.kubernetes.io/name: knative-serving
     spec:
       affinity:
@@ -8600,7 +8621,7 @@ spec:
       serviceAccountName: controller
       containers:
         - name: webhook
-          image: gcr.io/knative-releases/knative.dev/serving/cmd/webhook@sha256:0d9c4d4971d9b67eaf5ce1359f6ff334145d32b3c0cb9e650ab9fab687396696
+          image: gcr.io/knative-releases/knative.dev/serving/cmd/webhook@sha256:8754cefd1f1db905495de5ba707b37459cc212b830d40962162654986d264d74
           resources:
             requests:
               cpu: 100m
@@ -8662,7 +8683,7 @@ metadata:
     app: webhook
     role: webhook
     app.kubernetes.io/component: webhook
-    app.kubernetes.io/version: "1.20.0"
+    app.kubernetes.io/version: "1.21.1"
     app.kubernetes.io/name: knative-serving
   name: webhook
   namespace: knative-serving
@@ -8688,7 +8709,7 @@ metadata:
   labels:
     app.kubernetes.io/component: webhook
     app.kubernetes.io/name: knative-serving
-    app.kubernetes.io/version: "1.20.0"
+    app.kubernetes.io/version: "1.21.1"
 webhooks:
   - admissionReviewVersions: ["v1", "v1beta1"]
     clientConfig:
@@ -8715,7 +8736,7 @@ metadata:
   labels:
     app.kubernetes.io/component: webhook
     app.kubernetes.io/name: knative-serving
-    app.kubernetes.io/version: "1.20.0"
+    app.kubernetes.io/version: "1.21.1"
 webhooks:
   - admissionReviewVersions: ["v1", "v1beta1"]
     clientConfig:
@@ -8757,7 +8778,7 @@ metadata:
   labels:
     app.kubernetes.io/component: webhook
     app.kubernetes.io/name: knative-serving
-    app.kubernetes.io/version: "1.20.0"
+    app.kubernetes.io/version: "1.21.1"
 webhooks:
   - admissionReviewVersions: ["v1", "v1beta1"]
     clientConfig:
@@ -8801,6 +8822,6 @@ metadata:
   labels:
     app.kubernetes.io/component: webhook
     app.kubernetes.io/name: knative-serving
-    app.kubernetes.io/version: "1.20.0"
+    app.kubernetes.io/version: "1.21.1"
 ---
 

--- a/scripts/synchronize-knative-manifests.sh
+++ b/scripts/synchronize-knative-manifests.sh
@@ -7,9 +7,9 @@ source "${SCRIPT_DIRECTORY}/library.sh"
 setup_error_handling
 
 COMPONENT_NAME="knative"
-KN_SERVING_RELEASE="v1.20.0" # Must be a release
-KN_EXTENSION_RELEASE="v1.20.1" # Must be a release
-KN_EVENTING_RELEASE="v1.20.0" # Must be a release
+KN_SERVING_RELEASE="v1.21.1" # Must be a release
+KN_EXTENSION_RELEASE="v1.21.1" # Must be a release
+KN_EVENTING_RELEASE="v1.21.0" # Must be a release
 BRANCH_NAME=${BRANCH_NAME:=synchronize-${COMPONENT_NAME}-manifests-${KN_SERVING_RELEASE?}}
 
 # Path configurations


### PR DESCRIPTION
## ✏️ Summary of Changes
- Bump Knative sync script pins:
  - serving: `v1.21.1`
  - net-istio: `v1.21.1`
  - eventing: `v1.21.0`
- Regenerate upstream Knative serving/eventing manifests
- Update Knative version references in `common/knative/README.md` and root `README.md`

## 📦 Dependencies
- None

## 🐛 Related Issues
- Follow-up component sync after cert-manager sync script updates

## ✅ Contributor Checklist
- [x] I have tested these changes with kustomize.
- [x] All commits are signed-off to satisfy the DCO check.
- [ ] I have considered adding my company to the adopters page.