### PR TITLE
Fix ClusterRoleBinding namespace patch operation for workflow controller

### DIFF
--- a/applications/pipeline/upstream/third-party/argo/installs/cluster/workflow-controller-clusterrolebinding-patch.json
+++ b/applications/pipeline/upstream/third-party/argo/installs/cluster/workflow-controller-clusterrolebinding-patch.json
@@ -1,6 +1,6 @@
 [
   {
-    "op": "replace",
+    "op": "add",
     "path": "/subjects/0/namespace",
     "value": "kubeflow"
   }


### PR DESCRIPTION
# ✏️ Summary of Changes

This PR updates the JSON patch operation used in:

```text
applications/pipeline/upstream/third-party/argo/installs/cluster/workflow-controller-clusterrolebinding-patch.json
```

The existing patch uses:

```json
"op": "replace"
```

for:

```text
/subjects/0/namespace
```

In a Kubernetes v1.35 MicroK8s environment, the `namespace` field was absent during patch application, causing the deployment to fail because RFC6902 requires the target path to exist for the `replace` operation.

This PR changes the operation to:

```json
"op": "add"
```

which allows the namespace field to be created when absent and resolves the deployment issue.

The Kubeflow deployment completed successfully after this change.

# 📦 Dependencies

None.

# 🐛 Related Issues

Fixes #3459 

# ✅ Contributor Checklist

* [x] I have tested these changes with kustomize. See [[Installation Prerequisites](https://github.com/kubeflow/manifests#prerequisites)](https://github.com/kubeflow/manifests#prerequisites).
* [x] All commits are [*[signed-off](https://github.com/kubeflow/community/tree/master/dco-signoff-hook#signing-off-commits)*](https://github.com/kubeflow/community/tree/master/dco-signoff-hook#signing-off-commits) to satisfy the DCO check.
* [ ] I have considered adding my company to the adopters page to support Kubeflow and help the community, since I expect help from the community for my issue.

---