### PR TITLE
Add test-profile for Kubeflow profiles

### DIFF
--- a/applications/profiles/upstream/overlays/standalone/test-profiles/test-profile.yaml
+++ b/applications/profiles/upstream/overlays/standalone/test-profiles/test-profile.yaml
@@ -1,0 +1,8 @@
+apiVersion: kubeflow.org/v1
+kind: Profile
+metadata:
+  name: test-profile
+spec:
+  owner:
+    kind: User
+    name: test-user


### PR DESCRIPTION
Added a test-profile for Kubeflow Profiles in the standalone environment.  
This addresses the Profiles Standalone Deployment failure fixes #3381 by ensuring that a sample profile is available for the Profiles controller.  The test-profile was tested locally, and it successfully created the namespace, service accounts, and role bindings required for the test-profile.  This change helps verify that the Profiles controller works correctly even when no default profiles exist.