### PR TITLE
docs: Add ARM64/aarch64 architecture support note and issue tracking

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,7 +110,7 @@ The `example` directory contains an example kustomization for the single command
 
 ### ARM64 / aarch64 note
 
-Kubeflow on ARM64/aarch64 may not be fully supported yet because some component container images might not be available for `linux/arm64`.
+Kubeflow on ARM64/aarch64 may not be fully supported yet because some OCI images might not be available for `linux/arm64`.
 If you hit image pull errors such as “no matching manifest for linux/arm64”, please track/report details in kubeflow/manifests#2745 and take a look at the [Google Summer of Code project for Kubeflow on ARM64](https://www.kubeflow.org/events/upcoming-events/gsoc-2026/#project--end-to-end-arm64-support--validation-on-kubeflow).
 
 ---


### PR DESCRIPTION
# Pull Request Template for Kubeflow Manifests

## ✏️ Summary of Changes
Added documentation note about ARM64/aarch64 architecture support status in the README.md Prerequisites section. This helps users understand known limitations when deploying Kubeflow on ARM64 systems and directs them to the tracking issue for reporting problems.

## 📦 Dependencies
None.

## 🐛 Related Issues
See #2745

## ✅ Contributor Checklist
  - [x] I have tested these changes with kustomize. See [Installation Prerequisites](https://github.com/kubeflow/manifests#prerequisites).
  - [x] All commits are [_signed-off_](https://github.com/kubeflow/community/tree/master/dco-signoff-hook#signing-off-commits) to satisfy the DCO check.
  - [ ] I have considered adding my company to the adopters page to support Kubeflow and help the community, since I expect help from the community for my issue (see [1.](https://github.com/kubeflow/community/issues/833) and [2.](https://github.com/kubeflow/community/blob/master/ADOPTERS.md#adopters-of-kubeflow-platform)).

---     
 
> You can join the CNCF Slack and access our meetings at the [Kubeflow Community](https://www.kubeflow.org/docs/about/community/) website. Our channel on the CNCF Slack is here [**#kubeflow-platform**](https://app.slack.com/client/T08PSQ7BQ/C073W572LA2).