### PR TITLE
fix(model-registry): add namespace to kustomization overlays to prevent deployment to default namespace

### DIFF
--- a/applications/model-registry/upstream/options/catalog/overlays/demo/kustomization.yaml
+++ b/applications/model-registry/upstream/options/catalog/overlays/demo/kustomization.yaml
@@ -1,6 +1,8 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 
+namespace: kubeflow
+
 resources:
 - ../../base
 

--- a/applications/model-registry/upstream/options/istio/kustomization.yaml
+++ b/applications/model-registry/upstream/options/istio/kustomization.yaml
@@ -1,6 +1,8 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 
+namespace: kubeflow
+
 resources:
 - istio-authorization-policy.yaml
 - destination-rule.yaml

--- a/applications/model-registry/upstream/overlays/postgres/kustomization.yaml
+++ b/applications/model-registry/upstream/overlays/postgres/kustomization.yaml
@@ -1,6 +1,8 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 
+namespace: kubeflow
+
 resources:
 - model-registry-db-pvc.yaml
 - model-registry-db-deployment.yaml


### PR DESCRIPTION
## Summary

Fix model-registry and catalog resources deploying to `default` namespace instead of `kubeflow` when using `kustomize build example/`.

Fixes #3457

## Root Cause

Three of the four model-registry kustomization overlays added in #3318 were missing `namespace: kubeflow`. The CI install script (`model_registry_install.sh`) uses `kubectl apply -n kubeflow`, which masked the issue during CI, but the documented deployment path (`kustomize build example/ | kubectl apply -f -`) has no namespace override — resources land in `default`.

Christian's `istioctl analyze` output confirmed:
```
Error [IST0101] (VirtualService default/model-registry) Referenced gateway not found: "kubeflow-gateway"
Warning [IST0174] (DestinationRule default/model-registry-service) The host ... does not match any services in the mesh
```

## Changes

| File | Change |
|---|---|
| `upstream/overlays/postgres/kustomization.yaml` | add `namespace: kubeflow` |
| `upstream/options/istio/kustomization.yaml` | add `namespace: kubeflow` |
| `upstream/options/catalog/overlays/demo/kustomization.yaml` | add `namespace: kubeflow` |

No change needed for `options/ui/overlays/istio/kustomization.yaml` — already has `namespace: kubeflow`.

## Design Decision

This matches the pattern used by every other component in `example/kustomization.yaml`:
- **KServe models-web-app**: `overlays/kubeflow/kustomization.yaml` → `namespace: kubeflow`
- **Katib**: `installs/katib-with-kubeflow/kustomization.yaml` → `namespace: kubeflow`
- **Model Registry UI** (already correct): `options/ui/overlays/istio/kustomization.yaml` → `namespace: kubeflow`

## Verification

After this fix, `kustomize build example/` produces all model-registry resources with `namespace: kubeflow` in their metadata, matching runtime behavior in CI and resolving the Istio gateway/service reference errors.

## Contributor Checklist

- [x] DCO sign-off included
- [x] Matches existing codebase patterns
- [x] Minimal scope — only the 3 files that need the fix
- [x] Root cause identified and stated in one sentence

Signed-off-by: Siddhant Jain <siddhantjainofficial26@gmail.com>
