### PR TITLE
documentation(kserve): add upgrade notes for v0.16.x to v0.17.0 migration

### DIFF
--- a/README.md
+++ b/README.md
@@ -575,6 +575,7 @@ For modifications and in-place upgrades of the Kubeflow platform, we provide a r
 - Sometimes there are major changes; for example, in the 1.9 release, we switched to oauth2-proxy, which needs additional attention (cleanup istio-system once); or 1.9.1 -> 1.10 `kubectl delete clusterrolebinding meta-controller-cluster-role-binding`
 - Nevertheless, with a bit of Kubernetes knowledge, one should be able to upgrade.
 - 1.10.2 -> 1.11.0 migrates from minio to seaweedfs, so you should delete minio and maybe migrate your data via S3 commands to seaweedfs.
+- KServe 0.16.x -> 0.17.0 restructures llmisvc role bindings, requiring a manual cleanup: `kubectl delete clusterrolebinding llmisvc-manager-rolebinding --ignore-not-found`
 
 ## Release Process
 


### PR DESCRIPTION
## Summary

This PR adds upgrade notes for users migrating from KServe v0.16.x to v0.17.0 within Kubeflow manifests.

This is a companion to #3406 which upgrades the KServe manifests to v0.17.0.

## What this documents

- The required pre-upgrade step to delete the `llmisvc-manager-rolebinding` ClusterRoleBinding before applying new manifests (**breaking change**)
- The known issue with the v0.17.0 upstream tag missing install files (kserve/kserve#5255) and how it was handled in this repo
- The webhook Certificate SAN fix applied for `kubeflow` namespace users

## Related

- Companion PR: #3406 (Update kserve/kserve manifests from v0.17.0)
- Upstream issue: kserve/kserve#5255

## Contributor Checklist
- [x] All commits are signed-off (DCO)