### PR TITLE
Synchronize oauth2-proxy manifests to v7.15.2

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,7 +83,7 @@ This repository periodically synchronizes all official Kubeflow components from 
 | Knative | common/knative/knative-serving <br /> common/knative/knative-eventing | [v1.22.0](https://github.com/knative/serving/releases/tag/knative-v1.22.0) <br /> [v1.22.0](https://github.com/knative/eventing/releases/tag/knative-v1.22.0) | 1450m | 1038Mi | 0GB |
 | Cert Manager | common/cert-manager | [1.20.2](https://github.com/cert-manager/cert-manager/releases/tag/v1.20.2) | 3m | 128Mi | 0GB |
 | Dex | common/dex | [2.45.1](https://github.com/dexidp/dex/releases/tag/v2.45.1) | 3m | 27Mi | 0GB |
-| OAuth2-Proxy | common/oauth2-proxy | [7.14.3](https://github.com/oauth2-proxy/oauth2-proxy/releases/tag/v7.14.3) | 3m | 27Mi | 0GB |
+| OAuth2-Proxy | common/oauth2-proxy | [7.15.2](https://github.com/oauth2-proxy/oauth2-proxy/releases/tag/v7.15.2) | 3m | 27Mi | 0GB |
 | **Total** | | | **4380m** | **12341Mi** | **65GB** |
 
 

--- a/common/oauth2-proxy/base/deployment.yaml
+++ b/common/oauth2-proxy/base/deployment.yaml
@@ -23,7 +23,7 @@ spec:
           name: oauth2-proxy-theme
       containers:
       - name: oauth2-proxy
-        image: quay.io/oauth2-proxy/oauth2-proxy:v7.14.3
+        image: quay.io/oauth2-proxy/oauth2-proxy:v7.15.2
         args:
         - --http-address=0.0.0.0:4180
         - --config=/etc/oauth2_proxy/oauth2_proxy.cfg

--- a/scripts/synchronize-oauth2-proxy-manifests.sh
+++ b/scripts/synchronize-oauth2-proxy-manifests.sh
@@ -5,7 +5,7 @@ source "${SCRIPT_DIRECTORY}/library.sh"
 setup_error_handling
 COMPONENT_NAME="oauth2-proxy"
 REPOSITORY_NAME="oauth2-proxy/oauth2-proxy"
-COMMIT="v7.14.3"
+COMMIT="v7.15.2"
 BRANCH_NAME=${BRANCH_NAME:=synchronize-${COMPONENT_NAME}-manifests-${COMMIT?}}
 MANIFESTS_DIRECTORY=$(dirname $SCRIPT_DIRECTORY)
 DESTINATION_DIRECTORY=$MANIFESTS_DIRECTORY/common/${COMPONENT_NAME}


### PR DESCRIPTION
## Summary
- Synchronizes oauth2-proxy manifests from v7.14.3 to v7.15.2 using `scripts/synchronize-oauth2-proxy-manifests.sh`.
- Updates the oauth2-proxy image tag and top-level README version reference.
- Keeps this separate from Helm chart changes so the Helm chart PR can be rebased after the Kustomize baseline lands.

## Validation
- `git diff --check HEAD~1..HEAD`
- `kustomize build common/oauth2-proxy/base`
- `kustomize build common/oauth2-proxy/overlays/m2m-dex-only`
- `kustomize build common/oauth2-proxy/overlays/m2m-dex-and-kind`
- `kustomize build common/oauth2-proxy/overlays/m2m-dex-and-eks`