### PR TITLE
test: group dashboard and notebooks installs

### DIFF
--- a/.github/workflows/admission_webhook_test.yaml
+++ b/.github/workflows/admission_webhook_test.yaml
@@ -6,6 +6,7 @@ on:
     - .github/workflows/admission_webhook_test.yaml
     - applications/dashboard/**
     - tests/istio*
+    - tests/install_dashboard.sh
     - common/cert-manager/**
     - common/istio*/**
 
@@ -32,8 +33,5 @@ jobs:
     - name: Install cert-manager
       run: ./tests/cert_manager_install.sh
 
-    - name: Build & Apply manifests
-      run: |
-        cd applications/dashboard/upstream/poddefaults-webhooks
-        kustomize build overlays/cert-manager | kubectl apply -f -
-        kubectl wait --for=condition=Ready pods --all --all-namespaces --timeout 180s
+    - name: Install Dashboard
+      run: ./tests/install_dashboard.sh

--- a/.github/workflows/centraldashboard_test.yaml
+++ b/.github/workflows/centraldashboard_test.yaml
@@ -5,7 +5,10 @@ on:
     - tests/install_KinD_create_KinD_cluster_install_kustomize.sh
     - .github/workflows/centraldashboard_test.yaml
     - applications/dashboard/**
+    - common/cert-manager/**
     - tests/istio*
+    - tests/cert_manager_install.sh
+    - tests/install_dashboard.sh
     - common/istio*/**
 
 permissions:
@@ -25,8 +28,11 @@ jobs:
     - name: Create kubeflow namespace
       run: kustomize build common/kubeflow-namespace/base | kubectl apply -f -
 
+    - name: Install cert-manager
+      run: ./tests/cert_manager_install.sh
+
     - name: Install Istio
       run: ./tests/istio-cni_install.sh
 
-    - name: Install central-dashboard
-      run: ./tests/central_dashboard_install.sh
+    - name: Install Dashboard
+      run: ./tests/install_dashboard.sh

--- a/.github/workflows/dex_oauth2-proxy_test.yaml
+++ b/.github/workflows/dex_oauth2-proxy_test.yaml
@@ -11,6 +11,8 @@ on:
     - common/dex/base/**
     - tests/istio*
     - tests/dex_login_test.py
+    - tests/install_dashboard.sh
+    - tests/multi_tenancy_install.sh
 
 permissions:
   contents: read
@@ -47,8 +49,8 @@ jobs:
     - name: Install dex
       run: ./tests/dex_install.sh
 
-    - name: Install central-dashboard
-      run: ./tests/central_dashboard_install.sh
+    - name: Install Dashboard
+      run: ./tests/install_dashboard.sh
 
     - name: Create KF Profile
       run: ./tests/kubeflow_profile_install.sh

--- a/.github/workflows/full_kubeflow_integration_test.yaml
+++ b/.github/workflows/full_kubeflow_integration_test.yaml
@@ -51,8 +51,8 @@ jobs:
     - name: Install Dex
       run: ./tests/dex_install.sh
 
-    - name: Install Central Dashboard
-      run: ./tests/central_dashboard_install.sh
+    - name: Install Dashboard
+      run: ./tests/install_dashboard.sh
 
     - name: Install Knative
       run: ./tests/knative_install.sh
@@ -66,17 +66,8 @@ jobs:
     - name: Create KF Profile
       run: ./tests/kubeflow_profile_install.sh
 
-    - name: Install Jupyter Web Application
-      run: kustomize build applications/notebooks-v1/upstream/jupyter-web-app/overlays/istio/ | kubectl apply -f -
-
-    - name: Install Notebook Controller
-      run: kustomize build applications/notebooks-v1/upstream/notebook-controller/overlays/kubeflow/ | kubectl apply -f -
-
-    - name: Install Admission Webhook
-      run: kustomize build applications/dashboard/upstream/poddefaults-webhooks/overlays/cert-manager | kubectl apply -f -
-
-    - name: Install Volumes Web Application
-      run: ./tests/volumes_web_application_install.sh
+    - name: Install Notebooks v1
+      run: ./tests/install_notebooks_v1.sh
 
     - name: Install Katib
       run: ./tests/katib_install.sh

--- a/.github/workflows/istio_validation.yaml
+++ b/.github/workflows/istio_validation.yaml
@@ -6,6 +6,7 @@ on:
     - tests/install_KinD_create_KinD_cluster_install_kustomize.sh
     - tests/istio*
     - tests/ambient*
+    - tests/multi_tenancy_install.sh
     - .github/workflows/istio_validation.yaml
     - common/istio/**
     - common/cert-manager/**

--- a/.github/workflows/jupyter_web_application_test.yaml
+++ b/.github/workflows/jupyter_web_application_test.yaml
@@ -4,8 +4,11 @@ on:
     paths:
     - tests/install_KinD_create_KinD_cluster_install_kustomize.sh
     - .github/workflows/jupyter_web_application_test.yaml
-    - applications/notebooks-v1/upstream/jupyter-web-app/**
+    - applications/notebooks-v1/**
+    - common/cert-manager/**
     - tests/istio*
+    - tests/cert_manager_install.sh
+    - tests/install_notebooks_v1.sh
     - common/istio*/**
 
 permissions:
@@ -25,11 +28,11 @@ jobs:
     - name: Create kubeflow namespace
       run: kustomize build common/kubeflow-namespace/base | kubectl apply -f -
 
+    - name: Install cert-manager
+      run: ./tests/cert_manager_install.sh
+
     - name: Install Istio
       run: ./tests/istio-cni_install.sh
 
-    - name: Build & Apply manifests
-      run: |
-        cd applications/notebooks-v1/upstream/jupyter-web-app
-        kustomize build overlays/istio | kubectl apply -f -
-        kubectl wait --for=condition=Ready pods --all --all-namespaces --timeout 180s
+    - name: Install Notebooks v1
+      run: ./tests/install_notebooks_v1.sh

--- a/.github/workflows/katib_test.yaml
+++ b/.github/workflows/katib_test.yaml
@@ -8,6 +8,7 @@ on:
     - applications/katib/upstream/**
     - common/istio*/**
     - tests/istio*
+    - tests/multi_tenancy_install.sh
     - common/cert-manager/**
     - experimental/security/PSS/*
 

--- a/.github/workflows/kserve_models_web_application_test.yaml
+++ b/.github/workflows/kserve_models_web_application_test.yaml
@@ -8,6 +8,7 @@ on:
     - tests/kserve*
 
     - tests/istio*
+    - tests/multi_tenancy_install.sh
     - common/istio*/**
     - common/knative/**
     - common/oauth2-proxy/**

--- a/.github/workflows/kserve_test.yaml
+++ b/.github/workflows/kserve_test.yaml
@@ -14,6 +14,7 @@ on:
     - tests/oauth2-proxy_install.sh
     - common/cert-manager/**
     - tests/istio*
+    - tests/multi_tenancy_install.sh
     - common/knative/**
     - tests/knative_install.sh
 

--- a/.github/workflows/model_catalog_test.yaml
+++ b/.github/workflows/model_catalog_test.yaml
@@ -6,6 +6,7 @@ on:
     - .github/workflows/model_catalog*
     - applications/model-registry/upstream/options/catalog/**
     - tests/istio*
+    - tests/multi_tenancy_install.sh
     - common/istio*/**
 
 permissions:

--- a/.github/workflows/model_registry_test.yaml
+++ b/.github/workflows/model_registry_test.yaml
@@ -8,6 +8,7 @@ on:
     - .github/workflows/model_registry_test.yaml
     - applications/model-registry/upstream/**
     - tests/istio*
+    - tests/multi_tenancy_install.sh
     - common/istio*/**
 
 permissions:

--- a/.github/workflows/notebook_controller_test.yaml
+++ b/.github/workflows/notebook_controller_test.yaml
@@ -5,9 +5,12 @@ on:
     - tests/install_KinD_create_KinD_cluster_install_kustomize.sh
     - .github/workflows/notebook_controller_m2m_test.yaml
     - applications/notebooks-v1/**
+    - common/cert-manager/**
     - common/oauth2-proxy/**
     - common/istio*/**
     - tests/istio*
+    - tests/cert_manager_install.sh
+    - tests/install_notebooks_v1.sh
     - tests/oauth2-proxy_install.sh
     - tests/multi_tenancy_install.sh
 
@@ -28,6 +31,9 @@ jobs:
     - name: Create kubeflow namespace
       run: kustomize build common/kubeflow-namespace/base | kubectl apply -f -
 
+    - name: Install cert-manager
+      run: ./tests/cert_manager_install.sh
+
     - name: Install Istio
       run: ./tests/istio-cni_install.sh
 
@@ -40,12 +46,8 @@ jobs:
     - name: Install KF Multi Tenancy
       run: ./tests/multi_tenancy_install.sh
 
-    - name: Build & Apply manifests
-      run: |
-        kustomize build applications/notebooks-v1/upstream/jupyter-web-app/overlays/istio/ | kubectl apply -f -
-        kustomize build applications/notebooks-v1/upstream/notebook-controller/overlays/kubeflow/ | kubectl apply -f -
-        kubectl wait --for=condition=Ready pods --all --all-namespaces --timeout=300s \
-          --field-selector=status.phase!=Succeeded
+    - name: Install Notebooks v1
+      run: ./tests/install_notebooks_v1.sh
 
     - name: Create KF Profile
       run: kustomize build common/user-namespace/base | kubectl apply -f -

--- a/.github/workflows/pipeline_run_from_notebook.yaml
+++ b/.github/workflows/pipeline_run_from_notebook.yaml
@@ -7,6 +7,9 @@ on:
     - applications/notebooks-v1/**
     - applications/pipeline/upstream/**
     - tests/istio*
+    - tests/install_dashboard.sh
+    - tests/install_notebooks_v1.sh
+    - tests/multi_tenancy_install.sh
     - common/cert-manager/**
     - common/oauth2-proxy/**
     - common/istio*/**
@@ -46,13 +49,11 @@ jobs:
     - name: Install KF Pipelines
       run: ./tests/pipelines_install.sh
 
-    - name: Build & Apply manifests
-      run: |
-        kustomize build applications/notebooks-v1/upstream/jupyter-web-app/overlays/istio/ | kubectl apply -f -
-        kustomize build applications/notebooks-v1/upstream/notebook-controller/overlays/kubeflow/ | kubectl apply -f -
-        kustomize build applications/dashboard/upstream/poddefaults-webhooks/overlays/cert-manager | kubectl apply -f -
-        kubectl wait --for=condition=Ready pods --all --all-namespaces --timeout 300s \
-          --field-selector=status.phase!=Succeeded
+    - name: Install Dashboard
+      run: ./tests/install_dashboard.sh
+
+    - name: Install Notebooks v1
+      run: ./tests/install_notebooks_v1.sh
 
     - name: Create KF Profile
       run: ./tests/kubeflow_profile_install.sh

--- a/.github/workflows/pipeline_test.yaml
+++ b/.github/workflows/pipeline_test.yaml
@@ -6,6 +6,7 @@ on:
     - .github/workflows/pipeline_test.yaml
     - applications/pipeline/upstream/**
     - tests/istio*
+    - tests/multi_tenancy_install.sh
     - tests/oauth2-proxy_install.sh
     - common/cert-manager/**
     - common/oauth2-proxy/**

--- a/.github/workflows/profiles_test.yaml
+++ b/.github/workflows/profiles_test.yaml
@@ -5,7 +5,10 @@ on:
     - tests/install_KinD_create_KinD_cluster_install_kustomize.sh
     - .github/workflows/profiles_test.yaml
     - applications/dashboard/**
+    - common/cert-manager/**
     - tests/istio*
+    - tests/cert_manager_install.sh
+    - tests/install_dashboard.sh
     - common/istio*/**
 
 permissions:
@@ -24,11 +27,11 @@ jobs:
     - name: Create kubeflow namespace
       run: kustomize build common/kubeflow-namespace/base | kubectl apply -f -
 
+    - name: Install cert-manager
+      run: ./tests/cert_manager_install.sh
+
     - name: Install Istio
       run: ./tests/istio-cni_install.sh
 
-    - name: Build & Apply manifests
-      run: |
-        cd applications/dashboard/upstream/profile-controller
-        kustomize build overlays/kubeflow | kubectl apply -f -
-        kubectl wait --for=condition=Ready pods --all --all-namespaces --timeout 180s
+    - name: Install Dashboard
+      run: ./tests/install_dashboard.sh

--- a/.github/workflows/ray_test.yaml
+++ b/.github/workflows/ray_test.yaml
@@ -6,6 +6,7 @@ on:
     - .github/workflows/ray_test.yaml
     - experimental/ray/*
     - tests/istio*
+    - tests/multi_tenancy_install.sh
     - tests/oauth2-proxy_install.sh
     - common/cert-manager/*
     - common/oauth2-proxy/*

--- a/.github/workflows/spark_test.yaml
+++ b/.github/workflows/spark_test.yaml
@@ -7,6 +7,7 @@ on:
     - applications/spark/**
     - tests/spark*.sh
     - tests/istio*
+    - tests/multi_tenancy_install.sh
     - tests/oauth2-proxy_install.sh
     - common/cert-manager/**
     - common/oauth2-proxy/**

--- a/.github/workflows/tensorboard_controller_test.yaml
+++ b/.github/workflows/tensorboard_controller_test.yaml
@@ -4,8 +4,11 @@ on:
     paths:
     - tests/install_KinD_create_KinD_cluster_install_kustomize.sh
     - .github/workflows/tensorboard_controller_test.yaml
-    - applications/notebooks-v1/upstream/tensorboard-controller/**
+    - applications/notebooks-v1/**
+    - common/cert-manager/**
     - tests/istio*
+    - tests/cert_manager_install.sh
+    - tests/install_notebooks_v1.sh
     - common/istio*/**
 
 permissions:
@@ -26,11 +29,11 @@ jobs:
     - name: Create kubeflow namespace
       run: kustomize build common/kubeflow-namespace/base | kubectl apply -f -
 
+    - name: Install cert-manager
+      run: ./tests/cert_manager_install.sh
+
     - name: Install Istio
       run: ./tests/istio-cni_install.sh
 
-    - name: Build & Apply manifests
-      run: |
-        cd applications/notebooks-v1/upstream/tensorboard-controller
-        kustomize build overlays/kubeflow | kubectl apply -f -
-        kubectl wait --for=condition=Ready pods --all --all-namespaces --timeout 180s
+    - name: Install Notebooks v1
+      run: ./tests/install_notebooks_v1.sh

--- a/.github/workflows/tensorboards_web_application_test.yaml
+++ b/.github/workflows/tensorboards_web_application_test.yaml
@@ -4,8 +4,11 @@ on:
     paths:
     - tests/install_KinD_create_KinD_cluster_install_kustomize.sh
     - .github/workflows/tensorboards_web_application_test.yaml
-    - applications/notebooks-v1/upstream/tensorboards-web-app/**
+    - applications/notebooks-v1/**
+    - common/cert-manager/**
     - tests/istio*
+    - tests/cert_manager_install.sh
+    - tests/install_notebooks_v1.sh
     - common/istio*/**
 
 permissions:
@@ -26,11 +29,11 @@ jobs:
     - name: Create kubeflow namespace
       run: kustomize build common/kubeflow-namespace/base | kubectl apply -f -
 
+    - name: Install cert-manager
+      run: ./tests/cert_manager_install.sh
+
     - name: Install Istio
       run: ./tests/istio-cni_install.sh
 
-    - name: Build & Apply manifests
-      run: |
-        cd applications/notebooks-v1/upstream/tensorboards-web-app
-        kustomize build overlays/istio | kubectl apply -f -
-        kubectl wait --for=condition=Ready pods --all --all-namespaces --timeout 180s
+    - name: Install Notebooks v1
+      run: ./tests/install_notebooks_v1.sh

--- a/.github/workflows/trainer_test.yaml
+++ b/.github/workflows/trainer_test.yaml
@@ -7,6 +7,7 @@ on:
     - applications/trainer/**
     - tests/trainer*
     - tests/istio*
+    - tests/multi_tenancy_install.sh
     - tests/oauth2-proxy_install.sh
     - common/cert-manager/**
     - common/oauth2-proxy/**

--- a/.github/workflows/training_operator_test.yaml
+++ b/.github/workflows/training_operator_test.yaml
@@ -7,6 +7,7 @@ on:
     - applications/training-operator/upstream/**
     - tests/training_operator_job.yaml
     - tests/istio*
+    - tests/multi_tenancy_install.sh
     - tests/oauth2-proxy_install.sh
     - common/cert-manager/**
     - common/oauth2-proxy/**

--- a/.github/workflows/volumes_web_application_test.yaml
+++ b/.github/workflows/volumes_web_application_test.yaml
@@ -4,13 +4,13 @@ on:
     paths:
     - tests/install_KinD_create_KinD_cluster_install_kustomize.sh
     - .github/workflows/volumes_web_application_test.yaml
-    - applications/notebooks-v1/upstream/volumes-web-app/**
+    - applications/notebooks-v1/**
     - tests/istio*
     - common/istio*/**
     - common/oauth2-proxy/**
+    - tests/install_notebooks_v1.sh
     - tests/oauth2-proxy_install.sh
     - tests/multi_tenancy_install.sh
-    - tests/volumes_web_application_install.sh
     - tests/volumes_web_application_test.sh
 
 permissions:
@@ -52,8 +52,8 @@ jobs:
     - name: Create KF Profile
       run: ./tests/kubeflow_profile_install.sh
 
-    - name: Install Volumes Web Application
-      run: ./tests/volumes_web_application_install.sh
+    - name: Install Notebooks v1
+      run: ./tests/install_notebooks_v1.sh
 
     - name: Wait for VWA Pods
       run: |

--- a/tests/central_dashboard_install.sh
+++ b/tests/central_dashboard_install.sh
@@ -1,5 +1,0 @@
-#!/bin/bash
-set -euxo pipefail
-
-kustomize build applications/dashboard/upstream/centraldashboard/overlays/kserve | kubectl apply -f -
-kubectl wait --for=condition=Ready pods --all -n kubeflow --timeout=180s

--- a/tests/install_dashboard.sh
+++ b/tests/install_dashboard.sh
@@ -1,0 +1,13 @@
+#!/bin/bash
+set -euxo pipefail
+
+echo "Installing Kubeflow Dashboard ..."
+
+kustomize build applications/dashboard/overlays/istio | kubectl apply -f -
+
+kubectl -n kubeflow rollout status deployment/dashboard --timeout=300s
+kubectl -n kubeflow rollout status deployment/poddefaults-webhook-deployment --timeout=300s
+kubectl -n kubeflow rollout status deployment/profiles-deployment --timeout=300s
+kubectl wait --for=condition=Established --timeout=60s crd/profiles.kubeflow.org
+kubectl wait --for=condition=Established --timeout=60s crd/poddefaults.kubeflow.org
+kubectl wait --for=condition=Ready pods -n kubeflow -l app.kubernetes.io/part-of=kubeflow-dashboard --timeout=300s

--- a/tests/install_notebooks_v1.sh
+++ b/tests/install_notebooks_v1.sh
@@ -1,0 +1,13 @@
+#!/bin/bash
+set -euxo pipefail
+
+echo "Installing Kubeflow Notebooks v1 ..."
+
+kustomize build applications/notebooks-v1/overlays/istio | kubectl apply -f -
+
+kubectl -n kubeflow rollout status deployment/jupyter-web-app-deployment --timeout=300s
+kubectl -n kubeflow rollout status deployment/notebook-controller-deployment --timeout=300s
+kubectl -n kubeflow rollout status deployment/pvcviewer-controller-manager --timeout=300s
+kubectl -n kubeflow rollout status deployment/tensorboard-controller-deployment --timeout=300s
+kubectl -n kubeflow rollout status deployment/tensorboards-web-app-deployment --timeout=300s
+kubectl -n kubeflow rollout status deployment/volumes-web-app-deployment --timeout=300s

--- a/tests/multi_tenancy_install.sh
+++ b/tests/multi_tenancy_install.sh
@@ -3,9 +3,9 @@ set -euxo pipefail
 
 echo "Installing Profiles Controller with PSS (Pod Security Standards)"
 kustomize build applications/dashboard/upstream/profile-controller/overlays/kubeflow-pss | kubectl apply -f -
-kubectl -n kubeflow rollout status deployment/profiles-deployment --timeout 180s
-kubectl -n kubeflow wait --for=condition=Ready pods -l app=profile-controller --timeout 180s
+kubectl -n kubeflow rollout status deployment/profiles-deployment --timeout=300s
+kubectl -n kubeflow wait --for=condition=Ready pods -l app=profile-controller --timeout=300s
+kubectl wait --for=condition=Established --timeout=60s crd/profiles.kubeflow.org
 
 echo "Installing Multitenancy Kubeflow Roles"
 kustomize build common/kubeflow-roles/base | kubectl apply -f -
-

--- a/tests/volumes_web_application_install.sh
+++ b/tests/volumes_web_application_install.sh
@@ -1,8 +1,0 @@
-#!/bin/bash
-set -euxo pipefail
-
-cd applications/notebooks-v1/upstream/volumes-web-app
-kustomize build overlays/istio | kubectl apply -f -
-cd ../../../../
-
-kubectl wait --for=condition=Available deployment/volumes-web-app-deployment -n kubeflow --timeout=180s


### PR DESCRIPTION
## Summary

- add grouped install helpers for `applications/dashboard/overlays/istio` and `applications/notebooks-v1/overlays/istio`
- replace direct dashboard/notebooks-v1 upstream installs in workflows with the grouped helpers
- remove obsolete central dashboard and volumes install wrappers
- keep multi-tenancy focused on Profile Controller + Kubeflow roles, with Profile CRD readiness wait

## Verification

- `! rg -n '(kustomize build|cd) applications/(dashboard|notebooks-v1)/upstream' .github tests --glob '*.yaml' --glob '*.yml' --glob '*.sh' --glob '!tests/multi_tenancy_install.sh'`
- `bash -n tests/install_dashboard.sh tests/install_notebooks_v1.sh tests/multi_tenancy_install.sh`
- `shellcheck tests/install_dashboard.sh tests/install_notebooks_v1.sh tests/multi_tenancy_install.sh`
- workflow YAML parse with Python
- `yamllint --config-file .yamllint.yaml` on changed workflows
- `kustomize build applications/dashboard/overlays/istio`
- `kustomize build applications/dashboard/upstream/profile-controller/overlays/kubeflow-pss`
- `kustomize build applications/notebooks-v1/overlays/istio`
- `git diff --check`

Fixes #3446
