### PR TITLE
Update Kubeflow Workspaces manifests to v2.0.0-alpha.3

### DIFF
--- a/applications/workspaces/upstream/backend/base/kustomization.yaml
+++ b/applications/workspaces/upstream/backend/base/kustomization.yaml
@@ -18,4 +18,4 @@ labels:
 images:
 - name: workspaces-backend
   newName: ghcr.io/kubeflow/notebooks/workspaces-backend
-  newTag: v2.0.0-alpha.2
+  newTag: v2.0.0-alpha.3

--- a/applications/workspaces/upstream/controller/base/crd/kubeflow.org_workspacekinds.yaml
+++ b/applications/workspaces/upstream/controller/base/crd/kubeflow.org_workspacekinds.yaml
@@ -317,6 +317,8 @@ spec:
                       environment variables for Workspace Pods (MUTABLE)
                        - the following go template functions are available:
                           - `httpPathPrefix(portId string)`: returns the HTTP path prefix of the specified port
+                    example:
+                      NB_PREFIX: '{{ httpPathPrefix ''jupyterlab'' }}'
                     items:
                       description: EnvVar represents an environment variable present
                         in a Container.
@@ -3711,15 +3713,14 @@ spec:
                                 header manipulation rules for incoming HTTP requests
                                  - sets the `spec.http[].headers.request` of the Istio VirtualService
                                    https://istio.io/latest/docs/reference/config/networking/virtual-service/#Headers-HeaderOperations
-                                 - the following string templates are available:
-                                    - `.PathPrefix`: the path prefix of the Workspace (e.g. '/workspace/connect/{profile_name}/{workspace_name}/')
                               properties:
                                 add:
                                   additionalProperties:
                                     type: string
-                                  description: append the given values to the headers
-                                    specified by keys (will create a comma-separated
-                                    list of values)
+                                  description: |-
+                                    append the given values to the headers specified by keys (will create a comma-separated list of values)
+                                     - the following go template functions are available in the values:
+                                        - `httpPathPrefix(portId string)`: returns the HTTP path prefix of the specified port
                                   example:
                                     My-Header: value-to-append
                                   type: object
@@ -3733,10 +3734,13 @@ spec:
                                 set:
                                   additionalProperties:
                                     type: string
-                                  description: overwrite the headers specified by
-                                    key with the given values
+                                  description: |-
+                                    overwrite the headers specified by key with the given values
+                                     - the following go template functions are available in the values:
+                                        - `httpPathPrefix(portId string)`: returns the HTTP path prefix of the specified port
                                   example:
-                                    X-RStudio-Root-Path: '{{ .PathPrefix }}'
+                                    X-RStudio-Root-Path: '{{ httpPathPrefix ''rstudio''
+                                      }}'
                                   type: object
                               type: object
                           type: object

--- a/applications/workspaces/upstream/controller/base/manager/kustomization.yaml
+++ b/applications/workspaces/upstream/controller/base/manager/kustomization.yaml
@@ -19,4 +19,4 @@ labels:
 images:
 - name: workspaces-controller
   newName: ghcr.io/kubeflow/notebooks/workspaces-controller
-  newTag: v2.0.0-alpha.2
+  newTag: v2.0.0-alpha.3

--- a/applications/workspaces/upstream/controller/base/manager/user_cluster_roles.yaml
+++ b/applications/workspaces/upstream/controller/base/manager/user_cluster_roles.yaml
@@ -1,3 +1,9 @@
+##
+## WARNING: Kubernetes will REMOVE any existing content of `rules` when using `aggregationRule`. 
+##          So, we define both the `aggregate-to-kubeflow-workspaces-edit` and `kubeflow-workspaces-edit` 
+##          even though only `kubeflow-workspaces-edit` is indented to be used in a binding.
+##          https://kubernetes.io/docs/reference/access-authn-authz/rbac/#aggregated-clusterroles
+##
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:

--- a/applications/workspaces/upstream/controller/samples/rstudio_v1beta1_workspacekind.yaml
+++ b/applications/workspaces/upstream/controller/samples/rstudio_v1beta1_workspacekind.yaml
@@ -26,7 +26,8 @@ spec:
           removePathPrefix: true
           requestHeaders:
             set:
-              "X-RStudio-Root-Path": "{{ .PathPrefix }}"
+              "X-RStudio-Root-Path": |-
+                {{ httpPathPrefix "rstudio" }}
     extraEnv: []
     extraVolumeMounts:
       - name: "dshm"

--- a/applications/workspaces/upstream/frontend/base/kustomization.yaml
+++ b/applications/workspaces/upstream/frontend/base/kustomization.yaml
@@ -16,4 +16,4 @@ labels:
 images:
 - name: workspaces-frontend
   newName: ghcr.io/kubeflow/notebooks/workspaces-frontend
-  newTag: v2.0.0-alpha.2
+  newTag: v2.0.0-alpha.3

--- a/scripts/synchronize-kubeflow-workspaces-manifests.sh
+++ b/scripts/synchronize-kubeflow-workspaces-manifests.sh
@@ -6,7 +6,7 @@ setup_error_handling
 COMPONENT_NAME="workspaces"
 REPOSITORY_NAME="kubeflow/notebooks"
 REPOSITORY_URL="https://github.com/kubeflow/notebooks.git"
-COMMIT="v2.0.0-alpha.2"
+COMMIT="v2.0.0-alpha.3"
 REPOSITORY_DIRECTORY="$COMPONENT_NAME"
 SOURCE_DIRECTORY=${SOURCE_DIRECTORY:=/tmp/${COMPONENT_NAME}}
 BRANCH_NAME=${BRANCH_NAME:=synchronize-${COMPONENT_NAME}-manifests-${COMMIT?}}


### PR DESCRIPTION
# Pull Request Template for Kubeflow Manifests

## ✏️ Summary of Changes

Synchronize the new [v2.0.0-alpha.3](https://github.com/kubeflow/notebooks/releases/tag/v2.0.0-alpha.3) Kubeflow Workspaces release into the `kubeflow/manifests` repo.

## 📦 Dependencies

_none_

## 🐛 Related Issues

_none_

## ✅ Contributor Checklist

- [x] I have tested these changes with kustomize. See [Installation Prerequisites](https://github.com/kubeflow/manifests#prerequisites).
- [x] All commits are [_signed-off_](https://github.com/kubeflow/community/tree/master/dco-signoff-hook#signing-off-commits) to satisfy the DCO check.
- [x] I have considered adding my company to the adopters page to support Kubeflow and help the community, since I expect help from the community for my issue (see [1.](https://github.com/kubeflow/community/issues/833) and [2.](https://github.com/kubeflow/community/blob/master/ADOPTERS.md#adopters-of-kubeflow-platform)).
