### PR TITLE
test: validate dashboard axios image override

### DIFF
--- a/applications/dashboard/upstream/centraldashboard/base/kustomization.yaml
+++ b/applications/dashboard/upstream/centraldashboard/base/kustomization.yaml
@@ -15,8 +15,8 @@ resources:
 
 images:
 - name: dashboard
-  newName: ghcr.io/kubeflow/dashboard/dashboard
-  newTag: v2.0.0-rc.1
+  newName: ttl.sh/kubeflow-dashboard-axios-pr273-8177310-1778415462
+  newTag: 24h
 
 configMapGenerator:
 - envs:


### PR DESCRIPTION
## Summary

Temporary validation PR for `kubeflow/dashboard#273`.

This overrides the Central Dashboard image in `kubeflow/manifests` to a temporary image built from dashboard PR head commit `8177310df6a7802a1c1df68c182eb1a53dfcc5de` and pushed to:

- `ttl.sh/kubeflow-dashboard-axios-pr273-8177310-1778415462:24h`

## Purpose

Use upstream `kubeflow/manifests` CI as the first integration gate before doing manual login, offline checks, and screenshots for the dashboard PR.

## Scope

- Minimal manifests-side image override only
- No intended product change for merge as-is
- Draft PR until CI completes and manual validation follows

## Local verification

- `kustomize build applications/dashboard/upstream/centraldashboard/overlays/kserve`
- `kustomize build applications/dashboard/overlays/istio`
