### PR TITLE
test(spark): harden webhook readiness checks

### DIFF
--- a/tests/spark_install.sh
+++ b/tests/spark_install.sh
@@ -13,6 +13,11 @@ kubectl -n kubeflow get pod -l app.kubernetes.io/name=spark-operator
 
 # Wait for the operator webhook to be ready.
 kubectl -n kubeflow wait --for=condition=available --timeout=180s deploy/spark-operator-webhook
+kubectl -n kubeflow wait \
+  --for=condition=Ready \
+  pod \
+  -l app.kubernetes.io/name=spark-operator,app.kubernetes.io/component=webhook \
+  --timeout=180s
 # Wait for the webhook endpoint to be registered and routable
 kubectl -n kubeflow wait \
   --for=jsonpath='{.subsets[0].addresses[0].targetRef.kind}'=Pod \


### PR DESCRIPTION
## ✏️ Summary of Changes
This PR makes the Spark CI install/test path more robust by strengthening webhook readiness checks in `tests/spark_install.sh`.

The original failure mode was not in the Spark manifests themselves. The `Test Spark` workflow could proceed after `deploy/spark-operator-webhook` became `Available`, but the API server still hit a transient admission failure when creating `SparkApplication` resources:

- the Spark operator webhook deployment existed,
- but the webhook endpoint was not yet fully reachable on `spark-operator-webhook-svc:9443`,
- and the first `SparkApplication` apply failed with `connection refused`.

This PR hardens the test setup by:
- increasing the controller availability wait from `60s` to `180s`,
- increasing the webhook availability wait from `30s` to `180s`,
- waiting for `endpoints/spark-operator-webhook-svc` to contain a pod-backed address before the Spark test continues.

This keeps the fix narrowly scoped to test robustness and avoids changing the Spark component manifests.

## 📦 Dependencies
- None

## 🐛 Related Issues
- Follow-up to review feedback on `#3366` asking to make the Spark test more robust and identify the exact failing step.

## ✅ Validation
Local validation was run on a fresh kind cluster using the same workflow shape as the GitHub Actions Spark job:
- `kustomize build common/kubeflow-namespace/base | kubectl apply -f -`
- `./tests/istio-cni_install.sh`
- `./tests/oauth2-proxy_install.sh`
- `./tests/cert_manager_install.sh`
- `./tests/multi_tenancy_install.sh`
- `kustomize build common/user-namespace/base | kubectl apply -f -`
- `cd applications/spark && ../../tests/spark_install.sh && ../../tests/spark_test.sh kubeflow-user-example-com`

Observed result after this patch:
- first `SparkApplication` apply succeeded,
- no webhook `connection refused`,
- Spark application reached `RUNNING`,
- driver pod completed with `Succeeded`.

## ✅ Contributor Checklist
- [x] I have tested these changes with kustomize. See [Installation Prerequisites](https://github.com/kubeflow/manifests#prerequisites).
- [x] All commits are [_signed-off_](https://github.com/kubeflow/community/tree/master/dco-signoff-hook#signing-off-commits) to satisfy the DCO check.
- [ ] I have considered adding my company to the adopters page to support Kubeflow and help the community, since I expect help from the community for my issue (see [1.](https://github.com/kubeflow/community/issues/833) and [2.](https://github.com/kubeflow/community/blob/master/ADOPTERS.md#adopters-of-kubeflow-platform)).
