### PR TITLE
fix: Use released registry images for JobSet and LeaderWorkerSet

### DIFF
--- a/applications/trainer/upstream/third-party/jobset/kustomization.yaml
+++ b/applications/trainer/upstream/third-party/jobset/kustomization.yaml
@@ -4,6 +4,11 @@ kind: Kustomization
 resources:
   - https://github.com/kubernetes-sigs/jobset/releases/download/v0.11.0/manifests.yaml
 
+images:
+  - name: us-central1-docker.pkg.dev/k8s-staging-images/jobset/jobset
+    newName: registry.k8s.io/jobset/jobset
+    newTag: v0.11.0
+
 # Add required patches.
 patches:
   # Remove namespace from the JobSet release manifests.

--- a/applications/trainer/upstream/third-party/leaderworkerset/kustomization.yaml
+++ b/applications/trainer/upstream/third-party/leaderworkerset/kustomization.yaml
@@ -4,6 +4,11 @@ kind: Kustomization
 resources:
   - https://github.com/kubernetes-sigs/lws//config/default?ref=v0.8.0
 
+images:
+  - name: us-central1-docker.pkg.dev/k8s-staging-images/lws/lws
+    newName: registry.k8s.io/lws/lws
+    newTag: v0.8.0
+
 # Transform all namespace references from lws-system to be set by parent overlay
 namespace: kubeflow-system
 


### PR DESCRIPTION
# Pull Request Template for Kubeflow Manifests

## ✏️ Summary of Changes

Redirect `JobSet` and `LeaderWorkerSet` images from the staging registry to the stable registry (registry.k8s.io), fixing `ImagePullBackOff` errors in CI.

In this case it's also fine to modify the upstream folder, as the next sync from the trainer folks should override this.

Backport of kubeflow/trainer@37cb3320.

## 📦 Dependencies
> List any dependencies or related PRs (e.g., "Depends on #123").

_none_

## 🐛 Related Issues
> Link any issues that are resolved or affected by this PR.

https://github.com/kubeflow/manifests/issues/3447

## ✅ Contributor Checklist
  - [x] I have tested these changes with kustomize. See [Installation Prerequisites](https://github.com/kubeflow/manifests#prerequisites).
  - [x] All commits are [_signed-off_](https://github.com/kubeflow/community/tree/master/dco-signoff-hook#signing-off-commits) to satisfy the DCO check.
  - [x] I have considered adding my company to the adopters page to support Kubeflow and help the community, since I expect help from the community for my issue (see [1.](https://github.com/kubeflow/community/issues/833) and [2.](https://github.com/kubeflow/community/blob/master/ADOPTERS.md#adopters-of-kubeflow-platform)).
