### PR TITLE
fix(hub): deploy model registry to user profile namespace instead of default

### DIFF
--- a/.github/workflows/full_kubeflow_integration_test.yaml
+++ b/.github/workflows/full_kubeflow_integration_test.yaml
@@ -202,6 +202,23 @@ jobs:
     - name: Apply Pod Security Standards Restricted
       run: ./tests/PSS_enable.sh restricted
 
+    - name: Verify No Components in Default Namespace
+      run: |
+        echo "==== Checking for leaked resources in default namespace ===="
+        DEFAULT_PODS=$(kubectl get pods -n default --no-headers --ignore-not-found 2>/dev/null | grep -v "^$" | wc -l)
+        if [ "${DEFAULT_PODS}" -gt 0 ]; then
+          echo "ERROR: Found ${DEFAULT_PODS} pod(s) in the default namespace."
+          echo "No Kubeflow component should deploy to the default namespace."
+          echo ""
+          echo "==== Diagnostic dump ===="
+          kubectl get all -n default
+          echo ""
+          echo "==== Pod details ===="
+          kubectl get pods -n default -o wide
+          exit 1
+        fi
+        echo "PASS: default namespace is clean (0 pods)."
+
     - name: Verify Components
       run: kubectl get pods --all-namespaces | grep -E '(Error|CrashLoopBackOff)' && exit 1 || true
 

--- a/.github/workflows/full_kubeflow_integration_test.yaml
+++ b/.github/workflows/full_kubeflow_integration_test.yaml
@@ -202,12 +202,12 @@ jobs:
     - name: Apply Pod Security Standards Restricted
       run: ./tests/PSS_enable.sh restricted
 
-    - name: Verify No Components in Default Namespace
+    - name: Fail if there are resources in the "default" namespace
       run: |
-        echo "==== Checking for leaked resources in default namespace ===="
+        echo "==== Checking for resources in the default namespace ===="
         DEFAULT_PODS=$(kubectl get pods -n default --no-headers --ignore-not-found 2>/dev/null | grep -v "^$" | wc -l)
         if [ "${DEFAULT_PODS}" -gt 0 ]; then
-          echo "ERROR: Found ${DEFAULT_PODS} pod(s) in the default namespace."
+          echo "ERROR: Found ${DEFAULT_PODS} pods in the default namespace."
           echo "No Kubeflow component should deploy to the default namespace."
           echo ""
           echo "==== Diagnostic dump ===="
@@ -217,7 +217,7 @@ jobs:
           kubectl get pods -n default -o wide
           exit 1
         fi
-        echo "PASS: default namespace is clean (0 pods)."
+        echo "PASSED: The default namespace does not contain pods."
 
     - name: Verify Components
       run: kubectl get pods --all-namespaces | grep -E '(Error|CrashLoopBackOff)' && exit 1 || true

--- a/.github/workflows/model_registry_test.yaml
+++ b/.github/workflows/model_registry_test.yaml
@@ -6,8 +6,7 @@ on:
     paths:
     - tests/install_KinD_create_KinD_cluster_install_kustomize.sh
     - .github/workflows/model_registry_test.yaml
-    - applications/hub/upstream/**
-    - applications/hub/overlays/**
+    - applications/hub/**
     - tests/istio*
     - tests/multi_tenancy_install.sh
     - tests/profile_controller_install.sh

--- a/.github/workflows/model_registry_test.yaml
+++ b/.github/workflows/model_registry_test.yaml
@@ -7,6 +7,7 @@ on:
     - tests/install_KinD_create_KinD_cluster_install_kustomize.sh
     - .github/workflows/model_registry_test.yaml
     - applications/hub/upstream/**
+    - applications/hub/overlays/**
     - tests/istio*
     - tests/multi_tenancy_install.sh
     - tests/profile_controller_install.sh

--- a/applications/hub/overlays/kustomization.yaml
+++ b/applications/hub/overlays/kustomization.yaml
@@ -1,0 +1,61 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+namespace: kubeflow-user-example-com
+
+resources:
+- ../upstream/overlays/postgres
+- ../upstream/options/istio
+- ../upstream/options/ui/overlays/istio
+- ../upstream/options/catalog/overlays/demo
+
+patches:
+# Gateway references: Istio resolves gateway names relative to the
+# VirtualService namespace. kubeflow-gateway lives in the kubeflow namespace,
+# so VirtualServices in kubeflow-user-example-com must use the fully-qualified
+# cross-namespace reference.
+- target:
+    group: networking.istio.io
+    version: v1alpha3
+    kind: VirtualService
+    name: model-registry
+  patch: |-
+    - op: replace
+      path: /spec/gateways/0
+      value: kubeflow/kubeflow-gateway
+    - op: replace
+      path: /spec/http/0/route/0/destination/host
+      value: model-registry-service.kubeflow-user-example-com.svc.cluster.local
+- target:
+    group: networking.istio.io
+    version: v1alpha3
+    kind: VirtualService
+    name: model-registry-ui
+  patch: |-
+    - op: replace
+      path: /spec/gateways/0
+      value: kubeflow/kubeflow-gateway
+    - op: replace
+      path: /spec/http/0/route/0/destination/host
+      value: model-registry-ui-service.kubeflow-user-example-com.svc.cluster.local
+
+# Destination host FQDNs: services move to kubeflow-user-example-com with the
+# namespace override. DestinationRule hosts must reference the correct namespace.
+- target:
+    group: networking.istio.io
+    version: v1alpha3
+    kind: DestinationRule
+    name: model-registry-service
+  patch: |-
+    - op: replace
+      path: /spec/host
+      value: model-registry-service.kubeflow-user-example-com.svc.cluster.local
+- target:
+    group: networking.istio.io
+    version: v1alpha3
+    kind: DestinationRule
+    name: model-registry-ui
+  patch: |-
+    - op: replace
+      path: /spec/host
+      value: model-registry-ui-service.kubeflow-user-example-com.svc.cluster.local

--- a/example/kustomization.yaml
+++ b/example/kustomization.yaml
@@ -86,14 +86,8 @@ resources:
 # Spark Operator
 - ../applications/spark/spark-operator/overlays/kubeflow
 
-# Model Registry
-- ../applications/hub/upstream/overlays/postgres
-# Model Registry Istio networking (VirtualService for /api/model_registry/)
-- ../applications/hub/upstream/options/istio
-# Model Registry UI
-- ../applications/hub/upstream/options/ui/overlays/istio
-# Model Catalog (demo)
-- ../applications/hub/upstream/options/catalog/overlays/demo
+# Hub (Model Registry + Model Catalog)
+- ../applications/hub/overlays
 
 # Ray is an experimental integration
 # Here is the documentation for Ray: https://docs.ray.io/en/latest/

--- a/example/kustomization.yaml
+++ b/example/kustomization.yaml
@@ -86,7 +86,7 @@ resources:
 # Spark Operator
 - ../applications/spark/spark-operator/overlays/kubeflow
 
-# Hub (Model Registry + Model Catalog)
+# Hub (Model Registry + UI + Istio resources + Model Catalog)
 - ../applications/hub/overlays
 
 # Ray is an experimental integration

--- a/tests/model_catalog_install.sh
+++ b/tests/model_catalog_install.sh
@@ -3,7 +3,7 @@ set -euxo pipefail
 
 (
     cd applications/hub/upstream/options/catalog/base
-    kustomize build . | kubectl apply -n kubeflow -f -
+    kustomize build . | kubectl apply -n kubeflow-user-example-com -f -
 )
 
-kubectl wait --for=condition=Available deployment/model-catalog-server -n kubeflow --timeout=120s
+kubectl wait --for=condition=Available deployment/model-catalog-server -n kubeflow-user-example-com --timeout=120s

--- a/tests/model_catalog_test.sh
+++ b/tests/model_catalog_test.sh
@@ -2,19 +2,19 @@
 set -euxo pipefail
 
 
-if ! kubectl get deployment/model-catalog-server -n kubeflow; then
+if ! kubectl get deployment/model-catalog-server -n kubeflow-user-example-com; then
     echo "ERROR: Model Catalog deployment not found"
     exit 1
 fi
 
-if ! kubectl get svc/model-catalog -n kubeflow; then
+if ! kubectl get svc/model-catalog -n kubeflow-user-example-com; then
     echo "ERROR: Model Catalog service not found"
     exit 1
 fi
 
-kubectl get pods -n kubeflow -l app.kubernetes.io/name=model-catalog,app.kubernetes.io/component=server
+kubectl get pods -n kubeflow-user-example-com -l app.kubernetes.io/name=model-catalog,app.kubernetes.io/component=server
 
-nohup kubectl port-forward svc/model-catalog -n kubeflow 8082:8080 &
+nohup kubectl port-forward svc/model-catalog -n kubeflow-user-example-com 8082:8080 &
 PORT_FORWARD_PID=$!
 
 MAX_RETRIES=30

--- a/tests/model_registry_install.sh
+++ b/tests/model_registry_install.sh
@@ -9,6 +9,12 @@ set -euxo pipefail
 
 echo "Installing Model Registry components..."
 
+# Fail fast if the profile namespace has not been provisioned
+if ! kubectl get namespace kubeflow-user-example-com >/dev/null 2>&1; then
+    echo "ERROR: namespace kubeflow-user-example-com does not exist. Create a Kubeflow Profile first."
+    exit 1
+fi
+
 # Build and apply all Hub components (Model Registry + Istio + UI + Catalog)
 # The overlay sets namespace: kubeflow-user-example-com and patches Istio
 # gateway references and destination host FQDNs.

--- a/tests/model_registry_install.sh
+++ b/tests/model_registry_install.sh
@@ -3,84 +3,72 @@ set -euxo pipefail
 
 # Install Model Registry server, UI, database, and catalog components
 # This script can be used for local testing without GitHub Actions
-# Prerequisites: kubeflow namespace must exist, kustomize must be installed
+# Prerequisites: kubeflow-user-example-com namespace must exist (created by Profile controller),
+#                kustomize must be installed
 # Usage: ./tests/model_registry_install.sh
 
 echo "Installing Model Registry components..."
 
-# Build and apply Model Registry server with database
-echo "Deploying Model Registry server (with database)..."
-kustomize build applications/hub/upstream/overlays/postgres \
-  | kubectl apply -n kubeflow -f -
-
-# Build and apply Model Registry Istio networking
-echo "Deploying Model Registry Istio resources..."
-kustomize build applications/hub/upstream/options/istio \
-  | kubectl apply -n kubeflow -f -
-
-# Build and apply Model Registry UI with Istio integration
-echo "Deploying Model Registry UI..."
-kustomize build applications/hub/upstream/options/ui/overlays/istio \
-  | kubectl apply -n kubeflow -f -
-
-# Build and apply Model Catalog (demo overlay)
-echo "Deploying Model Catalog..."
-kustomize build applications/hub/upstream/options/catalog/overlays/demo \
-  | kubectl apply -n kubeflow -f -
+# Build and apply all Hub components (Model Registry + Istio + UI + Catalog)
+# The overlay sets namespace: kubeflow-user-example-com and patches Istio
+# gateway references and destination host FQDNs.
+echo "Deploying Hub components to kubeflow-user-example-com..."
+kustomize build applications/hub/overlays \
+  | kubectl apply -f -
 
 # Wait for Model Registry database deployment
 echo "Waiting for Model Registry database to become ready..."
-if ! kubectl wait --for=condition=available -n kubeflow deployment/model-registry-db --timeout=120s; then
+if ! kubectl wait --for=condition=available -n kubeflow-user-example-com deployment/model-registry-db --timeout=120s; then
     echo "ERROR: Model Registry database deployment failed"
-    kubectl get pods -n kubeflow -l component=db
-    kubectl describe deployment/model-registry-db -n kubeflow
-    kubectl logs deployment/model-registry-db -n kubeflow
+    kubectl get pods -n kubeflow-user-example-com -l component=db
+    kubectl describe deployment/model-registry-db -n kubeflow-user-example-com
+    kubectl logs deployment/model-registry-db -n kubeflow-user-example-com
     exit 1
 fi
 
 # Wait for Model Registry server deployment
 echo "Waiting for Model Registry server to become ready..."
-if ! kubectl wait --for=condition=available -n kubeflow deployment/model-registry-deployment --timeout=120s; then
+if ! kubectl wait --for=condition=available -n kubeflow-user-example-com deployment/model-registry-deployment --timeout=120s; then
     echo "ERROR: Model Registry server deployment failed"
-    kubectl get pods -n kubeflow -l component=model-registry-server
-    kubectl describe deployment/model-registry-deployment -n kubeflow
-    kubectl logs deployment/model-registry-deployment -n kubeflow --all-containers
+    kubectl get pods -n kubeflow-user-example-com -l component=model-registry-server
+    kubectl describe deployment/model-registry-deployment -n kubeflow-user-example-com
+    kubectl logs deployment/model-registry-deployment -n kubeflow-user-example-com --all-containers
     exit 1
 fi
 
 # Wait for Model Registry UI deployment
 echo "Waiting for Model Registry UI to become ready..."
-if ! kubectl wait --for=condition=available -n kubeflow deployment/model-registry-ui --timeout=120s; then
+if ! kubectl wait --for=condition=available -n kubeflow-user-example-com deployment/model-registry-ui --timeout=120s; then
     echo "ERROR: Model Registry UI deployment failed"
-    kubectl get pods -n kubeflow -l app=model-registry-ui
-    kubectl describe deployment/model-registry-ui -n kubeflow
-    kubectl logs deployment/model-registry-ui -n kubeflow --all-containers
+    kubectl get pods -n kubeflow-user-example-com -l app=model-registry-ui
+    kubectl describe deployment/model-registry-ui -n kubeflow-user-example-com
+    kubectl logs deployment/model-registry-ui -n kubeflow-user-example-com --all-containers
     exit 1
 fi
 
 # Wait for Model Catalog PostgreSQL StatefulSet
 echo "Waiting for Model Catalog database to become ready..."
-if ! kubectl wait --for=condition=ready -n kubeflow pod \
+if ! kubectl wait --for=condition=ready -n kubeflow-user-example-com pod \
   -l app.kubernetes.io/name=postgres,app.kubernetes.io/part-of=model-catalog \
   --timeout=120s; then
     echo "ERROR: Model Catalog database pod failed"
-    kubectl get pods -n kubeflow -l app.kubernetes.io/part-of=model-catalog
-    kubectl describe statefulset/model-catalog-postgres -n kubeflow
-    kubectl logs statefulset/model-catalog-postgres -n kubeflow
+    kubectl get pods -n kubeflow-user-example-com -l app.kubernetes.io/part-of=model-catalog
+    kubectl describe statefulset/model-catalog-postgres -n kubeflow-user-example-com
+    kubectl logs statefulset/model-catalog-postgres -n kubeflow-user-example-com
     exit 1
 fi
 
 # Wait for Model Catalog server deployment
 echo "Waiting for Model Catalog server to become ready..."
-if ! kubectl wait --for=condition=available -n kubeflow deployment/model-catalog-server --timeout=120s; then
+if ! kubectl wait --for=condition=available -n kubeflow-user-example-com deployment/model-catalog-server --timeout=120s; then
     echo "ERROR: Model Catalog server deployment failed"
-    kubectl get pods -n kubeflow -l app.kubernetes.io/part-of=model-catalog
-    kubectl describe deployment/model-catalog-server -n kubeflow
-    kubectl logs deployment/model-catalog-server -n kubeflow --all-containers
+    kubectl get pods -n kubeflow-user-example-com -l app.kubernetes.io/part-of=model-catalog
+    kubectl describe deployment/model-catalog-server -n kubeflow-user-example-com
+    kubectl logs deployment/model-catalog-server -n kubeflow-user-example-com --all-containers
     exit 1
 fi
 
 echo "Model Registry installation complete!"
-kubectl get pods -n kubeflow -l component=model-registry-server
-kubectl get pods -n kubeflow -l app=model-registry-ui
-kubectl get pods -n kubeflow -l app.kubernetes.io/part-of=model-catalog
+kubectl get pods -n kubeflow-user-example-com -l component=model-registry-server
+kubectl get pods -n kubeflow-user-example-com -l app=model-registry-ui
+kubectl get pods -n kubeflow-user-example-com -l app.kubernetes.io/part-of=model-catalog

--- a/tests/model_registry_test.sh
+++ b/tests/model_registry_test.sh
@@ -23,7 +23,6 @@ PORT_FORWARD_PID=$!
 cleanup_port_forward() {
   if [ -n "$PORT_FORWARD_PID" ]; then
     kill "$PORT_FORWARD_PID" 2>/dev/null
-    wait "$PORT_FORWARD_PID" 2>/dev/null
   fi
 }
 trap cleanup_port_forward EXIT

--- a/tests/model_registry_test.sh
+++ b/tests/model_registry_test.sh
@@ -17,7 +17,17 @@ echo "=== Model Registry Integration Tests ==="
 # enforced here. These tests validate the Model Registry REST API functionality.
 # AuthorizationPolicy enforcement is validated through the gateway tests below.
 echo "Test 1: Direct Model Registry API access..."
-nohup kubectl port-forward svc/model-registry-service -n kubeflow-user-example-com 8081:8080 &
+nohup kubectl port-forward svc/model-registry-service -n kubeflow-user-example-com 8081:8080 >/dev/null 2>&1 &
+PORT_FORWARD_PID=$!
+
+cleanup_port_forward() {
+  if [ -n "$PORT_FORWARD_PID" ]; then
+    kill "$PORT_FORWARD_PID" 2>/dev/null
+    wait "$PORT_FORWARD_PID" 2>/dev/null
+  fi
+}
+trap cleanup_port_forward EXIT
+
 timeout 30s bash -c 'until curl -s localhost:8081 > /dev/null 2>&1; do sleep 1; done'
 
 # ---- Test 2: Create a RegisteredModel ----

--- a/tests/model_registry_test.sh
+++ b/tests/model_registry_test.sh
@@ -17,7 +17,7 @@ echo "=== Model Registry Integration Tests ==="
 # enforced here. These tests validate the Model Registry REST API functionality.
 # AuthorizationPolicy enforcement is validated through the gateway tests below.
 echo "Test 1: Direct Model Registry API access..."
-nohup kubectl port-forward svc/model-registry-service -n kubeflow 8081:8080 &
+nohup kubectl port-forward svc/model-registry-service -n kubeflow-user-example-com 8081:8080 &
 timeout 30s bash -c 'until curl -s localhost:8081 > /dev/null 2>&1; do sleep 1; done'
 
 # ---- Test 2: Create a RegisteredModel ----


### PR DESCRIPTION
## summary

deploys hub (model registry + model catalog) to the user profile namespace (`kubeflow-user-example-com`) instead of `default`. creates a manifests-level overlay with namespace assignment and 6 istio patches. adds a default namespace isolation guard to the full integration test workflow.

fixes #3457

## root cause

[#3318](https://github.com/kubeflow/manifests/pull/3318) added 4 hub upstream references to `example/kustomization.yaml`. three of them had no `namespace:` directive. the continuous integration install script masked this by passing `-n kubeflow` to `kubectl apply`, but the documented single-command install (`kustomize build example | kubectl apply -f -`) deployed everything to `default`.

```
$ kubectl get pod -n default
model-catalog-postgres-0                    1/1     Running
model-catalog-server-895b9c7bb-w9hdv        2/2     Running
model-registry-db-bf6ff894f-m9vns           1/1     Running
model-registry-deployment-fbfc6587f-rkvjv   2/2     Running
```

## why `kubeflow-user-example-com` and not `kubeflow`

per pboyd's direction: model registry must live in the user profile namespace for dashboard integration. deploying to `kubeflow` breaks the dashboard ([hub#1045](https://github.com/kubeflow/hub/issues/1045)). hub upstream must stay namespace-agnostic ([hub#2709](https://github.com/kubeflow/hub/issues/2709) — closed).

## namespace architecture

```mermaid
graph TB
    subgraph cluster["kubernetes cluster"]
        subgraph kf["namespace: kubeflow"]
            gw["kubeflow-gateway<br/>(istio ingress)"]
            dashboard["central dashboard"]
        end

        subgraph user["namespace: kubeflow-user-example-com"]
            subgraph registry["model registry"]
                mr_deploy["model-registry-deployment"]
                mr_db["model-registry-db"]
                mr_ui["model-registry-ui"]
                mr_vs["VirtualService: model-registry"]
                mr_ui_vs["VirtualService: model-registry-ui"]
                mr_dr["DestinationRule: model-registry-service"]
                mr_ui_dr["DestinationRule: model-registry-ui"]
                mr_authz["AuthorizationPolicy"]
            end

            subgraph catalog["model catalog"]
                mc_server["model-catalog-server"]
                mc_postgres["model-catalog-postgres"]
                mc_configmaps["ConfigMaps: sources, perf-data"]
            end
        end

        subgraph def["namespace: default"]
            empty["empty — no kubeflow components"]
        end

        gw -- "patched: kubeflow/kubeflow-gateway" --> mr_vs
        gw -- "patched: kubeflow/kubeflow-gateway" --> mr_ui_vs
        mr_vs --> mr_deploy
        mr_ui_vs --> mr_ui
        mr_deploy --> mr_db
        mc_server --> mc_postgres
    end

    style kf fill:#1a3a5c,stroke:#4a9eff,color:#ffffff
    style user fill:#2d4a1a,stroke:#6abf40,color:#ffffff
    style def fill:#4a1a1a,stroke:#ff4a4a,color:#ffffff
    style registry fill:#1a4a2d,stroke:#40bf6a,color:#ffffff
    style catalog fill:#4a3a1a,stroke:#bf9f40,color:#ffffff
```

**note:** the current upstream [kubeflow/hub](https://github.com/kubeflow/hub) bundles model registry and model catalog as a single kustomize unit. this overlay deploys both to `kubeflow-user-example-com`. per the [hub documentation](https://www.kubeflow.org/docs/components/hub/overview/#what-is-kubeflow-hub), model catalog is a read-only discovery service that should logically be a cluster-wide singleton in `kubeflow`. splitting it into a separate `kubeflow`-namespace deployment is pending maintainer direction (discussed in [this comment](https://github.com/kubeflow/manifests/pull/3475#issuecomment-4530766496)).

## changes

| file | change |
|---|---|
| `applications/hub/overlays/kustomization.yaml` | [NEW] overlay wrapping 4 upstream resources with `namespace: kubeflow-user-example-com` and 4 JSON6902 patch entries (6 operations) |
| `example/kustomization.yaml` | replace 4 upstream paths with single overlay reference |
| `tests/model_registry_install.sh` | use single overlay build, add namespace existence check, update all namespace references to `kubeflow-user-example-com` |
| `tests/model_registry_test.sh` | fix port-forward namespace, add trap-based cleanup |
| `tests/model_catalog_install.sh` | update namespace reference to `kubeflow-user-example-com` |
| `tests/model_catalog_test.sh` | update namespace reference to `kubeflow-user-example-com` |
| `.github/workflows/model_registry_test.yaml` | broaden continuous integration trigger path to `applications/hub/**` |
| `.github/workflows/full_kubeflow_integration_test.yaml` | add default namespace isolation guard that fails continuous integration if any pods exist in `default` |

## istio patches (6 operations across 4 entries)

setting `namespace: kubeflow-user-example-com` moves all resources out of `kubeflow`. six hardcoded istio references break and need patching:

**gateway references (2):** istio resolves gateway names relative to the virtualservice namespace. `kubeflow-gateway` lives in `kubeflow` ([kf-istio-resources.yaml](https://github.com/kubeflow/manifests/blob/master/common/istio/kubeflow-istio-resources/base/kf-istio-resources.yaml)), so virtualservices in `kubeflow-user-example-com` must use `kubeflow/kubeflow-gateway`. this matches [workspaces](https://github.com/kubeflow/manifests/blob/master/applications/workspaces/upstream/istio/kustomization.yaml), [kserve](https://github.com/kubeflow/manifests/blob/master/applications/kserve/models-web-app/overlays/kubeflow/kustomization.yaml), and [notebooks](https://github.com/kubeflow/manifests/blob/master/applications/dashboard/upstream/notebooks-web-app/upstream/overlays/istio/kustomization.yaml).

**destination fully qualified domain names (4):** services move to `kubeflow-user-example-com` with the overlay, so fully qualified domain names change from `.kubeflow.svc.cluster.local` to `.kubeflow-user-example-com.svc.cluster.local`.

| # | resource | field | before | after |
|---|---|---|---|---|
| 1 | VirtualService/model-registry | gateways[0] | kubeflow-gateway | kubeflow/kubeflow-gateway |
| 2 | VirtualService/model-registry-ui | gateways[0] | kubeflow-gateway | kubeflow/kubeflow-gateway |
| 3 | VirtualService/model-registry | destination.host | ...kubeflow.svc... | ...kubeflow-user-example-com.svc... |
| 4 | DestinationRule/model-registry-service | host | ...kubeflow.svc... | ...kubeflow-user-example-com.svc... |
| 5 | VirtualService/model-registry-ui | destination.host | ...kubeflow.svc... | ...kubeflow-user-example-com.svc... |
| 6 | DestinationRule/model-registry-ui | host | ...kubeflow.svc... | ...kubeflow-user-example-com.svc... |

## what is not changed

- no upstream files in `applications/hub/upstream/` modified (hub stays namespace-agnostic)
- no yaml manifests outside the overlay
- authorization policies reference `istio-system` service accounts — namespace-independent, no patch needed

## continuous integration ordering verification

profile namespace `kubeflow-user-example-com` is created before hub install in both continuous integration paths:

- **full integration:** Create KF Profile (step 69) → Install Model Registry (step 91)
- **standalone:** Create KF Profile (step 51) → Install Model Registry (step 54)

cc @pboyd @christian-heusel
