### PR TITLE
test(ci): harden Kustomize checksum verification

### DIFF
--- a/tests/install_KinD_create_KinD_cluster_install_kustomize.sh
+++ b/tests/install_KinD_create_KinD_cluster_install_kustomize.sh
@@ -70,7 +70,11 @@ echo "Install Kustomize ..."
 {
     KUSTOMIZE_ASSET="kustomize_${KUSTOMIZE_VERSION}_linux_amd64.tar.gz"
     curl --fail --show-error --silent --location --remote-name "https://github.com/kubernetes-sigs/kustomize/releases/download/kustomize%2F${KUSTOMIZE_VERSION}/${KUSTOMIZE_ASSET}"
-    curl --fail --show-error --silent --location "https://github.com/kubernetes-sigs/kustomize/releases/download/kustomize%2F${KUSTOMIZE_VERSION}/checksums.txt" | grep -F "  ${KUSTOMIZE_ASSET}" > checksums.txt
+    curl --fail --show-error --silent --location "https://github.com/kubernetes-sigs/kustomize/releases/download/kustomize%2F${KUSTOMIZE_VERSION}/checksums.txt" | grep "  ${KUSTOMIZE_ASSET}$" > checksums.txt
+    if [ "$(wc -l < checksums.txt)" -ne 1 ]; then
+       echo "Failed to verify Kustomize checksums: expected exactly one checksum entry for ${KUSTOMIZE_ASSET}"
+       exit 1
+    fi
     if ! sha256sum --check checksums.txt; then
        echo "Failed to verify Kustomize checksums"
        exit 1


### PR DESCRIPTION
## ✏️ Summary of Changes
This PR hardens the shared Kustomize install path in `tests/install_KinD_create_KinD_cluster_install_kustomize.sh`.

The recent CI failures were happening before any component-specific tests ran, during the Kustomize bootstrap step. Across reruns, the failure signature varied:
- checksum mismatch
- `checksums.txt: no properly formatted checksum lines found`

This change makes the Kustomize verification step more explicit and less brittle by:
- matching the checksum entry for the exact expected asset name (`kustomize_v5.7.1_linux_amd64.tar.gz`),
- using `curl --fail --show-error` so bad HTTP responses fail earlier and more clearly,
- reusing the explicit asset variable for extraction.

This is intentionally scoped to the shared CI/bootstrap path and does not modify any component manifests.

## 📦 Dependencies
- None

## 🐛 Related Issues
- Follow-up to repeated CI failures in the shared `Install KinD, Create KinD cluster and Install kustomize` step, observed while validating `#3367`.

## ✅ Validation
Validated locally against the current upstream `kustomize/v5.7.1` release metadata and download assets:

```bash
KUSTOMIZE_VERSION=v5.7.1
KUSTOMIZE_ASSET="kustomize_${KUSTOMIZE_VERSION}_linux_amd64.tar.gz"
curl --fail --show-error --silent --location --remote-name \
  "https://github.com/kubernetes-sigs/kustomize/releases/download/kustomize%2F${KUSTOMIZE_VERSION}/${KUSTOMIZE_ASSET}"
curl --fail --show-error --silent --location \
  "https://github.com/kubernetes-sigs/kustomize/releases/download/kustomize%2F${KUSTOMIZE_VERSION}/checksums.txt" \
  | grep -F "  ${KUSTOMIZE_ASSET}" > checksums.txt
sha256sum --check checksums.txt
```

Observed result:
- exact asset checksum verification passed locally.

## ✅ Contributor Checklist
- [x] I have tested these changes with kustomize. See [Installation Prerequisites](https://github.com/kubeflow/manifests#prerequisites).
- [x] All commits are [_signed-off_](https://github.com/kubeflow/community/tree/master/dco-signoff-hook#signing-off-commits) to satisfy the DCO check.
- [ ] I have considered adding my company to the adopters page to support Kubeflow and help the community, since I expect help from the community for my issue (see [1.](https://github.com/kubeflow/community/issues/833) and [2.](https://github.com/kubeflow/community/blob/master/ADOPTERS.md#adopters-of-kubeflow-platform)).
