### PR TITLE
fix(networkpolicy): align model-catalog podSelector with upstream deployment labels

### DIFF
--- a/common/kubeflow-namespace/base/kubeflow/model-catalog.yaml
+++ b/common/kubeflow-namespace/base/kubeflow/model-catalog.yaml
@@ -5,11 +5,9 @@ metadata:
   namespace: kubeflow
 spec:
   podSelector:
-    matchExpressions:
-    - key: component
-      operator: In
-      values:
-      - model-catalog-server
+    matchLabels:
+      app.kubernetes.io/name: model-catalog
+      app.kubernetes.io/component: server
   ingress:
   - from:
     - namespaceSelector:


### PR DESCRIPTION
## summary

the model-catalog NetworkPolicy in `common/kubeflow-namespace/base/kubeflow/model-catalog.yaml` uses `component: model-catalog-server` in its podSelector. the upstream catalog deployment at `applications/hub/upstream/options/catalog/base/deployment.yaml` does not have this label — it uses `app.kubernetes.io/name: model-catalog` and `app.kubernetes.io/component: server`.

the podSelector matches zero pods, making the NetworkPolicy a no-op.

## root cause

the model-registry deployment uses the bare `component: model-registry-server` label, and the model-catalog NetworkPolicy was likely templated from the model-registry one without updating the selector for the catalog's different labeling convention.

## verification

deployed to a kind cluster and confirmed the mismatch:

```bash
$ kubectl get pods -n kubeflow -l component=model-catalog-server
No resources found in kubeflow namespace.

$ kubectl get pods -n kubeflow --show-labels -l app.kubernetes.io/name=model-catalog
model-catalog-server-7596579449-d4wkq  app.kubernetes.io/component=server,app.kubernetes.io/name=model-catalog,app.kubernetes.io/part-of=model-catalog
```
## changes

| file | change |
|------|--------|
| `common/kubeflow-namespace/base/kubeflow/model-catalog.yaml` | podSelector changed from `matchExpressions` on `component: model-catalog-server` to `matchLabels` on `app.kubernetes.io/name: model-catalog` + `app.kubernetes.io/component: server` |

## what is not changed

- ingress rules (profile namespaces + istio-system) unchanged
- port 8080 unchanged
- policyTypes unchanged

cc @juliusvonkohout
