### PR TITLE
knative: add eventing security overlay

### DIFF
--- a/.github/workflows/full_kubeflow_integration_test.yaml
+++ b/.github/workflows/full_kubeflow_integration_test.yaml
@@ -54,8 +54,11 @@ jobs:
     - name: Install Central Dashboard
       run: ./tests/central_dashboard_install.sh
 
-    - name: Install Knative
-      run: ./tests/knative_install.sh
+    - name: Install Knative Serving
+      run: ./tests/knative_serving_install.sh
+
+    - name: Install Knative Eventing
+      run: ./tests/knative_eventing_install.sh
 
     - name: Install KServe
       run: ./tests/kserve_install.sh

--- a/.github/workflows/kserve_models_web_application_test.yaml
+++ b/.github/workflows/kserve_models_web_application_test.yaml
@@ -6,6 +6,7 @@ on:
     - .github/workflows/kserve_models_web_application_test.yaml
     - applications/kserve/**
     - tests/kserve*
+    - tests/knative_serving_install.sh
 
     - tests/istio*
     - common/istio*/**
@@ -48,8 +49,8 @@ jobs:
     - name: Install Multi-Tenancy
       run: ./tests/multi_tenancy_install.sh
 
-    - name: Install Knative
-      run: ./tests/knative_install.sh
+    - name: Install Knative Serving
+      run: ./tests/knative_serving_install.sh
 
     - name: Install KServe
       run: ./tests/kserve_install.sh

--- a/.github/workflows/kserve_test.yaml
+++ b/.github/workflows/kserve_test.yaml
@@ -15,7 +15,7 @@ on:
     - common/cert-manager/**
     - tests/istio*
     - common/knative/**
-    - tests/knative_install.sh
+    - tests/knative_serving_install.sh
 
 permissions:
   contents: read
@@ -44,8 +44,8 @@ jobs:
     - name: Install cert-manager
       run: ./tests/cert_manager_install.sh
 
-    - name: Install knative CNI
-      run: ./tests/knative_install.sh
+    - name: Install Knative Serving
+      run: ./tests/knative_serving_install.sh
 
     - name: Install KServe
       run: ./tests/kserve_install.sh

--- a/README.md
+++ b/README.md
@@ -351,13 +351,13 @@ kustomize build applications/admission-webhook/upstream/overlays/cert-manager | 
 #### Knative (used by KServe)
 
 ```sh
-./tests/knative_install.sh
+./tests/knative_serving_install.sh
 ```
 
 Optionally, you can install Knative Eventing, which can be used for inference request logging:
 
 ```sh
-kustomize build common/knative/knative-eventing/base | kubectl apply -f -
+./tests/knative_eventing_install.sh
 ```
 
 #### KServe model serving and KServe models web application

--- a/common/knative/knative-eventing/overlays/security/allow-webhook-apiserver.yaml
+++ b/common/knative/knative-eventing/overlays/security/allow-webhook-apiserver.yaml
@@ -1,0 +1,23 @@
+kind: NetworkPolicy
+apiVersion: networking.k8s.io/v1
+metadata:
+  name: webhook-apiserver
+  namespace: knative-eventing
+spec:
+  podSelector:
+    matchExpressions:
+    - key: app
+      operator: In
+      values:
+      - eventing-webhook
+    - key: role
+      operator: In
+      values:
+      - eventing-webhook
+  # The kubernetes api server must reach the webhook
+  ingress:
+  - ports:
+    - protocol: TCP
+      port: 8443
+  policyTypes:
+  - Ingress

--- a/common/knative/knative-eventing/overlays/security/default-allow-same-namespace.yaml
+++ b/common/knative/knative-eventing/overlays/security/default-allow-same-namespace.yaml
@@ -1,0 +1,12 @@
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: default-allow-same-namespace-knative-eventing
+  namespace: knative-eventing
+spec:
+  podSelector: {}
+  ingress:
+  - from:
+    - podSelector: {}
+  policyTypes:
+  - Ingress

--- a/common/knative/knative-eventing/overlays/security/kustomization.yaml
+++ b/common/knative/knative-eventing/overlays/security/kustomization.yaml
@@ -1,0 +1,11 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+- ../../base
+- allow-webhook-apiserver.yaml
+- default-allow-same-namespace.yaml
+
+patches:
+- path: namespace-patch.yaml
+- path: patches/request-reply-security-context.yaml

--- a/common/knative/knative-eventing/overlays/security/namespace-patch.yaml
+++ b/common/knative/knative-eventing/overlays/security/namespace-patch.yaml
@@ -1,0 +1,6 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: knative-eventing
+  labels:
+    pod-security.kubernetes.io/enforce: restricted

--- a/common/knative/knative-eventing/overlays/security/patches/request-reply-security-context.yaml
+++ b/common/knative/knative-eventing/overlays/security/patches/request-reply-security-context.yaml
@@ -1,0 +1,18 @@
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: request-reply
+  namespace: knative-eventing
+spec:
+  template:
+    spec:
+      containers:
+        - name: request-reply
+          securityContext:
+            allowPrivilegeEscalation: false
+            runAsNonRoot: true
+            capabilities:
+              drop:
+                - ALL
+            seccompProfile:
+              type: RuntimeDefault

--- a/tests/knative_eventing_install.sh
+++ b/tests/knative_eventing_install.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+set -euo pipefail
+
+kustomize build common/knative/knative-eventing/overlays/security | kubectl apply -f -
+
+kubectl rollout status deployment/eventing-controller -n knative-eventing --timeout=120s
+kubectl rollout status deployment/eventing-webhook -n knative-eventing --timeout=120s
+kubectl rollout status statefulset/request-reply -n knative-eventing --timeout=120s
+kubectl get namespace knative-eventing -o jsonpath='{.metadata.labels.pod-security\.kubernetes\.io/enforce}' | grep -x restricted
+kubectl get networkpolicy default-allow-same-namespace-knative-eventing -n knative-eventing
+kubectl get networkpolicy webhook-apiserver -n knative-eventing

--- a/tests/knative_install.sh
+++ b/tests/knative_install.sh
@@ -20,18 +20,7 @@ kubectl wait --for=condition=Available deployment/autoscaler -n knative-serving 
 kubectl wait --for=condition=Available deployment/controller -n knative-serving --timeout=10s
 kubectl wait --for=condition=Available deployment/webhook -n knative-serving --timeout=10s
 
-set +e
-for ((i=1; i<=3; i++)); do
-    if kustomize build common/knative/knative-eventing/overlays/security | kubectl apply -f -; then
-        break
-    fi
-    if [[ "${i}" -eq 3 ]]; then
-        echo "Failed to apply knative-eventing security overlay after 3 attempts" >&2
-        exit 1
-    fi
-    sleep 10
-done
-set -e
+kustomize build common/knative/knative-eventing/overlays/security | kubectl apply -f -
 
 kubectl rollout status deployment/eventing-controller -n knative-eventing --timeout=120s
 kubectl rollout status deployment/eventing-webhook -n knative-eventing --timeout=120s
@@ -39,5 +28,3 @@ kubectl rollout status statefulset/request-reply -n knative-eventing --timeout=1
 kubectl get namespace knative-eventing -o jsonpath='{.metadata.labels.pod-security\.kubernetes\.io/enforce}' | grep -x restricted
 kubectl get networkpolicy default-allow-same-namespace-knative-eventing -n knative-eventing
 kubectl get networkpolicy webhook-apiserver -n knative-eventing
-kubectl get deployment -n knative-serving
-kubectl get deployment,statefulset -n knative-eventing

--- a/tests/knative_install.sh
+++ b/tests/knative_install.sh
@@ -19,4 +19,25 @@ kubectl wait --for=condition=Available deployment/activator -n knative-serving -
 kubectl wait --for=condition=Available deployment/autoscaler -n knative-serving --timeout=10s
 kubectl wait --for=condition=Available deployment/controller -n knative-serving --timeout=10s
 kubectl wait --for=condition=Available deployment/webhook -n knative-serving --timeout=10s
+
+set +e
+for ((i=1; i<=3; i++)); do
+    if kustomize build common/knative/knative-eventing/overlays/security | kubectl apply -f -; then
+        break
+    fi
+    if [[ "${i}" -eq 3 ]]; then
+        echo "Failed to apply knative-eventing security overlay after 3 attempts" >&2
+        exit 1
+    fi
+    sleep 10
+done
+set -e
+
+kubectl rollout status deployment/eventing-controller -n knative-eventing --timeout=120s
+kubectl rollout status deployment/eventing-webhook -n knative-eventing --timeout=120s
+kubectl rollout status statefulset/request-reply -n knative-eventing --timeout=120s
+kubectl get namespace knative-eventing -o jsonpath='{.metadata.labels.pod-security\.kubernetes\.io/enforce}' | grep -x restricted
+kubectl get networkpolicy default-allow-same-namespace-knative-eventing -n knative-eventing
+kubectl get networkpolicy webhook-apiserver -n knative-eventing
 kubectl get deployment -n knative-serving
+kubectl get deployment,statefulset -n knative-eventing

--- a/tests/knative_serving_install.sh
+++ b/tests/knative_serving_install.sh
@@ -19,12 +19,3 @@ kubectl wait --for=condition=Available deployment/activator -n knative-serving -
 kubectl wait --for=condition=Available deployment/autoscaler -n knative-serving --timeout=10s
 kubectl wait --for=condition=Available deployment/controller -n knative-serving --timeout=10s
 kubectl wait --for=condition=Available deployment/webhook -n knative-serving --timeout=10s
-
-kustomize build common/knative/knative-eventing/overlays/security | kubectl apply -f -
-
-kubectl rollout status deployment/eventing-controller -n knative-eventing --timeout=120s
-kubectl rollout status deployment/eventing-webhook -n knative-eventing --timeout=120s
-kubectl rollout status statefulset/request-reply -n knative-eventing --timeout=120s
-kubectl get namespace knative-eventing -o jsonpath='{.metadata.labels.pod-security\.kubernetes\.io/enforce}' | grep -x restricted
-kubectl get networkpolicy default-allow-same-namespace-knative-eventing -n knative-eventing
-kubectl get networkpolicy webhook-apiserver -n knative-eventing


### PR DESCRIPTION
## Summary
- add a merged `common/knative/knative-eventing/overlays/security` overlay
- add eventing NetworkPolicies and a restricted PSS namespace patch as an opt-in overlay
- patch `request-reply` in the overlay so `restricted` PSS works in-cluster



