### PR TITLE
helm: synCHRONIZE kserve models web app chart

### DIFF
--- a/experimental/helm/charts/kserve-models-web-app/Chart.yaml
+++ b/experimental/helm/charts/kserve-models-web-app/Chart.yaml
@@ -4,7 +4,7 @@ name: kserve-models-web-application
 
 description: A Helm chart for KServe Models Web App - Model serving management UI on Kubernetes
 
-version: 0.1.0
+version: 0.1.1
 
 appVersion: v0.18.0
 

--- a/experimental/helm/charts/kserve-models-web-app/Chart.yaml
+++ b/experimental/helm/charts/kserve-models-web-app/Chart.yaml
@@ -6,7 +6,7 @@ description: A Helm chart for KServe Models Web App - Model serving management U
 
 version: 0.1.0
 
-appVersion: v0.16.1
+appVersion: v0.18.0
 
 home: https://github.com/kserve/kserve
 

--- a/experimental/helm/charts/kserve-models-web-app/templates/istio/virtualservice.yaml
+++ b/experimental/helm/charts/kserve-models-web-app/templates/istio/virtualservice.yaml
@@ -5,8 +5,8 @@ metadata:
   name: {{ include "kserve-models-web-app.virtualServiceName" . }}
   namespace: {{ include "kserve-models-web-app.namespace" . }}
   labels:
-    {{- include "kserve-models-web-app.labels" . | nindent 4 }}
-    {{- include "kserve-models-web-app.kustomizeLabels" . | nindent 4 }}
+    helm.sh/chart: {{ include "kserve-models-web-app.chart" . }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
     {{- if .Values.kubeflow.enabled }}
     {{- include "kserve-models-web-app.kserveLabels" . | nindent 4 }}
     {{- end }}
@@ -41,4 +41,4 @@ spec:
         port:
           number: {{ .Values.service.port }}
   {{- end }}
-{{- end }} 
+{{- end }}

--- a/experimental/helm/charts/kserve-models-web-app/templates/rbac/clusterrole.yaml
+++ b/experimental/helm/charts/kserve-models-web-app/templates/rbac/clusterrole.yaml
@@ -33,6 +33,8 @@ rules:
   - inferenceservices/status
   - inferencegraphs
   - inferencegraphs/status
+  - trainedmodels
+  - trainedmodels/status
   verbs:
   - get
   - list

--- a/experimental/helm/charts/kserve-models-web-app/values.yaml
+++ b/experimental/helm/charts/kserve-models-web-app/values.yaml
@@ -19,7 +19,7 @@ global:
   # -- Image registry for KServe Models Web App images
   imageRegistry: ghcr.io/kserve
   # -- Global image tag for KServe Models Web App
-  imageTag: 0.16.1
+  imageTag: 0.18.0
   # -- Global image pull policy
   imagePullPolicy: Always
   # -- Global image pull secrets


### PR DESCRIPTION
# Pull Request Template for Kubeflow Manifests

## ✏️ Summary of Changes
This PR syncs `experimental/helm/charts/kserve-models-web-app` with the Kustomize models web app update merged in #3477.

It updates the Helm chart to render the current Kustomize shape:

- `ghcr.io/kserve/models-web-app:0.18.0`
- `trainedmodels` and `trainedmodels/status` RBAC resources
- VirtualService labels aligned with the updated Kustomize component output

This fixes the current `Compare All Scenarios` baseline failure for `kserve-models-web-app`, which is blocking unrelated Helm chart PRs because the workflow runs all registered comparison scenarios.

## 📦 Dependencies
Related to #3477.

This unblocks the shared Helm comparison workflow for unrelated Helm PRs such as #3478, #3479, and #3480.

## 🐛 Related Issues
Part of #3423.

## ✅ Contributor Checklist
  - [x] I have tested these changes with kustomize. See [Installation Prerequisites](https://github.com/kubeflow/manifests#prerequisites).
  - [x] All commits are [_signed-off_](https://github.com/kubeflow/community/tree/master/dco-signoff-hook#signing-off-commits) to satisfy the DCO check.
  - [ ] I have considered adding my company to the adopters page to support Kubeflow and help the community, since I expect help from the community for my issue (see [1.](https://github.com/kubeflow/community/issues/833) and [2.](https://github.com/kubeflow/community/blob/master/ADOPTERS.md#adopters-of-kubeflow-platform)).

## Validation

```bash
helm lint experimental/helm/charts/kserve-models-web-app
./tests/helm_kustomize_compare.sh kserve-models-web-app base
./tests/helm_kustomize_compare.sh kserve-models-web-app kubeflow
./tests/helm_kustomize_compare_all.sh
git diff --check
```

All commands passed locally.
