### PR TITLE
fix(hub): split model catalog into kubeflow namespace as cluster-wide singleton

### DIFF
--- a/.github/workflows/full_kubeflow_integration_test.yaml
+++ b/.github/workflows/full_kubeflow_integration_test.yaml
@@ -91,6 +91,9 @@ jobs:
     - name: Install Model Registry
       run: ./tests/model_registry_install.sh
 
+    - name: Install Model Catalog
+      run: ./tests/model_catalog_install.sh
+
     - name: Install Spark
       run: chmod u+x tests/*.sh && ./tests/spark_install.sh
 

--- a/.github/workflows/model_catalog_test.yaml
+++ b/.github/workflows/model_catalog_test.yaml
@@ -4,8 +4,7 @@ on:
     paths:
     - tests/install_KinD_create_KinD_cluster_install_kustomize.sh
     - .github/workflows/model_catalog*
-    - applications/hub/upstream/options/catalog/**
-    - applications/hub/overlays/model-catalog/**
+    - applications/hub/**
     - tests/istio*
     - tests/multi_tenancy_install.sh
     - tests/profile_controller_install.sh

--- a/.github/workflows/model_catalog_test.yaml
+++ b/.github/workflows/model_catalog_test.yaml
@@ -5,6 +5,7 @@ on:
     - tests/install_KinD_create_KinD_cluster_install_kustomize.sh
     - .github/workflows/model_catalog*
     - applications/hub/upstream/options/catalog/**
+    - applications/hub/overlays/model-catalog/**
     - tests/istio*
     - tests/multi_tenancy_install.sh
     - tests/profile_controller_install.sh

--- a/applications/hub/overlays/model-catalog/kustomization.yaml
+++ b/applications/hub/overlays/model-catalog/kustomization.yaml
@@ -1,0 +1,10 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+# Model Catalog is a read-only discovery service that aggregates external model
+# sources. It is a cluster-wide singleton deployed to the kubeflow namespace,
+# unlike Model Registry which is per-tenant in the user profile namespace.
+namespace: kubeflow
+
+resources:
+- ../../upstream/options/catalog/overlays/demo

--- a/applications/hub/overlays/model-catalog/kustomization.yaml
+++ b/applications/hub/overlays/model-catalog/kustomization.yaml
@@ -1,9 +1,6 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 
-# Model Catalog is a read-only discovery service that aggregates external model
-# sources. It is a cluster-wide singleton deployed to the kubeflow namespace,
-# unlike Model Registry which is per-tenant in the user profile namespace.
 namespace: kubeflow
 
 resources:

--- a/applications/hub/overlays/model-registry/kustomization.yaml
+++ b/applications/hub/overlays/model-registry/kustomization.yaml
@@ -4,10 +4,9 @@ kind: Kustomization
 namespace: kubeflow-user-example-com
 
 resources:
-- ../upstream/overlays/postgres
-- ../upstream/options/istio
-- ../upstream/options/ui/overlays/istio
-- ../upstream/options/catalog/overlays/demo
+- ../../upstream/overlays/postgres
+- ../../upstream/options/istio
+- ../../upstream/options/ui/overlays/istio
 
 patches:
 # Gateway references: Istio resolves gateway names relative to the

--- a/example/kustomization.yaml
+++ b/example/kustomization.yaml
@@ -86,8 +86,10 @@ resources:
 # Spark Operator
 - ../applications/spark/spark-operator/overlays/kubeflow
 
-# Hub (Model Registry + UI + Istio resources + Model Catalog)
-- ../applications/hub/overlays
+# Hub — Model Registry (per-tenant: deployed to user profile namespace)
+- ../applications/hub/overlays/model-registry
+# Hub — Model Catalog (cluster-wide singleton: deployed to kubeflow namespace)
+- ../applications/hub/overlays/model-catalog
 
 # Ray is an experimental integration
 # Here is the documentation for Ray: https://docs.ray.io/en/latest/

--- a/tests/model_catalog_install.sh
+++ b/tests/model_catalog_install.sh
@@ -8,17 +8,17 @@ kustomize build applications/hub/overlays/model-catalog \
 if ! kubectl wait --for=condition=ready -n kubeflow pod \
   -l app.kubernetes.io/name=postgres,app.kubernetes.io/part-of=model-catalog \
   --timeout=120s; then
-    kubectl get pods -n kubeflow -l app.kubernetes.io/part-of=model-catalog || true
-    kubectl describe statefulset/model-catalog-postgres -n kubeflow || true
-    kubectl logs statefulset/model-catalog-postgres -n kubeflow || true
+    kubectl get pods -n kubeflow -l app.kubernetes.io/part-of=model-catalog
+    kubectl describe statefulset/model-catalog-postgres -n kubeflow
+    kubectl logs statefulset/model-catalog-postgres -n kubeflow
     exit 1
 fi
 
 # Wait for catalog server
 if ! kubectl wait --for=condition=available -n kubeflow deployment/model-catalog-server --timeout=120s; then
-    kubectl get pods -n kubeflow -l app.kubernetes.io/part-of=model-catalog || true
-    kubectl describe deployment/model-catalog-server -n kubeflow || true
-    kubectl logs deployment/model-catalog-server -n kubeflow --all-containers || true
+    kubectl get pods -n kubeflow -l app.kubernetes.io/part-of=model-catalog
+    kubectl describe deployment/model-catalog-server -n kubeflow
+    kubectl logs deployment/model-catalog-server -n kubeflow --all-containers
     exit 1
 fi
 

--- a/tests/model_catalog_install.sh
+++ b/tests/model_catalog_install.sh
@@ -1,9 +1,46 @@
 #!/bin/bash
 set -euxo pipefail
 
-(
-    cd applications/hub/upstream/options/catalog/base
-    kustomize build . | kubectl apply -n kubeflow-user-example-com -f -
-)
+# Install Model Catalog as a cluster-wide singleton in the kubeflow namespace
+# This script can be used for local testing without GitHub Actions
+# Prerequisites: kubeflow namespace must exist, kustomize must be installed
+# Usage: ./tests/model_catalog_install.sh
 
-kubectl wait --for=condition=Available deployment/model-catalog-server -n kubeflow-user-example-com --timeout=120s
+echo "Installing Model Catalog components..."
+
+# Fail fast if the kubeflow namespace has not been provisioned
+if ! kubectl get namespace kubeflow >/dev/null 2>&1; then
+    echo "ERROR: namespace kubeflow does not exist."
+    exit 1
+fi
+
+# Build and apply Model Catalog components (server + database)
+# The overlay sets namespace: kubeflow for cluster-wide singleton deployment.
+echo "Deploying Model Catalog components to kubeflow..."
+kustomize build applications/hub/overlays/model-catalog \
+  | kubectl apply -f -
+
+# Wait for Model Catalog PostgreSQL StatefulSet
+echo "Waiting for Model Catalog database to become ready..."
+if ! kubectl wait --for=condition=ready -n kubeflow pod \
+  -l app.kubernetes.io/name=postgres,app.kubernetes.io/part-of=model-catalog \
+  --timeout=120s; then
+    echo "ERROR: Model Catalog database pod failed"
+    kubectl get pods -n kubeflow -l app.kubernetes.io/part-of=model-catalog
+    kubectl describe statefulset/model-catalog-postgres -n kubeflow
+    kubectl logs statefulset/model-catalog-postgres -n kubeflow
+    exit 1
+fi
+
+# Wait for Model Catalog server deployment
+echo "Waiting for Model Catalog server to become ready..."
+if ! kubectl wait --for=condition=available -n kubeflow deployment/model-catalog-server --timeout=120s; then
+    echo "ERROR: Model Catalog server deployment failed"
+    kubectl get pods -n kubeflow -l app.kubernetes.io/part-of=model-catalog
+    kubectl describe deployment/model-catalog-server -n kubeflow
+    kubectl logs deployment/model-catalog-server -n kubeflow --all-containers
+    exit 1
+fi
+
+echo "Model Catalog installation complete!"
+kubectl get pods -n kubeflow -l app.kubernetes.io/part-of=model-catalog

--- a/tests/model_catalog_install.sh
+++ b/tests/model_catalog_install.sh
@@ -1,46 +1,25 @@
 #!/bin/bash
 set -euxo pipefail
 
-# Install Model Catalog as a cluster-wide singleton in the kubeflow namespace
-# This script can be used for local testing without GitHub Actions
-# Prerequisites: kubeflow namespace must exist, kustomize must be installed
-# Usage: ./tests/model_catalog_install.sh
-
-echo "Installing Model Catalog components..."
-
-# Fail fast if the kubeflow namespace has not been provisioned
-if ! kubectl get namespace kubeflow >/dev/null 2>&1; then
-    echo "ERROR: namespace kubeflow does not exist."
-    exit 1
-fi
-
-# Build and apply Model Catalog components (server + database)
-# The overlay sets namespace: kubeflow for cluster-wide singleton deployment.
-echo "Deploying Model Catalog components to kubeflow..."
 kustomize build applications/hub/overlays/model-catalog \
   | kubectl apply -f -
 
-# Wait for Model Catalog PostgreSQL StatefulSet
-echo "Waiting for Model Catalog database to become ready..."
+# Wait for catalog database
 if ! kubectl wait --for=condition=ready -n kubeflow pod \
   -l app.kubernetes.io/name=postgres,app.kubernetes.io/part-of=model-catalog \
   --timeout=120s; then
-    echo "ERROR: Model Catalog database pod failed"
     kubectl get pods -n kubeflow -l app.kubernetes.io/part-of=model-catalog || true
     kubectl describe statefulset/model-catalog-postgres -n kubeflow || true
     kubectl logs statefulset/model-catalog-postgres -n kubeflow || true
     exit 1
 fi
 
-# Wait for Model Catalog server deployment
-echo "Waiting for Model Catalog server to become ready..."
+# Wait for catalog server
 if ! kubectl wait --for=condition=available -n kubeflow deployment/model-catalog-server --timeout=120s; then
-    echo "ERROR: Model Catalog server deployment failed"
     kubectl get pods -n kubeflow -l app.kubernetes.io/part-of=model-catalog || true
     kubectl describe deployment/model-catalog-server -n kubeflow || true
     kubectl logs deployment/model-catalog-server -n kubeflow --all-containers || true
     exit 1
 fi
 
-echo "Model Catalog installation complete!"
 kubectl get pods -n kubeflow -l app.kubernetes.io/part-of=model-catalog

--- a/tests/model_catalog_install.sh
+++ b/tests/model_catalog_install.sh
@@ -26,9 +26,9 @@ if ! kubectl wait --for=condition=ready -n kubeflow pod \
   -l app.kubernetes.io/name=postgres,app.kubernetes.io/part-of=model-catalog \
   --timeout=120s; then
     echo "ERROR: Model Catalog database pod failed"
-    kubectl get pods -n kubeflow -l app.kubernetes.io/part-of=model-catalog
-    kubectl describe statefulset/model-catalog-postgres -n kubeflow
-    kubectl logs statefulset/model-catalog-postgres -n kubeflow
+    kubectl get pods -n kubeflow -l app.kubernetes.io/part-of=model-catalog || true
+    kubectl describe statefulset/model-catalog-postgres -n kubeflow || true
+    kubectl logs statefulset/model-catalog-postgres -n kubeflow || true
     exit 1
 fi
 
@@ -36,9 +36,9 @@ fi
 echo "Waiting for Model Catalog server to become ready..."
 if ! kubectl wait --for=condition=available -n kubeflow deployment/model-catalog-server --timeout=120s; then
     echo "ERROR: Model Catalog server deployment failed"
-    kubectl get pods -n kubeflow -l app.kubernetes.io/part-of=model-catalog
-    kubectl describe deployment/model-catalog-server -n kubeflow
-    kubectl logs deployment/model-catalog-server -n kubeflow --all-containers
+    kubectl get pods -n kubeflow -l app.kubernetes.io/part-of=model-catalog || true
+    kubectl describe deployment/model-catalog-server -n kubeflow || true
+    kubectl logs deployment/model-catalog-server -n kubeflow --all-containers || true
     exit 1
 fi
 

--- a/tests/model_catalog_test.sh
+++ b/tests/model_catalog_test.sh
@@ -1,12 +1,6 @@
 #!/bin/bash
 set -euxo pipefail
 
-# Test Model Catalog API in the kubeflow namespace (cluster-wide singleton)
-# Prerequisites: Model Catalog installed (run model_catalog_install.sh first)
-# Usage: ./tests/model_catalog_test.sh
-
-echo "=== Model Catalog Integration Tests ==="
-
 if ! kubectl get deployment/model-catalog-server -n kubeflow; then
     echo "ERROR: Model Catalog deployment not found"
     exit 1
@@ -52,6 +46,3 @@ else
     echo "ERROR: Model Catalog API returned unexpected status code: $HTTP_CODE"
     exit 1
 fi
-
-echo ""
-echo "=== All Model Catalog tests passed! ==="

--- a/tests/model_catalog_test.sh
+++ b/tests/model_catalog_test.sh
@@ -1,21 +1,33 @@
 #!/bin/bash
 set -euxo pipefail
 
+# Test Model Catalog API in the kubeflow namespace (cluster-wide singleton)
+# Prerequisites: Model Catalog installed (run model_catalog_install.sh first)
+# Usage: ./tests/model_catalog_test.sh
 
-if ! kubectl get deployment/model-catalog-server -n kubeflow-user-example-com; then
+echo "=== Model Catalog Integration Tests ==="
+
+if ! kubectl get deployment/model-catalog-server -n kubeflow; then
     echo "ERROR: Model Catalog deployment not found"
     exit 1
 fi
 
-if ! kubectl get svc/model-catalog -n kubeflow-user-example-com; then
+if ! kubectl get svc/model-catalog -n kubeflow; then
     echo "ERROR: Model Catalog service not found"
     exit 1
 fi
 
-kubectl get pods -n kubeflow-user-example-com -l app.kubernetes.io/name=model-catalog,app.kubernetes.io/component=server
+kubectl get pods -n kubeflow -l app.kubernetes.io/name=model-catalog,app.kubernetes.io/component=server
 
-nohup kubectl port-forward svc/model-catalog -n kubeflow-user-example-com 8082:8080 &
+nohup kubectl port-forward svc/model-catalog -n kubeflow 8082:8080 &
 PORT_FORWARD_PID=$!
+
+cleanup_port_forward() {
+  if [ -n "$PORT_FORWARD_PID" ]; then
+    kill "$PORT_FORWARD_PID" 2>/dev/null
+  fi
+}
+trap cleanup_port_forward EXIT
 
 MAX_RETRIES=30
 RETRY_COUNT=0
@@ -25,7 +37,6 @@ while ! curl -s localhost:8082 > /dev/null; do
     RETRY_COUNT=$((RETRY_COUNT + 1))
     if [ $RETRY_COUNT -ge $MAX_RETRIES ]; then
         echo "ERROR: Port-forwarding failed to become ready"
-        kill $PORT_FORWARD_PID 2>/dev/null 
         exit 1
     fi
 done
@@ -38,10 +49,8 @@ if [ "$HTTP_CODE" -eq 200 ] || [ "$HTTP_CODE" -eq 404 ]; then
     echo "Model Catalog API is responding (HTTP $HTTP_CODE)"
 else
     echo "ERROR: Model Catalog API returned unexpected status code: $HTTP_CODE"
-    kill $PORT_FORWARD_PID 2>/dev/null 
     exit 1
 fi
 
-kill $PORT_FORWARD_PID 2>/dev/null 
-
-
+echo ""
+echo "=== All Model Catalog tests passed! ==="

--- a/tests/model_catalog_test.sh
+++ b/tests/model_catalog_test.sh
@@ -18,8 +18,8 @@ PORT_FORWARD_PID=$!
 
 cleanup_port_forward() {
   if [ -n "$PORT_FORWARD_PID" ]; then
-    kill "$PORT_FORWARD_PID" 2>/dev/null || true
-    wait "$PORT_FORWARD_PID" 2>/dev/null || true
+    kill "$PORT_FORWARD_PID" 2>/dev/null
+    wait "$PORT_FORWARD_PID" 2>/dev/null
   fi
 }
 trap cleanup_port_forward EXIT

--- a/tests/model_catalog_test.sh
+++ b/tests/model_catalog_test.sh
@@ -24,7 +24,8 @@ PORT_FORWARD_PID=$!
 
 cleanup_port_forward() {
   if [ -n "$PORT_FORWARD_PID" ]; then
-    kill "$PORT_FORWARD_PID" 2>/dev/null
+    kill "$PORT_FORWARD_PID" 2>/dev/null || true
+    wait "$PORT_FORWARD_PID" 2>/dev/null || true
   fi
 }
 trap cleanup_port_forward EXIT

--- a/tests/model_catalog_test.sh
+++ b/tests/model_catalog_test.sh
@@ -16,14 +16,6 @@ kubectl get pods -n kubeflow -l app.kubernetes.io/name=model-catalog,app.kuberne
 nohup kubectl port-forward svc/model-catalog -n kubeflow 8082:8080 &
 PORT_FORWARD_PID=$!
 
-cleanup_port_forward() {
-  if [ -n "$PORT_FORWARD_PID" ]; then
-    kill "$PORT_FORWARD_PID" 2>/dev/null
-    wait "$PORT_FORWARD_PID" 2>/dev/null
-  fi
-}
-trap cleanup_port_forward EXIT
-
 MAX_RETRIES=30
 RETRY_COUNT=0
 while ! curl -s localhost:8082 > /dev/null; do

--- a/tests/model_catalog_test.sh
+++ b/tests/model_catalog_test.sh
@@ -16,6 +16,14 @@ kubectl get pods -n kubeflow -l app.kubernetes.io/name=model-catalog,app.kuberne
 nohup kubectl port-forward svc/model-catalog -n kubeflow 8082:8080 &
 PORT_FORWARD_PID=$!
 
+cleanup_port_forward() {
+  if [ -n "$PORT_FORWARD_PID" ]; then
+    kill "$PORT_FORWARD_PID" 2>/dev/null || true
+    wait "$PORT_FORWARD_PID" 2>/dev/null || true
+  fi
+}
+trap cleanup_port_forward EXIT
+
 MAX_RETRIES=30
 RETRY_COUNT=0
 while ! curl -s localhost:8082 > /dev/null; do

--- a/tests/model_registry_install.sh
+++ b/tests/model_registry_install.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 set -euxo pipefail
 
-# Install Model Registry server, UI, database, and catalog components
+# Install Model Registry server, UI, database, and Istio components
 # This script can be used for local testing without GitHub Actions
 # Prerequisites: kubeflow-user-example-com namespace must exist (created by Profile controller),
 #                kustomize must be installed
@@ -15,11 +15,11 @@ if ! kubectl get namespace kubeflow-user-example-com >/dev/null 2>&1; then
     exit 1
 fi
 
-# Build and apply all Hub components (Model Registry + Istio + UI + Catalog)
+# Build and apply Model Registry components (server + database + UI + Istio)
 # The overlay sets namespace: kubeflow-user-example-com and patches Istio
 # gateway references and destination host FQDNs.
-echo "Deploying Hub components to kubeflow-user-example-com..."
-kustomize build applications/hub/overlays \
+echo "Deploying Model Registry components to kubeflow-user-example-com..."
+kustomize build applications/hub/overlays/model-registry \
   | kubectl apply -f -
 
 # Wait for Model Registry database deployment
@@ -52,29 +52,6 @@ if ! kubectl wait --for=condition=available -n kubeflow-user-example-com deploym
     exit 1
 fi
 
-# Wait for Model Catalog PostgreSQL StatefulSet
-echo "Waiting for Model Catalog database to become ready..."
-if ! kubectl wait --for=condition=ready -n kubeflow-user-example-com pod \
-  -l app.kubernetes.io/name=postgres,app.kubernetes.io/part-of=model-catalog \
-  --timeout=120s; then
-    echo "ERROR: Model Catalog database pod failed"
-    kubectl get pods -n kubeflow-user-example-com -l app.kubernetes.io/part-of=model-catalog
-    kubectl describe statefulset/model-catalog-postgres -n kubeflow-user-example-com
-    kubectl logs statefulset/model-catalog-postgres -n kubeflow-user-example-com
-    exit 1
-fi
-
-# Wait for Model Catalog server deployment
-echo "Waiting for Model Catalog server to become ready..."
-if ! kubectl wait --for=condition=available -n kubeflow-user-example-com deployment/model-catalog-server --timeout=120s; then
-    echo "ERROR: Model Catalog server deployment failed"
-    kubectl get pods -n kubeflow-user-example-com -l app.kubernetes.io/part-of=model-catalog
-    kubectl describe deployment/model-catalog-server -n kubeflow-user-example-com
-    kubectl logs deployment/model-catalog-server -n kubeflow-user-example-com --all-containers
-    exit 1
-fi
-
 echo "Model Registry installation complete!"
 kubectl get pods -n kubeflow-user-example-com -l component=model-registry-server
 kubectl get pods -n kubeflow-user-example-com -l app=model-registry-ui
-kubectl get pods -n kubeflow-user-example-com -l app.kubernetes.io/part-of=model-catalog

--- a/tests/model_registry_install.sh
+++ b/tests/model_registry_install.sh
@@ -1,57 +1,37 @@
 #!/bin/bash
 set -euxo pipefail
 
-# Install Model Registry server, UI, database, and Istio components
-# This script can be used for local testing without GitHub Actions
-# Prerequisites: kubeflow-user-example-com namespace must exist (created by Profile controller),
-#                kustomize must be installed
-# Usage: ./tests/model_registry_install.sh
-
-echo "Installing Model Registry components..."
-
-# Fail fast if the profile namespace has not been provisioned
 if ! kubectl get namespace kubeflow-user-example-com >/dev/null 2>&1; then
     echo "ERROR: namespace kubeflow-user-example-com does not exist. Create a Kubeflow Profile first."
     exit 1
 fi
 
-# Build and apply Model Registry components (server + database + UI + Istio)
-# The overlay sets namespace: kubeflow-user-example-com and patches Istio
-# gateway references and destination host FQDNs.
-echo "Deploying Model Registry components to kubeflow-user-example-com..."
 kustomize build applications/hub/overlays/model-registry \
   | kubectl apply -f -
 
-# Wait for Model Registry database deployment
-echo "Waiting for Model Registry database to become ready..."
+# Wait for registry database
 if ! kubectl wait --for=condition=available -n kubeflow-user-example-com deployment/model-registry-db --timeout=120s; then
-    echo "ERROR: Model Registry database deployment failed"
     kubectl get pods -n kubeflow-user-example-com -l component=db
     kubectl describe deployment/model-registry-db -n kubeflow-user-example-com
     kubectl logs deployment/model-registry-db -n kubeflow-user-example-com
     exit 1
 fi
 
-# Wait for Model Registry server deployment
-echo "Waiting for Model Registry server to become ready..."
+# Wait for registry server
 if ! kubectl wait --for=condition=available -n kubeflow-user-example-com deployment/model-registry-deployment --timeout=120s; then
-    echo "ERROR: Model Registry server deployment failed"
     kubectl get pods -n kubeflow-user-example-com -l component=model-registry-server
     kubectl describe deployment/model-registry-deployment -n kubeflow-user-example-com
     kubectl logs deployment/model-registry-deployment -n kubeflow-user-example-com --all-containers
     exit 1
 fi
 
-# Wait for Model Registry UI deployment
-echo "Waiting for Model Registry UI to become ready..."
+# Wait for registry UI
 if ! kubectl wait --for=condition=available -n kubeflow-user-example-com deployment/model-registry-ui --timeout=120s; then
-    echo "ERROR: Model Registry UI deployment failed"
     kubectl get pods -n kubeflow-user-example-com -l app=model-registry-ui
     kubectl describe deployment/model-registry-ui -n kubeflow-user-example-com
     kubectl logs deployment/model-registry-ui -n kubeflow-user-example-com --all-containers
     exit 1
 fi
 
-echo "Model Registry installation complete!"
 kubectl get pods -n kubeflow-user-example-com -l component=model-registry-server
 kubectl get pods -n kubeflow-user-example-com -l app=model-registry-ui


### PR DESCRIPTION
## summary

splits the combined hub overlay into two: model registry stays in `kubeflow-user-example-com` (per-tenant), model catalog moves to `kubeflow` (cluster-wide singleton). follow-up to #3475 per julius's direction.

fixes the architectural concern raised in #3475 — model catalog is a read-only discovery service that aggregates external sources and should not be duplicated per tenant.

## root cause

pr #3475 deployed both model registry and model catalog to `kubeflow-user-example-com` via a single overlay with `namespace: kubeflow-user-example-com`. this was correct for model registry (per-tenant metadata store) but incorrect for model catalog (cluster-wide read-only singleton). the upstream hub packages both as a single kustomize unit, so splitting required a second overlay.

## namespace architecture

```
┌─────────────────────────────────────────────────────────┐
│  kubeflow namespace (cluster-wide services)             │
│                                                         │
│  ┌────────────────────────┐  ┌───────────────────────┐  │
│  │ model-catalog-server   │  │ model-catalog-postgres │  │
│  │ (read-only discovery)  │  │ (catalog database)     │  │
│  └────────────────────────┘  └───────────────────────┘  │
└─────────────────────────────────────────────────────────┘

┌─────────────────────────────────────────────────────────┐
│  kubeflow-user-example-com namespace (per-tenant)       │
│                                                         │
│  ┌─────────────────────┐  ┌──────────────────────────┐  │
│  │ model-registry-     │  │ model-registry-db        │  │
│  │ deployment           │  │ (user metadata store)    │  │
│  └─────────────────────┘  └──────────────────────────┘  │
│  ┌─────────────────────┐                                │
│  │ model-registry-ui   │  + istio VirtualServices,     │
│  │                     │    DestinationRules,           │
│  └─────────────────────┘    AuthorizationPolicy         │
└─────────────────────────────────────────────────────────┘
```

## why this split is safe

- model catalog has **zero** istio resources (no VirtualService, no DestinationRule) — no istio patches needed for the kubeflow namespace deployment
- model catalog's `PGHOST` env var references `model-catalog-postgres` (same-namespace service dns) — self-contained, no cross-namespace database dependency
- model catalog and model registry have **zero** runtime cross-dependencies — catalog is a standalone read-only aggregator
- no upstream files modified

## changes

| file | change |
|---|---|
| `applications/hub/overlays/kustomization.yaml` | **DELETED** — replaced by two split overlays |
| `applications/hub/overlays/model-registry/kustomization.yaml` | **NEW** — model registry + UI + istio, `namespace: kubeflow-user-example-com`, all 4 istio patch entries (6 operations) preserved |
| `applications/hub/overlays/model-catalog/kustomization.yaml` | **NEW** — model catalog only, `namespace: kubeflow`, no patches needed |
| `example/kustomization.yaml` | single overlay reference replaced with two separate references |
| `tests/model_registry_install.sh` | build path updated to `model-registry/`, catalog install sections removed (handled by `model_catalog_install.sh`) |
| `tests/model_catalog_install.sh` | rewritten to use the new `model-catalog` overlay, namespace changed to `kubeflow`, added diagnostic output on failure |
| `tests/model_catalog_test.sh` | all namespace references changed from `kubeflow-user-example-com` to `kubeflow`, added trap-based port-forward cleanup |
| `.github/workflows/model_catalog_test.yaml` | added `applications/hub/overlays/model-catalog/**` to ci trigger paths |
| `.github/workflows/full_kubeflow_integration_test.yaml` | added `Install Model Catalog` step after `Install Model Registry` — catalog is no longer installed by the registry script |

## what is not changed

- no upstream files in `applications/hub/upstream/` modified
- all 6 istio patch operations preserved identically in the model-registry overlay
- model registry test scripts and ci workflow unchanged (registry namespace stays `kubeflow-user-example-com`)
- authorization policies reference istio-system service accounts — namespace-independent, no patch needed

## local build verification

```
$ kubectl kustomize applications/hub/overlays/model-registry | grep "namespace:" | sort -u
  namespace: kubeflow-user-example-com

$ kubectl kustomize applications/hub/overlays/model-catalog | grep "namespace:" | sort -u
  namespace: kubeflow
```

cc @juliusvonkohout
