### PR TITLE
helm: align hub image tags with kustomize

### DIFF
--- a/experimental/helm/charts/hub/ci/ci-values.yaml
+++ b/experimental/helm/charts/hub/ci/ci-values.yaml
@@ -12,7 +12,7 @@ server:
   dataStoreType: embedmd
 
   image:
-    tag: "v0.3.9"
+    tag: "v0.3.10"
 
   # Configure readiness probe
   rest:

--- a/experimental/helm/charts/hub/ci/values-db.yaml
+++ b/experimental/helm/charts/hub/ci/values-db.yaml
@@ -10,7 +10,7 @@ server:
   replicas: 1
   dataStoreType: embedmd
   image:
-    tag: "v0.3.9"
+    tag: "v0.3.10"
   resources:
     limits:
       cpu: 200m

--- a/experimental/helm/charts/hub/ci/values-postgres.yaml
+++ b/experimental/helm/charts/hub/ci/values-postgres.yaml
@@ -10,7 +10,7 @@ server:
   replicas: 1
   dataStoreType: embedmd
   image:
-    tag: "v0.3.9"
+    tag: "v0.3.10"
   resources:
     limits:
       cpu: 200m

--- a/experimental/helm/charts/hub/ci/values-ui-integrated.yaml
+++ b/experimental/helm/charts/hub/ci/values-ui-integrated.yaml
@@ -5,7 +5,7 @@ ui:
 
   image:
     repository: ui
-    tag: "v0.3.9"
+    tag: "v0.3.10"
     pullPolicy: Always
 
   containerPort: 8080

--- a/experimental/helm/charts/hub/ci/values-ui-istio.yaml
+++ b/experimental/helm/charts/hub/ci/values-ui-istio.yaml
@@ -9,7 +9,7 @@ ui:
 
   image:
     repository: ui
-    tag: "v0.3.9"
+    tag: "v0.3.10"
     pullPolicy: Always
 
   containerPort: 8080

--- a/experimental/helm/charts/hub/ci/values-ui-standalone.yaml
+++ b/experimental/helm/charts/hub/ci/values-ui-standalone.yaml
@@ -9,7 +9,7 @@ ui:
 
   image:
     repository: ui
-    tag: "v0.3.9"
+    tag: "v0.3.10"
     pullPolicy: Always
 
   containerPort: 8080

--- a/experimental/helm/charts/hub/ci/values-ui.yaml
+++ b/experimental/helm/charts/hub/ci/values-ui.yaml
@@ -5,7 +5,7 @@ ui:
 
   image:
     repository: ui
-    tag: "v0.3.9"
+    tag: "v0.3.10"
     pullPolicy: Always
 
   containerPort: 8080

--- a/experimental/helm/charts/hub/values.yaml
+++ b/experimental/helm/charts/hub/values.yaml
@@ -42,7 +42,7 @@ server:
     # -- Server image repository
     repository: server
     # -- Server image tag (overrides global.imageTag if set)
-    tag: "v0.3.10"
+    tag: ""
     # -- Server image pull policy (overrides global.imagePullPolicy if set)
     pullPolicy: ""
 
@@ -178,7 +178,7 @@ ui:
     # -- UI image repository
     repository: model-registry-ui
     # -- UI image tag
-    tag: "v0.3.10"
+    tag: ""
     # -- UI image pull policy
     pullPolicy: ""
 

--- a/experimental/helm/charts/hub/values.yaml
+++ b/experimental/helm/charts/hub/values.yaml
@@ -18,7 +18,7 @@ global:
   # -- Image registry for Model Registry images
   imageRegistry: ghcr.io/kubeflow/hub
   # -- Global image tag for all Model Registry components
-  imageTag: v0.3.9
+  imageTag: v0.3.10
   # -- Global image pull policy
   imagePullPolicy: IfNotPresent
   # -- Global image pull secrets
@@ -42,7 +42,7 @@ server:
     # -- Server image repository
     repository: server
     # -- Server image tag (overrides global.imageTag if set)
-    tag: "v0.3.8"
+    tag: "v0.3.10"
     # -- Server image pull policy (overrides global.imagePullPolicy if set)
     pullPolicy: ""
 
@@ -178,7 +178,7 @@ ui:
     # -- UI image repository
     repository: model-registry-ui
     # -- UI image tag
-    tag: "v0.3.8"
+    tag: "v0.3.10"
     # -- UI image pull policy
     pullPolicy: ""
 


### PR DESCRIPTION
## Summary
- Align Hub Helm default image tags with the current Kustomize baseline.
- Update Hub CI values from `v0.3.9` to `v0.3.10` so Helm/Kustomize comparison matches the updated Hub manifests.
- Keep the fix scoped to Hub chart values only.

## Root Cause
`applications/hub/upstream` now renders Hub images with `v0.3.10`, but the Helm chart defaults and comparison fixture values still referenced older tags (`v0.3.8`/`v0.3.9`). This caused `Compare All Scenarios` to fail on Hub / Model Registry resources.

## Validation
- `helm lint experimental/helm/charts/hub/`
- `VERBOSE=true ./tests/helm_kustomize_compare_all.sh hub` with Helm `v4.2.2`
- `VERBOSE=true ./tests/helm_kustomize_compare_all.sh` with Helm `v4.2.2`
- `git diff --check`