### PR TITLE
Synchronize cert-manager manifests to v1.20.2

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,7 +81,7 @@ This repository periodically synchronizes all official Kubeflow components from 
 | Spark Operator	|	applications/spark/spark-operator	|	[2.5.0](https://github.com/kubeflow/spark-operator/tree/v2.5.0) | 9m | 41Mi | 0GB |
 | Istio | common/istio | [1.30.0](https://github.com/istio/istio/releases/tag/1.30.0) | 750m | 2364Mi | 0GB |
 | Knative | common/knative/knative-serving <br /> common/knative/knative-eventing | [v1.22.0](https://github.com/knative/serving/releases/tag/knative-v1.22.0) <br /> [v1.22.0](https://github.com/knative/eventing/releases/tag/knative-v1.22.0) | 1450m | 1038Mi | 0GB |
-| Cert Manager | common/cert-manager | [1.19.4](https://github.com/cert-manager/cert-manager/releases/tag/v1.19.4) | 3m | 128Mi | 0GB |
+| Cert Manager | common/cert-manager | [1.20.2](https://github.com/cert-manager/cert-manager/releases/tag/v1.20.2) | 3m | 128Mi | 0GB |
 | Dex | common/dex | [2.45.1](https://github.com/dexidp/dex/releases/tag/v2.45.1) | 3m | 27Mi | 0GB |
 | OAuth2-Proxy | common/oauth2-proxy | [7.14.3](https://github.com/oauth2-proxy/oauth2-proxy/releases/tag/v7.14.3) | 3m | 27Mi | 0GB |
 | **Total** | | | **4380m** | **12341Mi** | **65GB** |

--- a/common/cert-manager/base/upstream/cert-manager.yaml
+++ b/common/cert-manager/base/upstream/cert-manager.yaml
@@ -30,7 +30,7 @@ metadata:
     app.kubernetes.io/name: "cert-manager"
     app.kubernetes.io/instance: "cert-manager"
     app.kubernetes.io/component: "crds"
-    app.kubernetes.io/version: "v1.19.4"
+    app.kubernetes.io/version: "v1.20.2"
 spec:
   group: acme.cert-manager.io
   names:
@@ -305,6 +305,22 @@ spec:
                                 The TenantID of the Azure Service Principal used to authenticate with Azure DNS.
                                 If set, ClientID and ClientSecret must also be set.
                               type: string
+                            zoneType:
+                              description: |-
+                                ZoneType determines which type of Azure DNS zone to use.
+
+                                Valid values are:
+                                  - AzurePublicZone  (default): Use a public Azure DNS zone.
+                                  - AzurePrivateZone: Use an Azure Private DNS zone.
+
+                                If not specified, AzurePublicZone is used.
+
+                                Support for Azure Private DNS zones is currently
+                                experimental and may change in future releases.
+                              enum:
+                                - AzurePublicZone
+                                - AzurePrivateZone
+                              type: string
                           required:
                             - resourceGroupName
                             - subscriptionID
@@ -428,7 +444,7 @@ spec:
                               description: |-
                                 The IP address or hostname of an authoritative DNS server supporting
                                 RFC2136 in the form host:port. If the host is an IPv6 address it must be
-                                enclosed in square brackets (e.g [2001:db8::1]) ; port is optional.
+                                enclosed in square brackets (e.g [2001:db8::1]); port is optional.
                                 This field is required.
                               type: string
                             protocol:
@@ -478,8 +494,8 @@ spec:
                               description: |-
                                 The AccessKeyID is used for authentication.
                                 Cannot be set when SecretAccessKeyID is set.
-                                If neither the Access Key nor Key ID are set, we fall-back to using env
-                                vars, shared credentials file or AWS Instance metadata,
+                                If neither the Access Key nor Key ID are set, we fall back to using env
+                                vars, shared credentials file, or AWS Instance metadata,
                                 see: https://docs.aws.amazon.com/sdk-for-go/v1/developer-guide/configuring-sdk.html#specifying-credentials
                               type: string
                             accessKeyIDSecretRef:
@@ -487,8 +503,8 @@ spec:
                                 The SecretAccessKey is used for authentication. If set, pull the AWS
                                 access key ID from a key within a Kubernetes Secret.
                                 Cannot be set when AccessKeyID is set.
-                                If neither the Access Key nor Key ID are set, we fall-back to using env
-                                vars, shared credentials file or AWS Instance metadata,
+                                If neither the Access Key nor Key ID are set, we fall back to using env
+                                vars, shared credentials file, or AWS Instance metadata,
                                 see: https://docs.aws.amazon.com/sdk-for-go/v1/developer-guide/configuring-sdk.html#specifying-credentials
                               properties:
                                 key:
@@ -577,8 +593,8 @@ spec:
                             secretAccessKeySecretRef:
                               description: |-
                                 The SecretAccessKey is used for authentication.
-                                If neither the Access Key nor Key ID are set, we fall-back to using env
-                                vars, shared credentials file or AWS Instance metadata,
+                                If neither the Access Key nor Key ID are set, we fall back to using env
+                                vars, shared credentials file, or AWS Instance metadata,
                                 see: https://docs.aws.amazon.com/sdk-for-go/v1/developer-guide/configuring-sdk.html#specifying-credentials
                               properties:
                                 key:
@@ -1935,9 +1951,10 @@ spec:
                                           operator:
                                             description: |-
                                               Operator represents a key's relationship to the value.
-                                              Valid operators are Exists and Equal. Defaults to Equal.
+                                              Valid operators are Exists, Equal, Lt, and Gt. Defaults to Equal.
                                               Exists is equivalent to wildcard for value, so that a pod can
                                               tolerate all taints of a particular category.
+                                              Lt and Gt perform numeric comparisons (requires feature gate TaintTolerationComparisonOperators).
                                             type: string
                                           tolerationSeconds:
                                             description: |-
@@ -3146,9 +3163,10 @@ spec:
                                           operator:
                                             description: |-
                                               Operator represents a key's relationship to the value.
-                                              Valid operators are Exists and Equal. Defaults to Equal.
+                                              Valid operators are Exists, Equal, Lt, and Gt. Defaults to Equal.
                                               Exists is equivalent to wildcard for value, so that a pod can
                                               tolerate all taints of a particular category.
+                                              Lt and Gt perform numeric comparisons (requires feature gate TaintTolerationComparisonOperators).
                                             type: string
                                           tolerationSeconds:
                                             description: |-
@@ -3296,6 +3314,10 @@ spec:
             - metadata
             - spec
           type: object
+      selectableFields:
+        - jsonPath: .spec.issuerRef.group
+        - jsonPath: .spec.issuerRef.kind
+        - jsonPath: .spec.issuerRef.name
       served: true
       storage: true
       subresources:
@@ -3313,7 +3335,7 @@ metadata:
     app.kubernetes.io/name: "cert-manager"
     app.kubernetes.io/instance: "cert-manager"
     app.kubernetes.io/component: "crds"
-    app.kubernetes.io/version: "v1.19.4"
+    app.kubernetes.io/version: "v1.20.2"
 spec:
   group: acme.cert-manager.io
   names:
@@ -3572,6 +3594,10 @@ spec:
             - metadata
             - spec
           type: object
+      selectableFields:
+        - jsonPath: .spec.issuerRef.group
+        - jsonPath: .spec.issuerRef.kind
+        - jsonPath: .spec.issuerRef.name
       served: true
       storage: true
       subresources:
@@ -3589,7 +3615,7 @@ metadata:
     app.kubernetes.io/name: "cert-manager"
     app.kubernetes.io/instance: "cert-manager"
     app.kubernetes.io/component: "crds"
-    app.kubernetes.io/version: "v1.19.4"
+    app.kubernetes.io/version: "v1.20.2"
 spec:
   group: cert-manager.io
   names:
@@ -3893,6 +3919,10 @@ spec:
                   type: string
               type: object
           type: object
+      selectableFields:
+        - jsonPath: .spec.issuerRef.group
+        - jsonPath: .spec.issuerRef.kind
+        - jsonPath: .spec.issuerRef.name
       served: true
       storage: true
       subresources:
@@ -3910,7 +3940,7 @@ metadata:
     app.kubernetes.io/name: "cert-manager"
     app.kubernetes.io/instance: "cert-manager"
     app.kubernetes.io/component: "crds"
-    app.kubernetes.io/version: "v1.19.4"
+    app.kubernetes.io/version: "v1.20.2"
 spec:
   group: cert-manager.io
   names:
@@ -4353,9 +4383,6 @@ spec:
                         will be generated whenever a re-issuance occurs.
                         Default is `Always`.
                         The default was changed from `Never` to `Always` in cert-manager >=v1.18.0.
-                        The new default can be disabled by setting the
-                        `--feature-gates=DefaultPrivateKeyRotationPolicyAlways=false` option on
-                        the controller component.
                       enum:
                         - Never
                         - Always
@@ -4711,6 +4738,10 @@ spec:
                   type: integer
               type: object
           type: object
+      selectableFields:
+        - jsonPath: .spec.issuerRef.group
+        - jsonPath: .spec.issuerRef.kind
+        - jsonPath: .spec.issuerRef.name
       served: true
       storage: true
       subresources:
@@ -4728,7 +4759,7 @@ metadata:
     app.kubernetes.io/name: "cert-manager"
     app.kubernetes.io/instance: "cert-manager"
     app.kubernetes.io/component: "crds"
-    app.kubernetes.io/version: "v1.19.4"
+    app.kubernetes.io/version: "v1.20.2"
 spec:
   group: cert-manager.io
   names:
@@ -5116,6 +5147,22 @@ spec:
                                       The TenantID of the Azure Service Principal used to authenticate with Azure DNS.
                                       If set, ClientID and ClientSecret must also be set.
                                     type: string
+                                  zoneType:
+                                    description: |-
+                                      ZoneType determines which type of Azure DNS zone to use.
+
+                                      Valid values are:
+                                        - AzurePublicZone  (default): Use a public Azure DNS zone.
+                                        - AzurePrivateZone: Use an Azure Private DNS zone.
+
+                                      If not specified, AzurePublicZone is used.
+
+                                      Support for Azure Private DNS zones is currently
+                                      experimental and may change in future releases.
+                                    enum:
+                                      - AzurePublicZone
+                                      - AzurePrivateZone
+                                    type: string
                                 required:
                                   - resourceGroupName
                                   - subscriptionID
@@ -5239,7 +5286,7 @@ spec:
                                     description: |-
                                       The IP address or hostname of an authoritative DNS server supporting
                                       RFC2136 in the form host:port. If the host is an IPv6 address it must be
-                                      enclosed in square brackets (e.g [2001:db8::1]) ; port is optional.
+                                      enclosed in square brackets (e.g [2001:db8::1]); port is optional.
                                       This field is required.
                                     type: string
                                   protocol:
@@ -5289,8 +5336,8 @@ spec:
                                     description: |-
                                       The AccessKeyID is used for authentication.
                                       Cannot be set when SecretAccessKeyID is set.
-                                      If neither the Access Key nor Key ID are set, we fall-back to using env
-                                      vars, shared credentials file or AWS Instance metadata,
+                                      If neither the Access Key nor Key ID are set, we fall back to using env
+                                      vars, shared credentials file, or AWS Instance metadata,
                                       see: https://docs.aws.amazon.com/sdk-for-go/v1/developer-guide/configuring-sdk.html#specifying-credentials
                                     type: string
                                   accessKeyIDSecretRef:
@@ -5298,8 +5345,8 @@ spec:
                                       The SecretAccessKey is used for authentication. If set, pull the AWS
                                       access key ID from a key within a Kubernetes Secret.
                                       Cannot be set when AccessKeyID is set.
-                                      If neither the Access Key nor Key ID are set, we fall-back to using env
-                                      vars, shared credentials file or AWS Instance metadata,
+                                      If neither the Access Key nor Key ID are set, we fall back to using env
+                                      vars, shared credentials file, or AWS Instance metadata,
                                       see: https://docs.aws.amazon.com/sdk-for-go/v1/developer-guide/configuring-sdk.html#specifying-credentials
                                     properties:
                                       key:
@@ -5388,8 +5435,8 @@ spec:
                                   secretAccessKeySecretRef:
                                     description: |-
                                       The SecretAccessKey is used for authentication.
-                                      If neither the Access Key nor Key ID are set, we fall-back to using env
-                                      vars, shared credentials file or AWS Instance metadata,
+                                      If neither the Access Key nor Key ID are set, we fall back to using env
+                                      vars, shared credentials file, or AWS Instance metadata,
                                       see: https://docs.aws.amazon.com/sdk-for-go/v1/developer-guide/configuring-sdk.html#specifying-credentials
                                     properties:
                                       key:
@@ -6746,9 +6793,10 @@ spec:
                                                 operator:
                                                   description: |-
                                                     Operator represents a key's relationship to the value.
-                                                    Valid operators are Exists and Equal. Defaults to Equal.
+                                                    Valid operators are Exists, Equal, Lt, and Gt. Defaults to Equal.
                                                     Exists is equivalent to wildcard for value, so that a pod can
                                                     tolerate all taints of a particular category.
+                                                    Lt and Gt perform numeric comparisons (requires feature gate TaintTolerationComparisonOperators).
                                                   type: string
                                                 tolerationSeconds:
                                                   description: |-
@@ -7957,9 +8005,10 @@ spec:
                                                 operator:
                                                   description: |-
                                                     Operator represents a key's relationship to the value.
-                                                    Valid operators are Exists and Equal. Defaults to Equal.
+                                                    Valid operators are Exists, Equal, Lt, and Gt. Defaults to Equal.
                                                     Exists is equivalent to wildcard for value, so that a pod can
                                                     tolerate all taints of a particular category.
+                                                    Lt and Gt perform numeric comparisons (requires feature gate TaintTolerationComparisonOperators).
                                                   type: string
                                                 tolerationSeconds:
                                                   description: |-
@@ -8216,8 +8265,8 @@ spec:
                               properties:
                                 audiences:
                                   description: |-
-                                    TokenAudiences is an optional list of extra audiences to include in the token passed to Vault. The default token
-                                    consisting of the issuer's namespace and name is always included.
+                                    TokenAudiences is an optional list of extra audiences to include in the token passed to Vault.
+                                    The default audiences are always included in the token.
                                   items:
                                     type: string
                                   type: array
@@ -8345,16 +8394,16 @@ spec:
                   type: object
                 venafi:
                   description: |-
-                    Venafi configures this issuer to sign certificates using a Venafi TPP
-                    or Venafi Cloud policy zone.
+                    Venafi configures this issuer to sign certificates using a CyberArk Certificate Manager Self-Hosted
+                    or SaaS policy zone.
                   properties:
                     cloud:
                       description: |-
-                        Cloud specifies the Venafi cloud configuration settings.
-                        Only one of TPP or Cloud may be specified.
+                        Cloud specifies the CyberArk Certificate Manager SaaS configuration settings.
+                        Only one of CyberArk Certificate Manager may be specified.
                       properties:
                         apiTokenSecretRef:
-                          description: APITokenSecretRef is a secret key selector for the Venafi Cloud API token.
+                          description: APITokenSecretRef is a secret key selector for the CyberArk Certificate Manager SaaS API token.
                           properties:
                             key:
                               description: |-
@@ -8372,7 +8421,7 @@ spec:
                           type: object
                         url:
                           description: |-
-                            URL is the base URL for Venafi Cloud.
+                            URL is the base URL for CyberArk Certificate Manager SaaS.
                             Defaults to "https://api.venafi.cloud/".
                           type: string
                       required:
@@ -8380,13 +8429,13 @@ spec:
                       type: object
                     tpp:
                       description: |-
-                        TPP specifies Trust Protection Platform configuration settings.
-                        Only one of TPP or Cloud may be specified.
+                        TPP specifies CyberArk Certificate Manager Self-Hosted configuration settings.
+                        Only one of CyberArk Certificate Manager may be specified.
                       properties:
                         caBundle:
                           description: |-
                             Base64-encoded bundle of PEM CAs which will be used to validate the certificate
-                            chain presented by the TPP server. Only used if using HTTPS; ignored for HTTP.
+                            chain presented by the CyberArk Certificate Manager Self-Hosted server. Only used if using HTTPS; ignored for HTTP.
                             If undefined, the certificate bundle in the cert-manager controller container
                             is used to validate the chain.
                           format: byte
@@ -8394,7 +8443,7 @@ spec:
                         caBundleSecretRef:
                           description: |-
                             Reference to a Secret containing a base64-encoded bundle of PEM CAs
-                            which will be used to validate the certificate chain presented by the TPP server.
+                            which will be used to validate the certificate chain presented by the CyberArk Certificate Manager Self-Hosted server.
                             Only used if using HTTPS; ignored for HTTP. Mutually exclusive with CABundle.
                             If neither CABundle nor CABundleSecretRef is defined, the certificate bundle in
                             the cert-manager controller container is used to validate the TLS connection.
@@ -8415,7 +8464,7 @@ spec:
                           type: object
                         credentialsRef:
                           description: |-
-                            CredentialsRef is a reference to a Secret containing the Venafi TPP API credentials.
+                            CredentialsRef is a reference to a Secret containing the CyberArk Certificate Manager Self-Hosted API credentials.
                             The secret must contain the key 'access-token' for the Access Token Authentication,
                             or two keys, 'username' and 'password' for the API Keys Authentication.
                           properties:
@@ -8429,7 +8478,7 @@ spec:
                           type: object
                         url:
                           description: |-
-                            URL is the base URL for the vedsdk endpoint of the Venafi TPP instance,
+                            URL is the base URL for the vedsdk endpoint of the CyberArk Certificate Manager Self-Hosted instance,
                             for example: "https://tpp.example.com/vedsdk".
                           type: string
                       required:
@@ -8438,8 +8487,8 @@ spec:
                       type: object
                     zone:
                       description: |-
-                        Zone is the Venafi Policy Zone to use for this issuer.
-                        All requests made to the Venafi platform will be restricted by the named
+                        Zone is the Certificate Manager Policy Zone to use for this issuer.
+                        All requests made to the Certificate Manager platform will be restricted by the named
                         zone policy.
                         This field is required.
                       type: string
@@ -8545,7 +8594,7 @@ metadata:
     app.kubernetes.io/name: "cert-manager"
     app.kubernetes.io/instance: "cert-manager"
     app.kubernetes.io/component: "crds"
-    app.kubernetes.io/version: "v1.19.4"
+    app.kubernetes.io/version: "v1.20.2"
 spec:
   group: cert-manager.io
   names:
@@ -8932,6 +8981,22 @@ spec:
                                       The TenantID of the Azure Service Principal used to authenticate with Azure DNS.
                                       If set, ClientID and ClientSecret must also be set.
                                     type: string
+                                  zoneType:
+                                    description: |-
+                                      ZoneType determines which type of Azure DNS zone to use.
+
+                                      Valid values are:
+                                        - AzurePublicZone  (default): Use a public Azure DNS zone.
+                                        - AzurePrivateZone: Use an Azure Private DNS zone.
+
+                                      If not specified, AzurePublicZone is used.
+
+                                      Support for Azure Private DNS zones is currently
+                                      experimental and may change in future releases.
+                                    enum:
+                                      - AzurePublicZone
+                                      - AzurePrivateZone
+                                    type: string
                                 required:
                                   - resourceGroupName
                                   - subscriptionID
@@ -9055,7 +9120,7 @@ spec:
                                     description: |-
                                       The IP address or hostname of an authoritative DNS server supporting
                                       RFC2136 in the form host:port. If the host is an IPv6 address it must be
-                                      enclosed in square brackets (e.g [2001:db8::1]) ; port is optional.
+                                      enclosed in square brackets (e.g [2001:db8::1]); port is optional.
                                       This field is required.
                                     type: string
                                   protocol:
@@ -9105,8 +9170,8 @@ spec:
                                     description: |-
                                       The AccessKeyID is used for authentication.
                                       Cannot be set when SecretAccessKeyID is set.
-                                      If neither the Access Key nor Key ID are set, we fall-back to using env
-                                      vars, shared credentials file or AWS Instance metadata,
+                                      If neither the Access Key nor Key ID are set, we fall back to using env
+                                      vars, shared credentials file, or AWS Instance metadata,
                                       see: https://docs.aws.amazon.com/sdk-for-go/v1/developer-guide/configuring-sdk.html#specifying-credentials
                                     type: string
                                   accessKeyIDSecretRef:
@@ -9114,8 +9179,8 @@ spec:
                                       The SecretAccessKey is used for authentication. If set, pull the AWS
                                       access key ID from a key within a Kubernetes Secret.
                                       Cannot be set when AccessKeyID is set.
-                                      If neither the Access Key nor Key ID are set, we fall-back to using env
-                                      vars, shared credentials file or AWS Instance metadata,
+                                      If neither the Access Key nor Key ID are set, we fall back to using env
+                                      vars, shared credentials file, or AWS Instance metadata,
                                       see: https://docs.aws.amazon.com/sdk-for-go/v1/developer-guide/configuring-sdk.html#specifying-credentials
                                     properties:
                                       key:
@@ -9204,8 +9269,8 @@ spec:
                                   secretAccessKeySecretRef:
                                     description: |-
                                       The SecretAccessKey is used for authentication.
-                                      If neither the Access Key nor Key ID are set, we fall-back to using env
-                                      vars, shared credentials file or AWS Instance metadata,
+                                      If neither the Access Key nor Key ID are set, we fall back to using env
+                                      vars, shared credentials file, or AWS Instance metadata,
                                       see: https://docs.aws.amazon.com/sdk-for-go/v1/developer-guide/configuring-sdk.html#specifying-credentials
                                     properties:
                                       key:
@@ -10562,9 +10627,10 @@ spec:
                                                 operator:
                                                   description: |-
                                                     Operator represents a key's relationship to the value.
-                                                    Valid operators are Exists and Equal. Defaults to Equal.
+                                                    Valid operators are Exists, Equal, Lt, and Gt. Defaults to Equal.
                                                     Exists is equivalent to wildcard for value, so that a pod can
                                                     tolerate all taints of a particular category.
+                                                    Lt and Gt perform numeric comparisons (requires feature gate TaintTolerationComparisonOperators).
                                                   type: string
                                                 tolerationSeconds:
                                                   description: |-
@@ -11773,9 +11839,10 @@ spec:
                                                 operator:
                                                   description: |-
                                                     Operator represents a key's relationship to the value.
-                                                    Valid operators are Exists and Equal. Defaults to Equal.
+                                                    Valid operators are Exists, Equal, Lt, and Gt. Defaults to Equal.
                                                     Exists is equivalent to wildcard for value, so that a pod can
                                                     tolerate all taints of a particular category.
+                                                    Lt and Gt perform numeric comparisons (requires feature gate TaintTolerationComparisonOperators).
                                                   type: string
                                                 tolerationSeconds:
                                                   description: |-
@@ -12032,8 +12099,8 @@ spec:
                               properties:
                                 audiences:
                                   description: |-
-                                    TokenAudiences is an optional list of extra audiences to include in the token passed to Vault. The default token
-                                    consisting of the issuer's namespace and name is always included.
+                                    TokenAudiences is an optional list of extra audiences to include in the token passed to Vault.
+                                    The default audiences are always included in the token.
                                   items:
                                     type: string
                                   type: array
@@ -12161,16 +12228,16 @@ spec:
                   type: object
                 venafi:
                   description: |-
-                    Venafi configures this issuer to sign certificates using a Venafi TPP
-                    or Venafi Cloud policy zone.
+                    Venafi configures this issuer to sign certificates using a CyberArk Certificate Manager Self-Hosted
+                    or SaaS policy zone.
                   properties:
                     cloud:
                       description: |-
-                        Cloud specifies the Venafi cloud configuration settings.
-                        Only one of TPP or Cloud may be specified.
+                        Cloud specifies the CyberArk Certificate Manager SaaS configuration settings.
+                        Only one of CyberArk Certificate Manager may be specified.
                       properties:
                         apiTokenSecretRef:
-                          description: APITokenSecretRef is a secret key selector for the Venafi Cloud API token.
+                          description: APITokenSecretRef is a secret key selector for the CyberArk Certificate Manager SaaS API token.
                           properties:
                             key:
                               description: |-
@@ -12188,7 +12255,7 @@ spec:
                           type: object
                         url:
                           description: |-
-                            URL is the base URL for Venafi Cloud.
+                            URL is the base URL for CyberArk Certificate Manager SaaS.
                             Defaults to "https://api.venafi.cloud/".
                           type: string
                       required:
@@ -12196,13 +12263,13 @@ spec:
                       type: object
                     tpp:
                       description: |-
-                        TPP specifies Trust Protection Platform configuration settings.
-                        Only one of TPP or Cloud may be specified.
+                        TPP specifies CyberArk Certificate Manager Self-Hosted configuration settings.
+                        Only one of CyberArk Certificate Manager may be specified.
                       properties:
                         caBundle:
                           description: |-
                             Base64-encoded bundle of PEM CAs which will be used to validate the certificate
-                            chain presented by the TPP server. Only used if using HTTPS; ignored for HTTP.
+                            chain presented by the CyberArk Certificate Manager Self-Hosted server. Only used if using HTTPS; ignored for HTTP.
                             If undefined, the certificate bundle in the cert-manager controller container
                             is used to validate the chain.
                           format: byte
@@ -12210,7 +12277,7 @@ spec:
                         caBundleSecretRef:
                           description: |-
                             Reference to a Secret containing a base64-encoded bundle of PEM CAs
-                            which will be used to validate the certificate chain presented by the TPP server.
+                            which will be used to validate the certificate chain presented by the CyberArk Certificate Manager Self-Hosted server.
                             Only used if using HTTPS; ignored for HTTP. Mutually exclusive with CABundle.
                             If neither CABundle nor CABundleSecretRef is defined, the certificate bundle in
                             the cert-manager controller container is used to validate the TLS connection.
@@ -12231,7 +12298,7 @@ spec:
                           type: object
                         credentialsRef:
                           description: |-
-                            CredentialsRef is a reference to a Secret containing the Venafi TPP API credentials.
+                            CredentialsRef is a reference to a Secret containing the CyberArk Certificate Manager Self-Hosted API credentials.
                             The secret must contain the key 'access-token' for the Access Token Authentication,
                             or two keys, 'username' and 'password' for the API Keys Authentication.
                           properties:
@@ -12245,7 +12312,7 @@ spec:
                           type: object
                         url:
                           description: |-
-                            URL is the base URL for the vedsdk endpoint of the Venafi TPP instance,
+                            URL is the base URL for the vedsdk endpoint of the CyberArk Certificate Manager Self-Hosted instance,
                             for example: "https://tpp.example.com/vedsdk".
                           type: string
                       required:
@@ -12254,8 +12321,8 @@ spec:
                       type: object
                     zone:
                       description: |-
-                        Zone is the Venafi Policy Zone to use for this issuer.
-                        All requests made to the Venafi platform will be restricted by the named
+                        Zone is the Certificate Manager Policy Zone to use for this issuer.
+                        All requests made to the Certificate Manager platform will be restricted by the named
                         zone policy.
                         This field is required.
                       type: string
@@ -12362,7 +12429,7 @@ metadata:
     app.kubernetes.io/name: cainjector
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/component: "cainjector"
-    app.kubernetes.io/version: "v1.19.4"
+    app.kubernetes.io/version: "v1.20.2"
 ---
 # Source: cert-manager/templates/serviceaccount.yaml
 apiVersion: v1
@@ -12376,7 +12443,7 @@ metadata:
     app.kubernetes.io/name: cert-manager
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/component: "controller"
-    app.kubernetes.io/version: "v1.19.4"
+    app.kubernetes.io/version: "v1.20.2"
 ---
 # Source: cert-manager/templates/webhook-serviceaccount.yaml
 apiVersion: v1
@@ -12390,7 +12457,7 @@ metadata:
     app.kubernetes.io/name: webhook
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/component: "webhook"
-    app.kubernetes.io/version: "v1.19.4"
+    app.kubernetes.io/version: "v1.20.2"
 ---
 # Source: cert-manager/templates/cainjector-rbac.yaml
 apiVersion: rbac.authorization.k8s.io/v1
@@ -12402,7 +12469,7 @@ metadata:
     app.kubernetes.io/name: cainjector
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/component: "cainjector"
-    app.kubernetes.io/version: "v1.19.4"
+    app.kubernetes.io/version: "v1.20.2"
 rules:
   - apiGroups: ["cert-manager.io"]
     resources: ["certificates"]
@@ -12434,7 +12501,7 @@ metadata:
     app.kubernetes.io/name: cert-manager
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/component: "controller"
-    app.kubernetes.io/version: "v1.19.4"
+    app.kubernetes.io/version: "v1.20.2"
 rules:
   - apiGroups: ["cert-manager.io"]
     resources: ["issuers", "issuers/status"]
@@ -12460,7 +12527,7 @@ metadata:
     app.kubernetes.io/name: cert-manager
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/component: "controller"
-    app.kubernetes.io/version: "v1.19.4"
+    app.kubernetes.io/version: "v1.20.2"
 rules:
   - apiGroups: ["cert-manager.io"]
     resources: ["clusterissuers", "clusterissuers/status"]
@@ -12486,7 +12553,7 @@ metadata:
     app.kubernetes.io/name: cert-manager
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/component: "controller"
-    app.kubernetes.io/version: "v1.19.4"
+    app.kubernetes.io/version: "v1.20.2"
 rules:
   - apiGroups: ["cert-manager.io"]
     resources: ["certificates", "certificates/status", "certificaterequests", "certificaterequests/status"]
@@ -12521,7 +12588,7 @@ metadata:
     app.kubernetes.io/name: cert-manager
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/component: "controller"
-    app.kubernetes.io/version: "v1.19.4"
+    app.kubernetes.io/version: "v1.20.2"
 rules:
   - apiGroups: ["acme.cert-manager.io"]
     resources: ["orders", "orders/status"]
@@ -12541,6 +12608,9 @@ rules:
   - apiGroups: ["acme.cert-manager.io"]
     resources: ["orders/finalizers"]
     verbs: ["update"]
+  - apiGroups: ["cert-manager.io"]
+    resources: ["clusterissuers/finalizers", "issuers/finalizers"]
+    verbs: ["update"]
   - apiGroups: [""]
     resources: ["secrets"]
     verbs: ["get", "list", "watch"]
@@ -12559,7 +12629,7 @@ metadata:
     app.kubernetes.io/name: cert-manager
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/component: "controller"
-    app.kubernetes.io/version: "v1.19.4"
+    app.kubernetes.io/version: "v1.20.2"
 rules:
   # Use to update challenge resource status
   - apiGroups: ["acme.cert-manager.io"]
@@ -12619,7 +12689,7 @@ metadata:
     app.kubernetes.io/name: cert-manager
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/component: "controller"
-    app.kubernetes.io/version: "v1.19.4"
+    app.kubernetes.io/version: "v1.20.2"
 rules:
   - apiGroups: ["cert-manager.io"]
     resources: ["certificates", "certificaterequests"]
@@ -12637,10 +12707,10 @@ rules:
     resources: ["ingresses/finalizers"]
     verbs: ["update"]
   - apiGroups: ["gateway.networking.k8s.io"]
-    resources: ["gateways", "httproutes"]
+    resources: ["gateways", "httproutes", "listenersets"]
     verbs: ["get", "list", "watch"]
   - apiGroups: ["gateway.networking.k8s.io"]
-    resources: ["gateways/finalizers", "httproutes/finalizers"]
+    resources: ["gateways/finalizers", "httproutes/finalizers", "listenersets/finalizers"]
     verbs: ["update"]
   - apiGroups: [""]
     resources: ["events"]
@@ -12656,7 +12726,7 @@ metadata:
     app.kubernetes.io/name: cert-manager
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/component: "controller"
-    app.kubernetes.io/version: "v1.19.4"
+    app.kubernetes.io/version: "v1.20.2"
     rbac.authorization.k8s.io/aggregate-to-cluster-reader: "true"
 rules:
   - apiGroups: ["cert-manager.io"]
@@ -12673,7 +12743,7 @@ metadata:
     app.kubernetes.io/name: cert-manager
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/component: "controller"
-    app.kubernetes.io/version: "v1.19.4"
+    app.kubernetes.io/version: "v1.20.2"
     rbac.authorization.k8s.io/aggregate-to-view: "true"
     rbac.authorization.k8s.io/aggregate-to-edit: "true"
     rbac.authorization.k8s.io/aggregate-to-admin: "true"
@@ -12696,7 +12766,7 @@ metadata:
     app.kubernetes.io/name: cert-manager
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/component: "controller"
-    app.kubernetes.io/version: "v1.19.4"
+    app.kubernetes.io/version: "v1.20.2"
     rbac.authorization.k8s.io/aggregate-to-edit: "true"
     rbac.authorization.k8s.io/aggregate-to-admin: "true"
 rules:
@@ -12721,7 +12791,7 @@ metadata:
     app.kubernetes.io/name: cert-manager
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/component: "cert-manager"
-    app.kubernetes.io/version: "v1.19.4"
+    app.kubernetes.io/version: "v1.20.2"
 rules:
   - apiGroups: ["cert-manager.io"]
     resources: ["signers"]
@@ -12743,7 +12813,7 @@ metadata:
     app.kubernetes.io/name: cert-manager
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/component: "cert-manager"
-    app.kubernetes.io/version: "v1.19.4"
+    app.kubernetes.io/version: "v1.20.2"
 rules:
   - apiGroups: ["certificates.k8s.io"]
     resources: ["certificatesigningrequests"]
@@ -12769,7 +12839,7 @@ metadata:
     app.kubernetes.io/name: webhook
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/component: "webhook"
-    app.kubernetes.io/version: "v1.19.4"
+    app.kubernetes.io/version: "v1.20.2"
 rules:
 - apiGroups: ["authorization.k8s.io"]
   resources: ["subjectaccessreviews"]
@@ -12785,7 +12855,7 @@ metadata:
     app.kubernetes.io/name: cainjector
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/component: "cainjector"
-    app.kubernetes.io/version: "v1.19.4"
+    app.kubernetes.io/version: "v1.20.2"
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
@@ -12805,7 +12875,7 @@ metadata:
     app.kubernetes.io/name: cert-manager
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/component: "controller"
-    app.kubernetes.io/version: "v1.19.4"
+    app.kubernetes.io/version: "v1.20.2"
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
@@ -12825,7 +12895,7 @@ metadata:
     app.kubernetes.io/name: cert-manager
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/component: "controller"
-    app.kubernetes.io/version: "v1.19.4"
+    app.kubernetes.io/version: "v1.20.2"
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
@@ -12845,7 +12915,7 @@ metadata:
     app.kubernetes.io/name: cert-manager
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/component: "controller"
-    app.kubernetes.io/version: "v1.19.4"
+    app.kubernetes.io/version: "v1.20.2"
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
@@ -12865,7 +12935,7 @@ metadata:
     app.kubernetes.io/name: cert-manager
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/component: "controller"
-    app.kubernetes.io/version: "v1.19.4"
+    app.kubernetes.io/version: "v1.20.2"
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
@@ -12885,7 +12955,7 @@ metadata:
     app.kubernetes.io/name: cert-manager
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/component: "controller"
-    app.kubernetes.io/version: "v1.19.4"
+    app.kubernetes.io/version: "v1.20.2"
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
@@ -12905,7 +12975,7 @@ metadata:
     app.kubernetes.io/name: cert-manager
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/component: "controller"
-    app.kubernetes.io/version: "v1.19.4"
+    app.kubernetes.io/version: "v1.20.2"
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
@@ -12925,7 +12995,7 @@ metadata:
     app.kubernetes.io/name: cert-manager
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/component: "cert-manager"
-    app.kubernetes.io/version: "v1.19.4"
+    app.kubernetes.io/version: "v1.20.2"
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
@@ -12945,7 +13015,7 @@ metadata:
     app.kubernetes.io/name: cert-manager
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/component: "cert-manager"
-    app.kubernetes.io/version: "v1.19.4"
+    app.kubernetes.io/version: "v1.20.2"
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
@@ -12965,7 +13035,7 @@ metadata:
     app.kubernetes.io/name: webhook
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/component: "webhook"
-    app.kubernetes.io/version: "v1.19.4"
+    app.kubernetes.io/version: "v1.20.2"
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
@@ -12987,7 +13057,7 @@ metadata:
     app.kubernetes.io/name: cainjector
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/component: "cainjector"
-    app.kubernetes.io/version: "v1.19.4"
+    app.kubernetes.io/version: "v1.20.2"
 rules:
   # Used for leader election by the controller
   # cert-manager-cainjector-leader-election is used by the CertificateBased injector controller
@@ -13013,7 +13083,7 @@ metadata:
     app.kubernetes.io/name: cert-manager
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/component: "controller"
-    app.kubernetes.io/version: "v1.19.4"
+    app.kubernetes.io/version: "v1.20.2"
 rules:
   - apiGroups: ["coordination.k8s.io"]
     resources: ["leases"]
@@ -13034,7 +13104,7 @@ metadata:
     app.kubernetes.io/name: cert-manager
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/component: "controller"
-    app.kubernetes.io/version: "v1.19.4"
+    app.kubernetes.io/version: "v1.20.2"
 rules:
   - apiGroups: [""]
     resources: ["serviceaccounts/token"]
@@ -13052,7 +13122,7 @@ metadata:
     app.kubernetes.io/name: webhook
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/component: "webhook"
-    app.kubernetes.io/version: "v1.19.4"
+    app.kubernetes.io/version: "v1.20.2"
 rules:
 - apiGroups: [""]
   resources: ["secrets"]
@@ -13077,7 +13147,7 @@ metadata:
     app.kubernetes.io/name: cainjector
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/component: "cainjector"
-    app.kubernetes.io/version: "v1.19.4"
+    app.kubernetes.io/version: "v1.20.2"
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role
@@ -13100,7 +13170,7 @@ metadata:
     app.kubernetes.io/name: cert-manager
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/component: "controller"
-    app.kubernetes.io/version: "v1.19.4"
+    app.kubernetes.io/version: "v1.20.2"
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role
@@ -13122,7 +13192,7 @@ metadata:
     app.kubernetes.io/name: cert-manager
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/component: "controller"
-    app.kubernetes.io/version: "v1.19.4"
+    app.kubernetes.io/version: "v1.20.2"
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role
@@ -13143,7 +13213,7 @@ metadata:
     app.kubernetes.io/name: webhook
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/component: "webhook"
-    app.kubernetes.io/version: "v1.19.4"
+    app.kubernetes.io/version: "v1.20.2"
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role
@@ -13164,7 +13234,7 @@ metadata:
     app.kubernetes.io/name: cainjector
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/component: "cainjector"
-    app.kubernetes.io/version: "v1.19.4"
+    app.kubernetes.io/version: "v1.20.2"
 spec:
   type: ClusterIP
   ports:
@@ -13187,7 +13257,7 @@ metadata:
     app.kubernetes.io/name: cert-manager
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/component: "controller"
-    app.kubernetes.io/version: "v1.19.4"
+    app.kubernetes.io/version: "v1.20.2"
 spec:
   type: ClusterIP
   ports:
@@ -13211,7 +13281,7 @@ metadata:
     app.kubernetes.io/name: webhook
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/component: "webhook"
-    app.kubernetes.io/version: "v1.19.4"
+    app.kubernetes.io/version: "v1.20.2"
 spec:
   type: ClusterIP
   ports:
@@ -13239,7 +13309,7 @@ metadata:
     app.kubernetes.io/name: cainjector
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/component: "cainjector"
-    app.kubernetes.io/version: "v1.19.4"
+    app.kubernetes.io/version: "v1.20.2"
 spec:
   replicas: 1
   selector:
@@ -13254,7 +13324,7 @@ spec:
         app.kubernetes.io/name: cainjector
         app.kubernetes.io/instance: cert-manager
         app.kubernetes.io/component: "cainjector"
-        app.kubernetes.io/version: "v1.19.4"
+        app.kubernetes.io/version: "v1.20.2"
       annotations:
         prometheus.io/path: "/metrics"
         prometheus.io/scrape: 'true'
@@ -13268,7 +13338,7 @@ spec:
           type: RuntimeDefault
       containers:
         - name: cert-manager-cainjector
-          image: "quay.io/jetstack/cert-manager-cainjector:v1.19.4"
+          image: "quay.io/jetstack/cert-manager-cainjector:v1.20.2"
           imagePullPolicy: IfNotPresent
           args:
           - --v=2
@@ -13302,7 +13372,7 @@ metadata:
     app.kubernetes.io/name: cert-manager
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/component: "controller"
-    app.kubernetes.io/version: "v1.19.4"
+    app.kubernetes.io/version: "v1.20.2"
 spec:
   replicas: 1
   selector:
@@ -13317,7 +13387,7 @@ spec:
         app.kubernetes.io/name: cert-manager
         app.kubernetes.io/instance: cert-manager
         app.kubernetes.io/component: "controller"
-        app.kubernetes.io/version: "v1.19.4"
+        app.kubernetes.io/version: "v1.20.2"
       annotations:
         prometheus.io/path: "/metrics"
         prometheus.io/scrape: 'true'
@@ -13331,13 +13401,13 @@ spec:
           type: RuntimeDefault
       containers:
         - name: cert-manager-controller
-          image: "quay.io/jetstack/cert-manager-controller:v1.19.4"
+          image: "quay.io/jetstack/cert-manager-controller:v1.20.2"
           imagePullPolicy: IfNotPresent
           args:
           - --v=2
           - --cluster-resource-namespace=$(POD_NAMESPACE)
           - --leader-election-namespace=kube-system
-          - --acme-http01-solver-image=quay.io/jetstack/cert-manager-acmesolver:v1.19.4
+          - --acme-http01-solver-image=quay.io/jetstack/cert-manager-acmesolver:v1.20.2
           - --max-concurrent-challenges=60
           ports:
           - containerPort: 9402
@@ -13384,7 +13454,7 @@ metadata:
     app.kubernetes.io/name: webhook
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/component: "webhook"
-    app.kubernetes.io/version: "v1.19.4"
+    app.kubernetes.io/version: "v1.20.2"
 spec:
   replicas: 1
   selector:
@@ -13399,7 +13469,7 @@ spec:
         app.kubernetes.io/name: webhook
         app.kubernetes.io/instance: cert-manager
         app.kubernetes.io/component: "webhook"
-        app.kubernetes.io/version: "v1.19.4"
+        app.kubernetes.io/version: "v1.20.2"
       annotations:
         prometheus.io/path: "/metrics"
         prometheus.io/scrape: 'true'
@@ -13413,7 +13483,7 @@ spec:
           type: RuntimeDefault
       containers:
         - name: cert-manager-webhook
-          image: "quay.io/jetstack/cert-manager-webhook:v1.19.4"
+          image: "quay.io/jetstack/cert-manager-webhook:v1.20.2"
           imagePullPolicy: IfNotPresent
           args:
           - --v=2
@@ -13477,7 +13547,7 @@ metadata:
     app.kubernetes.io/name: webhook
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/component: "webhook"
-    app.kubernetes.io/version: "v1.19.4"
+    app.kubernetes.io/version: "v1.20.2"
   annotations:
     cert-manager.io/inject-ca-from-secret: "cert-manager/cert-manager-webhook-ca"
 webhooks:
@@ -13516,7 +13586,7 @@ metadata:
     app.kubernetes.io/name: webhook
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/component: "webhook"
-    app.kubernetes.io/version: "v1.19.4"
+    app.kubernetes.io/version: "v1.20.2"
   annotations:
     cert-manager.io/inject-ca-from-secret: "cert-manager/cert-manager-webhook-ca"
 webhooks:

--- a/scripts/synchronize-cert-manager-manifests.sh
+++ b/scripts/synchronize-cert-manager-manifests.sh
@@ -5,7 +5,7 @@ source "${SCRIPT_DIRECTORY}/library.sh"
 setup_error_handling
 COMPONENT_NAME="cert-manager"
 REPOSITORY_NAME="cert-manager/cert-manager"
-COMMIT="v1.19.4"
+COMMIT="v1.20.2"
 BRANCH_NAME=${BRANCH_NAME:=synchronize-${COMPONENT_NAME}-manifests-${COMMIT?}}
 MANIFESTS_DIRECTORY=$(dirname $SCRIPT_DIRECTORY)
 DESTINATION_DIRECTORY=$MANIFESTS_DIRECTORY/common/${COMPONENT_NAME}


### PR DESCRIPTION
## Summary
- Synchronizes cert-manager manifests from v1.19.4 to v1.20.2 using `scripts/synchronize-cert-manager-manifests.sh`.
- Updates the top-level README version reference.
- Keeps this separate from Helm chart changes so the Helm chart PR can be rebased after the Kustomize baseline lands.

## Validation
- `git diff --check HEAD~1..HEAD`
- `kustomize build common/cert-manager/base`
- `kustomize build common/cert-manager/overlays/kubeflow`