### PR TITLE
test: update Kind bootstrap to Kubernetes 1.36

### DIFF
--- a/tests/install_KinD_create_KinD_cluster_install_kustomize.sh
+++ b/tests/install_KinD_create_KinD_cluster_install_kustomize.sh
@@ -1,8 +1,8 @@
 #!/bin/bash
 set -euxo pipefail
 
-KIND_VERSION="v0.31.0"
-KIND_NODE_IMAGE="kindest/node:v1.35.0@sha256:452d707d4862f52530247495d180205e029056831160e22870e37e3f6c1ac31f"
+KIND_VERSION="v0.32.0"
+KIND_NODE_IMAGE="kindest/node:v1.36.1@sha256:3489c7674813ba5d8b1a9977baea8a6e553784dab7b84759d1014dbd78f7ebd5"
 KUSTOMIZE_VERSION="v5.8.1"
 USER_BINARY_DIRECTORY="$HOME/.local/bin"
 
@@ -47,14 +47,16 @@ kind: Cluster
 # See: https://kubernetes.slack.com/archives/CEKK1KTN2/p1600268272383600
 kubeadmConfigPatches:
   - |
-    apiVersion: kubeadm.k8s.io/v1beta3
+    apiVersion: kubeadm.k8s.io/v1beta4
     kind: ClusterConfiguration
     metadata:
       name: config
     apiServer:
       extraArgs:
-        \"service-account-issuer\": \"https://kubernetes.default.svc\"
-        \"service-account-signing-key-file\": \"/etc/kubernetes/pki/sa.key\"
+        - name: service-account-issuer
+          value: https://kubernetes.default.svc
+        - name: service-account-signing-key-file
+          value: /etc/kubernetes/pki/sa.key
 nodes:
 - role: control-plane
   image: ${KIND_NODE_IMAGE}


### PR DESCRIPTION
## Summary
- Update the shared Kind bootstrap script to Kind `v0.32.0` and the Kind Kubernetes `v1.36.1` node image from the upstream Kind release.
- Update the `kubeadmConfigPatches` payload to `kubeadm.k8s.io/v1beta4` and the list-shaped `apiServer.extraArgs` format used by Kubernetes `v1.36+`.

## Validation
- `bash -n tests/install_KinD_create_KinD_cluster_install_kustomize.sh`
- `git diff --check HEAD~1..HEAD`
- Local temporary-home smoke test: ran `tests/install_KinD_create_KinD_cluster_install_kustomize.sh`; confirmed `kind v0.32.0`, `kubectl` client `v1.36.1`, `kustomize v5.8.1`, and all three `kubeflow` Kind nodes Ready on Kubernetes `v1.36.1` with containerd `2.3.1`.
