### PR TITLE
Synchronize Dex manifests to v2.45.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,7 +82,7 @@ This repository periodically synchronizes all official Kubeflow components from 
 | Istio | common/istio | [1.30.0](https://github.com/istio/istio/releases/tag/1.30.0) | 750m | 2364Mi | 0GB |
 | Knative | common/knative/knative-serving <br /> common/knative/knative-eventing | [v1.21.1](https://github.com/knative/serving/releases/tag/knative-v1.21.1) <br /> [v1.21.0](https://github.com/knative/eventing/releases/tag/knative-v1.21.0) | 1450m | 1038Mi | 0GB |
 | Cert Manager | common/cert-manager | [1.19.4](https://github.com/cert-manager/cert-manager/releases/tag/v1.19.4) | 3m | 128Mi | 0GB |
-| Dex | common/dex | [2.45.0](https://github.com/dexidp/dex/releases/tag/v2.45.0) | 3m | 27Mi | 0GB |
+| Dex | common/dex | [2.45.1](https://github.com/dexidp/dex/releases/tag/v2.45.1) | 3m | 27Mi | 0GB |
 | OAuth2-Proxy | common/oauth2-proxy | [7.14.3](https://github.com/oauth2-proxy/oauth2-proxy/releases/tag/v7.14.3) | 3m | 27Mi | 0GB |
 | **Total** | | | **4380m** | **12341Mi** | **65GB** |
 

--- a/common/dex/base/deployment.yaml
+++ b/common/dex/base/deployment.yaml
@@ -16,7 +16,7 @@ spec:
     spec:
       serviceAccountName: dex
       containers:
-      - image: ghcr.io/dexidp/dex:v2.45.0
+      - image: ghcr.io/dexidp/dex:v2.45.1
         name: dex
         command: ["dex", "serve", "/etc/dex/cfg/config.yaml"]
         ports:

--- a/scripts/synchronize-dex-manifests.sh
+++ b/scripts/synchronize-dex-manifests.sh
@@ -6,7 +6,7 @@ setup_error_handling
 COMPONENT_NAME="dex"
 REPOSITORY_NAME="dexidp/dex"
 REPOSITORY_URL="https://github.com/dexidp/dex.git"
-COMMIT="v2.45.0"
+COMMIT="v2.45.1"
 REPOSITORY_DIRECTORY="dex"
 SOURCE_DIRECTORY=${SOURCE_DIRECTORY:=/tmp/kubeflow-${COMPONENT_NAME}}
 BRANCH_NAME=${BRANCH_NAME:=synchronize-${COMPONENT_NAME}-manifests-${COMMIT?}}


### PR DESCRIPTION
## Summary
- Synchronizes Dex manifests from v2.45.0 to v2.45.1 using `scripts/synchronize-dex-manifests.sh`.
- Updates the Dex image tag, upstream CRD copy, and top-level README version reference.
- Keeps this separate from Helm chart changes so the Helm chart PR can be rebased after the Kustomize baseline lands.

## Validation
- `git diff --check HEAD~1..HEAD`
- `kustomize build common/dex/base`
- `kustomize build common/dex/overlays/istio`
- `kustomize build common/dex/overlays/oauth2-proxy`