### PR TITLE
knative: drop dead configmap filters

### DIFF
--- a/scripts/synchronize-knative-manifests.sh
+++ b/scripts/synchronize-knative-manifests.sh
@@ -39,8 +39,6 @@ yq eval -i '... comments=""' $DESTINATION_DIRECTORY/knative-eventing/base/upstre
 yq eval -i '... comments=""' $DESTINATION_DIRECTORY/knative-eventing/base/upstream/mt-channel-broker.yaml
 yq eval -i '... comments=""' $DESTINATION_DIRECTORY/knative-eventing-post-install-jobs/base/eventing-post-install.yaml
 yq eval -i 'select(.kind == "Job" and .metadata.generateName == "storage-version-migration-eventing-") | .metadata.name = "storage-version-migration-eventing"' $DESTINATION_DIRECTORY/knative-eventing-post-install-jobs/base/eventing-post-install.yaml
-yq eval -i 'select((.kind == "ConfigMap" and .metadata.name == "config-observability") | not)' $DESTINATION_DIRECTORY/knative-eventing/base/upstream/in-memory-channel.yaml
-yq eval -i 'select((.kind == "ConfigMap" and .metadata.name == "config-tracing") | not)' $DESTINATION_DIRECTORY/knative-eventing/base/upstream/in-memory-channel.yaml
 replace_in_file() {
   local SOURCE_TEXT=$1
   local DESTINATION_TEXT=$2


### PR DESCRIPTION
## ✏️ Summary of Changes
This PR is a small follow-up to   https://github.com/kubeflow/manifests/pull/3375#issuecomment-3986377704 and removes two dead `yq eval` filters from `scripts/synchronize-knative-manifests.sh`:

- `config-observability` filter on `common/knative/knative-eventing/base/upstream/in-memory-channel.yaml`
- `config-tracing` filter on `common/knative/knative-eventing/base/upstream/in-memory-channel.yaml`

These lines were originally intended to filter redundant Eventing ConfigMaps from the in-memory channel manifest, but for the current Knative inputs they are no longer affecting the final generated output.

I did **not** remove the other remaining `yq` calls:
- the job-name stabilization still has to stay, because removing it breaks the post-install job bases
- the comment-stripping calls are not needed for builds, but removing them rewrites several tracked upstream YAML files and would turn this into a larger churn PR

## 📦 Dependencies
- Follow-up to `#3375`
- Addresses mentor follow-up comment: `#issuecomment-3986377704`

## 🐛 Related Issues
- Knative sync-script cleanup after the `explode(.)` removal in `#3375`

## ✅ Contributor Checklist
- [x] I have tested these changes locally with kustomize.
- [x] All commits are [_signed-off_](https://github.com/kubeflow/community/tree/master/dco-signoff-hook#signing-off-commits) to satisfy the DCO check.
- [ ] I have considered adding my company to the adopters page to support Kubeflow and help the community, since I expect help from the community for my issue.

## Local Validation
Validated in a clean worktree and disposable repos:
- inventory of all remaining `yq eval` calls in `scripts/synchronize-knative-manifests.sh`
- disposable-repo A/B runs against current `upstream/master`
- `kustomize v5.8.1 build` on:
  - `common/knative/knative-serving/base`
  - `common/knative/knative-eventing/base`
  - `common/knative/knative-serving-post-install-jobs/base`
  - `common/knative/knative-eventing-post-install-jobs/base`

Observed result:
- removing these two filter lines caused no output drift
- all 4 Knative builds still passed
- removing the job-name stabilization lines broke both post-install job base builds
- removing comment stripping caused large tracked YAML churn, so that was intentionally left out of this minimal follow-up

