### PR TITLE
chore: update Helm image tags for model-registry and notebook-controller

### DIFF
--- a/experimental/helm/charts/model-registry/ci/ci-values.yaml
+++ b/experimental/helm/charts/model-registry/ci/ci-values.yaml
@@ -12,7 +12,7 @@ server:
   dataStoreType: embedmd
   
   image:
-    tag: "v0.3.7"
+    tag: "v0.3.8"
     
   # Configure readiness probe
   rest:

--- a/experimental/helm/charts/model-registry/ci/ci-values.yaml
+++ b/experimental/helm/charts/model-registry/ci/ci-values.yaml
@@ -10,10 +10,10 @@ server:
   replicas: 1
   # Configure for embedmd datastore
   dataStoreType: embedmd
-  
+
   image:
     tag: "v0.3.8"
-    
+
   # Configure readiness probe
   rest:
     readinessProbe:
@@ -22,11 +22,11 @@ server:
       periodSeconds: 60
       timeoutSeconds: 2
       failureThreshold: 3
-      
+
   # Disable gRPC container for embedmd mode
   grpc:
     enabled: false
-    
+
   resources:
     limits:
       cpu: 200m
@@ -43,26 +43,26 @@ configMap:
     MODEL_REGISTRY_DATA_STORE_TYPE: "embedmd"
 
 database:
-  type: sqlite  
+  type: sqlite
   mysql:
-    enabled: false  
+    enabled: false
 
 ui:
-  enabled: false  
+  enabled: false
 
 controller:
-  enabled: false  
+  enabled: false
   rbac:
-    create: false  
+    create: false
 
 istio:
-  enabled: false  
+  enabled: false
 
 monitoring:
-  enabled: false  
+  enabled: false
 
 security:
   networkPolicy:
-    enabled: false  
+    enabled: false
   podSecurityPolicy:
-    enabled: false  
+    enabled: false

--- a/experimental/helm/charts/model-registry/ci/values-db.yaml
+++ b/experimental/helm/charts/model-registry/ci/values-db.yaml
@@ -76,4 +76,4 @@ configMap:
     MODEL_REGISTRY_DATA_STORE_TYPE: "embedmd"
 
 rbac:
-  create: true 
+  create: true

--- a/experimental/helm/charts/model-registry/ci/values-db.yaml
+++ b/experimental/helm/charts/model-registry/ci/values-db.yaml
@@ -10,7 +10,7 @@ server:
   replicas: 1
   dataStoreType: embedmd
   image:
-    tag: "v0.3.7"
+    tag: "v0.3.8"
   resources:
     limits:
       cpu: 200m

--- a/experimental/helm/charts/model-registry/ci/values-postgres.yaml
+++ b/experimental/helm/charts/model-registry/ci/values-postgres.yaml
@@ -54,8 +54,8 @@ database:
         cpu: 100m
         memory: 128Mi
     persistence:
-      enabled: true  
-      size: 10Gi      
+      enabled: true
+      size: 10Gi
   external:
     enabled: false
 
@@ -86,4 +86,4 @@ configMap:
     MODEL_REGISTRY_DATA_STORE_TYPE: "embedmd"
 
 rbac:
-  create: true 
+  create: true

--- a/experimental/helm/charts/model-registry/ci/values-postgres.yaml
+++ b/experimental/helm/charts/model-registry/ci/values-postgres.yaml
@@ -10,7 +10,7 @@ server:
   replicas: 1
   dataStoreType: embedmd
   image:
-    tag: "v0.3.7"
+    tag: "v0.3.8"
   resources:
     limits:
       cpu: 200m

--- a/experimental/helm/charts/model-registry/ci/values-ui-integrated.yaml
+++ b/experimental/helm/charts/model-registry/ci/values-ui-integrated.yaml
@@ -2,37 +2,37 @@
 ui:
   enabled: true
   replicas: 1
-  
+
   image:
-    repository: ui  
+    repository: ui
     tag: "v0.3.8"
-    pullPolicy: Always  
-    
+    pullPolicy: Always
+
   containerPort: 8080
-  
+
 
   args:
     - "--deployment-mode=kubeflow"
     - "--port=8080"
-    
+
   serviceAccount:
     create: true
     automountServiceAccountToken: false
-    
+
   rbac:
     create: true
-    
+
   service:
     type: ClusterIP
     port: 8080
-    
+
   resources:
     limits:
       memory: 2Gi
     requests:
       cpu: 500m
       memory: 2Gi
-      
+
   livenessProbe:
     enabled: true
     path: /healthcheck
@@ -41,7 +41,7 @@ ui:
     periodSeconds: 30
     successThreshold: 1
     failureThreshold: 3
-    
+
   readinessProbe:
     enabled: true
     path: /healthcheck
@@ -50,15 +50,15 @@ ui:
     periodSeconds: 30
     successThreshold: 1
     failureThreshold: 3
-    
+
   istio:
     enabled: false
     virtualService:
       enabled: false
-    
+
 server:
   enabled: false
-  
+
 database:
   mysql:
     enabled: false
@@ -66,15 +66,15 @@ database:
     enabled: false
   external:
     enabled: false
-    
+
 controller:
   enabled: false
   rbac:
     create: false
-  
+
 monitoring:
   enabled: false
-  
+
 storage:
   csi:
-    enabled: false 
+    enabled: false

--- a/experimental/helm/charts/model-registry/ci/values-ui-integrated.yaml
+++ b/experimental/helm/charts/model-registry/ci/values-ui-integrated.yaml
@@ -5,7 +5,7 @@ ui:
   
   image:
     repository: ui  
-    tag: "v0.3.7"
+    tag: "v0.3.8"
     pullPolicy: Always  
     
   containerPort: 8080

--- a/experimental/helm/charts/model-registry/ci/values-ui-istio.yaml
+++ b/experimental/helm/charts/model-registry/ci/values-ui-istio.yaml
@@ -9,7 +9,7 @@ ui:
   
   image:
     repository: ui  
-    tag: "v0.3.7"
+    tag: "v0.3.8"
     pullPolicy: Always
     
   containerPort: 8080

--- a/experimental/helm/charts/model-registry/ci/values-ui-istio.yaml
+++ b/experimental/helm/charts/model-registry/ci/values-ui-istio.yaml
@@ -6,51 +6,51 @@ global:
 ui:
   enabled: true
   replicas: 1
-  
+
   image:
-    repository: ui  
+    repository: ui
     tag: "v0.3.8"
     pullPolicy: Always
-    
+
   containerPort: 8080
-  
+
   args:
   - "--deployment-mode=kubeflow"
   - "--port=8080"
-  
+
   serviceAccount:
     create: true
-    automountServiceAccountToken: false  
-    
+    automountServiceAccountToken: false
+
   rbac:
     create: true
-    
+
   service:
     type: ClusterIP
-    port: 80  
-    
+    port: 80
+
   resources:
     limits:
       memory: 2Gi
     requests:
       cpu: 500m
       memory: 2Gi
-      
+
   istio:
     enabled: true
-    
+
     virtualService:
       enabled: true
-      
+
     destinationRule:
       enabled: true
-      
+
     authorizationPolicy:
       enabled: true
-    
+
 server:
   enabled: false
-  
+
 database:
   type: external
   mysql:
@@ -59,18 +59,18 @@ database:
     enabled: false
   external:
     enabled: false
-    
+
 controller:
   enabled: false
   rbac:
     create: false
-  
+
 istio:
   enabled: false
-  
+
 monitoring:
   enabled: false
-  
+
 storage:
   csi:
-    enabled: false 
+    enabled: false

--- a/experimental/helm/charts/model-registry/ci/values-ui-standalone.yaml
+++ b/experimental/helm/charts/model-registry/ci/values-ui-standalone.yaml
@@ -1,30 +1,30 @@
 # CI values for testing UI standalone functionality
 
 global:
-  includeNamespace: true  
+  includeNamespace: true
 
 ui:
   enabled: true
   replicas: 1
-  
+
   image:
-    repository: ui  
+    repository: ui
     tag: "v0.3.8"
-    pullPolicy: Always  
-    
+    pullPolicy: Always
+
   containerPort: 8080
-    
+
   args:
     - "--deployment-mode=standalone"
     - "--port=8080"
-    
+
   resources:
     limits:
       memory: 2Gi
     requests:
       cpu: 500m
       memory: 2Gi
-      
+
   livenessProbe:
     enabled: true
     path: /healthcheck
@@ -33,7 +33,7 @@ ui:
     periodSeconds: 30
     successThreshold: 1
     failureThreshold: 3
-    
+
   readinessProbe:
     enabled: true
     path: /healthcheck
@@ -42,7 +42,7 @@ ui:
     periodSeconds: 30
     successThreshold: 1
     failureThreshold: 3
-    
+
   standalone:
     enabled: true
     serviceAccess:
@@ -50,26 +50,26 @@ ui:
       users:
       - "user@example.com"
       clusterRole: "cluster-admin"
-      
+
   serviceAccount:
     create: true
     automountServiceAccountToken: false
-    
+
   rbac:
     create: true
-    
+
   service:
     type: ClusterIP
     port: 8080
-    
+
   istio:
     enabled: false
     virtualService:
       enabled: false
-    
+
 server:
   enabled: false
-  
+
 database:
   mysql:
     enabled: false
@@ -77,15 +77,15 @@ database:
     enabled: false
   external:
     enabled: false
-    
+
 controller:
   enabled: false
   rbac:
     create: false
-  
+
 monitoring:
   enabled: false
-  
+
 storage:
   csi:
-    enabled: false 
+    enabled: false

--- a/experimental/helm/charts/model-registry/ci/values-ui-standalone.yaml
+++ b/experimental/helm/charts/model-registry/ci/values-ui-standalone.yaml
@@ -9,7 +9,7 @@ ui:
   
   image:
     repository: ui  
-    tag: "v0.3.7"
+    tag: "v0.3.8"
     pullPolicy: Always  
     
   containerPort: 8080

--- a/experimental/helm/charts/model-registry/ci/values-ui.yaml
+++ b/experimental/helm/charts/model-registry/ci/values-ui.yaml
@@ -5,7 +5,7 @@ ui:
   
   image:
     repository: ui  
-    tag: "v0.3.7"
+    tag: "v0.3.8"
     pullPolicy: Always  
     
   containerPort: 8080

--- a/experimental/helm/charts/model-registry/ci/values-ui.yaml
+++ b/experimental/helm/charts/model-registry/ci/values-ui.yaml
@@ -2,32 +2,32 @@
 ui:
   enabled: true
   replicas: 1
-  
+
   image:
-    repository: ui  
+    repository: ui
     tag: "v0.3.8"
-    pullPolicy: Always  
-    
+    pullPolicy: Always
+
   containerPort: 8080
-    
+
   serviceAccount:
     create: true
     automountServiceAccountToken: false
-    
+
   rbac:
     create: true
-    
+
   service:
     type: ClusterIP
     port: 8080
-    
+
   resources:
     limits:
       memory: 2Gi
     requests:
       cpu: 500m
       memory: 2Gi
-      
+
   livenessProbe:
     enabled: true
     path: /healthcheck
@@ -36,7 +36,7 @@ ui:
     periodSeconds: 30
     successThreshold: 1
     failureThreshold: 3
-    
+
   readinessProbe:
     enabled: true
     path: /healthcheck
@@ -45,15 +45,15 @@ ui:
     periodSeconds: 30
     successThreshold: 1
     failureThreshold: 3
-    
+
   istio:
     enabled: false
     virtualService:
       enabled: false
-    
+
 server:
   enabled: false
-  
+
 database:
   mysql:
     enabled: false
@@ -61,15 +61,15 @@ database:
     enabled: false
   external:
     enabled: false
-    
+
 controller:
   enabled: false
   rbac:
     create: false
-  
+
 monitoring:
   enabled: false
-  
+
 storage:
   csi:
-    enabled: false 
+    enabled: false

--- a/experimental/helm/charts/model-registry/values.yaml
+++ b/experimental/helm/charts/model-registry/values.yaml
@@ -42,7 +42,7 @@ server:
     # -- Server image repository
     repository: server
     # -- Server image tag (overrides global.imageTag if set)
-    tag: "v0.3.7"
+    tag: "v0.3.8"
     # -- Server image pull policy (overrides global.imagePullPolicy if set)
     pullPolicy: ""
     
@@ -178,7 +178,7 @@ ui:
     # -- UI image repository
     repository: model-registry-ui
     # -- UI image tag 
-    tag: "v0.3.7"
+    tag: "v0.3.8"
     # -- UI image pull policy
     pullPolicy: ""
     

--- a/experimental/helm/charts/model-registry/values.yaml
+++ b/experimental/helm/charts/model-registry/values.yaml
@@ -18,7 +18,7 @@ global:
   # -- Image registry for Model Registry images
   imageRegistry: ghcr.io/kubeflow/model-registry
   # -- Global image tag for all Model Registry components
-  imageTag: latest
+  imageTag: v0.3.8
   # -- Global image pull policy
   imagePullPolicy: IfNotPresent
   # -- Global image pull secrets
@@ -34,10 +34,10 @@ server:
   enabled: true
   # -- Number of server replicas
   replicas: 1
-  
-  # -- Data store type for the model registry 
+
+  # -- Data store type for the model registry
   dataStoreType: mlmd
-  
+
   image:
     # -- Server image repository
     repository: server
@@ -45,47 +45,47 @@ server:
     tag: "v0.3.8"
     # -- Server image pull policy (overrides global.imagePullPolicy if set)
     pullPolicy: ""
-    
+
   # -- Server resource requests and limits
   resources: {}
-    
+
   # -- Node selector for server pods
   nodeSelector: {}
-  
+
   # -- Tolerations for server pods
   tolerations: []
-  
+
   # -- Affinity rules for server pods
   affinity: {}
-  
+
   # -- Security context for server pods
   podSecurityContext:
     seccompProfile:
       type: RuntimeDefault
     runAsNonRoot: true
-  
+
   # -- Security context for server containers
   securityContext:
     allowPrivilegeEscalation: false
     capabilities:
       drop:
       - ALL
-    
+
   # -- Extra labels for server pods
   labels: {}
-  
+
   # -- Extra annotations for server pods
   annotations: {}
-  
+
   # -- Environment variables for server containers
   env: []
-  
+
   # -- Volume mounts for server containers
   volumeMounts: []
-  
+
   # -- Volumes for server pods
   volumes: []
-  
+
   # REST API configuration
   rest:
     # -- REST API port
@@ -94,7 +94,7 @@ server:
     hostname: "0.0.0.0"
     # -- REST API container name
     containerName: rest-container
-    
+
     # -- REST API liveness probe configuration
     livenessProbe:
       enabled: true
@@ -102,7 +102,7 @@ server:
       periodSeconds: 5
       timeoutSeconds: 2
       failureThreshold: 3
-      
+
     # -- REST API readiness probe configuration
     readinessProbe:
       enabled: true
@@ -110,8 +110,8 @@ server:
       periodSeconds: 5
       timeoutSeconds: 2
       failureThreshold: 3
-    
-  # gRPC configuration  
+
+  # gRPC configuration
   grpc:
     # -- gRPC port
     port: 9090
@@ -123,7 +123,7 @@ server:
     containerName: grpc-container
     # -- store server image
     mlmdImage: gcr.io/tfx-oss-public/ml_metadata_store_server:1.14.0
-    
+
     # -- gRPC liveness probe configuration
     livenessProbe:
       enabled: true
@@ -131,7 +131,7 @@ server:
       periodSeconds: 5
       timeoutSeconds: 2
       failureThreshold: 3
-      
+
     # -- gRPC readiness probe configuration
     readinessProbe:
       enabled: true
@@ -139,7 +139,7 @@ server:
       periodSeconds: 5
       timeoutSeconds: 2
       failureThreshold: 3
-    
+
     # -- gRPC security context
     securityContext:
       runAsUser: 65534
@@ -148,7 +148,7 @@ server:
       capabilities:
         drop:
         - ALL
-    
+
   service:
     # -- Server service type
     type: ClusterIP
@@ -156,7 +156,7 @@ server:
     annotations: {}
     # -- Server service labels
     labels: {}
-    
+
   serviceAccount:
     # -- Create service account for server
     create: true
@@ -173,18 +173,18 @@ ui:
   enabled: false
   # -- Number of UI replicas
   replicas: 1
-  
+
   image:
     # -- UI image repository
     repository: model-registry-ui
-    # -- UI image tag 
+    # -- UI image tag
     tag: "v0.3.8"
     # -- UI image pull policy
     pullPolicy: ""
-    
+
   # -- UI container port
   containerPort: 8080
-  
+
   # -- UI resource requests and limits
   resources:
     limits:
@@ -192,31 +192,31 @@ ui:
     requests:
       cpu: 500m
       memory: 2Gi
-    
+
   # -- Node selector for UI pods
   nodeSelector: {}
-  
+
   # -- Tolerations for UI pods
   tolerations: []
-  
+
   # -- Affinity rules for UI pods
   affinity: {}
-  
+
   # -- Security context for UI pods
   podSecurityContext: {}
-  
+
   # -- Security context for UI containers
   securityContext: {}
-  
+
   # -- Extra labels for UI pods
   labels: {}
-  
+
   # -- Extra annotations for UI pods
   podAnnotations: {}
-  
+
   # -- Environment variables for UI containers
   env: []
-  
+
   # -- Liveness probe configuration for UI
   livenessProbe:
     enabled: true
@@ -226,7 +226,7 @@ ui:
     periodSeconds: 30
     successThreshold: 1
     failureThreshold: 3
-    
+
   # -- Readiness probe configuration for UI
   readinessProbe:
     enabled: true
@@ -236,7 +236,7 @@ ui:
     periodSeconds: 30
     successThreshold: 1
     failureThreshold: 3
-  
+
   service:
     # -- UI service type
     type: ClusterIP
@@ -244,9 +244,9 @@ ui:
     port: 8080
     # -- UI service annotations
     annotations: {}
-    # -- UI service node port 
+    # -- UI service node port
     nodePort: ""
-    
+
   serviceAccount:
     # -- Create service account for UI
     create: true
@@ -256,15 +256,15 @@ ui:
     annotations: {}
     # -- Automount service account token
     automountServiceAccountToken: true
-    
+
   rbac:
     # -- Create RBAC resources for UI
     create: true
-    
+
   standalone:
     # -- Enable standalone mode for UI
     enabled: false
-    
+
     serviceAccess:
       # -- Enable service access for standalone mode
       enabled: false
@@ -273,7 +273,7 @@ ui:
       - user@example.com
       # -- Cluster role to assign
       clusterRole: cluster-admin
-      
+
   # -- Istio configuration for UI
   istio:
     enabled: false
@@ -284,19 +284,19 @@ ui:
     authorizationPolicy:
       enabled: false
 
-# Controller configuration  
+# Controller configuration
 controller:
   # -- Enable the Model Registry controller
   enabled: false
   # -- Number of controller replicas
   replicas: 1
   useSimpleNames: false
-  
+
   # -- Controller ports configuration
   ports:
     health: 8081
     metrics: 8443
-  
+
   image:
     # -- Controller image repository
     repository: controller
@@ -304,7 +304,7 @@ controller:
     tag: ""
     # -- Controller image pull policy (overrides global.imagePullPolicy if set)
     pullPolicy: ""
-    
+
   # -- Controller resource requests and limits
   resources:
     limits:
@@ -312,25 +312,25 @@ controller:
     requests:
       cpu: 10m
       memory: 64Mi
-    
+
   # -- Node selector for controller pods
   nodeSelector: {}
-  
+
   # -- Tolerations for controller pods
   tolerations: []
-  
+
   # -- Affinity rules for controller pods
   affinity: {}
-  
+
   # -- Security context for controller pods
   podSecurityContext: {}
-  
+
   # -- Security context for controller containers
   securityContext: {}
-  
+
   # -- Extra annotations for controller pods
   podAnnotations: {}
-  
+
   # -- Environment variables configuration
   env:
     namespaceLabel: ""
@@ -346,7 +346,7 @@ controller:
     inferenceServiceController: ""
     # -- Additional environment variables
     additional: []
-  
+
   # -- Liveness probe configuration
   livenessProbe:
     enabled: true
@@ -354,7 +354,7 @@ controller:
     periodSeconds: 20
     timeoutSeconds: 1
     failureThreshold: 3
-    
+
   # -- Readiness probe configuration
   readinessProbe:
     enabled: true
@@ -362,12 +362,12 @@ controller:
     periodSeconds: 10
     timeoutSeconds: 1
     failureThreshold: 3
-  
+
   # -- Metrics configuration
   metrics:
     enabled: false
     port: 8443
-    
+
     service:
       # -- Metrics service type
       type: ClusterIP
@@ -377,12 +377,12 @@ controller:
       targetPort: 8443
       # -- Metrics service annotations
       annotations: {}
-    
+
   # -- Service configuration
   service:
     type: ClusterIP
     annotations: {}
-  
+
   serviceAccount:
     # -- Create service account for controller
     create: true
@@ -392,13 +392,13 @@ controller:
     annotations: {}
     # -- Automount API credentials
     automount: true
-  
+
   # -- RBAC configuration for controller
   rbac:
     create: true
     # -- Additional RBAC rules for controller
     rules: []
-    
+
   networkPolicy:
     # -- Enable NetworkPolicy for controller
     enabled: false
@@ -407,44 +407,44 @@ controller:
 
 # Database configuration
 database:
-  type: mysql  
-  
+  type: mysql
+
   # -- Database resource naming configuration
   resourceNames:
     mysql:
-      # -- PVC name for MySQL 
+      # -- PVC name for MySQL
       pvcName: ""
-      # -- Service name for MySQL   
+      # -- Service name for MySQL
       serviceName: ""
-      # -- Deployment name for MySQL 
+      # -- Deployment name for MySQL
       deploymentName: ""
     postgres:
-      # -- PVC name for Postgres 
+      # -- PVC name for Postgres
       pvcName: ""
-      # -- Service name for Postgres 
+      # -- Service name for Postgres
       serviceName: ""
-      # -- Deployment name for Postgres 
+      # -- Deployment name for Postgres
       deploymentName: ""
-  
+
   mysql:
     enabled: true
     image:
       repository: mysql
       tag: "8.3"
     auth:
-      database: metadb  
-      username: root    
+      database: metadb
+      username: root
       # password: ""    # auto-generated if not provided
-      rootPassword: test  
+      rootPassword: test
       existingSecret: ""
     service:
       port: 3306
-      # -- Service name 
+      # -- Service name
       name: ""
     persistence:
       enabled: true
       size: 10Gi
-      
+
   postgres:
     enabled: false
     image:
@@ -457,7 +457,7 @@ database:
       existingSecret: ""
     service:
       port: 5432
-      # -- Service name 
+      # -- Service name
       name: ""
     persistence:
       enabled: true
@@ -469,7 +469,7 @@ database:
       requests:
         cpu: 100m
         memory: 128Mi
-        
+
   external:
     enabled: false
     host: ""
@@ -483,7 +483,7 @@ database:
 istio:
   # -- Enable Istio integration
   enabled: false
-  
+
   gateway:
     # -- Enable Istio Gateway
     enabled: false
@@ -493,7 +493,7 @@ istio:
     hosts: ["*"]
     # -- Gateway TLS configuration
     tls: {}
-    
+
   virtualService:
     # -- Enable Istio VirtualService
     enabled: false
@@ -501,13 +501,13 @@ istio:
     hosts: ["*"]
     # -- VirtualService gateways
     gateways: ["kubeflow-gateway"]
-    
+
   destinationRule:
     # -- Enable Istio DestinationRule
     enabled: false
     # -- DestinationRule traffic policy
     trafficPolicy: {}
-    
+
   authorizationPolicy:
     # -- Enable Istio AuthorizationPolicy
     enabled: false
@@ -520,7 +520,7 @@ istio:
 monitoring:
   # -- Enable monitoring
   enabled: false
-  
+
   serviceMonitor:
     # -- Enable ServiceMonitor for Prometheus
     enabled: false
@@ -532,7 +532,7 @@ monitoring:
     labels: {}
     # -- ServiceMonitor annotations
     annotations: {}
-    
+
   prometheusRule:
     # -- Enable PrometheusRule
     enabled: false
@@ -552,7 +552,7 @@ security:
     ingress: []
     # -- NetworkPolicy egress rules
     egress: []
-    
+
   podSecurityPolicy:
     # -- Enable PodSecurityPolicy
     enabled: false
@@ -593,7 +593,7 @@ storage:
   csi:
     # -- Enable CSI storage initializer
     enabled: false
-    
+
     image:
       # -- CSI storage initializer image repository
       repository: ghcr.io/kubeflow/model-registry/storage-initializer
@@ -601,7 +601,7 @@ storage:
       tag: ""
       # -- CSI storage initializer image pull policy
       pullPolicy: IfNotPresent
-      
+
     # -- CSI storage initializer resources
     resources:
       requests:
@@ -609,10 +609,10 @@ storage:
         cpu: 100m
       limits:
         memory: 1Gi
-        
+
     # -- CSI storage initializer environment variables
     env: []
-    
+
     # -- Supported URI formats
     supportedUriFormats:
     - prefix: "model-registry://"
@@ -628,4 +628,4 @@ service:
   # -- Service display configuration
   annotations:
     displayName: "Kubeflow Model Registry"
-    description: "An example model registry" 
+    description: "An example model registry"

--- a/experimental/helm/charts/notebook-controller/Chart.yaml
+++ b/experimental/helm/charts/notebook-controller/Chart.yaml
@@ -1,8 +1,8 @@
 apiVersion: v2
 name: notebook-controller
 description: A Helm chart for Kubeflow Notebook Controller - Jupyter notebook management on Kubernetes
-version: 1.10.0
-appVersion: v1.10.0
+version: 1.11.0-rc.1
+appVersion: 1.11.0-rc.1
 keywords:
 - kubeflow
 - jupyter

--- a/experimental/helm/charts/notebook-controller/ci/base-values.yaml
+++ b/experimental/helm/charts/notebook-controller/ci/base-values.yaml
@@ -7,8 +7,8 @@ fullnameOverride: ""
 
 global:
   namespace: notebook-controller-system
-  imageRegistry: ghcr.io/kubeflow/kubeflow
-  imageTag: v1.10.0
+  imageRegistry: ghcr.io/kubeflow/notebooks
+  imageTag: v1.11.0-rc.1
 
 # Common labels 
 commonLabels:

--- a/experimental/helm/charts/notebook-controller/ci/kubeflow-values.yaml
+++ b/experimental/helm/charts/notebook-controller/ci/kubeflow-values.yaml
@@ -5,8 +5,8 @@ nameOverride: "notebook-controller"
 
 global:
   namespace: kubeflow
-  imageRegistry: ghcr.io/kubeflow/kubeflow
-  imageTag: v1.10.0
+  imageRegistry: ghcr.io/kubeflow/notebooks
+  imageTag: v1.11.0-rc.1
 
 # Common labels 
 commonLabels:

--- a/experimental/helm/charts/notebook-controller/ci/standalone-values.yaml
+++ b/experimental/helm/charts/notebook-controller/ci/standalone-values.yaml
@@ -7,8 +7,8 @@ fullnameOverride: ""
 
 global:
   namespace: notebook-controller-system
-  imageRegistry: ghcr.io/kubeflow/kubeflow
-  imageTag: v1.10.0
+  imageRegistry: ghcr.io/kubeflow/notebooks
+  imageTag: v1.11.0-rc.1
 
 # Common labels 
 commonLabels:

--- a/experimental/helm/charts/notebook-controller/crds/kubeflow.org_notebooks.yaml
+++ b/experimental/helm/charts/notebook-controller/crds/kubeflow.org_notebooks.yaml
@@ -2,19 +2,21 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.8.0
-  creationTimestamp: null
+    controller-gen.kubebuilder.io/version: v0.16.4
   labels:
     app: notebook-controller
     kustomize.component: notebook-controller
   name: notebooks.kubeflow.org
 spec:
+  conversion:
+    strategy: None
   group: kubeflow.org
   names:
     kind: Notebook
     listKind: NotebookList
     plural: notebooks
     singular: notebook
+  preserveUnknownFields: false
   scope: Namespaced
   versions:
   - name: v1
@@ -78,6 +80,7 @@ spec:
                                             type: object
                                           type: array
                                       type: object
+                                      x-kubernetes-map-type: atomic
                                     weight:
                                       format: int32
                                       type: integer
@@ -124,10 +127,12 @@ spec:
                                             type: object
                                           type: array
                                       type: object
+                                      x-kubernetes-map-type: atomic
                                     type: array
                                 required:
                                 - nodeSelectorTerms
                                 type: object
+                                x-kubernetes-map-type: atomic
                             type: object
                           podAffinity:
                             properties:
@@ -159,6 +164,7 @@ spec:
                                                 type: string
                                               type: object
                                           type: object
+                                          x-kubernetes-map-type: atomic
                                         namespaceSelector:
                                           properties:
                                             matchExpressions:
@@ -182,6 +188,7 @@ spec:
                                                 type: string
                                               type: object
                                           type: object
+                                          x-kubernetes-map-type: atomic
                                         namespaces:
                                           items:
                                             type: string
@@ -225,6 +232,7 @@ spec:
                                             type: string
                                           type: object
                                       type: object
+                                      x-kubernetes-map-type: atomic
                                     namespaceSelector:
                                       properties:
                                         matchExpressions:
@@ -248,6 +256,7 @@ spec:
                                             type: string
                                           type: object
                                       type: object
+                                      x-kubernetes-map-type: atomic
                                     namespaces:
                                       items:
                                         type: string
@@ -289,6 +298,7 @@ spec:
                                                 type: string
                                               type: object
                                           type: object
+                                          x-kubernetes-map-type: atomic
                                         namespaceSelector:
                                           properties:
                                             matchExpressions:
@@ -312,6 +322,7 @@ spec:
                                                 type: string
                                               type: object
                                           type: object
+                                          x-kubernetes-map-type: atomic
                                         namespaces:
                                           items:
                                             type: string
@@ -355,6 +366,7 @@ spec:
                                             type: string
                                           type: object
                                       type: object
+                                      x-kubernetes-map-type: atomic
                                     namespaceSelector:
                                       properties:
                                         matchExpressions:
@@ -378,6 +390,7 @@ spec:
                                             type: string
                                           type: object
                                       type: object
+                                      x-kubernetes-map-type: atomic
                                     namespaces:
                                       items:
                                         type: string
@@ -423,6 +436,7 @@ spec:
                                         required:
                                         - key
                                         type: object
+                                        x-kubernetes-map-type: atomic
                                       fieldRef:
                                         properties:
                                           apiVersion:
@@ -432,6 +446,7 @@ spec:
                                         required:
                                         - fieldPath
                                         type: object
+                                        x-kubernetes-map-type: atomic
                                       resourceFieldRef:
                                         properties:
                                           containerName:
@@ -447,6 +462,7 @@ spec:
                                         required:
                                         - resource
                                         type: object
+                                        x-kubernetes-map-type: atomic
                                       secretKeyRef:
                                         properties:
                                           key:
@@ -458,6 +474,7 @@ spec:
                                         required:
                                         - key
                                         type: object
+                                        x-kubernetes-map-type: atomic
                                     type: object
                                 required:
                                 - name
@@ -473,6 +490,7 @@ spec:
                                       optional:
                                         type: boolean
                                     type: object
+                                    x-kubernetes-map-type: atomic
                                   prefix:
                                     type: string
                                   secretRef:
@@ -482,6 +500,7 @@ spec:
                                       optional:
                                         type: boolean
                                     type: object
+                                    x-kubernetes-map-type: atomic
                                 type: object
                               type: array
                             image:
@@ -609,6 +628,7 @@ spec:
                                       format: int32
                                       type: integer
                                     service:
+                                      default: ''
                                       type: string
                                   required:
                                   - port
@@ -713,6 +733,7 @@ spec:
                                       format: int32
                                       type: integer
                                     service:
+                                      default: ''
                                       type: string
                                   required:
                                   - port
@@ -871,6 +892,7 @@ spec:
                                       format: int32
                                       type: integer
                                     service:
+                                      default: ''
                                       type: string
                                   required:
                                   - port
@@ -979,8 +1001,8 @@ spec:
                           - name
                           - image
                           type: object
-                        type: array
                         minItems: 1
+                        type: array
                       dnsConfig:
                         properties:
                           nameservers:
@@ -1036,6 +1058,7 @@ spec:
                                         required:
                                         - key
                                         type: object
+                                        x-kubernetes-map-type: atomic
                                       fieldRef:
                                         properties:
                                           apiVersion:
@@ -1045,6 +1068,7 @@ spec:
                                         required:
                                         - fieldPath
                                         type: object
+                                        x-kubernetes-map-type: atomic
                                       resourceFieldRef:
                                         properties:
                                           containerName:
@@ -1060,6 +1084,7 @@ spec:
                                         required:
                                         - resource
                                         type: object
+                                        x-kubernetes-map-type: atomic
                                       secretKeyRef:
                                         properties:
                                           key:
@@ -1071,6 +1096,7 @@ spec:
                                         required:
                                         - key
                                         type: object
+                                        x-kubernetes-map-type: atomic
                                     type: object
                                 required:
                                 - name
@@ -1086,6 +1112,7 @@ spec:
                                       optional:
                                         type: boolean
                                     type: object
+                                    x-kubernetes-map-type: atomic
                                   prefix:
                                     type: string
                                   secretRef:
@@ -1095,6 +1122,7 @@ spec:
                                       optional:
                                         type: boolean
                                     type: object
+                                    x-kubernetes-map-type: atomic
                                 type: object
                               type: array
                             image:
@@ -1222,6 +1250,7 @@ spec:
                                       format: int32
                                       type: integer
                                     service:
+                                      default: ''
                                       type: string
                                   required:
                                   - port
@@ -1326,6 +1355,7 @@ spec:
                                       format: int32
                                       type: integer
                                     service:
+                                      default: ''
                                       type: string
                                   required:
                                   - port
@@ -1484,6 +1514,7 @@ spec:
                                       format: int32
                                       type: integer
                                     service:
+                                      default: ''
                                       type: string
                                   required:
                                   - port
@@ -1619,6 +1650,7 @@ spec:
                             name:
                               type: string
                           type: object
+                          x-kubernetes-map-type: atomic
                         type: array
                       initContainers:
                         items:
@@ -1651,6 +1683,7 @@ spec:
                                         required:
                                         - key
                                         type: object
+                                        x-kubernetes-map-type: atomic
                                       fieldRef:
                                         properties:
                                           apiVersion:
@@ -1660,6 +1693,7 @@ spec:
                                         required:
                                         - fieldPath
                                         type: object
+                                        x-kubernetes-map-type: atomic
                                       resourceFieldRef:
                                         properties:
                                           containerName:
@@ -1675,6 +1709,7 @@ spec:
                                         required:
                                         - resource
                                         type: object
+                                        x-kubernetes-map-type: atomic
                                       secretKeyRef:
                                         properties:
                                           key:
@@ -1686,6 +1721,7 @@ spec:
                                         required:
                                         - key
                                         type: object
+                                        x-kubernetes-map-type: atomic
                                     type: object
                                 required:
                                 - name
@@ -1701,6 +1737,7 @@ spec:
                                       optional:
                                         type: boolean
                                     type: object
+                                    x-kubernetes-map-type: atomic
                                   prefix:
                                     type: string
                                   secretRef:
@@ -1710,6 +1747,7 @@ spec:
                                       optional:
                                         type: boolean
                                     type: object
+                                    x-kubernetes-map-type: atomic
                                 type: object
                               type: array
                             image:
@@ -1837,6 +1875,7 @@ spec:
                                       format: int32
                                       type: integer
                                     service:
+                                      default: ''
                                       type: string
                                   required:
                                   - port
@@ -1941,6 +1980,7 @@ spec:
                                       format: int32
                                       type: integer
                                     service:
+                                      default: ''
                                       type: string
                                   required:
                                   - port
@@ -2099,6 +2139,7 @@ spec:
                                       format: int32
                                       type: integer
                                     service:
+                                      default: ''
                                       type: string
                                   required:
                                   - port
@@ -2370,6 +2411,7 @@ spec:
                                     type: string
                                   type: object
                               type: object
+                              x-kubernetes-map-type: atomic
                             maxSkew:
                               format: int32
                               type: integer
@@ -2451,6 +2493,7 @@ spec:
                                     name:
                                       type: string
                                   type: object
+                                  x-kubernetes-map-type: atomic
                                 user:
                                   type: string
                               required:
@@ -2467,6 +2510,7 @@ spec:
                                     name:
                                       type: string
                                   type: object
+                                  x-kubernetes-map-type: atomic
                                 volumeID:
                                   type: string
                               required:
@@ -2497,6 +2541,7 @@ spec:
                                 optional:
                                   type: boolean
                               type: object
+                              x-kubernetes-map-type: atomic
                             csi:
                               properties:
                                 driver:
@@ -2508,6 +2553,7 @@ spec:
                                     name:
                                       type: string
                                   type: object
+                                  x-kubernetes-map-type: atomic
                                 readOnly:
                                   type: boolean
                                 volumeAttributes:
@@ -2534,6 +2580,7 @@ spec:
                                         required:
                                         - fieldPath
                                         type: object
+                                        x-kubernetes-map-type: atomic
                                       mode:
                                         format: int32
                                         type: integer
@@ -2554,6 +2601,7 @@ spec:
                                         required:
                                         - resource
                                         type: object
+                                        x-kubernetes-map-type: atomic
                                     required:
                                     - path
                                     type: object
@@ -2594,6 +2642,7 @@ spec:
                                           - kind
                                           - name
                                           type: object
+                                          x-kubernetes-map-type: atomic
                                         dataSourceRef:
                                           properties:
                                             apiGroup:
@@ -2606,6 +2655,7 @@ spec:
                                           - kind
                                           - name
                                           type: object
+                                          x-kubernetes-map-type: atomic
                                         resources:
                                           properties:
                                             limits:
@@ -2648,6 +2698,7 @@ spec:
                                                 type: string
                                               type: object
                                           type: object
+                                          x-kubernetes-map-type: atomic
                                         storageClassName:
                                           type: string
                                         volumeMode:
@@ -2694,6 +2745,7 @@ spec:
                                     name:
                                       type: string
                                   type: object
+                                  x-kubernetes-map-type: atomic
                               required:
                               - driver
                               type: object
@@ -2778,6 +2830,7 @@ spec:
                                     name:
                                       type: string
                                   type: object
+                                  x-kubernetes-map-type: atomic
                                 targetPortal:
                                   type: string
                               required:
@@ -2858,6 +2911,7 @@ spec:
                                           optional:
                                             type: boolean
                                         type: object
+                                        x-kubernetes-map-type: atomic
                                       downwardAPI:
                                         properties:
                                           items:
@@ -2872,6 +2926,7 @@ spec:
                                                   required:
                                                   - fieldPath
                                                   type: object
+                                                  x-kubernetes-map-type: atomic
                                                 mode:
                                                   format: int32
                                                   type: integer
@@ -2892,6 +2947,7 @@ spec:
                                                   required:
                                                   - resource
                                                   type: object
+                                                  x-kubernetes-map-type: atomic
                                               required:
                                               - path
                                               type: object
@@ -2919,6 +2975,7 @@ spec:
                                           optional:
                                             type: boolean
                                         type: object
+                                        x-kubernetes-map-type: atomic
                                       serviceAccountToken:
                                         properties:
                                           audience:
@@ -2973,6 +3030,7 @@ spec:
                                     name:
                                       type: string
                                   type: object
+                                  x-kubernetes-map-type: atomic
                                 user:
                                   type: string
                               required:
@@ -2994,6 +3052,7 @@ spec:
                                     name:
                                       type: string
                                   type: object
+                                  x-kubernetes-map-type: atomic
                                 sslEnabled:
                                   type: boolean
                                 storageMode:
@@ -3045,6 +3104,7 @@ spec:
                                     name:
                                       type: string
                                   type: object
+                                  x-kubernetes-map-type: atomic
                                 volumeName:
                                   type: string
                                 volumeNamespace:
@@ -3209,6 +3269,7 @@ spec:
                                             type: object
                                           type: array
                                       type: object
+                                      x-kubernetes-map-type: atomic
                                     weight:
                                       format: int32
                                       type: integer
@@ -3255,10 +3316,12 @@ spec:
                                             type: object
                                           type: array
                                       type: object
+                                      x-kubernetes-map-type: atomic
                                     type: array
                                 required:
                                 - nodeSelectorTerms
                                 type: object
+                                x-kubernetes-map-type: atomic
                             type: object
                           podAffinity:
                             properties:
@@ -3290,6 +3353,7 @@ spec:
                                                 type: string
                                               type: object
                                           type: object
+                                          x-kubernetes-map-type: atomic
                                         namespaceSelector:
                                           properties:
                                             matchExpressions:
@@ -3313,6 +3377,7 @@ spec:
                                                 type: string
                                               type: object
                                           type: object
+                                          x-kubernetes-map-type: atomic
                                         namespaces:
                                           items:
                                             type: string
@@ -3356,6 +3421,7 @@ spec:
                                             type: string
                                           type: object
                                       type: object
+                                      x-kubernetes-map-type: atomic
                                     namespaceSelector:
                                       properties:
                                         matchExpressions:
@@ -3379,6 +3445,7 @@ spec:
                                             type: string
                                           type: object
                                       type: object
+                                      x-kubernetes-map-type: atomic
                                     namespaces:
                                       items:
                                         type: string
@@ -3420,6 +3487,7 @@ spec:
                                                 type: string
                                               type: object
                                           type: object
+                                          x-kubernetes-map-type: atomic
                                         namespaceSelector:
                                           properties:
                                             matchExpressions:
@@ -3443,6 +3511,7 @@ spec:
                                                 type: string
                                               type: object
                                           type: object
+                                          x-kubernetes-map-type: atomic
                                         namespaces:
                                           items:
                                             type: string
@@ -3486,6 +3555,7 @@ spec:
                                             type: string
                                           type: object
                                       type: object
+                                      x-kubernetes-map-type: atomic
                                     namespaceSelector:
                                       properties:
                                         matchExpressions:
@@ -3509,6 +3579,7 @@ spec:
                                             type: string
                                           type: object
                                       type: object
+                                      x-kubernetes-map-type: atomic
                                     namespaces:
                                       items:
                                         type: string
@@ -3554,6 +3625,7 @@ spec:
                                         required:
                                         - key
                                         type: object
+                                        x-kubernetes-map-type: atomic
                                       fieldRef:
                                         properties:
                                           apiVersion:
@@ -3563,6 +3635,7 @@ spec:
                                         required:
                                         - fieldPath
                                         type: object
+                                        x-kubernetes-map-type: atomic
                                       resourceFieldRef:
                                         properties:
                                           containerName:
@@ -3578,6 +3651,7 @@ spec:
                                         required:
                                         - resource
                                         type: object
+                                        x-kubernetes-map-type: atomic
                                       secretKeyRef:
                                         properties:
                                           key:
@@ -3589,6 +3663,7 @@ spec:
                                         required:
                                         - key
                                         type: object
+                                        x-kubernetes-map-type: atomic
                                     type: object
                                 required:
                                 - name
@@ -3604,6 +3679,7 @@ spec:
                                       optional:
                                         type: boolean
                                     type: object
+                                    x-kubernetes-map-type: atomic
                                   prefix:
                                     type: string
                                   secretRef:
@@ -3613,6 +3689,7 @@ spec:
                                       optional:
                                         type: boolean
                                     type: object
+                                    x-kubernetes-map-type: atomic
                                 type: object
                               type: array
                             image:
@@ -3740,6 +3817,7 @@ spec:
                                       format: int32
                                       type: integer
                                     service:
+                                      default: ''
                                       type: string
                                   required:
                                   - port
@@ -3844,6 +3922,7 @@ spec:
                                       format: int32
                                       type: integer
                                     service:
+                                      default: ''
                                       type: string
                                   required:
                                   - port
@@ -4002,6 +4081,7 @@ spec:
                                       format: int32
                                       type: integer
                                     service:
+                                      default: ''
                                       type: string
                                   required:
                                   - port
@@ -4110,8 +4190,8 @@ spec:
                           - name
                           - image
                           type: object
-                        type: array
                         minItems: 1
+                        type: array
                       dnsConfig:
                         properties:
                           nameservers:
@@ -4167,6 +4247,7 @@ spec:
                                         required:
                                         - key
                                         type: object
+                                        x-kubernetes-map-type: atomic
                                       fieldRef:
                                         properties:
                                           apiVersion:
@@ -4176,6 +4257,7 @@ spec:
                                         required:
                                         - fieldPath
                                         type: object
+                                        x-kubernetes-map-type: atomic
                                       resourceFieldRef:
                                         properties:
                                           containerName:
@@ -4191,6 +4273,7 @@ spec:
                                         required:
                                         - resource
                                         type: object
+                                        x-kubernetes-map-type: atomic
                                       secretKeyRef:
                                         properties:
                                           key:
@@ -4202,6 +4285,7 @@ spec:
                                         required:
                                         - key
                                         type: object
+                                        x-kubernetes-map-type: atomic
                                     type: object
                                 required:
                                 - name
@@ -4217,6 +4301,7 @@ spec:
                                       optional:
                                         type: boolean
                                     type: object
+                                    x-kubernetes-map-type: atomic
                                   prefix:
                                     type: string
                                   secretRef:
@@ -4226,6 +4311,7 @@ spec:
                                       optional:
                                         type: boolean
                                     type: object
+                                    x-kubernetes-map-type: atomic
                                 type: object
                               type: array
                             image:
@@ -4353,6 +4439,7 @@ spec:
                                       format: int32
                                       type: integer
                                     service:
+                                      default: ''
                                       type: string
                                   required:
                                   - port
@@ -4457,6 +4544,7 @@ spec:
                                       format: int32
                                       type: integer
                                     service:
+                                      default: ''
                                       type: string
                                   required:
                                   - port
@@ -4615,6 +4703,7 @@ spec:
                                       format: int32
                                       type: integer
                                     service:
+                                      default: ''
                                       type: string
                                   required:
                                   - port
@@ -4750,6 +4839,7 @@ spec:
                             name:
                               type: string
                           type: object
+                          x-kubernetes-map-type: atomic
                         type: array
                       initContainers:
                         items:
@@ -4782,6 +4872,7 @@ spec:
                                         required:
                                         - key
                                         type: object
+                                        x-kubernetes-map-type: atomic
                                       fieldRef:
                                         properties:
                                           apiVersion:
@@ -4791,6 +4882,7 @@ spec:
                                         required:
                                         - fieldPath
                                         type: object
+                                        x-kubernetes-map-type: atomic
                                       resourceFieldRef:
                                         properties:
                                           containerName:
@@ -4806,6 +4898,7 @@ spec:
                                         required:
                                         - resource
                                         type: object
+                                        x-kubernetes-map-type: atomic
                                       secretKeyRef:
                                         properties:
                                           key:
@@ -4817,6 +4910,7 @@ spec:
                                         required:
                                         - key
                                         type: object
+                                        x-kubernetes-map-type: atomic
                                     type: object
                                 required:
                                 - name
@@ -4832,6 +4926,7 @@ spec:
                                       optional:
                                         type: boolean
                                     type: object
+                                    x-kubernetes-map-type: atomic
                                   prefix:
                                     type: string
                                   secretRef:
@@ -4841,6 +4936,7 @@ spec:
                                       optional:
                                         type: boolean
                                     type: object
+                                    x-kubernetes-map-type: atomic
                                 type: object
                               type: array
                             image:
@@ -4968,6 +5064,7 @@ spec:
                                       format: int32
                                       type: integer
                                     service:
+                                      default: ''
                                       type: string
                                   required:
                                   - port
@@ -5072,6 +5169,7 @@ spec:
                                       format: int32
                                       type: integer
                                     service:
+                                      default: ''
                                       type: string
                                   required:
                                   - port
@@ -5230,6 +5328,7 @@ spec:
                                       format: int32
                                       type: integer
                                     service:
+                                      default: ''
                                       type: string
                                   required:
                                   - port
@@ -5501,6 +5600,7 @@ spec:
                                     type: string
                                   type: object
                               type: object
+                              x-kubernetes-map-type: atomic
                             maxSkew:
                               format: int32
                               type: integer
@@ -5582,6 +5682,7 @@ spec:
                                     name:
                                       type: string
                                   type: object
+                                  x-kubernetes-map-type: atomic
                                 user:
                                   type: string
                               required:
@@ -5598,6 +5699,7 @@ spec:
                                     name:
                                       type: string
                                   type: object
+                                  x-kubernetes-map-type: atomic
                                 volumeID:
                                   type: string
                               required:
@@ -5628,6 +5730,7 @@ spec:
                                 optional:
                                   type: boolean
                               type: object
+                              x-kubernetes-map-type: atomic
                             csi:
                               properties:
                                 driver:
@@ -5639,6 +5742,7 @@ spec:
                                     name:
                                       type: string
                                   type: object
+                                  x-kubernetes-map-type: atomic
                                 readOnly:
                                   type: boolean
                                 volumeAttributes:
@@ -5665,6 +5769,7 @@ spec:
                                         required:
                                         - fieldPath
                                         type: object
+                                        x-kubernetes-map-type: atomic
                                       mode:
                                         format: int32
                                         type: integer
@@ -5685,6 +5790,7 @@ spec:
                                         required:
                                         - resource
                                         type: object
+                                        x-kubernetes-map-type: atomic
                                     required:
                                     - path
                                     type: object
@@ -5725,6 +5831,7 @@ spec:
                                           - kind
                                           - name
                                           type: object
+                                          x-kubernetes-map-type: atomic
                                         dataSourceRef:
                                           properties:
                                             apiGroup:
@@ -5737,6 +5844,7 @@ spec:
                                           - kind
                                           - name
                                           type: object
+                                          x-kubernetes-map-type: atomic
                                         resources:
                                           properties:
                                             limits:
@@ -5779,6 +5887,7 @@ spec:
                                                 type: string
                                               type: object
                                           type: object
+                                          x-kubernetes-map-type: atomic
                                         storageClassName:
                                           type: string
                                         volumeMode:
@@ -5825,6 +5934,7 @@ spec:
                                     name:
                                       type: string
                                   type: object
+                                  x-kubernetes-map-type: atomic
                               required:
                               - driver
                               type: object
@@ -5909,6 +6019,7 @@ spec:
                                     name:
                                       type: string
                                   type: object
+                                  x-kubernetes-map-type: atomic
                                 targetPortal:
                                   type: string
                               required:
@@ -5989,6 +6100,7 @@ spec:
                                           optional:
                                             type: boolean
                                         type: object
+                                        x-kubernetes-map-type: atomic
                                       downwardAPI:
                                         properties:
                                           items:
@@ -6003,6 +6115,7 @@ spec:
                                                   required:
                                                   - fieldPath
                                                   type: object
+                                                  x-kubernetes-map-type: atomic
                                                 mode:
                                                   format: int32
                                                   type: integer
@@ -6023,6 +6136,7 @@ spec:
                                                   required:
                                                   - resource
                                                   type: object
+                                                  x-kubernetes-map-type: atomic
                                               required:
                                               - path
                                               type: object
@@ -6050,6 +6164,7 @@ spec:
                                           optional:
                                             type: boolean
                                         type: object
+                                        x-kubernetes-map-type: atomic
                                       serviceAccountToken:
                                         properties:
                                           audience:
@@ -6104,6 +6219,7 @@ spec:
                                     name:
                                       type: string
                                   type: object
+                                  x-kubernetes-map-type: atomic
                                 user:
                                   type: string
                               required:
@@ -6125,6 +6241,7 @@ spec:
                                     name:
                                       type: string
                                   type: object
+                                  x-kubernetes-map-type: atomic
                                 sslEnabled:
                                   type: boolean
                                 storageMode:
@@ -6176,6 +6293,7 @@ spec:
                                     name:
                                       type: string
                                   type: object
+                                  x-kubernetes-map-type: atomic
                                 volumeName:
                                   type: string
                                 volumeNamespace:
@@ -6340,6 +6458,7 @@ spec:
                                             type: object
                                           type: array
                                       type: object
+                                      x-kubernetes-map-type: atomic
                                     weight:
                                       format: int32
                                       type: integer
@@ -6386,10 +6505,12 @@ spec:
                                             type: object
                                           type: array
                                       type: object
+                                      x-kubernetes-map-type: atomic
                                     type: array
                                 required:
                                 - nodeSelectorTerms
                                 type: object
+                                x-kubernetes-map-type: atomic
                             type: object
                           podAffinity:
                             properties:
@@ -6421,6 +6542,7 @@ spec:
                                                 type: string
                                               type: object
                                           type: object
+                                          x-kubernetes-map-type: atomic
                                         namespaceSelector:
                                           properties:
                                             matchExpressions:
@@ -6444,6 +6566,7 @@ spec:
                                                 type: string
                                               type: object
                                           type: object
+                                          x-kubernetes-map-type: atomic
                                         namespaces:
                                           items:
                                             type: string
@@ -6487,6 +6610,7 @@ spec:
                                             type: string
                                           type: object
                                       type: object
+                                      x-kubernetes-map-type: atomic
                                     namespaceSelector:
                                       properties:
                                         matchExpressions:
@@ -6510,6 +6634,7 @@ spec:
                                             type: string
                                           type: object
                                       type: object
+                                      x-kubernetes-map-type: atomic
                                     namespaces:
                                       items:
                                         type: string
@@ -6551,6 +6676,7 @@ spec:
                                                 type: string
                                               type: object
                                           type: object
+                                          x-kubernetes-map-type: atomic
                                         namespaceSelector:
                                           properties:
                                             matchExpressions:
@@ -6574,6 +6700,7 @@ spec:
                                                 type: string
                                               type: object
                                           type: object
+                                          x-kubernetes-map-type: atomic
                                         namespaces:
                                           items:
                                             type: string
@@ -6617,6 +6744,7 @@ spec:
                                             type: string
                                           type: object
                                       type: object
+                                      x-kubernetes-map-type: atomic
                                     namespaceSelector:
                                       properties:
                                         matchExpressions:
@@ -6640,6 +6768,7 @@ spec:
                                             type: string
                                           type: object
                                       type: object
+                                      x-kubernetes-map-type: atomic
                                     namespaces:
                                       items:
                                         type: string
@@ -6685,6 +6814,7 @@ spec:
                                         required:
                                         - key
                                         type: object
+                                        x-kubernetes-map-type: atomic
                                       fieldRef:
                                         properties:
                                           apiVersion:
@@ -6694,6 +6824,7 @@ spec:
                                         required:
                                         - fieldPath
                                         type: object
+                                        x-kubernetes-map-type: atomic
                                       resourceFieldRef:
                                         properties:
                                           containerName:
@@ -6709,6 +6840,7 @@ spec:
                                         required:
                                         - resource
                                         type: object
+                                        x-kubernetes-map-type: atomic
                                       secretKeyRef:
                                         properties:
                                           key:
@@ -6720,6 +6852,7 @@ spec:
                                         required:
                                         - key
                                         type: object
+                                        x-kubernetes-map-type: atomic
                                     type: object
                                 required:
                                 - name
@@ -6735,6 +6868,7 @@ spec:
                                       optional:
                                         type: boolean
                                     type: object
+                                    x-kubernetes-map-type: atomic
                                   prefix:
                                     type: string
                                   secretRef:
@@ -6744,6 +6878,7 @@ spec:
                                       optional:
                                         type: boolean
                                     type: object
+                                    x-kubernetes-map-type: atomic
                                 type: object
                               type: array
                             image:
@@ -6871,6 +7006,7 @@ spec:
                                       format: int32
                                       type: integer
                                     service:
+                                      default: ''
                                       type: string
                                   required:
                                   - port
@@ -6975,6 +7111,7 @@ spec:
                                       format: int32
                                       type: integer
                                     service:
+                                      default: ''
                                       type: string
                                   required:
                                   - port
@@ -7133,6 +7270,7 @@ spec:
                                       format: int32
                                       type: integer
                                     service:
+                                      default: ''
                                       type: string
                                   required:
                                   - port
@@ -7241,8 +7379,8 @@ spec:
                           - name
                           - image
                           type: object
-                        type: array
                         minItems: 1
+                        type: array
                       dnsConfig:
                         properties:
                           nameservers:
@@ -7298,6 +7436,7 @@ spec:
                                         required:
                                         - key
                                         type: object
+                                        x-kubernetes-map-type: atomic
                                       fieldRef:
                                         properties:
                                           apiVersion:
@@ -7307,6 +7446,7 @@ spec:
                                         required:
                                         - fieldPath
                                         type: object
+                                        x-kubernetes-map-type: atomic
                                       resourceFieldRef:
                                         properties:
                                           containerName:
@@ -7322,6 +7462,7 @@ spec:
                                         required:
                                         - resource
                                         type: object
+                                        x-kubernetes-map-type: atomic
                                       secretKeyRef:
                                         properties:
                                           key:
@@ -7333,6 +7474,7 @@ spec:
                                         required:
                                         - key
                                         type: object
+                                        x-kubernetes-map-type: atomic
                                     type: object
                                 required:
                                 - name
@@ -7348,6 +7490,7 @@ spec:
                                       optional:
                                         type: boolean
                                     type: object
+                                    x-kubernetes-map-type: atomic
                                   prefix:
                                     type: string
                                   secretRef:
@@ -7357,6 +7500,7 @@ spec:
                                       optional:
                                         type: boolean
                                     type: object
+                                    x-kubernetes-map-type: atomic
                                 type: object
                               type: array
                             image:
@@ -7484,6 +7628,7 @@ spec:
                                       format: int32
                                       type: integer
                                     service:
+                                      default: ''
                                       type: string
                                   required:
                                   - port
@@ -7588,6 +7733,7 @@ spec:
                                       format: int32
                                       type: integer
                                     service:
+                                      default: ''
                                       type: string
                                   required:
                                   - port
@@ -7746,6 +7892,7 @@ spec:
                                       format: int32
                                       type: integer
                                     service:
+                                      default: ''
                                       type: string
                                   required:
                                   - port
@@ -7881,6 +8028,7 @@ spec:
                             name:
                               type: string
                           type: object
+                          x-kubernetes-map-type: atomic
                         type: array
                       initContainers:
                         items:
@@ -7913,6 +8061,7 @@ spec:
                                         required:
                                         - key
                                         type: object
+                                        x-kubernetes-map-type: atomic
                                       fieldRef:
                                         properties:
                                           apiVersion:
@@ -7922,6 +8071,7 @@ spec:
                                         required:
                                         - fieldPath
                                         type: object
+                                        x-kubernetes-map-type: atomic
                                       resourceFieldRef:
                                         properties:
                                           containerName:
@@ -7937,6 +8087,7 @@ spec:
                                         required:
                                         - resource
                                         type: object
+                                        x-kubernetes-map-type: atomic
                                       secretKeyRef:
                                         properties:
                                           key:
@@ -7948,6 +8099,7 @@ spec:
                                         required:
                                         - key
                                         type: object
+                                        x-kubernetes-map-type: atomic
                                     type: object
                                 required:
                                 - name
@@ -7963,6 +8115,7 @@ spec:
                                       optional:
                                         type: boolean
                                     type: object
+                                    x-kubernetes-map-type: atomic
                                   prefix:
                                     type: string
                                   secretRef:
@@ -7972,6 +8125,7 @@ spec:
                                       optional:
                                         type: boolean
                                     type: object
+                                    x-kubernetes-map-type: atomic
                                 type: object
                               type: array
                             image:
@@ -8099,6 +8253,7 @@ spec:
                                       format: int32
                                       type: integer
                                     service:
+                                      default: ''
                                       type: string
                                   required:
                                   - port
@@ -8203,6 +8358,7 @@ spec:
                                       format: int32
                                       type: integer
                                     service:
+                                      default: ''
                                       type: string
                                   required:
                                   - port
@@ -8361,6 +8517,7 @@ spec:
                                       format: int32
                                       type: integer
                                     service:
+                                      default: ''
                                       type: string
                                   required:
                                   - port
@@ -8632,6 +8789,7 @@ spec:
                                     type: string
                                   type: object
                               type: object
+                              x-kubernetes-map-type: atomic
                             maxSkew:
                               format: int32
                               type: integer
@@ -8713,6 +8871,7 @@ spec:
                                     name:
                                       type: string
                                   type: object
+                                  x-kubernetes-map-type: atomic
                                 user:
                                   type: string
                               required:
@@ -8729,6 +8888,7 @@ spec:
                                     name:
                                       type: string
                                   type: object
+                                  x-kubernetes-map-type: atomic
                                 volumeID:
                                   type: string
                               required:
@@ -8759,6 +8919,7 @@ spec:
                                 optional:
                                   type: boolean
                               type: object
+                              x-kubernetes-map-type: atomic
                             csi:
                               properties:
                                 driver:
@@ -8770,6 +8931,7 @@ spec:
                                     name:
                                       type: string
                                   type: object
+                                  x-kubernetes-map-type: atomic
                                 readOnly:
                                   type: boolean
                                 volumeAttributes:
@@ -8796,6 +8958,7 @@ spec:
                                         required:
                                         - fieldPath
                                         type: object
+                                        x-kubernetes-map-type: atomic
                                       mode:
                                         format: int32
                                         type: integer
@@ -8816,6 +8979,7 @@ spec:
                                         required:
                                         - resource
                                         type: object
+                                        x-kubernetes-map-type: atomic
                                     required:
                                     - path
                                     type: object
@@ -8856,6 +9020,7 @@ spec:
                                           - kind
                                           - name
                                           type: object
+                                          x-kubernetes-map-type: atomic
                                         dataSourceRef:
                                           properties:
                                             apiGroup:
@@ -8868,6 +9033,7 @@ spec:
                                           - kind
                                           - name
                                           type: object
+                                          x-kubernetes-map-type: atomic
                                         resources:
                                           properties:
                                             limits:
@@ -8910,6 +9076,7 @@ spec:
                                                 type: string
                                               type: object
                                           type: object
+                                          x-kubernetes-map-type: atomic
                                         storageClassName:
                                           type: string
                                         volumeMode:
@@ -8956,6 +9123,7 @@ spec:
                                     name:
                                       type: string
                                   type: object
+                                  x-kubernetes-map-type: atomic
                               required:
                               - driver
                               type: object
@@ -9040,6 +9208,7 @@ spec:
                                     name:
                                       type: string
                                   type: object
+                                  x-kubernetes-map-type: atomic
                                 targetPortal:
                                   type: string
                               required:
@@ -9120,6 +9289,7 @@ spec:
                                           optional:
                                             type: boolean
                                         type: object
+                                        x-kubernetes-map-type: atomic
                                       downwardAPI:
                                         properties:
                                           items:
@@ -9134,6 +9304,7 @@ spec:
                                                   required:
                                                   - fieldPath
                                                   type: object
+                                                  x-kubernetes-map-type: atomic
                                                 mode:
                                                   format: int32
                                                   type: integer
@@ -9154,6 +9325,7 @@ spec:
                                                   required:
                                                   - resource
                                                   type: object
+                                                  x-kubernetes-map-type: atomic
                                               required:
                                               - path
                                               type: object
@@ -9181,6 +9353,7 @@ spec:
                                           optional:
                                             type: boolean
                                         type: object
+                                        x-kubernetes-map-type: atomic
                                       serviceAccountToken:
                                         properties:
                                           audience:
@@ -9235,6 +9408,7 @@ spec:
                                     name:
                                       type: string
                                   type: object
+                                  x-kubernetes-map-type: atomic
                                 user:
                                   type: string
                               required:
@@ -9256,6 +9430,7 @@ spec:
                                     name:
                                       type: string
                                   type: object
+                                  x-kubernetes-map-type: atomic
                                 sslEnabled:
                                   type: boolean
                                 storageMode:
@@ -9307,6 +9482,7 @@ spec:
                                     name:
                                       type: string
                                   type: object
+                                  x-kubernetes-map-type: atomic
                                 volumeName:
                                   type: string
                                 volumeNamespace:
@@ -9410,12 +9586,3 @@ spec:
     storage: false
     subresources:
       status: {}
-  preserveUnknownFields: false
-  conversion:
-    strategy: None
-status:
-  acceptedNames:
-    kind: ''
-    plural: ''
-  conditions: []
-  storedVersions: []

--- a/experimental/helm/charts/notebook-controller/templates/rbac/clusterrole.yaml
+++ b/experimental/helm/charts/notebook-controller/templates/rbac/clusterrole.yaml
@@ -17,12 +17,6 @@ metadata:
   {{- end }}
 rules:
 - apiGroups:
-  - apps
-  resources:
-  - statefulsets
-  verbs:
-  - '*'
-- apiGroups:
   - ""
   resources:
   - events
@@ -46,7 +40,12 @@ rules:
   - services
   verbs:
   - '*'
-
+- apiGroups:
+  - apps
+  resources:
+  - statefulsets
+  verbs:
+  - '*'
 - apiGroups:
   - kubeflow.org
   resources:

--- a/experimental/helm/charts/notebook-controller/values.yaml
+++ b/experimental/helm/charts/notebook-controller/values.yaml
@@ -17,9 +17,9 @@ global:
   # -- Namespace to install Notebook Controller
   namespace: kubeflow
   # -- Image registry for Notebook Controller images
-  imageRegistry: ghcr.io/kubeflow/kubeflow
+  imageRegistry: ghcr.io/kubeflow/notebooks
   # -- Global image tag for the notebook controller
-  imageTag: v1.10.0
+  imageTag: v1.11.0-rc.1
   # -- Global image pull policy
   imagePullPolicy: IfNotPresent
   # -- Global image pull secrets


### PR DESCRIPTION
Align model-registry Helm chart tags with Kustomize v0.3.8 so Helm/Kustomize compare scenarios match for base, db/postgres overlays, and UI scenarios.