### PR TITLE
Update kubeflow/notebooks manifests to v1.11.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,13 +64,8 @@ This repository periodically synchronizes all official Kubeflow components from 
 | - | - | - | - | - | - |
 | Training Operator | applications/training-operator/upstream | [v1.9.2](https://github.com/kubeflow/training-operator/tree/v1.9.2/manifests) | 3m | 25Mi | 0GB |
 | Trainer | applications/trainer/upstream | [v2.2.0](https://github.com/kubeflow/trainer/tree/v2.2.0/manifests) | 8m | 143Mi | 0GB |
-| Notebook Controller | applications/notebooks-v1/upstream/notebook-controller | [v1.11.0-rc.1](https://github.com/kubeflow/notebooks/tree/v1.11.0-rc.1/components/notebook-controller/config) | 5m | 93Mi | 0GB |
-| PVC Viewer Controller | applications/notebooks-v1/upstream/pvcviewer-controller | [v1.11.0-rc.1](https://github.com/kubeflow/notebooks/tree/v1.11.0-rc.1/components/pvcviewer-controller/config) | 15m | 128Mi | 0GB |
-| Tensorboard Controller | applications/notebooks-v1/upstream/tensorboard-controller | [v1.11.0-rc.1](https://github.com/kubeflow/notebooks/tree/v1.11.0-rc.1/components/tensorboard-controller/config) | 15m | 128Mi | 0GB |
+| Kubeflow Notebooks | applications/notebooks-v1/upstream/ | [v1.11.0](https://github.com/kubeflow/notebooks/tree/v1.11.0/) | 43m | 806Mi | 0GB |
 | Kubeflow Dashboard | applications/dashboard/upstream/ | [v2.0.0](https://github.com/kubeflow/dashboard/tree/v2.0.0/) | 10m | 302Mi | 0GB |
-| Jupyter Web Application | applications/notebooks-v1/upstream/jupyter-web-app | [v1.11.0-rc.1](https://github.com/kubeflow/notebooks/tree/v1.11.0-rc.1/components/crud-web-apps/jupyter/manifests) | 4m | 231Mi | 0GB |
-| Tensorboards Web Application | applications/notebooks-v1/upstream/tensorboards-web-app | [v1.11.0-rc.1](https://github.com/kubeflow/notebooks/tree/v1.11.0-rc.1/components/crud-web-apps/tensorboards/manifests) |  |  |  |
-| Volumes Web Application | applications/notebooks-v1/upstream/volumes-web-app | [v1.11.0-rc.1](https://github.com/kubeflow/notebooks/tree/v1.11.0-rc.1/components/crud-web-apps/volumes/manifests) | 4m | 226Mi | 0GB |
 | Katib | applications/katib/upstream | [v0.19.0](https://github.com/kubeflow/katib/tree/v0.19.0/manifests/v1beta1) | 13m | 476Mi | 10GB |
 | KServe Models Web Application | applications/kserve/models-web-app | [v0.18.0](https://github.com/kserve/models-web-app/tree/v0.18.0/manifests/kustomize) | 6m | 259Mi  | 0GB |
 | KServe | applications/kserve/kserve | [v0.18.0](https://github.com/kserve/kserve/tree/v0.18.0) | 600m | 1200Mi | 0GB |

--- a/applications/notebooks-v1/upstream/jupyter-web-app/base/configs/spawner_ui_config.yaml
+++ b/applications/notebooks-v1/upstream/jupyter-web-app/base/configs/spawner_ui_config.yaml
@@ -37,16 +37,15 @@ spawnerFormDefaults:
   ################################################################
   image:
     # the default container image
-    value: ghcr.io/kubeflow/kubeflow/notebook-servers/jupyter-scipy:v1.11.0-rc.1
+    value: ghcr.io/kubeflow/kubeflow/notebook-servers/jupyter-scipy:v1.11.0
 
     # the list of available container images in the dropdown
     options:
-    - ghcr.io/kubeflow/kubeflow/notebook-servers/jupyter-scipy:v1.11.0-rc.1
-    - ghcr.io/kubeflow/kubeflow/notebook-servers/jupyter-pytorch-full:v1.11.0-rc.1
-    - ghcr.io/kubeflow/kubeflow/notebook-servers/jupyter-pytorch-cuda-full:v1.11.0-rc.1
-    - ghcr.io/kubeflow/kubeflow/notebook-servers/jupyter-pytorch-gaudi-full:v1.11.0-rc.1
-    - ghcr.io/kubeflow/kubeflow/notebook-servers/jupyter-tensorflow-full:v1.11.0-rc.1
-    - ghcr.io/kubeflow/kubeflow/notebook-servers/jupyter-tensorflow-cuda-full:v1.11.0-rc.1
+    - ghcr.io/kubeflow/kubeflow/notebook-servers/jupyter-scipy:v1.11.0
+    - ghcr.io/kubeflow/kubeflow/notebook-servers/jupyter-pytorch-full:v1.11.0
+    - ghcr.io/kubeflow/kubeflow/notebook-servers/jupyter-pytorch-cuda-full:v1.11.0
+    - ghcr.io/kubeflow/kubeflow/notebook-servers/jupyter-tensorflow-full:v1.11.0
+    - ghcr.io/kubeflow/kubeflow/notebook-servers/jupyter-tensorflow-cuda-full:v1.11.0
 
   ################################################################
   # VSCode-like Container Images (Group 1)
@@ -61,11 +60,11 @@ spawnerFormDefaults:
   ################################################################
   imageGroupOne:
     # the default container image
-    value: ghcr.io/kubeflow/kubeflow/notebook-servers/codeserver-python:v1.11.0-rc.1
+    value: ghcr.io/kubeflow/kubeflow/notebook-servers/codeserver-python:v1.11.0
 
     # the list of available container images in the dropdown
     options:
-    - ghcr.io/kubeflow/kubeflow/notebook-servers/codeserver-python:v1.11.0-rc.1
+    - ghcr.io/kubeflow/kubeflow/notebook-servers/codeserver-python:v1.11.0
 
   ################################################################
   # RStudio-like Container Images (Group 2)
@@ -82,11 +81,11 @@ spawnerFormDefaults:
   ################################################################
   imageGroupTwo:
     # the default container image
-    value: ghcr.io/kubeflow/kubeflow/notebook-servers/rstudio-tidyverse:v1.11.0-rc.1
+    value: ghcr.io/kubeflow/kubeflow/notebook-servers/rstudio-tidyverse:v1.11.0
 
     # the list of available container images in the dropdown
     options:
-    - ghcr.io/kubeflow/kubeflow/notebook-servers/rstudio-tidyverse:v1.11.0-rc.1
+    - ghcr.io/kubeflow/kubeflow/notebook-servers/rstudio-tidyverse:v1.11.0
 
   ################################################################
   # CPU Resources

--- a/applications/notebooks-v1/upstream/jupyter-web-app/base/kustomization.yaml
+++ b/applications/notebooks-v1/upstream/jupyter-web-app/base/kustomization.yaml
@@ -23,7 +23,7 @@ commonLabels:
 images:
 - name: ghcr.io/kubeflow/notebooks/jupyter-web-app
   newName: ghcr.io/kubeflow/notebooks/jupyter-web-app
-  newTag: v1.11.0-rc.1
+  newTag: v1.11.0
 # We need the name to be unique without the suffix because the original name is what
 # gets used with patches
 configMapGenerator:

--- a/applications/notebooks-v1/upstream/notebook-controller/base/kustomization.yaml
+++ b/applications/notebooks-v1/upstream/notebook-controller/base/kustomization.yaml
@@ -5,4 +5,4 @@ resources:
 images:
 - name: ghcr.io/kubeflow/notebooks/notebook-controller
   newName: ghcr.io/kubeflow/notebooks/notebook-controller
-  newTag: v1.11.0-rc.1
+  newTag: v1.11.0

--- a/applications/notebooks-v1/upstream/pvcviewer-controller/base/kustomization.yaml
+++ b/applications/notebooks-v1/upstream/pvcviewer-controller/base/kustomization.yaml
@@ -6,4 +6,4 @@ resources:
 images:
 - name: ghcr.io/kubeflow/notebooks/pvcviewer-controller
   newName: ghcr.io/kubeflow/notebooks/pvcviewer-controller
-  newTag: v1.11.0-rc.1
+  newTag: v1.11.0

--- a/applications/notebooks-v1/upstream/tensorboard-controller/base/kustomization.yaml
+++ b/applications/notebooks-v1/upstream/tensorboard-controller/base/kustomization.yaml
@@ -14,4 +14,4 @@ patchesStrategicMerge:
 images:
 - name: ghcr.io/kubeflow/notebooks/tensorboard-controller
   newName: ghcr.io/kubeflow/notebooks/tensorboard-controller
-  newTag: v1.11.0-rc.1
+  newTag: v1.11.0

--- a/applications/notebooks-v1/upstream/tensorboards-web-app/base/kustomization.yaml
+++ b/applications/notebooks-v1/upstream/tensorboards-web-app/base/kustomization.yaml
@@ -14,7 +14,7 @@ commonLabels:
 images:
 - name: ghcr.io/kubeflow/notebooks/tensorboards-web-app
   newName: ghcr.io/kubeflow/notebooks/tensorboards-web-app
-  newTag: v1.11.0-rc.1
+  newTag: v1.11.0
 # We need the name to be unique without the suffix because the original name is what
 # gets used with patches
 configMapGenerator:

--- a/applications/notebooks-v1/upstream/volumes-web-app/base/kustomization.yaml
+++ b/applications/notebooks-v1/upstream/volumes-web-app/base/kustomization.yaml
@@ -14,7 +14,7 @@ commonLabels:
 images:
 - name: ghcr.io/kubeflow/notebooks/volumes-web-app
   newName: ghcr.io/kubeflow/notebooks/volumes-web-app
-  newTag: v1.11.0-rc.1
+  newTag: v1.11.0
 # We need the name to be unique without the suffix because the original name is what
 # gets used with patches
 configMapGenerator:

--- a/scripts/synchronize-notebooks-v1-manifests.sh
+++ b/scripts/synchronize-notebooks-v1-manifests.sh
@@ -6,7 +6,7 @@ setup_error_handling
 COMPONENT_NAME="notebooks-v1"
 REPOSITORY_NAME="kubeflow/notebooks"
 REPOSITORY_URL="https://github.com/kubeflow/notebooks.git"
-COMMIT="v1.11.0-rc.1"
+COMMIT="v1.11.0"
 REPOSITORY_DIRECTORY="$COMPONENT_NAME"
 SOURCE_DIRECTORY=${SOURCE_DIRECTORY:=/tmp/${COMPONENT_NAME}-${COMPONENT_NAME}}
 BRANCH_NAME=${BRANCH_NAME:=synchronize-${COMPONENT_NAME}-${COMPONENT_NAME}-manifests-${COMMIT?}}
@@ -16,37 +16,33 @@ clone_and_checkout "$SOURCE_DIRECTORY" "$REPOSITORY_URL" "$REPOSITORY_DIRECTORY"
 copy_component_manifests() {
     local source_manifests_path=$1
     local destination_manifests_path=$2
-    local readme_path_pattern_for_replacement=$3
     local destination_directory="${MANIFESTS_DIRECTORY}/${destination_manifests_path}"
     if [ -d "$destination_directory" ]; then
         rm -r "$destination_directory"
     fi
     mkdir -p "$destination_directory"
     cp "${SOURCE_DIRECTORY}/${REPOSITORY_DIRECTORY}/${source_manifests_path}/"* "$destination_directory" -r
-    local source_text="\[.*\](https://github.com/${REPOSITORY_NAME}/tree/.*/components/${readme_path_pattern_for_replacement})"
-    local destination_text="\[${COMMIT}\](https://github.com/${REPOSITORY_NAME}/tree/${COMMIT}/components/${readme_path_pattern_for_replacement})"
+    local source_text="\[.*\](https://github.com/${REPOSITORY_NAME}/tree/.*/)"
+    local destination_text="\[${COMMIT}\](https://github.com/${REPOSITORY_NAME}/tree/${COMMIT}/)"
     update_readme "$MANIFESTS_DIRECTORY" "$source_text" "$destination_text"
 }
 TARGET_DIR="applications/notebooks-v1/upstream/"
+
 copy_component_manifests "components/crud-web-apps/jupyter/manifests" \
-    "${TARGET_DIR}/jupyter-web-app/" \
-    "crud-web-apps/jupyter/manifests"
+    "${TARGET_DIR}/jupyter-web-app/"
 copy_component_manifests "components/crud-web-apps/volumes/manifests" \
-    "${TARGET_DIR}/volumes-web-app/" \
-    "crud-web-apps/volumes/manifests"
+    "${TARGET_DIR}/volumes-web-app/"
 copy_component_manifests "components/crud-web-apps/tensorboards/manifests" \
-    "${TARGET_DIR}/tensorboards-web-app/" \
-    "crud-web-apps/tensorboards/manifests"
+    "${TARGET_DIR}/tensorboards-web-app/"
 copy_component_manifests "components/notebook-controller/config" \
-    "${TARGET_DIR}/notebook-controller/" \
-    "notebook-controller/config"
+    "${TARGET_DIR}/notebook-controller/"
 copy_component_manifests "components/tensorboard-controller/config" \
-    "${TARGET_DIR}/tensorboard-controller" \
-    "tensorboard-controller/config"
+    "${TARGET_DIR}/tensorboard-controller"
 copy_component_manifests "components/pvcviewer-controller/config" \
-    "${TARGET_DIR}/pvcviewer-controller/" \
-    "pvcviewer-controller/config"
-commit_changes "$MANIFESTS_DIRECTORY" "Update ${REPOSITORY_NAME} manifests from ${COMMIT}" \
+    "${TARGET_DIR}/pvcviewer-controller/"
+
+commit_changes "$MANIFESTS_DIRECTORY" "Update ${REPOSITORY_NAME} manifests to ${COMMIT}" \
   "${TARGET_DIR}" \
+  "${SCRIPT_DIRECTORY}/synchronize-notebooks-v1-manifests.sh" \
   "README.md"
 echo "Synchronization completed successfully."


### PR DESCRIPTION
# Pull Request Template for Kubeflow Manifests

## ✏️ Summary of Changes

Update Kubeflow Notebooks to `v1.11.0`.

## 📦 Dependencies

_None_

## 🐛 Related Issues

Related to https://github.com/kubeflow/manifests/issues/3465.

## ✅ Contributor Checklist

- [x] I have tested these changes with kustomize. See [Installation Prerequisites](https://github.com/kubeflow/manifests#prerequisites).
- [x] All commits are [_signed-off_](https://github.com/kubeflow/community/tree/master/dco-signoff-hook#signing-off-commits) to satisfy the DCO check.
- [x] I have considered adding my company to the adopters page to support Kubeflow and help the community, since I expect help from the community for my issue (see [1.](https://github.com/kubeflow/community/issues/833) and [2.](https://github.com/kubeflow/community/blob/master/ADOPTERS.md#adopters-of-kubeflow-platform)).
