### PR TITLE
feat(training-operator): replace secretGenerator with cert-manager Certificate for webhook TLS

### DIFF
--- a/applications/training-operator/upstream/overlays/kubeflow/certificate.yaml
+++ b/applications/training-operator/upstream/overlays/kubeflow/certificate.yaml
@@ -1,0 +1,23 @@
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: training-operator-webhook-cert
+spec:
+  isCA: true
+  commonName: training-operator.kubeflow.svc
+  dnsNames:
+  - training-operator.kubeflow.svc
+  - training-operator.kubeflow.svc.cluster.local
+  issuerRef:
+    kind: Issuer
+    name: training-operator-selfsigned-issuer
+  secretName: training-operator-webhook-cert
+
+---
+
+apiVersion: cert-manager.io/v1
+kind: Issuer
+metadata:
+  name: training-operator-selfsigned-issuer
+spec:
+  selfSigned: {}

--- a/applications/training-operator/upstream/overlays/kubeflow/kustomization.yaml
+++ b/applications/training-operator/upstream/overlays/kubeflow/kustomization.yaml
@@ -4,12 +4,11 @@ namespace: kubeflow
 resources:
   - ../../base
   - kubeflow-training-roles.yaml
+  - certificate.yaml
+
+patchesStrategicMerge:
+  - webhook-patch.yaml
 images:
   - name: ghcr.io/kubeflow/training-v1/training-operator
     newTag: v1-3f15cb8
-# TODO (tenzen-y): Once we support cert-manager, we need to remove this secret generation.
-# REF: https://github.com/kubeflow/training-operator/issues/2049
-secretGenerator:
-  - name: training-operator-webhook-cert
-    options:
-      disableNameSuffixHash: true
+

--- a/applications/training-operator/upstream/overlays/kubeflow/webhook-patch.yaml
+++ b/applications/training-operator/upstream/overlays/kubeflow/webhook-patch.yaml
@@ -1,0 +1,6 @@
+apiVersion: admissionregistration.k8s.io/v1
+kind: ValidatingWebhookConfiguration
+metadata:
+  name: validator.training-operator.kubeflow.org
+  annotations:
+    cert-manager.io/inject-ca-from: kubeflow/training-operator-webhook-cert


### PR DESCRIPTION
## Summary

Closes #3398

Resolves the long-standing TODO left by @tenzen-y in the Training Operator's Kubeflow overlay, which noted that once cert-manager is supported, the bare `secretGenerator` should be removed.

## Changes

| File | Change |
|---|---|
| `overlays/kubeflow/kustomization.yaml` | Removed `secretGenerator` block; added `certificate.yaml` as a resource and `webhook-patch.yaml` as a strategic merge patch |
| `overlays/kubeflow/certificate.yaml` | **New file**: self-signed cert-manager `Issuer` + `Certificate` for `training-operator.kubeflow.svc` |
| `overlays/kubeflow/webhook-patch.yaml` | **New file**: adds `cert-manager.io/inject-ca-from` annotation on the `ValidatingWebhookConfiguration` |

## Before

```yaml
# TODO (tenzen-y): Once we support cert-manager, we need to remove this secret generation.
# REF: https://github.com/kubeflow/training-operator/issues/2049
secretGenerator:
  - name: training-operator-webhook-cert
    options:
      disableNameSuffixHash: true
```

This created an **empty** Kubernetes Secret — no actual TLS certificate or CA data was ever put in it.

## After

cert-manager now manages a self-signed `Certificate` which populates `training-operator-webhook-cert` with real TLS data, and automatically injects the CA bundle into the `ValidatingWebhookConfiguration` via the `cert-manager.io/inject-ca-from` annotation.

This is the same pattern already used by:
- `applications/admission-webhook/upstream/overlays/cert-manager/`

## Testing

- `kustomize build applications/training-operator/upstream/overlays/kubeflow` builds without errors.
- cert-manager is a guaranteed dependency in the platform (`common/cert-manager`), so there is no new prerequisite.

## References

- Upstream tracking issue: https://github.com/kubeflow/training-operator/issues/2049
