### PR TITLE
fix(istio): replace PreferClose with PreferSameZone for Kubernetes v1.34

### DIFF
--- a/common/istio/istio-install/base/install.yaml
+++ b/common/istio/istio-install/base/install.yaml
@@ -2354,7 +2354,7 @@ data:
         metadata:
           annotations:
             {{ toJsonMap
-              (strdict "networking.istio.io/traffic-distribution" "PreferClose")
+              (strdict "networking.istio.io/traffic-distribution" "PreferSameZone")
               (omit .InfrastructureAnnotations
                 "kubectl.kubernetes.io/last-applied-configuration"
                 "gateway.istio.io/name-override"


### PR DESCRIPTION
## ✏️ Summary of Changes
This PR updates the Istio install manifest to avoid using the deprecated Kubernetes Service trafficDistribution value `PreferClose` (deprecated in Kubernetes v1.34).  
Specifically, it replaces `PreferClose` with `PreferSameZone` in:
- `common/istio/istio-install/base/install.yaml`

This preserves the intended locality preference behavior while keeping the manifests compatible with newer Kubernetes versions.

## 📦 Dependencies
None.

## 🐛 Related Issues
Fixes #3331

## ✅ Contributor Checklist
  - [x] I have tested these changes with kustomize. See [Installation Prerequisites](https://github.com/kubeflow/manifests#prerequisites).  
        Command run: `kustomize build example >/tmp/kubeflow-example.yaml` (completed successfully; only existing kustomize deprecation warnings were emitted).
  - [x] All commits are [_signed-off_](https://github.com/kubeflow/community/tree/master/dco-signoff-hook#signing-off-commits) to satisfy the DCO check.
  - [ ] I have considered adding my company to the adopters page to support Kubeflow and help the community, since I expect help from the community for my issue (see [1.](https://github.com/kubeflow/community/issues/833) and [2.](https://github.com/kubeflow/community/blob/master/ADOPTERS.md#adopters-of-kubeflow-platform)).