### PR TITLE
chore: Update the name of the Slack channel

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -3,6 +3,6 @@ contact_links:
 - name: Join the CNCF Slack and access our meetings.
   url: https://www.kubeflow.org/docs/about/community/
   about: Join our CNCF Slack Channel and access Kubeflow community meetings.
-- name: Our channel on the CNCF Slack is kubeflow-platform.
-  url: https://app.slack.com/client/T08PSQ7BQ/C073W572LA2
+- name: Our channel on the CNCF Slack is kubeflow-community-distribution.
+  url: https://cloud-native.slack.com/archives/C073W572LA2
   about: You can join our channel on the CNCF slack.

--- a/.github/ISSUE_TEMPLATE/issue-report.yml
+++ b/.github/ISSUE_TEMPLATE/issue-report.yml
@@ -28,7 +28,7 @@ body:
       required: false
     - label: I am available to work on this issue.
       required: false
-    - label: You can join the CNCF Slack and access our meetings at the [Kubeflow Community](https://www.kubeflow.org/docs/about/community/) website. Our channel on the CNCF Slack is here [**#kubeflow-platform**](https://app.slack.com/client/T08PSQ7BQ/C073W572LA2).
+    - label: You can join the CNCF Slack and access our meetings at the [Kubeflow Community](https://www.kubeflow.org/docs/about/community/) website. Our channel on the CNCF Slack is here [**#kubeflow-community-distribution**](https://cloud-native.slack.com/archives/C073W572LA2).
       required: false
 - type: dropdown
   id: version

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -10,11 +10,11 @@
 > Link any issues that are resolved or affected by this PR.
 
 ## ✅ Contributor Checklist
-  - [ ] I have tested these changes with kustomize. See [Installation Prerequisites](https://github.com/kubeflow/manifests#prerequisites).
-  - [ ] All commits are [_signed-off_](https://github.com/kubeflow/community/tree/master/dco-signoff-hook#signing-off-commits) to satisfy the DCO check.
-  - [ ] I have considered adding my company to the adopters page to support Kubeflow and help the community, since I expect help from the community for my issue (see [1.](https://github.com/kubeflow/community/issues/833) and [2.](https://github.com/kubeflow/community/blob/master/ADOPTERS.md#adopters-of-kubeflow-platform)).
 
----     
- 
-> You can join the CNCF Slack and access our meetings at the [Kubeflow Community](https://www.kubeflow.org/docs/about/community/) website. Our channel on the CNCF Slack is here [**#kubeflow-platform**](https://app.slack.com/client/T08PSQ7BQ/C073W572LA2).
-  
+- [ ] I have tested these changes with kustomize. See [Installation Prerequisites](https://github.com/kubeflow/manifests#prerequisites).
+- [ ] All commits are [_signed-off_](https://github.com/kubeflow/community/tree/master/dco-signoff-hook#signing-off-commits) to satisfy the DCO check.
+- [ ] I have considered adding my company to the adopters page to support Kubeflow and help the community, since I expect help from the community for my issue (see [1.](https://github.com/kubeflow/community/issues/833) and [2.](https://github.com/kubeflow/community/blob/master/ADOPTERS.md#adopters-of-kubeflow-platform)).
+
+---
+
+> You can join the CNCF Slack and access our meetings at the [Kubeflow Community](https://www.kubeflow.org/docs/about/community/) website. Our channel on the CNCF Slack is here [**#kubeflow-community-distribution**](https://cloud-native.slack.com/archives/C073W572LA2).

--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ This should only apply to “stable” components, as “alpha/beta” component
 
 - This repository is owned by the [Platform/Manifests/security Working Group](https://github.com/kubeflow/community/blob/master/wg-manifests/charter.md).
 - You can join the CNCF Slack and access our meetings at the [Kubeflow Community](https://www.kubeflow.org/docs/about/community/) website.
-- Our channel on the CNCF Slack is [**#kubeflow-platform**](https://app.slack.com/client/T08PSQ7BQ/C073W572LA2).
+- Our channel on the CNCF Slack is [**#kubeflow-community-distribution**](https://cloud-native.slack.com/archives/C073W572LA2).
 - You can also find our [biweekly meetings](https://bit.ly/kf-wg-manifests-meet), including the commentable [Agenda](https://bit.ly/kf-wg-manifests-notes).
 - If you want to contribute, please take a look at the [CONTRIBUTING.md](CONTRIBUTING.md).
 
@@ -83,7 +83,6 @@ This repository periodically synchronizes all official Kubeflow components from 
 | Dex | common/dex | [2.45.1](https://github.com/dexidp/dex/releases/tag/v2.45.1) | 3m | 27Mi | 0GB |
 | OAuth2-Proxy | common/oauth2-proxy | [7.15.2](https://github.com/oauth2-proxy/oauth2-proxy/releases/tag/v7.15.2) | 3m | 27Mi | 0GB |
 | **Total** | | | **4380m** | **12341Mi** | **65GB** |
-
 
 
 ## Installation

--- a/releases/README.md
+++ b/releases/README.md
@@ -2,7 +2,7 @@
 
 ### Release Team Meetings
 - [Monday 09:00 PST / 17:00 UTC](https://zoom-lfx.platform.linuxfoundation.org/meetings/kubeflow?view=week)
-- [Meeting Agenda and Notes](https://docs.google.com/document/d/1OUWifNf7hZ_QH3m1J3zjSUUk11yKUZnvom1BS2KxrUQ) 
+- [Meeting Agenda and Notes](https://docs.google.com/document/d/1OUWifNf7hZ_QH3m1J3zjSUUk11yKUZnvom1BS2KxrUQ)
 - [Calendar Invite](https://zoom-lfx.platform.linuxfoundation.org/meeting/92113176338?password=883a2c39-41a9-4395-b9f2-d2bd73e8c39e&invite=true)
 
 ### Resources
@@ -10,5 +10,5 @@
 - [Meeting Recordings](https://www.youtube.com/@Kubeflow)
 
 ### Contact
-- Slack [#kubeflow-platform](https://cloud-native.slack.com/archives/C073W572LA2) channel
+- Slack [#kubeflow-community-distribution](https://cloud-native.slack.com/archives/C073W572LA2) channel
 - GitHub Teams [@release-team](https://github.com/orgs/kubeflow/teams/release-team)


### PR DESCRIPTION
# Pull Request Template for Kubeflow Manifests

## ✏️ Summary of Changes

In the context of creating the Kubeflow Community Distribution the Slack channel was renamed from `#kubeflow-platform` to `#kubeflow-community-distribution`.

While fixing this reference in various places (excluding the historical release files) also make some drive-by fixes regarding the Markdown formatting.

## 📦 Dependencies

_None_

## 🐛 Related Issues

- https://github.com/kubeflow/website/pull/4385 (cc @andreyvelich)

## ✅ Contributor Checklist

- [ ] I have tested these changes with kustomize. See [Installation Prerequisites](https://github.com/kubeflow/manifests#prerequisites).
- [x] All commits are [_signed-off_](https://github.com/kubeflow/community/tree/master/dco-signoff-hook#signing-off-commits) to satisfy the DCO check.
- [x] I have considered adding my company to the adopters page to support Kubeflow and help the community, since I expect help from the community for my issue (see [1.](https://github.com/kubeflow/community/issues/833) and [2.](https://github.com/kubeflow/community/blob/master/ADOPTERS.md#adopters-of-kubeflow-platform)).
